### PR TITLE
(js-sdk):fix v2 client options support and updates version to 3.2.1

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/clientOptions.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/clientOptions.test.ts
@@ -1,0 +1,55 @@
+import { Firecrawl, type FirecrawlClientOptions } from '../../../index';
+
+describe('Firecrawl v2 Client Options', () => {
+  it('should accept v2 options including timeoutMs, maxRetries, and backoffFactor', () => {
+    const options: FirecrawlClientOptions = {
+      apiKey: 'test-key',
+      timeoutMs: 300,
+      maxRetries: 5,
+      backoffFactor: 0.5,
+    };
+
+    // Should not throw any type errors
+    const client = new Firecrawl(options);
+    
+    expect(client).toBeDefined();
+    expect(client).toBeInstanceOf(Firecrawl);
+  });
+
+  it('should work with minimal options', () => {
+    const options: FirecrawlClientOptions = {
+      apiKey: 'test-key',
+    };
+
+    const client = new Firecrawl(options);
+    
+    expect(client).toBeDefined();
+    expect(client).toBeInstanceOf(Firecrawl);
+  });
+
+  it('should work with all v2 options', () => {
+    const options: FirecrawlClientOptions = {
+      apiKey: 'test-key',
+      apiUrl: 'https://custom-api.firecrawl.dev',
+      timeoutMs: 60000,
+      maxRetries: 3,
+      backoffFactor: 1.0,
+    };
+
+    const client = new Firecrawl(options);
+    
+    expect(client).toBeDefined();
+    expect(client).toBeInstanceOf(Firecrawl);
+  });
+
+  it('should export FirecrawlClientOptions type', () => {
+    // This test ensures the type is properly exported
+    const options: FirecrawlClientOptions = {
+      apiKey: 'test-key',
+      timeoutMs: 300,
+    };
+
+    expect(options.timeoutMs).toBe(300);
+    expect(options.apiKey).toBe('test-key');
+  });
+});

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -13,8 +13,11 @@ export * from "./v2/types";
 export { default as FirecrawlAppV1 } from "./v1";
 
 import V1 from "./v1";
-import { FirecrawlClient as V2 } from "./v2/client";
+import { FirecrawlClient as V2, type FirecrawlClientOptions } from "./v2/client";
 import type { FirecrawlAppConfig } from "./v1";
+
+// Re-export v2 client options for convenience
+export type { FirecrawlClientOptions } from "./v2/client";
 
 /** Unified client: extends v2 and adds `.v1` for backward compatibility. */
 export class Firecrawl extends V2 {
@@ -23,9 +26,12 @@ export class Firecrawl extends V2 {
   private _v1Opts: FirecrawlAppConfig;
 
   /** @param opts API credentials and base URL. */
-  constructor(opts: FirecrawlAppConfig = {}) {
-    super(opts as any);
-    this._v1Opts = opts;
+  constructor(opts: FirecrawlClientOptions = {}) {
+    super(opts);
+    this._v1Opts = {
+      apiKey: opts.apiKey,
+      apiUrl: opts.apiUrl,
+    };
   }
 
   /** Access the legacy v1 client (instantiated on first access). */


### PR DESCRIPTION
- Bump version from 3.2.0 to 3.2.1 in package.json.
- Modify Firecrawl constructor to accept FirecrawlClientOptions for better flexibility.
- Re-export FirecrawlClientOptions type for convenience.
- Add unit tests for Firecrawl v2 client options to ensure proper functionality.

closes #2032 