### PR TITLE
feat: Add JSON format to Youtube Transcript

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -131,6 +131,7 @@ export type EngineScrapeResult = {
   postprocessorsUsed?: string[];
 
   proxyUsed: "basic" | "stealth";
+  json?: any;
 };
 
 const engineHandlers: {

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -691,8 +691,13 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
       }
     }
 
+    const wantsJson =
+      hasFormatOfType(meta.options.formats, "json") !== undefined ||
+      meta.internalOptions.v1OriginalFormat === "json";
+
     let document: Document = {
       markdown: engineResult.markdown,
+      json: wantsJson ? engineResult.json : undefined,
       rawHtml: engineResult.html,
       screenshot: engineResult.screenshot,
       actions: engineResult.actions,

--- a/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
@@ -44,7 +44,8 @@ export const youtubePostprocessor: Postprocessor = {
       initialData.endscreen?.endscreenRenderer?.elements || []
     ).filter(x => x.endscreenElementRenderer?.style === "VIDEO");
 
-    let preferredCaptionMarkdown = "";
+    let transcriptMarkdown = "";
+    let transcriptText: string | undefined;
 
     if (engineResult.youtubeTranscriptContent) {
       const initialSegments =
@@ -52,27 +53,110 @@ export const youtubePostprocessor: Postprocessor = {
           ?.updateEngagementPanelAction?.content?.transcriptRenderer?.content
           ?.transcriptSearchPanelRenderer?.body?.transcriptSegmentListRenderer
           ?.initialSegments ?? [];
-      const transcriptText = (
-        Array.isArray(initialSegments) ? initialSegments : []
-      )
+      transcriptText = (Array.isArray(initialSegments) ? initialSegments : [])
         .map(x => x?.transcriptSegmentRenderer?.snippet?.runs?.[0]?.text)
         .filter(Boolean)
         .join(" ");
-      preferredCaptionMarkdown = `## Transcript
+      transcriptMarkdown = `## Transcript
 
 ${transcriptText}
 `;
     }
 
-    const markdown = `\
+    const endscreenLinks = endscreen
+      .map(element => {
+        const renderer = element.endscreenElementRenderer;
+        if (!renderer) {
+          return undefined;
+        }
+
+        const title =
+          renderer.title?.simpleText ??
+          renderer.title?.runs?.map(run => run.text).join("");
+        const urlPath =
+          renderer.endpoint?.commandMetadata?.webCommandMetadata?.url;
+
+        if (!title || !urlPath) {
+          return undefined;
+        }
+
+        const thumbnail = renderer.thumbnail?.thumbnails?.slice(-1)?.[0];
+
+        return {
+          title,
+          url: new URL(urlPath, engineResult.url).toString(),
+          ...(thumbnail
+            ? {
+                thumbnail: {
+                  url: thumbnail.url,
+                  width: thumbnail.width,
+                  height: thumbnail.height,
+                },
+              }
+            : {}),
+        };
+      })
+      .filter(
+        (
+          value,
+        ): value is {
+          title: string;
+          url: string;
+          thumbnail?: { url: string; width: number; height: number };
+        } => value !== undefined,
+      );
+
+    const visibility = initialData.videoDetails.isPrivate
+      ? "Private"
+      : initialData.microformat.playerMicroformatRenderer.isUnlisted
+        ? "Unlisted"
+        : "Public";
+
+    const formattedLength = `${
+      lengthHours > 0 ? `${lengthHours.toString().padStart(2, "0")}:` : ""
+    }${lengthMinutes.toString().padStart(2, "0")}:${lengthTrueSeconds
+      .toString()
+      .padStart(2, "0")}`;
+
+    const json = {
+      title: initialData.videoDetails.title,
+      url: initialData.microformat.playerMicroformatRenderer.canonicalUrl,
+      visibility,
+      channel: {
+        name: initialData.videoDetails.author,
+        url: initialData.microformat.playerMicroformatRenderer.ownerProfileUrl,
+      },
+      uploadedAt: initialData.microformat.playerMicroformatRenderer.uploadDate,
+      publishedAt:
+        initialData.microformat.playerMicroformatRenderer.publishDate,
+      duration: {
+        seconds: lengthSeconds,
+        formatted: formattedLength,
+      },
+      stats: {
+        views: initialData.videoDetails.viewCount,
+        likes: initialData.microformat.playerMicroformatRenderer.likeCount,
+      },
+      category: initialData.microformat.playerMicroformatRenderer.category,
+      description: initialData.videoDetails.shortDescription,
+      thumbnail: {
+        url: largestThumbnail.url,
+        width: largestThumbnail.width,
+        height: largestThumbnail.height,
+      },
+      transcript: transcriptText,
+      endscreen: endscreenLinks,
+    };
+
+    const markdown = `
 ![Thumbnail (${largestThumbnail.width}x${largestThumbnail.height})](${largestThumbnail.url})
 # [${initialData.videoDetails.title}](${initialData.microformat.playerMicroformatRenderer.canonicalUrl})
 
-**Visibility**: ${initialData.videoDetails.isPrivate ? "Private" : initialData.microformat.playerMicroformatRenderer.isUnlisted ? "Unlisted" : "Public"}
+**Visibility**: ${visibility}
 **Uploaded by**: [${initialData.videoDetails.author}](${initialData.microformat.playerMicroformatRenderer.ownerProfileUrl})
 **Uploaded at**: ${initialData.microformat.playerMicroformatRenderer.uploadDate}
 **Published at**: ${initialData.microformat.playerMicroformatRenderer.publishDate}
-**Length**: ${lengthHours > 0 ? `${lengthHours.toString().padStart(2, "0")}:` : ""}${lengthMinutes.toString().padStart(2, "0")}:${lengthTrueSeconds.toString().padStart(2, "0")}
+**Length**: ${formattedLength}
 **Views**: ${initialData.videoDetails.viewCount}
 **Likes**: ${initialData.microformat.playerMicroformatRenderer.likeCount}
 **Category**: ${initialData.microformat.playerMicroformatRenderer.category}
@@ -83,18 +167,26 @@ ${transcriptText}
 ${initialData.videoDetails.shortDescription}
 \`\`\`
 
-${preferredCaptionMarkdown ? preferredCaptionMarkdown + "\n\n" : ""}\
-${
-  endscreen.length > 0
-    ? `## Endscreen
-    
-${endscreen.map(element => `- [${element.endscreenElementRenderer.title.simpleText}](${new URL(element.endscreenElementRenderer.endpoint.commandMetadata.webCommandMetadata.url, engineResult.url).toString()})`).join("\n")}`
-    : ""
-}`;
+${transcriptMarkdown ? transcriptMarkdown + "\n\n" : ""}${
+      endscreen.length > 0
+        ? `## Endscreen
+
+${endscreen
+  .map(
+    element =>
+      `- [${element.endscreenElementRenderer.title.simpleText}](${new URL(
+        element.endscreenElementRenderer.endpoint.commandMetadata.webCommandMetadata.url,
+        engineResult.url,
+      ).toString()})`,
+  )
+  .join("\n")}`
+        : ""
+    }`;
 
     return {
       ...engineResult,
       markdown,
+      json,
       postprocessorsUsed: [
         ...(engineResult.postprocessorsUsed ?? []),
         "youtube",


### PR DESCRIPTION
Add JSON format to Youtube Transcript.

This can't be tested locally since fire engine is required, but code is a bit straightforward.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds structured JSON output for YouTube scrapes so clients can request and consume transcript and video metadata without parsing markdown. This enables a “json” format for scrape results.

- **New Features**
  - YouTube postprocessor builds a JSON payload with title, URL, visibility, channel, dates, duration, stats, category, description, thumbnail, transcript text, and endscreen links.
  - EngineScrapeResult now supports a json field; scrapeURL returns json when the requested format includes “json” or v1OriginalFormat is “json”.
  - Markdown updated to use formatted duration and optional transcript section.

<!-- End of auto-generated description by cubic. -->

