### PR TITLE
Add unwrapTags feature (ENG-3563)

### DIFF
--- a/apps/api/native/src/html.rs
+++ b/apps/api/native/src/html.rs
@@ -339,6 +339,8 @@ pub struct TransformHtmlOptions {
   pub include_tags: Vec<String>,
   #[serde(default)]
   pub exclude_tags: Vec<String>,
+  #[serde(default)]
+  pub unwrap_tags: Vec<String>,
   pub only_main_content: bool,
   pub omce_signatures: Option<Vec<String>>,
 }
@@ -389,6 +391,32 @@ fn _transform_html_inner(opts: TransformHtmlOptions) -> Result<String, Box<dyn s
   }
   while let Ok(x) = document.select_first("script") {
     x.as_node().detach();
+  }
+
+  for selector in opts.unwrap_tags.iter() {
+    let nodes: Vec<_> = document
+      .select(selector)
+      .map_err(|_| "Failed to select unwrap tags")?
+      .collect();
+
+    for node in nodes {
+      let Some(parent) = node.as_node().parent() else {
+        continue;
+      };
+
+      let next_sibling = node.as_node().next_sibling();
+      let children: Vec<_> = node.as_node().children().collect();
+
+      for child in children {
+        if let Some(ref sibling) = next_sibling {
+          sibling.insert_before(child);
+        } else {
+          parent.append(child);
+        }
+      }
+
+      node.as_node().detach();
+    }
   }
 
   // OMCE first

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -334,6 +334,11 @@ const baseScrapeOptions = z
       .array()
       .transform(tags => tags.map(transformIframeSelector))
       .optional(),
+    unwrapTags: z
+      .string()
+      .array()
+      .transform(tags => tags.map(transformIframeSelector))
+      .optional(),
     onlyMainContent: z.boolean().default(true),
     timeout: z.number().int().positive().finite().safe().optional(),
     waitFor: z

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -357,6 +357,11 @@ const baseScrapeOptions = z
       .array()
       .transform(tags => tags.map(transformIframeSelector))
       .optional(),
+    unwrapTags: z
+      .string()
+      .array()
+      .transform(tags => tags.map(transformIframeSelector))
+      .optional(),
     onlyMainContent: z.boolean().default(true),
     timeout: z.number().int().positive().finite().safe().optional(),
     waitFor: z

--- a/apps/api/src/lib/__tests__/html-transformer.test.ts
+++ b/apps/api/src/lib/__tests__/html-transformer.test.ts
@@ -266,46 +266,62 @@ describe("HTML Transformer", () => {
   describe("transformHtml", () => {
     it("should transform HTML content according to options", async () => {
       const options: TransformHtmlOptions = {
-        html: "<div><p>Test</p><span>Remove me</span></div>",
+        html: '<div><p>Test</p><span>Remove me</span><code><a href="https://unwrapped.com/">Unwrap me</a></code></div>',
         url: "https://example.com",
-        includeTags: ["p"],
+        includeTags: ["p", "a"],
         excludeTags: ["span"],
+        unwrapTags: ["code"],
         onlyMainContent: true,
       };
 
       const result = await transformHtml(options);
       expect(result).toContain("<p>");
       expect(result).not.toContain("<span>");
+      expect(result).not.toContain("<code>");
+      expect(result).toContain(
+        '<a href="https://unwrapped.com/">Unwrap me</a>',
+      );
     });
 
     it("should handle complex content filtering", async () => {
       const options: TransformHtmlOptions = {
         html: `
-          <div class="wrapper">
-            <header>
-              <nav>Navigation</nav>
-            </header>
-            <main>
-              <article>
-                <h1>Title</h1>
-                <p>Important content</p>
-                <div class="ads">Advertisement</div>
-                <aside>Sidebar</aside>
-                <div class="social-share">Share buttons</div>
-              </article>
-            </main>
-            <footer>Footer content</footer>
-          </div>
-        `,
+        <div class="wrapper">
+        <header>
+          <nav>Navigation</nav>
+        </header>
+        <main>
+          <article>
+          <h1>Title</h1>
+          <p>Important <strong>bold</strong> content</p>
+          <div class="ads">Advertisement</div>
+          <aside>Sidebar</aside>
+          <div class="social-share">Share buttons</div>
+          <code><a href="https://example.com/link">Wrapped Link</a></code>
+          <em><span>Nested unwrap</span></em>
+          </article>
+        </main>
+        <footer>Footer content</footer>
+        </div>
+      `,
         url: "https://example.com",
-        includeTags: ["article", "h1", "p"],
+        includeTags: ["article", "h1", "p", "a", "strong", "span"],
         excludeTags: ["nav", "aside", "footer", ".ads", ".social-share"],
+        unwrapTags: ["code", "em"],
         onlyMainContent: true,
       };
 
       const result = await transformHtml(options);
       expect(result).toContain("<h1>Title</h1>");
-      expect(result).toContain("<p>Important content</p>");
+      expect(result).toContain(
+        "<p>Important <strong>bold</strong> content</p>",
+      );
+      expect(result).toContain(
+        '<a href="https://example.com/link">Wrapped Link</a>',
+      );
+      expect(result).toContain("Nested unwrap");
+      expect(result).not.toContain("<code>");
+      expect(result).not.toContain("<em>");
       expect(result).not.toContain("Navigation");
       expect(result).not.toContain("Advertisement");
       expect(result).not.toContain("Share buttons");
@@ -329,6 +345,7 @@ describe("HTML Transformer", () => {
         url: "https://example.com",
         includeTags: ["article", "p", "ul", "li"],
         excludeTags: [],
+        unwrapTags: [],
         onlyMainContent: true,
       };
 
@@ -344,6 +361,7 @@ describe("HTML Transformer", () => {
         url: "https://example.com",
         includeTags: [],
         excludeTags: [],
+        unwrapTags: [],
         onlyMainContent: false,
       };
 
@@ -357,6 +375,7 @@ describe("HTML Transformer", () => {
         url: "https://example.com",
         includeTags: [],
         excludeTags: [],
+        unwrapTags: [],
         onlyMainContent: false,
       };
 
@@ -378,6 +397,7 @@ describe("HTML Transformer", () => {
         url: "https://example.com",
         includeTags: ["p"],
         excludeTags: ["script", "style", "noscript"],
+        unwrapTags: [],
         onlyMainContent: true,
       };
 
@@ -401,6 +421,7 @@ describe("HTML Transformer", () => {
         url: "https://example.com",
         includeTags: ["p"],
         excludeTags: [],
+        unwrapTags: [],
         onlyMainContent: true,
       };
 
@@ -427,11 +448,11 @@ describe("HTML Transformer", () => {
         url: "https://example.com",
         includeTags: [],
         excludeTags: [],
+        unwrapTags: [],
         onlyMainContent: true,
       };
 
       const result = await transformHtml(options);
-      console.log(result);
       expect(result).toContain("https://example.com/fullurl");
       expect(result).toContain("http://example.net/fullurl");
       expect(result).toContain("https://example.com/pathurl");

--- a/apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts
@@ -97,6 +97,9 @@ export const htmlTransform = async (
       excludeTags: (scrapeOptions.excludeTags ?? [])
         .map(x => x.trim())
         .filter(x => x.length !== 0),
+      unwrapTags: (scrapeOptions.unwrapTags ?? [])
+        .map(x => x.trim())
+        .filter(x => x.length !== 0),
       onlyMainContent: scrapeOptions.onlyMainContent,
       omceSignatures: omce_signatures,
     });
@@ -127,6 +130,29 @@ export const htmlTransform = async (
   }
 
   soup("script, style, noscript, meta, head").remove();
+
+  if (
+    scrapeOptions.unwrapTags &&
+    scrapeOptions.unwrapTags.filter(x => x.trim().length !== 0).length > 0
+  ) {
+    scrapeOptions.unwrapTags.forEach(tag => {
+      const selector = tag.trim();
+      if (selector.length === 0) {
+        return;
+      }
+
+      soup(selector)
+        .toArray()
+        .forEach(element => {
+          const $element = soup(element);
+          const children = $element.contents().toArray();
+          children.forEach(child => {
+            $element.before(child);
+          });
+          $element.remove();
+        });
+    });
+  }
 
   if (
     scrapeOptions.excludeTags &&


### PR DESCRIPTION
sometimes a page may include something similar to:

```html
<div>
  <code>
    <a href="https://example.com">test</a>
  </code>
</div>
```

the a tag will not get parsed since it's inside of a code block, so it wouldn't be semantically valid.

unwrapping with the `code` tag would make the above html snippet resolve to:

```html
<div>
  <a href="https://example.com">test</a>
</div>
```

and result in the `a` tag being included in the markdown
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an unwrapTags option to the HTML transformer and scraper to remove specified wrapper elements and keep their children. Fixes ENG-3563 by ensuring links wrapped in tags like code are preserved in scraped output.

- **New Features**
  - Added unwrapTags to TransformHtmlOptions (native/html.rs) to unwrap matched elements and keep their children.
  - Exposed unwrapTags in v1 and v2 API schemas; accepts CSS selectors (trimmed and filtered).
  - Applied unwrapping in scraper htmlTransform before exclusion to rescue links and other content inside wrapper tags.
  - Updated tests to cover unwrapping behavior and interaction with includeTags/excludeTags.

<!-- End of auto-generated description by cubic. -->

