### PR TITLE
feat(api): add /team/queue-status endpoint

### DIFF
--- a/apps/api/src/__tests__/snips/v1/lib.ts
+++ b/apps/api/src/__tests__/snips/v1/lib.ts
@@ -367,13 +367,16 @@ export async function tokenUsage(identity: Identity): Promise<{ remaining_tokens
 
 export async function concurrencyCheck(identity: Identity): Promise<{ concurrency: number, maxConcurrency: number }> {
     const x = (await request(TEST_URL)
-        .get("/v1/concurrency-check")
+        .get("/v1/team/queue-status")
         .set("Authorization", `Bearer ${identity.apiKey}`)
         .set("Content-Type", "application/json"));
     
     expect(x.statusCode).toBe(200);
     expect(x.body.success).toBe(true);
-    return x.body;
+    return {
+        concurrency: x.body.activeJobsInQueue,
+        maxConcurrency: x.body.maxConcurrency,
+    };
 }
 
 export async function crawlWithConcurrencyTracking(body: CrawlRequestInput, identity: Identity): Promise<{

--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -311,13 +311,16 @@ export async function creditUsage(identity: Identity): Promise<{ remainingCredit
 
 export async function concurrencyCheck(identity: Identity): Promise<{ concurrency: number, maxConcurrency: number }> {
     const x = (await request(TEST_URL)
-        .get("/v2/concurrency-check")
+        .get("/v2/team/queue-status")
         .set("Authorization", `Bearer ${identity.apiKey}`)
         .set("Content-Type", "application/json"));
     
     expect(x.statusCode).toBe(200);
     expect(x.body.success).toBe(true);
-    return x.body;
+    return {
+        concurrency: x.body.activeJobsInQueue,
+        maxConcurrency: x.body.maxConcurrency,
+    };
 }
 
 export async function crawlWithConcurrencyTracking(body: CrawlRequestInput, identity: Identity): Promise<{

--- a/apps/api/src/controllers/v1/queue-status.ts
+++ b/apps/api/src/controllers/v1/queue-status.ts
@@ -1,0 +1,42 @@
+import { RateLimiterMode } from "src/types";
+import { getACUCTeam } from "../auth";
+import { AuthCreditUsageChunkFromTeam, RequestWithAuth } from "./types";
+import { Response } from "express";
+import { redisEvictConnection } from "src/services/redis";
+import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, countConcurrencyLimitedJobs, countConcurrencyLimitActiveJobs } from "src/lib/concurrency-limit";
+
+export type QueueStatusResponse = {
+    success: boolean;
+    jobsInQueue: number;
+    activeJobsInQueue: number;
+    waitingJobsInQueue: number;
+    maxConcurrency: number;
+    mostRecentSuccess: string | null;
+}
+
+export async function queueStatusController(req: RequestWithAuth<{}, undefined, QueueStatusResponse>, res: Response<QueueStatusResponse>) {
+    let otherACUC: AuthCreditUsageChunkFromTeam | null = null;
+  if (!req.acuc?.is_extract) {
+    otherACUC = await getACUCTeam(req.auth.team_id, false, true, RateLimiterMode.Extract);
+  } else {
+    otherACUC = await getACUCTeam(req.auth.team_id, false, true, RateLimiterMode.Crawl);
+  }
+
+  await cleanOldConcurrencyLimitEntries(req.auth.team_id);
+  const activeJobsOfTeam = await countConcurrencyLimitActiveJobs(req.auth.team_id);
+  await cleanOldConcurrencyLimitedJobs(req.auth.team_id);
+  const queuedJobsOfTeam = await countConcurrencyLimitedJobs(req.auth.team_id);
+
+  const mostRecentSuccess = await redisEvictConnection.get("most-recent-success:" + req.auth.team_id);
+
+  return res.status(200).json({
+    success: true,
+
+    jobsInQueue: activeJobsOfTeam + queuedJobsOfTeam,
+    activeJobsInQueue: activeJobsOfTeam,
+    waitingJobsInQueue: queuedJobsOfTeam,
+    maxConcurrency: req.acuc?.concurrency ?? 1,
+
+    mostRecentSuccess: mostRecentSuccess ? new Date(mostRecentSuccess).toISOString() : null,
+  });
+}

--- a/apps/api/src/controllers/v1/queue-status.ts
+++ b/apps/api/src/controllers/v1/queue-status.ts
@@ -1,9 +1,9 @@
-import { RateLimiterMode } from "src/types";
+import { RateLimiterMode } from "../../types";
 import { getACUCTeam } from "../auth";
 import { AuthCreditUsageChunkFromTeam, RequestWithAuth } from "./types";
 import { Response } from "express";
-import { redisEvictConnection } from "src/services/redis";
-import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, countConcurrencyLimitedJobs, countConcurrencyLimitActiveJobs } from "src/lib/concurrency-limit";
+import { redisEvictConnection } from "../../services/redis";
+import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, countConcurrencyLimitedJobs, countConcurrencyLimitActiveJobs } from "../../lib/concurrency-limit";
 
 export type QueueStatusResponse = {
     success: boolean;

--- a/apps/api/src/controllers/v2/queue-status.ts
+++ b/apps/api/src/controllers/v2/queue-status.ts
@@ -1,0 +1,42 @@
+import { RateLimiterMode } from "src/types";
+import { getACUCTeam } from "../auth";
+import { AuthCreditUsageChunkFromTeam, RequestWithAuth } from "./types";
+import { Response } from "express";
+import { redisEvictConnection } from "src/services/redis";
+import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, countConcurrencyLimitedJobs, countConcurrencyLimitActiveJobs } from "src/lib/concurrency-limit";
+
+export type QueueStatusResponse = {
+    success: boolean;
+    jobsInQueue: number;
+    activeJobsInQueue: number;
+    waitingJobsInQueue: number;
+    maxConcurrency: number;
+    mostRecentSuccess: string | null;
+}
+
+export async function queueStatusController(req: RequestWithAuth<{}, undefined, QueueStatusResponse>, res: Response<QueueStatusResponse>) {
+    let otherACUC: AuthCreditUsageChunkFromTeam | null = null;
+  if (!req.acuc?.is_extract) {
+    otherACUC = await getACUCTeam(req.auth.team_id, false, true, RateLimiterMode.Extract);
+  } else {
+    otherACUC = await getACUCTeam(req.auth.team_id, false, true, RateLimiterMode.Crawl);
+  }
+
+  await cleanOldConcurrencyLimitEntries(req.auth.team_id);
+  const activeJobsOfTeam = await countConcurrencyLimitActiveJobs(req.auth.team_id);
+  await cleanOldConcurrencyLimitedJobs(req.auth.team_id);
+  const queuedJobsOfTeam = await countConcurrencyLimitedJobs(req.auth.team_id);
+
+  const mostRecentSuccess = await redisEvictConnection.get("most-recent-success:" + req.auth.team_id);
+
+  return res.status(200).json({
+    success: true,
+
+    jobsInQueue: activeJobsOfTeam + queuedJobsOfTeam,
+    activeJobsInQueue: activeJobsOfTeam,
+    waitingJobsInQueue: queuedJobsOfTeam,
+    maxConcurrency: req.acuc?.concurrency ?? 1,
+
+    mostRecentSuccess: mostRecentSuccess ? new Date(mostRecentSuccess).toISOString() : null,
+  });
+}

--- a/apps/api/src/controllers/v2/queue-status.ts
+++ b/apps/api/src/controllers/v2/queue-status.ts
@@ -1,6 +1,7 @@
 import { RateLimiterMode } from "../../types";
 import { getACUCTeam } from "../auth";
-import { AuthCreditUsageChunkFromTeam, RequestWithAuth } from "./types";
+import { RequestWithAuth } from "./types";
+import { AuthCreditUsageChunkFromTeam } from "../v1/types";
 import { Response } from "express";
 import { redisEvictConnection } from "../../services/redis";
 import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, getConcurrencyLimitActiveJobsCount, getConcurrencyQueueJobsCount } from "../../lib/concurrency-limit";

--- a/apps/api/src/controllers/v2/queue-status.ts
+++ b/apps/api/src/controllers/v2/queue-status.ts
@@ -1,9 +1,9 @@
-import { RateLimiterMode } from "src/types";
+import { RateLimiterMode } from "../../types";
 import { getACUCTeam } from "../auth";
 import { AuthCreditUsageChunkFromTeam, RequestWithAuth } from "./types";
 import { Response } from "express";
-import { redisEvictConnection } from "src/services/redis";
-import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, countConcurrencyLimitedJobs, countConcurrencyLimitActiveJobs } from "src/lib/concurrency-limit";
+import { redisEvictConnection } from "../../services/redis";
+import { cleanOldConcurrencyLimitedJobs, cleanOldConcurrencyLimitEntries, countConcurrencyLimitedJobs, countConcurrencyLimitActiveJobs } from "../../lib/concurrency-limit";
 
 export type QueueStatusResponse = {
     success: boolean;

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -20,10 +20,10 @@ export async function cleanOldConcurrencyLimitEntries(
   await redisEvictConnection.zremrangebyscore(constructKey(team_id), -Infinity, now);
 }
 
-export async function countConcurrencyLimitActiveJobs(
+export async function getConcurrencyLimitActiveJobsCount(
   team_id: string,
 ): Promise<number> {
-  return await redisEvictConnection.zcard(constructKey(team_id));
+  return await redisEvictConnection.zcount(constructKey(team_id), Date.now(), Infinity);
 }
 
 export async function getConcurrencyLimitActiveJobs(
@@ -71,12 +71,6 @@ export async function cleanOldConcurrencyLimitedJobs(
   await redisEvictConnection.zremrangebyscore(constructQueueKey(team_id), -Infinity, now);
 }
 
-export async function countConcurrencyLimitedJobs(
-  team_id: string,
-): Promise<number> {
-  return await redisEvictConnection.zcard(constructQueueKey(team_id));
-}
-
 export async function takeConcurrencyLimitedJob(
   team_id: string,
 ): Promise<ConcurrencyLimitedJob | null> {
@@ -107,8 +101,7 @@ export async function getConcurrencyLimitedJobs(
 }
 
 export async function getConcurrencyQueueJobsCount(team_id: string): Promise<number> {
-  const count = await redisEvictConnection.zcard(constructQueueKey(team_id));
-  return count;
+  return await redisEvictConnection.zcount(constructQueueKey(team_id), Date.now(), Infinity);
 }
 
 export async function cleanOldCrawlConcurrencyLimitEntries(

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -1,4 +1,4 @@
-import { InternalOptions } from "src/scraper/scrapeURL";
+import { InternalOptions } from "../scraper/scrapeURL";
 import { Document, ScrapeOptions, TeamFlags } from "../controllers/v2/types";
 import { CostTracking } from "./extract/extraction-service";
 import { hasFormatOfType } from "./format-utils";

--- a/apps/api/src/routes/v1.ts
+++ b/apps/api/src/routes/v1.ts
@@ -33,6 +33,7 @@ import {
   wrap,
 } from "./shared";
 import { paymentMiddleware } from "x402-express";
+import { queueStatusController } from "../controllers/v1/queue-status";
 
 expressWs(express());
 
@@ -232,6 +233,12 @@ v1Router.get(
   "/team/token-usage",
   authMiddleware(RateLimiterMode.ExtractStatus),
   wrap(tokenUsageController),
+);
+
+v1Router.get(
+  "/team/queue-status",
+  authMiddleware(RateLimiterMode.CrawlStatus),
+  wrap(queueStatusController),
 );
 
 v1Router.post(

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -26,6 +26,7 @@ import {
   idempotencyMiddleware,
   wrap,
 } from "./shared";
+import { queueStatusController } from "../controllers/v2/queue-status";
 
 expressWs(express());
 
@@ -165,4 +166,10 @@ v2Router.get(
   "/concurrency-check",
   authMiddleware(RateLimiterMode.CrawlStatus),
   wrap(concurrencyCheckController),
+);
+
+v2Router.get(
+  "/team/queue-status",
+  authMiddleware(RateLimiterMode.CrawlStatus),
+  wrap(queueStatusController),
 );

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -824,7 +824,9 @@ export const processJobInternal = async (job: Job & { id: string }) => {
                     const result = await processJob(job);
                     if (result.success) {
                         try {
-                            await redisEvictConnection.set("most-recent-success:" + job.data.team_id, new Date().toISOString(), "EX", 60 * 60 * 24);
+                            if (job.data.team_id) {
+                                await redisEvictConnection.set("most-recent-success:" + job.data.team_id, new Date().toISOString(), "EX", 60 * 60 * 24);
+                            }
                         } catch (e) {
                             logger.warn("Failed to set most recent success", { error: e });
                         }

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -824,6 +824,12 @@ export const processJobInternal = async (job: Job & { id: string }) => {
                     const result = await processJob(job);
                     if (result.success) {
                         try {
+                            await redisEvictConnection.set("most-recent-success:" + job.data.team_id, new Date().toISOString(), "EX", 60 * 60 * 24);
+                        } catch (e) {
+                            logger.warn("Failed to set most recent success", { error: e });
+                        }
+
+                        try {
                             if (
                                 process.env.USE_DB_AUTHENTICATION === "true" &&
                                 (job.data.crawl_id || process.env.GCS_BUCKET_NAME)

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/usage.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/usage.test.ts
@@ -32,5 +32,13 @@ describe("v2.usage e2e", () => {
     const resp = await client.getTokenUsage();
     expect(typeof resp.remainingTokens).toBe("number");
   }, 60_000);
+
+  test("get_queue_status", async () => {
+    const resp = await client.getQueueStatus();
+    expect(typeof resp.jobsInQueue).toBe("number");
+    expect(typeof resp.activeJobsInQueue).toBe("number");
+    expect(typeof resp.waitingJobsInQueue).toBe("number");
+    expect(typeof resp.maxConcurrency).toBe("number");
+  }, 60_000);
 });
 

--- a/apps/js-sdk/firecrawl/src/v1/index.ts
+++ b/apps/js-sdk/firecrawl/src/v1/index.ts
@@ -569,6 +569,22 @@ export interface GenerateLLMsTextStatusResponse {
 }
 
 /**
+ * Response interface for queue status operations.
+ */
+export interface QueueStatusResponse {
+  success: boolean;
+  jobsInQueue: number;
+  activeJobsInQueue: number;
+  waitingJobsInQueue: number;
+  maxConcurrency: number;
+
+  /**
+   * ISO timestamp of the most recent successful scrape in the past 24 hours. Will be null if no successful scrape has occurred in the past 24 hours.
+   */
+  mostRecentSuccess: string | null;
+}
+
+/**
  * Main class for interacting with the Firecrawl API.
  * Provides methods for scraping, searching, crawling, and mapping web content.
  */
@@ -2026,6 +2042,28 @@ export default class FirecrawlApp {
       }
     }
     return { success: false, error: "Internal server error." };
+  }
+
+  /**
+   * Gets metrics about the team's scrape queue.
+   * @returns The current queue status.
+   */
+  async getQueueStatus(): Promise<QueueStatusResponse> {
+    const headers = this.prepareHeaders();
+    try {
+      const response: AxiosResponse = await this.getRequest(
+      `${this.apiUrl}/v1/team/queue-status`,
+        headers
+      );
+
+      return response.data;
+    } catch (error: any) {
+      if (error.response?.data?.error) {
+        throw new FirecrawlError(`Request failed with status code ${error.response.status}. Error: ${error.response.data.error} ${error.response.data.details ? ` - ${JSON.stringify(error.response.data.details)}` : ''}`, error.response.status);
+      } else {
+        throw new FirecrawlError(error.message, 500);
+      }
+    }
   }
 }
 

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -19,7 +19,7 @@ import {
   batchScrape as batchWaiter,
 } from "./methods/batch";
 import { startExtract, getExtractStatus, extract as extractWaiter } from "./methods/extract";
-import { getConcurrency, getCreditUsage, getTokenUsage } from "./methods/usage";
+import { getConcurrency, getCreditUsage, getQueueStatus, getTokenUsage } from "./methods/usage";
 import type {
   Document,
   ScrapeOptions,
@@ -266,6 +266,11 @@ export class FirecrawlClient {
   /** Recent token usage. */
   async getTokenUsage() {
     return getTokenUsage(this.http);
+  }
+
+  /** Metrics about the team's scrape queue. */
+  async getQueueStatus() {
+    return getQueueStatus(this.http);
   }
 
   // Watcher

--- a/apps/js-sdk/firecrawl/src/v2/methods/usage.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/usage.ts
@@ -1,4 +1,4 @@
-import type { ConcurrencyCheck, CreditUsage, TokenUsage } from "../types";
+import type { ConcurrencyCheck, CreditUsage, QueueStatusResponse, TokenUsage } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
 
@@ -37,3 +37,13 @@ export async function getTokenUsage(http: HttpClient): Promise<TokenUsage> {
   }
 }
 
+export async function getQueueStatus(http: HttpClient): Promise<QueueStatusResponse> {
+  try {
+    const res = await http.get<{ success: boolean; data?: QueueStatusResponse }>("/v2/team/queue-status");
+    if (res.status !== 200 || !res.data?.success) throwForBadResponse(res, "get queue status");
+    return res.data.data || (res.data as any);
+  } catch (err: any) {
+    if (err?.isAxiosError) return normalizeAxiosError(err, "get queue status");
+    throw err;
+  }
+}

--- a/apps/js-sdk/firecrawl/src/v2/methods/usage.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/usage.ts
@@ -39,9 +39,9 @@ export async function getTokenUsage(http: HttpClient): Promise<TokenUsage> {
 
 export async function getQueueStatus(http: HttpClient): Promise<QueueStatusResponse> {
   try {
-    const res = await http.get<{ success: boolean; data?: QueueStatusResponse }>("/v2/team/queue-status");
+    const res = await http.get<QueueStatusResponse>("/v2/team/queue-status");
     if (res.status !== 200 || !res.data?.success) throwForBadResponse(res, "get queue status");
-    return res.data.data || (res.data as any);
+    return res.data;
   } catch (err: any) {
     if (err?.isAxiosError) return normalizeAxiosError(err, "get queue status");
     throw err;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -376,3 +376,11 @@ export class SdkError extends Error {
   }
 }
 
+export interface QueueStatusResponse {
+  success: boolean;
+  jobsInQueue: number;
+  activeJobsInQueue: number;
+  waitingJobsInQueue: number;
+  maxConcurrency: number;
+  mostRecentSuccess: string | null;
+}

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -707,6 +707,10 @@ class FirecrawlClient:
         """Get recent token usage metrics (v2)."""
         return usage_methods.get_token_usage(self.http_client)
 
+    def get_queue_status(self):
+        """Get metrics about the team's scrape queue."""
+        return usage_methods.get_queue_status(self.http_client)
+
     def watcher(
         self,
         job_id: str,

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -491,7 +491,7 @@ class QueueStatusResponse(BaseModel):
     active_jobs_in_queue: int
     waiting_jobs_in_queue: int
     max_concurrency: int
-    most_recent_success: Optional[str] = None
+    most_recent_success: Optional[datetime] = None
 
 # Action types
 class WaitAction(BaseModel):

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -485,6 +485,14 @@ class TokenUsage(BaseModel):
     """Recent token usage metrics (if available)."""
     remaining_tokens: int
 
+class QueueStatusResponse(BaseModel):
+    """Metrics about the team's scrape queue."""
+    jobs_in_queue: int
+    active_jobs_in_queue: int
+    waiting_jobs_in_queue: int
+    max_concurrency: int
+    most_recent_success: Optional[str] = None
+
 # Action types
 class WaitAction(BaseModel):
     """Wait action to perform during scraping."""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new team queue status endpoint in v1 and v2 that returns live queue metrics and the most recent successful job timestamp. Exposes this in the JS and Python SDKs. Implements ENG-3160 (endpoint for fetching information about queued requests).

- **New Features**
  - API: GET /v1/team/queue-status and /v2/team/queue-status returning jobsInQueue, activeJobsInQueue, waitingJobsInQueue, maxConcurrency, and mostRecentSuccess (last 24h).
  - Infra: Redis helpers to count and clean active/queued jobs; scrape worker records mostRecentSuccess on successful jobs.
  - SDKs: JS (v1/v2) and Python (v2) add getQueueStatus with typed responses; e2e tests included.
  - Backward-compat: v2 /concurrency-check remains; tests now use /team/queue-status.

<!-- End of auto-generated description by cubic. -->

