### PR TITLE
Add gzipped sitemap support (ENG-3520)

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -14,7 +14,6 @@ import {
   isUrlAllowedByRobots,
 } from "../../lib/robots-txt";
 import { ScrapeJobTimeoutError } from "../../lib/error";
-import { Logger } from "winston";
 import { ScrapeOptions } from "../../controllers/v2/types";
 import { filterLinks } from "@mendable/firecrawl-rs";
 
@@ -833,15 +832,17 @@ export class WebCrawler {
     mock?: string,
     maxAge?: number,
   ): Promise<number> {
-    const sitemapUrl = url.endsWith(".xml")
-      ? url
-      : `${url}${url.endsWith("/") ? "" : "/"}sitemap.xml`;
+    const sitemapUrl =
+      url.endsWith(".xml") || url.endsWith(".xml.gz")
+        ? url
+        : `${url}${url.endsWith("/") ? "" : "/"}sitemap.xml`;
 
     this.logger.debug("Trying to fetch sitemap links", {
       method: "tryFetchSitemapLinks",
       originalUrl: url,
       sitemapUrl,
       isXmlUrl: url.endsWith(".xml"),
+      isGzUrl: url.endsWith(".xml.gz"),
     });
 
     let sitemapCount: number = 0;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds support for gzipped sitemaps (.xml.gz) so we can crawl compressed sitemap indexes and URL lists. This fulfills ENG-3520 by expanding sitemap discovery and parsing coverage.

- **New Features**
  - Detects .xml.gz in crawler sitemap URL resolution and logs.
  - Downloads and decompresses .xml.gz with fetchFileToBuffer + zlib.gunzip, then parses XML.
  - Treats .xml.gz as valid sitemap entries in indexes; filters non-sitemap URLs accordingly.

- **Bug Fixes**
  - Fixes reduce usage when aggregating child sitemap counts by adding an initial value.

<!-- End of auto-generated description by cubic. -->

