### PR TITLE
Add missing metadata fields to JS SDK (ENG-3439)

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -1,17 +1,17 @@
-import type { ZodTypeAny } from "zod";
+import type { ZodTypeAny } from 'zod';
 // Public types for Firecrawl JS/TS SDK v2 (camelCase only)
 
 export type FormatString =
-  | "markdown"
-  | "html"
-  | "rawHtml"
-  | "links"
-  | "images"
-  | "screenshot"
-  | "summary"
-  | "changeTracking"
-  | "json"
-  | "attributes";
+  | 'markdown'
+  | 'html'
+  | 'rawHtml'
+  | 'links'
+  | 'images'
+  | 'screenshot'
+  | 'summary'
+  | 'changeTracking'
+  | 'json'
+  | 'attributes';
 
 export interface Viewport {
   width: number;
@@ -23,27 +23,27 @@ export interface Format {
 }
 
 export interface JsonFormat extends Format {
-  type: "json";
+  type: 'json';
   prompt?: string;
   schema?: Record<string, unknown> | ZodTypeAny;
 }
 
 export interface ScreenshotFormat {
-  type: "screenshot";
+  type: 'screenshot';
   fullPage?: boolean;
   quality?: number;
   viewport?: Viewport | { width: number; height: number };
 }
 
 export interface ChangeTrackingFormat extends Format {
-  type: "changeTracking";
-  modes: ("git-diff" | "json")[];
+  type: 'changeTracking';
+  modes: ('git-diff' | 'json')[];
   schema?: Record<string, unknown>;
   prompt?: string;
   tag?: string;
 }
 export interface AttributesFormat extends Format {
-  type: "attributes";
+  type: 'attributes';
   selectors: Array<{
     selector: string;
     attribute: string;
@@ -64,51 +64,62 @@ export interface LocationConfig {
 }
 
 export interface WaitAction {
-  type: "wait";
+  type: 'wait';
   milliseconds?: number;
   selector?: string;
 }
 
 export interface ScreenshotAction {
-  type: "screenshot";
+  type: 'screenshot';
   fullPage?: boolean;
   quality?: number;
   viewport?: Viewport | { width: number; height: number };
 }
 
 export interface ClickAction {
-  type: "click";
+  type: 'click';
   selector: string;
 }
 
 export interface WriteAction {
-  type: "write";
+  type: 'write';
   text: string;
 }
 
 export interface PressAction {
-  type: "press";
+  type: 'press';
   key: string;
 }
 
 export interface ScrollAction {
-  type: "scroll";
-  direction: "up" | "down";
+  type: 'scroll';
+  direction: 'up' | 'down';
   selector?: string;
 }
 
 export interface ScrapeAction {
-  type: "scrape";
+  type: 'scrape';
 }
 
 export interface ExecuteJavascriptAction {
-  type: "executeJavascript";
+  type: 'executeJavascript';
   script: string;
 }
 
 export interface PDFAction {
-  type: "pdf";
-  format?: "A0" | "A1" | "A2" | "A3" | "A4" | "A5" | "A6" | "Letter" | "Legal" | "Tabloid" | "Ledger";
+  type: 'pdf';
+  format?:
+    | 'A0'
+    | 'A1'
+    | 'A2'
+    | 'A3'
+    | 'A4'
+    | 'A5'
+    | 'A6'
+    | 'Letter'
+    | 'Legal'
+    | 'Tabloid'
+    | 'Ledger';
   landscape?: boolean;
   scale?: number;
 }
@@ -133,7 +144,7 @@ export interface ScrapeOptions {
   timeout?: number;
   waitFor?: number;
   mobile?: boolean;
-  parsers?: Array<string | { type: "pdf"; maxPages?: number }>;
+  parsers?: Array<string | { type: 'pdf'; maxPages?: number }>;
   actions?: ActionOption[];
   location?: LocationConfig;
   skipTlsVerification?: boolean;
@@ -141,7 +152,7 @@ export interface ScrapeOptions {
   fastMode?: boolean;
   useMock?: string;
   blockAds?: boolean;
-  proxy?: "basic" | "stealth" | "auto" | string;
+  proxy?: 'basic' | 'stealth' | 'auto' | string;
   maxAge?: number;
   storeInCache?: boolean;
   integration?: string;
@@ -151,22 +162,62 @@ export interface WebhookConfig {
   url: string;
   headers?: Record<string, string>;
   metadata?: Record<string, string>;
-  events?: Array<"completed" | "failed" | "page" | "started">;
+  events?: Array<'completed' | 'failed' | 'page' | 'started'>;
 }
 
 export interface DocumentMetadata {
+  // Common metadata fields
   title?: string;
   description?: string;
+  url?: string;
   language?: string;
   keywords?: string | string[];
   robots?: string;
+
+  // OpenGraph and social metadata
   ogTitle?: string;
   ogDescription?: string;
   ogUrl?: string;
   ogImage?: string;
+  ogAudio?: string;
+  ogDeterminer?: string;
+  ogLocale?: string;
+  ogLocaleAlternate?: string[];
+  ogSiteName?: string;
+  ogVideo?: string;
+
+  // Dublin Core and other site metadata
+  favicon?: string;
+  dcTermsCreated?: string;
+  dcDateCreated?: string;
+  dcDate?: string;
+  dcTermsType?: string;
+  dcType?: string;
+  dcTermsAudience?: string;
+  dcTermsSubject?: string;
+  dcSubject?: string;
+  dcDescription?: string;
+  dcTermsKeywords?: string;
+
+  modifiedTime?: string;
+  publishedTime?: string;
+  articleTag?: string;
+  articleSection?: string;
+
+  // Response-level metadata
   sourceURL?: string;
   statusCode?: number;
+  scrapeId?: string;
+  numPages?: number;
+  contentType?: string;
+  proxyUsed?: 'basic' | 'stealth';
+  cacheState?: 'hit' | 'miss';
+  cachedAt?: string;
+  creditsUsed?: number;
+
+  // Error information
   error?: string;
+
   [key: string]: unknown;
 }
 
@@ -235,13 +286,15 @@ export interface SearchData {
 }
 
 export interface CategoryOption {
-  type: "github" | "research";
+  type: 'github' | 'research';
 }
 
 export interface SearchRequest {
   query: string;
-  sources?: Array<"web" | "news" | "images" | { type: "web" | "news" | "images" }>;
-  categories?: Array<"github" | "research" | CategoryOption>;
+  sources?: Array<
+    'web' | 'news' | 'images' | { type: 'web' | 'news' | 'images' }
+  >;
+  categories?: Array<'github' | 'research' | CategoryOption>;
   limit?: number;
   tbs?: string;
   location?: string;
@@ -256,7 +309,7 @@ export interface CrawlOptions {
   excludePaths?: string[] | null;
   includePaths?: string[] | null;
   maxDiscoveryDepth?: number | null;
-  sitemap?: "skip" | "include";
+  sitemap?: 'skip' | 'include';
   ignoreQueryParameters?: boolean;
   limit?: number | null;
   crawlEntireDomain?: boolean;
@@ -276,7 +329,7 @@ export interface CrawlResponse {
 }
 
 export interface CrawlJob {
-  status: "scraping" | "completed" | "failed" | "cancelled";
+  status: 'scraping' | 'completed' | 'failed' | 'cancelled';
   total: number;
   completed: number;
   creditsUsed?: number;
@@ -303,7 +356,7 @@ export interface BatchScrapeResponse {
 }
 
 export interface BatchScrapeJob {
-  status: "scraping" | "completed" | "failed" | "cancelled";
+  status: 'scraping' | 'completed' | 'failed' | 'cancelled';
   completed: number;
   total: number;
   creditsUsed?: number;
@@ -318,7 +371,7 @@ export interface MapData {
 
 export interface MapOptions {
   search?: string;
-  sitemap?: "only" | "include" | "skip";
+  sitemap?: 'only' | 'include' | 'skip';
   includeSubdomains?: boolean;
   limit?: number;
   timeout?: number;
@@ -329,7 +382,7 @@ export interface MapOptions {
 export interface ExtractResponse {
   success?: boolean;
   id?: string;
-  status?: "processing" | "completed" | "failed" | "cancelled";
+  status?: 'processing' | 'completed' | 'failed' | 'cancelled';
   data?: unknown;
   error?: string;
   warning?: string;
@@ -338,7 +391,7 @@ export interface ExtractResponse {
 }
 
 export interface AgentOptions {
-  model: "FIRE-1";
+  model: 'FIRE-1';
 }
 
 export interface ConcurrencyCheck {
@@ -418,9 +471,14 @@ export class SdkError extends Error {
   status?: number;
   code?: string;
   details?: unknown;
-  constructor(message: string, status?: number, code?: string, details?: unknown) {
+  constructor(
+    message: string,
+    status?: number,
+    code?: string,
+    details?: unknown
+  ) {
     super(message);
-    this.name = "FirecrawlSdkError";
+    this.name = 'FirecrawlSdkError';
     this.status = status;
     this.code = code;
     this.details = details;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds missing document metadata fields to the Firecrawl JS SDK v2 to match the Python SDK, improving type coverage for scrape results. Also updates the dev harness to run the extract worker and cleans up logs. Addresses Linear ENG-3439.

- **New Features**
  - Expanded DocumentMetadata (OpenGraph, Dublin Core, response-level fields like cacheState, cachedAt, creditsUsed, proxyUsed, scrapeId, numPages).
  - Bumped @mendable/firecrawl-js to 4.3.8.

- **Refactors**
  - Harness: add extract-worker scripts/port, adjust process colors, widen labels, reduce noisy logs.
  - map-utils: make helper functions internal (no export) and minor formatting.

<!-- End of auto-generated description by cubic. -->

