### PR TITLE
fix(#2042): update WeChat MP scraping headers to Chrome 120 for anti-bot bypass

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/urlSpecificParams.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/urlSpecificParams.ts
@@ -45,8 +45,8 @@ export const urlSpecificParams: Record<string, UrlSpecificParams> = {
   "mp.weixin.qq.com": {
     scrapeOptions: {
       headers: {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
         "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
         "Accept-Encoding": "gzip, deflate, br",
         "Cache-Control": "no-cache",
@@ -54,7 +54,11 @@ export const urlSpecificParams: Record<string, UrlSpecificParams> = {
         "Sec-Fetch-Dest": "document",
         "Sec-Fetch-Mode": "navigate",
         "Sec-Fetch-Site": "none",
-        "Upgrade-Insecure-Requests": "1"
+        "Sec-Fetch-User": "?1",
+        "Upgrade-Insecure-Requests": "1",
+        "sec-ch-ua": '"Not_A Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"'
       },
       waitFor: 3000,
       proxy: "stealth" as const

--- a/apps/api/src/scraper/scrapeURL/lib/urlSpecificParams.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/urlSpecificParams.ts
@@ -40,6 +40,29 @@ export const urlSpecificParams: Record<string, UrlSpecificParams> = {
   //     scrapeOptions: { waitFor: 2000 },
   //     internalOptions: { forceEngine: "fire-engine;playwright" }
   // },
+  
+  // WeChat MP domain requires special handling to avoid robot protection
+  "mp.weixin.qq.com": {
+    scrapeOptions: {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Cache-Control": "no-cache",
+        "Pragma": "no-cache",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Upgrade-Insecure-Requests": "1"
+      },
+      waitFor: 3000,
+      proxy: "stealth" as const
+    },
+    internalOptions: { 
+      forceEngine: "fire-engine;chrome-cdp;stealth" as const
+    },
+  },
   "digikey.com": {
     scrapeOptions: {},
     internalOptions: { forceEngine: "fire-engine;tlsclient" },


### PR DESCRIPTION
1. Fixes issue #2042 by modernizing mp.weixin.qq.com config.
2. Replaced outdated Chrome 91 UA with Chrome 120 + sec-ch-ua fields.
3. Added modern fetch/security headers to better simulate real browser traffic.
4. Ensures higher scraping success rate while keeping other domain configs intact.