### PR TITLE
fix(scrapeURL): fix HTML transforming logic

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -10,7 +10,7 @@ import {
   WebSearchResult,
 } from "../../lib/entities";
 import { agentOptionsExtract, ScrapeOptions as V1ScrapeOptions } from "../v1/types";
-import { InternalOptions } from "../../scraper/scrapeURL";
+import type { InternalOptions } from "../../scraper/scrapeURL";
 import { ErrorCodes } from "../../lib/error";
 import Ajv from "ajv";
 

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from "winston";
 import * as Sentry from "@sentry/node";
 
-import { Document, scrapeOptions, ScrapeOptions, TeamFlags } from "../../controllers/v2/types";
+import { type Document, scrapeOptions, type ScrapeOptions, type TeamFlags } from "../../controllers/v2/types";
 import { ScrapeOptions as ScrapeOptionsV1 } from "../../controllers/v1/types";
 import { logger as _logger } from "../../lib/logger";
 import {


### PR DESCRIPTION
Hit the wrong function with no fallback. Caused a few "All engines failed" errors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix URL scraping HTML transform by using the correct htmlTransform and a fallback: reprocess without onlyMainContent when the first pass yields empty markdown. Prevents "All engines failed" errors on pages where main-content detection removes all text.

<!-- End of auto-generated description by cubic. -->

