### PR TITLE
fix: prevent port conflicts between API server and worker service

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,7 @@
 # ===== Required ENVS ======
 NUM_WORKERS_PER_QUEUE=8
 PORT=3002
+WORKER_PORT=3005
 HOST=0.0.0.0
 REDIS_URL=redis://redis:6379 #for self-hosting using docker, use redis://redis:6379. For running locally, use redis://localhost:6379
 REDIS_RATE_LIMIT_URL=redis://redis:6379 #for self-hosting using docker, use redis://redis:6379. For running locally, use redis://localhost:6379

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -490,7 +490,7 @@ app.get("/liveness", (req, res) => {
   }
 });
 
-const workerPort = process.env.WORKER_PORT || process.env.PORT || 3005;
+const workerPort = process.env.WORKER_PORT || 3005;
 app.listen(workerPort, () => {
   _logger.info(`Liveness endpoint is running on port ${workerPort}`);
 });


### PR DESCRIPTION
### Problem

The worker service was falling back to process.env.PORT when WORKER_PORT was not explicitly set, causing port conflicts with the API server. This occurred because both services were trying to bind to the same port (3003).

### Root Cause

In src/services/queue-worker.ts, the worker port configuration had a fallback chain that included process.env.PORT:

```
// Before (problematic)
const workerPort = process.env.WORKER_PORT || process.env.PORT || 3005;
```

This meant if WORKER_PORT wasn't set, the worker would use the same port as the API server, causing "EADDRINUSE: address already in use" errors.

### Solution

1. Code Change: Removed the fallback to process.env.PORT in the worker configuration:

```
// After (fixed)
const workerPort = process.env.WORKER_PORT || 3005;
```

2. Documentation: Updated .env.example to explicitly show both PORT and WORKER_PORT with different default values.

### Impact

• Eliminates port conflicts between API server and worker service
• Makes port configuration more explicit and predictable
• Prevents "EADDRINUSE" errors during startup
• Maintains backward compatibility for existing configurations that explicitly set WORKER_PORT

### Testing

Verified that with this change:

• API server uses PORT=3002 (or configured value)
• Worker service uses WORKER_PORT=3005 (or configured value)
• No port conflicts occur during startup