### PR TITLE
Fix failed extract jobs stuck in processing

### DIFF
--- a/apps/api/src/controllers/__tests__/extract-status-controller.test.ts
+++ b/apps/api/src/controllers/__tests__/extract-status-controller.test.ts
@@ -1,0 +1,83 @@
+import { extractStatusController } from "../v2/extract-status";
+import { getExtract, getExtractExpiry } from "../../lib/extract/extract-redis";
+import { getExtractQueue } from "../../services/queue-service";
+import { supabaseGetJobByIdDirect } from "../../lib/supabase-jobs";
+
+jest.mock("../../lib/extract/extract-redis", () => ({
+  getExtract: jest.fn(),
+  getExtractExpiry: jest.fn(),
+}));
+
+jest.mock("../../services/queue-service", () => ({
+  getExtractQueue: jest.fn().mockReturnValue({
+    getJob: jest.fn(),
+  }),
+}));
+
+jest.mock("../../lib/supabase-jobs", () => ({
+  supabaseGetJobByIdDirect: jest.fn(),
+}));
+
+const mockGetExtract = getExtract as jest.MockedFunction<typeof getExtract>;
+const mockGetExtractExpiry = getExtractExpiry as jest.MockedFunction<
+  typeof getExtractExpiry
+>;
+const mockGetExtractQueue = getExtractQueue as jest.MockedFunction<
+  typeof getExtractQueue
+>;
+const mockSupabaseGetJobByIdDirect =
+  supabaseGetJobByIdDirect as jest.MockedFunction<
+    typeof supabaseGetJobByIdDirect
+  >;
+
+const createMockResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+  return res;
+};
+
+describe("extractStatusController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns failed status when redis record is marked failed", async () => {
+    const extractId = "extract-123";
+    const teamId = "team-1";
+    const errorMessage = "All provided URLs are invalid.";
+    const expiresAt = new Date("2025-01-01T00:00:00.000Z");
+
+    mockGetExtract.mockResolvedValue({
+      id: extractId,
+      team_id: teamId,
+      status: "failed",
+      error: errorMessage,
+    } as any);
+    mockGetExtractExpiry.mockResolvedValue(expiresAt);
+
+    const req = {
+      params: { jobId: extractId },
+      auth: { team_id: teamId },
+    } as any;
+    const res = createMockResponse();
+
+    await extractStatusController(req, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        status: "failed",
+        error: errorMessage,
+        data: [],
+        expiresAt: expiresAt.toISOString(),
+      }),
+    );
+    expect(mockGetExtract).toHaveBeenCalledWith(extractId);
+    expect(mockGetExtractExpiry).toHaveBeenCalledWith(extractId);
+    expect(mockGetExtractQueue).not.toHaveBeenCalled();
+    expect(mockSupabaseGetJobByIdDirect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/extract-worker.ts
+++ b/apps/api/src/services/extract-worker.ts
@@ -115,6 +115,7 @@ const processExtractJobInternal = async (
 
       await job.moveToCompleted(result, token, false);
       await updateExtract(job.data.extractId, {
+        status: "failed",
         error: result?.error ?? getErrorContactMessage(job.data.extractId),
       });
 


### PR DESCRIPTION
## Summary
- set Redis status to "failed" when extraction returns success: false without throwing
- add a focused Jest test ensuring the v2 extract status controller reports failed jobs correctly

## Testing
- pnpm test -- extract-status-controller


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure extract jobs that return success: false are marked as failed instead of staying stuck in processing. This fixes stale statuses and makes the v2 extract status API report failures correctly.

- **Bug Fixes**
  - Mark Redis extract status as failed when the worker gets success: false (preserves the error message).
  - Add a Jest test for the v2 extract-status controller to confirm it returns success: false with status: failed, error, empty data, and expiresAt from Redis.

<sup>Written for commit 2513676236d464bdb7c6821a8853bf37fd1b825a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

