### PR TITLE
Fire webhook events for scrape/batch scrape errors (ENG-3463)

### DIFF
--- a/apps/api/src/services/worker/crawl-logic.ts
+++ b/apps/api/src/services/worker/crawl-logic.ts
@@ -234,7 +234,7 @@ export async function finishCrawlIfNeeded(
         const sender = await createWebhookSender({
           teamId: job.data.team_id,
           jobId: job.data.crawl_id,
-          webhook: job.data.webhook as any,
+          webhook: job.data.webhook,
           v0: true,
         });
         if (sender) {
@@ -311,7 +311,7 @@ export async function finishCrawlIfNeeded(
         const sender = await createWebhookSender({
           teamId: job.data.team_id,
           jobId: job.data.crawl_id,
-          webhook: job.data.webhook as any,
+          webhook: job.data.webhook,
         });
         if (sender) {
           if (job.data.crawlerOptions !== null) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restore error webhooks for crawl and batch scrape failures so integrations get notified and can identify failing URLs. Addresses ENG-3463 by sending consistent failure events again.

- Bug Fixes
  - Emit CRAWL_PAGE/BATCH_SCRAPE_PAGE on errors with success: false and data: [{ metadata: { sourceURL } }].
  - Remove v1 gating; send error events for all crawl/batch scrape jobs (v0 payload for compatibility).
  - Clean up webhook sender usage: pass typed webhook (no any) and log only when a sender exists.

<!-- End of auto-generated description by cubic. -->

