### PR TITLE
fix(api/native/pdf-parser): trim null chars out of pdf titles

### DIFF
--- a/apps/api/sharedLibs/pdf-parser/src/lib.rs
+++ b/apps/api/sharedLibs/pdf-parser/src/lib.rs
@@ -31,7 +31,8 @@ fn _get_pdf_metadata(path: &str) -> Result<PDFMetadata, String> {
                 .map(|s| String::from_utf8_lossy(s).to_string())
                 .ok()
             )
-        );
+        )
+        .map(|x| x.trim_matches(|x| char::is_whitespace(x) || x == '\0').to_string());
     
     Ok(PDFMetadata { num_pages, title })
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Trim null bytes and surrounding whitespace from extracted PDF titles to ensure clean metadata and prevent stray characters in consumers. Addresses ENG-3407.

<!-- End of auto-generated description by cubic. -->

