### PR TITLE
Upgrade html-to-markdown dependency (ENG-3563)

### DIFF
--- a/apps/api/sharedLibs/go-html-to-md/go.mod
+++ b/apps/api/sharedLibs/go-html-to-md/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 toolchain go1.24.0
 
-require github.com/firecrawl/html-to-markdown v0.0.0-20250917145228-b6d0a75dfdba
+require github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3 // indirect

--- a/apps/api/sharedLibs/go-html-to-md/go.sum
+++ b/apps/api/sharedLibs/go-html-to-md/go.sum
@@ -3,8 +3,8 @@ github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/firecrawl/html-to-markdown v0.0.0-20250917145228-b6d0a75dfdba h1:VwJTbo/5DQl7qNJ2//bBxrcArLuh3Ook/MMvuHUAlrY=
-github.com/firecrawl/html-to-markdown v0.0.0-20250917145228-b6d0a75dfdba/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
+github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3 h1:lzHIpN3DszdL8V2JRK03WleWIeW2ssVmiMAbg67ES/A=
+github.com/firecrawl/html-to-markdown v0.0.0-20250922154302-32a7ad4a22c3/go.mod h1:jngam+MdNp7FZkhSTlFsuA5hXY21X0+vuiGlpgo2n5o=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgrade html-to-markdown in the API’s go-html-to-md shared lib to fix missing links in converted markdown and improve scraping accuracy. Aligns with ENG-3563 to ensure links are consistently included.

- **Dependencies**
  - Bump github.com/firecrawl/html-to-markdown to v0.0.0-20250922154302-32a7ad4a22c3 (go.mod, go.sum).

<!-- End of auto-generated description by cubic. -->

