### PR TITLE
[UPDATE]: Prioritize SearXNG for self-host

### DIFF
--- a/apps/api/src/search/v2/googlesearch.ts
+++ b/apps/api/src/search/v2/googlesearch.ts
@@ -8,19 +8,11 @@ const getRandomInt = (min: number, max: number): number =>
   Math.floor(Math.random() * (max - min + 1)) + min;
 
 function get_useragent(): string {
+  const lynx_version = `Lynx/${getRandomInt(2, 3)}.${getRandomInt(8, 9)}.${getRandomInt(0, 2)}`;
   const libwww_version = `libwww-FM/${getRandomInt(2, 3)}.${getRandomInt(13, 15)}`;
   const ssl_mm_version = `SSL-MM/${getRandomInt(1, 2)}.${getRandomInt(3, 5)}`;
   const openssl_version = `OpenSSL/${getRandomInt(1, 3)}.${getRandomInt(0, 4)}.${getRandomInt(0, 9)}`;
-
-  const modernAgents = [
-    `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${getRandomInt(138, 142)}.0.0.0 Safari/537.36 ${ssl_mm_version}`,
-    `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${getRandomInt(138, 142)}.0.0.0 Safari/537.36 ${openssl_version}`,
-    `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:${getRandomInt(110, 120)}.0) Gecko/20100101 Firefox/${getRandomInt(110, 120)}.0 ${libwww_version}`,
-    `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${getRandomInt(16, 17)}.${getRandomInt(0, 6)} Safari/605.1.15 ${ssl_mm_version}`,
-    `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${getRandomInt(138, 142)}.0.0.0 Safari/537.36 Edg/${getRandomInt(138, 142)}.0.0.0 ${openssl_version}`,
-  ];
-
-  return modernAgents[Math.floor(Math.random() * modernAgents.length)];
+  return `${lynx_version} ${libwww_version} ${ssl_mm_version} ${openssl_version}`;
 }
 
 async function _req(
@@ -53,13 +45,7 @@ async function _req(
     const resp = await axios.get("https://www.google.com/search", {
       headers: {
         "User-Agent": agent,
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Accept-Encoding": "gzip, deflate",
-        DNT: "1",
-        Connection: "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
+        Accept: "*/*",
       },
       params: params,
       proxy: proxies,

--- a/apps/api/src/search/v2/googlesearch.ts
+++ b/apps/api/src/search/v2/googlesearch.ts
@@ -8,11 +8,19 @@ const getRandomInt = (min: number, max: number): number =>
   Math.floor(Math.random() * (max - min + 1)) + min;
 
 function get_useragent(): string {
-  const lynx_version = `Lynx/${getRandomInt(2, 3)}.${getRandomInt(8, 9)}.${getRandomInt(0, 2)}`;
   const libwww_version = `libwww-FM/${getRandomInt(2, 3)}.${getRandomInt(13, 15)}`;
   const ssl_mm_version = `SSL-MM/${getRandomInt(1, 2)}.${getRandomInt(3, 5)}`;
   const openssl_version = `OpenSSL/${getRandomInt(1, 3)}.${getRandomInt(0, 4)}.${getRandomInt(0, 9)}`;
-  return `${lynx_version} ${libwww_version} ${ssl_mm_version} ${openssl_version}`;
+
+  const modernAgents = [
+    `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${getRandomInt(138, 142)}.0.0.0 Safari/537.36 ${ssl_mm_version}`,
+    `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${getRandomInt(138, 142)}.0.0.0 Safari/537.36 ${openssl_version}`,
+    `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:${getRandomInt(110, 120)}.0) Gecko/20100101 Firefox/${getRandomInt(110, 120)}.0 ${libwww_version}`,
+    `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${getRandomInt(16, 17)}.${getRandomInt(0, 6)} Safari/605.1.15 ${ssl_mm_version}`,
+    `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${getRandomInt(138, 142)}.0.0.0 Safari/537.36 Edg/${getRandomInt(138, 142)}.0.0.0 ${openssl_version}`,
+  ];
+
+  return modernAgents[Math.floor(Math.random() * modernAgents.length)];
 }
 
 async function _req(
@@ -45,7 +53,13 @@ async function _req(
     const resp = await axios.get("https://www.google.com/search", {
       headers: {
         "User-Agent": agent,
-        Accept: "*/*",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip, deflate",
+        DNT: "1",
+        Connection: "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
       },
       params: params,
       proxy: proxies,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,9 +41,9 @@ x-common-env: &common-env
   PROXY_SERVER: ${PROXY_SERVER}
   PROXY_USERNAME: ${PROXY_USERNAME}
   PROXY_PASSWORD: ${PROXY_PASSWORD}
-  SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT}
-  SEARXNG_ENGINES: ${SEARXNG_ENGINES}
-  SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES}
+  SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT:-http://searxng:8080}
+  SEARXNG_ENGINES: ${SEARXNG_ENGINES:-google,bing,duckduckgo}
+  SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES:-general}
 
 services:
   playwright-service:
@@ -71,6 +71,7 @@ services:
     depends_on:
       - redis
       - playwright-service
+      - searxng
     ports:
       - "${PORT:-3002}:${INTERNAL_PORT:-3002}"
     command: node dist/src/harness.js --start-docker
@@ -96,6 +97,29 @@ services:
       - backend
     ports:
       - "5432:5432"
+
+  searxng:
+    image: searxng/searxng:latest
+    container_name: searxng
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    environment:
+      - SEARXNG_BASE_URL=http://localhost:8080/
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+    networks:
+      - backend
 
 networks:
   backend:

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -1,0 +1,56 @@
+# SearXNG configuration for Firecrawl
+use_default_settings: true
+
+server:
+  port: 8080
+  bind_address: "0.0.0.0"
+  secret_key: "change_this_secret_key_in_production"
+  base_url: false
+  image_proxy: false
+
+ui:
+  static_use_hash: false
+
+search:
+  safe_search: 0
+  autocomplete: ""
+  default_lang: "en"
+  formats:
+    - html
+    - json
+
+engines:
+  - name: google
+    engine: google
+    shortcut: g
+    use_mobile_ui: false
+
+  - name: bing
+    engine: bing
+    shortcut: bi
+
+  - name: duckduckgo
+    engine: duckduckgo
+    shortcut: ddg
+
+  - name: startpage
+    engine: startpage
+    shortcut: sp
+
+  - name: yahoo
+    engine: yahoo
+    shortcut: yh
+
+enabled_plugins:
+  - 'Hash plugin'
+  - 'Search on category select'
+  - 'Self Information'
+  - 'Tracker URL remover'
+
+disabled_engines:
+  - 'bing images'
+  - 'bing news'
+  - 'bing videos'
+  - 'google images'
+  - 'google news'
+  - 'google videos'

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -2,18 +2,10 @@
 use_default_settings: true
 
 server:
-  port: 8080
-  bind_address: "0.0.0.0"
   secret_key: "change_this_secret_key_in_production"
-  base_url: false
-  image_proxy: false
-
-ui:
-  static_use_hash: false
 
 search:
   safe_search: 0
-  autocomplete: ""
   default_lang: "en"
   formats:
     - html
@@ -23,7 +15,6 @@ engines:
   - name: google
     engine: google
     shortcut: g
-    use_mobile_ui: false
 
   - name: bing
     engine: bing
@@ -32,25 +23,3 @@ engines:
   - name: duckduckgo
     engine: duckduckgo
     shortcut: ddg
-
-  - name: startpage
-    engine: startpage
-    shortcut: sp
-
-  - name: yahoo
-    engine: yahoo
-    shortcut: yh
-
-enabled_plugins:
-  - 'Hash plugin'
-  - 'Search on category select'
-  - 'Self Information'
-  - 'Tracker URL remover'
-
-disabled_engines:
-  - 'bing images'
-  - 'bing news'
-  - 'bing videos'
-  - 'google images'
-  - 'google news'
-  - 'google videos'


### PR DESCRIPTION
Fixes: #2139 
use existing SearXNG service in docker-compose with multi-engine support

tested OK:
v2 - 
<img width="1085" height="632" alt="image" src="https://github.com/user-attachments/assets/60190129-4bb0-4ca1-bd36-e8586bb27222" />
v1 - 
<img width="950" height="578" alt="image" src="https://github.com/user-attachments/assets/123ca8dd-12b1-4c09-a25b-c20781120cbe" />
