### PR TITLE
fix(v2/search): overlay doc fields via spread operator

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -474,15 +474,7 @@ export async function searchController(
             const doc = resultsMap.get(item.url);
             return {
               ...item, // Preserve ALL original fields
-              // Override/add scraped content
-              markdown: doc?.markdown,
-              html: doc?.html,
-              rawHtml: doc?.rawHtml,
-              links: doc?.links,
-              screenshot: doc?.screenshot,
-              summary: doc?.summary,
-              metadata: doc?.metadata,
-              json: doc?.json
+              ...doc, // Override/add scraped content
             };
           });
         }
@@ -493,13 +485,7 @@ export async function searchController(
             const doc = item.url ? resultsMap.get(item.url) : undefined;
             return {
               ...item, // Preserve ALL original fields
-              // Add scraped content if available
-              markdown: doc?.markdown,
-              html: doc?.html,
-              rawHtml: doc?.rawHtml,
-              summary: doc?.summary,
-              metadata: doc?.metadata,
-              json: doc?.json
+              ...doc, // Override/add scraped content
             };
           });
         }
@@ -510,13 +496,7 @@ export async function searchController(
             const doc = item.url ? resultsMap.get(item.url) : undefined;
             return {
               ...item, // Preserve ALL original fields
-              // Add scraped content if available
-              markdown: doc?.markdown,
-              html: doc?.html,
-              rawHtml: doc?.rawHtml,
-              summary: doc?.summary,
-              metadata: doc?.metadata,
-              json: doc?.json
+              ...doc, // Override/add scraped content
             };
           });
         }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Use object spread to overlay scraped doc fields onto v2 search results, preserving original item fields and letting doc fields override when present. Fixes inconsistent/missing overlays across result types (e.g., links, screenshot, metadata) and reduces duplication.

<!-- End of auto-generated description by cubic. -->

