### PR TITLE
feat(crawl): implement URL modification handling in crawl controller

### DIFF
--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -14,12 +14,17 @@ import { generateCrawlerOptionsFromPrompt } from "../../scraper/scrapeURL/transf
 import { CostTracking } from "../../lib/cost-tracking";
 import { checkPermissions } from "../../lib/permissions";
 import { buildPromptWithWebsiteStructure } from "../../lib/map-utils";
+import { modifyCrawlUrl } from "../../utils/url-utils";
 
 export async function crawlController(
   req: RequestWithAuth<{}, CrawlResponse, CrawlRequest>,
   res: Response<CrawlResponse>,
 ) {
   const preNormalizedBody = req.body;
+
+  // Check for URL modification before parsing
+  const urlModificationInfo = modifyCrawlUrl(preNormalizedBody.url);
+
   req.body = crawlRequestSchema.parse(req.body);
 
   const permissions = checkPermissions(req.body, req.acuc?.flags);
@@ -219,6 +224,9 @@ export async function crawlController(
     success: true,
     id,
     url: `${protocol}://${req.get("host")}/v2/crawl/${id}`,
+    ...(urlModificationInfo.wasModified && {
+      warning: `The URL you provided included a '/*' suffix, which has been removed to ensure a more targeted and efficient crawl.`,
+    }),
     ...(req.body.prompt && {
       promptGeneratedOptions: promptGeneratedOptions,
       finalCrawlerOptions: finalCrawlerOptions,

--- a/apps/api/src/utils/url-utils.ts
+++ b/apps/api/src/utils/url-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Utility functions for URL handling and modification
+ */
+
+/**
+ * Modifies a crawl URL by stripping the /* suffix if present
+ * @param url - The URL to potentially modify
+ * @returns Object containing the modified URL, modification flag, and original URL
+ */
+export function modifyCrawlUrl(url: string): {
+  url: string;
+  wasModified: boolean;
+  originalUrl: string;
+} {
+  if (url.endsWith("/*")) {
+    return {
+      url: url.slice(0, -2),
+      wasModified: true,
+      originalUrl: url,
+    };
+  }
+  return {
+    url: url,
+    wasModified: false,
+    originalUrl: url,
+  };
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Strip trailing "/*" from crawl URLs for a more targeted crawl. Return a clear warning in the response when this happens.

- **New Features**
  - Automatically remove trailing "/*" from crawl URLs.
  - Return a warning in CrawlResponse when the URL was modified.
  - Added modifyCrawlUrl utility and applied it via a CRAWL_URL schema transform (only for crawl requests).

- **Refactors**
  - Centralized URL validation in BASE_URL_SCHEMA and replaced usages with URL in other schemas.
  - Updated CrawlResponse types to include optional warning.
  - Scoped dedupeMapDocumentArray and queryIndex in map-utils to internal use.

<!-- End of auto-generated description by cubic. -->

