### PR TITLE
fix(js-sdk): zod-to-json-schema import

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
@@ -1,5 +1,5 @@
-import { type FormatOption, type JsonFormat, type ScrapeOptions, type ScreenshotFormat } from "../types";
-import zodToJsonSchema from "zod-to-json-schema";
+import { type FormatOption, type JsonFormat, type ScrapeOptions, type ScreenshotFormat, type ChangeTrackingFormat } from "../types";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export function ensureValidFormats(formats?: FormatOption[]): void {
   if (!formats) return;
@@ -23,6 +23,19 @@ export function ensureValidFormats(formats?: FormatOption[]): void {
           (j as any).schema = zodToJsonSchema(maybeSchema);
         } catch {
           // If conversion fails, leave as-is; server-side may still handle, or request will fail explicitly
+        }
+      }
+      continue;
+    }
+    if ((fmt as ChangeTrackingFormat).type === "changeTracking") {
+      const ct = fmt as ChangeTrackingFormat;
+      const maybeSchema: any = ct.schema as any;
+      const isZod = !!maybeSchema && (typeof maybeSchema.safeParse === "function" || typeof maybeSchema.parse === "function") && !!maybeSchema._def;
+      if (isZod) {
+        try {
+          (ct as any).schema = zodToJsonSchema(maybeSchema);
+        } catch {
+          // Best-effort conversion; if it fails, leave original value
         }
       }
       continue;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the zod-to-json-schema import in the Firecrawl JS SDK and adds Zod schema support for the changeTracking format by auto-converting to JSON Schema. This prevents runtime errors and lets users pass Zod schemas to changeTracking.

- **Bug Fixes**
  - Use named import { zodToJsonSchema }.
  - Convert Zod schemas in changeTracking to JSON Schema when possible; fall back gracefully.
  - Bump package version to 4.3.1.

<!-- End of auto-generated description by cubic. -->

