### PR TITLE
Fix BullMQ workers on Windows

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -362,10 +362,10 @@ let cantAcceptConnectionCount = 0;
  * @param filePath - The file path to convert
  * @returns A properly formatted path/URL for the current platform
  */
-function getWorkerPath(filePath: string): string {
+function getWorkerPath(filePath: string): string | URL {
   if (process.platform === 'win32' && path.isAbsolute(filePath)) {
     // On Windows, convert absolute paths to file:// URLs for ESM compatibility
-    return pathToFileURL(filePath).href;
+    return pathToFileURL(filePath);
   }
   return filePath;
 }


### PR DESCRIPTION
The commit https://github.com/firecrawl/firecrawl/commit/f0ee5912270e412559e3a9db7f567f3d2338adc0 introduces a bug that makes workers fail to load on Windows at all. As per Node documentation (https://nodejs.org/api/fs.html#file-url-paths), you should pass in `file:///` URLs as a `URL` object, not a string.

For context, I couldn't reproduce the error that the original commit attempted to address. Workers run correctly on [the prior commit](https://github.com/firecrawl/firecrawl/commit/a1b7de7b8ac10ca58f5b670b85a093e42a044ea8).

That said, since I believe the issue _is_ technically possible, I've updated the implementation rather than removing it.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes BullMQ workers failing to load on Windows by returning a URL object (not a string) for file:/// worker paths. Follows Node’s file-URL rules so ESM workers resolve correctly on Windows; other platforms unaffected.

<!-- End of auto-generated description by cubic. -->

