### PR TITLE
feat(api/ci): test with RabbitMQ on prod

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -164,6 +164,10 @@ jobs:
         image: redis
         ports:
           - 6379:6379
+      rabbitmq:
+        image: rabbitmq
+        ports:
+          - 5672:5672
     env:
       BULL_AUTH_KEY: ${{ secrets.BULL_AUTH_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -202,6 +206,7 @@ jobs:
       IDMUX_URL: ${{ secrets.IDMUX_URL }}
       LOG_ENCRYPTION_KEY: ${{ secrets.LOG_ENCRYPTION_KEY }}
       NUQ_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      NUQ_RABBITMQ_URL: amqp://localhost:5672
       HOST: 0.0.0.0
     steps:
       - uses: actions/checkout@v5

--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -328,6 +328,7 @@ function startServices(command?: string[]): Services {
       : "pnpm server:production:nobuild",
     {
       NUQ_REDUCE_NOISE: "true",
+      NUQ_POD_NAME: "api",
     },
   );
 
@@ -338,6 +339,7 @@ function startServices(command?: string[]): Services {
       : "pnpm worker:production",
     {
       NUQ_REDUCE_NOISE: "true",
+      NUQ_POD_NAME: "worker",
     },
   );
 
@@ -350,22 +352,25 @@ function startServices(command?: string[]): Services {
       {
         NUQ_WORKER_PORT: String(3006 + i),
         NUQ_REDUCE_NOISE: "true",
+        NUQ_POD_NAME: `nuq-worker-${i}`,
       },
     ),
   );
 
-  const nuqPrefetchWorker = process.env.NUQ_RABBITMQ_URL
-    ? execForward(
-        "nuq-prefetch-worker",
-        process.argv[2] === "--start-docker"
-          ? "node --import ./dist/src/otel.js dist/src/services/worker/nuq-prefetch-worker.js"
-          : "pnpm nuq-prefetch-worker:production",
-        {
-          NUQ_PREFETCH_WORKER_PORT: String(3011),
-          NUQ_REDUCE_NOISE: "true",
-        },
-      )
-    : undefined;
+  const nuqPrefetchWorker =
+    process.env.NUQ_RABBITMQ_URL
+      ? execForward(
+          "nuq-prefetch-worker",
+          process.argv[2] === "--start-docker"
+            ? "node --import ./dist/src/otel.js dist/src/services/worker/nuq-prefetch-worker.js"
+            : "pnpm nuq-prefetch-worker:production",
+          {
+            NUQ_PREFETCH_WORKER_PORT: String(3011),
+            NUQ_REDUCE_NOISE: "true",
+            NUQ_POD_NAME: "nuq-prefetch-worker",
+          },
+        )
+      : undefined;
 
   const indexWorker =
     process.env.USE_DB_AUTHENTICATION === "true"
@@ -376,6 +381,7 @@ function startServices(command?: string[]): Services {
             : "pnpm index-worker:production",
           {
             NUQ_REDUCE_NOISE: "true",
+            NUQ_POD_NAME: "index-worker",
           },
         )
       : undefined;

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -773,7 +773,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
 
       const start = Date.now();
       try {
-        const result = await nuqPool.query(`UPDATE ${this.queueName} SET status = 'failed'::nuq.job_status, lock = null, locked_at = null, finished_at = now(), failedreason = $3 WHERE id = $1 AND lock = $2 RETURNING id`,
+        const result = await nuqPool.query(`UPDATE ${this.queueName} SET status = 'failed'::nuq.job_status, lock = null, locked_at = null, finished_at = now(), failedreason = $3 WHERE id = $1 AND lock = $2 RETURNING id, listen_channel_id;`,
           [id, lock, failedReason],
         );
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enabled RabbitMQ in the prod CI test-server workflow to verify queue integration end-to-end. Supports ENG-3663 by spinning up RabbitMQ and wiring the app to it.

- **New Features**
  - Start RabbitMQ service in GitHub Actions (port 5672).
  - Set NUQ_RABBITMQ_URL to amqp://localhost:5672 for the test job.

<!-- End of auto-generated description by cubic. -->

