### PR TITLE
feat(api/otel): much improved tracing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -77,6 +77,7 @@
     "@google-cloud/storage": "^7.16.0",
     "@mendable/firecrawl-rs": "workspace:*",
     "@openrouter/ai-sdk-provider": "^0.4.5",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.62.0",
     "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: ^0.4.5
         version: 0.4.5(zod@3.24.2)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.62.0
         version: 0.62.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -14,161 +14,262 @@ import { hasFormatOfType } from "../../lib/format-utils";
 import { TransportableError } from "../../lib/error";
 import { scrapeQueue } from "../../services/worker/nuq";
 import { checkPermissions } from "../../lib/permissions";
+import { withSpan, setSpanAttributes, SpanKind } from "../../lib/otel-tracer";
 
 export async function scrapeController(
   req: RequestWithAuth<{}, ScrapeResponse, ScrapeRequest>,
   res: Response<ScrapeResponse>,
 ) {
-  // Get timing data from middleware (includes all middleware processing time)
-  const middlewareStartTime = (req as any).requestTiming?.startTime || new Date().getTime();
-  const controllerStartTime = new Date().getTime();
+  return withSpan(
+    "api.scrape.request",
+    async span => {
+      // Get timing data from middleware (includes all middleware processing time)
+      const middlewareStartTime =
+        (req as any).requestTiming?.startTime || new Date().getTime();
+      const controllerStartTime = new Date().getTime();
 
-  const jobId = uuidv4();
-  const preNormalizedBody = { ...req.body };
-  req.body = scrapeRequestSchema.parse(req.body);
+      const jobId = uuidv4();
+      const preNormalizedBody = { ...req.body };
 
-  const permissions = checkPermissions(req.body, req.acuc?.flags);
-  if (permissions.error) {
-    return res.status(403).json({
-      success: false,
-      error: permissions.error,
-    });
-  }
+      // Set initial span attributes
+      setSpanAttributes(span, {
+        "scrape.job_id": jobId,
+        "scrape.url": req.body.url,
+        "scrape.team_id": req.auth.team_id,
+        "scrape.api_key_id": req.acuc?.api_key_id,
+        "scrape.middleware_time_ms": controllerStartTime - middlewareStartTime,
+      });
 
-  const zeroDataRetention =
-    req.acuc?.flags?.forceZDR || req.body.zeroDataRetention;
+      // Validation span
+      await withSpan("api.scrape.validate", async validateSpan => {
+        req.body = scrapeRequestSchema.parse(req.body);
+        setSpanAttributes(validateSpan, {
+          "validation.success": true,
+        });
+      });
 
-  const logger = _logger.child({
-    method: "scrapeController",
-    jobId,
-    scrapeId: jobId,
-    teamId: req.auth.team_id,
-    team_id: req.auth.team_id,
-    zeroDataRetention,
-  });
+      // Permission check span
+      const permissions = await withSpan(
+        "api.scrape.check_permissions",
+        async permSpan => {
+          const perms = checkPermissions(req.body, req.acuc?.flags);
+          setSpanAttributes(permSpan, {
+            "permissions.success": !perms.error,
+            "permissions.error": perms.error,
+          });
+          return perms;
+        },
+      );
 
-  const middlewareTime = controllerStartTime - middlewareStartTime;
-  
-  logger.debug("Scrape " + jobId + " starting", {
-    version: "v2",
-    scrapeId: jobId,
-    request: req.body,
-    originalRequest: preNormalizedBody,
-    account: req.account,
-  });
+      if (permissions.error) {
+        setSpanAttributes(span, {
+          "scrape.error": permissions.error,
+          "scrape.status_code": 403,
+        });
+        return res.status(403).json({
+          success: false,
+          error: permissions.error,
+        });
+      }
 
-  const origin = req.body.origin;
-  const timeout = req.body.timeout;
+      const zeroDataRetention =
+        req.acuc?.flags?.forceZDR || req.body.zeroDataRetention;
 
-
-  const isDirectToBullMQ =
-    process.env.SEARCH_PREVIEW_TOKEN !== undefined &&
-    process.env.SEARCH_PREVIEW_TOKEN === req.body.__searchPreviewToken;
-
-  const jobPriority = await getJobPriority({
-    team_id: req.auth.team_id,
-    basePriority: 10,
-  });
-
-  const job = await addScrapeJob(
-    {
-      url: req.body.url,
-      mode: "single_urls",
-      team_id: req.auth.team_id,
-      scrapeOptions: {
-        ...req.body,
-        ...(req.body.__experimental_cache
-          ? {
-              maxAge: req.body.maxAge ?? 4 * 60 * 60 * 1000, // 4 hours
-            }
-          : {}),
-      },
-      internalOptions: {
+      const logger = _logger.child({
+        method: "scrapeController",
+        jobId,
+        scrapeId: jobId,
         teamId: req.auth.team_id,
-        saveScrapeResultToGCS: process.env.GCS_FIRE_ENGINE_BUCKET_NAME
-          ? true
-          : false,
-        unnormalizedSourceURL: preNormalizedBody.url,
-        bypassBilling: isDirectToBullMQ,
+        team_id: req.auth.team_id,
         zeroDataRetention,
-        teamFlags: req.acuc?.flags ?? null,
-      },
-      origin,
-      integration: req.body.integration,
-      startTime: controllerStartTime,
-      zeroDataRetention,
-      apiKeyId: req.acuc?.api_key_id ?? null,
-    },
-    jobId,
-    jobPriority,
-    isDirectToBullMQ,
-  );
+      });
 
-  const totalWait =
-    (req.body.waitFor ?? 0) +
-    (req.body.actions ?? []).reduce(
-      (a, x) => (x.type === "wait" ? (x.milliseconds ?? 0) : 0) + a,
-      0,
-    );
+      const middlewareTime = controllerStartTime - middlewareStartTime;
 
-  let doc: Document;
-  try {
-    doc = await waitForJob(
-      job ?? jobId,
-      timeout !== undefined ? timeout + totalWait : null,
-      zeroDataRetention,
-      logger,
-    );
-  } catch (e) {
-    logger.error(`Error in scrapeController`, {
-      version: "v2",
-      error: e,
-    });
+      logger.debug("Scrape " + jobId + " starting", {
+        version: "v2",
+        scrapeId: jobId,
+        request: req.body,
+        originalRequest: preNormalizedBody,
+        account: req.account,
+      });
 
-    if (zeroDataRetention) {
+      setSpanAttributes(span, {
+        "scrape.zero_data_retention": zeroDataRetention,
+        "scrape.origin": req.body.origin,
+        "scrape.timeout": req.body.timeout,
+      });
+
+      const origin = req.body.origin;
+      const timeout = req.body.timeout;
+
+      const isDirectToBullMQ =
+        process.env.SEARCH_PREVIEW_TOKEN !== undefined &&
+        process.env.SEARCH_PREVIEW_TOKEN === req.body.__searchPreviewToken;
+
+      const jobPriority = await getJobPriority({
+        team_id: req.auth.team_id,
+        basePriority: 10,
+      });
+
+      // Job enqueuing span
+      const job = await withSpan(
+        "api.scrape.enqueue_job",
+        async enqueueSpan => {
+          const result = await addScrapeJob(
+            {
+              url: req.body.url,
+              mode: "single_urls",
+              team_id: req.auth.team_id,
+              scrapeOptions: {
+                ...req.body,
+                ...(req.body.__experimental_cache
+                  ? {
+                      maxAge: req.body.maxAge ?? 4 * 60 * 60 * 1000, // 4 hours
+                    }
+                  : {}),
+              },
+              internalOptions: {
+                teamId: req.auth.team_id,
+                saveScrapeResultToGCS: process.env.GCS_FIRE_ENGINE_BUCKET_NAME
+                  ? true
+                  : false,
+                unnormalizedSourceURL: preNormalizedBody.url,
+                bypassBilling: isDirectToBullMQ,
+                zeroDataRetention,
+                teamFlags: req.acuc?.flags ?? null,
+              },
+              origin,
+              integration: req.body.integration,
+              startTime: controllerStartTime,
+              zeroDataRetention,
+              apiKeyId: req.acuc?.api_key_id ?? null,
+            },
+            jobId,
+            jobPriority,
+            isDirectToBullMQ,
+          );
+
+          setSpanAttributes(enqueueSpan, {
+            "job.priority": jobPriority,
+            "job.direct_to_bullmq": isDirectToBullMQ,
+          });
+
+          return result;
+        },
+      );
+
+      const totalWait =
+        (req.body.waitFor ?? 0) +
+        (req.body.actions ?? []).reduce(
+          (a, x) => (x.type === "wait" ? (x.milliseconds ?? 0) : 0) + a,
+          0,
+        );
+
+      let doc: Document;
+      try {
+        // Wait for job completion span
+        doc = await withSpan("api.scrape.wait_for_job", async waitSpan => {
+          setSpanAttributes(waitSpan, {
+            "wait.timeout": timeout !== undefined ? timeout + totalWait : null,
+            "wait.job_id": jobId,
+          });
+
+          const result = await waitForJob(
+            job ?? jobId,
+            timeout !== undefined ? timeout + totalWait : null,
+            zeroDataRetention,
+            logger,
+          );
+
+          setSpanAttributes(waitSpan, {
+            "wait.success": true,
+          });
+
+          return result;
+        });
+      } catch (e) {
+        logger.error(`Error in scrapeController`, {
+          version: "v2",
+          error: e,
+        });
+
+        setSpanAttributes(span, {
+          "scrape.error": e instanceof Error ? e.message : String(e),
+          "scrape.error_type":
+            e instanceof TransportableError ? e.code : "unknown",
+        });
+
+        if (zeroDataRetention) {
+          await scrapeQueue.removeJob(jobId, logger);
+        }
+
+        if (e instanceof TransportableError) {
+          const statusCode = e.code === "SCRAPE_TIMEOUT" ? 408 : 500;
+          setSpanAttributes(span, {
+            "scrape.status_code": statusCode,
+          });
+          return res.status(statusCode).json({
+            success: false,
+            code: e.code,
+            error: e.message,
+          });
+        } else {
+          setSpanAttributes(span, {
+            "scrape.status_code": 500,
+          });
+          return res.status(500).json({
+            success: false,
+            error: `(Internal server error) - ${e && e.message ? e.message : e}`,
+          });
+        }
+      }
+
       await scrapeQueue.removeJob(jobId, logger);
-    }
 
-    if (e instanceof TransportableError) {
-      return res.status(e.code === "SCRAPE_TIMEOUT" ? 408 : 500).json({
-        success: false,
-        code: e.code,
-        error: e.message,
+      if (!hasFormatOfType(req.body.formats, "rawHtml")) {
+        if (doc && doc.rawHtml) {
+          delete doc.rawHtml;
+        }
+      }
+
+      const totalRequestTime = new Date().getTime() - middlewareStartTime;
+      const controllerTime = new Date().getTime() - controllerStartTime;
+
+      // Set final span attributes
+      setSpanAttributes(span, {
+        "scrape.success": true,
+        "scrape.status_code": 200,
+        "scrape.total_request_time_ms": totalRequestTime,
+        "scrape.controller_time_ms": controllerTime,
+        "scrape.document.status_code": doc?.metadata?.statusCode,
+        "scrape.document.content_type": doc?.metadata?.contentType,
+        "scrape.document.error": doc?.metadata?.error,
       });
-    } else {
-      return res.status(500).json({
-        success: false,
-        error: `(Internal server error) - ${e && e.message ? e.message : e}`,
+
+      logger.info("Request metrics", {
+        version: "v2",
+        scrapeId: jobId,
+        mode: "scrape",
+        middlewareStartTime,
+        controllerStartTime,
+        middlewareTime,
+        controllerTime,
+        totalRequestTime,
       });
-    }
-  }
 
-  await scrapeQueue.removeJob(jobId, logger);
-  
-
-  if (!hasFormatOfType(req.body.formats, "rawHtml")) {
-    if (doc && doc.rawHtml) {
-      delete doc.rawHtml;
-    }
-  }
-
-  const totalRequestTime = new Date().getTime() - middlewareStartTime;
-  const controllerTime = new Date().getTime() - controllerStartTime;
-  logger.info("Request metrics", {
-    version: "v2",
-    scrapeId: jobId,
-    mode: "scrape",
-    middlewareStartTime,
-    controllerStartTime,
-    middlewareTime,
-    controllerTime,
-    totalRequestTime,
-  });
-  
-
-  return res.status(200).json({
-    success: true,
-    data: doc,
-    scrape_id: origin?.includes("website") ? jobId : undefined,
-  });
+      return res.status(200).json({
+        success: true,
+        data: doc,
+        scrape_id: origin?.includes("website") ? jobId : undefined,
+      });
+    },
+    {
+      attributes: {
+        "http.method": "POST",
+        "http.route": "/v2/scrape",
+      },
+      kind: SpanKind.SERVER,
+    },
+  );
 }

--- a/apps/api/src/lib/otel-tracer.ts
+++ b/apps/api/src/lib/otel-tracer.ts
@@ -1,0 +1,173 @@
+import {
+  trace,
+  context,
+  SpanStatusCode,
+  Span,
+  SpanKind,
+  Attributes,
+  propagation,
+} from "@opentelemetry/api";
+// import { Logger } from 'winston';
+
+const tracer = trace.getTracer("firecrawl-api", "1.0.0");
+
+export { SpanKind };
+
+// Trace context propagation utilities
+export interface SerializedTraceContext {
+  traceParent?: string;
+  traceState?: string;
+}
+
+export function serializeTraceContext(): SerializedTraceContext {
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+
+  return {
+    traceParent: carrier.traceparent,
+    traceState: carrier.tracestate,
+  };
+}
+
+function deserializeTraceContext(serialized: SerializedTraceContext): any {
+  if (!serialized.traceParent) {
+    return context.active();
+  }
+
+  const carrier: Record<string, string> = {
+    traceparent: serialized.traceParent,
+  };
+
+  if (serialized.traceState) {
+    carrier.tracestate = serialized.traceState;
+  }
+
+  return propagation.extract(context.active(), carrier);
+}
+
+// export function withTraceContext<T>(serializedContext: SerializedTraceContext, fn: () => T): T {
+//   const ctx = deserializeTraceContext(serializedContext);
+//   return context.with(ctx, fn);
+// }
+
+export async function withTraceContextAsync<T>(
+  serializedContext: SerializedTraceContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const ctx = deserializeTraceContext(serializedContext);
+  return context.with(ctx, fn);
+}
+
+interface SpanOptions {
+  attributes?: Attributes;
+  kind?: SpanKind;
+}
+
+function startSpan(name: string, options?: SpanOptions): Span {
+  return tracer.startSpan(name, {
+    attributes: options?.attributes,
+    kind: options?.kind || SpanKind.INTERNAL,
+  });
+}
+
+export async function withSpan<T>(
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  options?: SpanOptions,
+): Promise<T> {
+  const span = startSpan(name, options);
+
+  try {
+    const result = await context.with(
+      trace.setSpan(context.active(), span),
+      () => fn(span),
+    );
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (error) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+
+    if (error instanceof Error) {
+      span.recordException(error);
+    }
+
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+
+// export function withSpanSync<T>(
+//   name: string,
+//   fn: (span: Span) => T,
+//   options?: SpanOptions
+// ): T {
+//   const span = startSpan(name, options);
+
+//   try {
+//     const result = context.with(
+//       trace.setSpan(context.active(), span),
+//       () => fn(span)
+//     );
+//     span.setStatus({ code: SpanStatusCode.OK });
+//     return result;
+//   } catch (error) {
+//     span.setStatus({
+//       code: SpanStatusCode.ERROR,
+//       message: error instanceof Error ? error.message : String(error),
+//     });
+
+//     if (error instanceof Error) {
+//       span.recordException(error);
+//     }
+
+//     throw error;
+//   } finally {
+//     span.end();
+//   }
+// }
+
+export function setSpanAttributes(span: Span, attributes: Attributes): void {
+  Object.entries(attributes).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      span.setAttribute(key, value);
+    }
+  });
+}
+
+// export function setSpanError(span: Span, error: Error | unknown, logger?: Logger): void {
+//   const errorMessage = error instanceof Error ? error.message : String(error);
+
+//   span.setStatus({
+//     code: SpanStatusCode.ERROR,
+//     message: errorMessage,
+//   });
+
+//   if (error instanceof Error) {
+//     span.recordException(error);
+//     span.setAttributes({
+//       'error.type': error.constructor.name,
+//       'error.message': error.message,
+//       'error.stack': error.stack,
+//     });
+//   }
+
+//   if (logger) {
+//     logger.error('Span error recorded', { error, spanName: span.spanContext().traceId });
+//   }
+// }
+
+// export function getActiveSpan(): Span | undefined {
+//   return trace.getActiveSpan();
+// }
+
+// export function createChildSpan(name: string, parentSpan?: Span, options?: SpanOptions): Span {
+//   const ctx = parentSpan
+//     ? trace.setSpan(context.active(), parentSpan)
+//     : context.active();
+
+//   return context.with(ctx, () => startSpan(name, options));
+// }

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -32,6 +32,7 @@ import { hasFormatOfType } from "../../../../lib/format-utils";
 import { Action } from "../../../../controllers/v1/types";
 import { AbortManagerThrownError } from "../../lib/abortManager";
 import { youtubePostprocessor } from "../../postprocessors/youtube";
+import { withSpan, setSpanAttributes } from "../../../../lib/otel-tracer";
 
 // This function does not take `Meta` on purpose. It may not access any
 // meta values to construct the request -- that must be done by the
@@ -49,407 +50,457 @@ async function performFireEngineScrape<
   abort?: AbortSignal,
   production = true,
 ): Promise<FireEngineCheckStatusSuccess> {
-  const scrape = await fireEngineScrape(
-    meta,
-    logger.child({ method: "fireEngineScrape" }),
-    request,
-    mock,
-    abort,
-    production,
-  );
+  return withSpan("engine.fire-engine.perform_scrape", async span => {
+    const startTime = Date.now();
+    let pollCount = 0;
 
-  let status: FireEngineCheckStatusSuccess | undefined = undefined;
-  if ((scrape as any).processing) {
-    const errorLimit = 3;
-    let errors: any[] = [];
+    setSpanAttributes(span, {
+      "fire-engine.url": request.url,
+      "fire-engine.priority": request.priority,
+      "fire-engine.wait": (request as any).wait,
+      "fire-engine.screenshot": (request as any).screenshot,
+      "fire-engine.fullpage": (request as any).fullPage,
+      "fire-engine.proxy": (request as any).proxy,
+      "fire-engine.mobile": (request as any).mobile,
+      "fire-engine.skip_tls": (request as any).skipTlsVerification,
+      "fire-engine.production": production,
+    });
+    const scrape = await fireEngineScrape(
+      meta,
+      logger.child({ method: "fireEngineScrape" }),
+      request,
+      mock,
+      abort,
+      production,
+    );
 
-    while (status === undefined) {
-      if (errors.length >= errorLimit) {
-        logger.error("Error limit hit.", { errors });
-        fireEngineDelete(
-          logger.child({
-            method: "performFireEngineScrape/fireEngineDelete",
-            afterErrors: errors,
-          }),
-          (scrape as any).jobId,
-          mock,
-          undefined,
-          production,
-        );
-        throw new Error("Error limit hit. See e.cause.errors for errors.", {
-          cause: { errors },
-        });
-      }
+    let status: FireEngineCheckStatusSuccess | undefined = undefined;
+    if ((scrape as any).processing) {
+      const errorLimit = 3;
+      let errors: any[] = [];
 
-      meta.abort.throwIfAborted();
-
-      try {
-        status = await fireEngineCheckStatus(
-          meta,
-          logger.child({ method: "fireEngineCheckStatus" }),
-          (scrape as any).jobId,
-          mock,
-          abort,
-          production,
-        );
-      } catch (error) {
-        if (error instanceof StillProcessingError) {
-          // nop
-        } else if (
-          error instanceof EngineError ||
-          error instanceof SiteError ||
-          error instanceof SSLError ||
-          error instanceof DNSResolutionError ||
-          error instanceof ActionError ||
-          error instanceof UnsupportedFileError ||
-          error instanceof FEPageLoadFailed ||
-          error instanceof ProxySelectionError
-        ) {
+      while (status === undefined) {
+        if (errors.length >= errorLimit) {
+          logger.error("Error limit hit.", { errors });
           fireEngineDelete(
             logger.child({
               method: "performFireEngineScrape/fireEngineDelete",
-              afterError: error,
+              afterErrors: errors,
             }),
             (scrape as any).jobId,
             mock,
             undefined,
             production,
           );
-          logger.debug("Fire-engine scrape job failed.", {
-            error,
-            jobId: (scrape as any).jobId,
+          throw new Error("Error limit hit. See e.cause.errors for errors.", {
+            cause: { errors },
           });
-          throw error;
-        } else if (error instanceof AbortManagerThrownError) {
-          fireEngineDelete(
-            logger.child({
-              method: "performFireEngineScrape/fireEngineDelete",
-              afterError: error,
-            }),
+        }
+
+        meta.abort.throwIfAborted();
+
+        try {
+          pollCount++;
+          status = await fireEngineCheckStatus(
+            meta,
+            logger.child({ method: "fireEngineCheckStatus" }),
             (scrape as any).jobId,
             mock,
-            undefined,
+            abort,
             production,
           );
-          throw error;
-        } else {
-          errors.push(error);
-          logger.debug(
-            `An unexpeceted error occurred while calling checkStatus. Error counter is now at ${errors.length}.`,
-            { error, jobId: (scrape as any).jobId },
-          );
-          Sentry.captureException(error);
+        } catch (error) {
+          if (error instanceof StillProcessingError) {
+            // nop
+          } else if (
+            error instanceof EngineError ||
+            error instanceof SiteError ||
+            error instanceof SSLError ||
+            error instanceof DNSResolutionError ||
+            error instanceof ActionError ||
+            error instanceof UnsupportedFileError ||
+            error instanceof FEPageLoadFailed ||
+            error instanceof ProxySelectionError
+          ) {
+            fireEngineDelete(
+              logger.child({
+                method: "performFireEngineScrape/fireEngineDelete",
+                afterError: error,
+              }),
+              (scrape as any).jobId,
+              mock,
+              undefined,
+              production,
+            );
+            logger.debug("Fire-engine scrape job failed.", {
+              error,
+              jobId: (scrape as any).jobId,
+            });
+            throw error;
+          } else if (error instanceof AbortManagerThrownError) {
+            fireEngineDelete(
+              logger.child({
+                method: "performFireEngineScrape/fireEngineDelete",
+                afterError: error,
+              }),
+              (scrape as any).jobId,
+              mock,
+              undefined,
+              production,
+            );
+            throw error;
+          } else {
+            errors.push(error);
+            logger.debug(
+              `An unexpeceted error occurred while calling checkStatus. Error counter is now at ${errors.length}.`,
+              { error, jobId: (scrape as any).jobId },
+            );
+            Sentry.captureException(error);
+          }
         }
       }
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+    } else {
+      status = scrape as FireEngineCheckStatusSuccess;
     }
 
-    await new Promise(resolve => setTimeout(resolve, 500));
-  } else {
-    status = scrape as FireEngineCheckStatusSuccess;
-  }
+    await specialtyScrapeCheck(
+      logger.child({
+        method: "performFireEngineScrape/specialtyScrapeCheck",
+      }),
+      status.responseHeaders,
+      status,
+    );
 
-  await specialtyScrapeCheck(
-    logger.child({
-      method: "performFireEngineScrape/specialtyScrapeCheck",
-    }),
-    status.responseHeaders,
-    status,
-  );
+    const contentType =
+      (Object.entries(status.responseHeaders ?? {}).find(
+        x => x[0].toLowerCase() === "content-type",
+      ) ?? [])[1] ?? "";
 
-  const contentType =
-    (Object.entries(status.responseHeaders ?? {}).find(
-      x => x[0].toLowerCase() === "content-type",
-    ) ?? [])[1] ?? "";
+    if (contentType.includes("application/json")) {
+      status.content = await getInnerJson(status.content);
+    }
 
-  if (contentType.includes("application/json")) {
-    status.content = await getInnerJson(status.content);
-  }
+    if (status.file) {
+      const content = status.file.content;
+      delete status.file;
+      status.content = Buffer.from(content, "base64").toString("utf8"); // TODO: handle other encodings via Content-Type tag
+    }
 
-  if (status.file) {
-    const content = status.file.content;
-    delete status.file;
-    status.content = Buffer.from(content, "base64").toString("utf8"); // TODO: handle other encodings via Content-Type tag
-  }
+    fireEngineDelete(
+      logger.child({
+        method: "performFireEngineScrape/fireEngineDelete",
+      }),
+      (scrape as any).jobId,
+      mock,
+      undefined,
+      production,
+    );
 
-  fireEngineDelete(
-    logger.child({
-      method: "performFireEngineScrape/fireEngineDelete",
-    }),
-    (scrape as any).jobId,
-    mock,
-    undefined,
-    production,
-  );
+    setSpanAttributes(span, {
+      "fire-engine.poll_count": pollCount,
+      "fire-engine.duration_ms": Date.now() - startTime,
+      "fire-engine.status_code": status.pageStatusCode,
+      "fire-engine.content_length": status.content?.length,
+      "fire-engine.has_screenshot": !!status.screenshot,
+      "fire-engine.has_pdf": !!(status as any).pdf,
+      "fire-engine.job_id": (scrape as any).jobId,
+    });
 
-  return status;
+    return status;
+  });
 }
 
 export async function scrapeURLWithFireEngineChromeCDP(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
-  const actions: Action[] = [
-    // Transform waitFor option into an action (unsupported by chrome-cdp)
-    ...(meta.options.waitFor !== 0
-      ? [
-          {
-            type: "wait" as const,
-            milliseconds:
-              meta.options.waitFor > 30000 ? 30000 : meta.options.waitFor,
-          },
-        ]
-      : []),
-
-    // Include specified actions
-    ...(meta.options.actions ?? []),
-
-    // Transform screenshot format into an action (unsupported by chrome-cdp)
-    ...(hasFormatOfType(meta.options.formats, "screenshot")
-      ? [
-          {
-            type: "screenshot" as const,
-            fullPage:
-              hasFormatOfType(meta.options.formats, "screenshot")?.fullPage ||
-              false,
-            ...(hasFormatOfType(meta.options.formats, "screenshot")?.viewport
-              ? {
-                  viewport: hasFormatOfType(meta.options.formats, "screenshot")!
-                    .viewport,
-                }
-              : {}),
-          },
-        ]
-      : []),
-  ];
-
-  const totalWait = actions.reduce(
-    (a, x) => (x.type === "wait" ? (x.milliseconds ?? 1000) + a : a),
-    0,
-  );
-
-  const request: FireEngineScrapeRequestCommon &
-    FireEngineScrapeRequestChromeCDP = {
-    url: meta.rewrittenUrl ?? meta.url,
-    engine: "chrome-cdp",
-    instantReturn: false,
-    skipTlsVerification: meta.options.skipTlsVerification,
-    headers: meta.options.headers,
-    ...(actions.length > 0
-      ? {
-          actions,
-        }
-      : {}),
-    priority: meta.internalOptions.priority,
-    geolocation: meta.options.location,
-    mobile: meta.options.mobile,
-    timeout: meta.abort.scrapeTimeout() ?? 300000,
-    disableSmartWaitCache: meta.internalOptions.disableSmartWaitCache,
-    mobileProxy: meta.featureFlags.has("stealthProxy"),
-    saveScrapeResultToGCS:
-      !meta.internalOptions.zeroDataRetention &&
-      meta.internalOptions.saveScrapeResultToGCS,
-    zeroDataRetention: meta.internalOptions.zeroDataRetention,
-    ...(youtubePostprocessor.shouldRun(
-      meta,
-      new URL(meta.rewrittenUrl ?? meta.url),
-    )
-      ? { blockMedia: false }
-      : {}),
-  };
-
-  let response = await performFireEngineScrape(
-    meta,
-    meta.logger.child({
-      method: "scrapeURLWithFireEngineChromeCDP/callFireEngine",
-      request,
-    }),
-    request,
-    meta.mock,
-    meta.abort.asSignal(),
-    true,
-  );
-
-  if (hasFormatOfType(meta.options.formats, "screenshot")) {
-    // meta.logger.debug(
-    //   "Transforming screenshots from actions into screenshot field",
-    //   { screenshots: response.screenshots },
-    // );
-    if (response.screenshots) {
-      response.screenshot = response.screenshots.slice(-1)[0];
-      response.screenshots = response.screenshots.slice(0, -1);
-    }
-    // meta.logger.debug("Screenshot transformation done", {
-    //   screenshots: response.screenshots,
-    //   screenshot: response.screenshot,
-    // });
-  }
-
-  if (!response.url) {
-    meta.logger.warn("Fire-engine did not return the response's URL", {
-      response,
-      sourceURL: meta.url,
+  return withSpan("engine.fire-engine.chrome-cdp", async span => {
+    setSpanAttributes(span, {
+      "engine.type": "fire-engine-chrome-cdp",
+      "engine.url": meta.url,
+      "engine.team_id": meta.internalOptions.teamId,
     });
-  }
+    const actions: Action[] = [
+      // Transform waitFor option into an action (unsupported by chrome-cdp)
+      ...(meta.options.waitFor !== 0
+        ? [
+            {
+              type: "wait" as const,
+              milliseconds:
+                meta.options.waitFor > 30000 ? 30000 : meta.options.waitFor,
+            },
+          ]
+        : []),
 
-  return {
-    url: response.url ?? meta.url,
+      // Include specified actions
+      ...(meta.options.actions ?? []),
 
-    html: response.content,
-    error: response.pageError,
-    statusCode: response.pageStatusCode,
+      // Transform screenshot format into an action (unsupported by chrome-cdp)
+      ...(hasFormatOfType(meta.options.formats, "screenshot")
+        ? [
+            {
+              type: "screenshot" as const,
+              fullPage:
+                hasFormatOfType(meta.options.formats, "screenshot")?.fullPage ||
+                false,
+              ...(hasFormatOfType(meta.options.formats, "screenshot")?.viewport
+                ? {
+                    viewport: hasFormatOfType(
+                      meta.options.formats,
+                      "screenshot",
+                    )!.viewport,
+                  }
+                : {}),
+            },
+          ]
+        : []),
+    ];
 
-    contentType:
-      (Object.entries(response.responseHeaders ?? {}).find(
-        x => x[0].toLowerCase() === "content-type",
-      ) ?? [])[1] ?? undefined,
+    const totalWait = actions.reduce(
+      (a, x) => (x.type === "wait" ? (x.milliseconds ?? 1000) + a : a),
+      0,
+    );
 
-    screenshot: response.screenshot,
-    ...(actions.length > 0
-      ? {
-          actions: {
-            screenshots: response.screenshots ?? [],
-            scrapes: response.actionContent ?? [],
-            javascriptReturns: (response.actionResults ?? [])
-              .filter(x => x.type === "executeJavascript")
-              .map(x =>
-                JSON.parse((x.result as any as { return: string }).return),
-              ),
-            pdfs: (response.actionResults ?? [])
-              .filter(x => x.type === "pdf")
-              .map(x => x.result.link),
-          },
-        }
-      : {}),
+    const request: FireEngineScrapeRequestCommon &
+      FireEngineScrapeRequestChromeCDP = {
+      url: meta.rewrittenUrl ?? meta.url,
+      engine: "chrome-cdp",
+      instantReturn: false,
+      skipTlsVerification: meta.options.skipTlsVerification,
+      headers: meta.options.headers,
+      ...(actions.length > 0
+        ? {
+            actions,
+          }
+        : {}),
+      priority: meta.internalOptions.priority,
+      geolocation: meta.options.location,
+      mobile: meta.options.mobile,
+      timeout: meta.abort.scrapeTimeout() ?? 300000,
+      disableSmartWaitCache: meta.internalOptions.disableSmartWaitCache,
+      mobileProxy: meta.featureFlags.has("stealthProxy"),
+      saveScrapeResultToGCS:
+        !meta.internalOptions.zeroDataRetention &&
+        meta.internalOptions.saveScrapeResultToGCS,
+      zeroDataRetention: meta.internalOptions.zeroDataRetention,
+      ...(youtubePostprocessor.shouldRun(
+        meta,
+        new URL(meta.rewrittenUrl ?? meta.url),
+      )
+        ? { blockMedia: false }
+        : {}),
+    };
 
-    proxyUsed: response.usedMobileProxy ? "stealth" : "basic",
-    youtubeTranscriptContent: response.youtubeTranscriptContent,
-  };
+    let response = await performFireEngineScrape(
+      meta,
+      meta.logger.child({
+        method: "scrapeURLWithFireEngineChromeCDP/callFireEngine",
+        request,
+      }),
+      request,
+      meta.mock,
+      meta.abort.asSignal(),
+      true,
+    );
+
+    if (hasFormatOfType(meta.options.formats, "screenshot")) {
+      // meta.logger.debug(
+      //   "Transforming screenshots from actions into screenshot field",
+      //   { screenshots: response.screenshots },
+      // );
+      if (response.screenshots) {
+        response.screenshot = response.screenshots.slice(-1)[0];
+        response.screenshots = response.screenshots.slice(0, -1);
+      }
+      // meta.logger.debug("Screenshot transformation done", {
+      //   screenshots: response.screenshots,
+      //   screenshot: response.screenshot,
+      // });
+    }
+
+    if (!response.url) {
+      meta.logger.warn("Fire-engine did not return the response's URL", {
+        response,
+        sourceURL: meta.url,
+      });
+    }
+
+    return {
+      url: response.url ?? meta.url,
+
+      html: response.content,
+      error: response.pageError,
+      statusCode: response.pageStatusCode,
+
+      contentType:
+        (Object.entries(response.responseHeaders ?? {}).find(
+          x => x[0].toLowerCase() === "content-type",
+        ) ?? [])[1] ?? undefined,
+
+      screenshot: response.screenshot,
+      ...(actions.length > 0
+        ? {
+            actions: {
+              screenshots: response.screenshots ?? [],
+              scrapes: response.actionContent ?? [],
+              javascriptReturns: (response.actionResults ?? [])
+                .filter(x => x.type === "executeJavascript")
+                .map(x =>
+                  JSON.parse((x.result as any as { return: string }).return),
+                ),
+              pdfs: (response.actionResults ?? [])
+                .filter(x => x.type === "pdf")
+                .map(x => x.result.link),
+            },
+          }
+        : {}),
+
+      proxyUsed: response.usedMobileProxy ? "stealth" : "basic",
+      youtubeTranscriptContent: response.youtubeTranscriptContent,
+    };
+  });
 }
 
 export async function scrapeURLWithFireEnginePlaywright(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
-  const totalWait = meta.options.waitFor;
-
-  const request: FireEngineScrapeRequestCommon &
-    FireEngineScrapeRequestPlaywright = {
-    url: meta.rewrittenUrl ?? meta.url,
-    engine: "playwright",
-    instantReturn: false,
-
-    headers: meta.options.headers,
-    priority: meta.internalOptions.priority,
-    screenshot:
-      hasFormatOfType(meta.options.formats, "screenshot") !== undefined,
-    fullPageScreenshot: hasFormatOfType(meta.options.formats, "screenshot")
-      ?.fullPage,
-    wait: meta.options.waitFor,
-    geolocation: meta.options.location,
-    blockAds: meta.options.blockAds,
-    mobileProxy: meta.featureFlags.has("stealthProxy"),
-
-    timeout: meta.abort.scrapeTimeout() ?? 300000,
-    saveScrapeResultToGCS:
-      !meta.internalOptions.zeroDataRetention &&
-      meta.internalOptions.saveScrapeResultToGCS,
-    zeroDataRetention: meta.internalOptions.zeroDataRetention,
-  };
-
-  let response = await performFireEngineScrape(
-    meta,
-    meta.logger.child({
-      method: "scrapeURLWithFireEnginePlaywright/callFireEngine",
-      request,
-    }),
-    request,
-    meta.mock,
-    meta.abort.asSignal(),
-  );
-
-  if (!response.url) {
-    meta.logger.warn("Fire-engine did not return the response's URL", {
-      response,
-      sourceURL: meta.url,
+  return withSpan("engine.fire-engine.playwright", async span => {
+    setSpanAttributes(span, {
+      "engine.type": "fire-engine-playwright",
+      "engine.url": meta.url,
+      "engine.team_id": meta.internalOptions.teamId,
     });
-  }
+    const totalWait = meta.options.waitFor;
 
-  return {
-    url: response.url ?? meta.url,
+    const request: FireEngineScrapeRequestCommon &
+      FireEngineScrapeRequestPlaywright = {
+      url: meta.rewrittenUrl ?? meta.url,
+      engine: "playwright",
+      instantReturn: false,
 
-    html: response.content,
-    error: response.pageError,
-    statusCode: response.pageStatusCode,
+      headers: meta.options.headers,
+      priority: meta.internalOptions.priority,
+      screenshot:
+        hasFormatOfType(meta.options.formats, "screenshot") !== undefined,
+      fullPageScreenshot: hasFormatOfType(meta.options.formats, "screenshot")
+        ?.fullPage,
+      wait: meta.options.waitFor,
+      geolocation: meta.options.location,
+      blockAds: meta.options.blockAds,
+      mobileProxy: meta.featureFlags.has("stealthProxy"),
 
-    contentType:
-      (Object.entries(response.responseHeaders ?? {}).find(
-        x => x[0].toLowerCase() === "content-type",
-      ) ?? [])[1] ?? undefined,
+      timeout: meta.abort.scrapeTimeout() ?? 300000,
+      saveScrapeResultToGCS:
+        !meta.internalOptions.zeroDataRetention &&
+        meta.internalOptions.saveScrapeResultToGCS,
+      zeroDataRetention: meta.internalOptions.zeroDataRetention,
+    };
 
-    ...(response.screenshots !== undefined && response.screenshots.length > 0
-      ? {
-          screenshot: response.screenshots[0],
-        }
-      : {}),
+    let response = await performFireEngineScrape(
+      meta,
+      meta.logger.child({
+        method: "scrapeURLWithFireEnginePlaywright/callFireEngine",
+        request,
+      }),
+      request,
+      meta.mock,
+      meta.abort.asSignal(),
+    );
 
-    proxyUsed: response.usedMobileProxy ? "stealth" : "basic",
-  };
+    if (!response.url) {
+      meta.logger.warn("Fire-engine did not return the response's URL", {
+        response,
+        sourceURL: meta.url,
+      });
+    }
+
+    return {
+      url: response.url ?? meta.url,
+
+      html: response.content,
+      error: response.pageError,
+      statusCode: response.pageStatusCode,
+
+      contentType:
+        (Object.entries(response.responseHeaders ?? {}).find(
+          x => x[0].toLowerCase() === "content-type",
+        ) ?? [])[1] ?? undefined,
+
+      ...(response.screenshots !== undefined && response.screenshots.length > 0
+        ? {
+            screenshot: response.screenshots[0],
+          }
+        : {}),
+
+      proxyUsed: response.usedMobileProxy ? "stealth" : "basic",
+    };
+  });
 }
 
 export async function scrapeURLWithFireEngineTLSClient(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
-  const request: FireEngineScrapeRequestCommon &
-    FireEngineScrapeRequestTLSClient = {
-    url: meta.rewrittenUrl ?? meta.url,
-    engine: "tlsclient",
-    instantReturn: false,
-
-    headers: meta.options.headers,
-    priority: meta.internalOptions.priority,
-
-    atsv: meta.internalOptions.atsv,
-    geolocation: meta.options.location,
-    disableJsDom: meta.internalOptions.v0DisableJsDom,
-    mobileProxy: meta.featureFlags.has("stealthProxy"),
-
-    timeout: meta.abort.scrapeTimeout() ?? 300000,
-    saveScrapeResultToGCS:
-      !meta.internalOptions.zeroDataRetention &&
-      meta.internalOptions.saveScrapeResultToGCS,
-    zeroDataRetention: meta.internalOptions.zeroDataRetention,
-  };
-
-  let response = await performFireEngineScrape(
-    meta,
-    meta.logger.child({
-      method: "scrapeURLWithFireEngineTLSClient/callFireEngine",
-      request,
-    }),
-    request,
-    meta.mock,
-    meta.abort.asSignal(),
-  );
-
-  if (!response.url) {
-    meta.logger.warn("Fire-engine did not return the response's URL", {
-      response,
-      sourceURL: meta.url,
+  return withSpan("engine.fire-engine.tlsclient", async span => {
+    setSpanAttributes(span, {
+      "engine.type": "fire-engine-tlsclient",
+      "engine.url": meta.url,
+      "engine.team_id": meta.internalOptions.teamId,
     });
-  }
+    const request: FireEngineScrapeRequestCommon &
+      FireEngineScrapeRequestTLSClient = {
+      url: meta.rewrittenUrl ?? meta.url,
+      engine: "tlsclient",
+      instantReturn: false,
 
-  return {
-    url: response.url ?? meta.url,
+      headers: meta.options.headers,
+      priority: meta.internalOptions.priority,
 
-    html: response.content,
-    error: response.pageError,
-    statusCode: response.pageStatusCode,
+      atsv: meta.internalOptions.atsv,
+      geolocation: meta.options.location,
+      disableJsDom: meta.internalOptions.v0DisableJsDom,
+      mobileProxy: meta.featureFlags.has("stealthProxy"),
 
-    contentType:
-      (Object.entries(response.responseHeaders ?? {}).find(
-        x => x[0].toLowerCase() === "content-type",
-      ) ?? [])[1] ?? undefined,
+      timeout: meta.abort.scrapeTimeout() ?? 300000,
+      saveScrapeResultToGCS:
+        !meta.internalOptions.zeroDataRetention &&
+        meta.internalOptions.saveScrapeResultToGCS,
+      zeroDataRetention: meta.internalOptions.zeroDataRetention,
+    };
 
-    proxyUsed: response.usedMobileProxy ? "stealth" : "basic",
-  };
+    let response = await performFireEngineScrape(
+      meta,
+      meta.logger.child({
+        method: "scrapeURLWithFireEngineTLSClient/callFireEngine",
+        request,
+      }),
+      request,
+      meta.mock,
+      meta.abort.asSignal(),
+    );
+
+    if (!response.url) {
+      meta.logger.warn("Fire-engine did not return the response's URL", {
+        response,
+        sourceURL: meta.url,
+      });
+    }
+
+    return {
+      url: response.url ?? meta.url,
+
+      html: response.content,
+      error: response.pageError,
+      statusCode: response.pageStatusCode,
+
+      contentType:
+        (Object.entries(response.responseHeaders ?? {}).find(
+          x => x[0].toLowerCase() === "content-type",
+        ) ?? [])[1] ?? undefined,
+
+      proxyUsed: response.usedMobileProxy ? "stealth" : "basic",
+    };
+  });
 }
 
 export function fireEngineMaxReasonableTime(

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -10,11 +10,13 @@ import { ExtractorOptions, Document } from "./lib/entities";
 import { InternalOptions } from "./scraper/scrapeURL";
 import type { CostTracking } from "./lib/cost-tracking";
 import { webhookSchema } from "./services/webhook/schema";
+import { SerializedTraceContext } from "./lib/otel-tracer";
 
 type ScrapeJobCommon = {
   concurrencyLimited?: boolean;
   team_id: string;
   zeroDataRetention: boolean;
+  traceContext?: SerializedTraceContext;
 };
 
 export type ScrapeJobData = ScrapeJobCommon &


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds end-to-end OpenTelemetry tracing across the scrape flow with span instrumentation and trace context propagation from HTTP request to queue to worker to engine. Improves visibility and debugging of scrape jobs.

- **New Features**
  - Added tracer utils: withSpan, setSpanAttributes, serializeTraceContext, withTraceContextAsync.
  - Instrumented controller, scraper engine loop, NuQ queue operations, and worker processing with spans.
  - Propagated trace context via ScrapeJobData.traceContext; workers restore context to link spans to the original request.
  - Added useful span attributes (job_id, team_id, mode, crawl_id, url) for quicker diagnosis.
  - Replaced timing logs in parts of NuQ with spans for consistent metrics.

- **Dependencies**
  - Added @opentelemetry/api ^1.9.0.

<!-- End of auto-generated description by cubic. -->

