### PR TITLE
post-incident changes

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -190,6 +190,7 @@ export async function fireEngineScrape<
     body: request,
     logger: logger.child({ method: "fireEngineScrape/robustFetch" }),
     tryCount: 3,
+    ignoreFailureStatus: true, // sends 500 on processing and various codes on errors
     mock,
     abort,
   });

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -436,7 +436,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
 
     const waitUntilWaterfall =
       getEngineMaxReasonableTime(meta, engine) +
-      parseInt(process.env.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS ?? "0", 10);
+      parseInt(process.env.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS || "0", 10);
 
     if (
       !isFinite(waitUntilWaterfall) ||

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -434,7 +434,9 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
   while (remainingEngines.length > 0) {
     const { engine, unsupportedFeatures } = remainingEngines.shift()!;
 
-    const waitUntilWaterfall = getEngineMaxReasonableTime(meta, engine);
+    const waitUntilWaterfall =
+      getEngineMaxReasonableTime(meta, engine) +
+      parseInt(process.env.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS ?? "0", 10);
 
     if (
       !isFinite(waitUntilWaterfall) ||

--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -685,7 +685,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecrawl"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "axum",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes TLSClient processing timeouts by allowing Fire Engine fetches to tolerate transient error statuses, and adds SCRAPEURL_ENGINE_WATERFALL_DELAY_MS to tune engine waterfall timing. Addresses ENG-3432.

- **Bug Fixes**
  - Fire Engine robustFetch now sets ignoreFailureStatus: true so non-2xx (e.g., 500 while processing) doesn’t abort polling, preventing premature failures/timeouts.

- **New Features**
  - New env: SCRAPEURL_ENGINE_WATERFALL_DELAY_MS (ms). Added to getEngineMaxReasonableTime to adjust waterfall delay; default 0.

<!-- End of auto-generated description by cubic. -->

