### PR TITLE
fix(nuq-postgres): align pg_cron database name with docker-compose config

### DIFF
--- a/apps/nuq-postgres/Dockerfile
+++ b/apps/nuq-postgres/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux; \
 RUN set -eux; \
     conf_sample="/usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample"; \
     sed -ri "s/^#?shared_preload_libraries\s*=.*/shared_preload_libraries = 'pg_cron'/" "$conf_sample"; \
-    printf "\n# Added for pg_cron\ncron.database_name = 'postgres'\n" >> "$conf_sample"
+    printf "\n# Added for pg_cron\ncron.database_name = 'firecrawl'\n" >> "$conf_sample"
 
 # Copy nuq.sql so it is executed as part of the initdb sequence
 COPY nuq.sql /docker-entrypoint-initdb.d/010-nuq.sql


### PR DESCRIPTION
## Summary
- Fixes #2551
- Aligns pg_cron database configuration in Dockerfile with docker-compose.yaml
- Changes `cron.database_name` from 'postgres' to 'firecrawl'

## Problem
The nuq-postgres service was crashing on startup with the error:
```
ERROR: can only create extension in database postgres
DETAIL: Jobs must be scheduled from the database configured in cron.database_name
```

This occurred because:
1. The Dockerfile configured pg_cron for database 'postgres'
2. docker-compose.yaml creates database 'firecrawl'
3. pg_cron extension can only be created in the database specified in cron.database_name

## Solution
Modified `apps/nuq-postgres/Dockerfile` line 18 to set `cron.database_name = 'firecrawl'` to match the `POSTGRES_DB` environment variable from docker-compose.yaml.

## Test plan
- [x] Stop existing containers: `docker compose down`
- [x] Rebuild nuq-postgres image: `docker compose build nuq-postgres`
- [x] Start services: `docker compose up -d`
- [x] Verify all containers are running
- [x] Check logs for pg_cron jobs executing correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align pg_cron with docker-compose by setting cron.database_name to "firecrawl" to fix nuq-postgres startup crashes and ensure pg_cron jobs run.

- **Bug Fixes**
  - Set cron.database_name to "firecrawl" in apps/nuq-postgres/Dockerfile to match POSTGRES_DB, resolving the "can only create extension in database postgres" error.

<sup>Written for commit c4446474684b7e2c9fdb1f8c6b25cc59267537de. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

