### PR TITLE
fix(firecrawl): resolve syntax issue in error handling

### DIFF
--- a/apps/python-sdk/firecrawl/firecrawl.py
+++ b/apps/python-sdk/firecrawl/firecrawl.py
@@ -2343,7 +2343,7 @@ class FirecrawlApp:
                 else:
                     error_message = f"Server returned empty response with status {response.status_code}"
                     error_details = "No additional details available"
-+        except ValueError:
+            except ValueError:
                 error_message = f"Server returned unreadable response with status {response.status_code}"
                 error_details = "No additional details available"
         


### PR DESCRIPTION
## PR Summary
This small PR fixes the syntax issue in error handling of firecrawl, added in PR #1827.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a syntax error in firecrawl's error handling to ensure exceptions are caught correctly.

<!-- End of auto-generated description by cubic. -->

