### PR TITLE
Fix crawl credit checking (ENG-3624)

### DIFF
--- a/apps/api/src/routes/v1.ts
+++ b/apps/api/src/routes/v1.ts
@@ -125,7 +125,7 @@ v1Router.post(
   "/crawl",
   authMiddleware(RateLimiterMode.Crawl),
   countryCheck,
-  checkCreditsMiddleware(),
+  checkCreditsMiddleware(1),
   blocklistMiddleware,
   idempotencyMiddleware,
   wrap(crawlController),

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -201,7 +201,7 @@ v2Router.post(
   "/crawl",
   authMiddleware(RateLimiterMode.Crawl),
   countryCheck,
-  checkCreditsMiddleware(),
+  checkCreditsMiddleware(1),
   blocklistMiddleware,
   idempotencyMiddleware,
   wrap(crawlController),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix credit checks for /crawl so at least 1 credit is required per request, even when no page limit is set. Applies to both v1 and v2 routes via checkCreditsMiddleware(1), addressing ENG-3624.

<!-- End of auto-generated description by cubic. -->

