### PR TITLE
Fix infinite loop when scraping a forbidden webpage (ENG-3339)

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -12,6 +12,7 @@ import {
   PDFInsufficientTimeError,
   PDFPrefetchFailed,
   RemoveFeatureError,
+  EngineUnsuccessfulError,
 } from "../../error";
 import { readFile, unlink } from "node:fs/promises";
 import path from "node:path";
@@ -200,7 +201,12 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       if (ct && !ct.includes("application/pdf")) {
         // if downloaded file wasn't a PDF
         if (meta.pdfPrefetch === undefined) {
-          throw new PDFAntibotError();
+          // for non-PDF URLs, this is expected, not anti-bot
+          if (!meta.featureFlags.has("pdf")) {
+            throw new EngineUnsuccessfulError("pdf");
+          } else {
+            throw new PDFAntibotError();
+          }
         } else {
           throw new PDFPrefetchFailed();
         }
@@ -233,7 +239,12 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     if (ct && !ct.includes("application/pdf")) {
       // if downloaded file wasn't a PDF
       if (meta.pdfPrefetch === undefined) {
-        throw new PDFAntibotError();
+        // for non-PDF URLs, this is expected, not anti-bot
+        if (!meta.featureFlags.has("pdf")) {
+          throw new EngineUnsuccessfulError("pdf");
+        } else {
+          throw new PDFAntibotError();
+        }
       } else {
         throw new PDFPrefetchFailed();
       }


### PR DESCRIPTION
Resolves #2056 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents an infinite loop when the PDF scraper hits a forbidden or non‑PDF page by treating it as an unsuccessful PDF engine run instead of anti‑bot. Aligns with ENG-3339 and lets the orchestrator fall back or stop retrying.

- **Bug Fixes**
  - When Content-Type isn’t application/pdf and the pdf feature flag is off, throw EngineUnsuccessfulError("pdf") instead of PDFAntibotError.
  - Anti-bot and prefetch error handling remain unchanged for real PDF flows.

<!-- End of auto-generated description by cubic. -->

