### PR TITLE
Add webhook events for extract endpoint (ENG-1293)

### DIFF
--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -24,6 +24,18 @@ export async function oldExtract(
 ) {
   // Means that are in the non-queue system
   // TODO: Remove this once all teams have transitioned to the new system
+
+  if (req.body.webhook) {
+    callWebhook({
+      teamId: req.auth.team_id,
+      crawlId: extractId,
+      data: {},
+      webhook: req.body.webhook,
+      v1: true,
+      eventType: "extract.started",
+    });
+  }
+
   try {
     let result;
     const model = req.body.agent?.model;

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -84,6 +84,38 @@ export const url = z.preprocess(
 const strictMessage =
   "Unrecognized key in body -- please review the v1 API documentation for request body changes";
 
+const BLACKLISTED_WEBHOOK_HEADERS = ["x-firecrawl-signature"];
+export const webhookSchema = z.preprocess(
+  x => {
+    if (typeof x === "string") {
+      return { url: x };
+    } else {
+      return x;
+    }
+  },
+  z
+    .object({
+      url: z.string().url(),
+      headers: z.record(z.string(), z.string()).default({}),
+      metadata: z.record(z.string(), z.string()).default({}),
+      events: z
+        .array(z.enum(["completed", "failed", "page", "started"]))
+        .default(["completed", "failed", "page", "started"]),
+    })
+    .strict(strictMessage)
+    .refine(
+      obj => {
+        const blacklistedLower = BLACKLISTED_WEBHOOK_HEADERS.map(h =>
+          h.toLowerCase(),
+        );
+        return !Object.keys(obj.headers).some(key =>
+          blacklistedLower.includes(key.toLowerCase()),
+        );
+      },
+      `The following headers are not allowed: ${BLACKLISTED_WEBHOOK_HEADERS.join(", ")}`,
+    ),
+);
+
 export const agentExtractModelValue = "fire-1";
 export const isAgentExtractModelValid = (x: string | undefined) =>
   x?.toLowerCase() === agentExtractModelValue;
@@ -613,6 +645,7 @@ export const extractV1Options = z
     agent: agentOptionsExtract.optional(),
     __experimental_showCostTracking: z.boolean().default(false),
     ignoreInvalidURLs: z.boolean().default(false),
+    webhook: webhookSchema.optional(),
   })
   .strict(strictMessage)
   .refine(obj => obj.urls || obj.prompt, {
@@ -678,38 +711,6 @@ export const scrapeRequestSchema = baseScrapeOptions
 
 export type ScrapeRequest = z.infer<typeof scrapeRequestSchema>;
 export type ScrapeRequestInput = z.input<typeof scrapeRequestSchema>;
-
-const BLACKLISTED_WEBHOOK_HEADERS = ["x-firecrawl-signature"];
-export const webhookSchema = z.preprocess(
-  x => {
-    if (typeof x === "string") {
-      return { url: x };
-    } else {
-      return x;
-    }
-  },
-  z
-    .object({
-      url: z.string().url(),
-      headers: z.record(z.string(), z.string()).default({}),
-      metadata: z.record(z.string(), z.string()).default({}),
-      events: z
-        .array(z.enum(["completed", "failed", "page", "started"]))
-        .default(["completed", "failed", "page", "started"]),
-    })
-    .strict(strictMessage)
-    .refine(
-      obj => {
-        const blacklistedLower = BLACKLISTED_WEBHOOK_HEADERS.map(h =>
-          h.toLowerCase(),
-        );
-        return !Object.keys(obj.headers).some(key =>
-          blacklistedLower.includes(key.toLowerCase()),
-        );
-      },
-      `The following headers are not allowed: ${BLACKLISTED_WEBHOOK_HEADERS.join(", ")}`,
-    ),
-);
 
 export const batchScrapeRequestSchema = baseScrapeOptions
   .extend({

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -90,6 +90,38 @@ export const url = z.preprocess(
 const strictMessage =
   "Unrecognized key in body -- please review the v2 API documentation for request body changes";
 
+const BLACKLISTED_WEBHOOK_HEADERS = ["x-firecrawl-signature"];
+export const webhookSchema = z.preprocess(
+  x => {
+    if (typeof x === "string") {
+      return { url: x };
+    } else {
+      return x;
+    }
+  },
+  z
+    .object({
+      url: z.string().url(),
+      headers: z.record(z.string(), z.string()).default({}),
+      metadata: z.record(z.string(), z.string()).default({}),
+      events: z
+        .array(z.enum(["completed", "failed", "page", "started"]))
+        .default(["completed", "failed", "page", "started"]),
+    })
+    .strict(strictMessage)
+    .refine(
+      obj => {
+        const blacklistedLower = BLACKLISTED_WEBHOOK_HEADERS.map(h =>
+          h.toLowerCase(),
+        );
+        return !Object.keys(obj.headers).some(key =>
+          blacklistedLower.includes(key.toLowerCase()),
+        );
+      },
+      `The following headers are not allowed: ${BLACKLISTED_WEBHOOK_HEADERS.join(", ")}`,
+    ),
+);
+
 const ACTIONS_MAX_WAIT_TIME = 60;
 const MAX_ACTIONS = 50;
 function calculateTotalWaitTime(
@@ -535,6 +567,7 @@ export const extractOptions = z
       .optional(),
     __experimental_showCostTracking: z.boolean().default(false),
     ignoreInvalidURLs: z.boolean().default(true),
+    webhook: webhookSchema.optional(),
   })
   .strict(strictMessage)
   .refine(obj => obj.urls || obj.prompt, {
@@ -576,38 +609,6 @@ export const scrapeRequestSchema = baseScrapeOptions
 
 export type ScrapeRequest = z.infer<typeof scrapeRequestSchema>;
 export type ScrapeRequestInput = z.input<typeof scrapeRequestSchema>;
-
-const BLACKLISTED_WEBHOOK_HEADERS = ["x-firecrawl-signature"];
-export const webhookSchema = z.preprocess(
-  x => {
-    if (typeof x === "string") {
-      return { url: x };
-    } else {
-      return x;
-    }
-  },
-  z
-    .object({
-      url: z.string().url(),
-      headers: z.record(z.string(), z.string()).default({}),
-      metadata: z.record(z.string(), z.string()).default({}),
-      events: z
-        .array(z.enum(["completed", "failed", "page", "started"]))
-        .default(["completed", "failed", "page", "started"]),
-    })
-    .strict(strictMessage)
-    .refine(
-      obj => {
-        const blacklistedLower = BLACKLISTED_WEBHOOK_HEADERS.map(h =>
-          h.toLowerCase(),
-        );
-        return !Object.keys(obj.headers).some(key =>
-          blacklistedLower.includes(key.toLowerCase()),
-        );
-      },
-      `The following headers are not allowed: ${BLACKLISTED_WEBHOOK_HEADERS.join(", ")}`,
-    ),
-);
 
 export const batchScrapeRequestSchema = baseScrapeOptions
   .extend({

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -120,6 +120,17 @@ const processExtractJobInternal = async (
   }, jobLockExtendInterval);
 
   try {
+    if (job.data.request.webhook) {
+      callWebhook({
+        teamId: job.data.teamId,
+        crawlId: job.data.extractId,
+        data: {},
+        webhook: job.data.request.webhook,
+        v1: true,
+        eventType: "extract.started",
+      });
+    }
+
     let result: ExtractResult | null = null;
 
     const model = job.data.request.agent?.model;

--- a/apps/api/src/services/webhook.ts
+++ b/apps/api/src/services/webhook.ts
@@ -231,6 +231,8 @@ export const callWebhook = async ({
           });
         }
       }
+    } else if (eventType === "extract.completed") {
+      dataToSend.push(data);
     }
 
     const payload = {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -209,4 +209,6 @@ export type WebhookEventType =
   | "batch_scrape.started"
   | "crawl.completed"
   | "batch_scrape.completed"
-  | "crawl.failed";
+  | "crawl.failed"
+  | "extract.completed"
+  | "extract.failed";

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -210,5 +210,6 @@ export type WebhookEventType =
   | "crawl.completed"
   | "batch_scrape.completed"
   | "crawl.failed"
+  | "extract.started"
   | "extract.completed"
   | "extract.failed";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds webhook support to the extract endpoint, firing extract.started, extract.completed, and extract.failed with relevant payloads. Aligns with ENG-1293 to enable async notifications for extraction jobs.

- **New Features**
  - Accepts optional webhook in v1/v2 extract requests (string or object), with header blacklist (x-firecrawl-signature), metadata, and event filters.
  - Triggers extract.started when an extract begins (v1 endpoint and queue worker).
  - Sends extract.completed with the result payload and extract.failed on errors.
  - Updates webhook service to handle extract.completed payloads and adds new event types to WebhookEventType.

<!-- End of auto-generated description by cubic. -->

