### PR TITLE
feat(countryCheck): better protection against XFF spoofing

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -81,6 +81,10 @@ app.use(bodyParser.json({ limit: "10mb" }));
 
 app.use(cors()); // Add this line to enable CORS
 
+if (process.env.EXPRESS_TRUST_PROXY) {
+  app.set("trust proxy", parseInt(process.env.EXPRESS_TRUST_PROXY, 10));
+}
+
 const serverAdapter = new ExpressAdapter();
 serverAdapter.setBasePath(`/admin/${process.env.BULL_AUTH_KEY}/queues`);
 

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -204,24 +204,23 @@ export function countryCheck(
   if (!couldBeRestricted) {
     return next();
   }
-  
-  const _ip = req.headers["x-forwarded-for"] || req.socket.remoteAddress || "";
-  const ip = Array.isArray(_ip) ? _ip[0] : _ip.split(",")[0];
 
-  if (!ip) {
+  logger.debug("debug: ip", { ip: req.ip });
+  
+  if (!req.ip) {
     logger.warn("IP address not found, unable to check country");
     return next();
   }
 
-  const country = geoip.lookup(ip);
+  const country = geoip.lookup(req.ip);
   if (!country || !country.country) {
-    logger.warn("IP address country data not found", { ip });
+    logger.warn("IP address country data not found", { ip: req.ip });
     return next();
   }
 
   const restricted = process.env.RESTRICTED_COUNTRIES?.split(",") ?? [];
   if (restricted.includes(country.country)) {
-    logger.warn("Denied access to restricted country", { ip, country: country.country, teamId: req.auth.team_id });
+    logger.warn("Denied access to restricted country", { ip: req.ip, country: country.country, teamId: req.auth.team_id });
     return res.status(403).json({
       success: false,
       error: "Use of headers, actions, and the FIRE-1 agent is not allowed by default in your country. Please contact us at help@firecrawl.com",

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -205,8 +205,6 @@ export function countryCheck(
     return next();
   }
 
-  logger.debug("debug: ip", { ip: req.ip });
-  
   if (!req.ip) {
     logger.warn("IP address not found, unable to check country");
     return next();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Hardened country-based access checks by using Express req.ip and a configurable trust proxy to prevent X-Forwarded-For spoofing. Improves accuracy of geo lookups and logging.

- **Bug Fixes**
  - Use req.ip for geo lookup and logs; remove manual XFF parsing.
  - Support EXPRESS_TRUST_PROXY to set app.set("trust proxy") for correct client IPs behind proxies.

- **Migration**
  - If behind proxies, set EXPRESS_TRUST_PROXY to the number of trusted hops (e.g., 1). Otherwise leave unset.

<!-- End of auto-generated description by cubic. -->

