### PR TITLE
Add DISABLE_CRAWL and DISABLE_MAP environment variables

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -80,6 +80,10 @@ USE_DB_AUTHENTICATION=false
 
 ## === Other ===
 
+# Disable crawl or map endpoints entirely (set to "true" to turn off)
+# DISABLE_CRAWL=false
+# DISABLE_MAP=false
+
 # Supabase Setup (used to support DB authentication, advanced logging, etc.)
 # SUPABASE_ANON_TOKEN=
 # SUPABASE_URL=

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,6 +37,10 @@ SUPABASE_ANON_TOKEN=
 SUPABASE_URL=
 SUPABASE_SERVICE_TOKEN=
 
+# Disable crawl/map endpoints at the router level
+DISABLE_CRAWL=false
+DISABLE_MAP=false
+
 # Other Optionals
 # use if you've set up authentication and want to test with a real API key
 TEST_API_KEY=

--- a/apps/api/src/controllers/__tests__/feature-flags.test.ts
+++ b/apps/api/src/controllers/__tests__/feature-flags.test.ts
@@ -1,0 +1,66 @@
+import { vi } from "vitest";
+import { crawlController as crawlControllerV2 } from "../v2/crawl";
+import { mapController as mapControllerV2 } from "../v2/map";
+
+const originalCrawlEnv = process.env.DISABLE_CRAWL;
+const originalMapEnv = process.env.DISABLE_MAP;
+
+const resetEnv = (key: "DISABLE_CRAWL" | "DISABLE_MAP", value: string | undefined) => {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+};
+
+const mockResponse = () => {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+};
+
+const baseAuth = { team_id: "team" };
+
+describe("feature disable flags", () => {
+  afterEach(() => {
+    resetEnv("DISABLE_CRAWL", originalCrawlEnv);
+    resetEnv("DISABLE_MAP", originalMapEnv);
+  });
+
+  it("returns 403 for crawl when DISABLE_CRAWL is true", async () => {
+    process.env.DISABLE_CRAWL = "true";
+    const req: any = {
+      body: { url: "https://example.com" },
+      auth: baseAuth,
+      acuc: undefined,
+      account: { remainingCredits: 1 },
+    };
+    const res = mockResponse();
+
+    await crawlControllerV2(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+
+  it("returns 403 for map when DISABLE_MAP is true", async () => {
+    process.env.DISABLE_MAP = "true";
+    const req: any = {
+      body: { url: "https://example.com" },
+      auth: baseAuth,
+      acuc: undefined,
+      account: { remainingCredits: 1 },
+    };
+    const res = mockResponse();
+
+    await mapControllerV2(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+});

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -24,11 +24,19 @@ import {
 } from "../../services/worker/nuq-router";
 import { logRequest } from "../../services/logging/log_job";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
+import {
+  featureDisabledBody,
+  isCrawlDisabled,
+} from "../../lib/feature-flags";
 
 export async function crawlController(
   req: RequestWithAuth<{}, CrawlResponse, CrawlRequest>,
   res: Response<CrawlResponse>,
 ) {
+  if (isCrawlDisabled()) {
+    return res.status(403).json(featureDisabledBody("crawl"));
+  }
+
   const preNormalizedBody = req.body;
   req.body = crawlRequestSchema.parse(req.body);
 

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -31,6 +31,10 @@ import {
 import { MapTimeoutError } from "../../lib/error";
 import { checkPermissions } from "../../lib/permissions";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
+import {
+  featureDisabledBody,
+  isMapDisabled,
+} from "../../lib/feature-flags";
 
 configDotenv();
 const redis = new Redis(config.REDIS_URL!);
@@ -363,6 +367,10 @@ export async function mapController(
   req: RequestWithAuth<{}, MapResponse, MapRequest>,
   res: Response<MapResponse>,
 ) {
+  if (isMapDisabled()) {
+    return res.status(403).json(featureDisabledBody("map"));
+  }
+
   // Get timing data from middleware (includes all middleware processing time)
   const middlewareStartTime =
     (req as any).requestTiming?.startTime || new Date().getTime();

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -26,11 +26,19 @@ import {
 } from "../../services/worker/nuq-router";
 import { logRequest } from "../../services/logging/log_job";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
+import {
+  featureDisabledBody,
+  isCrawlDisabled,
+} from "../../lib/feature-flags";
 
 export async function crawlController(
   req: RequestWithAuth<{}, CrawlResponse, CrawlRequest>,
   res: Response<CrawlResponse>,
 ) {
+  if (isCrawlDisabled()) {
+    return res.status(403).json(featureDisabledBody("crawl"));
+  }
+
   const preNormalizedBody = req.body;
   req.body = crawlRequestSchema.parse(req.body);
 

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -16,6 +16,10 @@ import { v7 as uuidv7 } from "uuid";
 import { isBaseDomain, extractBaseDomain } from "../../lib/url-utils";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 import { resolveViaAvgrab } from "../../lib/avgrab-resolve";
+import {
+  featureDisabledBody,
+  isMapDisabled,
+} from "../../lib/feature-flags";
 
 configDotenv();
 
@@ -23,6 +27,10 @@ export async function mapController(
   req: RequestWithAuth<{}, MapResponse, MapRequest>,
   res: Response<MapResponse>,
 ) {
+  if (isMapDisabled()) {
+    return res.status(403).json(featureDisabledBody("map"));
+  }
+
   const logger = _logger.child({
     jobId: uuidv7(),
     teamId: req.auth.team_id,

--- a/apps/api/src/lib/feature-flags.ts
+++ b/apps/api/src/lib/feature-flags.ts
@@ -1,0 +1,27 @@
+type DisableableFeature = "crawl" | "map";
+
+const TRUE_STRING = "true";
+
+const featureNames: Record<DisableableFeature, string> = {
+  crawl: "Crawl",
+  map: "Map",
+};
+
+function isEnvToggleEnabled(name: string): boolean {
+  return process.env[name]?.toLowerCase() === TRUE_STRING;
+}
+
+export function isCrawlDisabled(): boolean {
+  return isEnvToggleEnabled("DISABLE_CRAWL");
+}
+
+export function isMapDisabled(): boolean {
+  return isEnvToggleEnabled("DISABLE_MAP");
+}
+
+export function featureDisabledBody(feature: DisableableFeature) {
+  return {
+    success: false as const,
+    error: `${featureNames[feature]} endpoint disabled by server configuration`,
+  };
+}

--- a/apps/api/src/routes/v1.ts
+++ b/apps/api/src/routes/v1.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { RequestHandler } from "express";
 import { config } from "../config";
 import { crawlController } from "../controllers/v1/crawl";
 // import { crawlStatusController } from "../../src/controllers/v1/crawl-status";
@@ -48,6 +48,11 @@ import {
   isX402Enabled,
 } from "../lib/x402";
 import { deprecationMiddleware } from "../lib/deprecations";
+import {
+  featureDisabledBody,
+  isCrawlDisabled,
+  isMapDisabled,
+} from "../lib/feature-flags";
 
 expressWs(express());
 
@@ -121,6 +126,20 @@ v1Router.use(requestTimingMiddleware("v1"));
 //     facilitator,
 //   ),
 // );
+
+const crawlDisabledHandler: RequestHandler = (_req, res) =>
+  res.status(403).json(featureDisabledBody("crawl"));
+
+const mapDisabledHandler: RequestHandler = (_req, res) =>
+  res.status(403).json(featureDisabledBody("map"));
+
+if (isCrawlDisabled()) {
+  v1Router.use("/crawl", crawlDisabledHandler);
+}
+
+if (isMapDisabled()) {
+  v1Router.use("/map", mapDisabledHandler);
+}
 
 v1Router.post(
   "/scrape",

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { RequestHandler } from "express";
 import multer from "multer";
 import { config } from "../config";
 import { RateLimiterMode } from "../types";
@@ -79,6 +79,11 @@ import {
   unsubscribeMonitorEmailController,
   updateMonitorController,
 } from "../controllers/v2/monitor";
+import {
+  featureDisabledBody,
+  isCrawlDisabled,
+  isMapDisabled,
+} from "../lib/feature-flags";
 
 expressWs(express());
 
@@ -236,6 +241,20 @@ v2Router.use(requestTimingMiddleware("v2"));
 // Internal: trusted-proxy (hosted MCP) keyless eligibility probe. Secret-gated
 // inside the controller; no auth middleware.
 v2Router.get("/keyless/eligibility", wrap(keylessEligibilityController));
+
+const crawlDisabledHandler: RequestHandler = (_req, res) =>
+  res.status(403).json(featureDisabledBody("crawl"));
+
+const mapDisabledHandler: RequestHandler = (_req, res) =>
+  res.status(403).json(featureDisabledBody("map"));
+
+if (isCrawlDisabled()) {
+  v2Router.use("/crawl", crawlDisabledHandler);
+}
+
+if (isMapDisabled()) {
+  v2Router.use("/map", mapDisabledHandler);
+}
 
 v2Router.post(
   "/search",


### PR DESCRIPTION
## Summary
Adds two environment variables to allow self-hosted administrators to disable crawl and map endpoints at runtime without code changes.

## Problem
Self-hosted installations may want to restrict functionality to specific operations (e.g., only scraping). Currently, there's no way to disable crawl or map endpoints without modifying code or routing infrastructure.

## Solution
Added two environment variables that disable endpoints when set to `true`:
- `DISABLE_CRAWL` - Disables all crawl-related endpoints
- `DISABLE_MAP` - Disables all map-related endpoints

Both default to `false` (endpoints enabled).

## Implementation

### Router-level middleware
- Intercepts requests to crawl/map paths early
- Returns HTTP 403 Forbidden with descriptive error message
- Prevents unnecessary processing

### Controller-level checks (defense in depth)
- Validates flags before processing requests
- Prevents programmatic access bypassing routes
- Consistent behavior across v1 and v2 APIs

### Affected endpoints
**DISABLE_CRAWL covers:**
- `/v1/crawl`, `/v2/crawl`
- `/v2/crawl/:id`, `/v2/crawl/:id/cancel`
- `/v2/crawl-status-ws`, `/v2/crawl-errors`
- All crawl status/preview/cancel/ongoing endpoints

**DISABLE_MAP covers:**
- `/v1/map`, `/v2/map`
- All map-related endpoints in both versions

## Changes
- `apps/api/src/lib/feature-flags.ts` - Helper functions for checking flags
- `apps/api/src/routes/v1.ts` - Middleware for v1 endpoints
- `apps/api/src/routes/v2.ts` - Middleware for v2 endpoints
- `apps/api/src/controllers/v1/crawl.ts` - Controller-level check
- `apps/api/src/controllers/v1/map.ts` - Controller-level check
- `apps/api/src/controllers/v2/crawl.ts` - Controller-level check
- `apps/api/src/controllers/v2/map.ts` - Controller-level check
- `SELF_HOST.md` - Documentation for new env vars
- `apps/api/.env.example` - Example configuration
- `apps/api/src/controllers/__tests__/feature-flags.test.ts` - Tests

## Use Cases
- Self-hosted installations that only need scraping functionality
- Preventing accidental crawl/map operations
- Installation-specific feature restrictions
- Resource management for constrained environments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `DISABLE_CRAWL` and `DISABLE_MAP` env flags so self-hosted admins can turn off crawl and map endpoints at runtime. Works for v1 and v2 and blocks requests early with 403 and a clear message.

- **New Features**
  - Router-level guards return 403 with a clear “endpoint disabled by server configuration” message.
  - Controller checks add defense in depth across v1 and v2.
  - Docs updated in `SELF_HOST.md` and `.env.example`.
  - Tests added for flag behavior.

- **Migration**
  - Set `DISABLE_CRAWL=true` or `DISABLE_MAP=true` to disable the endpoints.
  - Defaults are `false`; no changes needed if you want them enabled.

<sup>Written for commit f6bd8a049c6fd97e3055c749b7ba75761aa38359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

