### PR TITLE
fix(search): include 'summary' in v2 /search response when using scrapeOptions.formats (#2024)

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -318,6 +318,7 @@ export async function searchController(
           rawHtml: doc.rawHtml,
           links: doc.links,
           screenshot: doc.screenshot,
+          summary: doc.summary,
           metadata: doc.metadata,
         }));
         
@@ -361,6 +362,7 @@ export async function searchController(
             markdown: scrapedDoc?.markdown,
             html: scrapedDoc?.html,
             rawHtml: scrapedDoc?.rawHtml,
+            summary: scrapedDoc?.summary,
             metadata: scrapedDoc?.metadata,
           };
         });


### PR DESCRIPTION
This PR fixes issue #2024 where the v2 /search endpoint did not include the 'summary' field 
in results when using scrapeOptions: { formats: ['summary'] }.

- Added support to properly attach summary field to each search result
- Ensured consistent behavior with v2 /scrape endpoint
- Verified fix in API playground and local environment

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes missing summary in v2 /search results when scrapeOptions.formats includes 'summary'. Responses now include summary for each result, matching v2 /scrape and addressing #2024.

<!-- End of auto-generated description by cubic. -->

