### PR TITLE
Fix file leak in PDF engine temp file cleanup

### DIFF
--- a/apps/api/src/__tests__/snips/v2/parsers.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parsers.test.ts
@@ -4,6 +4,8 @@ import {
   TEST_SUITE_WEBSITE,
 } from "../lib";
 import { scrape, scrapeRaw, scrapeTimeout, idmux, Identity } from "./lib";
+import { promises as fs } from "fs";
+import os from "os";
 
 let identity: Identity;
 
@@ -18,6 +20,34 @@ beforeAll(async () => {
 describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
   const pdfUrl = `${TEST_SUITE_WEBSITE}/example.pdf`;
   const htmlUrl = TEST_SUITE_WEBSITE;
+  const fakePdfHtmlUrl = `${TEST_SUITE_WEBSITE}/not-a-pdf.pdf`;
+
+  async function listTempFilesForScrape(scrapeId: string): Promise<string[]> {
+    if (!scrapeId) {
+      throw new Error("scrapeId is required to inspect temp files");
+    }
+    const files = await fs.readdir(os.tmpdir());
+    return files.filter(file => file.startsWith(`tempFile-${scrapeId}`));
+  }
+
+  async function expectTempFilesCleaned(
+    scrapeId: string,
+    attempts = 5,
+    delayMs = 300,
+  ): Promise<void> {
+    for (let i = 0; i < attempts; i++) {
+      const leaked = await listTempFilesForScrape(scrapeId);
+      if (leaked.length === 0) {
+        return;
+      }
+      if (i < attempts - 1) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+
+    const leaked = await listTempFilesForScrape(scrapeId);
+    expect(leaked).toEqual([]);
+  }
 
   describe("Array format", () => {
     it.concurrent(
@@ -311,6 +341,71 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
         expect(response.metadata.numPages).toBe(1);
       },
       scrapeTimeout * 2,
+    );
+  });
+
+  describe("Temp file cleanup (memory leak regression)", () => {
+    it.concurrent(
+      "cleans up temp files after successful PDF parse",
+      async () => {
+        const response = await scrape(
+          {
+            url: pdfUrl,
+            parsers: ["pdf"],
+          },
+          identity,
+        );
+
+        expect(response.markdown).toBeDefined();
+        expect(response.markdown).toContain("PDF Test File");
+        expect(response.metadata.scrapeId).toBeDefined();
+
+        await expectTempFilesCleaned(response.metadata.scrapeId!);
+      },
+      scrapeTimeout * 2,
+    );
+
+    it.concurrent(
+      "cleans up temp files after PDF parse failure (non-PDF content)",
+      async () => {
+        const response = await scrape(
+          {
+            url: fakePdfHtmlUrl,
+            parsers: ["pdf"],
+          },
+          identity,
+        );
+
+        expect(response.markdown).toBeDefined();
+        expect(response.metadata.scrapeId).toBeDefined();
+
+        await expectTempFilesCleaned(response.metadata.scrapeId!);
+      },
+      scrapeTimeout * 2,
+    );
+
+    it.concurrent(
+      "cleans up temp files after multiple PDF operations",
+      async () => {
+        const scrapeIds: string[] = [];
+
+        for (let i = 0; i < 3; i++) {
+          const response = await scrape(
+            {
+              url: i === 1 ? fakePdfHtmlUrl : pdfUrl,
+              parsers: ["pdf"],
+            },
+            identity,
+          );
+          expect(response.metadata.scrapeId).toBeDefined();
+          scrapeIds.push(response.metadata.scrapeId!);
+        }
+
+        await Promise.all(
+          scrapeIds.map(scrapeId => expectTempFilesCleaned(scrapeId, 8, 250)),
+        );
+      },
+      scrapeTimeout * 6,
     );
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -297,125 +297,139 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           headers: meta.options.headers,
         });
 
-  if ((response as any).headers) {
-    // if downloadFile was used
-    const r: Response = response as any;
-    const ct = r.headers.get("Content-Type");
-    if (ct && !ct.includes("application/pdf")) {
-      // if downloaded file wasn't a PDF
-      if (meta.pdfPrefetch === undefined) {
-        // for non-PDF URLs, this is expected, not anti-bot
-        if (!meta.featureFlags.has("pdf")) {
-          throw new EngineUnsuccessfulError("pdf");
+  try {
+    if ((response as any).headers) {
+      // if downloadFile was used
+      const r: Response = response as any;
+      const ct = r.headers.get("Content-Type");
+      if (ct && !ct.includes("application/pdf")) {
+        // if downloaded file wasn't a PDF
+        if (meta.pdfPrefetch === undefined) {
+          // for non-PDF URLs, this is expected, not anti-bot
+          if (!meta.featureFlags.has("pdf")) {
+            throw new EngineUnsuccessfulError("pdf");
+          } else {
+            throw new PDFAntibotError();
+          }
         } else {
-          throw new PDFAntibotError();
+          throw new PDFPrefetchFailed();
         }
-      } else {
-        throw new PDFPrefetchFailed();
       }
     }
-  }
 
-  const pdfMetadata = await getPdfMetadata(tempFilePath);
-  const effectivePageCount = maxPages
-    ? Math.min(pdfMetadata.numPages, maxPages)
-    : pdfMetadata.numPages;
+    const pdfMetadata = await getPdfMetadata(tempFilePath);
+    const effectivePageCount = maxPages
+      ? Math.min(pdfMetadata.numPages, maxPages)
+      : pdfMetadata.numPages;
 
-  if (
-    effectivePageCount * MILLISECONDS_PER_PAGE >
-    (meta.abort.scrapeTimeout() ?? Infinity)
-  ) {
-    throw new PDFInsufficientTimeError(
-      effectivePageCount,
-      effectivePageCount * MILLISECONDS_PER_PAGE + 5000,
-    );
-  }
+    if (
+      effectivePageCount * MILLISECONDS_PER_PAGE >
+      (meta.abort.scrapeTimeout() ?? Infinity)
+    ) {
+      throw new PDFInsufficientTimeError(
+        effectivePageCount,
+        effectivePageCount * MILLISECONDS_PER_PAGE + 5000,
+      );
+    }
 
-  let result: PDFProcessorResult | null = null;
+    let result: PDFProcessorResult | null = null;
 
-  const base64Content = (await readFile(tempFilePath)).toString("base64");
+    const base64Content = (await readFile(tempFilePath)).toString("base64");
 
-  // First try RunPod MU if conditions are met
-  if (
-    base64Content.length < MAX_FILE_SIZE &&
-    process.env.RUNPOD_MU_API_KEY &&
-    process.env.RUNPOD_MU_POD_ID
-  ) {
-    const muV1StartedAt = Date.now();
-    try {
-      result = await scrapePDFWithRunPodMU(
+    // First try RunPod MU if conditions are met
+    if (
+      base64Content.length < MAX_FILE_SIZE &&
+      process.env.RUNPOD_MU_API_KEY &&
+      process.env.RUNPOD_MU_POD_ID
+    ) {
+      const muV1StartedAt = Date.now();
+      try {
+        result = await scrapePDFWithRunPodMU(
+          {
+            ...meta,
+            logger: meta.logger.child({
+              method: "scrapePDF/scrapePDFWithRunPodMU",
+            }),
+          },
+          tempFilePath,
+          base64Content,
+          maxPages,
+        );
+        const muV1DurationMs = Date.now() - muV1StartedAt;
+        meta.logger
+          .child({ method: "scrapePDF/MUv1Experiment" })
+          .info("MU v1 completed", {
+            durationMs: muV1DurationMs,
+            url: meta.rewrittenUrl ?? meta.url,
+            pages: effectivePageCount,
+            success: true,
+          });
+      } catch (error) {
+        if (
+          error instanceof RemoveFeatureError ||
+          error instanceof AbortManagerThrownError
+        ) {
+          throw error;
+        }
+        meta.logger.warn(
+          "RunPod MU failed to parse PDF (could be due to timeout) -- falling back to parse-pdf",
+          { error },
+        );
+        Sentry.captureException(error);
+        const muV1DurationMs = Date.now() - muV1StartedAt;
+        meta.logger
+          .child({ method: "scrapePDF/MUv1Experiment" })
+          .info("MU v1 failed", {
+            durationMs: muV1DurationMs,
+            url: meta.rewrittenUrl ?? meta.url,
+            pages: effectivePageCount,
+            success: false,
+          });
+      }
+    }
+
+    // If RunPod MU failed or wasn't attempted, use PdfParse
+    if (!result) {
+      result = await scrapePDFWithParsePDF(
         {
           ...meta,
           logger: meta.logger.child({
-            method: "scrapePDF/scrapePDFWithRunPodMU",
+            method: "scrapePDF/scrapePDFWithParsePDF",
           }),
         },
         tempFilePath,
-        base64Content,
-        maxPages,
       );
-      const muV1DurationMs = Date.now() - muV1StartedAt;
-      meta.logger
-        .child({ method: "scrapePDF/MUv1Experiment" })
-        .info("MU v1 completed", {
-          durationMs: muV1DurationMs,
-          url: meta.rewrittenUrl ?? meta.url,
-          pages: effectivePageCount,
-          success: true,
+    }
+
+    return {
+      url: response.url ?? meta.rewrittenUrl ?? meta.url,
+      statusCode: response.status,
+      html: result?.html ?? "",
+      markdown: result?.markdown ?? "",
+      pdfMetadata: {
+        // Rust parser gets the metadata incorrectly, so we overwrite the page count here with the effective page count
+        // TODO: fix this later
+        numPages: effectivePageCount,
+        title: pdfMetadata.title,
+      },
+
+      proxyUsed: "basic",
+    };
+  } finally {
+    // Clean up temporary file - ensures cleanup happens regardless of success or failure
+    // Unlike document engine, PDF engine always works with temp files (both prefetch and downloadFile paths)
+    if (tempFilePath) {
+      try {
+        await unlink(tempFilePath);
+      } catch (error) {
+        // Ignore errors when cleaning up temp files (e.g., file already deleted or doesn't exist)
+        meta.logger?.warn("Failed to clean up temporary PDF file", {
+          error,
+          tempFilePath,
         });
-    } catch (error) {
-      if (
-        error instanceof RemoveFeatureError ||
-        error instanceof AbortManagerThrownError
-      ) {
-        throw error;
       }
-      meta.logger.warn(
-        "RunPod MU failed to parse PDF (could be due to timeout) -- falling back to parse-pdf",
-        { error },
-      );
-      Sentry.captureException(error);
-      const muV1DurationMs = Date.now() - muV1StartedAt;
-      meta.logger
-        .child({ method: "scrapePDF/MUv1Experiment" })
-        .info("MU v1 failed", {
-          durationMs: muV1DurationMs,
-          url: meta.rewrittenUrl ?? meta.url,
-          pages: effectivePageCount,
-          success: false,
-        });
     }
   }
-
-  // If RunPod MU failed or wasn't attempted, use PdfParse
-  if (!result) {
-    result = await scrapePDFWithParsePDF(
-      {
-        ...meta,
-        logger: meta.logger.child({
-          method: "scrapePDF/scrapePDFWithParsePDF",
-        }),
-      },
-      tempFilePath,
-    );
-  }
-
-  await unlink(tempFilePath);
-
-  return {
-    url: response.url ?? meta.rewrittenUrl ?? meta.url,
-    statusCode: response.status,
-    html: result?.html ?? "",
-    markdown: result?.markdown ?? "",
-    pdfMetadata: {
-      // Rust parser gets the metadata incorrectly, so we overwrite the page count here with the effective page count
-      // TODO: fix this later
-      numPages: effectivePageCount,
-      title: pdfMetadata.title,
-    },
-
-    proxyUsed: "basic",
-  };
 }
 
 export function pdfMaxReasonableTime(meta: Meta): number {


### PR DESCRIPTION
## Summary
Fixes a critical file leak where temporary PDF files were not cleaned up when errors occurred during PDF processing, causing disk space exhaustion.

## Problem
The PDF engine (`apps/api/src/scraper/scrapeURL/engines/pdf/index.ts`) created temporary files in `/tmp` but only cleaned them up on the success path. When errors occurred (non-PDF content, parsing failures, timeouts), these files were orphaned, leading to disk space exhaustion over time.

### Root Cause
- Line 296: `downloadFile()` creates temp files in `/tmp/tempFile-{id}--{uuid}`
- Lines 309-314, 328: Multiple error paths that throw without cleanup
- Line 403: `await unlink(tempFilePath)` only reached on success
- No try/finally block to ensure cleanup

## Solution
Wrapped PDF processing code in a `try/finally` block following the same pattern used in the document engine:
- Cleanup always runs regardless of success or failure
- Simplified condition to `if (tempFilePath)` covering both:
  - Files created by `downloadFile()` (the common leak scenario)
  - Files from `pdfPrefetch` (prefetched files)
- Error handling in cleanup logs warnings without masking original errors

## Changes
- `apps/api/src/scraper/scrapeURL/engines/pdf/index.ts`: Added try/finally block for guaranteed cleanup
- `apps/api/src/__tests__/snips/v2/parsers.test.ts`: Added regression tests for temp file cleanup

## Tests
Added E2E tests to verify:
1. ✅ Temp files cleaned up after successful PDF parse
2. ✅ Temp files cleaned up after PDF parse failures (non-PDF content)
3. ✅ No file accumulation over multiple operations (the actual leak scenario)

Tests use `scrapeId` tracking for precise validation without race conditions.

## Impact
- **Before**: Temp files accumulated indefinitely on error paths
- **After**: All temp files cleaned up regardless of success/failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical temp file leak in the PDF engine by guaranteeing cleanup on all paths. Prevents disk space exhaustion during mixed-content crawls and failed parses.

- **Bug Fixes**
  - Wrapped PDF processing in a try/finally to always unlink the temp file.
  - Cleanup runs when tempFilePath exists, covering both downloadFile and pdfPrefetch paths.
  - Added regression tests to confirm cleanup after successful parses, failures (non-PDF), and multiple operations.

<sup>Written for commit f0c31ed4380d37b3c0e979abb8ce5fe3f5c6991b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

