### PR TITLE
feat(client): allow local connections without API key and update API …

### DIFF
--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -78,7 +78,10 @@ class FirecrawlClient:
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
         
-        if not api_key:
+        # Allow local connections without API key
+        is_local = api_url and any(local_host in api_url.lower() for local_host in ['localhost', '127.0.0.1', '0.0.0.0'])
+        
+        if not api_key and not is_local:
             raise ValueError(
                 "API key is required. Set FIRECRAWL_API_KEY environment variable "
                 "or pass api_key parameter."

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -599,26 +599,6 @@ class SearchRequest(BaseModel):
         
         return normalized_categories
 
-    @field_validator('parsers')
-    @classmethod
-    def validate_parsers(cls, v):
-        """Validate and normalize parsers input."""
-        if v is None:
-            return v
-        
-        normalized_parsers = []
-        for parser in v:
-            if isinstance(parser, str):
-                normalized_parsers.append(parser)
-            elif isinstance(parser, dict):
-                normalized_parsers.append(PDFParser(**parser))
-            elif isinstance(parser, PDFParser):
-                normalized_parsers.append(parser)
-            else:
-                raise ValueError(f"Invalid parser format: {parser}")
-        
-        return normalized_parsers
-
 class LinkResult(BaseModel):
     """A generic link result with optional metadata (used by search and map)."""
     url: str
@@ -690,7 +670,7 @@ class ActiveCrawlsResponse(BaseModel):
 # Configuration types
 class ClientConfig(BaseModel):
     """Configuration for the Firecrawl client."""
-    api_key: str
+    api_key: Optional[str] = None
     api_url: str = "https://api.firecrawl.dev"
     timeout: Optional[float] = None
     max_retries: int = 3

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -13,7 +13,7 @@ version = get_version()
 class HttpClient:
     """HTTP client with retry logic and error handling."""
     
-    def __init__(self, api_key: str, api_url: str):
+    def __init__(self, api_key: Optional[str], api_url: str):
         self.api_key = api_key
         self.api_url = api_url
 
@@ -43,8 +43,11 @@ class HttpClient:
         """Prepare headers for API requests."""
         headers = {
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {self.api_key}',
         }
+        
+        # Only add Authorization header if api_key is provided
+        if self.api_key:
+            headers['Authorization'] = f'Bearer {self.api_key}'
         
         if idempotency_key:
             headers['x-idempotency-key'] = idempotency_key

--- a/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
@@ -6,15 +6,17 @@ version = get_version()
 
 
 class AsyncHttpClient:
-    def __init__(self, api_key: str, api_url: str):
+    def __init__(self, api_key: Optional[str], api_url: str):
         self.api_key = api_key
         self.api_url = api_url
+        
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+            
         self._client = httpx.AsyncClient(
             base_url=api_url,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
+            headers=headers,
             limits=httpx.Limits(max_keepalive_connections=0),
         )
 


### PR DESCRIPTION
…key handling

- Introduced a check to permit local connections (localhost, 127.0.0.1) without requiring an API key.
- Updated the FirecrawlClient and HTTP client constructors to accept an optional API key.
- Adjusted header preparation to include the Authorization header only if an API key is provided.