### PR TITLE
fix: handle `$ref` for recursive schema validation

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -72,16 +72,37 @@ function normalizeSchemaForOpenAI(schema: any): any {
 
   function normalizeObject(obj: any): any {
     if (typeof obj !== "object" || obj === null) return obj;
-    if (Array.isArray(obj)) return obj;
+    if (Array.isArray(obj)) {
+      return obj.map(item => normalizeObject(item));
+    }
 
     if (visited.has(obj)) return obj;
     visited.add(obj);
 
     const normalized = { ...obj };
 
-    // handle $ref recursion - preserve as-is for OpenAI compatibility
+    // Handle $ref recursion - preserve as-is for OpenAI compatibility
     if (normalized.hasOwnProperty("$ref")) {
       return normalized;
+    }
+
+    if (normalized.hasOwnProperty("$defs")) {
+      const { $defs, ...rest } = normalized;
+      const processedRest = {};
+
+      for (const [key, value] of Object.entries(rest)) {
+        if (
+          typeof value === "object" &&
+          value !== null &&
+          !value.hasOwnProperty("$ref")
+        ) {
+          processedRest[key] = normalizeObject(value);
+        } else {
+          processedRest[key] = value;
+        }
+      }
+
+      return { ...processedRest, $defs };
     }
 
     if (

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -79,6 +79,11 @@ function normalizeSchemaForOpenAI(schema: any): any {
 
     const normalized = { ...obj };
 
+    // handle $ref recursion - preserve as-is for OpenAI compatibility
+    if (normalized.hasOwnProperty("$ref")) {
+      return normalized;
+    }
+
     if (
       normalized.type === "object" &&
       normalized.hasOwnProperty("properties") &&
@@ -111,7 +116,11 @@ function normalizeSchemaForOpenAI(schema: any): any {
     }
 
     for (const [key, value] of Object.entries(normalized)) {
-      if (typeof value === "object" && value !== null) {
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        !value.hasOwnProperty("$ref")
+      ) {
         normalized[key] = normalizeObject(value);
       }
     }
@@ -135,6 +144,10 @@ function validateSchemaForOpenAI(schema: any): boolean {
     if (visited.has(obj)) return false;
     visited.add(obj);
 
+    if (obj.hasOwnProperty("$ref")) {
+      return false;
+    }
+
     if (
       obj.type === "object" &&
       !obj.hasOwnProperty("properties") &&
@@ -145,7 +158,11 @@ function validateSchemaForOpenAI(schema: any): boolean {
     }
 
     for (const value of Object.values(obj)) {
-      if (typeof value === "object" && value !== null) {
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        !value.hasOwnProperty("$ref")
+      ) {
         if (hasInvalidStructure(value)) return true;
       }
     }
@@ -156,7 +173,7 @@ function validateSchemaForOpenAI(schema: any): boolean {
 }
 
 const OPENAI_SCHEMA_ERROR_MESSAGE =
-  "Schema contains invalid structure for OpenAI: object type with no 'properties' defined but 'additionalProperties: true' (schema-less dictionary not supported by OpenAI). Please define specific properties for your object.";
+  "Schema contains invalid structure for OpenAI: object type with no 'properties' defined but 'additionalProperties: true' (schema-less dictionary not supported by OpenAI). Please define specific properties for your object. Note: Recursive schemas using '$ref' are supported.";
 
 const ACTIONS_MAX_WAIT_TIME = 60;
 const MAX_ACTIONS = 50;

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -194,7 +194,6 @@ const resolveRefs = (
 ): any => {
   if (!obj || typeof obj !== "object" || depth > 10) return obj;
 
-  // Emergency safeguard: if we detect any recursive patterns, abort immediately
   const objString = JSON.stringify(obj);
   if (objString.includes("#/$defs/") && objString.includes('"$ref"')) {
     console.warn(
@@ -203,7 +202,7 @@ const resolveRefs = (
     return obj;
   }
 
-  // Prevent infinite recursion by checking if we've already processed this object
+  // Prevent infinite recursion
   if (visited.has(obj)) return obj;
   visited.add(obj);
 
@@ -279,9 +278,6 @@ export async function extractData({
 
   if (schema) {
     const defs = schema.$defs || {};
-
-    // Always skip reference resolution if we detect any $defs or $ref patterns
-    // This is a safe approach that avoids infinite recursion entirely
     const schemaString = JSON.stringify(schema);
     const hasAnyRefs =
       schema.$defs ||
@@ -297,7 +293,6 @@ export async function extractData({
           hasRefPathInString: schemaString.includes("#/$defs/"),
         },
       );
-      // Don't call resolveRefs at all when we detect recursive patterns
     } else {
       logger.info("No recursive references detected, resolving refs", {
         schema,

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -120,29 +120,115 @@ function prepareSmartScrapeSchema(
   return { schemaToUse: wrappedSchema };
 }
 
+const hasRecursiveRefs = (schema: any, defs: any): boolean => {
+  if (!defs || typeof defs !== "object") return false;
+
+  for (const [defName, defValue] of Object.entries(defs)) {
+    if (containsRecursiveRef(defValue, defName, defs)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const containsRecursiveRef = (
+  obj: any,
+  targetDefName: string,
+  defs: any,
+  visited = new Set(),
+): boolean => {
+  if (!obj || typeof obj !== "object") return false;
+
+  const objKey = JSON.stringify(obj);
+  if (visited.has(objKey)) return false;
+  visited.add(objKey);
+
+  if (obj.$ref && typeof obj.$ref === "string") {
+    const refPath = obj.$ref.split("/");
+    if (refPath[0] === "#" && refPath[1] === "$defs") {
+      const defName = refPath[refPath.length - 1];
+      if (defName === targetDefName) {
+        visited.delete(objKey);
+        return true;
+      }
+      if (defs[defName]) {
+        const isRecursive = containsRecursiveRef(
+          defs[defName],
+          targetDefName,
+          defs,
+          visited,
+        );
+        visited.delete(objKey);
+        return isRecursive;
+      }
+    }
+  }
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      if (containsRecursiveRef(item, targetDefName, defs, visited)) {
+        visited.delete(objKey);
+        return true;
+      }
+    }
+  } else {
+    for (const value of Object.values(obj)) {
+      if (containsRecursiveRef(value, targetDefName, defs, visited)) {
+        visited.delete(objKey);
+        return true;
+      }
+    }
+  }
+
+  visited.delete(objKey);
+  return false;
+};
+
 // Resolve all $defs references in the schema
-const resolveRefs = (obj: any, defs: any): any => {
-  if (!obj || typeof obj !== "object") return obj;
+const resolveRefs = (
+  obj: any,
+  defs: any,
+  visited = new WeakSet(),
+  depth = 0,
+): any => {
+  if (!obj || typeof obj !== "object" || depth > 10) return obj;
+
+  // Emergency safeguard: if we detect any recursive patterns, abort immediately
+  const objString = JSON.stringify(obj);
+  if (objString.includes("#/$defs/") && objString.includes('"$ref"')) {
+    console.warn(
+      "resolveRefs: Detected recursive schema pattern, aborting to prevent infinite recursion",
+    );
+    return obj;
+  }
+
+  // Prevent infinite recursion by checking if we've already processed this object
+  if (visited.has(obj)) return obj;
+  visited.add(obj);
 
   if (obj.$ref && typeof obj.$ref === "string") {
     // Handle $ref references
     const refPath = obj.$ref.split("/");
     if (refPath[0] === "#" && refPath[1] === "$defs") {
       const defName = refPath[refPath.length - 1];
-      return resolveRefs({ ...defs[defName] }, defs);
+      if (defs[defName]) {
+        return resolveRefs({ ...defs[defName] }, defs, visited, depth + 1);
+      }
     }
+    return obj; // Return original if ref can't be resolved
   }
 
   // Handle arrays
   if (Array.isArray(obj)) {
-    return obj.map(item => resolveRefs(item, defs));
+    return obj.map(item => resolveRefs(item, defs, visited, depth + 1));
   }
 
   // Handle objects
   const resolved: any = {};
   for (const [key, value] of Object.entries(obj)) {
     if (key === "$defs") continue;
-    resolved[key] = resolveRefs(value, defs);
+    resolved[key] = resolveRefs(value, defs, visited, depth + 1);
   }
   return resolved;
 };
@@ -193,11 +279,35 @@ export async function extractData({
 
   if (schema) {
     const defs = schema.$defs || {};
-    schema = resolveRefs(schema, defs);
-    delete schema.$defs;
-    logger.info("Resolved schema refs", {
-      schema,
-    });
+
+    // Always skip reference resolution if we detect any $defs or $ref patterns
+    // This is a safe approach that avoids infinite recursion entirely
+    const schemaString = JSON.stringify(schema);
+    const hasAnyRefs =
+      schema.$defs ||
+      schemaString.includes('"$ref"') ||
+      schemaString.includes("#/$defs/");
+
+    if (hasAnyRefs) {
+      logger.info(
+        "Detected schema with references, preserving as-is to avoid recursion",
+        {
+          hasDefsProperty: !!schema.$defs,
+          hasRefInString: schemaString.includes('"$ref"'),
+          hasRefPathInString: schemaString.includes("#/$defs/"),
+        },
+      );
+      // Don't call resolveRefs at all when we detect recursive patterns
+    } else {
+      logger.info("No recursive references detected, resolving refs", {
+        schema,
+      });
+      schema = resolveRefs(schema, defs);
+      delete schema.$defs;
+      logger.info("Resolved schema refs", {
+        schema,
+      });
+    }
   }
 
   const { schemaToUse } = prepareSmartScrapeSchema(schema, logger, isSingleUrl);

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -25,6 +25,46 @@ import { extractData } from "../lib/extractSmartScrape";
 import { CostTracking } from "../../../lib/cost-tracking";
 import { isAgentExtractModelValid } from "../../../controllers/v1/types";
 import { hasFormatOfType } from "../../../lib/format-utils";
+
+// Smart model selection based on schema
+function detectRecursiveSchema(schema: any): boolean {
+  if (!schema || typeof schema !== "object") return false;
+
+  const schemaString = JSON.stringify(schema);
+  const hasRefs =
+    schemaString.includes('"$ref"') ||
+    schemaString.includes("#/$defs/") ||
+    schemaString.includes("#/definitions/");
+  const hasDefs = !!(schema.$defs || schema.definitions);
+
+  return hasRefs || hasDefs;
+}
+
+function selectModelForSchema(schema?: any): {
+  modelName: string;
+  reason: string;
+} {
+  if (!schema) {
+    return { modelName: "gpt-4o-mini", reason: "no_schema" };
+  }
+
+  const isRecursive = detectRecursiveSchema(schema);
+
+  if (isRecursive) {
+    logger.info(`Model: gpt-4o | hasRef: true`);
+    return {
+      modelName: "gpt-4o",
+      reason: "recursive_schema_detected",
+    };
+  }
+
+  logger.info(`Model: gpt-4o-mini | hasRef: false`);
+  return {
+    modelName: "gpt-4o-mini",
+    reason: "simple_schema",
+  };
+}
+
 // TODO: fix this, it's horrible
 type LanguageModelV1ProviderMetadata = {
   anthropic?: {
@@ -259,7 +299,7 @@ export async function generateCompletions({
   markdown,
   previousWarning,
   isExtractEndpoint,
-  model = getModel("gpt-4o", "openai"),
+  model = getModel("gpt-4o-mini", "openai"), // Default model, will be overridden by smart selection
   mode = "object",
   providerOptions,
   retryModel = getModel("claude-3-5-sonnet-20240620", "anthropic"),
@@ -897,8 +937,11 @@ export async function performLLMExtract(
       options: jsonFormat,
       markdown: document.markdown,
       previousWarning: document.warning,
-      model: getModel("gpt-4o", "openai"),
-      retryModel: getModel("gpt-4o", "openai"),
+      model: (() => {
+        const selection = selectModelForSchema(jsonFormat.schema);
+        return getModel(selection.modelName, "openai");
+      })(),
+      retryModel: getModel("gpt-4o", "openai"), // Always use premium model for retries
       costTrackingOptions: {
         costTracking: meta.costTracking,
         metadata: {
@@ -1089,8 +1132,17 @@ export async function performSummary(
       },
       markdown: trimOutput.text,
       previousWarning: document.warning,
-      model: getModel("gpt-4o-mini", "openai"),
-      retryModel: getModel("gpt-4o", "openai"),
+      model: (() => {
+        // Summary always uses simple schema, so will use gpt-4o-mini
+        const inlineSchema = {
+          type: "object",
+          properties: { summary: { type: "string" } },
+          required: ["summary"],
+        };
+        const selection = selectModelForSchema(inlineSchema);
+        return getModel(selection.modelName, "openai");
+      })(),
+      retryModel: getModel("gpt-4o", "openai"), // Always use premium model for retries
       costTrackingOptions: {
         costTracking: meta.costTracking,
         metadata: {

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -259,7 +259,7 @@ export async function generateCompletions({
   markdown,
   previousWarning,
   isExtractEndpoint,
-  model = getModel("gpt-4o-mini", "openai"),
+  model = getModel("gpt-4o", "openai"),
   mode = "object",
   providerOptions,
   retryModel = getModel("claude-3-5-sonnet-20240620", "anthropic"),
@@ -897,7 +897,7 @@ export async function performLLMExtract(
       options: jsonFormat,
       markdown: document.markdown,
       previousWarning: document.warning,
-      model: getModel("gpt-4o-mini", "openai"),
+      model: getModel("gpt-4o", "openai"),
       retryModel: getModel("gpt-4o", "openai"),
       costTrackingOptions: {
         costTracking: meta.costTracking,

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -299,7 +299,7 @@ export async function generateCompletions({
   markdown,
   previousWarning,
   isExtractEndpoint,
-  model = getModel("gpt-4o-mini", "openai"), // Default model, will be overridden by smart selection
+  model = getModel("gpt-4o-mini", "openai"),
   mode = "object",
   providerOptions,
   retryModel = getModel("claude-3-5-sonnet-20240620", "anthropic"),
@@ -1132,7 +1132,6 @@ export async function performSummary(
       markdown: trimOutput.text,
       previousWarning: document.warning,
       model: (() => {
-        // Summary always uses simple schema, so will use gpt-4o-mini
         const inlineSchema = {
           type: "object",
           properties: { summary: { type: "string" } },
@@ -1141,7 +1140,7 @@ export async function performSummary(
         const selection = selectModelForSchema(inlineSchema);
         return getModel(selection.modelName, "openai");
       })(),
-      retryModel: getModel("gpt-4o", "openai"), // Always use premium model for retries
+      retryModel: getModel("gpt-4o", "openai"),
       costTrackingOptions: {
         costTracking: meta.costTracking,
         metadata: {

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -930,6 +930,8 @@ export async function performLLMExtract(
 
     // let generationOptions = { ...originalOptions }; // Start with original options
 
+    const modelSelection = selectModelForSchema(jsonFormat.schema);
+
     const generationOptions: GenerateCompletionsOptions = {
       logger: meta.logger.child({
         method: "performLLMExtract/generateCompletions",
@@ -937,11 +939,8 @@ export async function performLLMExtract(
       options: jsonFormat,
       markdown: document.markdown,
       previousWarning: document.warning,
-      model: (() => {
-        const selection = selectModelForSchema(jsonFormat.schema);
-        return getModel(selection.modelName, "openai");
-      })(),
-      retryModel: getModel("gpt-4o", "openai"), // Always use premium model for retries
+      model: getModel(modelSelection.modelName, "openai"),
+      retryModel: getModel("gpt-4o", "openai"),
       costTrackingOptions: {
         costTracking: meta.costTracking,
         metadata: {


### PR DESCRIPTION
ref: https://discord.com/channels/1226707384710332458/1421817976566452234
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix handling of $ref in schema normalization and validation to support recursive JSON Schemas. Prevents false errors and infinite recursion in OpenAI schema processing.

- **Bug Fixes**
  - Preserve $ref nodes as-is during normalization.
  - Skip recursion into $ref objects.
  - Treat $ref as valid in validation and update the error message to note recursive schema support.

<!-- End of auto-generated description by cubic. -->

