### PR TITLE
Filter out invalidated index records (ENG-3396)

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -246,6 +246,7 @@ export async function scrapeURLWithIndex(
     .from("index")
     .select("id, created_at, status")
     .eq("url_hash", urlHash)
+    .is("invalidated_at", null)
     .gte("created_at", new Date(Date.now() - maxAge).toISOString())
     .eq("is_mobile", meta.options.mobile)
     .eq("block_ads", meta.options.blockAds);


### PR DESCRIPTION
can be merged once col + index added
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip invalidated index records when fetching cached scrape results by filtering on invalidated_at IS NULL. Prevents using stale entries and aligns with ENG-3396 index invalidation.

- **Migration**
  - Requires invalidated_at column (and an index on it) on the index table before deploy.

<!-- End of auto-generated description by cubic. -->

