### PR TITLE
feat(ab): add consistently at producer level, not consumer level

### DIFF
--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -5,7 +5,7 @@ import { getACUCTeam } from "../controllers/auth";
 import { getCrawl, StoredCrawl } from "./crawl-redis";
 import { getScrapeQueue } from "../services/queue-service";
 import { logger } from "./logger";
-import { abTestJob } from "../services/queue-jobs";
+import { abTestJob } from "../services/ab-test";
 
 const constructKey = (team_id: string) => "concurrency-limiter:" + team_id;
 const constructQueueKey = (team_id: string) =>

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -5,6 +5,7 @@ import { getACUCTeam } from "../controllers/auth";
 import { getCrawl, StoredCrawl } from "./crawl-redis";
 import { getScrapeQueue } from "../services/queue-service";
 import { logger } from "./logger";
+import { abTestJob } from "../services/queue-jobs";
 
 const constructKey = (team_id: string) => "concurrency-limiter:" + team_id;
 const constructQueueKey = (team_id: string) =>
@@ -273,6 +274,8 @@ export async function concurrentJobDone(job: Job) {
             await new Promise(resolve => setTimeout(resolve, sc.crawlerOptions.delay * 1000));
           }
         }
+
+        abTestJob(nextJob.job.data);
 
         (await getScrapeQueue()).add(
           nextJob.job.id,

--- a/apps/api/src/services/ab-test.ts
+++ b/apps/api/src/services/ab-test.ts
@@ -1,0 +1,48 @@
+import { WebScraperOptions } from "../types";
+import { logger as _logger } from "../lib/logger";
+import { robustFetch } from "../scraper/scrapeURL/lib/fetch";
+
+export function abTestJob(webScraperOptions: WebScraperOptions) {
+    // Global A/B test: mirror request to staging /v1/scrape based on SCRAPEURL_AB_RATE
+    const abLogger = _logger.child({ method: "ABTestToStaging" });
+    try {
+        const abRateEnv = process.env.SCRAPEURL_AB_RATE;
+        const abHostEnv = process.env.SCRAPEURL_AB_HOST;
+        const abRate = abRateEnv !== undefined ? Math.max(0, Math.min(1, Number(abRateEnv))) : 0;
+        const shouldABTest = webScraperOptions.mode === "single_urls"
+            && !webScraperOptions.zeroDataRetention
+            && !webScraperOptions.internalOptions?.zeroDataRetention
+            && abRate > 0
+            && Math.random() <= abRate
+            && abHostEnv
+            && webScraperOptions.internalOptions?.v1Agent === undefined
+            && webScraperOptions.internalOptions?.v1JSONAgent === undefined;
+        if (shouldABTest) {
+            (async () => {
+                try {
+                    abLogger.info("A/B-testing scrapeURL to staging");
+                    const abort = AbortSignal.timeout(Math.min(60000, (webScraperOptions.scrapeOptions.timeout ?? 30000) + 10000));
+                    await robustFetch({
+                        url: `http://${abHostEnv}/v2/scrape`,
+                        method: "POST",
+                        body: {
+                            url: webScraperOptions.url,
+                            ...webScraperOptions.scrapeOptions,
+                            origin: (webScraperOptions.scrapeOptions as any).origin ?? "api",
+                        },
+                        logger: abLogger,
+                        tryCount: 1,
+                        ignoreResponse: true,
+                        mock: null,
+                        abort,
+                    });
+                    abLogger.info("A/B-testing scrapeURL (staging) request sent");
+                } catch (error) {
+                    abLogger.warn("A/B-testing scrapeURL (staging) failed", { error });
+                }
+            })();
+        }
+    } catch (error) {
+        abLogger.warn("Failed to initiate A/B test to staging", { error });
+    }
+}

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -53,12 +53,7 @@ async function _addScrapeJobToConcurrencyQueue(
   }, webScraperOptions.crawl_id ? Infinity :(webScraperOptions.scrapeOptions?.timeout ?? (60 * 1000)));
 }
 
-export async function _addScrapeJobToBullMQ(
-  webScraperOptions: WebScraperOptions,
-  options: any,
-  jobId: string,
-  jobPriority: number,
-): Promise<Job> {
+export function abTestJob(webScraperOptions: WebScraperOptions) {
   // Global A/B test: mirror request to staging /v1/scrape based on SCRAPEURL_AB_RATE
   const abLogger = _logger.child({ method: "ABTestToStaging" });
   try {
@@ -101,6 +96,15 @@ export async function _addScrapeJobToBullMQ(
   } catch (error) {
     abLogger.warn("Failed to initiate A/B test to staging", { error });
   }
+}
+
+export async function _addScrapeJobToBullMQ(
+  webScraperOptions: WebScraperOptions,
+  options: any,
+  jobId: string,
+  jobPriority: number,
+): Promise<Job> {
+  abTestJob(webScraperOptions);
 
   if (
     webScraperOptions &&

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -23,6 +23,7 @@ import { Job } from "bullmq";
 import { ScrapeJobTimeoutError, TransportableError } from "../lib/error";
 import { deserializeTransportableError } from "../lib/error-serde";
 import { robustFetch } from '../scraper/scrapeURL/lib/fetch';
+import { abTestJob } from "./ab-test";
 
 /**
  * Checks if a job is a crawl or batch scrape based on its options
@@ -51,51 +52,6 @@ async function _addScrapeJobToConcurrencyQueue(
     },
     priority: jobPriority,
   }, webScraperOptions.crawl_id ? Infinity :(webScraperOptions.scrapeOptions?.timeout ?? (60 * 1000)));
-}
-
-export function abTestJob(webScraperOptions: WebScraperOptions) {
-  // Global A/B test: mirror request to staging /v1/scrape based on SCRAPEURL_AB_RATE
-  const abLogger = _logger.child({ method: "ABTestToStaging" });
-  try {
-    const abRateEnv = process.env.SCRAPEURL_AB_RATE;
-    const abHostEnv = process.env.SCRAPEURL_AB_HOST;
-    const abRate = abRateEnv !== undefined ? Math.max(0, Math.min(1, Number(abRateEnv))) : 0;
-    const shouldABTest = webScraperOptions.mode === "single_urls"
-      && !webScraperOptions.zeroDataRetention
-      && !webScraperOptions.internalOptions?.zeroDataRetention
-      && abRate > 0
-      && Math.random() <= abRate
-      && abHostEnv
-      && webScraperOptions.internalOptions?.v1Agent === undefined
-      && webScraperOptions.internalOptions?.v1JSONAgent === undefined;
-    if (shouldABTest) {
-      (async () => {
-        try {
-          abLogger.info("A/B-testing scrapeURL to staging");
-          const abort = AbortSignal.timeout(Math.min(60000, (webScraperOptions.scrapeOptions.timeout ?? 30000) + 10000));
-          await robustFetch({
-            url: `http://${abHostEnv}/v2/scrape`,
-            method: "POST",
-            body: {
-              url: webScraperOptions.url,
-              ...webScraperOptions.scrapeOptions,
-              origin: (webScraperOptions.scrapeOptions as any).origin ?? "api",
-            },
-            logger: abLogger,
-            tryCount: 1,
-            ignoreResponse: true,
-            mock: null,
-            abort,
-          });
-          abLogger.info("A/B-testing scrapeURL (staging) request sent");
-        } catch (error) {
-          abLogger.warn("A/B-testing scrapeURL (staging) failed", { error });
-        }
-      })();
-    }
-  } catch (error) {
-    abLogger.warn("Failed to initiate A/B test to staging", { error });
-  }
 }
 
 export async function _addScrapeJobToBullMQ(


### PR DESCRIPTION
Allows us to forward the correct amount of load.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Move A/B mirroring to the producer side so every scrape job consistently mirrors to staging as intended. This ensures we forward the correct share of load.

- **Refactors**
  - Extracted abTestJob(webScraperOptions) from _addScrapeJobToBullMQ.
  - Call abTestJob when initially enqueuing a scrape job and when releasing the next job via the concurrency limiter.
  - A/B rate still controlled by SCRAPEURL_AB_RATE; logs on failures remain.

<!-- End of auto-generated description by cubic. -->

