### PR TITLE
Propagate timeout to Axios in Node SDK (ENG-3474)

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
@@ -54,6 +54,11 @@ export class HttpClient {
         if (cfg.method && ["post", "put", "patch"].includes(cfg.method.toLowerCase())) {
           const data = (cfg.data ?? {}) as Record<string, unknown>;
           cfg.data = { ...data, origin: typeof data.origin === "string" && data.origin.includes("mcp") ? data.origin : `js-sdk@${version}` };
+          
+          // If timeout is specified in the body, use it to override the request timeout
+          if (typeof data.timeout === "number") {
+            cfg.timeout = data.timeout + 5000;
+          }
         }
         const res = await this.instance.request<T>(cfg);
         if (res.status === 502 && attempt < this.maxRetries - 1) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Propagates the timeout from request payloads to Axios in the Firecrawl JS SDK, adding a 5s buffer to avoid premature client timeouts. Addresses Linear ENG-3474 and bumps @mendable/firecrawl-js to 4.3.7.

<!-- End of auto-generated description by cubic. -->

