### PR TITLE
Fix Playwright Content-Type Handling

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -142,7 +142,7 @@ const scrapePage = async (page: Page, url: string, waitUntil: 'load' | 'networki
   if (response) {
     headers = await response.allHeaders();
     ct = Object.entries(headers).find(x => x[0].toLowerCase() === "content-type")?.[1];
-    if (ct && (ct[1].includes("application/json") || ct[1].includes("text/plain"))) {
+    if (ct && (ct.includes("application/json") || ct.includes("text/plain"))) {
       content = (await response.body()).toString("utf8"); // TODO: determine real encoding
     }
   }


### PR DESCRIPTION
The old implementation checked the second character of the `Content-Type` header instead of the actual value. Updated to properly detect JSON/plain text.