### PR TITLE
(v2/search) 3x faster + Async Scraping

### DIFF
--- a/apps/api/src/__tests__/snips/v2/billing.test.ts
+++ b/apps/api/src/__tests__/snips/v2/billing.test.ts
@@ -199,7 +199,7 @@ describe("Billing tests", () => {
             const rc1 = (await creditUsage(identity)).remainingCredits;
 
             const results = await search({
-                query: "firecrawl",
+                query: "coconut",
                 scrapeOptions: {
                     formats: ["markdown"],
                 },
@@ -221,7 +221,7 @@ describe("Billing tests", () => {
             const rc1 = (await creditUsage(identity)).remainingCredits;
 
             const results = await search({
-                query: "firecrawl filetype:pdf",
+                query: "coconut filetype:pdf",
                 scrapeOptions: {
                     formats: ["markdown"],
                     parsers: ["pdf"],
@@ -246,7 +246,7 @@ describe("Billing tests", () => {
             const rc1 = (await creditUsage(identity)).remainingCredits;
 
             const results = await search({
-                query: "firecrawl filetype:pdf",
+                query: "coconut filetype:pdf",
                 scrapeOptions: {
                     formats: ["markdown"],
                     parsers: [],

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -76,6 +76,7 @@ async function startScrapeJob(
       team_id: options.teamId,
       scrapeOptions: {
         ...options.scrapeOptions,
+        // TODO: fix this
         maxAge: 3 * 24 * 60 * 60 * 1000, // 3 days
       },
       internalOptions: { teamId: options.teamId, bypassBilling: options.bypassBilling ?? true, zeroDataRetention },
@@ -547,7 +548,8 @@ export async function searchController(
     // - For no scraping: Bill based on search results count
     if (!isSearchPreview && (!shouldScrape || (shouldScrape && !isAsyncScraping))) {
       billTeam(req.auth.team_id, req.acuc?.sub_id, credits_billed).catch((error) => {
-        logger.error("Failed to bill team", { teamId: req.auth.team_id, subId: req.acuc?.sub_id, credits_billed, error });
+        logger.error(`Failed to bill team ${req.acuc?.sub_id} for ${credits_billed} credits: ${error}`);
+        
       });
     }
 
@@ -574,6 +576,7 @@ export async function searchController(
           ...req.body,
           query: undefined,
           scrapeOptions: undefined,
+          asyncScraping: isAsyncScraping,
         },
         origin: req.body.origin,
         integration: req.body.integration,

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -547,7 +547,7 @@ export async function searchController(
     // - For no scraping: Bill based on search results count
     if (!isSearchPreview && (!shouldScrape || (shouldScrape && !isAsyncScraping))) {
       billTeam(req.auth.team_id, req.acuc?.sub_id, credits_billed).catch((error) => {
-        logger.error(`Failed to bill team ${req.auth.team_id} for ${credits_billed} credits: ${error}`);
+        logger.error("Failed to bill team", { teamId: req.auth.team_id, subId: req.acuc?.sub_id, credits_billed, error });
       });
     }
 

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1329,6 +1329,7 @@ export const searchRequestSchema = z
     integration: z.nativeEnum(IntegrationEnum).optional().transform(val => val || null),
     timeout: z.number().int().positive().finite().safe().default(60000),
     ignoreInvalidURLs: z.boolean().optional().default(false),
+    asyncScraping: z.boolean().optional().default(false),
     __searchPreviewToken: z.string().optional(),
     scrapeOptions: baseScrapeOptions
       .extend({
@@ -1455,6 +1456,17 @@ export type SearchResponse =
     success: true;
     warning?: string;
     data: import("../../lib/entities").SearchV2Response;
+    creditsUsed: number;
+  }
+  | {
+    success: true;
+    warning?: string;
+    data: import("../../lib/entities").SearchV2Response;
+    scrapeIds: {
+      web?: string[];
+      news?: string[];
+      images?: string[];
+    };
     creditsUsed: number;
   };
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make v2 search ~3x faster by parallelizing scraping and adding an async mode that queues jobs and returns IDs immediately. Also adds image result scraping and simplifies billing.

- **New Features**
  - asyncScraping flag in search request (default false).
  - When asyncScraping=true: queue scrapes for web/news/images and return scrapeIds grouped by type.
  - Sync and async paths scrape web/news/images in parallel.
  - Updated SearchResponse to include scrapeIds only in async mode.

- **Migration**
  - To use async: send asyncScraping=true; read scrapeIds from the response.
  - Sync behavior remains the same, but billing is simplified:
    - Sync: credits are summed per scraped doc (removed extra 1 credit per image).
    - Async: credits billed equal the number of queued scrape jobs.

<!-- End of auto-generated description by cubic. -->

