### PR TITLE
Fix graceful credit handling in account object (ENG-3495)

### DIFF
--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -138,7 +138,11 @@ export function authMiddleware(
       req.auth = { team_id };
       req.acuc = chunk ?? undefined;
       if (chunk) {
-        req.account = { remainingCredits: chunk.remaining_credits };
+        req.account = {
+          remainingCredits: chunk.price_should_be_graceful
+            ? chunk.remaining_credits + chunk.price_credits
+            : chunk.remaining_credits,
+        };
       }
       next();
     })().catch(err => next(err));


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes remainingCredits computation in auth middleware to include grace credits when price_should_be_graceful is true. Prevents crawls from stopping early under grace mode (ENG-3495).

- **Bug Fixes**
  - Set req.account.remainingCredits to remaining_credits + price_credits when in graceful pricing; otherwise use remaining_credits.

<!-- End of auto-generated description by cubic. -->

