### PR TITLE
Reduce playwright-service image size by 1 GB by installing only Chromium

### DIFF
--- a/apps/playwright-service-ts/Dockerfile
+++ b/apps/playwright-service-ts/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 ENV PLAYWRIGHT_BROWSERS_PATH=/tmp/.cache
 
 # Install Playwright dependencies
-RUN npx playwright install --with-deps
+RUN npx playwright install chromium --with-deps
 
 RUN npm run build
 


### PR DESCRIPTION
This PR introduces an easy win to reduce the Docker image size of `playwright-service` from 2.55 GB to 1.55 GB. 🎉🎉

By playing around with the code, I saw that the Dockerfile runs `RUN npx playwright install --with-deps`, which installs not only Chromium, but also Firefox and whatnot. But the code only uses Chromium, hardcoded.
So by changing it to `RUN npx playwright install chromium --with-deps` it now only installs Chromium. 


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduce the playwright-service Docker image by ~1 GB by installing only Chromium. Image size drops from 2.55 GB to 1.55 GB and aligns with our Chromium-only usage.

- Switched from "npx playwright install --with-deps" to "npx playwright install chromium --with-deps" in the Dockerfile.

<!-- End of auto-generated description by cubic. -->

