### PR TITLE
fix(docker): add Python dependencies for `node-gyp` compilation

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     pkg-config \
+    python3 \
+    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust


### PR DESCRIPTION
The Docker build was failing because node-gyp couldn't find Python, which is required to compile native Node.js modules (bufferutil, utf-8-validate, libpq).

Error was: "gyp ERR! find Python You need to install the latest version of Python"