### PR TITLE
[Bug] JS SDK network issue #1912 - Intermittent "No response received while trying to scrape URL" Error

### DIFF
--- a/apps/js-sdk/firecrawl/src/v1/index.ts
+++ b/apps/js-sdk/firecrawl/src/v1/index.ts
@@ -1681,7 +1681,11 @@ export default class FirecrawlApp {
    * @returns True if the status code indicates a retryable error
    */
   private isRetryableHttpStatus(status: number): boolean {
-    return [408, 429, 502, 503, 504].includes(status);
+    // Only retry on status codes that are safe and won't cause double billing:
+    // 408 Request Timeout - server explicitly didn't process the request
+    // 429 Too Many Requests - rate limited, request wasn't processed
+    // Note: 5xx errors (502, 503, 504) are NOT retried to prevent double billing
+    return [408, 429].includes(status);
   }
 
   /**

--- a/apps/js-sdk/test-retry-logic.js
+++ b/apps/js-sdk/test-retry-logic.js
@@ -19,7 +19,8 @@ class NetworkRetryDemo {
     }
     
     if (error.response?.status) {
-      return [408, 429, 502, 503, 504].includes(error.response.status);
+      // Only retry on status codes that are safe and won't cause double billing
+      return [408, 429].includes(error.response.status);
     }
     
     const message = error.message?.toLowerCase() || '';
@@ -79,7 +80,11 @@ class NetworkRetryDemo {
   }
 
   isRetryableHttpStatus(status) {
-    return [408, 429, 502, 503, 504].includes(status);
+    // Only retry on status codes that are safe and won't cause double billing:
+    // 408 Request Timeout - server explicitly didn't process the request
+    // 429 Too Many Requests - rate limited, request wasn't processed
+    // Note: 5xx errors (502, 503, 504) are NOT retried to prevent double billing
+    return [408, 429].includes(status);
   }
 
   // Simulate different network conditions
@@ -145,7 +150,7 @@ async function demonstrateRetryLogic() {
   console.log('2. ✅ Exponential backoff with jitter to avoid thundering herd');
   console.log('3. ✅ Configurable retry attempts (default: 3)');
   console.log('4. ✅ Better error messages with context');
-  console.log('5. ✅ Retryable HTTP status codes (408, 429, 502, 503, 504)');
+  console.log('5. ✅ Retryable HTTP status codes (408, 429) - 5xx codes removed to prevent double billing');
   console.log('6. ✅ Timeout improvements (default 30s)');
 }
 

--- a/apps/js-sdk/test-retry-logic.js
+++ b/apps/js-sdk/test-retry-logic.js
@@ -1,0 +1,153 @@
+// Test script to demonstrate the network retry functionality
+// This would be used to verify the fix for issue #1912
+
+// Mock implementation to simulate the retry logic we added
+class NetworkRetryDemo {
+  constructor() {
+    this.maxRetries = 3;
+    this.baseDelay = 1000;
+  }
+
+  isRetryableError(error) {
+    if (error.code) {
+      return [
+        'ECONNRESET',
+        'ETIMEDOUT', 
+        'ENOTFOUND',
+        'ECONNREFUSED'
+      ].includes(error.code);
+    }
+    
+    if (error.response?.status) {
+      return [408, 429, 502, 503, 504].includes(error.response.status);
+    }
+    
+    const message = error.message?.toLowerCase() || '';
+    return message.includes('socket hang up') || 
+           message.includes('network error') || 
+           message.includes('timeout');
+  }
+
+  calculateBackoffDelay(attempt, baseDelay) {
+    const exponentialDelay = baseDelay * Math.pow(2, attempt);
+    const jitter = Math.random() * 0.1 * exponentialDelay;
+    return Math.min(exponentialDelay + jitter, 30000);
+  }
+
+  async scrapeUrlWithRetry(url, params = {}) {
+    let lastError;
+    
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        console.log(`Attempt ${attempt + 1}/${this.maxRetries + 1} for ${url}`);
+        
+        // Simulate API call (would be actual axios.post in real implementation)
+        const response = await this.makeApiCall(url, params);
+        
+        if (response.status === 200) {
+          console.log('✅ Success on attempt', attempt + 1);
+          return {
+            success: true,
+            data: response.data,
+            attempts: attempt + 1
+          };
+        } else if (this.isRetryableHttpStatus(response.status) && attempt < this.maxRetries) {
+          lastError = new Error(`HTTP ${response.status}: Server error`);
+          const delay = this.calculateBackoffDelay(attempt, this.baseDelay);
+          console.log(`⏳ Retrying in ${Math.round(delay)}ms due to HTTP ${response.status}`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        } else {
+          throw new Error(`Non-retryable HTTP error: ${response.status}`);
+        }
+      } catch (error) {
+        lastError = error;
+        
+        if (this.isRetryableError(error) && attempt < this.maxRetries) {
+          const delay = this.calculateBackoffDelay(attempt, this.baseDelay);
+          console.log(`⏳ Retrying in ${Math.round(delay)}ms due to: ${error.message}`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        }
+        
+        // Non-retryable error or final attempt
+        throw new Error(`Failed after ${attempt + 1} attempts. Last error: ${error.message}`);
+      }
+    }
+    
+    throw new Error(`All ${this.maxRetries + 1} attempts failed. Last error: ${lastError?.message}`);
+  }
+
+  isRetryableHttpStatus(status) {
+    return [408, 429, 502, 503, 504].includes(status);
+  }
+
+  // Simulate different network conditions
+  async makeApiCall(url, params) {
+    const random = Math.random();
+    
+    // Simulate various failure scenarios
+    if (random < 0.3) {
+      // 30% chance of network timeout
+      const error = new Error('socket hang up');
+      error.code = 'ECONNRESET';
+      throw error;
+    } else if (random < 0.5) {
+      // 20% chance of server error
+      return {
+        status: 503,
+        data: { error: 'Service temporarily unavailable' }
+      };
+    } else if (random < 0.7) {
+      // 20% chance of timeout
+      const error = new Error('timeout of 30000ms exceeded');
+      error.code = 'ETIMEDOUT';
+      throw error;
+    } else {
+      // 30% chance of success
+      return {
+        status: 200,
+        data: {
+          success: true,
+          markdown: '# Sample scraped content',
+          url: url
+        }
+      };
+    }
+  }
+}
+
+// Demo function
+async function demonstrateRetryLogic() {
+  console.log('🚀 Demonstrating Network Retry Logic for Firecrawl SDK\n');
+  console.log('This simulates the fix for issue #1912: Intermittent network errors\n');
+  
+  const demo = new NetworkRetryDemo();
+  
+  try {
+    const result = await demo.scrapeUrlWithRetry('https://example.com', {
+      formats: ['json'],
+      timeout: 30000
+    });
+    
+    console.log('\n✅ Final Result:', {
+      success: result.success,
+      attempts: result.attempts,
+      url: result.data.url
+    });
+    
+  } catch (error) {
+    console.log('\n❌ Final Error:', error.message);
+  }
+  
+  console.log('\n📝 Summary of improvements:');
+  console.log('1. ✅ Automatic retry on network errors (ECONNRESET, ETIMEDOUT, etc.)');
+  console.log('2. ✅ Exponential backoff with jitter to avoid thundering herd');
+  console.log('3. ✅ Configurable retry attempts (default: 3)');
+  console.log('4. ✅ Better error messages with context');
+  console.log('5. ✅ Retryable HTTP status codes (408, 429, 502, 503, 504)');
+  console.log('6. ✅ Timeout improvements (default 30s)');
+}
+
+// Run the demo
+demonstrateRetryLogic().catch(console.error);

--- a/et --soft eddf305c
+++ b/et --soft eddf305c
@@ -1,0 +1,4033 @@
+[33mf68060c6[m[33m ([m[1;36mHEAD -> [m[1;32mdeveloper[m[33m, [m[1;31morigin/developer[m[33m)[m fixed error in worker queue
+[33meddf305c[m Js SDK network issue
+[33ma1b7de7b[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m Update crawl-status.ts
+[33mcadfd218[m feat(api): check request country (#2012)
+[33m46567088[m (sdks): fix unit tests
+[33m85a2402d[m fix: add explicit pydantic>=2.0 dependency requirement (#2010)
+[33m011ebee9[m fix(js-sdk/v2/search): result mapping (#2004)
+[33m61c3abcb[m (python-sdk): fixed search types + added max_keepalive_connections to fix event loop is closed bug (#2005)
+[33m0330601d[m fix(ci/publish-python): publish for both packages
+[33mac278ccc[m Fix search validation of custom date ranges and "qdr:h" (#1993)
+[33maea634ae[m feat(ci): re-add python publish
+[33ma4a2fcf5[m fix(scrapeURL): fix HTML transforming logic (#1999)
+[33m8d7af1af[m fix(dependabot): bad security-updates config
+[33m6af184d6[m fix(scrapeURL): odd timeout on large HTML (#1994)
+[33m03c3bf29[m feat(ab): add consistently at producer level, not consumer level (#1990)
+[33mac604759[m fix(api): pkgvuln
+[33m9fd5cebf[m Merge pull request #1989 from ScottBrenner/patch-1
+[33mf4a84cca[m Dependabot version updates for GitHub Actions
+[33mf5b9c388[m Nick: credits used added to search v2
+[33mf5d901b9[m (python-sdk)fix: added normalizer for document.metadata, also added m… (#1986)
+[33m5773f160[m fix(api/abtest): better
+[33m71218e7c[m feat(api/abtest): send off AB requests at a higher level
+[33m0d4c0e0e[m Revert "Merge pull request #1982 from firecrawl/mog/v2-queue-multiplex"
+[33m8d1c9363[m Merge pull request #1982 from firecrawl/mog/v2-queue-multiplex
+[33m105e7d36[m feat(api/worker): better queue selection
+[33m23b07905[m feat(api): queue multiplexing
+[33m4814c368[m fix(v1/extract): use direct db job read
+[33m7a83099e[m feat(v1/map): parallelize
+[33m4934b21c[m JS SDK fixes
+[33m1f21ec32[m feat(html-transformer): exclude
+[33me3eebfb7[m Update __init__.py
+[33m41b5e272[m Update package.json
+[33ma514cea3[m Update types.ts
+[33m99dcc36e[m (sdks): fixed origin, batch aio and tests
+[33m2f3bc4e7[m mendableai -> firecrawl
+[33m51733d0c[m Merge pull request #1841 from mendableai/nsc/v2
+[33m55bed952[m Merge branch 'main' into nsc/v2
+[33m9a7d95ad[m archive js sdk
+[33medc59007[m fix map search
+[33mf0665fa8[m feat(scrapeURL): AI maxAge
+[33m2cdd131d[m fix(v2/map): ignore query params defaults
+[33mdc7ca98d[m Update firecrawl_logo.png
+[33m4f904e77[m updated readme
+[33m74cb155f[m change remaining_credits to remainingCredits
+[33mcaf4d474[m (js/ts-sdk): fix zod infer
+[33m044bc33a[m Nick: fix json valdiation
+[33m4ef24355[m Create example_v2.py
+[33m0e3b9d2f[m fix python types + json/pydantic
+[33m6849d938[m Nick: FirecrawlApp compatible
+[33m0dd3ac8f[m feat(crawl-status): refactor (#1971)
+[33mb7d7b8e5[m Merge
+[33m06a0198a[m feat(api): add OTEL everywhere (#1969)
+[33mc0c4c7b8[m fix(crawl-status, extract-status): reduce the use of BullMQ getState (#1968)
+[33m308e4f43[m fix(queue-service): reduce redis connections to BullMQ (#1966)
+[33m45690295[m fix types
+[33m5df2f3cb[m fix(v1/scrape): default to basic proxy
+[33mc3d8408d[m scrape: auto proxy by default
+[33mc07b8836[m extract: ignore invalid by default
+[33mfd26d17b[m crawl: no more allowBackwardLinks
+[33mdbbee4a1[m stupid test case (cont.)
+[33m7ebab2a6[m stupid test case
+[33mfacba27e[m feat(scrapeURL): improve waterfalling MRT logic
+[33mc4c2bbd8[m delete cache
+[33m55e8d443[m (sdks): added summary, fixed usage tests and v2 client for python
+[33m306e697b[m Update crawl.ts
+[33ma9c3e7ac[m fix(concurrency-limit): add staggering to the setTimeout
+[33m2e2967ce[m fix(concurency-limit): bump timeout and log if removed
+[33mce6e164a[m fix(concurrency-limit): give getNextConcurrentJob some room to breathe
+[33m2a710e94[m Nick:
+[33mf672e542[m fix v2 bulljobs shit
+[33me251516a[m fix usage stuff
+[33m79c822dd[m map changes
+[33m17008ace[m Merge branch 'main' into nsc/v2
+[33m6e59bbd2[m fix(map): returning excessive query parameters
+[33m4638e4a6[m fix test
+[33mc1700e06[m fix in python sdk
+[33m548f19aa[m feat(v2/crawl): change sitemap param
+[33ma9141a41[m fix(api/admin/metrics): store queues in a set
+[33me57f1657[m fix(types): update maxAge default value to 2 days in baseScrapeOptions
+[33m5e64ecba[m fix(api): stop using bulljobs_teams table (#1962)
+[33me907a9a7[m feat(api/admin): prometheus metrics about cc limit queue (#1963)
+[33m356b04fb[m further crawl-errors improvements
+[33m588fe390[m feat(crawl-errors): take advantage of TransportableError
+[33m4f46316f[m fix(v2): bad route for credit-usage and token-usage
+[33m298fd149[m feat(api): log network info for debug log correlation
+[33m51b49eed[m Merge branch 'nsc/v2' of https://github.com/mendableai/firecrawl into nsc/v2
+[33m537f6c4e[m (python/js/ts-sdks): readmes, e2e tests w idmux etc all good
+[33mcfb09fd0[m Update mu (#1959)
+[33m8237be0e[m Test new mu version (#1958)
+[33m0118dd7a[m fix(rust-sdk): pkg vuln
+[33m8532a832[m feat(v0): better usage tracking
+[33mf797fe69[m fix(index-worker): precrawl job never moved to completed
+[33m8c6b2bef[m fix(index-worker); precrawl stalling
+[33m1a0e44a7[m feat(v1/search): add query to logs to make debugging 502s easier
+[33mefede5e3[m Update mu (#1959)
+[33mf4d90460[m Merge branch 'nsc/v2' of https://github.com/mendableai/firecrawl into nsc/v2
+[33md44baed8[m (js-sdk): mostly done
+[33m4a66bd5b[m fix(v2/map): respect limit when sitemap=only
+[33mb2c64254[m Test new mu version (#1958)
+[33mb32fa6fa[m feat(v2): error handling (#1957)
+[33m2fa17fac[m fix(rust-sdk): pkg vuln
+[33m31a81a95[m feat(v2): extract (#1955)
+[33m78e1a859[m feat(v2): crawl-status-ws
+[33mec69c309[m (js-sdk): methods done. todo: e2e/unit tests
+[33m5cd20c82[m feat(v0): better usage tracking
+[33m7635e44a[m feat(v2/concurrency-check): correct max concurrency
+[33m5ae53bb6[m fix(v2): pull over crawl cancel and active
+[33m9c001a91[m feat(v2/timeout): initial new waterfalling system (ENG-2922) (#1950)
+[33m10b72028[m (python-sdk): extract v2
+[33md31d39d6[m (python-sdk): batch, map, ws improv and aio methods. e2e tests done.
+[33m29c684b7[m fix(index-worker): precrawl job never moved to completed
+[33me2b27dc7[m fix(index-worker); precrawl stalling
+[33m0365e3d7[m feat(v1/search): add query to logs to make debugging 502s easier
+[33mcb00392c[m fix(changeTracking): fix tag support
+[33m1f829672[m fix(tests/changeTracking): bump timeout for LLM-based
+[33m5e14f629[m fix(index): save contentType to index
+[33m33fb6bb8[m fix(map): full functionality
+[33mfa36ad66[m fix map and some tests
+[33mf5abba80[m fix types
+[33m21cbfec3[m Merge branch 'main' into nsc/v2
+[33m64e3e794[m ENG-3089: Support both string and object format inputs in v2 scrape API (#1932)
+[33me9b21943[m fix(tests/scrape): make `maxAge: 0` explicit in Index tests (#1946)
+[33m2b3b871f[m feat(ci): audit NPM packages on PR (#1947)
+[33m8be0eb8c[m test(v2/crawl): implement tests for crawl API with prompt parameter (#1929)
+[33m91d19fea[m feat(api/ai-sdk): add labels to vertex/google calls (#1944)
+[33mae6a0524[m feat(scrape-worker): reintroduce OTEL for accurate LLM cost tracking (#1943)
+[33m506c4b26[m feat(scrapeURL/pdf): add further logging to analyze remaining time in timeout messages
+[33mf5b73b64[m fix(scrapeURL/pdf): better timeout error for PDF scrapes (#1942)
+[33mbd5adfea[m fix(queue-worker): turn off useWorkerThreads in sandboxed scrape worker (#1941)
+[33m8b89470f[m Merge pull request #1852 from mendableai/draft/search-with-x402
+[33mdd6b46d3[m (python-sdk): removed client duplication, bunch of type fixing, added map method + e2e/unit tests
+[33m96150667[m fix(test-suite): vuln in pkg
+[33m8498a18c[m debug(scrapeURL/ab): use a huge maxAge
+[33m99a4432a[m fix(scrapeURL/ab): do not forward AI-ful requests
+[33m055f9c36[m fix(scrapeURL/ab): make host configurable
+[33ma53e2222[m feat(scrapeURL): replace f-e a/b with scrapeURL a/b
+[33m0c8a5410[m feat(scrapeURL): optional A/B test to staging
+[33m08c8f420[m (python-sdk): scrape is done!
+[33m392cb5fe[m fix(queue-worker): remove OTEL undici/http instrumentations
+[33me17a711f[m fix(scrapeURL/fire-engine): improved fix
+[33m52e3313b[m fix(scrapeURL/fire-engine): handle "Operation timed out" error correctly
+[33mbb5a3d48[m fix(robustFetch): use pre-created agent
+[33m5f4666b7[m debug: log hits to liveness endpoints
+[33md2b325f8[m (python-sdk): get_crawl_errors and active_crawls, got rid of useless tests
+[33m904bba62[m fix(queue-worker): disable cacheable lookup for liveness check
+[33m797577e2[m fix(queue-worker): reduce concurrency
+[33ma6fc5c38[m fix(queue-worker): remove misbehaving stall check
+[33m7611f819[m feat(crawl-redis): reduce `crawl:<id>:visited` size in Redis by 16x (#1936)
+[33m320868de[m debug(crawl-redis): fix
+[33mb75c3de8[m debug(crawl-redis): prove correct behaviour for ENG-3085
+[33m7a85b9f4[m (python-sdk): crawl done
+[33mbfbff896[m fix: prevent PDF scrapes with parsePDF:false from being indexed (#1933)
+[33m1a984285[m Revert "fix(queue-worker): decrease concurrency to avoid stalling other workers"
+[33m33bf7eb1[m fix(queue-worker): decrease concurrency to avoid stalling other workers
+[33m50779eeb[m debug: remove langfuseotel from scrape worker
+[33m3f0873c7[m add claude file
+[33m631dc981[m (python-sdk): wip - crawl endpoints
+[33m4365b3dd[m fix(search): allow maxAge to have effect
+[33m71829dbd[m feat(python-sdk): add agent parameter support to scrape_url method (#1919)
+[33mcb1415aa[m ENG-3088: Change parsers parameter from object to array format (#1931)
+[33m06bd9d60[m debug: turn off langfuse debug
+[33m26b7c8c6[m debug: skip OTEL setup on Sentry
+[33m5998744d[m chore: update pnpm-lock.yaml with new package versions and dependencies
+[33m31227c66[m Merge branch 'main' into draft/search-with-x402
+[33m22b4a9ea[m debug: langfuse
+[33m908e9776[m feat: langfuse integration (#1928)
+[33m76a5aa05[m fix(queue-jobs): log concurrency limited
+[33m3b254324[m fix(queue-worker): lower pressure by doubling lock duration
+[33m75e3cd55[m fix: handle --max-old-space-size flag for worker threads (#1922)
+[33mf22fba62[m (python-sdk): wip - base structure and search endpoint
+[33m899c6b45[m fix(queue-worker): increases per-worker concurrency
+[33m2d856d52[m fix pdf scrapes
+[33ma4ffd546[m v2: scrape-status
+[33m24d2a647[m fix change tracking coerce
+[33m8d481760[m fix change tracking tests
+[33m113a2bf8[m more test fixes
+[33ma0a22cb4[m more test fixes
+[33m6d6ea0af[m fix iframe i/e on v2
+[33m0b64cee6[m fix v2 test
+[33md3bda3f0[m fix search
+[33mebb2c0d9[m fix
+[33m425adfbf[m fix(snips): ...
+[33m051cc2bf[m feat(snips): split into v1/v2
+[33m40267b6e[m Fix v1 API JSON/extract format backward compatibility on v2 (#1917)
+[33mff87297e[m feat(v2): Set default maxAge to 4 hours for scrape endpoint (#1915)
+[33m3ce09a21[m Merge branch 'main' into nsc/v2
+[33m634d391b[m feat(api/dx): add test harness
+[33mb0727d3e[m feat(scrape-v2): Implement skipTlsVerification support for fetch and playwright engines (#1911)
+[33md453c83a[m feat(v2): Add viewport parameter for screenshots (#1910)
+[33m4a76f348[m fix(api/v2/fromV1): move changeTrackingOptions
+[33m83c0fdb9[m fix(api): add database fallback to crawl errors endpoint (#1909)
+[33m2c572317[m chore: fix minor inconveniences
+[33m41117556[m Update domain-frequency.ts
+[33m9a3a354d[m (feat/index) Domain frequency aggregator (#1908)
+[33m166ce2c7[m Nick: search formats fix
+[33mc0932208[m Nick: crawl params preview
+[33mcff8b2b4[m Update queue-worker.ts
+[33m45ce12c8[m Nick
+[33m2990f33e[m fix: WORKER_PORT
+[33m129e4e2c[m add parsers format
+[33m07082a7e[m fix: summary + fill out new params
+[33mcbb4aef1[m Nick: reqs
+[33m2857507b[m delete parsepdf fromv1
+[33m7c9db568[m dep hell 2
+[33mf662436a[m fix dependency hell
+[33m70af6aa1[m Merge branch 'nsc/v2' of https://github.com/mendableai/firecrawl into nsc/v2
+[33md0f33752[m better logs
+[33ma3f40575[m Merge branch 'main' into nsc/v2
+[33m7400e10e[m feat(v2): parsers + merge w/ main (#1907)
+[33m9f0df422[m feat(api): separate redis connections for scrape Queue, QueueEvents, and Worker
+[33mcba422f1[m fix(docs): correct link to Map (#1904)
+[33m5bf3316e[m RM Multiplexer for now
+[33maad5de25[m Reapply "feat(queue): split jobs 4 ways"
+[33m18428832[m Revert "feat(queue): split jobs 4 ways"
+[33mfdf75ad8[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m5991fe08[m Revert "Nick: increasing multiplexity"
+[33mb38d11ea[m Nick: increasing multiplexity
+[33m76204742[m feat(queue): split jobs 4 ways
+[33meb08174c[m Revert "Nick: increasing multiplexity"
+[33mbda01054[m Nick: increasing multiplexity
+[33m87eee527[m Nick: wip
+[33me6a61e3d[m feat: queue multiplexing (#1902)
+[33m6ed1442b[m Revert "feat(queue): split jobs 4 ways"
+[33m03e7d4ce[m Revert "fix(queue-worker): proper concurrency"
+[33mcf9010a1[m fix(queue-worker): proper concurrency
+[33m5acaeb36[m feat(queue): split jobs 4 ways
+[33m4c023407[m Improve error handling in Python SDK for non-JSON responses (#1827)
+[33m269c7097[m feat(python-sdk): implement missing crawl_entire_domain parameter (#1896)
+[33m21103b5a[m fix: convert timeout from milliseconds to seconds in Python SDK (#1894)
+[33m27badf3e[m fix(crawl-redis): attempt to cleanup crawl memory post finish (#1901)
+[33m4f8ec996[m fix: remove sentry tracing
+[33m77d3fd00[m fix: remove overwhelming logs
+[33m0f44d947[m queue-worker: move scrape worker to separate threads (ENG-3008) (#1879)
+[33me7e2c02d[m feat(crawler): replace robotstxt library with texting_robots for ENG-3016 (#1895)
+[33m85a92a05[m fix(queue-jobs): better timeout resilience
+[33m4a6b46d0[m fix: better logging
+[33mcdc08d40[m fix(queue-jobs): bttr logci
+[33m42a1d9f1[m add new redis for qe
+[33m32bab69a[m fix: use waiting
+[33m78d008c3[m Revert "Revert "fix: get rid of debug redis reinstantiation""
+[33mfa42177a[m fix(queue-jobs): go back to doing setinterval in waitforjob
+[33mcf5eea0e[m feat: add crawlTtlHours team flag to replace teamIdsExcludedFromExpiry (#1899)
+[33m2cf42d71[m fix(queue-service): improve redis error logging
+[33m7a9f859e[m Revert "fix: get rid of debug redis reinstantiation"
+[33m385d0af2[m fix(redis): don't fail if /data/redis exists already
+[33m50e88cfc[m Revert "revert all haphazard changes made while bughunting"
+[33mb153e533[m feat(api): docker build cache
+[33mc04571d5[m debug(queue-worker): log currently running jobs (non-zdr)
+[33mc63fdd6e[m debug: improve system monitor
+[33m86086ee5[m revert all haphazard changes made while bughunting
+[33m68a02879[m debug: further
+[33m5d8949a7[m debug(system-monitor): log mem usag
+[33m0ec9a137[m debug: log when urlsHandler is invoked
+[33ma7aa0cb2[m Fix Pydantic field name shadowing issues causing import NameError (#1800)
+[33m26ce736f[m debug: log acceptConnection metrics
+[33m96a92106[m Revert "fix(go): add mutex to prevent concurrent access issues in html-to-markdown (#1883)"
+[33m049d2e6b[m fix(js-sdk): add retry logic for socket hang up errors in monitorJobStatus (ENG-3029) (#1893)
+[33m70e139b2[m feat: better log attribute propagation (ENG-2934) (#1857)
+[33mb75ac6c8[m fix: get rid of debug redis reinstantiation
+[33m52e7d0d3[m fix(go): add mutex to prevent concurrent access issues in html-to-markdown (#1883)
+[33m8d896424[m Revert "update koffi (#1876)"
+[33m5867fb67[m Revert "Revert "Update batch_billing.ts (#1860)""
+[33mcb115ce6[m Revert "Update batch_billing.ts (#1860)"
+[33mc8b6687c[m Revert "fix(html-to-markdown): reinitialize converter lib for every conversion (#1872)"
+[33m5a2ccb80[m Revert "fix(go): experiment: build go lib in the final container"
+[33ma022b864[m fix(go): experiment: build go lib in the final container
+[33mba3e4cd3[m fix: improve robots.txt HTML filtering to check content structure (#1880)
+[33m588cd1f3[m Revert "temp(Dockerfile): build go in final run"
+[33ma53a0db2[m Revert "fix(Dockerfile):"
+[33mf226789c[m fix(Dockerfile):
+[33mcb67662e[m temp(Dockerfile): build go in final run
+[33m743764d7[m fix(Dockerfile): get pinned dependencies
+[33m76f00296[m fix(crawl-status): another missing get: true
+[33m0fbdee5d[m Merge branch 'main' into nsc/v2
+[33mbbceb005[m Revert "Merge branch 'nsc/v2' of https://github.com/mendableai/firecrawl into nsc/v2"
+[33mf16f79ac[m Merge branch 'nsc/v2' of https://github.com/mendableai/firecrawl into nsc/v2
+[33m92593145[m feat(v2): add natural language prompt support to crawl API (#1877)
+[33mde6b668a[m fix(crawl-status): rpc with get: true
+[33m9fe4ea3d[m fix(crawl-status): move back
+[33m05edb9ab[m fix(crawl-status): other rpc
+[33me9bfd772[m update koffi (#1876)
+[33m9c303b89[m undo race
+[33m327af520[m fix(crawl-status): move count_jobs_of_crawl_team after checks (#1875)
+[33m4eef75b0[m Revert "fix(go): Lock to version 1.24.4"
+[33m7e00c23b[m feat(go): build with race detection
+[33m503728e9[m fix(go): Lock to version 1.24.4
+[33m1cf5e734[m Revert go version in Dockerfile (#1873)
+[33m5f0715ae[m fix(html-to-markdown): reinitialize converter lib for every conversion (#1872)
+[33m8e792d8a[m fix(crawl): correct maxConcurrency calculation (#1871)
+[33mb4731e49[m Merge branch 'main' into draft/search-with-x402
+[33m4dcdc080[m chore: update pnpm-lock.yaml
+[33mc2fde39b[m chore: update pnpm-lock.yaml with dependency version upgrades for bullmq, ioredis, and coinbase SDK
+[33m1cf70edd[m feat: add type definitions for x402 and x402-express modules
+[33m07bbe2cb[m Nick: moving count_jobs_of_crawl_team to read replica
+[33mca8f1a32[m Nick: fixes crawl stuck issue
+[33mec4062b9[m Nick: re-enabling queue events
+[33m258e94c7[m Revert "fix(queue-worker): disable event listening"
+[33m82de6d76[m fix(checkStatus): further logging
+[33m6d66b735[m Revert "disable index"
+[33m341eaa64[m fix crawl status
+[33m75be6681[m connection spawning
+[33m3f7600de[m fix crawl-status
+[33m6ba417f7[m more logging + more separate connections
+[33mb12c175b[m add scrape jobs on separate connections
+[33m093f2ab8[m disable index
+[33m7959e497[m update bullmq
+[33m9d69c664[m better polling
+[33mfb0181be[m reduce polling speed
+[33me698628c[m use separate redis connections for polling
+[33m7d8ab004[m update ioredis
+[33m63c42c69[m fix(queue-worker): disable event listening
+[33mc568b614[m update redis
+[33m84e2e5ce[m mor elogs
+[33mfa3eda70[m more logs (#1864)
+[33m8c5b500e[m further logging (#1863)
+[33m49fb065e[m fix(queue-service): get rid of done billing jobs much faster (#1862)
+[33mc34cef2d[m logs (#1861)
+[33m2f3a0428[m fix(search): type error cuz of v2 rebase
+[33m6da8056d[m Update batch_billing.ts (#1860)
+[33m28e6a350[m fix(v2): change tracking without options
+[33m7934fc0f[m fix(v2): billing
+[33m473f97ad[m test: better fail logging
+[33m40ee01a9[m ci: upload encrypted logs
+[33m3580ada5[m fix hosting w/o vertex
+[33mca0fc701[m v2 json fixes
+[33m5b22fd98[m feat: add object format support for screenshot in v2 API
+[33m98d25535[m feat(v2/scrape): port json to use gemini-2.5-flash
+[33m53f2f7ff[m fix(v2): devin tests
+[33m0311a440[m fix(v2): batch scrape v1 compat 400
+[33m91e33708[m fix(v2): experimental omce domain
+[33m10bfec58[m v2 scrape changes: change tracking
+[33m281ce258[m v2 scrape changes + rebase scrapeurl on v2
+[33me05fa9b2[m fix v2-scrape-skip-tls.test.ts
+[33m78dceed6[m run test suite when merging into v2
+[33mfebfa783[m feat: implement summary format for v1 and v2 APIs (#1856)
+[33ma76290b3[m feat: remove systemPrompt override capability from v2 JSON mode (#1855)
+[33mdda783e7[m feat: remove Fire-1 model from v2 API while keeping v1 functionality (#1854)
+[33me1e5f574[m feat: change skipTlsVerification default to true in v2 API (#1853)
+[33md95331a9[m update shit to use v2
+[33mda2d0542[m yeeted max depth
+[33mb4e0866b[m feat: implement v2 batch scrape with improved error handling (#1851)
+[33mbb57be02[m Nick: search v2 wip
+[33m81003116[m Nick:
+[33m0af0fac4[m Nick: init
+[33me86798f9[m fix(worker/antistall/kickoff): bad check (#1859)
+[33m878b15c4[m chore: update dependencies and fix logging in x402 search controller
+[33m4721e615[m Merge branch 'main' into draft/search-with-x402
+[33m2c7f9f3f[m chore: update pnpm-lock.yaml with dependency version upgrades
+[33m0f335501[m refactor: remove generate payment header functionality and related references
+[33mfc080ea9[m Refactor API endpoints and update pricing
+[33m659e05b7[m feat: Add iframe selector transformation for includeTags and excludeTags (#1850)
+[33ma08f343a[m Add __experimental_omceDomain flag for debugging and benchmarking (#1844)
+[33mebdd2ea9[m fix(crawler/sitemap): improvements (#1842)
+[33m104b6327[m ENG-2829: Fix isSubdomain bug (#1845)
+[33m42684703[m Fix ignoreQueryParameters being ignored in URL deduplication - ENG-2804 (#1846)
+[33m4df50180[m Add allowTeammateInvites flag to TeamFlags type (#1847)
+[33m0f477bea[m Fix robots.txt parser panic with content type validation (#1843)
+[33me0b26f8f[m feat: rewrite sitemap XML parsing from JavaScript to Rust (ENG-2904) (#1840)
+[33ma9fa2f0a[m Nick: search v2 wip
+[33m5b1051b8[m Nick:
+[33m3f29bca0[m Merge branch 'main' into nsc/v2
+[33m392d2c0f[m Nick: init
+[33m5506dd98[m fix(queue-worker): improve stalled job cleaner (ENG-2907) (#1839)
+[33m30347c84[m fix(queue-worker): clean up stalled jobs to not get crawls stuck (#1838)
+[33m3ecbc2f0[m fix(crawl): only extend URLs at pre-finish if changeTracking is on (#1837)
+[33m4093f43b[m fix(js-sdk): remaining pkg vulns (#1835)
+[33maf8892b4[m chore(deps): bump esbuild and tsx in /apps/js-sdk (#1834)
+[33m3a9445a3[m chore(deps): bump axios from 1.6.8 to 1.11.0 in /apps/js-sdk (#1833)
+[33ma2f5c1f3[m chore(deps): bump form-data from 4.0.0 to 4.0.4 in /apps/js-sdk (#1832)
+[33m44b491e2[m fix: more packaging vulns (#1831)
+[33m31a4e184[m fix(api): update vulnerable pkgs (#1829)
+[33md6d760bf[m changed browser location to be accessible by every user (#1819)
+[33m17241e09[m Restore Rust link filtering logic (#1822)
+[33m26926e56[m fix(python-sdk): add max_age parameter to scrape_url validation (#1825)
+[33mb8500648[m feat(types): add JSON schema validation to schema options in extractOptions and baseScrapeOptions (#1803)
+[33me6f0b1ec[m fixes actions dict attributeError (#1824)
+[33mb23535cd[m (feat/rtxt) Improved robots control on scrape via flags  (#1820)
+[33m8e125b79[m Add blocked domain exception
+[33m6849ab16[m fix(api/v1/types): depth check throws error if URL is invalid (#1821)
+[33m5d378e62[m Add blocked domain exception
+[33ma96ddf9e[m draft: search with x402
+[33me8531b99[m Add another blocked URL exception
+[33me8d4e516[m Add a couple exceptions to our blocked list (#1816)
+[33m21a5c8a9[m Add another customer exemption to crawl job expirarion
+[33m51a7ad4a[m Nick: no sections edge case (#1814)
+[33ma30af244[m Fix bug which sometimes caused crawl to only return 1 result (#1810)
+[33m10796b0d[m Fix search endpoint PDF billing when parsePDF=false (#1806)
+[33m4d596c43[m Update llmExtract.ts
+[33mba04a686[m Update generic-ai.ts
+[33m7336e84f[m fix(crawler): handle negative limit
+[33m7695a8c7[m fix(crawler): handle infinite limit
+[33m8d41c993[m feat(crawler): show serde error
+[33ma4f4145f[m feat(crawler): port filterLinks to Rust (#1801)
+[33m24a5a719[m timeouts for index engine
+[33mce4e00fd[m feat(precrawl): increase budget as discussed
+[33ma818946e[m sdk-fix: ensure async error handling in AsyncFirecrawlApp methods, update version to 2.16.1 (#1802)
+[33m725cdf48[m feat(precrawl): graceful failure if one item is incorrect
+[33m521965b5[m add precrawl queue to bullboard
+[33ma57277ea[m feat: precrawl worker (#1783)
+[33m3a98d091[m hotfix2
+[33m4560e14e[m hotfix
+[33m69b32ebf[m fix(crawl-status): keep working even if jobs are ejected from bullmq (#1799)
+[33mcd3c3b70[m Add temporary exemption for crawl expiry (#1796)
+[33mad967d4d[m [sdk] fixes missing headers param in scrape_url (#1795)
+[33m9a6c4900[m insert omce jobs upon scrape (#1786)
+[33me3c45cd4[m fix(extract): improve enforcement (#1790)
+[33m3b284bb2[m Revert "Add temporary exception for Faire team ID to bypass job expiration (#…" (#1789)
+[33mff9544cd[m feat: make URL protocol checks case-insensitive (#1788)
+[33m5f722a97[m fix(scrapeURL/index): exclude waitfor (#1787)
+[33m37968b34[m fix request frequency insert
+[33mfb676adb[m fix error logging
+[33mbb2cc103[m fix batch sizes
+[33mad2f0992[m frequency logging
+[33m6337afea[m feat(scrapeURL): log cache age in request frequency (#1784)
+[33m0e591dec[m feat(scrapeURL/proxy/auto): retry on 401
+[33meab6909c[m feat(index): store request frequency for precrawling (#1782)
+[33md7204e48[m fix(scrapeURL/index): horrible no-good very bad index url bug (#1780)
+[33m02ee2680[m don't log the diff text
+[33m99faef68[m feat(search): improve param logging (#1777)
+[33m8f119d80[m html-transformer: never panic (#1778)
+[33m9cad755c[m Revert "fix(api/html-transformer): relative base tag URL handling (#1776)"
+[33m4e81246a[m fix(api/html-transformer): relative base tag URL handling (#1776)
+[33m71c82241[m fix(api/html-transformer): stop panicing on arabic sites (#1773)
+[33m4a274529[m fix(api): f-e timeout handling (#1774)
+[33m725d416d[m temp: disable punycode test, site is down
+[33mcea7a354[m feat: mu test completed
+[33mac875b8a[m docs: kubernetes simple update (#1772)
+[33m13335a33[m feat: test RunPod MU new version (#1771)
+[33m7cac330c[m revert: resume A/B testing
+[33m2add2d13[m temp: stop A/B testing
+[33m87baa231[m Nick: reverting ssl changes to py sdk
+[33m8922d7eb[m Add created_at field to /crawl/active endpoint response (#1718)
+[33m9cc32c28[m feat(html-transformer, scrapeURL): omce support (#1764)
+[33m58081963[m fix(logger): correct method names in logger.child calls (#1731)
+[33m80799557[m fix(zdr): missing zdr clause on runWebScraper logger
+[33m8f36f7c0[m Update SELF_HOST.md
+[33mb28d4f72[m Make worker Express server port configurable via environment variable (#1748)
+[33m61059d68[m chore(ab): ramp up
+[33m5d406643[m feat(scrapeURL/fire-engine): start AB testing (#1763)
+[33m82e76a74[m fix: replace hardcoded search billing with calculateCreditsToBeBilled (#1714)
+[33m251e42c2[m feat: add waitFor validation rule to enforce waitFor <= timeout/2 (#1751)
+[33mb5b6ca0a[m Add end-to-end test for deep research functionality (ENG-2627) (#1760)
+[33m46850d1e[m Implement fallback mechanism for onlyMainContent scraping (ENG-2499) (#1759)
+[33m88549c26[m html-transformer improvements (#1762)
+[33m8d81209f[m fix(html-transformer): check base tag when resolving relative URLs (#1761)
+[33mde1bc96a[m Implement JavaScript-only base href handling (ENG-2302) (#1756)
+[33m4c1af8b9[m Make error message for backwards crawling more clear (#1758)
+[33m6d8e7718[m fix(api/deep-research): bad default values leading to bug on self-host (#1754)
+[33ma9f4b1f2[m Add URL depth validation to crawl requests (ENG-2617) (#1753)
+[33mde4094b1[m Add health check endpoint for Playwright service (ENG-2585) (#1752)
+[33m17973710[m bugfix zero_data_retention param and certifi dependency (#1749)
+[33m8b54a37b[m Merge pull request #1715 from mendableai/feat/integration-param-pythonsdk
+[33m72b9074e[m Fix queue worker liveness endpoint for self-hosted environments (#1747)
+[33m30b7e173[m feat(firecrawl): add integration parameter support and enhance kwargs handling
+[33mdcbed186[m Add local environment configuration to docker-compose services (#1742)
+[33me3dc2e87[m chore: bump js sdk
+[33m4506b211[m feat(api): zero data retention (ENG-2376) (#1687)
+[33m1f1f7330[m fix(map): pass timeout to sitemap fetch (#1741)
+[33mec298f58[m Update search.ts
+[33m3e09f9fb[m Nick: init (#1740)
+[33m6c2f432d[m feat(crawl-status): better creditsUsed field (#1738)
+[33mebf98e3c[m feat(queue-worker): decrease job lock duration to pick up jobs on dead workers faster (#1737)
+[33m400d497f[m feat(scrapeURL): ask user to increase timeout if there's a DOM.getDocument or queryAXTree error (#1739)
+[33m1816cfc4[m feat: implement IDN support with Punycode encoding (#1735)
+[33m8a282e3f[m fix(auto_charge): bad hourly counter logic (#1736)
+[33mb4eedce3[m (feat/ledger) Ledger events (#1728)
+[33m13f012c5[m add pdf prefetch log for debugging (ENG-2542) (#1734)
+[33m91629527[m proxy used improvement (#1727)
+[33m9b95a17c[m fix json format on search (#1729)
+[33m17ff8be6[m Nick; (#1726)
+[33m57b8e66b[m feat(api/worker): liveness check in queueing -- don't take jobs when the worker is dying (#1725)
+[33mc4adc687[m Update index.ts
+[33mcaec228f[m Nick: version bump
+[33mfa5b96c5[m Add parsePDF parameter to JS SDK (#1720)
+[33m070d1c1d[m Fix unreachable allowSubdomains code in crawler filterURL method (#1719)
+[33m2b87ea65[m feat: improve DNS resolution error message (#1724)
+[33m55d5c1f4[m feat(scrapeURL/skipTlsVerification): improve error message (#1723)
+[33m9ed26e1e[m feat(sdk/python): add pdf action (ENG-2515) (#1722)
+[33md8796e45[m feat: Screenshot quality (#1721)
+[33m9a5d40c3[m Allow international URLs to pass validation (#1717)
+[33m1919799b[m feat(python-sdk): add parsePDF parameter support (#1713)
+[33m89e57ace[m Add temporary exception for Faire team ID to bypass job expiration (#1716)
+[33mf4714f48[m fix(js-sdk/extract): use same zod fallback logic (#1711)
+[33m3d04c208[m fix(api): cached acuc didn't have the is_extract flag set (#1712)
+[33mbc906581[m fix(concurrency-limit): overlogging (#1709)
+[33mcc3afa25[m fix(concurrency-limit): scan instead of taking jobs (#1708)
+[33mae94edd4[m feat(api/ci): idmux (#1707)
+[33m86603de6[m fix(api): instantiate Storage only once (#1706)
+[33m11f46948[m fix(api/batch/scrape): maxConcurrency field support when using ignoreInvalidURLs (#1705)
+[33me7a62dd4[m fix(api): pdf bug + testing bugs (#1704)
+[33mfe905755[m fix(v1): check credits variable scope collision (#1703)
+[33me3948ae5[m feat(api): pdf action + housekeeping (#1702)
+[33m78a3579d[m feat: add relevanceai as part of the integrations
+[33m439619ff[m fix(api/v1/crawl/ongoing): only crawls, no batch scrape (#1701)
+[33m1fdf9591[m feat(api): optimize job count query and improve error handling (#1700)
+[33mc3117249[m fix(api): handle errors better in redis-less crawl status (#1699)
+[33m66cde50a[m fix(api): enhance error handler with optional ACUC data (#1698)
+[33me06ec2d0[m fix(api): improve error logging with structured error object (#1697)
+[33m7ed19c0a[m feat(scrapeURL): separate URL rewrites to different function
+[33m9174e0c8[m fix(api): CI (#1692)
+[33m2082243c[m feat(scrape): support Google Slides (#1693)
+[33m4b03ffca[m fix(search): respect parsePDF in pricing (#1690)
+[33m125e1ada[m feat(scrapeURL): support cookies in safeFetch (#1688)
+[33m3f0b8b8e[m Remove old cache mechanisms (redis cache, PDF cache, crawl maps, etc.) (FIR-2266) (#1667)
+[33m363afb80[m Nick: updated openapi specs
+[33m80f71774[m Nick: bump version
+[33m09aabbed[m feat: add followInternalLinks parameter as semantic replacement for allowBackwardLinks (#1684)
+[33mf9394282[m feat(scrape): support Google Docs (FIR-1365) (#1686)
+[33mf8983fff[m Concurrency limit refactor + `maxConcurrency` parameter (FIR-2191) (#1643)
+[33ma8e3c296[m feat(scrape, extract): creditsUsed, tokensUsed fields (FIR-2336) (#1683)
+[33mfbd81b41[m fix(scrape): log FIRE-1 credits billed on failures properly (FIR-2331) (#1682)
+[33mebc1de9d[m feat(crawl-status): refactor to work after a redis flush (#1664)
+[33mcd2e0f86[m Add deployment type field to bug report template (#1681)
+[33m199115c7[m stop testing new mu
+[33mf46f845e[m fix: send the request to new mu version before the main one to achieve better sync
+[33mee7b29b3[m feat: Test mu v3 (#1678)
+[33m5ca8e2e9[m feat(index): store short titles and descriptions (#1677)
+[33m9710bdff[m Improve URL filtering error messages with specific denial reasons (FIR-2352) (#1676)
+[33mc6482eaf[m Nick: prevent additional logging on /extract scrapes
+[33mea321b49[m fix search test timeouts
+[33m38c57952[m feat(vertex): fix vertex ai provider bug and update model references to use "gemini-2.5-pro" (#1668)
+[33m0bf23071[m feat(index): add domain splitting for improved map querying (#1666)
+[33m07224b8c[m feat: use index in search and extract (#1660)
+[33mf2963427[m feat(index): remove unused columns (#1662)
+[33m89e42b11[m fix(api): remove query parameter sanitization that was breaking extracts (#1661)
+[33m3c03d070[m feat: add credits_billed everywhere (FIR-2286) (#1655)
+[33mbf3b2a35[m Improve concurrency limit email notifications (#1658)
+[33m255be2a2[m Fix PLAYWRIGHT_MICROSERVICE_URL env var to use /scrape endpoint (#1654)
+[33m19dd086e[m improve auto recharge logging
+[33m9964d11c[m Update v1.ts
+[33m117af9f6[m fix(readme): clarify that scrape_options must be a ScrapeOptions instance in crawl_url and typo fixes. (#1647)
+[33m623d3980[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m07b77e1a[m Update __init__.py
+[33ma3291175[m fix(js-sdk/tests): fix the testing situation (FIR-2253) (#1644)
+[33m4659155b[m remove logs
+[33m3b6be76d[m debug(index): time insights
+[33m8ef3e848[m feat(gcs-jobs): ditch exists check to cut lookup time in half (#1641)
+[33m6e887376[m feat(apps/test-suite): add Rafa's index benchmark notebook
+[33m6d1b9bf1[m debug(api/scrape): more logging
+[33m0c7f864e[m debug(api/scrape): increased logging to diagnose scrape fluke length
+[33m43379926[m feat(sdk): Index parameters + other missing parameters (#1638)
+[33m1de0ae39[m Index testing improvements (FIR-2214) (#1637)
+[33m78580f65[m feat(webhook): refactor callWebhook and add logWebhook (FIR-2218) (#1629)
+[33mf050b169[m feat(api/index): port queryIndexAtSplitLevel to RPC (FIR-2241) (#1640)
+[33ma08d52e4[m feat(scrapeURL/index): don't put results by "dumb" engines into the index
+[33maf88218f[m feat: update mu (#1639)
+[33m6ca551a8[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m8c402717[m Update map.ts
+[33m4bf64d2c[m feat(scraper): runpod v2 parallel testing (#1636)
+[33mb2e0f657[m Merge pull request #1635 from mendableai/refactor/api-integration-parameter
+[33m6e1f8d6c[m feat(api): propagate integration field in queue worker job processing
+[33m71caf8ae[m Merge pull request #1632 from mendableai/feat/api-integration-parameter
+[33mabb8919e[m feat(js-sdk): changeTrackingOptions.tag
+[33m34a18a2d[m feat(changeTracking): support tags (FIR-1940) (#1631)
+[33m6e63528b[m fix(crawl-redis): bad logic
+[33m4c49bb9f[m refactor: remove unnecessary logs and set integration as default to null
+[33m57a0aed4[m feat(api): add integration field to jobs and update related controllers and types
+[33ma05c4ae9[m feat(api): GET /crawl/ongoing (FIR-2189) (#1620)
+[33m077c5dd8[m feat(api/tests): add webhook tests + refactor batch scrape lib (#1630)
+[33m122ccd5e[m fix(ci):
+[33m11c1178c[m feat(ci): verify typescript errors
+[33m0f394a10[m feat(queue-worker): fix crawl pre-finishing logic (#1628)
+[33m8dd5bf7b[m feat(api/tests/scrape): Playwright test improvements (#1626)
+[33m95f204aa[m Index (FIR-2177) (#1605)
+[33m406d6966[m Testing improvements (FIR-2209) (#1623)
+[33me297cf8a[m feat(selfhost): deploy a playwright image (#1625)
+[33m41897139[m feat: enhance metadata extraction by including 'itemprop' attribute in HTML (#1624)
+[33me108ff35[m Update search.ts
+[33m9347de6a[m Update scrape.ts
+[33m86a9d352[m Update queue-jobs.ts
+[33mcbc47305[m Update search.ts
+[33mce425d96[m Merge branch 'nsc/bypass-billing-internal'
+[33m8c661f53[m Update scrape.ts
+[33mdc8cc99b[m Nick: bypass billing (#1622)
+[33m8967b314[m Nick: bypass billing
+[33mbf919ceb[m Nick: __searchPreviewToken
+[33mef789ce8[m Nick: __experimental
+[33m72be7347[m feat(api/scrape): credits_billed column + handle billing for `/scrape` calls on worker side with stricter timeout enforcement (FIR-2162) (#1607)
+[33m4167ec53[m fix(scrapeURL): only allow disabling the adblock on playwright (FIR-2200) (#1616)
+[33m7a8be132[m remove indexes that are no longer used
+[33m98ceda9b[m feat(search): ignore concurrency limit for search (FIR-2187) (#1617)
+[33m1396451d[m bump rust version pt.2
+[33m07fb651a[m bump rust version
+[33m6a76ccfa[m webhook param for crawl (#1609)
+[33m9297afd1[m Nick: search
+[33ma8e04827[m feat(search): bill for PDFs properly
+[33ma2f41fb6[m feat(api/server): wait 60s for GCE load balancer drain timeout
+[33m3ea221b0[m fix(api/queue): tighten expiries on indexQueue jobs
+[33mc9dd0e60[m fix(api/queue): tighten expiries on billingQueue jobs
+[33m93655b5c[m feat(scrapeURL/pdf): bill n credits per page (FIR-1934) (#1553)
+[33m38c96b52[m feat(scrapeURL): handle contentType JSON better in markdown conversion (#1604)
+[33m7e73b015[m fix(queue-worker): call webhook after job is in DB
+[33m706d378a[m feat(api/v1/scrape-status): log supa lookup errors
+[33m3557c902[m feat(js-sdk): auto mode proxy (FIR-2145) (#1602)
+[33ma5efff07[m feat(apps/api): add support for a separate, non-eviction Redis (#1600)
+[33m756b452a[m Update batch_billing.ts
+[33m299e3e29[m Update batch_billing.ts
+[33ma36c6a4f[m feat(scrapeURL): add unnormalizedSourceURL for url matching DX (FIR-2137) (#1601)
+[33m474e5a05[m fix(crawler): always set expiry on sitemap links in redis
+[33mc3738063[m less logs even more
+[33m492d97e8[m reduce logging
+[33ma3145cca[m fix(extract-status): be able to get extract status even after TTL lapses (#1599)
+[33m8389a1a7[m fix(html-transformer): bad outName for og:locale:alternate (FIR-2101) (#1597)
+[33m3ec17e2d[m fix(v1): avoid overwriting rateLimiterMode with FIRE-1 rate limiter (#1593)
+[33m3df687e4[m feat(queue-worker/afterJobDone): improved ccq insert logic (#1595)
+[33ma7894a27[m fix(scrapeURL/pdf): even better timeout detection
+[33m8571b5a9[m Revert "feat(queue-worker/afterJobDone): improved ccq insert logic"
+[33m97c63567[m feat(queue-worker/afterJobDone): improved ccq insert logic
+[33mf41af824[m fix(scrapeURL/pdf): better timeout error
+[33mbfe73130[m fix(scrapeURL/pdf/mu): remove log
+[33mb03670a8[m feat: parse PDFs on fc side and reject if too long for timeout (FIR-2083) (#1592)
+[33m321fff16[m ok what
+[33m00cc7339[m more logs
+[33mbb67b981[m check if enum is being overwritten somehow
+[33md4e7bde0[m add stack
+[33m6776292c[m more log
+[33m2e863da3[m feat(api/v1/authMiddleware): add log to debug extract agent preview mode
+[33m3e736f1e[m feat(concurrency-log): add cclog endpoint (FIR-2067) (#1589)
+[33mfd742991[m feat(scrapeURL, logJob): log pdf page count to db (FIR-2068) (#1587)
+[33mcc2c9684[m fix(robustFetch): selective logging (#1588)
+[33m749d89a5[m feat(api/v1/extract): ignoreInvalidURLs (#1585)
+[33m6478754f[m feat(api/extract): show extract as origin for scrapes originating from it (#1584)
+[33m85221032[m feat(api/v1/extract): log requests
+[33m938ef1cf[m feat(api/v1/map): log requests
+[33ma3aee9be[m fix(queue-worker): finish crawl if all addable URLs were already locked (#1582)
+[33m9bb97388[m feat(search): ignoreBlockedURLs (FIR-1954) (#1580)
+[33m3d4692f4[m Update SELF_HOST.md
+[33mc7bb9e77[m docs: add MAX_RAM and MAX_CPU environment variables documentation (#1581)
+[33mb8ea4021[m fix(services/webhook): greatly improved logging
+[33m9949403b[m FIR-2006: Fix maxUrls and timeLimit parameters in Deep Research API (#1569)
+[33m513f469b[m feat(python-sdk/CrawlWatcher): remove max payload size from WebSocket (FIR-2038) (#1577)
+[33m6d751613[m Fix sdk/undefined response handle error (#1578)
+[33ma5a915d6[m Fix: Concatenate metadata arrays into strings with exceptions (#1574)
+[33mf838190b[m hotfix: kill zombie workers, respect timeouts better (FIR-2034) (#1575)
+[33m5152019a[m Update docker-compose.yaml (#1566)
+[33m5fcd8bb0[m fix(api/search): log page options correctly (#1572)
+[33md8405de8[m fix(auto_charge): fix ACUC clear (#1571)
+[33m192d056b[m feat(scrapeURL/pdf/mu): add timeout and created_at (#1570)
+[33mfab4f005[m feat(scrapeURL): proxy auto mode (FIR-1853) (#1551)
+[33m8eeb3c5c[m FIR-1951: Add automatic URL encoding in preprocessing for special characters in query parameters (#1547)
+[33m7ccbbec4[m Fix LLMs.txt cache bug with subdomains and add bypass option (#1557)
+[33mab30c8e4[m Fix Supabase client configuration errors when USE_DB_AUTHENTICATION is false (#1534)
+[33m526165e1[m Add caching for RunPod PDF markdown results in GCS (#1561)
+[33mbd9673e1[m Mog/cachable lookup (#1560)
+[33md46ba959[m Revert "feat: use cacheable lookup everywhere (#1559)"
+[33mb8703b2a[m feat: use cacheable lookup everywhere (#1559)
+[33mf936befc[m feat(queue-worker): liveness check endpoint
+[33mb5b612c3[m feat(api/extract/fire-0): error logging (#1556)
+[33mb0c203e5[m Fix/optional chaining operators missing (#1549)
+[33mcee481a3[m fix(fire-engine): sslerror passthrough
+[33m3db2294b[m feat(scrapeURL): better error for SSL failures (#1552)
+[33m06189b96[m refactor: increase max limit for search request schema from 50 to 100 (#1545)
+[33m50592487[m create openAI provider using base url parameter (#1480)
+[33m0fd05a67[m Revert "Revert "fix(queue-worker, scrape): match billing logic and add billing for stealth proxies (#1521)""
+[33mfdeb0184[m feat(queue-worker): add more logs around crawl finishing logic
+[33m907cf1cf[m Update __init__.py
+[33m21adf047[m [Bug Fix] Make WaitAction milliseconds field optional in firecrawl-py (#1533)
+[33m7b03ab36[m Update openapi.json
+[33mfa581995[m feat(acuc): propagate team flags (FIR-1879) (#1522)
+[33m017a915a[m Revert "fix(queue-worker, scrape): match billing logic and add billing for stealth proxies (#1521)"
+[33me06c7cc2[m fix(queue-worker, scrape): match billing logic and add billing for stealth proxies (#1521)
+[33m0f325001[m fix(queue-jobs): never cc timeout jobs that are crawl-associated (makes no sense)
+[33m7ad9a00e[m fix(concurrency-limit): rework cc queue to work by time not priority (#1526)
+[33m5d07cccd[m Merge pull request #1523 from mendableai/refactor/map-limit
+[33mae12c326[m refactor: maximum links limit for map endpoint from 5000 to 30000
+[33m17728379[m Revert "Nick: log su usage"
+[33m6567ef81[m Nick: log su usage
+[33m0512ad6b[m Add delay parameter to crawl options in all SDKs (#1514)
+[33m411ecdf0[m Add crawl delay functionality with per-crawl concurrency limiting (FIR-249) (#1413)
+[33m510171ca[m Delete qwen 3
+[33ma0ed76d5[m Merge pull request #1510 from mendableai/devin/1746062769-qwen3-web-crawler-example
+[33mac02ad32[m Revert "Nick: past_due changes"
+[33m9449d7b0[m Nick: past_due changes
+[33mb646c3e9[m Remove OpenAI API key references, use only OpenRouter API key
+[33m018c6a61[m Add Qwen3 web crawler example using OpenRouter
+[33m8b88c26a[m Update v1.ts (#1509)
+[33meee613d1[m [feat] Implement GCS storage option for scrape results across controllers an… (#1500)
+[33mf0b15072[m Fix: Handle both dict and model instances in actions parameter (#1508)
+[33m6dbfd54e[m Update __init__.py
+[33m317fa43f[m Fix sdk/schemas (#1507)
+[33ma0a16758[m Nick: (#1506)
+[33m8053a7ce[m Nick: updates on pypi
+[33mc1643702[m Webhook param for batch scrape (#1505)
+[33me3e730f2[m Update version to 2.4.0 and enhance ExtractResponse model with additional fields for id, status, and expiresAt. (#1501)
+[33mf7a9a144[m Merge pull request #1489 from aparupganguly/feature/o4-mini-web-crawler
+[33m59e1343e[m Merge pull request #1487 from aparupganguly/feature/o3-crawler
+[33m5c3951b4[m Update __init__.py
+[33mca82015b[m Use async job status monitor for AsyncFirecrawlApp (#1498)
+[33m8b82e116[m Decrease diff warn threshold further
+[33me4f9a92e[m adjust diff warn threshold
+[33m0e7f2c85[m feat(diff): log if it takes a long time with params
+[33m37dabce1[m [feat] added second scrapeURLWithFireEngine (#1494)
+[33m9435c800[m fix(api/tests/scrape): don't test scrape status endpoint on self-host env
+[33m2f6520bc[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m22f7efed[m NIck: rm scrape events
+[33m1c421f2d[m Nick: (#1492)
+[33mfeda4ded[m Update README.md
+[33me532a96b[m (fix/search) Search logs fix (#1491)
+[33me10d4c7b[m [fix/sdk] kwargs params (#1490)
+[33m6920b85e[m Add examples/o4-mini web crawler
+[33md05274ef[m Add examples/o3 Web Crawler
+[33m1a02ef56[m fix(extract/fire-1): thinking tokens pricing
+[33mf47d8779[m fix(extract/oldExtract): do if for old/new extract
+[33m1afc6258[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33ma4323d8f[m fix:python-sdk
+[33mdf305c2a[m fix(): null-proof/nan-proof
+[33m0e027fe4[m fix(scrape): bill llm on fail
+[33mb3546245[m billing for smart scrape
+[33m0a86d273[m reenable
+[33m324b4e2e[m fix rounding
+[33m6d2347b5[m feat(llmExtract): add token tracking to all calls
+[33m438ea19f[m feat(extract): add thinking tokens
+[33m653a0207[m fix(calculateCost): accuracy 2.5
+[33m2b2e648d[m feat(smart-scrape): log failed costs
+[33m3909b664[m temp:
+[33m5453bed5[m temp: put everything back
+[33mf7b173fd[m Merge branch 'python-sdk/v2.0.1'
+[33m2c72097c[m Nick:
+[33m9e259571[m Python sdk/v2.1.0 (#1479)
+[33mc7df80e2[m Update __init__.py
+[33m91ebd140[m version bump
+[33m0aedef72[m fix
+[33m79bc54c1[m scrape options fixing types
+[33mf451b713[m fix acuc extract preview
+[33m3caeaae0[m fix(scrapeURL/llmExtract): fix schema-less JSON mode
+[33me583fdde[m Merge pull request #1477 from aparupganguly/examples/gpt-4.1-company-researcher
+[33md4935986[m Add examples/gpt-4.1 Company Researcher
+[33m16439b1c[m Nick: examples
+[33m4e678038[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mc69acdff[m Update v1.ts
+[33m89f00b22[m Update README.md
+[33mbc5c5a31[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33ma74b2dc5[m Nick: json config instead of extract config
+[33m06204bd8[m Update README.md
+[33m54712d27[m Update README.md
+[33m9d0baec5[m Merge branch 'sdk-improv/async'
+[33m06c54bc4[m Update __init__.py
+[33m29b36c5f[m [python-SDK] improvs/async (#1337)
+[33m9e67d7ba[m Nick:
+[33m37e076e1[m Merge branch 'sdk-improv/async' of https://github.com/mendableai/firecrawl into sdk-improv/async
+[33m9ba1ae9a[m Nick:
+[33m55c04d61[m Merge branch 'sdk-improv/async' of https://github.com/mendableai/firecrawl into sdk-improv/async
+[33m0915db51[m async functions
+[33ma3f31682[m Nick: python sdk 2.0
+[33mf3522666[m Nick: new examples
+[33m0001d6ea[m Merge branch 'sdk-improv/async' of https://github.com/mendableai/firecrawl into sdk-improv/async
+[33m0b62be58[m Update firecrawl.py
+[33m5db76992[m Merge branch 'sdk-improv/async' of https://github.com/mendableai/firecrawl into sdk-improv/async
+[33m8cd82b56[m async scrape
+[33m1aa0c092[m Update firecrawl.py
+[33m390f3d44[m Update firecrawl.py
+[33md8792d23[m Update firecrawl.py
+[33m5e6e41ab[m Update firecrawl.py
+[33ma655d24e[m scrape params commentary
+[33m8c5509cb[m Update firecrawl.py
+[33mb67bc707[m Merge branch 'sdk-improv/async' of https://github.com/mendableai/firecrawl into sdk-improv/async
+[33m85247991[m generic
+[33m28703201[m Merge branch 'sdk-improv/async' of https://github.com/mendableai/firecrawl into sdk-improv/async
+[33m8eb4e1a9[m Update firecrawl.py
+[33m23ef2665[m params
+[33m22cfdd6a[m added agent options types
+[33mf48937a5[m Update firecrawl.py
+[33md9780412[m Update firecrawl.py
+[33mc67425ad[m Merge branch 'main' into sdk-improv/async
+[33mec3d679c[m feat(rust-sdk): add agent options
+[33mf2c01340[m feat(rust): update rust sdk to support new features (#1446)
+[33m33aece8e[m more cost calc
+[33m9bea877e[m feat(extract): cost limit (#1473)
+[33m7df557e5[m feat(cost-tracking): add model tracking and more costs
+[33m5aa94690[m Update __init__.py
+[33mf844b329[m remove agent preview rate limiter
+[33m06770bc6[m fix(scrape/json): move back to 4o mini
+[33m8546bcac[m new cost tracking
+[33mba4df67d[m force 2.5
+[33m6a93293f[m feat(smart-scrape): use correct models for multi-entity assembly
+[33m751c30f1[m feat(extractSmartScrape): better pagination handling
+[33m509e6e65[m feat(llmExtract): more logging
+[33m4c5120e0[m feat(llm-extract): do more logging, even more
+[33mb45e3bda[m better logs
+[33mad7e3f62[m feat(extractSmartScrape): resolve refs in provided schema
+[33m5ee2434c[m more logs
+[33m772a3ea7[m Bump the SDK
+[33m4740254b[m feat(rquests.http): add extract
+[33mc7132512[m feat(extraction-service): send thisSessionId for single entity
+[33m7787a58b[m default timeout
+[33m39d10dc7[m feat: disable cost tracking
+[33m8766bc6f[m temp: don't... do that
+[33mdefc80af[m stream session IDs for single URLs
+[33md82f44c9[m feat(extract): log failed extracts
+[33maa202465[m minor cost tracking fix
+[33m51967c7c[m Merge branch 'main' into rafa/sessionIdsExtract
+[33mdcef6fbc[m feat(extractSmartScrape): mog it to 100 pages max
+[33m129b10e4[m fix(llmExtract): cost calculation
+[33mf92217e3[m wip
+[33m0d813b62[m feat: correlate smart scrape
+[33medd4c309[m FIX IT
+[33ma0691011[m asd
+[33m2245650b[m fix
+[33m2193bee1[m Improve logging
+[33m0935ec21[m feat(smartScrape): better loggin
+[33mb6abe4f2[m fix(smartScrape): pass extract id
+[33m80b507e6[m correlate with eid
+[33m512a2b1c[m feat(extract): run on original links if reranker is weird
+[33m13bd50ad[m feat(fetch): don't time out (for smart scrape)
+[33m0abe6008[m fix
+[33meea1267b[m feat(batchExtract): thingymajig
+[33md119552e[m bump rate limits
+[33m5515ca7a[m fix(llm-cost): update
+[33m524b9770[m Update queue-worker.ts
+[33mc8a8e96a[m un-gate scrape status, add test
+[33m3ccef5fb[m fix(v1): scrape-status with GCS
+[33m252a9ccc[m Refactor robustFetch logging to exclude sensitive parameters and improve error handling.
+[33ma840db9e[m Set default timeout to 120s when proxy is stealth (#1464)
+[33m31e24e90[m FIX DAT
+[33m0ee96039[m FIX MORE
+[33m9400b142[m fix typing
+[33medb40d75[m log session ID
+[33m6634d236[m (feat/fire-1) FIRE-1 (#1462)
+[33me2c4b0e7[m remove double v0 log
+[33m0446443b[m Nick: acuc cache on now
+[33mb415e625[m feat(scrape): get job result from GCS, avoid Redis (#1461)
+[33m0ac86abe[m Merge pull request #1460 from aparupganguly/examples/gpt-4.1-crawler
+[33m5dca350a[m Add examples/gpt-4.1-crawler
+[33m0b50349f[m feat(v0): fix jobs
+[33mebdf182b[m feat(auth): more ip
+[33m07cdde74[m feat(auth): preview acuc team more
+[33m713d5867[m fix(auth): preview acuc team
+[33m28574963[m feat(diff): better rpc (revert this if broken)
+[33mcf843245[m Merge branch 'devin/1744568481-add-wait-for-change-tracking'
+[33m94d0b4be[m Update types.ts
+[33m6bdae3cf[m Add waitFor of 5000ms for changeTracking format (#1450)
+[33m0c5bd855[m Update apps/api/src/__tests__/snips/scrape.test.ts
+[33m4026866c[m Fix waitFor check to handle undefined values
+[33m8bc2f167[m Move waitFor check for changeTracking to types.ts refine layer
+[33md8e3c36c[m feat(api): install git to docker to have proper diffs
+[33m870fe56e[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m723e7b7c[m Update diff.ts
+[33m9ab2a266[m Add waitFor of 5000ms for changeTracking format
+[33m5658232e[m feat(acuc): bump 30
+[33md260f367[m feat(acuc): bump
+[33m63a283bf[m js-sdk: once again again
+[33m58ad7f40[m js-sdk: once more
+[33m62c842e6[m js-sdk: fix tsup config
+[33m32798e22[m revert lock
+[33m557df1ab[m js-sdk: bump
+[33m3cf6d88b[m js-sdk: change ci
+[33m4414fbca[m fix lock
+[33m950a9512[m Nick:
+[33mc5079074[m js-sdk: bump
+[33ma03b26a4[m Update package.json
+[33mf09458ff[m fix(api/tests/scrape): schema change
+[33mef341399[m Add change tracking support to Python and JS SDKs (#1448)
+[33m138a9757[m (feat/change-tracking) Change Tracking Modes (#1445)
+[33mf18a6b20[m extract concurrency hotfix
+[33m6e9396dc[m feat(search): add further logging
+[33mb1fdc0e8[m Merge pull request #1419 from mendableai/feat/email-notifications
+[33mf52d6aab[m (feat/deep-research) Improvements to final analysis (#1443)
+[33m0bed648b[m Revert "Revert "Revert "temp: get acuc from main db"""
+[33md3b821e8[m Revert "Revert "temp: get acuc from main db""
+[33m8566bff3[m Revert "temp: get acuc from main db"
+[33mf16f0344[m temp: get acuc from main db
+[33m6a10f068[m ACUC: Dynamic Limits (FIR-1641) (#1434)
+[33mf2865f66[m temp: disable acuc caching
+[33ma461f72d[m temporarily disable some flaky tests
+[33m415603ac[m fixes
+[33m4294face[m feat(scrapeURL): reintroduce default timeout for simple queries (#1440)
+[33m7bb56430[m feat(log_job): is_migrated: true
+[33md925bf2f[m feat(log_job): stop putting docs in the db (#1438)
+[33m45efe3fd[m Merge pull request #1436 from mendableai/feat/increase-search-limit
+[33m78a920af[m fix(api/tests/scrape): bump timeout
+[33md3da790d[m feat(extraction-service): teamId logging
+[33mc81db851[m Merge pull request #1418 from aparupganguly/Feature/llama4-extractor
+[33mda2f17c7[m feat(api/search): add search endpoint and update request limits
+[33md506aece[m Merge pull request #1416 from aparupganguly/Feature/llama4-mv-crawler
+[33m9fd735f3[m feat(api/test/snips): disable flaky tests
+[33mdc1a17d5[m remove bad log
+[33m3a8de846[m read from GCS (again) (#1433)
+[33m670e4a6b[m Revert "feat(crawl-status): retrieve job data from GCS (#1427)"
+[33m673bf6a2[m feat(crawl-status): retrieve job data from GCS (#1427)
+[33mab6fb48e[m bump ver
+[33m8c801ed9[m Rename 'compare' format and property to 'changeTracking' (#1423)
+[33m62265c63[m feat(log_job): use atob
+[33mc69d1561[m fix(log_job): use service account credentials
+[33m37b13ba1[m feat(log_job): allow use of api key if specified
+[33mbd1c1b00[m feat(log_job): start saving jobs to GCS (#1424)
+[33m13212751[m Update Llama 4 Maverick extractor implementation
+[33m80bf732f[m feat: incorporate user preferences and notification categories
+[33m2f037fa1[m Add examples/llama4-maverick-web-extractor
+[33m17ea3ff3[m Add examples/ Llama 4 Maverick Crawler
+[33m66e65d94[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mf45fa120[m Update rate-limiter.ts
+[33mf5e5bdb7[m fix(llmExtract): arbitrary objects caused error to be thrown
+[33m570809aa[m fix(unvisitedUrls): filter with crawler
+[33m6bed5eca[m fix(rust-sdk): remove rustfmt (#1392)
+[33m41e09403[m Update email_notification.ts
+[33me1e39f88[m Nick: send notifications for crawl+batch scrape
+[33m7128f83a[m fix(js-sdk): isows import issues (FIR-1586) (FIR-1536) (#1411)
+[33mb57d5f2c[m Merge pull request #1409 from mendableai/feat/crawl-scrape-limit-notification
+[33m426151c9[m feat(queue-jobs): add function to determine job type and update notification logic for concurrency limits
+[33m8c1579df[m bump cc
+[33m2e2c3d52[m feat: add swoogo classes to force include main tags
+[33m24f51993[m compare format (FIR-1560) (#1405)
+[33mb3b63486[m cc manual
+[33m3300c6c5[m Merge pull request #1404 from mendableai/fix/add-notification-type
+[33mb900f34b[m feat(notification): add notification message for concurrency limit reached
+[33m7216799c[m revert mog changes
+[33m73a297d6[m Merge pull request #1398 from mendableai/refactor/email-concurrency-limit-reached
+[33m74684645[m feat(queue-jobs): implement conditional notification for concurrency limits based on team subscription status
+[33mee211132[m Nick:
+[33mc4255f4f[m Update auth.ts
+[33mb79b90fd[m Update auth.ts
+[33m58e587d9[m feat(queue-jobs): update notification logic for concurrency limits and add parameter (jsdocs) to batchScrapeUrls
+[33me0a3c549[m new acuc
+[33mb9dde3fc[m temp: move more to main instance
+[33m4f0510e7[m temp: switch over crawl fetches to main instance
+[33m830d15f2[m Merge pull request #1384 from aparupganguly/feature/v3-extractor
+[33m10ce20e0[m Merge pull request #1383 from aparupganguly/feature/v3-crawler
+[33mf0e0d3e2[m fix(api): crawl origin tracking (FIR-1499)
+[33m46048bc9[m feat(scrapeURL): return js returns from f-e (FIR-1535) (#1385)
+[33m28928f00[m Add examples/DeepSeekv3 company researcher
+[33mda765247[m Add examples/deepseek-v3-crawler
+[33m56d23cc6[m Merge pull request #1380 from aparupganguly/feature/gemini-2.5-crawler
+[33m4965c87c[m Merge pull request #1381 from aparupganguly/feature/gemini-2.5-company-extractor
+[33me799cf20[m increase manual rl
+[33m2b39788d[m manual rl
+[33mbe435980[m feature/gemini-2.5-company-extractor
+[33mcc7f38af[m Minor changes
+[33m6e8644a1[m Add examples/gemini-2.5-pro crawler
+[33m42236ef0[m feat(admin/check-fire-engine): better logging
+[33me8f27bef[m feat(rate-limiter): manual_etier2c
+[33m555dab50[m Nick: bump
+[33ma50dc106[m (feat/deep-research) Deep Research Alpha v1 - Structured Outputs + Customizability (#1365)
+[33m3ee58f7a[m Merge pull request #1378 from aparupganguly/feature/deep-research-apartment
+[33m87539aaf[m Add example/Deep-research Apartment finder
+[33mb5010cff[m Merge pull request #1369 from aparupganguly/fetaure/mistral-extractor
+[33m6a6199eb[m Add examples/mistral 3.1 company researcher
+[33m5e35782b[m update acuc
+[33m688eb894[m Merge pull request #1366 from aparupganguly/feature/mistral3.1-small
+[33m2fb29ee4[m Add examples/ mistra- small-3.1-crawler
+[33m867e5455[m Update rate-limiter.ts
+[33m3e0d3db9[m Update rate-limiter.ts
+[33m0bdaa97b[m acuc fix
+[33m6dc5b1cd[m feat(auth): acuc update
+[33me4256670[m Merge branch 'main' into sdk-improv/async
+[33m4f984d3f[m added origin to requests
+[33m723c1649[m Merge branch 'nsc/deep-research-prompts'
+[33m4fc5e6f6[m Nick: added analysis prompt to the sdks
+[33me97a279e[m Nick: let user format the analysis (#1351)
+[33md0b468ee[m feat(scrape/actions/click): add all parameter (FIR-1443) (#1342)
+[33m6d3c639f[m added 403s to sdk error handlers (#1357)
+[33md12feaea[m fix(crawl): allow execution time longer than 24h
+[33m010c8750[m Nick: let user format the analysis
+[33m7e7b7e10[m Nick: fixes py sdk
+[33mc514d141[m Merge branch 'nsc/feat/extract-no-urls'
+[33m6d250360[m Nick: bump
+[33m20c93db4[m (feat/extract) URLs can now be optional in /extract (#1346)
+[33m0fb9c1f3[m Update index.ts
+[33m200de9e7[m feat(scrape): add warning to document if it was concurrency limited (#1348)
+[33m670ca84a[m fix(v1/checkCredits): snap crawl limit to remaining credits if over without erroring out (#1350)
+[33m87ad53e7[m fix(api/tests/snips/billing): bump timeout
+[33m180770f1[m init and final (#1349)
+[33mbad82242[m fix(v1/scrape): make log show up in queries
+[33m611c2d9c[m feat(v1/scrape): add further logging to document scrape bugs better
+[33mf1206e48[m Nick: urls optional on extract
+[33mca93ba6c[m fix(js-sdk/crawl,batch-scrape): retry status call if it returns an error up to 3 times (#1343)
+[33mcc255d48[m fixed websocket params
+[33m97695dd5[m refator: dry request and error handling
+[33m905885ab[m Merge pull request #1336 from aparupganguly/feature/claude3.7-stock
+[33me7db5a2d[m tomkosms review
+[33m86f41460[m removed v0 in example
+[33mdb3faf85[m Claude 3.7 implementation
+[33m3641070e[m async
+[33mc3ebfafb[m fix(llmExtract): remove unsupported JSON schema properties (#1335)
+[33m387dd3aa[m fix(tests/snips/billing): don't wait 40s for nothing when self hosted
+[33mc7ae50d2[m fix(crawler): sitemaps poisoning crawls with unrelated links (#1334)
+[33mda6b7505[m Meaningful log message for high resource usage errors
+[33mc6cad942[m Nick: errors -> warn
+[33m7ec278a9[m Nick: fixes
+[33m134de67a[m (fix/map) Map failed to filter by path if indexed (#1333)
+[33mf87e1171[m fix: don't log bull secret
+[33mc53df865[m Update searxng.ts (#1319)
+[33m6a5a4e5b[m improv/types-and-comments-descs
+[33md54af977[m Update rate-limiter.ts
+[33mb87b0d9b[m Merge branch 'nsc/concurrent-browsers'
+[33me8861893[m Update search.ts
+[33m1e6b484a[m (feat/pricing) Concurrent Browsers - Improve rate limits (#1331)
+[33md438b235[m Update rate-limiter.ts
+[33m71b6b83e[m tally rework api switchover (#1328)
+[33m9edbdc98[m Update rate-limiter.ts
+[33m7cf2e52f[m feat(crawl): add maxDiscoveryDepth (#1329)
+[33md855f5a5[m fix(test/snips/scrape): allow more time for stealth proxy
+[33m97dee5de[m temp(ci/self-host): remove no-proxy option
+[33m337bc261[m temp: remove flakey ad-block tests
+[33me9804d25[m fix: resolve circular JSON structure error in search function (#1330)
+[33m0154e406[m fix(js-sdk/extract): fix zod type check with zod version discrepancy
+[33m4cc33e1e[m Nick: added team_id_o
+[33m0c457e6f[m adjust acuc balance
+[33m3786ad7f[m restart
+[33m7ec1437d[m Merge branch 'fix/preview_token'
+[33m1ced546b[m Update rate-limiter.ts
+[33m60346ecf[m Fix/p token (#1305)
+[33mf45b3c01[m Merge branch 'main' into fix/preview_token
+[33mb66e0ccb[m Nick:
+[33m55a4a3d7[m preview-token
+[33m39b13902[m fix: crawl
+[33ma1e6c13b[m move crawl to read replica
+[33m982b3da2[m Update auth.ts
+[33m5a149a1c[m Revert "fix(auth): always use replica for acuc"
+[33m783fad90[m Nick: more read replicas
+[33m949fb68b[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m4c4d51e6[m Revert "Update runWebScraper.ts"
+[33m57b31360[m fix(auth): always use replica for acuc
+[33m7b055120[m fix(credit_billing): teams check
+[33mae010a76[m Update blocklist.ts
+[33me6c3f209[m fix(preview): temporarily disable
+[33m72d894c2[m Update rate-limiter.ts
+[33m1de5a2c5[m Update batch_billing.ts
+[33meba28a42[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m40eacfac[m Update runWebScraper.ts
+[33me1cfe1da[m feat(crawl): includes/excludes fixes (FIR-1300) (#1303)
+[33mf8df18ed[m feat(feng-check): run on chrome-cdp
+[33mc22c87ab[m fix(crawler): check for more strings
+[33m4902d0ac[m Nick: fixes
+[33m8cfc946c[m Nick: fix system prompt missing from extract params
+[33m5a188693[m Truncate llmstxt cache based on maxurls limit & improve maxurls handling (#1285)
+[33m1beadf39[m fix
+[33m6dce8e9d[m asd
+[33m8620bf3d[m fix(auth): split load evenly between two instances
+[33m67ee2662[m feat(auth): force acuc on read replica
+[33m64af3ba7[m Revert "Update auth.ts"
+[33m72eb360e[m Merge pull request #1291 from aparupganguly/feature/claude3.7-extractor
+[33mbced299e[m examples/Add Claude 3.7 web extractor
+[33m9eb25786[m Update deep-research-service.ts
+[33maa54fd16[m Nick: only new activities/sources in the callback
+[33m33c59ee4[m Nick: fixes
+[33m30c1e92a[m Update deep-research-service.ts
+[33m22d4f0de[m (feat/deep-research) Alpha prep + Improvements (#1284)
+[33m9ad94788[m feat(tests/snips): add billing tests + misc billing fixes (FIR-1280) (#1283)
+[33m4f25f12a[m fix(ai): handle if AI returns a JSON code block (#1280)
+[33m522f2d2e[m Merge pull request #1267 from ceewaigit/main
+[33m42e92216[m docs: remove undefined "required" field (#1282)
+[33me8c698d6[m feat(crawler): handle cross-origin redirects differently than same-origin redirects (#1279)
+[33mfea249c5[m Update auth.ts
+[33m99e61c96[m Update index.ts
+[33mab8dcab6[m Merge pull request #1276 from aparupganguly/feature/gpt4.5-crawler
+[33m06cdd988[m examples/Add gpt 4.5 web crawler
+[33m05c29e82[m js-sdk: bump
+[33m856ec37d[m fix(ci/js-sdk): properly build SDK before publishing
+[33m904e69bf[m feat(supabase): add read replica routing (#1274)
+[33m39b61132[m Nick: fixed js sdk
+[33m44bf5922[m fix(acuc): cache for 1 hour
+[33mb72e21a6[m Nick: batch billing (#1264)
+[33m289e351c[m (feat/deep-research-alpha) Added Max Urls, Sources and Fixes (#1271)
+[33m1d3757b3[m bump map to 30k
+[33m78334e4e[m feat(self-host/ai): pass in the ollama envs into docker compose (#1269)
+[33m7bf04d40[m fix(scraper): improve charset detection regex to accurately parse meta tags (#1265)
+[33m75ac980f[m Add groq_web_crawler example and dependencies
+[33mbf1a7958[m Merge branch 'feat/fire-index'
+[33m31df2341[m Update log_job.ts
+[33mec90aaff[m Update log_job.ts
+[33m0f052039[m Update log_job.ts (#1263)
+[33m59d09f5c[m Update log_job.ts
+[33m115b6b61[m add initial codeowners
+[33m51bc7757[m fix(self-host/compose): pass SearXNG params
+[33m2da6d7bd[m Merge pull request #1257 from aparupganguly/feature/claude3.7-crawler
+[33m8c42b08b[m feat(v1/crawl-status-ws): update behavior to ignore errors like regular crawl-status (#1234)
+[33m6508afc6[m Implemented claude 3.7
+[33m15489be5[m feat(self-host/ai): use any OpenAI-compatible API (#1245)
+[33mb88b5739[m docker: force host to 0.0.0.0 to fix env precedence issues
+[33mb24ac0f6[m Nick: done (#1237)
+[33m5ab86b8b[m (fix/token-slicer) Fixes extract token limit issues (#1236)
+[33m76e1f29a[m Update Dockerfile (#1231) (#1232)
+[33mbfe6a0ab[m feat(self-host/docker-compose): add option to use Valkey
+[33m82adf81b[m feat(self-host/docker-compose): allow configuring the internal port of the api
+[33m9671e685[m Merge pull request #1229 from aparupganguly/feature/gemini-github-analyzer
+[33m448b44cd[m Implemented github analyzer
+[33m6c51ef40[m Update rate-limiter.ts
+[33m25d9bdb1[m (feat/ai-sdk) Migrate to AI-SDK (#1220)
+[33m943eb775[m Update eval_run.py
+[33m570dc28d[m bugfix eval run
+[33md211240f[m Update eval-prod.yml
+[33m04127cca[m Update eval-prod.yml
+[33ma1386363[m Merge pull request #1224 from mendableai/feat/eval-run-workflow
+[33m16c30577[m fix(crawl-redis): ignore empty includes/excludes (#1223)
+[33md7db58e4[m Feat/added eval run after deploy workflow
+[33m283a3bfe[m fix(scrapeURL/engines/fetch): discover charset and re-decode (#1221)
+[33me417f83c[m feat(self-host): ollama support (#1219)
+[33m192f0031[m Merge pull request #1206 from aparupganguly/feature/gemini-extractor
+[33me84c7325[m chore: remove dead code
+[33m62d11f21[m self-host: remove old playwright-service
+[33md5337183[m feat(self-host): rework docker-compose.yaml
+[33m305fbb37[m temp (#1218)
+[33m387cc606[m fix(ci/test-server): clean up old envs
+[33mfca349f3[m fix(ci/js-sdk): bad sed command
+[33m2151ca84[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m7db2d25e[m Nick:
+[33mc38dcd04[m feat(self-host): proxy support (FIR-1111) (#1212)
+[33mc75522f5[m feat(sdk): enforce timeout on client-side if set (#1204)
+[33mdc150152[m doc(self-host): update with searxng details
+[33m100168dd[m Add searxng for search endpoint (#1193)
+[33m04218de2[m Revert "feat(ci): use pull_request_target (+ manual approval)"
+[33m91420308[m feat(ci): use pull_request_target (+ manual approval)
+[33mda1670b7[m feat(map): mock support (FIR-1109) (#1213)
+[33mbc5a16d0[m feat(ci/test-server): build go markdown parser
+[33m7770929d[m fix(README): Adjust crawling example limit
+[33m11ed6792[m feat(scrapeURL/pdf): support PDF prefetch when parsePDF is off
+[33m5eb0235c[m feat(apps/api): remove Sentry builds
+[33mda467360[m fix(self-host): further changes
+[33m10d9b65f[m fix(self-host): update docs and dockerignore
+[33me4504b32[m Use correct list typing for py 3.8 support (#931)
+[33m55d047b6[m feat(scrapeURL): handle PDFs behind anti-bot (#1198)
+[33mbec52bef[m feat(self-host/docs): playwright-service-ts is now default
+[33m7f5ff802[m feat(self-host): use playwright-service-ts by default
+[33mc39cc278[m feat(ci/self-host): add playwright microservice tests (#1210)
+[33m037f6491[m Playwright page error schema (#1172)
+[33m46b187bc[m feat(v1/map): stop mapping if timed out via AbortController (#1205)
+[33m2200f084[m SELFHOST FIXES (#1207)
+[33mc1ca64fc[m fix(ci): retain fail status
+[33mf4f75fe1[m fix(ci): path to lock
+[33me9cb8ac9[m feat(ci): caching improvements
+[33m0eff9900[m feat(ci): upload logs
+[33m99765605[m feat(ci): self-hosted server test suite
+[33m8caeab26[m minor changes
+[33m21b22d9f[m Output re-structured
+[33mdab00166[m feat(ci): publish all JS SDK packages
+[33m3a4ef05a[m Output imporvements
+[33m1a9f6b98[m feat(github/ci): improvements
+[33m055f7d2d[m fix(concurrency-limit): move to renewing a lock on each job instead of estimating time to complete (#1197)
+[33macf1e606[m Nick: llmstxt improvements
+[33md4cf2269[m Update generate-llmstxt-service.ts
+[33m5e0036f8[m Implemented gemini 2.0 web extractor
+[33mf5de803a[m Nick: fixes
+[33ma60f3ff6[m Nick: fixes
+[33md984b504[m Add llmstxt generator endpoint (#1201)
+[33me373fab5[m fix(sdk/js): don't require CrawlScrapeOptions.formats
+[33m8e1e5986[m feat(sdk/js): bump
+[33m4fd26a3b[m feat(js-sdk): support scrapeOptions in ExtractParams
+[33m5c47e97d[m (feat/deep-research) Alpha implementation of deep research (#1202)
+[33mfc64f436[m fix(v1/types): fix extract -> json rename, ROUND II (FIR-1072) (#1199)
+[33m42050d3d[m fix
+[33mb136e42b[m feat(v1): proxy option / stealthProxy flag (FIR-1050) (#1196)
+[33me28a4446[m Revert "fix(v1/types): fix extract -> json rename (FIR-1072) (#1195)"
+[33m586a10f4[m fix(v1/types): fix extract -> json rename (FIR-1072) (#1195)
+[33m5ac6eb74[m Update self-hosted Kubernetes deployments examples for compatibility and consistency (#1177)
+[33maacbea1d[m fix(tests/snips/map): remove flaky useless test
+[33m58564bce[m Revert "temp: debugging"
+[33m97e6c28c[m temp: debugging
+[33m5c4021e8[m fix(scrapeURL/fire-engine): screenshot broken hotfix
+[33mb0534d07[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m03da3c36[m Update auth.ts
+[33m445b906a[m fix(scrapeURL/fire-engine): perform format screenshot after specified actions (#1192)
+[33m7ecbff3b[m fix(map): do not remove query parameters from results (FIR-1015) (#1191)
+[33m5cb29183[m update name of example
+[33m1491b5b1[m fix(scrapeURL/sb): enforce timeout (FIR-980) (#1183)
+[33mfd8b3890[m fix(crawl-status): consider concurrency limited jobs as prioritized (#1184)
+[33m7ac2b992[m Update auth.ts
+[33mce9d3d32[m Nick: adjust for old compatibility s2
+[33ma4cf8f43[m Revert "(feat/extract) Multi-entity prompt improvements (#1181)"
+[33md9c99e58[m fix(v1/batch/scrape): use scrape rate limit (#1182)
+[33m254580a2[m fix: relative url 2 full url use error base url (#584)
+[33m73e7884d[m fix(queue-worker/crawl): only report successful page count in num_docs (#1179)
+[33m584221a1[m (feat/extract) Multi-entity prompt improvements (#1181)
+[33m73ecaf74[m feat(v1/extract) Show sources out of __experimental (#1180)
+[33m1d9a0b96[m feat(v1/checkCredits): say "tokens" instead of "credits" if out of tokens (#1178)
+[33m582bbf8d[m Merge pull request #1175 from mayooear/feat/gemini-sub-links
+[33m32f98976[m fix: update gemini library. extract pdf links from markdowncontent
+[33ma1b7d6e6[m Merge pull request #1173 from mayooear/feat/gemini-sub-links
+[33mcb3bc5e4[m Add detection of PDF/image sub-links and extract text via Gemini
+[33mc67b052f[m Update gemini-2.0-crawler.py
+[33m78094e2f[m fix(html-transformer): Update free_string function parameter type (#1163)
+[33m52c0f78d[m chore: add Serper and Search API envs to docker-compose (#1147)
+[33mef9aad8b[m Merge pull request #1161 from aparupganguly/feature/gemini-2.0-crawler
+[33m6b313ad0[m Update types.ts
+[33mbc787de6[m fix(blocklist): behavioural fixes
+[33m36082565[m Merge pull request #1146 from mendableai/feat/wait-validation
+[33m290dd033[m Update apps/api/src/controllers/v1/types.ts
+[33m843cec97[m [FIR-796] feat(api/types): Add action and wait time validation for scrape requests
+[33mf33fa5bf[m Initial commit
+[33m2b7b7400[m Merge pull request #1144 from aparupganguly/feature/o3-mini-job-resource
+[33mac5c88bf[m added scrapeOptions to extract (#1133)
+[33m42f4f7ef[m Merge pull request #1139 from aparupganguly/feature/o3-mini-review-summarizer
+[33m46f05a75[m Job Resources Analyzer
+[33m892f3a41[m fix(scrape): allow getting valid JSON via rawHtml (FIR-852) (#1138)
+[33m401c1876[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m394a3106[m Update types.ts
+[33m996352c2[m Merge pull request #1117 from mendableai/feat/blocked-domains
+[33mfe276060[m Update pyproject.toml
+[33m844ba39f[m fix(sdks): MIT license
+[33m310ef665[m Implemented prodcut reviews summarizer using o3 mini
+[33m34fe360d[m fix(crawl-redis/generateURLPermutations): dedupe index.html/index.php/slash/bare URL ends (FIR-827) (#1134)
+[33maa1e820d[m Fix corepack and self hosting setup (#1131)
+[33m73d19aa0[m fix(dockerfile): Temporarily resolve corepack issue
+[33mb0f9e733[m Update o3-mini_web_crawler.py
+[33m1e7d42e8[m fix(concurrency-limit): allow for big crawls
+[33m1951b608[m Merge pull request #1130 from aparupganguly/feature/o3-company-researcher
+[33m7aa2db25[m Updated Model Parameters
+[33m5894076f[m Merge pull request #1120 from aparupganguly/feature-o3-crawler
+[33m01d656fe[m Minor Changes
+[33md5d3df9d[m Handled JSON format structure
+[33m61b989cc[m Initial Commit
+[33me0c292f8[m Merge pull request #1115 from aparupganguly/feature-r1-web-extractor
+[33mcdc747ab[m small edits
+[33mbcd74498[m test(blocklist): Enhance URL blocking test coverage with decrypted domain validation
+[33m8d7e8c4f[m added cached scrapes to extract (#1107)
+[33m4341b6e1[m Merge pull request #1118 from sami0596/patch-1
+[33m492b81d7[m Nick: origin api-sdk in python sdk
+[33m0a44d11b[m Update CONTRIBUTING.md
+[33m24e8aaf6[m feat(blocklist): Improve URL blocking with tldts parsing
+[33m8a8d7d64[m fix(concurrency): proper job timeouting
+[33me0269176[m Nick: disable auto rech for extract requests
+[33m6bfd24d9[m Nick: waitFor fixes
+[33m5819f606[m Update types.ts
+[33m26c61b96[m Update queue-jobs.ts
+[33mdb740a0c[m Update R1_web_crawler.py
+[33ma3b5666c[m Delete examples/R1_web_extractor/tempCodeRunnerFile.py
+[33m2dafe7fb[m minor changes
+[33m768e8057[m Added R1 web extractor feature
+[33m948f7866[m Added instructions for empty string to extract prompts (#1114)
+[33m68d3baaa[m v1.16.0 js sdk
+[33ma6722d4a[m feat(webhook): add event picker
+[33m7c0b3ad0[m (feat/conc) Move fully to a concurrency limit system (#1045)
+[33me2c3932d[m Update auto_charge.ts
+[33ma5853407[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mec2c0f67[m Added more safety guards to auto-rech
+[33m71878cf4[m fix(cc): hotfix
+[33ma7eb2f7c[m fix(crawler/rust): dedupe
+[33mc88176a5[m Update blocklist.ts
+[33m86f05a07[m feat(github/ci): connect to tailscale (FIR-748) (#1112)
+[33maaa16ee3[m feat(v0): store v0 users (team ID) in Redis for collection (#1111)
+[33mfa99c62f[m (feat/extract) Improved completions to use model's limits (#1109)
+[33mcf8f7d0c[m Update analyzeSchemaAndPrompt.ts (#1108)
+[33md09e0603[m feat(scrapeUrl/fire-engine): add blockAds flag (FIR-692) (#1106)
+[33m5733b82e[m fix(scrapeURL/fire-engine): default to separate US-generic proxy list if no location is specified (FIR-728) (#1104)
+[33m5c1b6751[m feat(github/ci): run snips tests instead of always-failing tests
+[33m74438a40[m Revert "Revert "feat(v1/map): timeout"" (#1105)
+[33m70562261[m Update source-tracker.ts
+[33m04c6f511[m (feat/extract) Add sources to the extraction (#1101)
+[33m2a0b4081[m chore(go-html-to-md): Update html-to-markdown dependency
+[33m831c6170[m Revert "feat(v1/map): timeout"
+[33m57e98e83[m feat(v1/map): timeout
+[33m17302829[m fix(crawl): relative URL page discovery issues
+[33mb8c4e198[m Fix bad WebSocket URL in CrawlWatcher (#1053)
+[33m6b9e65c4[m (feat/extract) Refactor and Reranker improvements (#1100)
+[33mad06cde4[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mc1a2981d[m default onlyMainContent=false for extract
+[33m9d448d18[m feat(v1): support cyrillic URLs
+[33m8af4e4b8[m fix(html-transformer): preserve title tag
+[33m61d7ba76[m Revert "Nick: extract api reference"
+[33m522c5b35[m Nick: extract api reference
+[33mce3c54d7[m fix(html-transformer.test): add further images
+[33mcf174796[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33md8d159b2[m Nick:
+[33meb22848e[m feat(test/html-transformer): add test for absolute URLs
+[33mf3982c08[m fix: adapt preview team checks
+[33m4d8f4109[m fix(rust): further select fixes
+[33m02caa72f[m Nick: added html-transformer unit tests
+[33m7fdecdc4[m Nick: fixed include tags bug
+[33mdacc5d4f[m fix(rust): improve
+[33m4a1ab6f0[m fix(rust): handle bad tok_1
+[33me8a6c1bb[m fix(rust): avoid panic always
+[33mce2c51f6[m fix(rust): bad comp
+[33ma2d94b52[m feat: rewrite html transformer in rust
+[33m9c40e0cc[m fix(v1): test override for team
+[33mafea2eea[m feat(v1): add insufficient credits stuff
+[33mfa5544ad[m Merge pull request #1090 from mendableai/nsc/new-re-rank
+[33m4747c6f5[m Update build-prompts.ts
+[33mca78739a[m fix(koffi): duplicate type name?
+[33m10133adc[m Update reranker.ts
+[33m2c391b01[m Nick:
+[33mb005450a[m port most of cheerio stuff to rust (#1089)
+[33md547192f[m Nick: fixed spread schemas
+[33m0d9c9f36[m feat(queue-worker): add verbosity for lock extension
+[33mce1fe6f0[m update bullmq
+[33m547c09c5[m Merge pull request #1087 from mendableai/docs/update-cancel-crawl-response
+[33m34e3911a[m docs: update cancel crawl response
+[33m3184e91f[m layers
+[33m64d11654[m rerank with lower threshold + back to map if lenght = 0
+[33m05d79a87[m fix(extract): oops
+[33m4db9a4a6[m fix(extraction-service): allow no multiEntityKeys if isMultiEntity is false
+[33m0dddf4c0[m fix(v1/extract): add job with explicit id
+[33m3f9b8a0b[m Merge pull request #1084 from mendableai/added-today-to-extract-prompts
+[33mf1cd891a[m added today to extract prompts
+[33ma1efe33c[m fix(scrapeQueue): change expiry to 1 hour
+[33ma7b56ab8[m feat(crawl-status): same for v0
+[33m95ce3c3b[m feat(crawl-status): allow for jobs to expire out of the redis
+[33m6f696d32[m feat(extract): add log on 0 links
+[33m5d56627b[m feat(extraction-service): highlight req schema generation
+[33m9da51a75[m feat(extract): add original schema to logs
+[33m561f0186[m fix build error
+[33m65573651[m feat(sitemap): change sitemap logging
+[33md3518e85[m feat(extract): add logging
+[33m434a435a[m fix(sitemap): increase limit to 20
+[33m1e28ba29[m fix(sitemap): increase limit
+[33mbee2b287[m fix(sitemap): better ordering
+[33m3761eb17[m feat(sitemap): reenable fallback to tlsclient
+[33m72198123[m fix(crawler): move sitemap deduplication to deeper in the process
+[33maa2c3690[m feat(sitemap): propagate crawlid
+[33ma922aac8[m fix(crawler): dumb sitemap limit
+[33m51a0e233[m fix(sitemap): temporarily disable tlsclient
+[33md1622477[m Update cache.ts
+[33mccb74a2b[m Nick: increased timeouts on extract + reduced extract redis usage
+[33m498558d3[m Nick: formatting done
+[33m994e1eb5[m Nick: rm logs
+[33m56f048ae[m Reapply "Nick:"
+[33m4b4385c5[m Revert "Nick:"
+[33me1ef826a[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m6718ce89[m Nick:
+[33m208bd4ca[m fix(extraction-service): marginally improve logging
+[33med929221[m feat(sitemap): switch around engine order
+[33m5a039e7b[m fix(v1/map): add wrapper around tryGetSitemap
+[33m5aad21b3[m Update extract.ts
+[33m669c694b[m R1 Crawler
+[33m04916f17[m Nick: bug fixes + acuc fixes + cache fixes
+[33m3604f2a3[m Nick: misc improvements
+[33mac0d10c4[m Nick: sitemap fetch only below threshold for /map
+[33mc7b21916[m Nick: fixed crawl maps index dedup
+[33m720a4291[m Nick: temp fix
+[33m2b9f63cf[m Nick: more permissive re-ranker
+[33mdcbe0b31[m fix(v1/crawl-status-ws): wait to send catchup before closing
+[33m16af54cf[m Nick: bump sdks
+[33mef69b1ac[m Nick: allowExternalLinks is now enableWebSearch
+[33ma5d379c9[m Update package.json
+[33m1aa3c0ab[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m5030fea6[m Update document-scraper.ts
+[33m9ad263da[m fix(js-sdk): typo
+[33m2d4f4de0[m fix(credit_billing): logs
+[33mae0d705f[m fix(v0/crawl): force kickoff
+[33m2cf7a4f5[m fix(batch-scrape): auto finish "kickoff" (no kickoff)
+[33mdad4a975[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mf385b250[m Update html-to-markdown.ts
+[33m60494882[m Update README.md
+[33m240e4e47[m Update auth.ts
+[33m1ca50e6e[m Update llmExtract.ts
+[33md7869496[m Reapply "Merge pull request #1068 from mendableai/nsc/llm-usage-extract"
+[33m8b17af40[m Revert "Merge pull request #1068 from mendableai/nsc/llm-usage-extract"
+[33m406f28c0[m Merge pull request #1068 from mendableai/nsc/llm-usage-extract
+[33m02dea238[m Update auth.ts
+[33m34ad9ec2[m Merge pull request #1073 from mendableai/nsc/index-queue
+[33m6637dce6[m fix: status
+[33me4b45e9e[m Update auth.ts
+[33mbaa2f947[m Update crawl-maps-index.ts
+[33m92b8d97b[m Nick:
+[33m513f61a2[m Nick: map improvements
+[33mc19af6ef[m Update map.ts
+[33m2e5785d8[m Nick: fetch sitemap timeout param
+[33m24ddcd4a[m Update check-fire-engine.ts
+[33m382476cb[m Nick: auth extract
+[33m81c347f5[m Update llmExtract.ts
+[33m64607f3f[m Update extraction-service.ts
+[33mb8a30a50[m Update llm-cost.ts
+[33m4e8e5872[m Update index.ts
+[33m0ec52613[m Nick:
+[33m88904a5c[m Nick: js-sdk 1.15.4
+[33ma7178c0c[m Nick: patch js-sdk
+[33m56776da2[m Nick: json output to new format
+[33m092da888[m Merge branch 'nsc/json-format'
+[33mf9d99ac6[m Nick: fixed type on js sdk
+[33m9109e78e[m Merge pull request #1072 from mendableai/nsc/json-format
+[33m5d62e826[m Nick:
+[33mb030a1c5[m Nick: extract to json in the sdks as well
+[33m34b40f6a[m Nick:
+[33m6383bf27[m Fix python sdk for extract
+[33m3363b2d6[m Make prompt not required for extract on python sdk
+[33m9cd48d7f[m Nick:
+[33m260a726f[m Merge branch 'main' into nsc/llm-usage-extract
+[33m6e3ceccb[m Nick: fixed billing and acuc cache
+[33m1f6abf95[m Nick: extract billing works
+[33m146dc479[m feat(sdk): check crawl/batch scrape errors
+[33mdbc6d078[m fix(queue-worker): bring done add to earlier
+[33m13abb2bc[m fix(crawl-redis/finishCrawl): increase logging to hunt down race condition
+[33m078c0679[m fix(crawl-status): improve finished checking
+[33me6531278[m feat(v1): crawl/batch scrape errors route
+[33mdcd3d6d9[m fix(kickoff): mark as finished if it errors out
+[33m5992c571[m fix(crawler): bad urls from sitemap
+[33m237d0dc1[m fix(requests.http): map
+[33m805bfa45[m fix(python-sdk): add JSON parse error reporting clarity
+[33md5929af0[m fix(queue-worker/kickoff): make crawls wait for kickoff to finish (matters on big sitemapped sites)
+[33m23bb1725[m fix(crawler): recognize sitemaps in robots.txt
+[33mfaf58dfc[m fix(removeUnwantedElements): post-includeTags excludeTags
+[33mde08b374[m feat: adjust CI testing
+[33m4a947e38[m fix(queue-worker): fill out time taken on failure too
+[33m8e57fdec[m Update package.json
+[33m80e5acf6[m Nick: error details for extract
+[33m6c94db7e[m fix(html,markdown): always get absolute links
+[33me824303d[m feat(html): always pick largest image from srcset
+[33m655753cd[m fix(url): allow domains with ports
+[33mca14c651[m Update model-prices.ts
+[33m4db02328[m Nick: introduce llm-usage cost analysis
+[33mde14c0a4[m Update package.json
+[33mc3937996[m feat(js-sdk): add further options to checkxstatus
+[33mcbe67d89[m feat(queue-worker): proactive job cancel
+[33mec039dcb[m fix(blocklist): unblock
+[33mdde3aeba[m fix(v1/crawl-status): fix stuck on 0 jobs
+[33mce2f6ff8[m fix(queue-worker/billing): fix crawl overbilling
+[33mdb89e365[m Update check-fire-engine.ts
+[33m957eea41[m Nick: extract without a schema should work as expected
+[33m61e6af2b[m Nick: streaming callback experimental
+[33m23d3257a[m Merge branch 'nsc/__experimental_streamSteps'
+[33mc323c646[m Update extract-redis.ts
+[33m2dc87a2e[m Update extraction-service.ts
+[33m0496b793[m Merge pull request #1063 from mendableai/nsc/__experimental_streamSteps
+[33m033e9bbf[m Nick: __experimental_streamSteps
+[33m558a7f4c[m Update package.json
+[33m9759f187[m Nick: temp file fixes
+[33mac6650e4[m Update requests.http
+[33m5e5b5ee0[m (feat/extract) New re-ranker + multi entity extraction (#1061)
+[33m5c62bb11[m  feat: new snips test framework (FIR-414) (#1033)
+[33m9a13c1de[m Nick: fixes to extract rephrase prompt
+[33ma82160a6[m Update crawl-redis.ts
+[33mf4d10c50[m Nick: formatting fixes
+[33md1f3b963[m feat: add scrapeId in document.metadata
+[33m29c1f126[m feat(scrape-status): adapt
+[33m2849ce2f[m fix(queue-worker): errored job logging
+[33m97bf5421[m fix(scrapeURL/loop): re-add is long enough check with lt 0
+[33m0da38691[m fix(queue-worker): graceful shutdown
+[33m3c614a2e[m fix(scrapeURL/engines/pdf,docx): support authorization
+[33m49e584f8[m fix(queue-worker/crawl): use SCARD to generate num_docs field
+[33m9e8c629f[m fix(log_job): don't redact with auth header
+[33m14f69680[m Update auth.ts
+[33m51cb4b16[m Nick: temp rl for /extract
+[33ma199208e[m Update rate-limiter.ts
+[33maa31508c[m Nick: links-billed update (temp)
+[33m363021ea[m feat(crawl): ensure url trimming
+[33m977a3e13[m fix(scrapeURL): remove short content check
+[33m0a41fdd3[m Merge branch 'nsc/extract-queue'
+[33m7918d0e1[m Nick: bump 1.12.0
+[33mf82a742c[m Merge pull request #1044 from mendableai/nsc/extract-queue
+[33mb98e289f[m Nick:
+[33ma185c05a[m Nick: sdk async and get status
+[33m9ec08d70[m Nick: fixed the sdks
+[33mdd147448[m Update types.ts
+[33m9fdcfb93[m Update index.ts
+[33m51636352[m Merge branch 'nsc/extract-queue' of https://github.com/mendableai/firecrawl into nsc/extract-queue
+[33m11af214d[m Nick: update extract in case there is an error
+[33m1f2a76fc[m Update apps/api/src/lib/extract/extraction-service.ts
+[33meb254547[m Nick:
+[33mc6a63793[m crawl incomplete issues
+[33mccfada98[m various queue fixes
+[33m86e34d7c[m Nick: wip
+[33m7a032755[m add comment
+[33m7d73ebdb[m fix(crawl): never invalidate first crawl scrape if redirects
+[33mb96b97ed[m fix(crawl): don't push rawhtml to db unless requested
+[33m35d1d859[m fix(crawler): also take the hostname of the base url when determining isInternalLink
+[33mbb275944[m Merge branch 'main' into nsc/extract-queue
+[33mb82cfa85[m Merge pull request #1038 from 1101-1/add_actual_random_useragent
+[33m736c3675[m use new agent generation instead of expired one
+[33mceb21049[m Merge pull request #1034 from mendableai/sdk/fixed-none-undefined-on-response
+[33m461842fe[m fix(v1/crawl-status): handle job's returnvalue being explicitly null (db race)
+[33mb92a4eb7[m fix(queue-worker): only do redirect handling logic on crawls, not batch scrape
+[33md48ddb88[m Update canonical-url.test.ts
+[33mf2e0bfbf[m Nick: url normalization
+[33mf25c0c6d[m Nick: added canonical tests
+[33maef040b4[m Nick: from cache fixes
+[33me8a9d8dd[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m05e845a9[m Update cache.ts
+[33m6bfdbcdb[m Merge pull request #1037 from mendableai/nsc/semantic-index-extract
+[33mc655c685[m Nick: fixed
+[33ma4f7c388[m Nick: fixed
+[33m8df1c679[m Update queue-worker.ts
+[33m499479c8[m Update url-processor.ts
+[33m432b4106[m Update queue-worker.ts
+[33m6b2e1cbb[m Nick: cache /extract scrapes
+[33m27457ed5[m Nick: init
+[33m81cf0588[m Merge branch 'main' into nsc/semantic-index-extract
+[33ma54a5dbb[m removed warnings
+[33m12cd9f08[m removed warnings
+[33mb223f6ae[m Merge branch 'sdk/fixed-none-undefined-on-response' of https://github.com/mendableai/firecrawl into sdk/fixed-none-undefined-on-response
+[33m55dad5ea[m fixed empty data with next causing infinite loop
+[33m2e53eb98[m Merge branch 'main' into sdk/fixed-none-undefined-on-response
+[33mbafcc008[m [SDK] fixed none and undefined on response
+[33m87757d9b[m Nick: fixed schemas on extract for node
+[33mad49503f[m Update search.ts
+[33mcbe07164[m Update search.ts
+[33me37ab843[m Update search.ts
+[33m8b64e915[m Update search.ts
+[33m7ce780ac[m Update search.ts
+[33mb244afbc[m Update README.md
+[33ma4b6dfec[m Nick: v1.8.0 - added /v1/search support
+[33mb61a1ccf[m Merge pull request #1032 from mendableai/nsc/v1-search
+[33m21bf89b6[m Update search.ts
+[33m22ae1730[m Update search.ts
+[33ma0dbf20c[m Update types.ts
+[33m25da20ef[m Nick: e2e
+[33meae393af[m Nick: fixed js sdk
+[33m07a6ba5d[m Nick:
+[33m35d72028[m Update search.ts
+[33md2742bec[m Nick: v1 search
+[33mef0fc8d0[m broader search if didnt find results
+[33mc9d91af8[m Merge branch 'main' into nsc/semantic-index-extract
+[33mc822e34d[m Nick: fixed extract schema
+[33mc3fd13a8[m Nick: fixed re-ranker and enabled url cache of 2hrs
+[33m07f4b714[m Update removeUnwantedElements.ts
+[33m33632d2f[m Update extraction-service.ts
+[33m27cc3dba[m Nick: rm vscode settings
+[33mbd81b41d[m Update queue-worker.ts
+[33me6da214a[m Nick: async background index
+[33m7a31306b[m Nick: url normalization + max metadata size
+[33mbf9d41d0[m Nick: index exploration
+[33m0847a603[m Merge pull request #1014 from mendableai/nsc/extract-url-trace
+[33m71a8f745[m fix(WebScraper/sitemap): await urlsHandler to fix race condition
+[33m8ae34a0d[m Nick: rm .xml from isFile
+[33m9005757d[m fix(queue-worker): do not follow redirect URLs if they are not allowed by the crawl options
+[33m4d1f92f4[m fix(scrapeURL/fetch): block loopback and link-local IPs
+[33me2553010[m Update index.ts
+[33mc1fa5a44[m Merge pull request #1016 from mendableai/mog/mineru
+[33m1eca61bf[m Update index.ts
+[33mf9d55efb[m Update index.ts
+[33mb8d7f9f2[m Nick: we are using runpod
+[33m5fcf3fa9[m Merge branch 'main' into mog/mineru
+[33ma431cafa[m Merge pull request #991 from RutamBhagat/rust-sdk-conditionally-enforce-api-key
+[33m65cf4cd7[m Merge pull request #1013 from yujunhui/main
+[33m05d5f84d[m Merge pull request #1018 from mendableai/feat/add-favicon-metadata
+[33meba5fda9[m Merge pull request #955 from mendableai/rafa/fix-default-on-schema-llm-extract
+[33ma4cf814f[m feat: return favicon url when scraping
+[33m0421f810[m Sitemap fixes (#1010)
+[33m6851281b[m Update __init__.py
+[33mcd08be7f[m Merge pull request #990 from RutamBhagat/python-sdk-conditionally-enforce-api-key
+[33mc5b6495e[m Merge pull request #1015 from mendableai/nsc/improves-sitemap-fetching
+[33m2ea0e9a2[m Merge pull request #1003 from RutamBhagat/credit-usage-api-docs
+[33me8f0a22e[m Update v1-openapi.json
+[33mf7cfbba6[m Merge branch 'main' into pr/1003
+[33m1abb544e[m Update index.test.ts
+[33m47729513[m feat(scrapeURL/fire-engine): explicitly delete job after scrape
+[33m0b55fb83[m feat(scrapeURL/pdf): switch to MinerU
+[33mece95e97[m Merge branch 'main' into nsc/extract-url-trace
+[33mc543f4f7[m feat(scrapeURL/pdf): update mock Blob implementation to pass TypeScript
+[33mf15ef0e7[m feat(scrapeURL/fire-engine/chrome-cdp): handle file downloads
+[33m4451c4f6[m Nick:
+[33m37f258b7[m Merge pull request #974 from mendableai/fix-sdk/next-in-when-502
+[33mbcc18e1c[m Merge branch 'main' into fix-sdk/next-in-when-502
+[33m4f65d350[m Update package.json
+[33m4332f18a[m Nick: making it optional for the user
+[33m233f347f[m Nick: refactor
+[33mf467a3ae[m Nick: init
+[33m2f39bddd[m fix: merge mock success data
+[33mc911aad2[m Update package.json
+[33mb1a5625b[m Revert "Merge pull request #997 from mendableai/feat/sdk-without-ws"
+[33m18ceaf10[m Update .gitignore
+[33m53cda5f8[m Merge pull request #997 from mendableai/feat/sdk-without-ws
+[33m0c1c4f2e[m Merge branch 'main' into feat/sdk-without-ws
+[33m51f79b55[m Merge pull request #1005 from RutamBhagat/contributing-md-docker-compose
+[33m67c643ad[m Merge pull request #989 from RutamBhagat/js-sdk-conditionally-enforce-api-key
+[33m7366f36e[m docs(CONTRIBUTING.md): Add Docker Compose setup instructions to CONTRIBUTING.md
+[33mca2d3dc6[m docs(credit-usage-api): add new endpoint documentation for credit usage
+[33m199bd2d1[m Merge branch 'main' into feat/sdk-without-ws
+[33ma9d31c8e[m Merge branch 'main' into feat/sdk-without-ws
+[33mf043f5fd[m Enhance error handling in E2E tests and introduce CrawlWatcher tests
+[33m818f5544[m Merge pull request #1001 from mendableai/nsc/block-list-string
+[33md1f3e26f[m Nick: blocklist string
+[33m8e947344[m Merge pull request #999 from mendableai/nsc/credit-usage-endpoint
+[33mba95df96[m Update rate-limiter.ts
+[33m62221522[m Nick: credit usage endpoint
+[33m58b80649[m Merge pull request #998 from mendableai/feat-sdk/try-catch-message-handler
+[33m63bbeadb[m Added try catch to message handler
+[33mf47e3114[m feat(rust-sdk): improve API key handling for cloud vs self-hosted services in FirecrawlApp
+[33m2b488cac[m chore: remove pytest dependency from pyproject.toml
+[33m3e60f175[m Nick: prompt should be optional on /extract sdks
+[33m8063474c[m Update __init__.py
+[33m525a71d7[m Update __init__.py
+[33m4fddc86e[m Update package.json
+[33md67db997[m Merge pull request #994 from mendableai/feat/added-id-to-ws-sdks
+[33med24853c[m Merge pull request #996 from mendableai/fix/title-extra-info
+[33mc8cd0148[m refactor: remove error logging for 'isows' module import in WebSocket initialization
+[33m071b9a01[m fix(scrapeURL/fire-engine): pass geolocation
+[33m6002bf32[m feat: dynamically import WebSocket module with error handling
+[33mcf2ec771[m fixed title extra info
+[33m066071cd[m Update llmExtract.ts
+[33m05605112[m Update extract.ts
+[33m2d37dca9[m Nick: introduced system prompt to /extract
+[33m75984b45[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33ma759a7ab[m Nick: small improvements
+[33m94267ff4[m Create o1_web_extractor.py
+[33m19246f62[m feat-SDK/added crawl id to ws
+[33me899ecbe[m Update llmExtract.ts
+[33me776847c[m feat(js-sdk): improve API key handling for cloud vs self-hosted services in FirecrawlApp
+[33m29cea4c5[m feat(python-sdk): improve API key handling for cloud vs self-hosted services in FirecrawlApp
+[33mbd36c441[m feat(queue-worker): improve team-based logging
+[33m780442d7[m feat: improve billing logging
+[33mac187452[m Nick: better filtering for urls that should be scraped
+[33m3b6edef9[m chore: formatting
+[33mb9f621be[m Nick: extract fixes
+[33m79e33563[m Nick: fixed extract issues
+[33m6d77879d[m Update extract.ts
+[33me26a0a65[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m0f8b8a71[m Update map.ts
+[33m4ad6665d[m Merge pull request #987 from mendableai/default-to-pdf-parse
+[33ma20a003c[m revert to pdf parse
+[33mdb8e9c36[m Merge pull request #984 from mendableai/default-to-pdf-parse
+[33m194353af[m Remove pdf parse
+[33m1402831a[m Replace pdf parse with pdf to md
+[33med7d15d2[m Update index.ts
+[33m654d6c6e[m fix(scrapeURL): increase timeToRun
+[33m47b968fe[m fix(scrapeURL/fire-engine): timeout calculation issues
+[33m7f57c868[m Revert "fix(scrapeURL): better timeToRun distribution"
+[33m284a6cce[m fix(scrapeURL): better timeToRun distribution
+[33m0013bdfc[m feat(v1/scrape): add more context to timeout logs
+[33m139e2c9a[m fix(runWebScraper): proper error handling
+[33m2c233bd3[m Update requests.http
+[33md8150c61[m added type to reqs example
+[33mb6802bc4[m merged with main
+[33m8192d756[m Merge branch 'main' into rafa/fix-default-on-schema-llm-extract
+[33meab30c47[m added unit tests
+[33m2de659d8[m fix(queue-jobs): fix concurrency limit
+[33m72d6a817[m fix(rate-limiter): raise crawlStatus limits
+[33me97ee4a4[m fix(WebScraper/tryGetSitemap): deduplicate sitemap links list
+[33m37f58efe[m fix(crawl-redis/lockURL): only add to visited_unique if lock succeeds
+[33m30fa78cd[m feat(queue-worker): fix redirect slipping
+[33m126b46ee[m Update issue_credits.ts
+[33m1214d219[m Nick: fix actions errors
+[33m20f89c34[m Merge pull request #978 from mendableai/nsc/timeout-fixes
+[33m0f3a27bf[m fix(scrapeURL/engines): better timeouts
+[33ma5256827[m Update index.ts
+[33m98f27b0a[m fix(crawl-redis/addCrawlJobDone): further ensure that completed doesn't go over total
+[33mb4a5e1a6[m fix(scrapeURL/fire-engine): timeout handling
+[33mafbd0129[m fix(scrapeURL/fire-engine): timeouts
+[33m5e267f92[m fix: adjust Playwright service response to match API schema expectations
+[33m842b522b[m feat: add scrapeOptions.fastMode
+[33m588f747e[m chore: formatting
+[33m4987880b[m Nick: random fixes
+[33m664ba69f[m Nick: f-eng monitoring test
+[33mc325c3aa[m Nick: node sdk patch
+[33mccbae4b1[m Update auth.ts
+[33m9cc65765[m feat(js-sdk/batch/scrape): add ignoreInvalidURLs option
+[33m4b5014d7[m feat(v1/batch/scrape): add ignoreInvalidURLs option
+[33me74e4bce[m feat(runWebScraper): retry a scrape max 3 times in a crawl if the status code is failure
+[33mbdbc05a4[m added check for object and trycatch as workaround for 502s
+[33m6b17a53d[m Update package.json
+[33m13afe4c7[m Update index.ts
+[33m6b41916e[m Merge pull request #971 from mendableai/Hash-Urls
+[33m98caf928[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m3b0d192d[m Update types.ts
+[33ma2998d44[m Hash Urls
+[33me06647b4[m Move full app examples to other repo
+[33m4c9e9836[m Merge pull request #970 from mendableai/nsc/webhooks-custom-metadata
+[33me22a0b59[m Nick: custom metadata
+[33m1d1a936f[m Merge pull request #954 from mendableai/rafa/fix-schema-base-model-extract
+[33mde57e7f4[m Nick: from dependencies to dev-dependencies
+[33m90f37335[m Merge pull request #965 from mendableai/nsc/fixed-prettier-formatting
+[33m8a1c4049[m Nick: revert trailing comma
+[33m52f2e733[m Nick: fixes
+[33m00335e2b[m Nick: fixed prettier
+[33me5fe9e15[m Create .env.example
+[33mf877fbfb[m fix(WebCrawler/isFile): add .wav
+[33md276a23d[m fix(scrapeURL/pdf): handle if a presumed PDF link returns HTML (e.g. 404)
+[33md9e017e5[m feat(queue-worker/crawl): solidify redirect behaviour
+[33mce460a3a[m fix(v1/crawl/status): completed more than total if some scrape jobs fail or are discarded
+[33mecad7697[m feat(scrapeURL/pdf): extend amount of time we're willing to wait for PDFs in crawl/batch scrape mode
+[33m85cbfbb5[m fix(crawl): disable smart wait
+[33m5d90a6c1[m Merge pull request #946 from BexTuychiev/price-tracker
+[33m2d35a52e[m Merge pull request #958 from mendableai/remove-microsoft
+[33m468b8cde[m removing microsoft from blocklist
+[33m877f072e[m feat: crawl log parser (poc)
+[33m4dbe0e62[m Update requests.http
+[33ma47e278c[m Nick: bump node sdk
+[33m5c81ea18[m fixed optional+default bug on llm schema
+[33m91a1a9a1[m fix(crawl-redis/lockURL): reduce logging
+[33m6776aee1[m feat(auth): extend rate limiter logging to make it easier to debug
+[33mfe6b003f[m fix(js-sdk/batchScrapeUrls): zod support
+[33mff878bc6[m bump version
+[33md8847bb4[m fixes schema warning
+[33ma093d55e[m Add assets for GitHub actions tutorialc
+[33mf007f243[m Update email_notification.ts
+[33m57ef4004[m Add README to auotmated price tracking project
+[33m4fc94aba[m Add a link to the assets directory that will work once the PR is merged
+[33m742c3df6[m Add assets for the Automated Amazon Price Tracking article
+[33m4d287bb7[m Nick: moving acuc temp to read replica
+[33m934363b4[m feat(queue-worker): add better logging for worker
+[33mf82b9c20[m fix(crawl-redis): oops
+[33m845c2744[m feat(app): add extra crawl logging (app-side only for now)
+[33mcce94289[m fix(v1/batch/scrape): horrid memory usage
+[33mf8e619b5[m fix(crawl-status): returnvalue filtering on active jobs
+[33m35d9d8e8[m Merge pull request #944 from BexTuychiev/scheduling_deploying_scrapers
+[33m5b7bd571[m Add assets for a new 'Deploying web scrapers' article
+[33mc5d75bef[m Add assets for a new 'Scheduling web scrapers' article
+[33m41d85920[m feat(v1/batch/scrape): appendToId
+[33m7bde0340[m auth: log team id
+[33m64546f12[m Update types.ts
+[33mf7207f91[m Nick: temp e-s-1
+[33m6b1f30e0[m fix(scrapeURL/removeUnwantedElements): try to fix onlyMainContent for poorly structured sites
+[33m88a16b18[m fix(crawl-status): ts error
+[33md8613899[m fix(crawl-status): handle failed jobs (oops)
+[33m712a1384[m fix(crawl-status): hard error bug
+[33m51a6b83f[m Nick: fixed the crawl + n - not respecting limit
+[33m39ff49a8[m Nick: reverted redirect fix
+[33mda96acdb[m Merge pull request #943 from mendableai/fix/key-error-data
+[33m7e9ad3cb[m fixed keyerror for data on sdk
+[33m4d2f4aad[m Update index.ts
+[33mf3aa3286[m Revert "Merge branch 'nsc/crawl-n--1-fixes'"
+[33m6d325b7c[m Merge branch 'nsc/crawl-n--1-fixes'
+[33m64800a1c[m Nick: rm fe for test
+[33m3d5704b7[m Merge pull request #941 from mendableai/nsc/crawl-n--1-fixes
+[33m43530b3b[m Nick: fixed n-1 w/ Rafa
+[33ma5eaa60e[m Merge pull request #940 from mendableai/nsc/crawl-fixes-not-respecting-limit
+[33m52806807[m Nick: crawl fixes
+[33m1477ab23[m Nick: log clear ACUC cache
+[33m99094418[m Nick: e2e tests for no schema extract
+[33meb2e51e5[m Nick: fixed /extract without a schema
+[33me485ea7e[m Merge pull request #939 from mendableai/fix/next-check-py-sdk
+[33m781adc21[m fixes while next loop
+[33m4bb46ed1[m Nick: extract prompt fixes and limit the number of urls
+[33m5ddb7eb9[m parameter
+[33m2988a56e[m Merge pull request #928 from BexTuychiev/hacker-news-scraper
+[33m42980c89[m fix(scrapeURL/fire-engine): fast fail on chrome error
+[33m137726ca[m feature: Add a log message for every file saved
+[33md777633b[m Add a new project to examples that shows how to scrape Hacker News website
+[33m60ea97c5[m fix(log_job): infinite loop
+[33m943bbae8[m fixed nested data inside extract
+[33m53e0cb6b[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m02cd5bcf[m Nick: bumped the status rl
+[33mb69c6f9f[m added library.tiktok to allowedKeywords
+[33mea1d3d70[m Nick: fix extract python sdk
+[33mdbda659e[m Nick: bump 1.9.1
+[33mbc0d66e9[m Nick: fixed extract types on node sdk
+[33m6c33b978[m Merge pull request #915 from mendableai/nsc/new-extract
+[33m5522d6af[m Update extract.ts
+[33md3a9d292[m return bug
+[33me2179524[m fix(crawl): finish crawl even if last one fails
+[33mf395c5b0[m fix(crawl): failed behaviour
+[33ma9a37398[m Merge pull request #918 from BexTuychiev/map-endpoint
+[33m8a26f08b[m Update extract.ts
+[33m2513efc9[m Update extract.ts
+[33ma18614cd[m Update queue-jobs.ts
+[33m18b864ea[m Update index.ts
+[33md817aa74[m Update v1.ts
+[33m30def84c[m Nick: scrape timeout + warnings
+[33mb693c6c2[m Update extract.ts
+[33m95bea6a3[m Nick: re-ranker safety + unit tests
+[33mc0fd2560[m Add notebook and markdown files for two articles: mastering /scrape and mastering /map
+[33mce6d3e21[m Update README.md
+[33m24724e95[m added new etier
+[33maa26dbe7[m Nick: map e2e tests
+[33m6fbfeafe[m Nick: fixed map settings
+[33maaddbdc1[m Update map.ts
+[33m5f4c8da1[m Update pnpm-lock.yaml
+[33m42922c68[m Update package.json
+[33m93e106d3[m Update v0.ts
+[33m3eaa3b38[m Nick: formatting
+[33mc78dae17[m Merge branch 'main' into nsc/new-extract
+[33m945183ff[m Update extract.ts
+[33md196b9d9[m Update extract.ts
+[33m9512d81e[m Update extract.ts
+[33m3de4997f[m Loggin num tokens
+[33m769f08c1[m Billing and log for extract
+[33m0e4e9a3b[m Nick:
+[33m09dd5136[m Update build-document.ts
+[33m67a29898[m Nick: fixes
+[33m98894641[m Update package.json
+[33m7b610354[m Merge pull request #914 from ad-angelo/node-mobile-support
+[33mc873ee46[m Update index.ts
+[33m28696da6[m Nick: gpt-4o
+[33m4248c68f[m Add Mobile Scraping
+[33md49f62fb[m Nick: extract fixes
+[33mb1eaecfd[m fix 2
+[33me2ddc6c6[m fix handling of badly formatted URLs
+[33mba6f29cd[m crawl fix, again
+[33mb468bb40[m crawl fixes
+[33mc9b0a805[m Nick:
+[33m103c3f28[m Update rate-limiter.ts
+[33md02a8bcb[m Nick: extract urls to extract
+[33maa01c0b6[m Create mastering-the-crawl-endpoint.ipynb
+[33m79a75e08[m feat(crawl): allowSubdomain
+[33m2fb8a3c8[m fix schema
+[33m53134b7c[m Rafa: removed throw error and added map to requests
+[33m36cf49c9[m Merge remote-tracking branch 'origin/main' into nsc/new-extract
+[33m91caa01c[m Update CONTRIBUTING.md
+[33m1328ae0f[m Update README.md
+[33ma3133675[m Create README.md
+[33m77e152cb[m added team_id to scrape-status endpoint
+[33m31a0471b[m fix(crawl-redis): ordered push to wrong side of list
+[33m1a0f13c0[m fix(webhook): add logging
+[33m1b032b05[m fix(map): make sitemapOnly simpler
+[33ma4d3dba8[m fix(map): ignore limit when using sitemapOnly
+[33m63787bc5[m fix(scrapeURL/fire-engine): wait longer if timeout is not specified
+[33m4cddcd52[m fix(scrapeURL/fire-engine): timeout-less scrape support (initial)
+[33m350d00d2[m fix(crawler): treat XML files as sitemaps (temporarily)
+[33mca2e33db[m fix(log_job): add force option to retry on supabase failure
+[33m7b02c45d[m fix(v1/types): better timeout primitives
+[33mc95a4a26[m fix(v1/batch/scrape): raise default timeout
+[33m3a342bfb[m fix(scrapeURL/playwright): JSON body fix
+[33m3c1b1909[m Update map.ts
+[33m95198971[m Merge branch 'nsc/sitemap-only'
+[33m7f084c6c[m Nick:
+[33me8bd089c[m Merge pull request #901 from mendableai/nsc/sitemap-only
+[33m3fcdf57d[m Update fireEngine.ts
+[33md62f12c9[m Nick: moved away from axios
+[33mf1554494[m Nick: sitemap only
+[33m431e64e7[m fix(batch/scrape/webhook): add batch_scrape.started
+[33m7bca4486[m Update package.json
+[33mdf05124e[m feat(v1/batch/scrape): webhooks
+[33m91f4fd81[m Update extract.ts
+[33m22848af5[m Nick:
+[33mebe9de2a[m Nick:
+[33m5056dcd8[m Update index.test.ts
+[33mbe5e6da5[m tests
+[33m45091430[m Merge branch 'nsc/new-extract' of https://github.com/mendableai/firecrawl into nsc/new-extract
+[33m796cd074[m Update extract.ts
+[33m1b5f6a09[m Update extract.ts
+[33md6749c21[m Nick: refactor and /* glob pattern support
+[33m41b45a84[m sdk allowexternallinks
+[33m3d6d650f[m Merge branch 'nsc/new-extract' of https://github.com/mendableai/firecrawl into nsc/new-extract
+[33m80d6cb16[m sdks wip
+[33m359c30fb[m fix(cache): don't cache on failure error code
+[33m49ff37af[m feat: cache
+[33m86a78a03[m fix(sitemap): scrape with tlsclient
+[33m62c8b63b[m Create README.md
+[33m5519f077[m fix(scrapeURL): adjust error message for clarity
+[33m0a1c9907[m fix(html-to-markdown): make error reporting less intrusive
+[33mbd928b15[m Nick: changed email from hello to help
+[33ma1c018fd[m Merge branch 'main' into nsc/new-extract
+[33m904c9049[m wip
+[33m0310cd2a[m fix(crawl): redirect rebase
+[33m0d1c4e4e[m Update package.json
+[33m32be2cf7[m feat(v1/webhook): complex webhook object w/ headers (#899)
+[33mea130296[m Merge pull request #895 from mendableai/nsc/redlock-email
+[33m25f32000[m mvp done?
+[33ma175c151[m wip
+[33m1a636b4e[m Update email_notification.ts
+[33m5ce4aaf0[m fix(crawl): initialURL setting is unnecessary
+[33m93ac20f9[m fix(queue-worker): do not kill crawl on one-page error
+[33m16e85028[m fix(scrapeURL/pdf,docx): ignore SSL when downloading PDF
+[33m807703d9[m wip
+[33m7081beff[m fix(scrapeURL/pdf): retry
+[33m9ace2ad0[m fix(scrapeURL/pdf): fix llamaparse upload
+[33m687ea696[m fix(requests.http): default to localhost baseUrl
+[33m3a5eee6e[m feat: improve requests.http using format features
+[33mf2ecf0cc[m fix(v0): crawl timeout errors
+[33m464b41a5[m Merge branch 'main' into nsc/new-extract
+[33ma23364e5[m Update extract.ts
+[33ma4f15260[m Nick:
+[33mfbabc779[m fix(crawler): relative URL handling on non-start pages (#893)
+[33md430cfcb[m Update extract.ts
+[33m5bbbb52a[m Update fireEngine.ts
+[33m740a4297[m feat(api): graceful shutdown for less 502 errors
+[33m540d4e5b[m Nick:
+[33mc327d688[m fix(queue-worker): don't log timeouts
+[33m9f8b8c19[m feat(scrapeURL): log URL for easy searching
+[33me95b6656[m fix(scrapeURL): don't log fetch request
+[33mf42740a1[m fix(scrapeURL): don't log engineResult
+[33m3815d246[m fix(scrape): better timeout handling
+[33maa9a47bc[m fix(queue-worker): logging job on batch scrape error
+[33m91f52287[m feat(batchScrape): handle timeout
+[33mf6db9f14[m fix(crawl-redis): batch scrape lockURL
+[33md8bb1f68[m fix(tests): maxDepth tests
+[33m68c9615f[m fix(crawl/maxDepth): fix maxDepth behaviour
+[33m7d576d13[m Update package.json
+[33ma8dc75f7[m feat(crawl): add parameter to treat differing query parameters as different URLs (#892)
+[33m5cb46dc4[m fix(html-to-markdown): build error
+[33m2ca22659[m fix(scrapeURL/llmExtract): fix schema-less LLM extract
+[33m56bebc81[m fix(html-to-markdown): reduce logging frequency
+[33md13a2e7d[m fix(scrapeURL): reduce logs
+[33m219f4732[m Merge pull request #881 from mendableai/fix/scroll-action
+[33mddbf3e45[m Update package.json
+[33m76637762[m Merge pull request #880 from mendableai/python-sdk/next-handler
+[33m9688bad6[m Update __init__.py
+[33m56a1ac07[m Merge pull request #878 from mendableai/mog/deduplicate-urls
+[33m8e4e49e4[m feat(generateURLPermutations): add tests
+[33me241871b[m fixed scroll action on js sdk
+[33mf097cddf[m feat(scrapeURL/fire-engine): adjust timeout for waitFor/wait actions
+[33me97864b8[m fix(scrapeURL/llmExtract): better schema normalization
+[33m1c55ce41[m feat(ci): add sentry auth token to builds
+[33m49df5537[m fix(scrapeURL, logger): remove buggy ArrayTransport that causes memory leak
+[33m84ad45c0[m Merge pull request #872 from mendableai/nsc/exec-js
+[33m628a98d5[m fix(scrapeURL): only retain ArrayTransport in testing
+[33meac3714c[m fixes scroll action
+[33m085ac3e7[m debug: worker stall check
+[33m27c5a93f[m added next handler for python sdk (js is ok)
+[33mef505f8d[m feat(scrapeURL/fire-engine): adjust timeout tuning
+[33m1acef8e4[m fix: converter missing
+[33mb8a6fb35[m fix(scrapeURL/checkStatus): bad handling of f-e under load
+[33mdc3a4e27[m move param to the right place
+[33m6ecf24b8[m feat(crawl): URL deduplication
+[33m25e94ffd[m fix(scrapeURL): do not submit LLM schema errors to Sentry
+[33ma297c99b[m fix(scrapeURL): error displaying
+[33m79cadcb7[m fix(scrapeURL/llmExtract): fill in required field as well
+[33m0588f340[m fix(scrapeURL/llmExtract): array schema fix
+[33m552d55c8[m fix(scrapeURL): includeTags/excludeTags
+[33m8d467c8c[m `WebScraper` refactor into `scrapeURL` (#714)
+[33m7500ebe4[m Nick: exec js actions
+[33med5a0d3c[m Update readme and examples
+[33m71e512b8[m predicted-outputs
+[33m75b48dce[m Merge pull request #849 from swyxio/patch-1
+[33m56179924[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m3cd1c426[m Update rate-limiter.ts
+[33mae5ba74e[m Merge pull request #869 from mendableai/fix/new-url-on-utils-extract-links
+[33mf07bbef7[m added trycatch and removed redundancy
+[33m2fa25cb9[m [Fix] Prevent Python Firecrawl logger from interfering with loggers in client applications (#613)
+[33m9e22c9a4[m Nick: etier1a
+[33ma5c98234[m haiku example
+[33m12c0aa6b[m Merge pull request #867 from mendableai/fix/remove-base64-images
+[33m8297e5be[m Merge branch 'main' into fix/remove-base64-images
+[33m4c5bb21a[m added remove base64 images options (true by default)
+[33m2eff27ba[m Merge pull request #847 from mendableai/nsc/mobile-support
+[33m45debc99[m Merge pull request #858 from mendableai/nsc/new-actions
+[33m61f65919[m bumped js-sdk version
+[33m28db4dd3[m fixed zod validation for wait
+[33m80beedb4[m Update index.ts
+[33m446acfcc[m Nick: support for the new actions
+[33m3911fe1f[m Fix
+[33m6e5c95d5[m fix bug
+[33m3eb79f12[m Fix dockerfile
+[33mc8b8a761[m Merge pull request #856 from mendableai/feat/iframe-support
+[33mae919ad8[m Fix go parser
+[33m2ae2931b[m Merge pull request #855 from mendableai/feat/iframe-support
+[33m367af951[m added iframe links to extractLinksFromHTML
+[33mfe02101a[m Iframe support
+[33m728d6a16[m Merge branch 'mog/concurrency-limit-2'
+[33m47d276d3[m Update rate-limiter.ts
+[33mf5c58e0c[m Merge pull request #824 from mendableai/mog/concurrency-limit-2
+[33mea85b1d6[m Merge branch 'main' into mog/concurrency-limit-2
+[33m17874e44[m Update CONTRIBUTING.md
+[33m121cd126[m Update CONTRIBUTING.md
+[33m96c579f1[m Nick: etier2c
+[33m0b409d76[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m983f344f[m Create claude_stock_analyzer.py
+[33me0ba339c[m Update auth.ts
+[33m6948ca6f[m Revert "Update auth.ts"
+[33m7152ac88[m Update auth.ts
+[33mc00cd213[m Nick: adds support for mobile web scraping
+[33mc96b36d0[m Merge pull request #830 from mendableai/nsc/geo-to-location
+[33m6d38c654[m Update package.json
+[33m07e76f2b[m Merge branch 'main' into nsc/geo-to-location
+[33mb6ce49e5[m Update index.ts
+[33m3d1bb82a[m Nick: languages support
+[33m0bad4360[m Nick: fixed the batch scrape + llm extract billing
+[33m726430c2[m Nick: llm extract in batch scrape
+[33m298a343a[m Merge pull request #831 from twlite/patch-1
+[33md2d5c0b6[m Merge pull request #838 from mendableai/nsc/rm-wait-before-click
+[33ma13c2442[m Merge pull request #628 from SearchApi/feature/add-searchapi-search
+[33m78badf8f[m Nick: wip
+[33mea0f458b[m Merge pull request #739 from s-smits/main
+[33m19ed0421[m Merge pull request #829 from mendableai/nsc/prevent-single-url-logs
+[33mfa8875d6[m Update single_url.ts
+[33m007e3edf[m Update README.md
+[33me3e8375c[m Add AgentOps Monitoring
+[33mb48eed57[m chore(README.md): use `satisfies` instead of `as` for ts example
+[33m877d5e43[m Update types.ts
+[33m68b2e1b2[m Update log_job.ts
+[33m8a4f4cb9[m Update README.md
+[33m9593ab80[m Update README.md
+[33m801f0f77[m Nick: fix auto charge failing when payment is through Link
+[33m20e5348e[m Merge pull request #809 from mendableai/nsc/pay-as-you-go-lw2
+[33m97b8d6c3[m Update auto_charge.ts
+[33m95c4652f[m Nick: 10min cooldown on auto charge
+[33m4468a49a[m concurrency limit fix PoC II.
+[33m4590577c[m Merge branch 'main' into nsc/pay-as-you-go-lw2
+[33mdbcf2d7f[m Nick: fix loggin for batch scrape
+[33m73e6db45[m Update email_notification.ts
+[33md965f2ce[m Nick: fixes
+[33m29b34270[m Merge branch 'main' into nsc/pay-as-you-go-lw2
+[33m9a4ccd08[m Claude Web Crawler with Batch Scrape
+[33m1da6360b[m feat(batch/scrape): restructure logs, add webhooks
+[33me3cb0099[m Merge branch 'mog/bulk-scrape'
+[33m19cac222[m Nick:
+[33m76ca7fdc[m Merge pull request #789 from mendableai/mog/bulk-scrape
+[33mb1103581[m Nick:
+[33mf0054da9[m Nick: lgtm
+[33mc7f21709[m Update example.py
+[33m60b6e6b1[m Nick: fixes
+[33md8abd157[m Nick: from bulk to batch
+[33m70c4e7c3[m feat(bulk/scrape): check credits via url list length
+[33m66e50531[m Merge branch 'main' into mog/bulk-scrape
+[33me0d3b761[m Merge pull request #808 from mendableai/feat/skipTlsVerification
+[33m7432f255[m Merge pull request #807 from mendableai/mog/acuc-cache-clear
+[33md375bca1[m Update acuc-cache-clear.ts
+[33mbbfdda88[m Nick: init
+[33macde353e[m skipTlsVerification on robots.txt scraping
+[33mbd55464b[m skipTlsVerification
+[33m6ed3104e[m feat: clear ACUC cache endpoint based on team ID
+[33m3cd328cf[m feat(bulk/scrape): add node and python SDK integration + docs
+[33m76c00738[m Nick: grok 2 example
+[33md2344aa1[m Revert "Nick: improved map ranking algorithm"
+[33medac6850[m Merge pull request #797 from rishi-raj-jain/patch-2
+[33m22d375ad[m Updates
+[33m9ab92283[m Merge pull request #796 from mendableai/fix/issue-663
+[33md31b85fa[m Merge pull request #793 from mendableai/fix/issue-665
+[33m9a265876[m Merge pull request #799 from Mefisto04/contribute
+[33me1d8e158[m Update SELF_HOST.md
+[33m209bbd13[m Merge pull request #798 from mendableai/nsc/improved-map-search
+[33mcf98d69b[m Update requirements.txt
+[33md113199a[m Update app.py
+[33m2b0c52ff[m Update SELF_HOST.md
+[33m7acd8d2e[m Nick: improved map ranking algorithm
+[33m8a4ee448[m Create output_01f6efd5-1297-4745-94b5-5972c10f17d6.json
+[33m42ec08c7[m Update websites.csv
+[33m7d851921[m Update app.py
+[33m2022db7f[m Update websites.csv
+[33mf5af938e[m Update requirements.txt
+[33mba3ee8ea[m Create .env.example
+[33madfc493c[m Create websites.csv
+[33m11fd630e[m Create requirements.txt
+[33m10381b5d[m Create app.py
+[33m18f69c90[m fix/missing error in response
+[33maed11e72[m fix encoding if error
+[33m6ebfcc85[m Merge pull request #790 from rishi-raj-jain/patch-1
+[33m79e65f31[m Update v1.ts
+[33m7d8df7d5[m Update requirements.txt
+[33ma110fdeb[m Update requirements.txt
+[33mdff71a81[m Delete README.md
+[33m5f69358c[m Swarm Extractor Example
+[33m03b37998[m feat: bulk scrape
+[33m081d7407[m Merge pull request #788 from mendableai/nsc/log-extractpr-options
+[33m06b8d24a[m Update scrape.ts
+[33ma73b0658[m Merge pull request #785 from mendableai/nsc/support-for-all-metadata
+[33m2ac50a16[m Update metadata.ts
+[33m8974230d[m Nick: formatting + error handling
+[33mc0384ea3[m Nick: added tests
+[33m417c7697[m Update metadata.ts
+[33mff906f77[m Update excludeTags.ts
+[33m2c1a98f0[m Update excludeTags.ts
+[33mcf8fe932[m Update credit_billing.ts
+[33me5a5ca24[m Update credit_billing.ts
+[33mffbf1604[m Merge pull request #784 from mendableai/nsc/geolocation
+[33m027158fa[m Nick:
+[33m795e5a92[m Update metadata.ts
+[33mb4f6a0f9[m Nick: geolocation
+[33mf49552e4[m Merge pull request #783 from mendableai/nsc/admin-notifications
+[33m54a54b9f[m Nick: admin init
+[33m7b1df226[m Delete check-queues.yml
+[33m784aa789[m Merge pull request #780 from mendableai/feat/improv-filter-perfomance
+[33m4afcd16e[m performance improv for ws
+[33m3afaab13[m feat/improv-crawl-status-filters
+[33mca84491c[m Merge pull request #779 from mendableai/fix/check-files
+[33m18080122[m fix/check files on crawl
+[33me40036ca[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mc3a9630e[m Reapply "Merge pull request #773 from mendableai/nsc/retries-acuc-price-credits-fallback"
+[33m2bf7b433[m fixed file blocking process
+[33ma6888ce1[m Revert "Merge pull request #773 from mendableai/nsc/retries-acuc-price-credits-fallback"
+[33mba9ad1ef[m Merge pull request #773 from mendableai/nsc/retries-acuc-price-credits-fallback
+[33m821c62c5[m Update credit_billing.ts
+[33m78b6127d[m Nick: retries for acuc
+[33m666082a7[m Nick: bump python patch to 1.3.1
+[33mec238a83[m Update firecrawl.py
+[33m03287821[m Update index.ts
+[33md3856371[m Update index.ts
+[33maf06b42c[m Update fireEngine.ts
+[33m35b15f1e[m Update fireEngine.ts
+[33m961b1010[m Nick: rm the cache for map for 24hrs
+[33m2eff7c29[m Nick: refactor openai swarm example
+[33mc2d79e18[m Create .env.example
+[33m3315648a[m Nick: open ai swarm and firecrawl
+[33mca85feb9[m Merge pull request #768 from Ruhi14/patch-1
+[33mcee124dc[m Update README.md
+[33m5ab52854[m Merge pull request #757 from busaud/patch-1
+[33m5f16688b[m Merge pull request #766 from mendableai/doc/issue-764
+[33m2d3d7c82[m fix/added unkwown status to job filter
+[33mca515216[m Merge pull request #761 from mendableai/fix/filter-status-unknown-jobs
+[33m5e5e11f3[m Merge pull request #767 from mendableai/nsc/fixes-credit-usage
+[33m0bff5b1a[m Update auth.ts
+[33m257a9511[m Update auth.ts
+[33me916ea7e[m updated openapi.json
+[33me57a8e9d[m better explain how includePaths and excludePaths work
+[33m5961eb6b[m Merge pull request #763 from fadkeabhi/Spelling-Corrections-in-README
+[33m3ecdd301[m Update README.md
+[33m5c42dbc0[m Merge pull request #762 from mendableai/feat/developer-notion-special-case
+[33mc1f98d03[m fixed developer.notion special case
+[33m8cbd94ed[m fix/filters failed and unknown jobs now
+[33m0d48f451[m Merge pull request #760 from mendableai/feat-sdks/cancel-crawl
+[33mbfed65d4[m Update package.json
+[33m2cde8773[m Nick: version bump
+[33m4960b2b0[m Merge branch 'main' into feat-sdks/cancel-crawl
+[33m5844b5bb[m Merge pull request #759 from mendableai/fix/issue-758
+[33m2689ffa7[m feat-sdk/cancel-crawl
+[33m68a4c2e4[m Fixed missing error handling in JS-SDK
+[33mf1132228[m fix: removing test teams concurrency limit
+[33m0934dd88[m Update README.md
+[33md4108043[m Merge pull request #755 from busaud/main
+[33mabb5ec74[m Update playwright.ts
+[33mf6ec45f0[m Merge pull request #747 from Harsh0707005/timeout-parameter-not-passed
+[33m222a34ca[m Update playwright.ts
+[33mc6ebbc6f[m bugfix: self-host crawling doesnt respect limit
+[33m52ec43aa[m Update index.ts
+[33m5ff6c64d[m Update index.ts
+[33m4bbe87ba[m Merge pull request #754 from mendableai/nsc/no-cluster-all
+[33m30a375d6[m Nick:
+[33m7847404e[m Merge remote-tracking branch 'origin/mog/no-cluster' into nsc/no-cluster-all
+[33m454296f0[m crm_lead_enrichment example
+[33m17d0ed06[m push
+[33mb2ae1a52[m fix(Dockerfile): remove chromium
+[33m2d365ebc[m fix(redis): protected mode off
+[33m237442fa[m Make sure the entrypoint script has the correct line endings
+[33mae464ada[m tests: teamIds
+[33md8df3a4d[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m1cd49a0a[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m154216e2[m Update examples
+[33m064ce482[m Update blocklist.ts
+[33m4020a7d7[m test: added test suite tokens
+[33m075b63b5[m feat(redis): add memory calcualtion when not running on fly
+[33maa3d4b8d[m Fixed Issue #734
+[33m5c0c952a[m Update website_params.ts
+[33m34b5d4b6[m Merge branch 'mendableai:main' into main
+[33m460f5581[m Add files via upload
+[33m96bc53ca[m Update README.md
+[33m4dd1df2a[m Update README.md
+[33m61dcbffe[m Update README.md
+[33mbcecb090[m Update README.md
+[33mf3261098[m Update README.md
+[33m072a949a[m Update README.md
+[33m800d0306[m Update README.md
+[33m7efe3486[m Update README.md
+[33m52929391[m Update README.md
+[33m36d16a1f[m Update README.md
+[33m1c021870[m Update website_qa_with_gemini_caching.ipynb
+[33me473a235[m Create README.md
+[33m1f1afeaa[m Update system-monitor.ts
+[33ma40fb3b0[m Update deploy-image.yml
+[33md0bd450f[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mbfbd2c83[m Update README.md
+[33m4a21a559[m Merge pull request #733 from mendableai/nsc/fixed-self-host-envs
+[33md316d52c[m fixes docker-compose and 401 error
+[33mdba96998[m Update fetch.ts
+[33m668ff3c7[m Update fetch.ts
+[33m25dd16bf[m Nick: removed 401
+[33m93657f6a[m Update queue-worker.ts
+[33m75658c58[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m9a056919[m Create deploy-image.yml
+[33m28b64fc7[m Change the gracefull shutdown signal
+[33m50c59b6d[m Update docker-compose.yaml
+[33m497ac332[m Merge pull request #732 from mendableai/fix/url-validation-params
+[33mcfd776a5[m fix: now urls with params are passing validation
+[33m99ca852e[m Merge pull request #731 from mendableai/nsc/crawl-fixes
+[33m85e9f7b9[m Merge pull request #727 from mendableai/nsc/error-js-sdk-improv
+[33m4f760882[m Update package.json
+[33mf743f2b9[m Update index.ts
+[33mc6a29efb[m Update crawl-status.ts
+[33mddd774ed[m Nick:
+[33m82551bb6[m Update index.test.ts
+[33m49bd9532[m Update types.ts
+[33m1a1ac9fd[m Nick:
+[33ma150aa82[m Nick: shouldnt fallback on a 400 + error code should be correct on page status code
+[33ma66ef186[m Merge pull request #728 from bytrangle/patch-1
+[33m961a8745[m Remove wait_until_done from python-sdk example
+[33m489a6433[m Update index.ts
+[33m26771e2e[m debug(zod): log unsupported protocol errors
+[33md1b83832[m Merge pull request #721 from mendableai/feat/concurrency-limit
+[33mac5e1fc1[m Update sitemap.ts
+[33mc6717fec[m Nick: got rid of job interval sleep and math.min
+[33m18f9cd09[m Nick: fixed more stuff
+[33mfe721fff[m fix(crawl-redis): normalize URL before locking
+[33mc0541cc9[m Update queue-worker.ts
+[33m37299fc0[m Update types.ts
+[33m8aa07afb[m Nick: fixes
+[33m92dbd33e[m Update queue-worker.ts
+[33m4d5477f3[m Nick: resolved conflicts
+[33m96245e38[m Update crawl.ts
+[33m258c67ce[m Revert "feat(queue-worker): always crawl links from content even if sitemapped"
+[33m445fc432[m Reapply "fix(v1/crawl): always use sitemap"
+[33m339b19ce[m Revert "fix(v1/crawl): always use sitemap"
+[33m5dc0fcf6[m fix(v1/crawl): always use sitemap
+[33m3c045c43[m feat(queue-worker): always crawl links from content even if sitemapped
+[33m1af26fe1[m Nick: sitemap fix
+[33mff4b7a83[m Merge pull request #685 from devflowinc/main
+[33m986262e1[m Update search.ts
+[33m0dd06d33[m fix(v0/search): pass job priority
+[33m20ffdbd1[m hotfix
+[33ma8df85fd[m fix(acuc): remove sentry capture
+[33m3621e191[m feat(concurrency-limit): set limit based on plan
+[33mc6a83ab9[m fix(api): entrypoint
+[33me44bdf7a[m bad dockerfile
+[33mf0a1a2e4[m fix: increase ulimit -n in docker
+[33md5e2a80e[m fix(crawl-status): keep 10 megabyte pages if they're the only thing in the output
+[33m975f0575[m Nick: max retries with axios-retry
+[33m92961cf7[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m1fdff87b[m Update single_url.ts
+[33m6283e8fc[m fix(logger): set default level to trace
+[33m5e8ef495[m feat(auth): log cache key in acuc update error
+[33me98f858e[m fix(api): playground scrape errors
+[33m8d44cb33[m Nick: fixed error message
+[33m2cb49332[m fix(ACUC): do not refresh cache every set
+[33m9bdd344b[m fix(redlock): use redlock.using for stability
+[33m250c3bb5[m fix(auth): move redlock settings
+[33m81245e68[m fix(auth/redlock): retry cached ACUC lock for 20 seconds
+[33m0f89f5e7[m fix(billTeam): cache update race condition
+[33md13a97f9[m fix(credit_billing): allow spending of exact credits
+[33m84bff8ad[m fix(billTeam): update cached ACUC after billing
+[33mf22ab5ff[m feat(db): implement bill_team RPC
+[33mc1f68c3e[m fix(credit_billing): return chunk.remaining_credits
+[33m2073063f[m fix(db): fix caching and rpc error
+[33mf8c70fe5[m feat(db): implement auth_credit_usage_chunk RPC
+[33m29815e08[m feat(v1/Document): add warning field
+[33m095babe7[m fix(queue-jobs): jobs with concurrency fails may vanish
+[33mb696bfc8[m fix(crawl-status): avoid race conditions where crawl may be deemed failed
+[33m75e32b0e[m Merge pull request #707 from mendableai/new_examples
+[33m20b998e6[m Delete o1_job_recommender.ipynb
+[33m5c4d436f[m Create o1_job_recommender.py
+[33mdec41719[m fix(queue-worker, queue-jobs): logic fixes
+[33md2881927[m fix(queue-worker): remove concurrency entries when done in sentry-less branch
+[33m53fce67c[m feat(queue-worker): PoC of concurrency limits
+[33m30058b1d[m Nick: increased timeout for chrome-cdp due to smart wait
+[33m51bc2f25[m remove actions crawler
+[33m289af6f8[m example
+[33ma9773a24[m Nick: increased timeout for chrome-cdp due to smart wait
+[33m953d4fb1[m fix(redlock): use redlock.using for stability
+[33meef116be[m fix(auth): move redlock settings
+[33m2c96d2ee[m fix(auth/redlock): retry cached ACUC lock for 20 seconds
+[33m1cca9b8a[m fix(billTeam): cache update race condition
+[33meb7317c0[m fix(credit_billing): allow spending of exact credits
+[33me67cbc2c[m fix(billTeam): update cached ACUC after billing
+[33m5a8eb17a[m feat(db): implement bill_team RPC
+[33m415fd9f3[m fix(credit_billing): return chunk.remaining_credits
+[33m417adf8e[m fix(db): fix caching and rpc error
+[33m331e826b[m feat(db): implement auth_credit_usage_chunk RPC
+[33mabdc08ed[m Merge pull request #679 from h4r5h4/fix/folder-name
+[33m1da026b2[m Update single_url.ts
+[33mb8266cc3[m Update website_params.ts
+[33mf00c0b82[m fix(v1/scrape): add total wait specified in request to timeout
+[33m3f138e55[m Update website_params.ts
+[33m43730b5d[m feat(WebScraper): always report error of last scraper in order
+[33m3e661a20[m fix(v1/crawl-cancel): avoid double authing
+[33m86744f6d[m Update README.md
+[33m41945256[m fix(blocklist): unblock TikTok Business page
+[33m4a623c08[m fix(fly): don't use Depot builders (doesn't work)
+[33ma59b5836[m Revert error tallying
+[33ma4b128e8[m fix(rust): blocklisted error test
+[33m483f97d2[m fix(v0/search): don't sent scrape fail errors to Sentry
+[33md927cafe[m fix(queue-worker): don't send scraping errors to sentry
+[33m677faa27[m fix(WebScraper): explicitly ignore 404s
+[33m83d8287c[m fix(v0, sentry): don't send all scraping methods failed errors to Sentry
+[33md2f70310[m fix(WebScraper): fatal error handler triggering for 404s
+[33m4721aa16[m Merge pull request #690 from mendableai/nsc/search-fix-version-v0
+[33m848a2b36[m Update package.json
+[33mdfdbae74[m Update fireEngine.ts
+[33mfbb5f230[m Update index.ts
+[33m607e4626[m Update package.json
+[33mdb161ac5[m Nick: press + write
+[33m380dcc2f[m Merge pull request #682 from mendableai/feat/actions
+[33m3fc5ce17[m Nick: fixed error handling for v0 scrape
+[33m0690cfea[m Merge branch 'main' into feat/actions
+[33m95e4c892[m fix(sdk/rust): license
+[33me1a34b0a[m Revert "feat(scrape): scroll down/up with actions if fullpagescreenshot"
+[33m815bfc8f[m feat(scrape): scroll down/up with actions if fullpagescreenshot
+[33md663bbf0[m feat(actions): add scroll
+[33m3dd912ec[m feat(actions): add typeText, pressKey, fix playwright screenshot/waitFor
+[33m719dfbcc[m Update docs
+[33m939040bf[m Update docs and example
+[33m3ec0bbe2[m feat(sdk/rust/crawl): paginate through results
+[33ma078cdbd[m Rust SDK 1.0.0
+[33m93a20442[m feat(sdk/rust): first batch of changes for 1.0.0
+[33m6aa46816[m Update README.md
+[33m74565a9d[m Merge pull request #639 from yekkhan/main
+[33mbbb8d418[m Merge pull request #623 from itasli/patch-1
+[33m92331824[m Update README.md
+[33m48eb6fc4[m Merge branch 'main' into pr/623
+[33mb2f61da7[m Nick: clarification on open source vs cloud
+[33m506d5c27[m Revert "return links"
+[33m2d597672[m return links
+[33mc45a132c[m Remove print statement in map
+[33m01f42b98[m feat(scrape): add error tallying instead of empty response
+[33mb8b8522b[m Nick: fixed map exception
+[33mef719404[m Merge pull request #674 from mendableai/nsc/map-pagination
+[33m80b4d7dc[m Update README.md
+[33m26825fc8[m bugfix: using onlyIncludeTags and removeTags together
+[33ma5322322[m Update README.md
+[33m00bb958b[m Update v1-openapi.json
+[33m03eb47d4[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m3a4dd8fc[m Nick: v1 openapi spec
+[33m712ca316[m minor fixes
+[33md338c340[m Update CONTRIBUTING.md
+[33m20d1855a[m feat(js-sdk): actions integration
+[33m093c064b[m feat(v1): add public actions api
+[33m42d677fe[m feat(fire-engine): port waitFor and screenshot to use actions
+[33mc28e1e29[m fix(v1/zod): formats: add error message if both sc and sc@fP
+[33m255db848[m Update package.json
+[33mb2b7f8d8[m fix(js-sdk): default type for LLM extract
+[33m43d8563b[m Update fly-direct.yml
+[33md76cb6a6[m fix space in the folder name
+[33ma0189acb[m Update fly.yml
+[33m31633317[m Update package.json
+[33m6b920aa8[m Merge pull request #677 from mendableai/fix/js-sdk-full-page-screenshot
+[33mfb8a2c75[m fixed screenshot typo and added test for fullpage screenshot
+[33m3c2bfe2d[m Update single_url.ts
+[33m18b024c2[m Update single_url.ts
+[33ma4039bd0[m Revert "Update single_url.ts"
+[33ma6e1b173[m Update README.md
+[33m66577d1d[m Update fly.yml
+[33m358f8f9d[m Update fly-direct.yml
+[33m4884439f[m Update fly.yml
+[33m473e8491[m Update README.md
+[33md21a797e[m Update fly.yml
+[33m0f8c0a57[m Update single_url.ts
+[33mb7444acb[m Merge pull request #676 from mendableai/o1-crawler
+[33m2619522f[m Merge branch 'main' into o1-crawler
+[33me5814479[m Update o1_web_crawler.py
+[33m9da34325[m Update map.ts
+[33m8c05aed6[m Finishing o1 crawler example
+[33m3900603a[m Almost done
+[33maf4804e1[m Merge branch 'main' into nsc/map-pagination
+[33m98de36fe[m Merge pull request #664 from mendableai/nsc/manual-rate-limit
+[33m030ecab6[m Update rate-limiter.ts
+[33m2ee7d1d0[m init
+[33m000a316c[m fix(fire-engine): poll more frequently
+[33mf7c4cee4[m fix(queue-worker): don't send LLM extract hallucination error to Sentry
+[33m0d1b46d4[m fix(js-sdk): improve error logging
+[33me6ac90c1[m Update package.json
+[33md30356a2[m fix(js-sdk): infer keyword collision
+[33md497284b[m feat(api/queue): auto-remove completed jobs after 25 hours
+[33m620b02f9[m Nick:
+[33ma2903e75[m feat(js-sdk): type-safe LLM extract
+[33meec22a56[m Nick: self host issue template
+[33mee38273f[m Merge pull request #653 from mendableai/mog/fix-status-job-get
+[33me1171ade[m Merge branch 'main' into mog/fix-status-job-get
+[33m503c8b3e[m Update package-lock.json
+[33me19dc687[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m99c1af0a[m Update package.json
+[33m5adfd74c[m feat(js-sdk/test): add API_URL env var
+[33mad70c30b[m fix(js-sdk): check at bad if
+[33m6e1cf2f4[m feat(js-sdk): fixes, update tests
+[33m5791d3a0[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m4cd1065a[m Update rate-limiter.ts
+[33mc92065ea[m Merge pull request #611 from MonsterDeveloper/fix-attw
+[33m51da0384[m Merge branch 'main' into fix-attw
+[33m75f4bcd2[m Merge pull request #614 from MonsterDeveloper/dependencies
+[33mf6fc71b4[m fix(js-sdk): bring back cjs exports
+[33m97ffabff[m fix(v1): converting bad docs always gives null
+[33m83a165db[m fix(v0/scrape): ensure url is string
+[33mad1a6fbc[m fix(v1/map): handle invalid URLs gracefully
+[33me19f7a10[m feat(js-sdk): paginate next on checkCrawlStatus + better types for CSR
+[33m4ebc35c9[m fix(crawl-status): add success: true
+[33mf855ad34[m bumping py-sdk version
+[33m93b7b313[m Merge pull request #654 from mendableai/fix/issue-644
+[33mee8a5421[m fix(py-sdk): removed asyncio package
+[33m1074e976[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m45237a29[m updated js-sdk examples
+[33ma7406031[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33ma17e1cac[m Rate bump
+[33mb4dbf755[m fix(v1): check if url is string in blocklistMiddleware
+[33m26f2095d[m fix(v1): proper Invalid URL handling
+[33mf8fbc71f[m fix(supabase-jobs): do not use RPCs
+[33ma6bcf7b4[m fix(v0/crawl-status): don't crash on big crawls when requesting jobs from supabase
+[33m2cbc4c59[m Merge pull request #649 from mendableai/nsc/chrome-cdp-for-params
+[33m17e419a7[m Nick:
+[33m31e973d9[m Merge pull request #648 from mendableai/nsc/fix-json-error-handler
+[33mca9a781e[m Update index.ts
+[33m22a5e858[m Update index.ts
+[33m4278fae5[m Update README.md
+[33m60a15d00[m Update types.ts
+[33m84fb00ec[m Merge pull request #640 from mendableai/nsc/improved-billing-notifications
+[33mfbdfa125[m Update credit_billing.ts
+[33m48c66551[m Update credit_billing.ts
+[33m32097fa2[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m5758af32[m Update website_params.ts
+[33mb3e2ca9a[m Merge pull request #638 from mendableai/nsc/removal-of-tags-in-include-main-content
+[33m1ea9131e[m feat: Update redis deployment to run redis with password if REDIS_PASSWORD is configured
+[33m7685853d[m [Fix] fix SELF_HOST.md kubernetes cluster-install link
+[33m79870e73[m Update excludeTags.ts
+[33ma0f9ab2b[m Update map.ts
+[33m0731b312[m Merge pull request #635 from shige/doc/update-self-host-v1.0.0
+[33me89e6d89[m Merge pull request #637 from mendableai/ETL-unicorn-example-app
+[33m2d245a35[m Delete combined_api_spec.json
+[33m2044e71f[m Docs to API Spec
+[33maa2cf686[m [Docs] upgraded the path of the self-hosted documentation URL to `/v1`.
+[33mf5b84e15[m Update sitemap.ts
+[33m554a0506[m Merge pull request #629 from mendableai/go-parser-singleton
+[33m4fa917f2[m Update README.md
+[33m82d6bf4e[m feat(go-parser): singleton
+[33mb3f21d43[m Update README.md
+[33mcb630bfc[m Update fireEngine.ts
+[33m8c1097e9[m fix: pageOptions
+[33mb301ffc9[m added missing variables
+[33ma37ec6d1[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mc6f1d809[m Update crawl.ts
+[33m7561bfe1[m added envs to github action workflows
+[33meb03a811[m Update crawl-status.ts
+[33m503e83e8[m Add SearchApi to search
+[33mf7461dac[m Merge pull request #608 from mendableai/feat/go-html-to-md-parser
+[33m9ee7b19c[m Merge branch 'feat/go-html-to-md-parser' of https://github.com/mendableai/firecrawl into feat/go-html-to-md-parser
+[33m34adf432[m Merge branch 'main' into feat/go-html-to-md-parser
+[33m82cb80c8[m Update map.ts
+[33mde9b9ef9[m Merge remote-tracking branch 'origin/main' into feat/go-html-to-md-parser
+[33ma0113dac[m Update credit_billing.ts
+[33mb8e9c445[m Merge pull request #624 from mendableai/nsc/check-credits-optimization
+[33m28c56355[m Update ci.yml
+[33mb7b99b53[m Merge branch 'main' into nsc/check-credits-optimization
+[33m85b824e1[m test: what about false false?
+[33m78edf13e[m test: usedbauth envs wth
+[33mcb8571ab[m fix: enforced dotenv config
+[33m5ecb2436[m Nick:
+[33m2d4dd1f9[m fix wrong link to self host documentation
+[33m3f462eab[m fix(cicd):
+[33m8fc313c1[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m1eb993a9[m Update __init__.py
+[33m22bf67cc[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m364ba9f9[m fix(cicd): mendable->firecrawl and waitfor
+[33ma2a63e42[m Rm print map
+[33mf98a8541[m fix(cicd): added use_db_auth to deploy workflow
+[33mad950a6c[m fixed controller res and tests
+[33m57aa6d18[m Update README.md
+[33m74ac8915[m details
+[33md836ba67[m added log to check response on cicd
+[33m28df3538[m fix(cicd): wait and moved rust publish
+[33m653b76fe[m Update README.md
+[33mf07c2bd2[m Merge pull request #619 from mendableai/nsc/bill-team-async
+[33m049a1118[m Nick:
+[33m3072d4a3[m Nick: fixed .sort coupons and sentry to withAuth
+[33m7561fd27[m Nick: debug the billing email system for free credits
+[33mc5e1d77a[m added invalid html tests
+[33md60fa6e0[m fixed dockerfile and function name. it's working
+[33mebf40354[m added log so we can check
+[33m6ccc22ba[m fix(sdk): js next pagination
+[33m411d7f31[m fix(sdks): fetch next/pagination
+[33m291d9e37[m now using compiled go/C lib with koffi
+[33m2b0e447b[m perf(js-sdk): move `dotenv` and `uuid` to `devDependencies`
+[33m2a8f55e5[m perf(js-sdk): remove whole `z` import and instead use type-only import
+[33mfe8f9d4b[m feat(js-sdk): drop `commonjs` outputs and simplify build process
+[33m41241f4d[m chore(.gitignore): add `apps/js-sdk/firecrawl/dist`
+[33m995a3ff5[m chore(tsconfig): modernize and remove commonjs
+[33mc3d90d49[m Merge pull request #516 from kevinswiber/fix/use-db-auth-in-single-url-scraper
+[33m08a9cb8d[m Merge branch 'main' into pr/516
+[33m32444548[m Nick:
+[33m2444f7c4[m Update scrape.ts
+[33m00dacaf9[m Nick: scrape id when origin is website for report system
+[33m48056ea1[m feat: added go html to md parser
+[33m11971da3[m Merge pull request #607 from mendableai/fix/v1-maxDepth
+[33m036eb925[m fix(v1): maxDepth
+[33m86b04777[m Update map.ts
+[33m304b3e75[m Update map.ts
+[33m4f3d421c[m Merge pull request #594 from mendableai/v1/webhooks
+[33mcb2dfe29[m Nick:
+[33m98029365[m fix(queue-worker): new getJobs, log on v0
+[33m44fe741c[m Update queue-worker.ts
+[33m758f729a[m Update queue-worker.ts
+[33m5c05bb12[m Update webhook.ts
+[33mae903705[m Update webhook.ts
+[33m0df2441d[m Nick: sdks good
+[33mb68a50fe[m Nick:
+[33m979697df[m Update queue-worker.ts
+[33m95b9dc91[m Nick: webhooks v1 working great
+[33mfaae98ec[m Merge branch 'main' into v1/webhooks
+[33mfe6abe8f[m Nick:
+[33m2ef43d5f[m Update rate-limiter.ts
+[33m8431be58[m Nick:
+[33maf5cc5f1[m Nick: 1.2 - v1 llm extract
+[33m055177cf[m Merge pull request #586 from mendableai/v1/llm-extract
+[33m0c595643[m Merge branch 'main' into v1/llm-extract
+[33m693dc14d[m remove invalid keys
+[33m6d1da2e2[m Update index.ts
+[33md347160f[m Nick:
+[33m522d256b[m Merge branch 'main' into v1/llm-extract
+[33mef5c8931[m Update scrape.ts
+[33m050cac51[m Update types.ts
+[33m012bc74e[m Revert "Update types.ts"
+[33m77766cf0[m Update types.ts
+[33m87e61f2d[m v0 working
+[33mdc189e1e[m feat: webhooks config on v1
+[33m7f1ed6b4[m Update README.md
+[33m23dfe90b[m Nick:
+[33m0732997a[m Merge branch 'main' into v1/llm-extract
+[33mc8e0bb93[m fix(crawl-status): handle null data when purging rawHtml
+[33m4f92bb4b[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m282962e3[m Nick:
+[33m6a6b4874[m fix(v1): don't fail on doc = null
+[33m71dab56e[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33md7dbc253[m Update crawl.ts
+[33m9de39cfa[m Merge pull request #591 from mendableai/mog/websocket-sdk
+[33m81bbab77[m Merge pull request #593 from mendableai/nsc/rpc-cloudflare-issues
+[33m234c6dae[m Update supabase-jobs.ts
+[33m7c8ca0c8[m Update types.ts
+[33mf4a49bc1[m Update types.ts
+[33ma2881e92[m Nick: llm extract support on node sdk
+[33m45e33563[m Nick: python working
+[33mbb480844[m Merge branch 'main' into v1/llm-extract
+[33m2fd9c285[m Merge pull request #582 from mendableai/fix--rawHtml-return-on-crawl
+[33mb8920d6f[m Nick:
+[33m552328d1[m Merge branch 'main' into v1/llm-extract
+[33mee3e5dc6[m Nick:
+[33m26d87bd0[m fix(api): handle zoderrors earlier
+[33m1805d901[m Update credit_billing.ts
+[33me5ca4364[m Nick: improvements to llm extract error handling
+[33m52ac1323[m Update auth.ts
+[33m636e39d3[m Merge branch 'main' into mog/websocket-sdk
+[33mae38c26f[m feat(v1-sdks): async crawl node, python websocket + async crawl + example
+[33mfd029592[m Merge pull request #590 from mendableai/new-read-me
+[33m4be51cee[m Update README.md
+[33m04648c4f[m Update README.md
+[33m8b7ee46d[m Add Firecrawl logo
+[33m7caaee28[m Update ui component to v1
+[33m41eb6209[m Nick: prompt option, still need to convert to new structured outputs
+[33m49e1cb7c[m Nick:
+[33m63264644[m Nick: fixed js-sdk map params
+[33m377e8ded[m removed v0 support
+[33m5f11275f[m Merge remote-tracking branch 'origin/main' into mog/websocket-sdk
+[33mdb85f1a7[m Update index.ts
+[33m1ecee903[m Merge pull request #373 from Sanix-Darker/f/rust-sdk
+[33meec6d868[m Merge branch 'main' into f/rust-sdk
+[33m53018a68[m feat(js-sdk): add crawlUrlAndWatch
+[33md4001e45[m fix(api/websocket): fix auth and termination
+[33m1174bc3c[m Nick: blocked sw/ra
+[33m7eefaffe[m fix: rawHtml for v0
+[33mf8323f9b[m fix: moved delete rawHtml to end of controller
+[33m02410aca[m Update runWebScraper.ts
+[33m67229c6b[m Nick: fixed credits issue
+[33mc3158b0f[m fix(v1): js-sdk fixed crawl type
+[33m70bff7f8[m Nick:
+[33m8be75acc[m Nick:
+[33mc7b3365f[m fix(v1): update readme - v1.0.1
+[33m9e87d05b[m Merge pull request #527 from mendableai/v1-webscraper
+[33m547da88c[m Update rate-limiter.test.ts
+[33m4edd9a34[m Nick: totalCount -> total, completedCount -> completed
+[33m2a56f89f[m Update index.test.ts
+[33m59547d71[m Update index.test.ts
+[33mb7f62f93[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m1c35534e[m fix(v1): check-status for preview
+[33maf67b14c[m Nick:
+[33m8fbff280[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m08387c06[m Update auth.ts
+[33mef2d8d01[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m5cbf0dca[m fix(v1): includeTags
+[33m7ba3f3bd[m Nick:
+[33m9a130340[m Nick:
+[33mecd07be4[m Nick: fixed issues
+[33m3039cc26[m Update README.md
+[33m4003d37f[m Nick:
+[33md872bf0c[m Merge branch 'main' into v1-webscraper
+[33m7565c2fc[m Update fly-direct.yml
+[33m51d1a2e5[m Add new example Web Scraping and Extraction with Firecrawl and Claude
+[33m9a43c6cd[m Nick:
+[33m7dff5cdf[m Nick: fixed sdk types and map preview
+[33m38ed845b[m Nick: fixed v0 backwards compatibility node sdk types
+[33mff08d709[m Merge pull request #566 from mendableai/nsc/job-priority
+[33me7d283c4[m Update job-priority.ts
+[33mca34f120[m Nick: bucket limit increase
+[33mf0dfcd6a[m Update job-priority.ts
+[33m080240e0[m Merge branch 'main' into nsc/job-priority
+[33m88239d72[m Merge branch 'main' into v1-webscraper
+[33m8c8d0602[m Update rate-limiter.test.ts
+[33mbd84e49a[m Update rate-limiter.ts
+[33ma0f9a81e[m Nick:
+[33mc009013f[m Nick: expire tests
+[33m43f6c0a1[m Update example.ts
+[33m8b53285a[m Update job-priority.ts
+[33m06b70a47[m Update job-priority.ts
+[33m1e08e6d3[m Merge branch 'main' into nsc/job-priority
+[33m861e2ebd[m Nick: 2x rate limits
+[33m170a8ebf[m Nick:
+[33m3850b000[m Nick: removing credit notification for now
+[33md3011970[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m463d38f7[m Update map.ts
+[33m1ef41b92[m feat: cancel
+[33mfb553a02[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m6ab6ef90[m Update auth.ts
+[33madc3e423[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m65faa3e1[m tests/feat: url validation
+[33m558acffb[m Nick: @rafaelsideguide isarray for includes/excludes
+[33m7d93eab0[m Nick:
+[33m14c0652e[m Update .gitignore
+[33m7f553fea[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m59dcc70d[m Delete temp-37564.rdb
+[33m72454de1[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m04556ded[m tests: e2e for crawl and crawl status
+[33m8c37ea6d[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33mf277a0e2[m Update package.json
+[33mf2f6f78d[m fix(url validation): sub paths
+[33m0bbb8bb2[m Nick:
+[33m98a770f3[m Nick: rm wip
+[33m6f68678b[m Nick:
+[33mb0bd71a3[m Merge branch 'main' into v1-webscraper
+[33m2d78c20d[m Nick:
+[33mfa7dc5b1[m Update rate-limiter.ts
+[33m4d0acc97[m Merge branch 'main' into v1-webscraper
+[33m0566e54d[m init
+[33m5606fe58[m Nick:
+[33m1baba3ce[m fix(go-sdk): submodules
+[33md591e0f5[m block corterix.com for performance issues
+[33m6f9a2687[m fixed turndown bug
+[33m96e91ab9[m convert webhook call to v1
+[33m4e196a91[m Delete autoscale.yml
+[33m1f99bfd3[m Update queue.ts
+[33mb80277d4[m Update queue.ts
+[33md87b62fe[m Nick:
+[33mb9e06e27[m Update queue.ts
+[33m8e78511e[m Update queue.ts
+[33m28d7a637[m Update queue.ts
+[33mb23bf2ee[m Update autoscale.yml
+[33m0dc592b3[m Update autoscale.yml
+[33m173f4ee1[m Nick: chrome cdp main | simple autoscaler
+[33m732e6af8[m Add internal link opportunities example
+[33m064ebfc5[m fix websocket
+[33m05c250d3[m Merge branch 'main' into v1-webscraper
+[33m2ab0dd2e[m fix(scrape): add further llm extraction catch
+[33m1054a139[m Merge branch 'main' into v1-webscraper
+[33m3d53f4e2[m Nick: unblocking pin
+[33m5ef3926d[m fix(scrape,search): handle failed jobs
+[33m866e7191[m further fixes
+[33meea530e0[m feat(v1): update for sentry
+[33me7f267b6[m Merge branch 'main' into v1-webscraper
+[33m52a05b8c[m rename "dragonfly" to "redis"
+[33m64e9be0c[m feat(redis): use bitnami image
+[33m8d9ff90b[m feat(fire-engine): propagate sentry trace
+[33m74ea820b[m fix: url and check for metadata
+[33m1f0abaca[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m1f779e26[m Update rate-limiter.ts
+[33m8e3c2b28[m fix(crawler): verify URL
+[33me690a6fd[m fix: remove QueueEvents
+[33m76c8e9f9[m fix
+[33mad82175f[m fix(scrape): poll
+[33m5f60a559[m workflow and npm now running v1 tests
+[33m30e80996[m Merge remote-tracking branch 'origin/v1/python-sdk' into v1-webscraper
+[33ma37681bd[m fix: replace jest, removed map for v0
+[33m7473b740[m fix: html and rawlhtmls for pdfs
+[33mdd737f12[m feat(sentry): add queue instrumentation to
+[33md2521612[m Update .gitignore
+[33m7265ab7c[m fix(search): filter docs properly
+[33mb1d61d85[m Merge remote-tracking branch 'origin/v1-webscraper' into v1/python-sdk
+[33mab88a75c[m fixes sdks
+[33md036738d[m fix(bullmq): duplicate redis connection for QueueEvents
+[33m6d48dbcd[m feat(sentry): add trace continuity for queue
+[33m6d92b852[m feat(scrape): record job result in span
+[33m5ca36fe9[m feat(api): add more captureExceptions
+[33m0e8fd6ce[m fix(scrape): ensure extractionSchema is an object if llm-extraction is specified
+[33m4bd2ff26[m fix(llm-extract): pass stacktrace properly
+[33me4adbaa8[m fix(llm-extract): handle llm-extract if scrape failed
+[33m670d253a[m fix(auth): fix error reporting
+[33m7d9f5bf8[m fix(crawl): don't use sitemap if it's empty
+[33m1f580dee[m fix(crawl): validate includes.excludes regexes
+[33mfbbc3878[m fix(crawler): make sure includes/excludes is an array
+[33m508568f9[m fix(search): handle scrape timeouts on search
+[33m14fa75ca[m fix(crawl): send error if url is not a string
+[33m8a778278[m Merge branch 'main' into nsc/job-priority
+[33m0cdf4158[m feat(sentry): add error handles to try-catch blocks
+[33m53ca7046[m Update index.ts
+[33m477c3257[m Nick:
+[33mc7bfe4ff[m Nick:
+[33m6bdb1d04[m Merge branch 'main' into nsc/job-priority
+[33me78d2af1[m Nick:
+[33me64d3815[m Merge branch 'main' into nsc/job-priority
+[33m0ea0a5db[m Nick: wip
+[33m0b37cbce[m Update .gitignore
+[33ma4686e3c[m fixing tests
+[33mfe2e8c0b[m includehtml fix
+[33m629da74a[m fix(sentry): decrease tracesSampleRate
+[33m55009e51[m fix: filter out invalid URLs from crawl links
+[33mdae1408e[m fix(Dockerfile): retain sentry auth token properly
+[33mac9783ed[m fix(sentry): adjust profiles sample rate to be even lower
+[33m9579f03c[m fix: import resolution
+[33m6104d742[m fix(sentry): drop profiling sample rate
+[33m3d5dc9d9[m feat(sentry): add log + server name
+[33m79f5d49d[m Merge pull request #562 from mendableai/nsc/sentry
+[33m85ff0c31[m Add worker ID to job attribute
+[33m3ad9bf7a[m Update GH Actions deployment
+[33m920702cd[m Update builder to handle uploading sourcemaps
+[33m86942728[m Add metadata for queue-worker and Express
+[33m35decb1a[m Nick:
+[33maf0e47a3[m Merge remote-tracking branch 'origin/v1/node-sdk' into v1/python-sdk
+[33m52abec41[m fixing delete
+[33mdb8c84ff[m Update requests.http
+[33mb6655386[m reverting delete, fixed express bug on checkCredits
+[33m138437d6[m commenting out delete, crashing on fire-engine
+[33m5e48bec1[m commenting out delete, crashing on fire-engine
+[33m90b32f16[m Nick: fixes
+[33m819ad50a[m Update fireEngine.ts
+[33me9d6ca19[m tests passing now
+[33m1b3ad60a[m Reapply "Merge pull request #561 from mendableai/bug/dealing-with-dns-error"
+[33m44162899[m Reapply "Merge pull request #561 from mendableai/bug/dealing-with-dns-error"
+[33mffe11a5b[m Revert "Merge pull request #561 from mendableai/bug/dealing-with-dns-error"
+[33m58182366[m fix: remove rawHtml properly
+[33m0f48823c[m Merge remote-tracking branch 'origin/v1-webscraper' into v1/node-sdk
+[33m9d64c8ee[m screenshot should not be undefined also
+[33m1368f9a8[m fix: treat existing screenshot as a scraper success condition
+[33m70d81ca6[m Merge remote-tracking branch 'origin/v1-webscraper' into v1/node-sdk
+[33m537fc689[m fixing request
+[33m2030ec60[m Merge pull request #561 from mendableai/bug/dealing-with-dns-error
+[33mf98be7d9[m Update fireEngine.ts
+[33m0c48c8a4[m Nick: billing for map
+[33mf494d2b7[m prioritize search lower
+[33m59eb552d[m Merge pull request #560 from mendableai/feat/cancel-fire-engine
+[33m1f27182a[m added try catch
+[33mefb91f9c[m fix(search): delete jobs after done
+[33m39388cdc[m Update crawl.ts
+[33m674adee1[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33mb36faeaf[m Nick:
+[33m2b221fd4[m Merge pull request #559 from mendableai/nsc/Nick-set-the-crawl-limit-to-the-remaining-credits
+[33mcf32893c[m add strict enforcement + move crawlerOptions to top-level in /crawl
+[33me326249a[m added check job and cancel to fire-engine requests
+[33m70d50b36[m fix(queue-worker): move dotenv config up
+[33mc5ad4ded[m Update crawl.ts
+[33mde0dc20a[m Update credit_billing.ts
+[33m5abd26a2[m Nick: set the crawl limit to the remaining credits
+[33me200ec9e[m Nick:
+[33m55dad82d[m Nick: fixed map search
+[33m27903247[m Nick: map tests and fixes
+[33mfa89d2e5[m v1 support for crawl/monitor status
+[33m7727302e[m Merge remote-tracking branch 'origin/v1-webscraper' into v1/node-sdk
+[33me160d552[m fixed test
+[33me1c9cbf7[m bug fixed. crawl should not stop if sitemap url is invalid
+[33m0dce5783[m Merge pull request #555 from mendableai/feat/beta-customers
+[33mecd47235[m added variables to beta customers
+[33m3dc298be[m Nick: 2x rate limits for standard and growth for /scrape
+[33m32aba441[m fixing merge issues
+[33m72461ce9[m Update index.test.ts
+[33mfd7fdc1d[m added blocklist middleware
+[33m5a441913[m Merge pull request #554 from mendableai/nsc/check-team-credits-limit
+[33me516e499[m Merge remote-tracking branch 'origin/v1-webscraper' into v1/node-sdk
+[33m8e4ca864[m Update crawl.ts
+[33m36b35dbc[m Update crawl.ts
+[33m4ffc6059[m Update queue-worker.ts
+[33mb8170aaa[m Update blocklist.ts
+[33m3fe82b4f[m Update queue-worker.ts
+[33mf7973801[m Nick:
+[33m47123be7[m Nick: weird activity block
+[33mff84f1fe[m Update map.ts
+[33m43143134[m Update map.ts
+[33maf9a0a6f[m Update map.ts
+[33mba5279ea[m Nick: all tests passing
+[33m5205c5f0[m Update map.ts
+[33m0c05d096[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33mab483532[m Nick: /map almost good
+[33meb84673b[m feat: crawl status websocket WIP
+[33me2a6ef26[m mount v1Router under v1 path
+[33m4c1b74da[m fix(map): remove robots.txt
+[33mc281fe62[m fix(crawl): propagate db fix to preview endpoint
+[33m803577ee[m feat(crawl): webhook
+[33me6738abf[m fix(crawl-status): retrieve from DB in bulk
+[33m086ba628[m fixed markdown format
+[33maabfaf0a[m clean up crawl-status, fix db ddos
+[33me5b807cc[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33mb311fe18[m Create temp-37564.rdb
+[33m7a613255[m map + search + scrape markdown bug
+[33m5896153d[m fix: crawl status and redis fixes
+[33m3fcb2193[m remove log
+[33mf20328bd[m crawl status and document stuff
+[33m0c057bb6[m Update index.test.ts
+[33mb3246455[m Update index.test.ts
+[33m5bac7988[m Update index.test.ts
+[33m290c7ee9[m Update index.test.ts
+[33m23a033fe[m Nick: fixes and more e2e tests
+[33m78ca9425[m Merge pull request #480 from mendableai/nsc/hyper-v81
+[33m37ae9a90[m Update index.test.ts
+[33m200ce8e2[m Merge branch 'v1-webscraper' of https://github.com/mendableai/firecrawl into v1-webscraper
+[33m21d3798e[m Nick: initial e2e v1 tests for /scrape
+[33m3f998b68[m scrape ready
+[33mb0d211ec[m Merge branch 'main' into v1-webscraper
+[33mfd6432e7[m fix(queue-worker): correct job success
+[33m6e549422[m fix(queue-worker): add cancelled to crawl log
+[33m9b1cb266[m added origin to request types
+[33md0a8382a[m fix(queue-worker): crawl finishing race condition
+[33m6bd52e63[m fix(queue-worker): fix linksOnPage undefined error
+[33m5a6570cb[m fix(webhooks): call back with parent crawl ID
+[33m7d324bd2[m Create checkCredits.ts
+[33mec361609[m Nick: added growth-2x plan
+[33m8b7569f8[m add zod, create middleware, update openapi declaration, add crawl logic
+[33m4165de17[m v1 restructure
+[33maf08ab0b[m fix bad module resolution
+[33mc917c8fb[m Merge branch 'main' into v1-webscraper
+[33m32c6b1f1[m Nick: remove active job alerts
+[33m0c143667[m fix: add checkandupdateurl to crawlPreview
+[33m81b2479d[m Merge pull request #459 from mendableai/feat/queue-scrapes
+[33mfc08ff45[m search port
+[33m86326f34[m Update single_url.test.ts
+[33m129a882b[m fix(scrape): give scrapes their real job id
+[33m965a5817[m fix(queue-worker): log jobs correctly
+[33mdad9d353[m use thomas's url validation
+[33me3279274[m fix: make playground crawl work
+[33mc5597bc7[m fix: robots.txt laoding
+[33m29f0d9ec[m propagate priority to fire-engine
+[33mb79d3d17[m fix
+[33m57730f6a[m priority changes
+[33m84661068[m fix: fix posthog, add dummy crawl DB items
+[33m829d115f[m added crates io token
+[33m81066cf9[m updating cargo pckg name n version
+[33m6e1074cd[m Update website_params.ts
+[33m6410e1a8[m Update params
+[33m697501cc[m Merge remote-tracking branch 'origin/main' into f/rust-sdk
+[33m8a5cad72[m fix(queue-worker): variable name collision
+[33m4d39025e[m workflows/ci
+[33mb8ec40dd[m fix(crawl): submit sitemapped jobs in bulk
+[33m2ca1017f[m fix(crawl): make request 0 of crawl jobs higher priority
+[33mf4466f6b[m fix(test-suite): add artillery
+[33mcfad067a[m fix(fly): change proxy limits
+[33ma6c81f9d[m fix: return all data when calling webhook
+[33m84a2fe86[m Merge pull request #537 from mendableai/feat/go-sdk-submodule
+[33mf86d2bb2[m added go-sdk as submodule
+[33me2472b9b[m Merge remote-tracking branch 'origin/v1/mockup-controllers' into v1-webscraper
+[33m2e5e480c[m fix(crawl): call webhooks
+[33m9f70be49[m Merge pull request #532 from matsubo/matsubo-patch-1
+[33ma33596de[m fix(log_job): add crawl_id
+[33m9252940b[m fix(crawl-status): sort data
+[33m8dbac026[m feat: offload crawl results to the DB
+[33m4bbc9db1[m fix: prioritize scrape jobs over crawl jobs
+[33m5f2af378[m fix(scrape): remove scrape job from queue after the job is done
+[33m2413e333[m fix(queue-worker): remove console.log
+[33md7549d4d[m feat: remove webScraperQueue
+[33m4a2c37dc[m Merge branch 'main' into feat/queue-scrapes
+[33m86e136be[m feat: crawl to scrape conversion
+[33mc82e9f3e[m Merge pull request #536 from mendableai/fix/e2e-tests
+[33ma4be95ac[m fixed tests
+[33mdd387c53[m Merge pull request #534 from KentHsu/fix/go-sdk-module-name
+[33m624efb72[m Removed obsoleted declaration
+[33mfd060c7e[m fix: go-sdk module name
+[33mc6bf78cf[m Update fly-direct.yml
+[33m76160a38[m Update single_url.ts
+[33m7c339ea1[m Update single_url.ts
+[33m09ca165d[m Merge pull request #531 from kevinswiber/fix/respect-docker-env-file-comments
+[33md06f4081[m Merge pull request #515 from wahpiangle/main
+[33m68103382[m Update search.ts
+[33m98be29c9[m Update parameters for platform.openai.com
+[33mc3aeed51[m Update single_url.ts
+[33m33aa5cf0[m Moving comments of .env.example values from end-of-line to above-line. Self-host docs suggest using .env.example as a base. However, Docker doesn't respect end-of-line comments. It sets the comment as the actual value of the variable. This fix prevents that.
+[33m9d187bf3[m Merge pull request #529 from mendableai/nsc/redlock-cache-auth
+[33m74a51251[m Nick: removed redlock
+[33m0bd1a820[m Update auth.ts
+[33m25a899ea[m Nick: redlock cache in auth
+[33mbbed6ef2[m added validation on every USE_DB_AUTHENTICATION call
+[33m36e4b2cf[m Update .env.example
+[33mfe179d0c[m Update redis troubleshooting in self host guide
+[33ma96ad4b0[m Update redis url to use comment
+[33mba2af74a[m Ensuring USE_DB_AUTHENTICATION is true in single URL scraper.
+[33me28c415c[m Nick:
+[33m5a778f2c[m fix(js-sdk): add type metadata to exports
+[33m6a78f6fe[m Merge pull request #497 from KentHsu/feat/add-go-sdk
+[33m0591000b[m bugfix includes excludes
+[33m1fda8829[m Merge branch 'mendableai:main' into feat/add-go-sdk
+[33m0221872a[m Update redis urls in example .env
+[33mb802ea02[m small improvements
+[33m0b8df5e2[m python sdk and tests
+[33mbf1d325a[m Merge pull request #512 from mendableai/nsc/digikey-tls
+[33mf1f56050[m Update website_params.ts
+[33mcf9d77d8[m typescript fixes
+[33mb0abad07[m Merge pull request #496 from tak-s/improve-logging-level
+[33mc16437e9[m fixed bunch of types
+[33m920b7f2f[m fix(runWebScraper): don't filter empty docs
+[33m55ec96c2[m fix(queue-worker): bad job lock extension time
+[33mab7a35c5[m fix(queue-worker): log lock extensions
+[33ma1c2ee5a[m fix: always complete job, no try
+[33m191dfbd9[m fix: move to completed in one place
+[33m457c082b[m Nick: fixed tests
+[33m8a992b15[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mb12e1157[m Nick: v35 bump
+[33m5fc7fcb7[m Merge branch 'main' into feat/queue-scrapes
+[33mfe9fdb57[m revert bad hotfixes
+[33mb7c01dcb[m fix(webScraperQueue): reduce retries to 2
+[33mcdf7bad5[m fix(runWebScraper): don't move to completed
+[33m9df8719e[m fix(queue-worker): raise queue log level to info
+[33m7bb92207[m fix(queue-worker): manually renew lock (testing)
+[33m8216266d[m fix(scrape_log): display error properly
+[33m2e2e80d6[m fix(scrape-events): updateScrapeResult fix
+[33mb5ec47fd[m fix(runWebScraper): don't fetch next job
+[33m44c9a227[m Merge pull request #508 from mendableai/mog/js-sdk-cjs
+[33m020a5efd[m Revert "Revert "Merge pull request #432 from mendableai/mog/js-sdk-cjs""
+[33m7380d779[m Merge branch 'main' into mog/js-sdk-cjs
+[33m5f772420[m fix(js-sdk): re-add types
+[33mf294d392[m Nick: revert
+[33m5da44728[m Revert "Merge pull request #432 from mendableai/mog/js-sdk-cjs"
+[33ma67a5c04[m Revert "Merge pull request #432 from mendableai/mog/js-sdk-cjs"
+[33mbb90e03d[m Merge pull request #432 from mendableai/mog/js-sdk-cjs
+[33m3fb23070[m Update index.ts
+[33md599d31e[m wip
+[33m6cdf4c68[m wip: map, crawl, scrape mockups
+[33m3321ca93[m Merge pull request #504 from mendableai/feat/fullpage-screenshot
+[33mb60ee30d[m fix(single_url): accept 500
+[33m06751a8e[m fix(crawl-status): missing partial data after cancel
+[33m810b98ec[m fix(scrape): fix timeout error code
+[33m3ae95a27[m fix(scrape): consider timeout property
+[33m8566ece7[m fix(scrape): pass extractorOptions
+[33m8e0aa696[m fix(crawl-status): partial_data
+[33m1ab119c8[m fix(scrape): don't double-bill for scrape
+[33m7c5cda7b[m fix(queue-worker): concurrency
+[33md7d63790[m fix(crawl-status): isCancelled should be status failed
+[33m03c84a93[m cleanup and fix cancelling
+[33m4d24a99d[m fix params
+[33me195ddbe[m Merge branch 'main' into nsc/hyper-v81
+[33m72f2c361[m Merge pull request #503 from mendableai/bugfix/empty-excludes
+[33m3edc3a3d[m added fullpagescreenshot capabilities, wip on fire-engine side
+[33mf32e8de1[m fixes the empty excludes.filter undefined bug
+[33mb2e1b2ca[m chore: add go-sdk-tests job
+[33m1378ffc1[m feat: add go-sdk
+[33maf9bc5c8[m Suppressed repetitive logs
+[33mdb926a41[m set LOGGING_LEVEL to environment
+[33m789c6cf5[m Merge pull request #494 from mendableai/nsc/website-param-fixes
+[33m1742e4ce[m Nick:
+[33m311f812a[m Merge branch 'nsc/amazon'
+[33m39aecd97[m Update redis-health.ts
+[33mddc0dac4[m Merge pull request #492 from mendableai/nsc/amazon
+[33m2e83a8a8[m Delete check-redis.yml
+[33mb448e3c3[m Update website_params.ts
+[33m893113a3[m Merge pull request #491 from mendableai/bugfix/issue-477
+[33m40516306[m Update sitemap.ts
+[33m8568b610[m bugfix for sitemaps
+[33maf68b7a7[m Merge pull request #475 from mendableai/bugfix/issue-466
+[33m72eebb0a[m Merge pull request #485 from mendableai/bugfix/issue-435
+[33mf48ff36b[m added .inc files and forced lower case comparison
+[33m4ab7fb00[m Merge pull request #484 from mendableai/nsc/fix-scaling-fix-email
+[33mad6f6eff[m Update fireEngine.ts
+[33mf9827b21[m Update credit_billing.ts
+[33m6d99dedd[m Nick: fixed tests
+[33ma28ecc1f[m Nick: caching
+[33m86c61b56[m Merge pull request #483 from mendableai/feat/improv-self-host
+[33mc7a38a4a[m Update SELF_HOST.md
+[33m52198f29[m Nick:
+[33m2d1ab43c[m Update SELF_HOST.md
+[33mf43d5e78[m Nick: scrape queue
+[33m7e002a8b[m Nick: bull mq
+[33m46bcbd93[m Merge branch 'main' into feat/queue-scrapes
+[33mfd2452ec[m Update scrape.ts
+[33m065ede7c[m Merge pull request #482 from mendableai/bugfix/switch-case-ratelimiter
+[33m8f5174ff[m Update auth.ts
+[33md25d7e72[m special case: developer.apple.com
+[33mc4469423[m Nick:
+[33m473e0832[m Merge branch 'nsc/fire-engine-first-layer'
+[33m5e8ffcf5[m Update website_params.ts
+[33maba95e5c[m Merge pull request #479 from mendableai/nsc/fire-engine-first-layer
+[33m7b813883[m Nick: first layer
+[33m8660df0e[m Merge pull request #478 from mendableai/nsc/cacheable-lookup
+[33me99c2568[m Update auth.ts
+[33m968a2dc7[m Nick:
+[33m04942bb9[m Nick:
+[33m267d4681[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mb4833c16[m Nick: increasing default timeout to 45s
+[33m7fa08100[m Merge pull request #414 from NiuBlibing/support_model_name
+[33m49e3e647[m bugfix for pdfs and logging pdf events, also added trycatchs for docx
+[33m4c9d62f6[m Nick: fixing sitemap fallback
+[33m091924a6[m Nick: moving machines from mia to virginia
+[33mcb97871f[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mff4266f0[m Update pdfProcessor.ts
+[33m0c2e3a72[m Merge pull request #460 from mendableai/nsc/admin-router
+[33m96cec2a6[m fix checking scrape log success content length
+[33m542270f4[m Merge pull request #461 from mendableai/nsc/small-handle-for-client-side-errors
+[33mdc6f8252[m Update email_notification.ts
+[33mf82ca3be[m Nick:
+[33m01fab6e0[m Update single_url.ts
+[33m56042d09[m Update single_url.ts
+[33m88f5efce[m Merge branch 'feat/scrape-monitoring'
+[33m32428725[m Update single_url.ts
+[33mffd430f1[m Merge pull request #457 from JakobStadlhuber/Readiness-Liveness-Probes
+[33m7129d799[m Update v0.ts
+[33me0954d7f[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m81aa9192[m fix
+[33m10e80f00[m Merge branch 'main' into nsc/admin-router
+[33m11e6b268[m Merge pull request #455 from mendableai/feat/scrape-monitoring
+[33me5b79754[m Merge branch 'main' into feat/scrape-monitoring
+[33m50d2426f[m Update scrape-events.ts
+[33m28a8a984[m Update admin.ts
+[33m2014d9dd[m Nick: admin router
+[33ma75d6889[m Merge pull request #450 from mendableai/feat/logger
+[33m1f1c068e[m changing from error to debug
+[33me720e1ba[m Merge remote-tracking branch 'origin/main' into feat/logger
+[33m309728a4[m updated logs
+[33m2c122175[m Merge pull request #449 from mendableai/bugfix/malformed-url-sitemap
+[33md1a3df6d[m fix: aaaaahhh
+[33m6ad7e244[m Update ingestion.tsx
+[33m6798695e[m feat: move scraper to queue
+[33m92843a35[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m1e13ddbe[m Nick: changes to the ui component
+[33m623b5472[m  fix(fly.toml): scale up memory limit
+[33m15890772[m Scale bump
+[33ma4bccbe3[m Firecrawl UI Template
+[33ma62c0730[m Delete package-lock.json
+[33m4cb091ad[m Update .gitignore
+[33m4596d0b2[m Add ReadMe and LICENSE
+[33m9654721b[m Vite commit
+[33mcc98f83f[m added failed and completed log events
+[33m2dc7be38[m Remove liveness and readiness probes from worker.yaml
+[33md68f3491[m Update Kubernetes YAMLs and add worker service
+[33mf26bda24[m Update Docker build paths in Kubernetes setup README
+[33m895e80ca[m Add liveness and readiness probes to Kubernetes configs
+[33mbe9e7f9e[m Update Kubernetes configs for playwright-service, api, and worker
+[33m60c74357[m feat(ScrapeEvents): log queue events
+[33m497aa5d2[m Update Kubernetes configs for playwright-service, api, and worker
+[33m4eca6bd3[m fix/check-for-auth-on-scrape-log
+[33m4ead89f9[m Merge pull request #453 from mendableai/nsc/notion-fix
+[33m3a1b8a97[m Update website_params.ts
+[33m8b48ec8d[m Update website_params.ts
+[33m4d35ad07[m feat(monitoring/scrape): include url, worker, response_size
+[33m64bcedee[m fix(monitoring): bad success check on scrape
+[33md57dbbd0[m fix: add jobId for scrape
+[33m71072fef[m fix(scrape-events): bad logic
+[33m7cd9bf92[m feat: scrape event logging to DB
+[33m5e728c1a[m Update apps/api/src/scraper/WebScraper/crawler.ts
+[33m1b7a0062[m Delete old comp
+[33m565bc094[m Basic react app
+[33m6208ecdb[m added logger
+[33ma0d89169[m init
+[33mf0b07b50[m Update index.ts
+[33ma684bd3c[m added regex for links in sitemap
+[33m252bc09e[m Merge pull request #447 from mendableai/nsc/speed-improvements
+[33mac692ef0[m Update CONTRIBUTING.md
+[33m30e706b4[m Update scrape.ts
+[33m8916fec6[m Update index.ts
+[33m575ddc9e[m Update scrape.ts
+[33me31a5007[m Nick: speed improvements
+[33m1bc36e1a[m Update fly-direct.yml
+[33mb229fbeb[m Update scrape_log.ts
+[33m5c02dbe2[m fix(isFile): added .tiff extension
+[33mf0e95ce3[m fix(WebCrawler): filter out file URLs when taking URLs from sitemap
+[33m95c6c63b[m fix(fly): raise heap limit to 4G per process
+[33m5f14f4f7[m Update blocklist.ts
+[33m6161b838[m Update scrape_log.ts
+[33mc402c853[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m2dd7398a[m Update scrape_log.ts
+[33m791e6b20[m fix action
+[33mf10f3f88[m Merge pull request #410 from mendableai/feat/fire-engine-chrome-cdp
+[33m9a1a2277[m Update crawl-cancel.ts
+[33m11768571[m Update crawl-cancel.ts
+[33mce804d3c[m Update crawl-cancel.ts
+[33md338b054[m Merge pull request #436 from mendableai/mog/fix-infinite-regex
+[33md2de01d3[m Nick: fixes
+[33m0b8047c7[m fix(WebScraper): infinite regex leading to fly.io instance hangs
+[33mf1113735[m Merge branch 'main' into feat/fire-engine-chrome-cdp
+[33m6d1d46a9[m Merge pull request #433 from mendableai/mog/js-sdk-tests-fix
+[33m01b5e8fc[m Merge pull request #429 from mendableai/mog/fix-job-stuck-2
+[33mb134ba92[m Merge pull request #427 from mendableai/docs/update-docs
+[33mf13ef02a[m Update openapi.json
+[33ma23b1254[m fix(js-sdk): transform tests with ts-jest and configure node
+[33m36126997[m fix(js-sdk): remove autogenerated index.d.ts from git and add to gitignore
+[33m2e62de4f[m fix(js-sdk): remove built files from repo and add to gitignore
+[33ma0b8a6ca[m feat(js-sdk): build both cjs and esm versions
+[33m12ec519f[m Update docker-compose.yaml
+[33m2fab2d8d[m Update scrape.ts
+[33m6609c1b6[m Update .env.local
+[33m17a1f9b5[m Update .env.example
+[33meda616d7[m Merge remote-tracking branch 'origin/main' into docs/update-docs
+[33m2b4ce120[m Update openapi.json
+[33m8160c311[m fix queue stuck bug via lock setting changes
+[33m8d5ebc9b[m Merge pull request #423 from mendableai/cjp/linksOnPage
+[33m5b24d26c[m Caleb; fixed test
+[33mc5d1e726[m Caleb: made changes per Rafaels requests
+[33m205cd63c[m Update openapi.json
+[33mf020048a[m Merge pull request #420 from mendableai/bugfix/empty-tags
+[33mda3c6bca[m Caleb: added a simple test
+[33m0b3c0ede[m Added tests per @nicks request
+[33m98c788ca[m Caleb: added a test to ensure links on page exists and isn't zero on mendable
+[33md7f18542[m Merge pull request #424 from mendableai/nsc/seperate-rate-limit
+[33m2bcbe4f3[m Create check-redis.yml
+[33m3c3412e8[m Update rate-limiter.test.ts
+[33mffc3b7c5[m Update index.ts
+[33mc9073a74[m Nick:
+[33md39d3be6[m Caleb: now extracting and returning a list of all links on the page for a customer
+[33mdba1fb2d[m Update removeUnwantedElements.ts
+[33mdb054501[m Merge pull request #391 from jhoseph88/feat/issue-387
+[33m548c8c1f[m Merge pull request #417 from mendableai/nsc/seperate-rate-limit
+[33m92202de1[m Update rate-limiter.ts
+[33m7f8953e9[m feat: add a small CHANGELOG for the rust-sdk client
+[33m7f596e7a[m Update README.md
+[33m4ef47f77[m Update models.ts
+[33m1b7ae545[m support custom models
+[33m5c65ec58[m Support chrome-cdp and restructure sitemap fire-engine support.
+[33m8efd444b[m Merge pull request #399 from mendableai/nsc/sitemap-fix-fire-engine
+[33m94979104[m Nick:
+[33md0c8d3ec[m Merge branch 'main' into nsc/sitemap-fix-fire-engine
+[33ma3b1703b[m Update fireEngine.ts
+[33m09bc2c7a[m Merge pull request #394 from mendableai/nsc/small-fe-print
+[33me098e88e[m Nick:
+[33mbfc7f588[m Update index.ts
+[33mda3e6525[m Merge pull request #398 from mendableai/nsc/slack-alerts-1
+[33m436e8922[m Nick: doing on the ci instead
+[33me61e94cb[m Merge pull request #397 from mendableai/nsc/slack-alerts-1
+[33mfc3328f3[m Update index.ts
+[33mfd18f226[m Nick: slack alerts
+[33m214a6ee6[m Merge pull request #396 from mendableai/bugfix/crawl-docker
+[33mf453bcf1[m bugfix docker self hosting
+[33mf2a08e0a[m Merge pull request #395 from kun432/kun432/fix-use-db-auth-check-for-selfhost
+[33m0ddaac6a[m Nick: fixed the other instances as well
+[33m5da03a8f[m Update fireEngine.ts
+[33mbd986a45[m fix USE_DB_AUTHENTICATION checks
+[33mb5b75086[m Update index.ts
+[33mc07a1912[m Merge pull request #393 from mendableai/mog/job-stuck-fix
+[33m0d3e09e7[m fix: try-catch job removal
+[33m69d72471[m Merge branch 'main' into mog/job-stuck-fix
+[33mc3eecf7b[m Update index.ts
+[33m3a744eb9[m feat: update the doc and version
+[33m2ae2ccad[m chore: update license on Cargo.toml
+[33m80af3905[m chore: update doc and libs
+[33m6ea36d38[m chore: no need for Makefile
+[33md7bbb22a[m feat: update fly github action
+[33m9deaa8b0[m feat: add rust sdk ci github action
+[33m0b19c940[m fix: format the rust code
+[33maa9d49cf[m fix(test): updates and keep relevant tests
+[33m21983011[m feat: update tests
+[33md86de4f5[m feat: add Debug to FireCrawl
+[33md8f67d50[m chore(doc): adding sdk rust lib
+[33m20932f7b[m feat(test): start implementing tests for the lib
+[33m2f6215c4[m feat: add dotenv and assert-match as dev dependencies
+[33m10957b74[m fix(bull): requeue jobs after restart
+[33mbcf596c3[m fix: license
+[33m04e94cdb[m chore: update cargo.toml file by adding more elements
+[33m961b2781[m Merge pull request #386 from mendableai/feat/fire-engine-fallback-for-sitemap
+[33m84de63db[m Merge pull request #375 from StefanTerdell/self-host-qol
+[33m30c11187[m Merge pull request #326 from mendableai/feat/save-docs-on-supabase
+[33m68828a5b[m Pass along current, total, current_step, and current_url in js sdk
+[33m7e3a3686[m fix: unpause globally
+[33mee1d4140[m feat: unpause by http request
+[33mf64a2d86[m fix: rename fly tomls to original
+[33mbd84290b[m fix: reenable hyperdx
+[33m09bca05b[m feat: fix iteration 3 (actually works)
+[33m9cd7d79b[m feat: avoid double SIGINT crashing
+[33meaa8db4b[m fix(fly): raise kill timeout for graceful shutdown
+[33mbffb9f8f[m feat: stuck job restoration iteration 2
+[33m404aeb3d[m feat: add an example rust code to tests it
+[33m3c49f0e0[m chore: update deps by allowing bumps + add uuid
+[33m86d0e88a[m removed hyperdx (they also have graceful shutdown) and tried to change the process for running on server. It didn't work.
+[33m7c3cc89a[m Merge branch 'feat/save-docs-on-supabase' of https://github.com/mendableai/firecrawl into feat/save-docs-on-supabase
+[33m9ad06fdf[m added fire-engine fallback for getting sitemaps
+[33m1a07e9d2[m feat: pick up and commit interrupted jobs from/to DB
+[33m6a524e1b[m feat: pick up and commit interrupted jobs from/to DB
+[33m77aa4658[m feat: graceful exit handler
+[33mfcc67a3c[m Merge pull request #370 from mendableai/bug/fixing-cicd
+[33m51e6579d[m Update README.md
+[33mf8e79dd7[m Update integrations
+[33mafb49e21[m Update SDKs to MIT license
+[33m002bfdf6[m Merge pull request #374 from StefanTerdell/fix-372
+[33m188fe562[m Optional jobId webhook URL templating
+[33mfcedcccf[m Include self hosted webhook env and allow connections to localhost
+[33ma2ae5f81[m Only check Supabase if configured to
+[33me24bbcc6[m feat: rust sdk initial commit
+[33me779dbbe[m Merge pull request #371 from mendableai/feat/issue-342
+[33mc2bba54b[m Added veeva to special case params
+[33ma2cdc520[m dependabot for security checks, fixed crawl test
+[33m2b36de60[m Merge pull request #349 from mendableai/dependabot/npm_and_yarn/apps/api/prod-deps-5b38a50718
+[33m0ab6cef4[m Merge remote-tracking branch 'origin/main' into dependabot/npm_and_yarn/apps/api/prod-deps-5b38a50718
+[33m914897c9[m Merge branch 'main' into feat/save-docs-on-supabase
+[33m538dc630[m Fixing rate-limiter-flexible package version
+[33md4e1a972[m Merge branch 'dependabot/npm_and_yarn/apps/test-suite/dev-deps-ffe2a14739'
+[33mc570fa92[m Merge pull request #347 from mendableai/dependabot/npm_and_yarn/apps/test-suite/prod-deps-d16537e256
+[33ma7aaa7e5[m Update SELF_HOST.md
+[33m5551f704[m Merge pull request #362 from snippet/self-host-docs-ts-playwright-service
+[33m8f46b821[m Merge pull request #361 from snippet/ts-playwright-service-docker
+[33m32849b01[m Nick:
+[33m5ecd9cb6[m Merge pull request #363 from mendableai/nsc/logging-scrapers
+[33m066d92f6[m Update single_url.ts
+[33mf5b2fbd7[m Nick: revision
+[33m2d30cc61[m Nick: comments
+[33m90c54c32[m Nick: refactor
+[33m90cf799a[m Update single_url.ts
+[33mb36406e4[m Nick: log scrpaers
+[33m8d09c5f9[m (Docs) Self Host added new ts playwright service instructions
+[33mb4292c1e[m setting up docker to ts playwright service
+[33mabb44bb1[m Merge pull request #346 from mendableai/dependabot/pip/apps/playwright-service/prod-deps-8f04296377
+[33mf967dadd[m Merge pull request #325 from snippet/playwright-scraper-api
+[33m2d0d5ac3[m Update for llm-extraction-from-raw-html
+[33m01751525[m Fixed PDF match custom scraping
+[33m96de948d[m Update index.test.ts
+[33m7b7154ba[m bugfixed pageStatusCode
+[33m50eecf04[m Update licence pyproject.toml
+[33mc2e00d19[m apps/api(deps): bump the prod-deps group in /apps/api with 28 updates
+[33m5bda5ec8[m apps/test-suite(deps-dev): bump typescript
+[33mad3e73b4[m apps/test-suite(deps): bump the prod-deps group
+[33m60de6bb6[m apps/playwright-service(deps): bump the prod-deps group
+[33m3d530b46[m Merge pull request #337 from Sanix-Darker/f/cleaner-docker-compose
+[33m46ddc813[m Merge pull request #338 from Sanix-Darker/dependabot
+[33mf0f449fe[m Merge pull request #336 from snippet/allow-external-content-links
+[33mdb4a7433[m Added e2e test
+[33m0821017f[m Update README.md
+[33m42cd58a6[m Merge pull request #332 from mendableai/feat/rawHtmlExtraction
+[33mc4f42398[m Update pnpm-lock.yaml
+[33m16aac7f8[m Update single_url.ts
+[33m6d0c7a9c[m Merge pull request #323 from mendableai/tests/crawl-limit-unit-tests
+[33m4d6e2561[m minor spacing and comment stuff
+[33me1af815f[m Update scrape.ts
+[33mcf8208e3[m feat(deps): making sure all deps are always up to date
+[33mff62b260[m feat: regroup what could be regroup in terms of environments variables between services (api and worker)
+[33m7ae195ba[m Update index.test.ts
+[33m837b4463[m Update index.test.ts
+[33mfe6e3aea[m Update index.test.ts
+[33m6c9f0dfc[m Add tests
+[33ma5fb4598[m new feature allowExternalContentLinks
+[33m87b54488[m update to includeRawHtml
+[33m70fcf2ce[m init
+[33m9bf74bc7[m Update single_url.ts
+[33m7e17498b[m Update single_url.ts
+[33m7dffaaa3[m Changed port and added "using with firecrawl" section on readme
+[33md66e1f78[m looking good
+[33mdbfae2d9[m Merge pull request #329 from george-zakharov/patch-1
+[33m5a0ec070[m Update CONTRIBUTING.md
+[33m017b0b25[m Merge pull request #328 from mendableai/nsc/includeOnlyTags
+[33m9e729894[m Update openapi.json
+[33m1ec0bf8a[m Update openapi.json
+[33m042f81dd[m Update removeUnwantedElements.test.ts
+[33m388ce3cb[m Nick: small changes
+[33m1d4907ac[m Nick:
+[33mc40da77b[m Added implementation for saving docs on supabase
+[33md833a132[m new playwright service
+[33m3b92fb84[m Merge pull request #322 from mendableai/tests/metadata
+[33m67d7650c[m Added to e2e_noAuth
+[33mac08e20c[m Merge pull request #321 from mendableai/bug/fix-issue-310
+[33md80046d1[m Gemini caching example
+[33m009df6c9[m Added crawl limit unit test
+[33m05eaa3c6[m Update index.test.ts
+[33m4381109d[m added default values and fixed pdf bug
+[33m45f27656[m Merge pull request #316 from snippet/types-webscraper
+[33m768a131b[m Merge pull request #318 from mendableai/bug/fix-custom-scrape-pdf-google-drive
+[33m5f69fc76[m Fixed the regex test
+[33mdbb22c8f[m Merge pull request #317 from mendableai/bug/fix-clean-jobs
+[33md02829d3[m fixed clean jobs
+[33m199cbe8b[m add some types
+[33m749b0c05[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33me7be17db[m Nick: metadata fixes and lock duration for bull decreased to 2 hrs
+[33mf84fb4b3[m Merge pull request #313 from snippet/google-search-term-fix
+[33m6ddf3a58[m fix multi-word search term issue: /search (w/o Serp)
+[33me5314ee8[m Merge pull request #312 from mendableai/rafa/investigating-crawl-bugs
+[33m90b7fff3[m Update crawler.ts
+[33m08c1fa79[m Update queue-worker.ts
+[33m3ebdf933[m removed console.logs
+[33m56d42d9c[m Nick:
+[33m21d29de8[m testing crawl with new.abb.com case
+[33m3c7b7e72[m NIck: fixes fallback
+[33mb394e646[m Merge pull request #308 from 100gle/fix-typo
+[33m3624ed20[m docs: Fix pydanti to pydantic
+[33m22541362[m Reduce web example bloat
+[33m8e39083d[m Update examples section
+[33m5cf2beff[m Update clean-before-24h-complete-jobs.yml
+[33m3746b620[m Merge pull request #303 from Lakr233/patch-1
+[33m3d1766ba[m Fix Broken Link
+[33mc4252b61[m Merge pull request #302 from mendableai/cjp/email-to-posthog-logging
+[33me59ba758[m Caleb: changed posthog logging so that It associates jobs with a group. No
+[33m5a91d842[m Caleb: solve for typechecking on idempotencyKey on my machine
+[33m32dde257[m Merge pull request #301 from mendableai/bugfix/issue-291
+[33m9c539e91[m Fixed includeHTML to use cleanedHtml as response
+[33m1c5a1dd4[m Merge pull request #297 from AndyMik90/feat/removeTags-regex
+[33mf5a9acc4[m Merge branch 'main' into feat/removeTags-regex
+[33m9f7afd1e[m fix for some complex cases
+[33m8db8997d[m Nick: test suite + fly
+[33md0c05acc[m Nick:
+[33m818751a2[m Merge pull request #294 from mendableai/tests/e2e-to-unit
+[33ma3115004[m Merge pull request #296 from NeevJewalkar/sdk-update
+[33m754c9fa0[m Update package.json
+[33m90a807c5[m Update index.ts
+[33m26e8bfc2[m Merge branch 'main' into pr/296
+[33mb53ba58b[m Merge pull request #282 from mendableai/nsc/rate-limiter-tests
+[33m3b6c9a85[m Merge pull request #298 from mendableai/feat/type-improvements
+[33m727e5de8[m Update index.test.ts
+[33mc54e797e[m (╯°□°)╯︵ ┻━┻
+[33m6e32522f[m Improvements on response document types
+[33m3c1af0aa[m Update ci.yml
+[33m20f14bcf[m Added some types
+[33mc2fc69af[m removed some e2e tests that are making the ci get stuck
+[33m6c726a02[m Moved to utils/removeUnwantedElements, added unit tests
+[33m8b3c3aae[m Added support for RegEx in removeTags
+[33me5ffda1e[m Added local host support for the javascript SDK
+[33mb2bd562b[m transcribed from e2e to unit tests for many cases
+[33mab038051[m Merge branch 'main' into nsc/rate-limiter-tests
+[33ma20d002a[m Delete test-run-report.json
+[33md236fe9a[m Merge pull request #285 from mendableai/feat/maxDepthRelative
+[33m519ab1ae[m Update unit tests
+[33mf0d4146b[m Merge branch 'feat/maxDepthRelative' of https://github.com/mendableai/firecrawl into feat/maxDepthRelative
+[33mff7b52ca[m Delete one more e2e test
+[33mb1eb6082[m Merge branch 'main' into feat/maxDepthRelative
+[33m34e37c56[m Add unit tests to replace e2e
+[33m2b40729c[m Update index.test.ts
+[33mf22759b2[m Update index.test.ts
+[33ma6b71977[m Fix for maxDepth
+[33m4ec86371[m Merge pull request #283 from mendableai/nsc/crawler-fixes
+[33m43767360[m Merge branch 'main' into nsc/rate-limiter-tests
+[33me88cb314[m Update crawler.ts
+[33m361cba41[m Merge pull request #175 from mendableai/test/load-testing
+[33m7b11ace8[m Create rate-limiter.test.ts
+[33me369d1dd[m Update index.test.ts
+[33me37aa3db[m Nick: fixed rate limit on status
+[33ma6ed2e69[m Update index.test.ts
+[33mad7795f9[m Merge remote-tracking branch 'origin/main' into test/load-testing
+[33m0ec26576[m Merge pull request #277 from mendableai/feat/maxDepthRelative
+[33m354712a8[m just changed the name for the test?
+[33m2c5f5c0e[m Merge branch 'main' into feat/maxDepthRelative
+[33m80c10393[m Update index.test.ts
+[33m42ed1f44[m Update index.test.ts
+[33m52d6201c[m Merge pull request #276 from mendableai/feat/issue-266
+[33m8830acce[m Update index.test.ts
+[33m278bb311[m Update index.test.ts
+[33m36a62727[m Update index.test.ts
+[33mf9c7ca93[m Merge branch 'main' into feat/issue-266
+[33m2c0a2c74[m Merge pull request #271 from mendableai/feat/issue-205
+[33m3e2e7631[m Merge branch 'main' into feat/issue-205
+[33m59451754[m Add tests
+[33m5fd228f9[m Merge pull request #253 from mattjoyce/py-sdk-improve-response-handling
+[33mafee5684[m Fixed tests' message and updated version
+[33m9b254c1c[m Update index.test.ts
+[33m5a5c532b[m Merge branch 'main' into py-sdk-improve-response-handling
+[33m9aba451b[m Update index.test.ts
+[33mcc2e3f05[m Merge pull request #256 from mattjoyce/feat-254-sdk-py-logging
+[33m6963a490[m Updated version
+[33m5dd18ca7[m fixed edge cases
+[33mab9de0f5[m Update maxDepth tests
+[33m393bd452[m Update index.test.ts
+[33m71c98d8b[m Update logic
+[33m095951aa[m Update test
+[33m5e8aa927[m Update index.ts
+[33mbf10e9d3[m Update index.test.ts
+[33m65d63bae[m Update index.ts
+[33m32e814be[m Update index.ts
+[33m6fc1ee32[m Merge pull request #275 from mendableai/feat/issue-273
+[33mbb859ae9[m Added metadata.pageStatusCode and metadata.pageError properties to the responses
+[33m676d6e8a[m Added pageOptions.removeTags
+[33md48c0df6[m Merge pull request #274 from mendableai/nsc/clusters
+[33m182f8d4d[m Update index.ts
+[33m11b6d5af[m Update fly.toml
+[33m67dc46b4[m Nick: clusters
+[33mbad0f571[m Merge pull request #272 from mendableai/bug/issue-258
+[33md20af257[m Added jobId to webhook data
+[33me37d1514[m added parsePDF option to pageOptions
+[33m48f6c19a[m Merge pull request #269 from mendableai/feat/allowbackwardcrawling-option
+[33m01c9f071[m fixed
+[33mdc6acbf1[m Merge remote-tracking branch 'origin/main' into feat/allowbackwardcrawling-option
+[33mf9323149[m Merge pull request #265 from mendableai/feat/issue-264
+[33m705f5ebe[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33md4df6f04[m Nick:
+[33m45dee639[m Merge pull request #262 from mendableai/nsc/webhook-self-host-fix
+[33m157fbe4a[m added bull auth key
+[33mdf3a678c[m getting back the cancel test, this should work
+[33mdef2ba99[m added tests
+[33mc08db830[m Merge pull request #268 from mendableai/nsc/abs-path-fix
+[33m1e3e06a1[m Update replacePaths.test.ts
+[33m2239e032[m Update replacePaths.test.ts
+[33m520739c9[m Nick: fixed bugs associated with absolute path replacements
+[33m788abdce[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mb87725c6[m Update openapi.json
+[33mee282c3d[m Added allowBackwardCrawling option
+[33ma9f93c2f[m Added route to clean completed jobs and a github action cron that triggers every 24h
+[33m06b0d01f[m Update examples
+[33m00c23855[m Update examples
+[33mda38dad9[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m9390816c[m Update openapi.json
+[33m15e791ff[m Merge pull request #263 from mendableai/nsc/pageoptions-crawler
+[33mf6b06ac2[m Nick: ignoreSitemap, better crawling algo
+[33m1bd0327e[m Merge branch 'main' into nsc/pageoptions-crawler
+[33m149d79a5[m Merge pull request #260 from mendableai/nsc/fix-deadlocks
+[33m99f2ffd6[m Update webhook.ts
+[33m7ae97786[m Update single_url.ts
+[33m913c1dd5[m Nick: fetch -> axios and fix timeouts
+[33m3091f013[m Nick:
+[33m827354a1[m Added logging to python sdk FIRECRAWL_LOGGING_LEVEL
+[33maafd23fa[m Merge pull request #252 from mattjoyce/fix-208-py-sdk-interval-poll-name
+[33m6fd9ce1c[m type hints and linting
+[33m7477c5e5[m Use error handler consistently
+[33m9f306736[m More detailed error handling
+[33mc71ea7a7[m Prepare headers consistently
+[33m8f9a165c[m Lint - whitespace
+[33m5f0df596[m Align param name with JS SDK
+[33mf24ca766[m Nick: removing rate limit emails for now
+[33m556c5764[m Update fly.yml
+[33m0e89f8b9[m fixing workflow
+[33m98d82c4c[m Update search.ts
+[33m5e80f8af[m Nick: llm extract 50
+[33m7b7a6f8a[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mf2695df2[m updated sdk versions
+[33m8dabf689[m Merge pull request #250 from mendableai/194-fixing-2
+[33m560f256a[m fixing minor problems on workflow
+[33m8bfec9e8[m Merge pull request #248 from mendableai/194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33me0958044[m Merge branch '194-sdk-ci-pipeline-for-publishing-pythonnode-sdk' of https://github.com/mendableai/firecrawl into 194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33m59e86150[m Update fly.yml
+[33m9d0643ed[m Merge branch 'main' of https://github.com/mendableai/firecrawl into 194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33m34742e8b[m Update fly.yml
+[33m4c3bfe4e[m Merge pull request #246 from mendableai/194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33mf5318ea7[m Update index.test.ts
+[33mcd7f9abc[m Update index.test.ts
+[33m7b9b668b[m Update index.test.ts
+[33m82e0ed4c[m Update index.test.ts
+[33mdac7612b[m Merge branch 'main' of https://github.com/mendableai/firecrawl into 194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33mc2ad3583[m Nick:
+[33m79ec9f04[m Merge branch 'main' of https://github.com/mendableai/firecrawl into 194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33mde06b13d[m Update rate-limiter.ts
+[33m27a8fd0c[m Update rate-limiter.ts
+[33m1129d333[m Update rate-limiter.ts
+[33mb3ad42ca[m updated workflows
+[33mb234b4be[m Merge branch 'main' into 194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33maf0bfca8[m Merge branch 'main' into 194-sdk-ci-pipeline-for-publishing-pythonnode-sdk
+[33m8132f22c[m nice
+[33mf1b5ec85[m Nick: fixes
+[33mdeae7dcd[m Update email_notification.ts
+[33mf725fa5a[m Update email_notification.ts
+[33mfb758fa0[m go
+[33mafc40214[m Update publish-js-sdk.yml
+[33m0a3846dc[m testing
+[33m0310da67[m Update rate-limiter.ts
+[33m01503c1f[m Nick:
+[33mb3cae4c8[m adding js and testing twine
+[33m63f0214d[m Update publish-python-sdk.yml
+[33mbc1c1e50[m updating version to check if it runs
+[33m5e17d2f6[m Update publish-python-sdk.yml
+[33m06aa426a[m Update check_version_has_incremented.py
+[33m3e091b0c[m Update publish-python-sdk.yml
+[33meb1dd54e[m Update publish-python-sdk.yml
+[33ma939f46f[m Update publish-python-sdk.yml
+[33m2744e3d4[m Update publish-python-sdk.yml
+[33mf9643bfa[m getting a bug from backslashes
+[33mbebd13fe[m Update publish-python-sdk.yml
+[33m5bf7b9d8[m Update publish-python-sdk.yml
+[33mfcea2d30[m for test purposes
+[33maf9e6c94[m Create publish-python-sdk.yml
+[33m7686ad57[m Merge pull request #196 from mattjoyce/main
+[33m525b4f2a[m Update rate-limiter.ts
+[33macb7de03[m Merge pull request #244 from mendableai/nsc/transactional-emails
+[33md7f8208c[m Update email_notification.ts
+[33mec10eb09[m Update credit_billing.ts
+[33m5991000d[m Update credit_billing.ts
+[33m5683bb2c[m Nick:
+[33m164676c7[m bugfix screenshot for readme pages
+[33m935406b9[m Merge branch 'main' into pr/196
+[33m88a52864[m Merge pull request #242 from mendableai/nsc/partial-data-changes
+[33mb4c6819a[m Nick:
+[33m0d51b11d[m missing breaks
+[33m64423441[m Merge branch 'main' into main
+[33mbeb7526d[m Update webhook.ts
+[33m1a16378f[m Merge pull request #234 from JakobStadlhuber/feat/webhook-self-hosted
+[33m9640bf08[m Merge pull request #238 from mendableai/feat/better-gdrive-pdf-fetch
+[33mff53db8c[m Merge pull request #236 from JakobStadlhuber/doc/kubernetes
+[33m7cb14ede[m Nick:
+[33m9e000ded[m Merge branch 'main' into feat/better-gdrive-pdf-fetch
+[33m6d76037f[m Merge pull request #239 from mendableai/feat/scroll-xpaths
+[33mccc55127[m Added scroll xpaths on fire-engine for handling readme docs
+[33mb5045d16[m [feat] improved the scrape for gdrive pdfs
+[33ma547f9a7[m Merge pull request #237 from mendableai/nsc/custom-vanta-refactor
+[33m96257b7b[m Update handleCustomScraping.ts
+[33mde049a5a[m Update README.md
+[33m73da34c8[m Update README.md
+[33mf98cd75c[m Merge pull request #140 from mendableai/calebpeffer-github-seo
+[33m674500af[m Nick:
+[33mf476e776[m Merge pull request #213 from mattjoyce/github-workflows
+[33m3cca2e3b[m Update Docker image names in README
+[33md54ec94b[m lgtm. Added some docs and requirements.txt
+[33m07246d0e[m Update README file in k8n directory
+[33m078d4c8d[m Add Kubernetes configuration for Firecrawl deployment
+[33mfc04d5b0[m Merge pull request #235 from mendableai/feat/gdrive-pdfs
+[33m5ae4d1ca[m Update single_url.ts
+[33m9e5ddec2[m Remove default webhook URL from .env.example
+[33m6208f420[m Add support for Self-Hosted Webhook URL Usage and added project_id into the webhook payload
+[33m93f30986[m build files
+[33m64a4338f[m Update single_url.ts
+[33m02fe470e[m Merge pull request #148 from mendableai/nsc/improvemnts-fixes-misc
+[33m665a40d9[m Merge pull request #212 from mendableai/bugfix/partial-data-js-sdk
+[33m1f4c6b7a[m Update package.json
+[33m19c67916[m Merge pull request #211 from mendableai/fix/rename-variables
+[33mf4f87b53[m Merge branch 'main' into bugfix/partial-data-js-sdk
+[33mf17cb1a0[m Merge pull request #224 from mattjoyce/playwright-service-bug-222
+[33m4e3a0495[m updated version 0.0.12 -> 0.0.13
+[33mb80fb374[m Merge branch 'main' into playwright-service-bug-222
+[33m6920ec8a[m bugfixing. already on main
+[33md6762386[m Update fly-direct.yml
+[33md10c0839[m Update fly-direct.yml
+[33m5d50b259[m Create fly-direct.yml
+[33md91b725c[m Update fly.toml
+[33mcbf8d79c[m Update pdfProcessor.ts
+[33m3fc9004b[m Update fly.toml
+[33m0cc7031a[m Update fly.yml
+[33m2ea01f14[m Update single_url.ts
+[33m3563e3ae[m Update fly.yml
+[33m854d5b3c[m Update single_url.ts
+[33m99059814[m Nick:
+[33m918059ee[m Merge branch 'main' into nsc/improvemnts-fixes-misc
+[33m93bb5327[m Merge branch 'nsc/improved-blocklist'
+[33m38e583f6[m Update socialBlockList.test.ts
+[33mb26c5f15[m Merge pull request #185 from mendableai/nsc/improved-blocklist
+[33mc69c89f8[m Nick:
+[33m48d1ec05[m Merge branch 'main' into nsc/improved-blocklist
+[33md30ced43[m Merge pull request #221 from mendableai/nsc/fwd-header-auth
+[33md865b0c5[m Merge pull request #229 from rombru/main
+[33m4987f901[m Merge branch 'mendableai:main' into main
+[33m4100cc92[m Update index.test.ts
+[33m3ff91ddd[m fix: use @ instead of # for default BULL_AUTH_KEY. hash mark is reserved for URI fragments.
+[33mc1aed136[m Update index.test.ts
+[33m30a0c5de[m Merge pull request #228 from mendableai/bugfix/fire-engine-content
+[33m1fc3a151[m Update single_url.ts
+[33m3ea801d9[m Commit Roast My Website
+[33mea04fe2e[m Add Roast My Website Example
+[33mfde522c3[m Update single_url.ts
+[33mdeefe65c[m Change the way the playwright response is parsed
+[33m14896a9f[m Fix PLAYWRIGHT_MICROSERVICE_URL
+[33m1eacad4e[m Clarifying wait type and name
+[33mc516140b[m Various Linting
+[33m2a39b538[m Add timeout to class and provide default.
+[33mc7d5a9ad[m Merge branch 'main' into nsc/fwd-header-auth
+[33m8cb62dde[m Update website_params.ts
+[33m3b8059ed[m Update single_url.ts
+[33m6bea8031[m Nick:
+[33m03ba4a9f[m Merge pull request #218 from mendableai/nsc/python-sdk-waiting-fixes
+[33m21391292[m Nick: v12
+[33m260e31c6[m Merge branch 'nsc/new-pricing'
+[33maa8133ca[m Update load-testing-example.ts
+[33m0c115c61[m Merge pull request #216 from mendableai/nsc/new-pricing
+[33md486d7da[m Merge pull request #207 from mendableai/feat/screenshot-support
+[33m6860ace4[m Nick:
+[33m6ceb7ff5[m Nick:
+[33m33f10a7f[m Nick: fixes
+[33mace46f34[m Nick: new limits, new pricing
+[33m677102e6[m Script to check local vs published versions
+[33m9f8792f0[m Script to check local vs published versions
+[33m5c4b3e8f[m Initial pyproject.toml
+[33mdec225d3[m Move version to __init__.py
+[33m2b763d84[m improved js response and test for getting partial_data
+[33m5b8b6902[m Update index.ts
+[33m6c939d53[m Nick: small refactor
+[33m37915e11[m Final push
+[33ma0e404f9[m init commit
+[33m51b0b88c[m Merge pull request #204 from mendableai/feat/custom-scraping-readme
+[33mee9a2184[m Added custom scraping conditions for readme docs
+[33m8911ddf1[m Merge branch 'nsc/wait-for-param'
+[33mc20c3872[m Update index.test.ts
+[33m0f43a129[m Update index.test.ts
+[33m7187eaef[m Merge pull request #200 from mendableai/nsc/wait-for-param
+[33mf53d25ef[m Merge branch 'main' into nsc/wait-for-param
+[33m1b3547dc[m Nick:
+[33m9b5e5b87[m Merge pull request #183 from mendableai/test-sdks
+[33m41b98f15[m Update README.md
+[33m71187b03[m added timeout
+[33md5c83803[m fixing idempotency test
+[33m41c4ef6a[m dotenv was missing
+[33m6b58da1c[m jest
+[33me87d39e6[m typo
+[33m127d2db1[m added js/ts sdk tests
+[33md0c4b24a[m missing redis
+[33m952ccd87[m envs
+[33mf32c1625[m missing node setup
+[33ma9b68d95[m Update test.py
+[33mc410dbe5[m Update python-tests.yml
+[33m667d3e4c[m Merge branch 'test-sdks' of https://github.com/mendableai/firecrawl into test-sdks
+[33m19decd10[m fixing workflow
+[33m3c8edf68[m Merge branch 'main' into test-sdks
+[33m63772ea7[m added github action workflow
+[33m1ef307cb[m Nick: checks
+[33m01cc91c5[m Update fly.staging.toml
+[33ma9e45cdb[m Merge pull request #191 from mattjoyce/main
+[33m1de53cc4[m Nick: fixes
+[33mefb821d6[m Merge branch 'main' into main
+[33med4226fd[m Update setup.py
+[33m1bbfb98d[m Merge pull request #186 from Keredu/main
+[33m67a53a9a[m Merge pull request #190 from simonha9/simonha9/improve-rate-limit-error-msg
+[33m7e2df7bd[m Update auth.ts
+[33m7948c6ce[m Nick: fixed pip issues
+[33mb061e120[m added python versions requirement
+[33mf00dffbb[m added misc PyPi keys
+[33mcd7f2602[m Added PyPi classifiers
+[33me5c6ac23[m Added long description to PyPi
+[33m115204e6[m Feat: Provide more details for 429 error msg
+[33m2192978f[m Limit on /search is not deterministic
+[33me9843460[m Update blocklist.ts
+[33me5c87195[m Update blocklist.ts
+[33m397769c7[m added python sdk e2e tests with pytest
+[33m4ce28593[m Merge pull request #132 from mendableai/feat/idempotency-key
+[33md39860c0[m Merge branch 'main' into feat/idempotency-key
+[33m605ba4c0[m Merge pull request #178 from mattjoyce/main
+[33m8c380d70[m Update firecrawl.py
+[33m65fe9c4f[m Merge branch 'main' into main
+[33m53a7ec0f[m Removed hard coded timeout
+[33me0d979ed[m Merge pull request #176 from mendableai/bug/data-check-in-python-sdk
+[33m53a214ce[m Merge pull request #168 from mendableai/nsc/allowed-keywords-in-blocklist
+[33me166c076[m Merge pull request #170 from qyou/fix-hardcode-timeout
+[33mc00580ea[m Merge pull request #181 from JakobStadlhuber/feat/proxy-support
+[33m9fc5a0ff[m Update comment in .env.example for proxy settings
+[33mb001aded[m Add proxy and media blocking configurations
+[33m6a5b9ca3[m Merge pull request #180 from mendableai/added-issue-templates
+[33m9562c837[m Update issue templates
+[33m7ca431b2[m crawl load tests 7 and 8
+[33mc201ea19[m added idempotency key to python sdk
+[33m35927a65[m Merge branch 'main' into feat/idempotency-key
+[33m184e4678[m bugfix on idempotency key check
+[33m96630154[m Merge pull request #1 from mendableai/main
+[33m106c18d1[m Use truthiness check for 'success' key in API response
+[33m5c21aed9[m adding pylintrc to allow longer lines
+[33m48e91c89[m Removed unnecessary If block
+[33m7d2efe5a[m Added request timeouts
+[33m96b19172[m Removed trailing whitespace
+[33m6216c853[m Time module already imported
+[33m8adf2b71[m Added Docstrings for functions
+[33m971e1f85[m Added module docstring
+[33m8d041c05[m rearranged logic for FIRECRAWL_API_URL
+[33maa6df430[m crawl load tests 6 and 7
+[33m4e397016[m Update main.py
+[33m73f1d09d[m Update website_params.ts
+[33mdf0550d2[m Merge pull request #143 from mendableai/bug/crawl-limit
+[33m3aa5f266[m Update main.py
+[33m3e63985e[m Update main.py
+[33m4dfc3712[m Update index.test.ts
+[33mf4a3469b[m Merge branch 'main' into bug/crawl-limit
+[33mff147f1f[m load testing for crawl
+[33m0d187f04[m Merge pull request #77 from tractorjuice/patch-1
+[33m04a0bef0[m Merge branch 'main' into test/load-testing
+[33me4573c08[m Update website_params.ts
+[33mf9ae1729[m Update firecrawl.py
+[33m068a240a[m load tests for scrape route
+[33mf915b080[m Merge pull request #174 from mendableai/nsc/fire-engine-beta
+[33mcb2bd0e7[m Update index.test.ts
+[33m253abb84[m Update rate-limiter.ts
+[33m229b9908[m Nick: only enable hyper dx in prod
+[33ma8ff2959[m Update single_url.ts
+[33ma5e718b0[m Nick: improvements
+[33m2e264a4c[m Update ci.yml
+[33m6285f12c[m Merge pull request #167 from mendableai/nsc/hyper-dx-integration
+[33m75f4e34d[m Merge branch 'main' into test/load-testing
+[33mec460650[m Update rate-limiter.ts
+[33m6a3ac13f[m Update load-test.yml
+[33mc47dae13[m update: wait until body attached in playwright-service
+[33m7f64fe88[m Update blocklist.ts
+[33m756f5446[m Nick: allowed keywords for now
+[33m01783dc3[m Update openapi.json
+[33m77a79b5a[m Nick: max num tokens for llm extract (for now) + slice the max
+[33m2644e1c0[m Update .env.example
+[33m9e61d431[m Nick: hyper dx integration init
+[33md5d0d488[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m60002e79[m Nick: python sdk bump
+[33m4bb536e5[m Merge pull request #166 from mattjoyce/main
+[33m7e5ef4de[m Allow override of API URL
+[33mc74f757b[m Update rate-limiter.ts
+[33m842e197f[m Merge pull request #151 from mendableai/feat/rate-limits
+[33m98a39b39[m Nick: increased rate limits
+[33m18fa15df[m Update index.test.ts
+[33m614c073a[m Nick: improvements
+[33mf473793b[m Merge branch 'main' into feat/rate-limits
+[33m4efebf7a[m Merge branch 'test/load-testing' of https://github.com/mendableai/firecrawl into test/load-testing
+[33m5792cd02[m Update fly.staging.toml
+[33m713f16fd[m Update README.md
+[33m0dc108cd[m Update README.md
+[33m43d0309b[m Merge pull request #160 from elimisteve/patch-1
+[33m81563130[m Update README.md: Typo fix
+[33mfae8954e[m Update SELF_HOST.md
+[33md667e141[m added fly staging load test
+[33m7630565c[m Create fly.staging.toml
+[33m7297b21d[m Added load testing using artillery
+[33ma480595a[m Update index.test.ts
+[33m54049be5[m Added e2e tests
+[33m6feb21cc[m Update website_params.ts
+[33m2a1f2e39[m Merge pull request #29 from mendableai/detect-pdfs
+[33m5be208f5[m Nick: fixed
+[33meb88447e[m Update index.test.ts
+[33mdf6c3d1e[m Merge branch 'main' into detect-pdfs
+[33m5c1e6d18[m Merge pull request #158 from mendableai/nsc/docx-support
+[33m9d635cb2[m Nick: docx support
+[33md407ec76[m Merge branch 'test/crawl-options'
+[33mbcce0544[m Update openapi.json
+[33ma3145909[m Merge pull request #153 from mendableai/test/crawl-options
+[33m80250fb5[m Update index.test.ts
+[33m098db179[m Update index.ts
+[33m93b1f033[m Update index.test.ts
+[33m123fb784[m Update index.test.ts
+[33m4a6cfb60[m Update index.test.ts
+[33m6ca36832[m Merge branch 'main' into test/crawl-options
+[33m24be4866[m Nick:
+[33made4e05c[m Nick: working
+[33mbfccaf67[m Nick: fixes most of it
+[33md9104337[m not working yet
+[33mfa014def[m Fixing child links only bug
+[33m2ba743fb[m Merge pull request #27 from eltociear/patch-1
+[33m0663d783[m Merge pull request #119 from chand1012/main
+[33meb36d4b3[m Update SELF_HOST.md
+[33mda8d9410[m fixed for testing the crawl algorithm only
+[33m95ffaa22[m Update crawl.test.ts
+[33mf15b8f85[m Update crawl.json
+[33m98dd672d[m Update crawl.json
+[33m499671c8[m Update crawl.test.ts
+[33m58053eb4[m Update rate-limiter.ts
+[33m4745d114[m Update crawl.test.ts
+[33m1601e93d[m Merge branch 'main' into test/crawl-options
+[33m3678d3c9[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mfd82982a[m Nick:
+[33m4925ee59[m added crawl test suite
+[33med211dc7[m Merge pull request #149 from mendableai/nsc/speed-up-crawl-4x
+[33m1b0d6341[m Update index.ts
+[33md10f81e7[m Nick: fixes
+[33m87570bdf[m Update index.ts
+[33md4574851[m Added rpc definition
+[33m47c20c80[m Update auth.ts
+[33me91c122c[m Merge branch 'main' into patch-1
+[33m7d8ceab6[m Merge branch 'feat/rate-limits' of https://github.com/mendableai/firecrawl into feat/rate-limits
+[33m0e0faa28[m Update auth.ts
+[33m672eddb9[m updated rpc
+[33m4761ea51[m Update rate-limiter.ts
+[33m40ad97de[m added rate limits
+[33m27e1e22a[m Update index.test.ts
+[33ma0fdc6f7[m Nick:
+[33m7f31959b[m Nick:
+[33m8a72cf55[m Nick:
+[33m26a092f7[m Update index.ts
+[33m8101cbee[m Update index.ts
+[33m86b84398[m Nick:
+[33ma96fc5b9[m Nick: 4x speed
+[33me26008a8[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m512449e1[m Nick: v21
+[33mbd27b0e1[m Merge pull request #142 from mendableai/doc/crawl-limit-default
+[33maa0c8188[m Nick: 408 handling
+[33m999176d5[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mf3ec21d9[m Update runWebScraper.ts
+[33mc9133f3d[m Merge pull request #145 from mendableai/nsc/timeout-scrape
+[33m65d89afb[m Nick:
+[33m3f090ffd[m Merge pull request #144 from mendableai/feat/gpt-4o
+[33m4cc46d4a[m Update models.ts
+[33m8eb2e95f[m Cleaned up
+[33m2ce04591[m Nick: disable vision right now
+[33m4737fe87[m Added missing instruction
+[33mf4348024[m Added check during scraping to deal with pdfs
+[33m5cbce060[m chore: Update docker-compose.yaml with default values for PORT and HOST
+[33mb498e988[m chore: Update docker-compose.yaml network configuration
+[33m2021a822[m chore: Add firecrawl network to docker-compose.yaml
+[33m02450660[m chore: Update docker-compose.yaml with default values for REDIS_URL and PLAYWRIGHT_MICROSERVICE_URL
+[33m5a2712fa[m Merge branch 'main' into detect-pdfs
+[33mbc6b929b[m [Bug] Fixing /crawl limit
+[33mdf16890f[m Added default value for crawlOptions.limit
+[33m18480b20[m Removed .env.example, improved docs and docker compose envs
+[33m66bd1e40[m Update website_params.ts
+[33mc02a82c2[m Update main.py
+[33mefc6fcb4[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m73687822[m Update main.py
+[33mf94b6053[m Merge pull request #139 from mendableai/nsc/refactor-scraping-order
+[33m9f2e90be[m Update README.md
+[33md21091bb[m Update single_url.ts
+[33mbe850086[m Nick: better
+[33m73e8da91[m Merge branch 'main' into nsc/refactor-scraping-order
+[33mbe5661a7[m Nick: a lot better
+[33m08d6c59a[m Merge pull request #134 from mendableai/cjp/switch-license-to-AGPL
+[33m5ab97bbe[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mfce17e6b[m Update credit_billing.ts
+[33m53ab33c2[m Update README.md
+[33m832a4f53[m Merge pull request #137 from mendableai/nsc/llm-extraction-zod-integration
+[33mf4d8b2c8[m Updated docs
+[33mc02d7aee[m Merge pull request #135 from mendableai/nsc/llm-extraction-zod-integration
+[33md6b4904e[m Update README.md
+[33m3b5f71c1[m Update README.md
+[33m10330342[m Update README.md
+[33maa6b84c5[m Nick: readme
+[33md9da4b53[m Update example.py
+[33m4c88d5da[m Nick: v8 python
+[33me6dbbf1b[m Nick: fixes js and pydantic implementation
+[33mc89964b2[m Nick:
+[33m9541ff6b[m Nick: 429 addressed
+[33m3bfef646[m Update index.test.ts
+[33m6ced8e73[m Update index.test.ts
+[33mc50076c3[m Update websites.json
+[33m12969288[m Update index.test.ts
+[33m9578856c[m Update fly.yml
+[33m6d6617d9[m Merge branch 'feat/test-suite'
+[33m1c459511[m Nick:
+[33m58efb6e9[m Update test_suite.yml
+[33m4a5f8762[m Merge pull request #118 from mendableai/feat/test-suite
+[33m0fae15a4[m Update fly.yml
+[33mfb7a8fd7[m Delete test_screenshot.png
+[33mc635688d[m Nick: test suite
+[33md34b4de6[m Update websites.json
+[33ma0a67f12[m Update index.test.ts
+[33mb7e3104c[m Ni
+[33mad58bc28[m Nick: test suite init
+[33mdc977577[m Update LICENSE
+[33m3f460af6[m Added idempotency key to crawl route
+[33m6956e501[m Merge pull request #131 from mendableai/feat/key-auth
+[33md280bcad[m Add keyAuth
+[33m056b0ec2[m Merge branch 'main' into feat/test-suite
+[33mb9fb49c8[m Merge pull request #130 from mendableai/feat/max-depth
+[33mdcedb8d7[m Merge branch 'main' into feat/max-depth
+[33m6505bf6b[m Merge branch 'main' into feat/max-depth
+[33m3459b77f[m Merge pull request #129 from mendableai/nsc/cancel-job
+[33mbdbee963[m Merge branch 'main' into nsc/cancel-job
+[33mf1eb6c5f[m Merge pull request #126 from mendableai/feat/to-markdown
+[33m61d615c0[m Added tests
+[33me1f52c53[m nested includeHtml inside pageOptions
+[33mf46bf19f[m Nick:
+[33m83f34086[m Added max depth option
+[33m2e3ff855[m Update crawl-cancel.ts
+[33m6d5da358[m Nick: cancel job
+[33m509250c4[m changed to `includeHtml`
+[33m538355f1[m Added toMarkdown option
+[33m6913fda7[m Update README.md
+[33mb32057ec[m Update SELF_HOST.md
+[33m43892535[m Merge branch 'nsc/initial-web-refac'
+[33md1b6f6dc[m Update fly.toml
+[33m797a7338[m Update README.md
+[33m3156e0ca[m Merge pull request #120 from mendableai/nsc/initial-web-refac
+[33mcd9a0840[m Update search.ts
+[33m5229a490[m Update search.ts
+[33mce7bab7b[m Update status.ts
+[33m15b774e9[m Update index.ts
+[33m67f135a5[m Update crawl-status.ts
+[33m2aa09a30[m Nick: partial docs working, cleaner
+[33m5a352b2b[m Remove selfhost api key
+[33m07012ca1[m Add docker compose file for self hosting
+[33m00373228[m Update index.ts
+[33mfbb4c63a[m [Test] Added integration tests suite
+[33mef6db3b7[m Update README.md
+[33m784b81e6[m Merge pull request #109 from mendableai/feat/posthog-logging
+[33m97288a38[m Merge pull request #110 from bllchmbrs/patch-1
+[33mf4cc2dbd[m Update README.md
+[33m3748f8e3[m Update README.md
+[33m21cdaf59[m Update log_job.ts
+[33mcaf3f9ee[m Add Posthog Logging
+[33m3c81ff19[m Update README.md
+[33m469c15de[m Update README.md
+[33m8a95cb42[m Update models.ts
+[33m49675365[m Update index.ts
+[33mf88c7285[m Update README.md
+[33m2f2b83b5[m Merge pull request #90 from mendableai/llm-extraction
+[33m768166b0[m Update single_url.ts
+[33ma3862595[m Update scrape.ts
+[33mdfcf39f4[m Update scrape.ts
+[33m3c7030db[m Nick: improvements
+[33mcbd9e88b[m Merge branch 'main' into llm-extraction
+[33m5ae05bda[m Update contradiction-testing-using-llms.mdx
+[33m4f526cff[m Nick: cleanup
+[33md9d206af[m Caleb:
+[33md1235a00[m Caleb: switched back to markdown for extraction
+[33mad9c8e77[m Caleb: commented out massive test
+[33ma32f2b37[m Caleb: logs work
+[33m3ca9e515[m Caleb: trying to get loggin workng
+[33ma095e1b6[m Resolve merge conflicts with main
+[33m35480bd2[m Update index.test.ts
+[33md3c36ada[m Update index.ts
+[33m79cd7d2e[m Merge branch 'llm-extraction' of https://github.com/mendableai/firecrawl into llm-extraction
+[33m4f7737c9[m Caleb: added ajv json schema validation.
+[33mf8b20779[m changed the request to do a HEAD to check for a PDF instead
+[33mb69feab9[m Merge branch 'main' into llm-extraction
+[33m71bdbf9f[m Merge pull request #67 from mendableai/feat/python-sdk-502
+[33m667f7403[m Caleb: converted llm response to json
+[33m2ad7a58e[m Caleb: first test passing
+[33m06497729[m Caleb: got it to a testable state I believe
+[33m6ee1f2d3[m Caleb: initially pulled inspiration code from https://github.com/mishushakov/llm-scraper
+[33ma72d2cc6[m Update README.md
+[33m4673cbb4[m Merge pull request #84 from mendableai/greenpay-fixes
+[33m23e3f880[m Merge pull request #83 from mendableai/website-specific-params
+[33m68838c9e[m Update single_url.ts
+[33md8ee4e90[m Update website_params.ts
+[33me6d7a476[m Update README.md
+[33m8e44696c[m Nick:
+[33m1dc6458c[m Update crawler.ts
+[33m0f694e06[m Update crawler.ts
+[33ma5d38039[m Add additional file extensions to crawler.ts
+[33mfb08f28e[m Merge pull request #66 from mendableai/feat/coupons
+[33m7689c31d[m Update credit_billing.ts
+[33m0a607b9e[m Merge branch 'main' into feat/coupons
+[33m6cf147f5[m Contradictions tutorial
+[33mfdd3b704[m Update README.md
+[33mfdf913e0[m Update index.test.ts
+[33m8e324534[m Update auth.ts
+[33m1f489989[m done
+[33mebd9be3d[m Merge pull request #68 from mdp/mdp/dotenv_jest
+[33mbb3da8df[m Update package.json
+[33mdf96fade[m Merge branch 'main' into pr/68
+[33m26f75a59[m Merge pull request #75 from mendableai/nsc/free-credits-increase
+[33md210a57a[m Update credit_billing.ts
+[33m24e1bdec[m Update credit_billing.ts
+[33m06675d1f[m almost finished
+[33mf368e94c[m Merge branch 'main' into mdp/dotenv_jest
+[33m4fce848e[m Update README.md
+[33m3ac87243[m Update openapi.json
+[33mfb0301c1[m Merge pull request #72 from mendableai/nsc/search-js-sdk
+[33mb7c7291b[m Nick: v15
+[33ma32e16a9[m Nick: added /search to the python sdk
+[33m6ea818fa[m Update version
+[33mf2af7408[m Update main.py
+[33ma3911bfc[m Update index.ts
+[33m03d1c64a[m Removed process.env call for API_KEY
+[33me8b8150b[m Chore: Add some basic jest tests
+[33ma7be09e4[m Fix: Remove dotenv from npm module
+[33md3ab2ea9[m [Feat] Implemented retry attempts to handle 502 errors
+[33m9c481e5e[m [Feat] Coupon system
+[33mabf69186[m Merge pull request #64 from mendableai/feat/allowed-urls
+[33m75597f72[m [Feat] Added allowed urls
+[33m75e82869[m Merge pull request #62 from mendableai/nsc/serper-params
+[33ma59ddf18[m Nick: default to serper
+[33mf2690f69[m Support for tbs, filter, lang, country and location with Serper search.
+[33m26c861db[m Update README.md
+[33md0a70de0[m Update README.md
+[33m427f658c[m Update README.md
+[33me7d385ad[m Update search.ts
+[33m3d18f2f7[m Update README.md
+[33m877af423[m Update openapi.json
+[33m307ea6f5[m Nick: improvements to search
+[33mf189589d[m Merge pull request #34 from mendableai/nsc/returnOnlyUrls
+[33m07e93ee5[m Update requests.http
+[33m523dd15a[m Merge pull request #13 from mendableai/bugfix/lowercase-all-urls
+[33m68cb9e60[m Merge branch 'main' into bugfix/lowercase-all-urls
+[33m942ac3b4[m Resolved merge conflicts between feat/added-anthropic-vision-api and main
+[33m3b5b868d[m Update requests.http
+[33m8939ca57[m Merge branch 'main' into nsc/returnOnlyUrls
+[33m56c81094[m Merge branch 'nsc/mvp-search'
+[33m479fa2f7[m Nick:
+[33mdda77dce[m Merge pull request #56 from mendableai/nsc/mvp-search
+[33mfdb2789e[m Nick: added url as return param
+[33m3abfd6b4[m Update search.ts
+[33m53cc4c39[m Update search.ts
+[33m734c76fc[m Merge branch 'main' into nsc/mvp-search
+[33mf0695c71[m Update single_url.ts
+[33m4328a68e[m Nick:
+[33me6779aff[m Nick: tests
+[33m9ded75ad[m Merge branch 'main' into nsc/mvp-search
+[33m6a1c7d48[m Merge pull request #55 from mendableai/feat/blocklist-social-media
+[33mf3c190c2[m Nick:
+[33m41263bb4[m Nick: serper support
+[33m8cb5d795[m Update googlesearch.ts
+[33m841279c7[m Update README.md
+[33m495adc9a[m Update googlesearch.ts
+[33m5e3e2ec9[m Nick:
+[33m01461578[m Nick: mvp
+[33m849c0b6e[m [Feat] Added blocklist for social media urls
+[33mb7f6b9be[m Merge pull request #53 from mendableai/feat/server-health-check-slack-message
+[33m9b01dc62[m Changed from active to waiting jobs
+[33ma680c7ce[m [Feat] Server health check + slack message
+[33mc70bc08d[m Merge pull request #52 from mendableai/nsc/fix-tables
+[33m306cfe4c[m Nick:
+[33m357914c0[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mbf2df7a8[m Nick: fix js-sdk
+[33m7bc7b179[m Merge pull request #46 from mattzcarey/patch-1
+[33mb33133f8[m Update data-extraction-using-llms.mdx
+[33m18450b5f[m Nick: tutorials
+[33mde7e1f50[m Update openapi.json
+[33m572b7e8d[m chore: add context.close
+[33m3ead2efd[m Update fly.yml
+[33m001bf0c5[m Update package.json
+[33m6560c968[m Update types.ts
+[33mcbff1b4f[m Merge pull request #40 from mendableai/cjp/contributors-guide-and
+[33m84be3d2b[m Update CONTRIBUTING.md
+[33m2f29a4da[m Update CONTRIBUTING.md
+[33m30a8482a[m Nick:
+[33m52620bab[m Nick: prod and local-no-auth tests
+[33m749bd5f4[m Merge branch 'cjp/contributors-guide-and' of https://github.com/mendableai/firecrawl into cjp/contributors-guide-and
+[33m898d729a[m Nick: tests
+[33m401f992c[m Caleb: added contributors guide
+[33mef4ffd3a[m Adding contributors guide
+[33m5cdbf3a0[m Nick: cleaner functions to handle authenticated requests that dont require ifs everywhere
+[33maa89e2e8[m Merge branch 'main' into cjp/contributors-guide-and
+[33mbe75aaa1[m Caleb: first version of supabase proxy to make db authentication optional
+[33mad7951a6[m Merge branch 'main' of https://github.com/mendableai/firecrawl into cjp/contributors-guide-and
+[33m3358c71f[m Merge branch 'main' into more-logging
+[33md2f808a5[m Update queue-worker.ts
+[33me6b46178[m Caleb: added .env.example
+[33mb361a762[m Caleb: added logging improvement
+[33m08e96543[m Merge pull request #38 from mendableai/more-logging
+[33m9b31e68a[m Update queue-worker.ts
+[33m0db0874b[m Nick:
+[33m19cba43e[m Merge pull request #37 from mendableai/refactor-index
+[33m4543c57e[m Nick:
+[33m5b8aed26[m Update scrape.ts
+[33m23b2190e[m Nick:
+[33md201a4e5[m Merge pull request #31 from mendableai/feat/js-sdk-v0011
+[33macec7668[m Merge pull request #35 from mendableai/nsc/job-logs
+[33md4e77740[m Merge pull request #36 from mendableai/nsc/rate-limit-fixes
+[33m5b3c75b0[m Nick:
+[33m43c2e877[m Update index.ts
+[33m408c7a47[m Nick: rate limit fixes
+[33m6aa3cc3c[m Nick:
+[33m1a3aa299[m Nick: return the only list of urls
+[33mddf9ff9c[m Nick:
+[33m39dca602[m Merge pull request #32 from mendableai/cjp/doc-fix
+[33m389ac90f[m Caleb: fixing some documentation and rebuilding the server
+[33mf1dd97af[m Update index.ts
+[33m84cebf61[m Nick:
+[33m005ac8f8[m Merge branch 'main' into detect-pdfs
+[33m5b937991[m Nick: a bit faster
+[33m890bde68[m added type declarations
+[33mde1e13d7[m Merge pull request #30 from mendableai/bugfix/scrape-test-failing
+[33m37ef8a01[m fixing scrape preview test
+[33mc5cb268b[m Update pdfProcessor.ts
+[33m43cfcec3[m Nick: disabling in crawl and sitemap for now
+[33m140529c6[m Nick: fixes pdfs not found
+[33m15cfc01f[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33ma144e13e[m Update rate-limiter.ts
+[33m384fb1db[m updating version
+[33m3c14b02f[m Merge pull request #25 from mendableai/feat/replace-all-paths-to-absolute-paths
+[33mbe258ea1[m Merge pull request #28 from mendableai/feat/better-types-for-jssdk
+[33m3ddff62a[m adding better doc and types for js-sdk
+[33m9e9d66f7[m refactor: fix typo in WebScraper/index.ts
+[33m72e1dadc[m adding option to replace all relative paths with absolute paths
+[33m2c066065[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33mbe35b323[m Nick: preview token tests
+[33me19874bb[m Merge pull request #22 from mendableai/feat/ci-cd-env-secrets
+[33m70497804[m adding all  tests
+[33m1c8ffc9f[m fixing deploy workflow
+[33mc627d221[m all working now
+[33mdab0568c[m testing tests
+[33m4018d7ca[m fixing workflow
+[33m4f1179db[m fixing workflow
+[33mca8c8b87[m fixing workflow
+[33m3f833737[m fixing test
+[33mefbb4e89[m fixing jest parameters
+[33mdae024ad[m fixing env position
+[33m2ca00d81[m adding openHandlesTimeout
+[33mdcccfab4[m adding other env secrets
+[33md7c797d0[m adding env secrets
+[33m44057cc7[m Merge pull request #21 from mendableai/feat/ci-cd-workflow
+[33m42de8460[m adding workflow
+[33ma2cc0cbf[m Merge pull request #20 from mendableai/feat/ci-cd
+[33mddb3b251[m adding ci-cd workflow
+[33m3e9e24aa[m Update index.ts
+[33m0f7ab410[m Update index.ts
+[33m0f6fdd7f[m Merge pull request #17 from mendableai/feat/pdf-parser
+[33m6112cc1c[m Update index.ts
+[33mc4cc4b92[m fixing document response
+[33m704a0594[m Update index.ts
+[33m57e5b360[m [Feat] Adding pdf parser
+[33m50cf97c7[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33me3a6bc4d[m Create openapi.json
+[33md55c23ec[m Update README.md
+[33m2bed55a3[m Nick:
+[33m7ce2dd97[m Merge pull request #14 from mendableai/nsc/clean-content
+[33mca2bf9cc[m Update single_url.ts
+[33m36abe0f7[m Nick:
+[33m9ab4cb47[m [Bugfix] Trim and Lowercase all urls
+[33m460763ba[m Merge pull request #11 from mendableai/feat/parse-to-markdown-tables
+[33m529e77d3[m Merge pull request #9 from szepeviktor/typos
+[33md4802767[m Merge pull request #4 from mendableai/feat/improving-reative-paths
+[33m52fb28bc[m Update index.ts
+[33mde439f65[m Update index.ts
+[33m871d5d91[m Update index.ts
+[33m08ed68ff[m Nick: fixes
+[33m650852cc[m Merge branch 'main' into feat/parse-to-markdown-tables
+[33mee8a0972[m adding unit tests and fixing the parse function
+[33m2eb81545[m Update index.test.ts
+[33m60245343[m Merge branch 'main' into feat/improving-reative-paths
+[33m417921ea[m Update index.ts
+[33mb375ce3e[m adding unit tests and bugfixing
+[33m82ed9515[m Update index.ts
+[33mc837f1cc[m Merge pull request #12 from mendableai/bugfix/normalized-api-on-crawl-status
+[33mdb15724b[m Update imageDescription.ts
+[33m27674a62[m Update index.ts
+[33m0eba1c1b[m Merge pull request #8 from szepeviktor/patch-1
+[33m25a9255c[m [bugfix] added normalized apikey to craw/status route
+[33mff622739[m Added a html to markdown table parser
+[33md628511b[m Delete apps/playwright-service/.DS_Store
+[33m11394ef2[m Delete apps/api/src/.DS_Store
+[33m51f94e9e[m Delete apps/.DS_Store
+[33m34ab21db[m Fix typos
+[33m24f02eda[m Update .gitignore
+[33m23d391bb[m Delete .DS_Store
+[33ma12f4d96[m Update README.md
+[33med5dc808[m Update imageDescription.ts
+[33m00941d94[m Added anthropic vision to getImageDescription function
+[33md23a7ae5[m improving relative paths
+[33ma0461030[m Spliting relative paths for images
+[33m3e4064bc[m moving js-sdk to monorepo
+[33m0113d667[m Update requests.http
+[33m00d20f9a[m Update README.md
+[33m52215ed8[m Update README.md
+[33m8892504a[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m4c4775e0[m Nick:
+[33mdf1d506d[m js-sdk ok!
+[33m15fd4e23[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m93627ae8[m Nick:
+[33m68a02f8d[m Update README.md
+[33mbe3eb211[m adding JS-SDK
+[33m36fe5f59[m Merge branch 'main' of https://github.com/mendableai/firecrawl
+[33m3d260e94[m Nick: fc- prefix
+[33m38852cc6[m Update README.md
+[33md3290643[m Update README.md
+[33m67686b38[m Update README.md
+[33mdfe22257[m Update README.md
+[33m2efad170[m Update README.md
+[33m32af4ac2[m Update requests.http
+[33m3dc732bc[m Update fly.yml
+[33m07bcdd09[m Update fly.yml
+[33m968c23e3[m Update fly.yml
+[33m33e25cb0[m Update fly.yml
+[33m3418858c[m Nick: revoked
+[33ma6c2a878[m Initial commit


### PR DESCRIPTION
Fixed intermittent network failures in Firecrawl JS SDK with automatic retry mechanism and exponential backoff

The Firecrawl JS SDK was experiencing intermittent failures with the error message "No response received while trying to scrape URL. This may be a network error or the server is unreachable." This occurred even when the same configuration and URL worked successfully at other times, indicating transient network issues rather than configuration problems.

solution --> 

- Added automatic retry logic with up to 3 attempts for network errors
- Implemented exponential backoff with jitter (1s, 2s, 4s delays)
- Enhanced error classification to distinguish retryable vs non-retryable errors
- Improved timeout handling with sensible defaults (30 seconds)
- Added support for retrying on specific HTTP status codes (408, 429, 502, 503, 504)
- Maintained 100% backward compatibility

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes intermittent “No response received while trying to scrape URL” errors (issue #1912) by adding automatic retries with exponential backoff and improved timeout/error handling. This makes scraping and SDK network calls more reliable under transient failures.

- **Bug Fixes**
  - Added automatic retry (up to 3 attempts) with exponential backoff + jitter for scrape, POST, and GET requests.
  - Retries on network errors and HTTP 408/429/502/503/504; clearer separation of retryable vs non-retryable errors.
  - Default timeout set to 30s (respects per-call overrides with a small buffer); better final error messages after all retries.
  - Added apps/js-sdk/test-retry-logic.js to simulate flaky networks; no breaking changes.

<!-- End of auto-generated description by cubic. -->

