### PR TITLE
Allow self-hosted webhook delivery to private IP addresses

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -114,6 +114,9 @@ BULL_AUTH_KEY=CHANGEME
 # Maximum RAM usage threshold (0.0-1.0). Worker will reject new jobs when memory usage exceeds this value.
 # Default: 0.8 (80%)
 # MAX_RAM=0.8
+
+# Set if you'd like to allow local webhooks to be sent to your self-hosted instance
+# ALLOW_LOCAL_WEBHOOKS=true
 ```
 
 3.  Build and run the Docker containers:

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -57,7 +57,7 @@ function makeSecureDispatcher(skipTlsVerification: boolean) {
     if (
       socket.remoteAddress &&
       isIPPrivate(socket.remoteAddress) &&
-      !Boolean(process.env.ALLOW_LOCAL_WEBHOOKS)
+      process.env.ALLOW_LOCAL_WEBHOOKS !== "true"
     ) {
       socket.destroy(new InsecureConnectionError());
     }

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -54,7 +54,11 @@ function makeSecureDispatcher(skipTlsVerification: boolean) {
     )!;
     const socket: Socket | TLSSocket = (client as any)[socketSymbol];
 
-    if (socket.remoteAddress && isIPPrivate(socket.remoteAddress)) {
+    if (
+      socket.remoteAddress &&
+      isIPPrivate(socket.remoteAddress) &&
+      !process.env.SELF_HOSTED_WEBHOOK_URL
+    ) {
       socket.destroy(new InsecureConnectionError());
     }
   });

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -57,7 +57,7 @@ function makeSecureDispatcher(skipTlsVerification: boolean) {
     if (
       socket.remoteAddress &&
       isIPPrivate(socket.remoteAddress) &&
-      !process.env.SELF_HOSTED_WEBHOOK_URL
+      !Boolean(process.env.ALLOW_LOCAL_WEBHOOKS)
     ) {
       socket.destroy(new InsecureConnectionError());
     }

--- a/apps/api/src/services/webhook/delivery.ts
+++ b/apps/api/src/services/webhook/delivery.ts
@@ -71,7 +71,7 @@ export class WebhookSender {
     const webhookHost = new URL(this.config.url).hostname;
     if (
       isIPPrivate(webhookHost) &&
-      !Boolean(process.env.ALLOW_LOCAL_WEBHOOKS)
+      process.env.ALLOW_LOCAL_WEBHOOKS !== "true"
     ) {
       this.logger.warn("Aborting webhook call to private IP address", {
         webhookUrl: this.config.url,

--- a/apps/api/src/services/webhook/delivery.ts
+++ b/apps/api/src/services/webhook/delivery.ts
@@ -69,7 +69,10 @@ export class WebhookSender {
 
   private async deliver(payload: any, scrapeId?: string): Promise<void> {
     const webhookHost = new URL(this.config.url).hostname;
-    if (isIPPrivate(webhookHost) && !process.env.SELF_HOSTED_WEBHOOK_URL) {
+    if (
+      isIPPrivate(webhookHost) &&
+      !Boolean(process.env.ALLOW_LOCAL_WEBHOOKS)
+    ) {
       this.logger.warn("Aborting webhook call to private IP address", {
         webhookUrl: this.config.url,
       });

--- a/apps/api/src/services/webhook/delivery.ts
+++ b/apps/api/src/services/webhook/delivery.ts
@@ -69,7 +69,7 @@ export class WebhookSender {
 
   private async deliver(payload: any, scrapeId?: string): Promise<void> {
     const webhookHost = new URL(this.config.url).hostname;
-    if (isIPPrivate(webhookHost)) {
+    if (isIPPrivate(webhookHost) && !process.env.SELF_HOSTED_WEBHOOK_URL) {
       this.logger.warn("Aborting webhook call to private IP address", {
         webhookUrl: this.config.url,
       });


### PR DESCRIPTION
Updated webhook delivery and safeFetch logic to allow calls to private IP addresses when running in a self-hosted environment.

If the environment variable `SELF_HOSTED_WEBHOOK_URL` is defined, the private IP restriction will be bypassed

This makes it possible to run Firecrawl with local/self-hosted automation tools (e.g., n8n) behind reverse proxies


fixes #2222


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Allows self-hosted deployments to call private IPs for webhooks and fetches when SELF_HOSTED_WEBHOOK_URL is set. Default behavior remains secure by blocking private IPs.

- **New Features**
  - Skip private IP checks in safeFetch and webhook delivery when SELF_HOSTED_WEBHOOK_URL is defined.
  - Enables integrations with local tools (e.g., n8n) behind reverse proxies.

- **Migration**
  - Set SELF_HOSTED_WEBHOOK_URL in self-hosted environments to permit private IP calls.
  - No changes needed for hosted/public setups; private IPs stay blocked.

<!-- End of auto-generated description by cubic. -->

