### PR TITLE
feat(scrapeURL/rewrite): scrape Google Drive TXT/PDF files and sheets

### DIFF
--- a/apps/api/src/__tests__/snips/v1/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v1/scrape.test.ts
@@ -937,11 +937,14 @@ describe("Scrape tests", () => {
         // text on the last page
         expect(response.markdown).toContain("Redistribution and use in source and binary forms, with or without modification");
       }, scrapeTimeout * 5);
+    });
+  }
 
+  describe("URL rewriting", () => {
+    if (!process.env.TEST_SUITE_SELF_HOSTED) {
       it.concurrent("scrapes Google Docs links as PDFs", async () => {
         const response = await scrape({
           url: "https://docs.google.com/document/d/1H-hOLYssS8xXl2o5hxj4ipE7yyhZAX1s7ADYM1Hdlzo/view",
-          timeout: scrapeTimeout * 5,
         }, identity);
 
         expect(response.markdown).toContain("This is a test to confirm Google Docs scraping abilities.");
@@ -950,13 +953,28 @@ describe("Scrape tests", () => {
       it.concurrent("scrapes Google Slides links as PDFs", async () => {
         const response = await scrape({
           url: "https://docs.google.com/presentation/d/1pDKL1UULpr6siq_eVWE1hjqt5MKCgSSuKS_MWahnHAQ/view",
-          timeout: scrapeTimeout * 5,
         }, identity);
 
         expect(response.markdown).toContain("This is a test to confirm Google Slides scraping abilities.");
       }, scrapeTimeout * 5);
-    });
-  }
+    }
+
+    it.concurrent("scrapes Google Drive PDF files as PDFs", async () => {
+      const response = await scrape({
+        url: "https://drive.google.com/file/d/1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu/view?usp=drive_link",
+      }, identity);
+
+      expect(response.markdown).toContain("This is a simple PDF file.");
+    }, scrapeTimeout * 5);
+
+    it.concurrent("scrapes Google Drive text files correctly", async () => {
+      const response = await scrape({
+        url: "https://drive.google.com/file/d/14m3ZVDnWJwwPSDHX6U6jkL7FXxOf6cHB/view?usp=sharing",
+      }, identity);
+
+      expect(response.markdown).toContain("This is a simple TXT file.");
+    }, scrapeTimeout * 5);
+  });
 
   if (!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL) {
     describe("JSON format", () => {

--- a/apps/api/src/__tests__/snips/v1/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v1/scrape.test.ts
@@ -974,6 +974,14 @@ describe("Scrape tests", () => {
 
       expect(response.markdown).toContain("This is a simple TXT file.");
     }, scrapeTimeout * 5);
+
+    it.concurrent("scrapes Google Sheets links correctly", async () => {
+      const response = await scrape({
+        url: "https://docs.google.com/spreadsheets/d/1DTpw_bbsf3OY17ZqEYEpW6lAmLdCRC2WfLrV0isG9ac/edit?usp=sharing",
+      }, identity);
+
+      expect(response.markdown).toContain("This is a test sheet.");
+    }, scrapeTimeout * 5);
   });
 
   if (!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL) {

--- a/apps/api/src/__tests__/snips/v1/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v1/scrape.test.ts
@@ -957,15 +957,15 @@ describe("Scrape tests", () => {
 
         expect(response.markdown).toContain("This is a test to confirm Google Slides scraping abilities.");
       }, scrapeTimeout * 5);
+
+      it.concurrent("scrapes Google Drive PDF files as PDFs", async () => {
+        const response = await scrape({
+          url: "https://drive.google.com/file/d/1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu/view?usp=drive_link",
+        }, identity);
+  
+        expect(response.markdown).toContain("This is a simple PDF file.");
+      }, scrapeTimeout * 5);
     }
-
-    it.concurrent("scrapes Google Drive PDF files as PDFs", async () => {
-      const response = await scrape({
-        url: "https://drive.google.com/file/d/1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu/view?usp=drive_link",
-      }, identity);
-
-      expect(response.markdown).toContain("This is a simple PDF file.");
-    }, scrapeTimeout * 5);
 
     it.concurrent("scrapes Google Drive text files correctly", async () => {
       const response = await scrape({

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -892,6 +892,15 @@ describe("Scrape tests", () => {
 
       expect(response.markdown).toContain("This is a simple TXT file.");
     }, scrapeTimeout * 5);
+
+    it.concurrent("scrapes Google Sheets links correctly", async () => {
+      const response = await scrape({
+        url: "https://docs.google.com/spreadsheets/d/1DTpw_bbsf3OY17ZqEYEpW6lAmLdCRC2WfLrV0isG9ac/edit?usp=sharing",
+        maxAge: 0,
+      }, identity);
+
+      expect(response.markdown).toContain("This is a test sheet.");
+    }, scrapeTimeout * 5);
   });
 
   if (!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL) {

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -873,16 +873,16 @@ describe("Scrape tests", () => {
 
         expect(response.markdown).toContain("This is a test to confirm Google Slides scraping abilities.");
       }, scrapeTimeout * 5);
+
+      it.concurrent("scrapes Google Drive PDF files as PDFs", async () => {
+        const response = await scrape({
+          url: "https://drive.google.com/file/d/1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu/view?usp=drive_link",
+          maxAge: 0,
+        }, identity);
+  
+        expect(response.markdown).toContain("This is a simple PDF file.");
+      }, scrapeTimeout * 5);
     }
-
-    it.concurrent("scrapes Google Drive PDF files as PDFs", async () => {
-      const response = await scrape({
-        url: "https://drive.google.com/file/d/1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu/view?usp=drive_link",
-        maxAge: 0,
-      }, identity);
-
-      expect(response.markdown).toContain("This is a simple PDF file.");
-    }, scrapeTimeout * 5);
 
     it.concurrent("scrapes Google Drive text files correctly", async () => {
       const response = await scrape({

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -851,10 +851,15 @@ describe("Scrape tests", () => {
         // text on the last page
         expect(response.markdown).toContain("Redistribution and use in source and binary forms, with or without modification");
       }, scrapeTimeout * 5);
+    });
+  }
 
+  describe("URL rewriting", () => {
+    if (!process.env.TEST_SUITE_SELF_HOSTED) {
       it.concurrent("scrapes Google Docs links as PDFs", async () => {
         const response = await scrape({
           url: "https://docs.google.com/document/d/1H-hOLYssS8xXl2o5hxj4ipE7yyhZAX1s7ADYM1Hdlzo/view",
+          maxAge: 0,
         }, identity);
 
         expect(response.markdown).toContain("This is a test to confirm Google Docs scraping abilities.");
@@ -868,8 +873,26 @@ describe("Scrape tests", () => {
 
         expect(response.markdown).toContain("This is a test to confirm Google Slides scraping abilities.");
       }, scrapeTimeout * 5);
-    });
-  }
+    }
+
+    it.concurrent("scrapes Google Drive PDF files as PDFs", async () => {
+      const response = await scrape({
+        url: "https://drive.google.com/file/d/1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu/view?usp=drive_link",
+        maxAge: 0,
+      }, identity);
+
+      expect(response.markdown).toContain("This is a simple PDF file.");
+    }, scrapeTimeout * 5);
+
+    it.concurrent("scrapes Google Drive text files correctly", async () => {
+      const response = await scrape({
+        url: "https://drive.google.com/file/d/14m3ZVDnWJwwPSDHX6U6jkL7FXxOf6cHB/view?usp=sharing",
+        maxAge: 0,
+      }, identity);
+
+      expect(response.markdown).toContain("This is a simple TXT file.");
+    }, scrapeTimeout * 5);
+  });
 
   if (!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL) {
     describe("JSON format", () => {

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -38,7 +38,8 @@ export async function specialtyScrapeCheck(
     });
   } else if (
     contentType === "application/pdf" ||
-    contentType.startsWith("application/pdf;")
+    contentType.startsWith("application/pdf;") ||
+    (contentType === "application/octet-stream" && (feRes?.file?.content.startsWith("JVBERi0") || feRes?.content.startsWith("%PDF-")))
   ) {
     // .pdf
     throw new AddFeatureError(["pdf"], await feResToPdfPrefetch(logger, feRes));

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -159,6 +159,11 @@ function rewriteUrl(url: string): string | undefined {
     if (id) {
       return `https://drive.google.com/uc?export=download&id=${id}`;
     }
+  } else if (url.startsWith("https://docs.google.com/spreadsheets/d/") || url.startsWith("http://docs.google.com/spreadsheets/d/")) {
+    const id = url.match(/\/spreadsheets\/d\/([-\w]+)/)?.[1];
+    if (id) {
+      return `https://docs.google.com/spreadsheets/d/${id}/gviz/tq?tqx=out:html`;
+    }
   }
 
   return undefined;

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -154,6 +154,11 @@ function rewriteUrl(url: string): string | undefined {
     if (id) {
       return `https://docs.google.com/presentation/d/${id}/export?format=pdf`;
     }
+  } else if (url.startsWith("https://drive.google.com/file/d/") || url.startsWith("http://drive.google.com/file/d/")) {
+    const id = url.match(/\/file\/d\/([-\w]+)/)?.[1];
+    if (id) {
+      return `https://drive.google.com/uc?export=download&id=${id}`;
+    }
   }
 
   return undefined;


### PR DESCRIPTION
Also solves ENG-2395
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enables scraping of public Google Drive PDF and TXT files by rewriting file URLs to direct downloads. Fixes the ENG-3146 inability to scrape public Drive PDFs and also covers ENG-2395.

- **Bug Fixes**
  - Rewrites drive.google.com/file/d/<id> to https://drive.google.com/uc?export=download&id=<id>.
  - Adds v1/v2 tests for Drive PDFs and TXT; v2 tests use maxAge: 0 to bypass cache.

<!-- End of auto-generated description by cubic. -->

