### PR TITLE
Add environment variable to disable blocklist

### DIFF
--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -13,7 +13,10 @@ type BlocklistBlob = {
 let blob: BlocklistBlob | null = null;
 
 export async function initializeBlocklist() {
-  if (process.env.USE_DB_AUTHENTICATION !== "true") {
+  if (
+    process.env.USE_DB_AUTHENTICATION !== "true" ||
+    process.env.DISABLE_BLOCKLIST === "true"
+  ) {
     blob = {
       blocklist: [],
       allowedKeywords: [],


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a DISABLE_BLOCKLIST environment variable to let the WebScraper skip the blocklist when set to "true". Default behavior stays the same; the blocklist runs unless this flag is "true" or USE_DB_AUTHENTICATION is not "true".

<!-- End of auto-generated description by cubic. -->

