### PR TITLE
feat: Optional api key for Self-Hosted Instances

### DIFF
--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -162,11 +162,11 @@ class Firecrawl:
     keeping a feature-frozen v1 available for incremental migration.
     """
     
-    def __init__(self, api_key: str = None, api_url: str = "https://api.firecrawl.dev"):
+    def __init__(self, api_key: Optional[str] = None, api_url: str = "https://api.firecrawl.dev"):
         """Initialize the unified client.
 
         Args:
-            api_key: Firecrawl API key (or set ``FIRECRAWL_API_KEY``)
+            api_key: (Optional[str]): API key for authenticating with the Firecrawl API.
             api_url: Base API URL (defaults to production)
         """
         self.api_key = api_key
@@ -213,7 +213,7 @@ class Firecrawl:
 class AsyncFirecrawl:
     """Async unified Firecrawl client (v2 by default, v1 under ``.v1``)."""
 
-    def __init__(self, api_key: str = None, api_url: str = "https://api.firecrawl.dev"):
+    def __init__(self, api_key: Optional[str] = None, api_url: str = "https://api.firecrawl.dev"):
         self.api_key = api_key
         self.api_url = api_url
         

--- a/apps/python-sdk/firecrawl/firecrawl.backup.py
+++ b/apps/python-sdk/firecrawl/firecrawl.backup.py
@@ -23,6 +23,7 @@ import websockets
 import aiohttp
 import asyncio
 from pydantic import Field
+from urllib.parse import urlparse
 
 
 def get_version():
@@ -448,7 +449,7 @@ class FirecrawlApp:
         self.api_url = api_url or os.getenv('FIRECRAWL_API_URL', 'https://api.firecrawl.dev')
         
         # Only require API key when using cloud service
-        if 'api.firecrawl.dev' in self.api_url and self.api_key is None:
+        if not self.api_key and urlparse(self.api_url).hostname == "api.firecrawl.dev":
             logger.warning("No API key provided for cloud service")
             raise ValueError('No API key provided')
             

--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -505,7 +505,7 @@ class V1FirecrawlApp:
         Initialize the V1FirecrawlApp instance with API key, API URL.
 
         Args:
-            api_key (Optional[str]): API key for authenticating with the Firecrawl API.
+            api_key (Optional[str]): API key (or set ``FIRECRAWL_API_KEY``)
             api_url (Optional[str]): Base URL for the Firecrawl API.
         """
         self.api_key = api_key or os.getenv('FIRECRAWL_API_KEY')

--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -2905,7 +2905,7 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
     Provides non-blocking alternatives to all V1FirecrawlApp operations.
     """
 
-    def __init__(self, api_key: str, api_url: str = "https://api.firecrawl.dev"):
+    def __init__(self, api_key: Optional[str] = None, api_url: str = "https://api.firecrawl.dev"):
         # Reuse V1 helpers (_prepare_headers, _validate_kwargs, _ensure_schema_dict, _get_error_message)
         super().__init__(api_key=api_key, api_url=api_url)
 

--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -23,6 +23,7 @@ import pydantic
 import websockets
 import aiohttp
 import asyncio
+from urllib.parse import urlparse
 
 logger : logging.Logger = logging.getLogger("firecrawl")
 
@@ -511,7 +512,7 @@ class V1FirecrawlApp:
         self.api_url = api_url or os.getenv('FIRECRAWL_API_URL', 'https://api.firecrawl.dev')
         
         # Only require API key when using cloud service
-        if 'api.firecrawl.dev' in self.api_url and self.api_key is None:
+        if not self.api_key and urlparse(self.api_url).hostname == "api.firecrawl.dev":
             logger.warning("No API key provided for cloud service")
             raise ValueError('No API key provided')
             

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -70,7 +70,7 @@ class FirecrawlClient:
         Initialize the Firecrawl client.
         
         Args:
-            api_key: Firecrawl API key (or set FIRECRAWL_API_KEY env var)
+            api_key: (Optional[str]): API key for authenticating with the Firecrawl API.
             api_url: Base URL for the Firecrawl API
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries for failed requests
@@ -78,8 +78,8 @@ class FirecrawlClient:
         """
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
-        
-        if not api_key:
+
+        if 'api.firecrawl.dev' in api_url and not api_key:
             raise ValueError(
                 "API key is required. Set FIRECRAWL_API_KEY environment variable "
                 "or pass api_key parameter."

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -5,6 +5,7 @@ This module provides the main client class that orchestrates all v2 functionalit
 """
 
 import os
+from urllib.parse import urlparse
 from typing import Optional, List, Dict, Any, Callable, Union, Literal
 from .types import (
     ClientConfig,
@@ -79,7 +80,7 @@ class FirecrawlClient:
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
 
-        if 'api.firecrawl.dev' in api_url and not api_key:
+        if not api_key and urlparse(api_url).hostname == "api.firecrawl.dev":
             raise ValueError(
                 "API key is required. Set FIRECRAWL_API_KEY environment variable "
                 "or pass api_key parameter."

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -71,7 +71,7 @@ class FirecrawlClient:
         Initialize the Firecrawl client.
         
         Args:
-            api_key: (Optional[str]): API key for authenticating with the Firecrawl API.
+            api_key: (Optional[str]): API key (or set ``FIRECRAWL_API_KEY``)
             api_url: Base URL for the Firecrawl API
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries for failed requests

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -50,8 +50,10 @@ class AsyncFirecrawlClient:
     def __init__(self, api_key: Optional[str] = None, api_url: str = "https://api.firecrawl.dev"):
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
-        if not api_key:
+        
+        if 'api.firecrawl.dev' in api_url and not api_key:
             raise ValueError("API key is required. Set FIRECRAWL_API_KEY or pass api_key.")
+        
         self.http_client = HttpClient(api_key, api_url)
         self.async_http_client = AsyncHttpClient(api_key, api_url)
 

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -4,6 +4,7 @@ Async v2 client mirroring the regular client surface using true async HTTP trans
 
 import os
 import asyncio
+from urllib.parse import urlparse
 from typing import Optional, List, Dict, Any, Union, Callable, Literal
 from .types import (
     ScrapeOptions,
@@ -51,7 +52,7 @@ class AsyncFirecrawlClient:
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
         
-        if 'api.firecrawl.dev' in api_url and not api_key:
+        if not api_key and urlparse(api_url).hostname == "api.firecrawl.dev":
             raise ValueError("API key is required. Set FIRECRAWL_API_KEY or pass api_key.")
         
         self.http_client = HttpClient(api_key, api_url)

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -762,7 +762,7 @@ class ActiveCrawlsRequest(BaseModel):
 # Configuration types
 class ClientConfig(BaseModel):
     """Configuration for the Firecrawl client."""
-    api_key: str
+    api_key: Optional[str] = None
     api_url: str = "https://api.firecrawl.dev"
     timeout: Optional[float] = None
     max_retries: int = 3

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -13,7 +13,7 @@ version = get_version()
 class HttpClient:
     """HTTP client with retry logic and error handling."""
     
-    def __init__(self, api_key: str, api_url: str):
+    def __init__(self, api_key: Optional[str], api_url: str):
         self.api_key = api_key
         self.api_url = api_url
 
@@ -43,8 +43,10 @@ class HttpClient:
         """Prepare headers for API requests."""
         headers = {
             'Content-Type': 'application/json',
-            'Authorization': f'Bearer {self.api_key}',
         }
+        
+        if self.api_key:
+            headers['Authorization'] = f'Bearer {self.api_key}'
         
         if idempotency_key:
             headers['x-idempotency-key'] = idempotency_key

--- a/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
@@ -6,15 +6,17 @@ version = get_version()
 
 
 class AsyncHttpClient:
-    def __init__(self, api_key: str, api_url: str):
+    def __init__(self, api_key: Optional[str], api_url: str):
         self.api_key = api_key
         self.api_url = api_url
+        
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+            
         self._client = httpx.AsyncClient(
             base_url=api_url,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
+            headers=headers,
             limits=httpx.Limits(max_keepalive_connections=0),
         )
 


### PR DESCRIPTION
This change makes the API key parameter optional when using a custom `api_url`, allowing users to use Firecrawl with self-hosted instances that don't require authentication.

fixes: #2075 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the API key optional for self-hosted Firecrawl instances by only requiring it for api.firecrawl.dev. This lets self-hosted deployments without auth use the Python SDK.

- **New Features**
  - api_key is now Optional in v1/v2 sync and async clients and config; missing key only errors when api_url includes "api.firecrawl.dev".
  - Authorization header is added only when an api_key is provided (sync and async HTTP clients).
  - Still reads FIRECRAWL_API_KEY by default; behavior for the hosted API is unchanged.

<!-- End of auto-generated description by cubic. -->

