### PR TITLE
fix: include json in v2 /search response when using scrapeOptions.formats

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -482,6 +482,7 @@ export async function searchController(
               screenshot: doc?.screenshot,
               summary: doc?.summary,
               metadata: doc?.metadata,
+              json: doc?.json
             };
           });
         }
@@ -498,6 +499,7 @@ export async function searchController(
               rawHtml: doc?.rawHtml,
               summary: doc?.summary,
               metadata: doc?.metadata,
+              json: doc?.json
             };
           });
         }
@@ -514,6 +516,7 @@ export async function searchController(
               rawHtml: doc?.rawHtml,
               summary: doc?.summary,
               metadata: doc?.metadata,
+              json: doc?.json
             };
           });
         }


### PR DESCRIPTION
Follow up to #2027.

This fixes the same issue as in #2024 but for json responses. Wasted more credits than I would've liked before I figured this out 😅

This basically just piggybacks off that original PR so if additional changes are needed lmk.