### PR TITLE
feat(api/acuc): support for graceful out-of-credits

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -93,6 +93,7 @@ const mockPreviewACUC: (team_id: string, is_extract: boolean) => AuthCreditUsage
     scrapeAgentPreview: 5,
   },
   price_credits: 99999999,
+  price_should_be_graceful: false,
   credits_used: 0,
   coupon_credits: 99999999,
   adjusted_credits_used: 0,
@@ -128,6 +129,7 @@ const mockACUC: () => AuthCreditUsageChunk = () => ({
     scrapeAgentPreview: 99999999,
   },
   price_credits: 99999999,
+  price_should_be_graceful: false,
   credits_used: 0,
   coupon_credits: 99999999,
   adjusted_credits_used: 0,
@@ -183,7 +185,7 @@ export async function getACUC(
       const client =
         Math.random() > (2/3) ? supabase_rr_service : supabase_service;
       ({ data, error } = await client.rpc(
-        "auth_credit_usage_chunk_32",
+        "auth_credit_usage_chunk_33",
         { input_key: api_key, i_is_extract: isExtract, tally_untallied_credits: true },
         { get: true },
       ));
@@ -304,7 +306,7 @@ export async function getACUCTeam(
       const client =
         Math.random() > (2/3) ? supabase_rr_service : supabase_service;
       ({ data, error } = await client.rpc(
-        "auth_credit_usage_chunk_32_from_team",
+        "auth_credit_usage_chunk_33_from_team",
         { input_team: team_id, i_is_extract: isExtract, tally_untallied_credits: true },
         { get: true },
       ));

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1079,6 +1079,7 @@ export type AuthCreditUsageChunk = {
   sub_user_id: string | null;
   price_id: string | null;
   price_credits: number; // credit limit with assoicated price, or free_credits (500) if free plan
+  price_should_be_graceful: boolean;
   credits_used: number;
   coupon_credits: number; // do not rely on this number to be up to date after calling a billTeam
   adjusted_credits_used: number; // credits this period minus coupons used

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -886,6 +886,7 @@ export type AuthCreditUsageChunk = {
   sub_user_id: string | null;
   price_id: string | null;
   price_credits: number; // credit limit with assoicated price, or free_credits (500) if free plan
+  price_should_be_graceful: boolean;
   credits_used: number;
   coupon_credits: number; // do not rely on this number to be up to date after calling a billTeam
   adjusted_credits_used: number; // credits this period minus coupons used


### PR DESCRIPTION
- uses new ACUC (see Linear) and adds 2x true limit for growth and above
- DB-level changes: new ACUC, new `should_be_graceful` column on prices, cron job doing grace period reports in Slack