### PR TITLE
Add Rust to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,11 @@ If you're contributing, note that the process is similar to other open source re
 First, start by installing dependencies:
 
 1. node.js [instructions](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs)
-2. pnpm [instructions](https://pnpm.io/installation)
-3. redis [instructions](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
-4. postgresql
-5. Docker (optional) (for running postgres)
+2. rust [instructions](https://www.rust-lang.org/tools/install)
+3. pnpm [instructions](https://pnpm.io/installation)
+4. redis [instructions](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
+5. postgresql
+6. Docker (optional) (for running postgres)
 
 You need to set up the PostgreSQL database by running the SQL file at `apps/nuq-postgres/nuq.sql`. Easiest way is to use the docker image inside `apps/nuq-postgres`. With Docker running, build the image:
 


### PR DESCRIPTION
Rust is required to run `pnpm build`.

```sh
native install$ pnpm build
│ > @mendable/firecrawl-rs@1.0.0 build /Users/**/Programming/firecrawl/apps/api/native
│ > napi build --platform --release
│ node:events:502
│       throw er; // Unhandled 'error' event
│       ^
│ Error: spawn cargo ENOENT
│     at ChildProcess._handle.onexit (node:internal/child_process:285:19)
│     at onErrorNT (node:internal/child_process:483:16)
│     at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
│ Emitted 'error' event on ChildProcess instance at:
│     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
│     at onErrorNT (node:internal/child_process:483:16)
│     at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
│   errno: -2,
│   code: 'ENOENT',
│   syscall: 'spawn cargo',
│   path: 'cargo',
│   spawnargs: [
│     'metadata',
│     '--manifest-path',
│     '/Users/**/Programming/firecrawl/apps/api/native/Cargo.toml',
│     '--format-version',
│     '1'
│   ]
│ }
│ Node.js v22.13.0
│  ELIFECYCLE  Command failed with exit code 1.
`