### PR TITLE
feat(api/crawl-status): use crawl_status_2 RPC

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -331,7 +331,7 @@ export async function crawlStatusController(
   if (process.env.USE_DB_AUTHENTICATION === "true") {
     // new DB-based path
     const { data, error } = await supabase_service.rpc(
-      "crawl_status_1",
+      "crawl_status_2",
       {
         i_team_id: req.auth.team_id,
         i_crawl_id: req.params.jobId,

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -349,7 +349,7 @@ export async function crawlStatusController(
   if (process.env.USE_DB_AUTHENTICATION === "true" && !isPreviewTeam) {
     // new DB-based path
     const { data, error } = await supabase_service.rpc(
-      "crawl_status_1",
+      "crawl_status_2",
       {
         i_team_id: req.auth.team_id,
         i_crawl_id: req.params.jobId,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Use the new crawl_status_2 RPC in the v1 and v2 crawl status controllers when DB authentication is enabled. Aligns with ENG-3680 and the updated Supabase function.

<!-- End of auto-generated description by cubic. -->

