### PR TITLE
feat(api): propagate api_key_id towards billing function

### DIFF
--- a/apps/api/src/__tests__/queue-concurrency-integration.test.ts
+++ b/apps/api/src/__tests__/queue-concurrency-integration.test.ts
@@ -67,6 +67,7 @@ describe("Queue Concurrency Integration", () => {
       scrapeOptions: defaultScrapeOptions,
       crawlerOptions: null,
       zeroDataRetention: false,
+      apiKeyId: null,
     } as WebScraperOptions;
 
     it("should add job directly to BullMQ when under concurrency limit", async () => {

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -74,6 +74,7 @@ export async function setCachedACUC(
 
 const mockPreviewACUC: (team_id: string, is_extract: boolean) => AuthCreditUsageChunk = (team_id, is_extract) => ({
   api_key: "preview",
+  api_key_id: 0,
   team_id,
   sub_id: null,
   sub_current_period_start: null,
@@ -110,6 +111,7 @@ const mockPreviewACUC: (team_id: string, is_extract: boolean) => AuthCreditUsage
 
 const mockACUC: () => AuthCreditUsageChunk = () => ({
   api_key: "bypass",
+  api_key_id: 0,
   team_id: "bypass",
   sub_id: "bypass",
   sub_current_period_start: new Date().toISOString(),

--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -213,6 +213,7 @@ export async function crawlController(req: Request, res: Response) {
                 crawl_id: id,
                 sitemapped: true,
                 zeroDataRetention: false, // not supported on v0
+                apiKeyId: chunk?.api_key_id ?? null,
               },
               opts: {
                 jobId: uuid,
@@ -257,6 +258,7 @@ export async function crawlController(req: Request, res: Response) {
           integration: req.body.integration,
           crawl_id: id,
           zeroDataRetention: false, // not supported on v0
+          apiKeyId: chunk?.api_key_id ?? null,
         },
         {
           priority: 15, // prioritize request 0 of crawl jobs same as scrape jobs

--- a/apps/api/src/controllers/v0/scrape.ts
+++ b/apps/api/src/controllers/v0/scrape.ts
@@ -44,6 +44,7 @@ export async function scrapeHelper(
   extractorOptions: ExtractorOptions,
   timeout: number,
   flags: TeamFlags,
+  apiKeyId: number | null,
 ): Promise<{
   success: boolean;
   error?: string;
@@ -87,6 +88,7 @@ export async function scrapeHelper(
       is_scrape: true,
       startTime: Date.now(),
       zeroDataRetention: false, // not supported on v0
+      apiKeyId,
     },
     {},
     jobId,
@@ -242,6 +244,7 @@ export async function scrapeController(req: Request, res: Response) {
       extractorOptions,
       timeout,
       chunk?.flags ?? null,
+      chunk?.api_key_id ?? null,
     );
     const endTime = new Date().getTime();
     const timeTakenInSeconds = (endTime - startTime) / 1000;
@@ -270,7 +273,7 @@ export async function scrapeController(req: Request, res: Response) {
       }
       if (creditsToBeBilled > 0) {
         // billing for doc done on queue end, bill only for llm extraction
-        billTeam(team_id, chunk?.sub_id, creditsToBeBilled, logger).catch(
+        billTeam(team_id, chunk?.sub_id, creditsToBeBilled, chunk?.api_key_id ?? null, logger).catch(
           (error) => {
             logger.error(
               `Failed to bill team ${team_id} for ${creditsToBeBilled} credits`,

--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -37,6 +37,7 @@ export async function searchHelper(
   pageOptions: PageOptions,
   searchOptions: SearchOptions,
   flags: TeamFlags,
+  api_key_id: number | null,
 ): Promise<{
   success: boolean;
   error?: string;
@@ -82,7 +83,7 @@ export async function searchHelper(
   );
 
   if (justSearch) {
-    billTeam(team_id, subscription_id, res.length).catch((error) => {
+    billTeam(team_id, subscription_id, res.length, api_key_id, logger).catch((error) => {
       logger.error(
         `Failed to bill team ${team_id} for ${res.length} credits: ${error}`,
       );
@@ -117,6 +118,7 @@ export async function searchHelper(
         internalOptions,
         startTime: Date.now(),
         zeroDataRetention: false, // not supported on v0
+        apiKeyId: api_key_id,
       },
       opts: {
         jobId: uuid,
@@ -218,6 +220,7 @@ export async function searchController(req: Request, res: Response) {
       pageOptions,
       searchOptions,
       chunk?.flags ?? null,
+      chunk?.api_key_id ?? null,
     );
     const endTime = new Date().getTime();
     const timeTakenInSeconds = (endTime - startTime) / 1000;

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -148,6 +148,7 @@ export async function batchScrapeController(
         webhook: req.body.webhook,
         internalOptions: sc.internalOptions,
         zeroDataRetention: zeroDataRetention ?? false,
+        apiKeyId: req.acuc.api_key_id,
       },
       opts: {
         jobId: uuidv4(),

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -148,7 +148,7 @@ export async function batchScrapeController(
         webhook: req.body.webhook,
         internalOptions: sc.internalOptions,
         zeroDataRetention: zeroDataRetention ?? false,
-        apiKeyId: req.acuc.api_key_id,
+        apiKeyId: req.acuc?.api_key_id ?? null,
       },
       opts: {
         jobId: uuidv4(),

--- a/apps/api/src/controllers/v1/concurrency-check.ts
+++ b/apps/api/src/controllers/v1/concurrency-check.ts
@@ -22,6 +22,6 @@ export async function concurrencyCheckController(
   return res.status(200).json({
     success: true,
     concurrency: activeJobsOfTeam.length,
-    maxConcurrency: req.acuc.concurrency,
+    maxConcurrency: req.acuc?.concurrency ?? 0,
   });
 }

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -132,6 +132,7 @@ export async function crawlController(
       webhook: req.body.webhook,
       v1: true,
       zeroDataRetention: zeroDataRetention || false,
+      apiKeyId: req.acuc.api_key_id,
     },
     {},
     crypto.randomUUID(),

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -132,7 +132,7 @@ export async function crawlController(
       webhook: req.body.webhook,
       v1: true,
       zeroDataRetention: zeroDataRetention || false,
-      apiKeyId: req.acuc.api_key_id,
+      apiKeyId: req.acuc?.api_key_id ?? null,
     },
     {},
     crypto.randomUUID(),

--- a/apps/api/src/controllers/v1/deep-research.ts
+++ b/apps/api/src/controllers/v1/deep-research.ts
@@ -56,8 +56,8 @@ export async function deepResearchController(
   const jobData = {
     request: req.body,
     teamId: req.auth.team_id,
-    subId: req.acuc.sub_id,
-    apiKeyId: req.acuc.api_key_id,
+    subId: req.acuc?.sub_id ?? undefined,
+    apiKeyId: req.acuc?.api_key_id ?? null,
     researchId,
   };
 

--- a/apps/api/src/controllers/v1/deep-research.ts
+++ b/apps/api/src/controllers/v1/deep-research.ts
@@ -56,7 +56,8 @@ export async function deepResearchController(
   const jobData = {
     request: req.body,
     teamId: req.auth.team_id,
-    subId: req.acuc?.sub_id,
+    subId: req.acuc.sub_id,
+    apiKeyId: req.acuc.api_key_id,
     researchId,
   };
 

--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -30,13 +30,15 @@ export async function oldExtract(
       result = await performExtraction(extractId, {
         request: req.body,
         teamId: req.auth.team_id,
-        subId: req.acuc?.sub_id ?? undefined,
+        subId: req.acuc.sub_id ?? undefined,
+        apiKeyId: req.acuc.api_key_id,
       });
     } else {
       result = await performExtraction_F0(extractId, {
         request: req.body,
         teamId: req.auth.team_id,
         subId: req.acuc?.sub_id ?? undefined,
+        apiKeyId: req.acuc.api_key_id,
       });
     }
 
@@ -103,6 +105,7 @@ export async function extractController(
     subId: req.acuc?.sub_id,
     extractId,
     agent: req.body.agent,
+    apiKeyId: req.acuc.api_key_id,
   };
 
   if (

--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -30,15 +30,15 @@ export async function oldExtract(
       result = await performExtraction(extractId, {
         request: req.body,
         teamId: req.auth.team_id,
-        subId: req.acuc.sub_id ?? undefined,
-        apiKeyId: req.acuc.api_key_id,
+        subId: req.acuc?.sub_id ?? undefined,
+        apiKeyId: req.acuc?.api_key_id ?? null,
       });
     } else {
       result = await performExtraction_F0(extractId, {
         request: req.body,
         teamId: req.auth.team_id,
         subId: req.acuc?.sub_id ?? undefined,
-        apiKeyId: req.acuc.api_key_id,
+        apiKeyId: req.acuc?.api_key_id ?? null,
       });
     }
 
@@ -105,7 +105,7 @@ export async function extractController(
     subId: req.acuc?.sub_id,
     extractId,
     agent: req.body.agent,
-    apiKeyId: req.acuc.api_key_id,
+    apiKeyId: req.acuc?.api_key_id ?? null,
   };
 
   if (

--- a/apps/api/src/controllers/v1/generate-llmstxt.ts
+++ b/apps/api/src/controllers/v1/generate-llmstxt.ts
@@ -24,7 +24,7 @@ export async function generateLLMsTextController(
   req: RequestWithAuth<{}, GenerateLLMsTextResponse, GenerateLLMsTextRequest>,
   res: Response<GenerateLLMsTextResponse>,
 ) {
-  if (req.acuc?.flags?.forceZDR) {
+  if (req.acuc.flags?.forceZDR) {
     return res.status(400).json({ success: false, error: "Your team has zero data retention enabled. This is not supported on llmstxt. Please contact support@firecrawl.com to unblock this feature." });
   }
 
@@ -34,7 +34,8 @@ export async function generateLLMsTextController(
   const jobData = {
     request: req.body,
     teamId: req.auth.team_id,
-    subId: req.acuc?.sub_id,
+    subId: req.acuc.sub_id,
+    apiKeyId: req.acuc.api_key_id,
     generationId,
   };
 

--- a/apps/api/src/controllers/v1/generate-llmstxt.ts
+++ b/apps/api/src/controllers/v1/generate-llmstxt.ts
@@ -24,7 +24,7 @@ export async function generateLLMsTextController(
   req: RequestWithAuth<{}, GenerateLLMsTextResponse, GenerateLLMsTextRequest>,
   res: Response<GenerateLLMsTextResponse>,
 ) {
-  if (req.acuc.flags?.forceZDR) {
+  if (req.acuc?.flags?.forceZDR) {
     return res.status(400).json({ success: false, error: "Your team has zero data retention enabled. This is not supported on llmstxt. Please contact support@firecrawl.com to unblock this feature." });
   }
 
@@ -34,8 +34,8 @@ export async function generateLLMsTextController(
   const jobData = {
     request: req.body,
     teamId: req.auth.team_id,
-    subId: req.acuc.sub_id,
-    apiKeyId: req.acuc.api_key_id,
+    subId: req.acuc?.sub_id ?? undefined,
+    apiKeyId: req.acuc?.api_key_id ?? null,
     generationId,
   };
 

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -373,7 +373,7 @@ export async function mapController(
   }
 
   // Bill the team
-  billTeam(req.auth.team_id, req.acuc?.sub_id, 1, req.acuc.api_key_id).catch((error) => {
+  billTeam(req.auth.team_id, req.acuc?.sub_id, 1, req.acuc?.api_key_id ?? null).catch((error) => {
     logger.error(
       `Failed to bill team ${req.auth.team_id} for 1 credit: ${error}`,
     );

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -373,7 +373,7 @@ export async function mapController(
   }
 
   // Bill the team
-  billTeam(req.auth.team_id, req.acuc?.sub_id, 1).catch((error) => {
+  billTeam(req.auth.team_id, req.acuc?.sub_id, 1, req.acuc.api_key_id).catch((error) => {
     logger.error(
       `Failed to bill team ${req.auth.team_id} for 1 credit: ${error}`,
     );

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -80,7 +80,7 @@ export async function scrapeController(
       integration: req.body.integration,
       startTime,
       zeroDataRetention: zeroDataRetention ?? false,
-      apiKeyId: req.acuc.api_key_id,
+      apiKeyId: req.acuc?.api_key_id ?? null,
     },
     {},
     jobId,

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -80,6 +80,7 @@ export async function scrapeController(
       integration: req.body.integration,
       startTime,
       zeroDataRetention: zeroDataRetention ?? false,
+      apiKeyId: req.acuc.api_key_id,
     },
     {},
     jobId,

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -41,6 +41,7 @@ export async function searchAndScrapeSearchResult(
     origin: string;
     timeout: number;
     scrapeOptions: ScrapeOptions;
+    apiKeyId: number | null;
   },
   logger: Logger,
   flags: TeamFlags,
@@ -80,6 +81,7 @@ async function scrapeSearchResult(
     origin: string;
     timeout: number;
     scrapeOptions: ScrapeOptions;
+    apiKeyId: number | null;
   },
   logger: Logger,
   flags: TeamFlags,
@@ -124,6 +126,7 @@ async function scrapeSearchResult(
         is_scrape: true,
         startTime: Date.now(),
         zeroDataRetention,
+        apiKeyId: options.apiKeyId,
       },
       {},
       jobId,
@@ -291,6 +294,7 @@ export async function searchController(
             origin: req.body.origin,
             timeout: req.body.timeout,
             scrapeOptions: req.body.scrapeOptions,
+            apiKeyId: req.acuc.api_key_id,
           },
           logger,
           req.acuc?.flags ?? null,
@@ -357,8 +361,9 @@ export async function searchController(
     if (!isSearchPreview) {
       billTeam(
         req.auth.team_id,
-        req.acuc?.sub_id,
+        req.acuc.sub_id,
         credits_billed,
+        req.acuc.api_key_id,
       ).catch((error) => {
         logger.error(
           `Failed to bill team ${req.auth.team_id} for ${responseData.data.length} credits: ${error}`,

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -294,7 +294,7 @@ export async function searchController(
             origin: req.body.origin,
             timeout: req.body.timeout,
             scrapeOptions: req.body.scrapeOptions,
-            apiKeyId: req.acuc.api_key_id,
+            apiKeyId: req.acuc?.api_key_id ?? null,
           },
           logger,
           req.acuc?.flags ?? null,
@@ -361,9 +361,9 @@ export async function searchController(
     if (!isSearchPreview) {
       billTeam(
         req.auth.team_id,
-        req.acuc.sub_id,
+        req.acuc?.sub_id ?? undefined,
         credits_billed,
-        req.acuc.api_key_id,
+        req.acuc?.api_key_id ?? null,
       ).catch((error) => {
         logger.error(
           `Failed to bill team ${req.auth.team_id} for ${responseData.data.length} credits: ${error}`,

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1073,6 +1073,7 @@ type Account = {
 
 export type AuthCreditUsageChunk = {
   api_key: string;
+  api_key_id: number;
   team_id: string;
   sub_id: string | null;
   sub_current_period_start: string | null;

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1131,14 +1131,6 @@ export interface RequestWithMaybeACUC<
   acuc?: AuthCreditUsageChunk;
 }
 
-export interface RequestWithACUC<
-  ReqParams = {},
-  ReqBody = undefined,
-  ResBody = undefined,
-> extends Request<ReqParams, ReqBody, ResBody> {
-  acuc: AuthCreditUsageChunk;
-}
-
 export interface RequestWithAuth<
   ReqParams = {},
   ReqBody = undefined,
@@ -1161,7 +1153,7 @@ export interface RequestWithAuth<
   ReqParams = {},
   ReqBody = undefined,
   ResBody = undefined,
-> extends RequestWithACUC<ReqParams, ReqBody, ResBody> {
+> extends RequestWithMaybeACUC<ReqParams, ReqBody, ResBody> {
   auth: AuthObject;
   account?: Account;
 }

--- a/apps/api/src/controllers/v1/x402-search.ts
+++ b/apps/api/src/controllers/v1/x402-search.ts
@@ -30,46 +30,6 @@ interface DocumentWithCostTracking {
   costTracking: ReturnType<typeof CostTracking.prototype.toJSON>;
 }
 
-// Used for deep research
-export async function searchAndScrapeX402SearchResult(
-  query: string,
-  options: {
-    teamId: string;
-    origin: string;
-    timeout: number;
-    scrapeOptions: ScrapeOptions;
-  },
-  logger: Logger,
-  flags: TeamFlags,
-): Promise<DocumentWithCostTracking[]> {
-  try {
-    const searchResults = await search({
-      query,
-      logger,
-      num_results: 5,
-    });
-
-    const documentsWithCostTracking = await Promise.all(
-      searchResults.map((result) =>
-        scrapeX402SearchResult(
-          {
-            url: result.url,
-            title: result.title,
-            description: result.description,
-          },
-          options,
-          logger,
-          flags,
-        ),
-      ),
-    );
-
-    return documentsWithCostTracking;
-  } catch (error) {
-    return [];
-  }
-}
-
 async function scrapeX402SearchResult(
   searchResult: { url: string; title: string; description: string },
   options: {
@@ -77,6 +37,7 @@ async function scrapeX402SearchResult(
     origin: string;
     timeout: number;
     scrapeOptions: ScrapeOptions;
+    apiKeyId: number | null;
   },
   logger: Logger,
   flags: TeamFlags,
@@ -119,6 +80,7 @@ async function scrapeX402SearchResult(
         is_scrape: true,
         startTime: Date.now(),
         zeroDataRetention,
+        apiKeyId: options.apiKeyId,
       },
       {},
       jobId,
@@ -286,6 +248,7 @@ export async function x402SearchController(
             origin: req.body.origin,
             timeout: req.body.timeout,
             scrapeOptions: req.body.scrapeOptions,
+            apiKeyId: req.acuc.api_key_id,
           },
           logger,
           req.acuc?.flags ?? null,

--- a/apps/api/src/controllers/v1/x402-search.ts
+++ b/apps/api/src/controllers/v1/x402-search.ts
@@ -248,7 +248,7 @@ export async function x402SearchController(
             origin: req.body.origin,
             timeout: req.body.timeout,
             scrapeOptions: req.body.scrapeOptions,
-            apiKeyId: req.acuc.api_key_id,
+            apiKeyId: req.acuc?.api_key_id ?? null,
           },
           logger,
           req.acuc?.flags ?? null,

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -148,6 +148,7 @@ export async function batchScrapeController(
         webhook: req.body.webhook,
         internalOptions: sc.internalOptions,
         zeroDataRetention,
+        apiKeyId: req.acuc.api_key_id,
       },
       opts: {
         jobId: uuidv4(),

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -148,7 +148,7 @@ export async function batchScrapeController(
         webhook: req.body.webhook,
         internalOptions: sc.internalOptions,
         zeroDataRetention,
-        apiKeyId: req.acuc.api_key_id,
+        apiKeyId: req.acuc?.api_key_id ?? null,
       },
       opts: {
         jobId: uuidv4(),

--- a/apps/api/src/controllers/v2/concurrency-check.ts
+++ b/apps/api/src/controllers/v2/concurrency-check.ts
@@ -1,9 +1,9 @@
 import {
-  AuthCreditUsageChunkFromTeam,
   ConcurrencyCheckParams,
   ConcurrencyCheckResponse,
   RequestWithAuth,
 } from "./types";
+import { AuthCreditUsageChunkFromTeam } from "../v1/types";
 import { Response } from "express";
 import { redisEvictConnection } from "../../../src/services/redis";
 import { getACUCTeam } from "../auth";

--- a/apps/api/src/controllers/v2/concurrency-check.ts
+++ b/apps/api/src/controllers/v2/concurrency-check.ts
@@ -14,6 +14,13 @@ export async function concurrencyCheckController(
   req: RequestWithAuth<ConcurrencyCheckParams, undefined, undefined>,
   res: Response<ConcurrencyCheckResponse>,
 ) {
+  if (!req.acuc) {
+    return res.status(401).json({
+      success: false,
+      error: "Unauthorized",
+    });
+  }
+
   let otherACUC: AuthCreditUsageChunkFromTeam | null = null;
   if (!req.acuc.is_extract) {
     otherACUC = await getACUCTeam(req.auth.team_id, false, true, RateLimiterMode.Extract);

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -139,7 +139,7 @@ export async function crawlController(
     },
     team_id: req.auth.team_id,
     createdAt: Date.now(),
-    maxConcurrency: req.body.maxConcurrency !== undefined ? Math.min(req.body.maxConcurrency, req.acuc.concurrency) : undefined,
+    maxConcurrency: req.body.maxConcurrency !== undefined ? (req.acuc?.concurrency !== undefined ? Math.min(req.body.maxConcurrency, req.acuc.concurrency) : req.body.maxConcurrency) : undefined,
     zeroDataRetention,
   };
 
@@ -173,7 +173,7 @@ export async function crawlController(
       webhook: req.body.webhook,
       v1: true,
       zeroDataRetention: zeroDataRetention || false,
-      apiKeyId: req.acuc.api_key_id,
+      apiKeyId: req.acuc?.api_key_id ?? null,
     },
     {},
     crypto.randomUUID(),

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -173,6 +173,7 @@ export async function crawlController(
       webhook: req.body.webhook,
       v1: true,
       zeroDataRetention: zeroDataRetention || false,
+      apiKeyId: req.acuc.api_key_id,
     },
     {},
     crypto.randomUUID(),

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -362,7 +362,7 @@ export async function mapController(
   }
 
   // Bill the team
-  billTeam(req.auth.team_id, req.acuc?.sub_id, 1).catch((error) => {
+  billTeam(req.auth.team_id, req.acuc.sub_id, 1, req.acuc.api_key_id).catch((error) => {
     logger.error(
       `Failed to bill team ${req.auth.team_id} for 1 credit: ${error}`,
     );

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -362,7 +362,7 @@ export async function mapController(
   }
 
   // Bill the team
-  billTeam(req.auth.team_id, req.acuc.sub_id, 1, req.acuc.api_key_id).catch((error) => {
+  billTeam(req.auth.team_id, req.acuc?.sub_id ?? undefined, 1, req.acuc?.api_key_id ?? null).catch((error) => {
     logger.error(
       `Failed to bill team ${req.auth.team_id} for 1 credit: ${error}`,
     );

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -82,6 +82,7 @@ export async function scrapeController(
       integration: req.body.integration,
       startTime,
       zeroDataRetention,
+      apiKeyId: req.acuc.api_key_id,
     },
     {},
     jobId,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -82,7 +82,7 @@ export async function scrapeController(
       integration: req.body.integration,
       startTime,
       zeroDataRetention,
-      apiKeyId: req.acuc.api_key_id,
+      apiKeyId: req.acuc?.api_key_id ?? null,
     },
     {},
     jobId,

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -313,7 +313,7 @@ export async function searchController(
         timeout: req.body.timeout,
         scrapeOptions: req.body.scrapeOptions,
         bypassBilling: !isAsyncScraping, // Async mode bills per job, sync mode bills manually
-        apiKeyId: req.acuc.api_key_id,
+        apiKeyId: req.acuc?.api_key_id ?? null,
       };
       
       const directToBullMQ = (req.acuc?.price_credits ?? 0) <= 3000;
@@ -551,7 +551,7 @@ export async function searchController(
     // - For async scraping: Jobs handle their own billing
     // - For no scraping: Bill based on search results count
     if (!isSearchPreview && (!shouldScrape || (shouldScrape && !isAsyncScraping))) {
-      billTeam(req.auth.team_id, req.acuc.sub_id, credits_billed, req.acuc.api_key_id).catch((error) => {
+      billTeam(req.auth.team_id, req.acuc?.sub_id ?? undefined, credits_billed, req.acuc?.api_key_id ?? null).catch((error) => {
         logger.error(`Failed to bill team ${req.acuc?.sub_id} for ${credits_billed} credits: ${error}`);
       });
     }

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -47,6 +47,7 @@ async function startScrapeJob(
     timeout: number;
     scrapeOptions: ScrapeOptions;
     bypassBilling?: boolean;
+    apiKeyId: number | null;
   },
   logger: Logger,
   flags: TeamFlags,
@@ -85,6 +86,7 @@ async function startScrapeJob(
       is_scrape: options.bypassBilling ?? false,
       startTime: Date.now(),
       zeroDataRetention,
+      apiKeyId: options.apiKeyId,
     },
     {},
     jobId,
@@ -103,6 +105,7 @@ async function scrapeSearchResult(
     timeout: number;
     scrapeOptions: ScrapeOptions;
     bypassBilling?: boolean;
+    apiKeyId: number | null;
   },
   logger: Logger,
   flags: TeamFlags,
@@ -310,6 +313,7 @@ export async function searchController(
         timeout: req.body.timeout,
         scrapeOptions: req.body.scrapeOptions,
         bypassBilling: !isAsyncScraping, // Async mode bills per job, sync mode bills manually
+        apiKeyId: req.acuc.api_key_id,
       };
       
       const directToBullMQ = (req.acuc?.price_credits ?? 0) <= 3000;
@@ -547,9 +551,8 @@ export async function searchController(
     // - For async scraping: Jobs handle their own billing
     // - For no scraping: Bill based on search results count
     if (!isSearchPreview && (!shouldScrape || (shouldScrape && !isAsyncScraping))) {
-      billTeam(req.auth.team_id, req.acuc?.sub_id, credits_billed).catch((error) => {
+      billTeam(req.auth.team_id, req.acuc.sub_id, credits_billed, req.acuc.api_key_id).catch((error) => {
         logger.error(`Failed to bill team ${req.acuc?.sub_id} for ${credits_billed} credits: ${error}`);
-        
       });
     }
 

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -9,7 +9,7 @@ import {
   Document as V0Document,
   WebSearchResult,
 } from "../../lib/entities";
-import { agentOptionsExtract, ScrapeOptions as V1ScrapeOptions } from "../v1/types";
+import { agentOptionsExtract, AuthCreditUsageChunk, ScrapeOptions as V1ScrapeOptions } from "../v1/types";
 import type { InternalOptions } from "../../scraper/scrapeURL";
 import { ErrorCodes } from "../../lib/error";
 import Ajv from "ajv";
@@ -899,44 +899,6 @@ type Account = {
   remainingCredits: number;
 };
 
-export type AuthCreditUsageChunk = {
-  api_key: string;
-  team_id: string;
-  sub_id: string | null;
-  sub_current_period_start: string | null;
-  sub_current_period_end: string | null;
-  sub_user_id: string | null;
-  price_id: string | null;
-  price_credits: number; // credit limit with assoicated price, or free_credits (500) if free plan
-  price_should_be_graceful: boolean;
-  credits_used: number;
-  coupon_credits: number; // do not rely on this number to be up to date after calling a billTeam
-  adjusted_credits_used: number; // credits this period minus coupons used
-  remaining_credits: number;
-  total_credits_sum: number;
-  plan_priority: {
-    bucketLimit: number;
-    planModifier: number;
-  };
-  rate_limits: {
-    crawl: number;
-    scrape: number;
-    search: number;
-    map: number;
-    extract: number;
-    preview: number;
-    crawlStatus: number;
-    extractStatus: number;
-    extractAgentPreview?: number;
-    scrapeAgentPreview?: number;
-  };
-  concurrency: number;
-  flags: TeamFlags;
-
-  // appended on JS-side
-  is_extract?: boolean;
-};
-
 export type TeamFlags = {
   ignoreRobots?: boolean;
   unblockedDomains?: string[];
@@ -947,8 +909,6 @@ export type TeamFlags = {
   allowTeammateInvites?: boolean;
   crawlTtlHours?: number;
 } | null;
-
-export type AuthCreditUsageChunkFromTeam = Omit<AuthCreditUsageChunk, "api_key">;
 
 export interface RequestWithMaybeACUC<
   ReqParams = {},

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -918,23 +918,6 @@ export interface RequestWithMaybeACUC<
   acuc?: AuthCreditUsageChunk;
 }
 
-export interface RequestWithACUC<
-  ReqParams = {},
-  ReqBody = undefined,
-  ResBody = undefined,
-> extends Request<ReqParams, ReqBody, ResBody> {
-  acuc: AuthCreditUsageChunk;
-}
-
-export interface RequestWithAuth<
-  ReqParams = {},
-  ReqBody = undefined,
-  ResBody = undefined,
-> extends Request<ReqParams, ReqBody, ResBody> {
-  auth: AuthObject;
-  account?: Account;
-}
-
 export interface RequestWithMaybeAuth<
   ReqParams = {},
   ReqBody = undefined,
@@ -948,7 +931,7 @@ export interface RequestWithAuth<
   ReqParams = {},
   ReqBody = undefined,
   ResBody = undefined,
-> extends RequestWithACUC<ReqParams, ReqBody, ResBody> {
+> extends RequestWithMaybeACUC<ReqParams, ReqBody, ResBody> {
   auth: AuthObject;
   account?: Account;
 }

--- a/apps/api/src/lib/deep-research/deep-research-service.ts
+++ b/apps/api/src/lib/deep-research/deep-research-service.ts
@@ -7,7 +7,7 @@ import { billTeam } from "../../services/billing/credit_billing";
 import { ExtractOptions } from "../../controllers/v1/types";
 import { CostTracking } from "../extract/extraction-service";
 import { getACUCTeam } from "../../controllers/auth";
-interface DeepResearchServiceOptions {
+export interface DeepResearchServiceOptions {
   researchId: string;
   teamId: string;
   query: string;

--- a/apps/api/src/lib/deep-research/deep-research-service.ts
+++ b/apps/api/src/lib/deep-research/deep-research-service.ts
@@ -19,11 +19,12 @@ interface DeepResearchServiceOptions {
   formats: string[];
   jsonOptions: ExtractOptions;
   subId?: string;
+  apiKeyId: number | null;
 }
 
 export async function performDeepResearch(options: DeepResearchServiceOptions) {
   const costTracking = new CostTracking();
-  const { researchId, teamId, timeLimit, subId, maxUrls } = options;
+  const { researchId, teamId, timeLimit, subId, maxUrls, apiKeyId } = options;
   const startTime = Date.now();
   let currentTopic = options.query;
   let urlsAnalyzed = 0;
@@ -140,6 +141,7 @@ export async function performDeepResearch(options: DeepResearchServiceOptions) {
             storeInCache: true,
             proxy: "basic",
           },
+          apiKeyId: apiKeyId,
         }, logger, acuc?.flags ?? null);
         return response.length > 0 ? response : [];
       });
@@ -395,7 +397,7 @@ export async function performDeepResearch(options: DeepResearchServiceOptions) {
       json: finalAnalysisJson,
     });
     // Bill team for usage based on URLs analyzed
-    billTeam(teamId, subId, credits_billed, logger).catch(
+    billTeam(teamId, subId, credits_billed, apiKeyId, logger).catch(
       (error) => {
         logger.error(
           `Failed to bill team ${teamId} for ${urlsAnalyzed} URLs analyzed`, { teamId, count: urlsAnalyzed, error },

--- a/apps/api/src/lib/extract/document-scraper.ts
+++ b/apps/api/src/lib/extract/document-scraper.ts
@@ -13,6 +13,7 @@ interface ScrapeDocumentOptions {
   timeout: number;
   isSingleUrl?: boolean;
   flags: TeamFlags | null;
+  apiKeyId: number | null;
 }
 
 export async function scrapeDocument(
@@ -58,6 +59,7 @@ export async function scrapeDocument(
         from_extract: true,
         startTime: Date.now(),
         zeroDataRetention: false, // not supported
+        apiKeyId: options.apiKeyId,
       },
       {},
       jobId,

--- a/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
@@ -13,6 +13,7 @@ interface ScrapeDocumentOptions {
   timeout: number;
   isSingleUrl?: boolean;
   flags: TeamFlags | null;
+  apiKeyId: number | null;
 }
 
 export async function scrapeDocument_F0(
@@ -59,6 +60,7 @@ export async function scrapeDocument_F0(
         from_extract: true,
         startTime: Date.now(),
         zeroDataRetention: false, // not supported
+        apiKeyId: options.apiKeyId,
       },
       {},
       jobId,

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -16,6 +16,7 @@ import { getACUCTeam } from "../../controllers/auth";
 interface GenerateLLMsTextServiceOptions {
   generationId: string;
   teamId: string;
+  apiKeyId: number;
   url: string;
   maxUrls: number;
   showFullText: boolean;
@@ -64,7 +65,7 @@ function limitLlmsTxtEntries(llmstxt: string, maxEntries: number): string {
 export async function performGenerateLlmsTxt(
   options: GenerateLLMsTextServiceOptions,
 ) {
-  const { generationId, teamId, url, maxUrls = 100, showFullText, cache = true, subId } =
+  const { generationId, teamId, url, maxUrls = 100, showFullText, cache = true, subId, apiKeyId } =
     options;
   const startTime = Date.now();
   const logger = _logger.child({
@@ -148,6 +149,7 @@ export async function performGenerateLlmsTxt(
                 timeout: 30000,
                 isSingleUrl: true,
                 flags: acuc?.flags ?? null,
+                apiKeyId,
               },
               [],
               logger,
@@ -252,7 +254,7 @@ export async function performGenerateLlmsTxt(
     });
 
     // Bill team for usage
-    billTeam(teamId, subId, urls.length, logger).catch((error) => {
+    billTeam(teamId, subId, urls.length, apiKeyId, logger).catch((error) => {
       logger.error(`Failed to bill team ${teamId} for ${urls.length} urls`, {
         teamId,
         count: urls.length,

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -16,7 +16,7 @@ import { getACUCTeam } from "../../controllers/auth";
 interface GenerateLLMsTextServiceOptions {
   generationId: string;
   teamId: string;
-  apiKeyId: number;
+  apiKeyId: number | null;
   url: string;
   maxUrls: number;
   showFullText: boolean;

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -2,10 +2,7 @@ import { Job } from "bullmq";
 import {
   WebScraperOptions,
   RunWebScraperParams,
-  RunWebScraperResult,
 } from "../types";
-import { billTeam } from "../services/billing/credit_billing";
-import { Document, TeamFlags } from "../controllers/v1/types";
 import { supabase_service } from "../services/supabase";
 import { logger as _logger } from "../lib/logger";
 import { configDotenv } from "dotenv";
@@ -13,7 +10,6 @@ import {
   scrapeURL,
   ScrapeUrlResponse,
 } from "../scraper/scrapeURL";
-import { Engine } from "../scraper/scrapeURL/engines";
 import { CostTracking } from "../lib/extract/extraction-service";
 configDotenv();
 

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -2,9 +2,9 @@ import { NextFunction, Request, Response } from "express";
 // import { crawlStatusController } from "../../src/controllers/v1/crawl-status";
 import {
   isAgentExtractModelValid,
-  RequestWithACUC,
   RequestWithAuth,
   RequestWithMaybeAuth,
+  RequestWithMaybeACUC,
 } from "../controllers/v1/types";
 import { RateLimiterMode } from "../types";
 import { authenticateUser } from "../controllers/auth";
@@ -31,7 +31,7 @@ export function checkCreditsMiddleware(
         }
       }
       const { success, remainingCredits, chunk } = await checkTeamCredits(
-        req.acuc,
+        req.acuc ?? null,
         req.auth.team_id,
         minimum ?? 1,
       );
@@ -55,7 +55,7 @@ export function checkCreditsMiddleware(
           return next();
         }
 
-        const currencyName = req.acuc.is_extract ? "tokens" : "credits";
+        const currencyName = req.acuc?.is_extract ? "tokens" : "credits";
         logger.error(
           `Insufficient ${currencyName}: ${JSON.stringify({ team_id: req.auth.team_id, minimum, remainingCredits })}`,
           {
@@ -164,7 +164,7 @@ export function idempotencyMiddleware(
   })().catch((err) => next(err));
 }
 export function blocklistMiddleware(
-  req: RequestWithACUC<any, any, any>,
+  req: RequestWithMaybeACUC<any, any, any>,
   res: Response,
   next: NextFunction,
 ) {

--- a/apps/api/src/services/billing/credit_billing.ts
+++ b/apps/api/src/services/billing/credit_billing.ts
@@ -20,23 +20,25 @@ export async function billTeam(
   team_id: string,
   subscription_id: string | null | undefined,
   credits: number,
+  api_key_id: number | null,
   logger?: Logger,
   is_extract: boolean = false,
 ) {
   // Maintain the withAuth wrapper for authentication
   return withAuth(
-    async (team_id, subscription_id, credits, logger, is_extract) => {
+    async (team_id: string, subscription_id: string | null | undefined, credits: number, api_key_id: number | null, logger: Logger | undefined, is_extract: boolean) => {
       // Within the authenticated context, queue the billing operation
-      return queueBillingOperation(team_id, subscription_id, credits, is_extract);
+      return queueBillingOperation(team_id, subscription_id, credits, api_key_id, is_extract);
     }, 
     { success: true, message: "No DB, bypassed." }
-  )(team_id, subscription_id, credits, logger, is_extract);
+  )(team_id, subscription_id, credits, api_key_id, logger, is_extract);
 }
 
 export async function supaBillTeam(
   team_id: string,
   subscription_id: string | null | undefined,
   credits: number,
+  api_key_id: number | null,
   __logger?: Logger,
   is_extract: boolean = false,
 ) {
@@ -51,7 +53,7 @@ export async function supaBillTeam(
   });
 
   _logger.warn("supaBillTeam was called directly. This function is deprecated and should only be called from batch_billing.ts");
-  queueBillingOperation(team_id, subscription_id, credits, is_extract).catch((err) => {
+  queueBillingOperation(team_id, subscription_id, credits, api_key_id, is_extract).catch((err) => {
     _logger.error("Error queuing billing operation", { err });
     Sentry.captureException(err);
   });

--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -61,7 +61,7 @@ const processBillingJobInternal = async (token: string, job: Job) => {
       await processBillingBatch();
     } else if (job.name === "bill_team") {
       // This is an individual billing operation that should be queued for batch processing
-      const { team_id, subscription_id, credits, is_extract } = job.data;
+      const { team_id, subscription_id, credits, is_extract, api_key_id } = job.data;
       
       logger.info(`Adding team ${team_id} billing operation to batch queue`, {
         credits,
@@ -70,7 +70,7 @@ const processBillingJobInternal = async (token: string, job: Job) => {
       });
       
       // Add to the REDIS batch queue 
-      await queueBillingOperation(team_id, subscription_id, credits, is_extract);
+      await queueBillingOperation(team_id, subscription_id, credits, api_key_id ?? null, is_extract);
     } else {
       logger.warn(`Unknown billing job type: ${job.name}`);
     }
@@ -181,6 +181,7 @@ const processPrecrawlJobInternal = async (token: string, job: Job) => {
             webhook: undefined,
             v1: true,
             zeroDataRetention: false,
+            apiKeyId: null,
           },
           {},
           crypto.randomUUID(),

--- a/apps/api/src/services/queue-service.ts
+++ b/apps/api/src/services/queue-service.ts
@@ -2,6 +2,7 @@ import { Queue, QueueEvents } from "bullmq";
 import { logger } from "../lib/logger";
 import IORedis from "ioredis";
 import { BullMQOtel } from "bullmq-otel";
+import type { DeepResearchServiceOptions } from "../lib/deep-research/deep-research-service";
 
 export type QueueFunction = () => Queue<any, any, string, any, any, string>;
 
@@ -104,7 +105,7 @@ export function getGenerateLlmsTxtQueue() {
 
 export function getDeepResearchQueue() {
   if (!deepResearchQueue) {
-    deepResearchQueue = new Queue(deepResearchQueueName, {
+    deepResearchQueue = new Queue<DeepResearchServiceOptions>(deepResearchQueueName, {
       connection: getRedisConnection(),
       defaultJobOptions: {
         removeOnComplete: {

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -120,12 +120,14 @@ const processExtractJobInternal = async (
         request: job.data.request,
         teamId: job.data.teamId,
         subId: job.data.subId,
+        apiKeyId: job.data.apiKeyId,
       });
     } else {
       result = await performExtraction_F0(job.data.extractId, {
         request: job.data.request,
         teamId: job.data.teamId,
         subId: job.data.subId,
+        apiKeyId: job.data.apiKeyId,
       });
     }
     // result = await performExtraction_F0(job.data.extractId, {
@@ -224,6 +226,7 @@ const processDeepResearchJobInternal = async (
       systemPrompt: job.data.request.systemPrompt,
       formats: job.data.request.formats,
       jsonOptions: job.data.request.jsonOptions,
+      apiKeyId: job.data.apiKeyId,
     });
 
     if (result.success) {
@@ -294,6 +297,7 @@ const processGenerateLlmsTxtJobInternal = async (
       showFullText: job.data.request.showFullText,
       subId: job.data.subId,
       cache: job.data.request.cache,
+      apiKeyId: job.data.apiKeyId,
     });
 
     if (result.success) {

--- a/apps/api/src/services/worker/crawl-logic.ts
+++ b/apps/api/src/services/worker/crawl-logic.ts
@@ -117,6 +117,7 @@ export async function finishCrawlIfNeeded(job: Job & { id: string }, sc: StoredC
                             webhook: job.data.webhook,
                             v1: job.data.v1,
                             zeroDataRetention: job.data.zeroDataRetention,
+                            apiKeyId: job.data.apiKeyId,
                         },
                         opts: {
                             jobId: uuid,

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -99,6 +99,7 @@ async function billScrapeJob(job: Job & { id: string }, document: Document | nul
                         is_extract: false,
                         timestamp: new Date().toISOString(),
                         originating_job_id: job.id,
+                        api_key_id: job.data.apiKeyId,
                     },
                     {
                         jobId: billingJobId,
@@ -331,6 +332,7 @@ async function processJob(job: Job & { id: string }) {
                                     webhook: job.data.webhook,
                                     v1: job.data.v1,
                                     zeroDataRetention: job.data.zeroDataRetention,
+                                    apiKeyId: job.data.apiKeyId,
                                 },
                                 {},
                                 jobId,
@@ -623,6 +625,7 @@ async function processKickoffJob(job: Job & { id: string }) {
                 v1: job.data.v1,
                 isCrawlSourceScrape: true,
                 zeroDataRetention: job.data.zeroDataRetention,
+                apiKeyId: job.data.apiKeyId,
             },
             {
                 priority: 15,
@@ -679,6 +682,7 @@ async function processKickoffJob(job: Job & { id: string }) {
                             webhook: job.data.webhook,
                             v1: job.data.v1,
                             zeroDataRetention: job.data.zeroDataRetention,
+                            apiKeyId: job.data.apiKeyId,
                         },
                         opts: {
                             jobId: uuid,
@@ -743,6 +747,7 @@ async function processKickoffJob(job: Job & { id: string }) {
                         webhook: job.data.webhook,
                         v1: job.data.v1,
                         zeroDataRetention: job.data.zeroDataRetention,
+                        apiKeyId: job.data.apiKeyId,
                     },
                     opts: {
                         jobId: uuid,

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import {
-  AuthCreditUsageChunk,
   BaseScrapeOptions,
   ScrapeOptions,
   Document as V2Document,
   webhookSchema,
   TeamFlags,
 } from "./controllers/v2/types";
+import { AuthCreditUsageChunk } from "./controllers/v1/types";
 import { ExtractorOptions, Document } from "./lib/entities";
 import { InternalOptions } from "./scraper/scrapeURL";
 import type { CostTracking } from "./lib/extract/extraction-service";
@@ -60,6 +60,7 @@ export interface WebScraperOptions {
   sentry?: any;
   is_extract?: boolean;
   concurrencyLimited?: boolean;
+  apiKeyId: number | null;
 }
 
 export interface RunWebScraperParams {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Propagates api_key_id from auth through job payloads to billing so credits are attributed per API key across scrape, search, crawl, extract, deep-research, and llmstxt. Updates batch billing and DB RPC to record api_key_id, aligning with ENG-3202.

- **New Features**
  - Added api_key_id to AuthCreditUsageChunk and passed it through controllers, WebScraperOptions, jobs, and workers.
  - Extended billTeam/queueBillingOperation/supaBillTeam to accept api_key_id; billing jobs now include it and batch grouping keys consider it.
  - Switched batch billing RPC to bill_team_5 with i_api_key_id; operations grouped by team, subscription, is_extract, and api_key_id.
  - Threaded apiKeyId through extract, deep-research, and generate-llmstxt services and their billing.
  - Removed duplicate AuthCreditUsageChunk in v2/types; now imported from v1/types. Minor import cleanups.

- **Migration**
  - Ensure the Supabase RPC bill_team_5 exists and accepts i_api_key_id.
  - Deploy backend so workers/queues pick up the new job payloads containing api_key_id.

<!-- End of auto-generated description by cubic. -->

