### PR TITLE
fix(scrape): Remove --single-process argument from chrome in playwright-service

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -55,7 +55,6 @@ const initializeBrowser = async () => {
       '--disable-accelerated-2d-canvas',
       '--no-first-run',
       '--no-zygote',
-      '--single-process',
       '--disable-gpu'
     ]
   });

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -55,6 +55,7 @@ const initializeBrowser = async () => {
       '--disable-accelerated-2d-canvas',
       '--no-first-run',
       '--no-zygote',
+      '--single-process',
       '--disable-gpu'
     ]
   });


### PR DESCRIPTION
Fixes: #1977 
Bug:
* When scraping with Playwright, the job fails and the service crashes with error: "browserContext.newPage: Target page, context or browser has been closed".
* Occurs from the second attempt to scrape with playwright onward.
Changes:
* Removed the --single-process argument from chrome in playwright-service-ts.