### PR TITLE
feat(playwright): Enable screenshot support for self-hosted Playwright engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -352,8 +352,8 @@ const engineOptions: {
     features: {
       actions: false,
       waitFor: true,
-      screenshot: false,
-      "screenshot@fullScreen": false,
+      screenshot: true,
+      "screenshot@fullScreen": true,
       pdf: false,
       document: false,
       atsv: false,

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -4,10 +4,14 @@ import { EngineScrapeResult } from "..";
 import { Meta } from "../..";
 import { robustFetch } from "../../lib/fetch";
 import { getInnerJson } from "@mendable/firecrawl-rs";
+import { hasFormatOfType } from "../../../../lib/format-utils";
 
 export async function scrapeURLWithPlaywright(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
+  const screenshotFormat = hasFormatOfType(meta.options.formats, "screenshot");
+  const wantsScreenshot = screenshotFormat !== undefined;
+
   const response = await robustFetch({
     url: config.PLAYWRIGHT_MICROSERVICE_URL!,
     headers: {
@@ -19,6 +23,10 @@ export async function scrapeURLWithPlaywright(
       timeout: meta.abort.scrapeTimeout(),
       headers: meta.options.headers,
       skip_tls_verification: meta.options.skipTlsVerification,
+      ...(wantsScreenshot ? {
+        screenshot: true,
+        fullPageScreenshot: screenshotFormat?.fullPage ?? false,
+      } : {}),
     },
     method: "POST",
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),
@@ -27,6 +35,7 @@ export async function scrapeURLWithPlaywright(
       pageStatusCode: z.number(),
       pageError: z.string().optional(),
       contentType: z.string().optional(),
+      screenshot: z.string().optional(),
     }),
     mock: meta.mock,
     abort: meta.abort.asSignal(),
@@ -42,6 +51,7 @@ export async function scrapeURLWithPlaywright(
     statusCode: response.pageStatusCode,
     error: response.pageError,
     contentType: response.contentType,
+    ...(response.screenshot ? { screenshot: response.screenshot } : {}),
 
     proxyUsed: "basic",
   };

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -80,6 +80,8 @@ interface UrlModel {
   headers?: { [key: string]: string };
   check_selector?: string;
   skip_tls_verification?: boolean;
+  screenshot?: boolean;
+  fullPageScreenshot?: boolean;
 }
 
 let browser: Browser;
@@ -219,7 +221,7 @@ app.get('/health', async (req: Request, res: Response) => {
 });
 
 app.post('/scrape', async (req: Request, res: Response) => {
-  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false }: UrlModel = req.body;
+  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false, screenshot = false, fullPageScreenshot = false }: UrlModel = req.body;
 
   console.log(`================= Scrape Request =================`);
   console.log(`URL: ${url}`);
@@ -228,6 +230,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   console.log(`Headers: ${headers ? JSON.stringify(headers) : 'None'}`);
   console.log(`Check Selector: ${check_selector ? check_selector : 'None'}`);
   console.log(`Skip TLS Verification: ${skip_tls_verification}`);
+  console.log(`Screenshot: ${screenshot} (fullPage: ${fullPageScreenshot})`);
   console.log(`==================================================`);
 
   if (!url) {
@@ -262,6 +265,12 @@ app.post('/scrape', async (req: Request, res: Response) => {
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);
     const pageError = result.status !== 200 ? getError(result.status) : undefined;
 
+    let screenshotData: string | undefined;
+    if (screenshot && page) {
+      const buffer = await page.screenshot({ fullPage: fullPageScreenshot, type: 'png' });
+      screenshotData = `data:image/png;base64,${buffer.toString('base64')}`;
+    }
+
     if (!pageError) {
       console.log(`✅ Scrape successful!`);
     } else {
@@ -272,7 +281,8 @@ app.post('/scrape', async (req: Request, res: Response) => {
       content: result.content,
       pageStatusCode: result.status,
       contentType: result.contentType,
-      ...(pageError && { pageError })
+      ...(pageError && { pageError }),
+      ...(screenshotData && { screenshot: screenshotData })
     });
 
   } catch (error) {


### PR DESCRIPTION
## Summary

The [self-hosting docs](https://docs.firecrawl.dev/contributing/self-host#considerations) state that screenshot support is available when the Playwright service is running:

| Capability | Cloud | Self-hosting |
|---|---|---|
| Screenshot support | Yes | Yes, when the Playwright service is running |

However, requesting `"formats": ["screenshot"]` on a self-hosted instance returns `SCRAPE_ALL_ENGINES_FAILED` with `Engines tried: []` — no engine is even selected.

**Root cause:** Three gaps in the implementation:

1. The standalone `playwright` engine has `screenshot: false` in its feature flags, so `buildFallbackList()` never selects it for screenshot requests
2. The Playwright engine (`engines/playwright/index.ts`) never sends a screenshot flag to the microservice
3. The Playwright microservice (`playwright-service-ts/api.ts`) never calls `page.screenshot()`

**This PR fixes all three:**

- **Playwright microservice**: Accepts `screenshot` and `fullPageScreenshot` request params. When `screenshot: true`, calls Playwright's `page.screenshot()` and returns the base64 PNG data in the response.
- **Playwright engine**: Detects screenshot format in the request, passes the flag to the microservice, includes `screenshot` in the response schema, and returns it in `EngineScrapeResult`.
- **Engine options**: Sets `screenshot: true` and `screenshot@fullScreen: true` for the standalone `playwright` engine.

## Test plan

- [ ] Self-hosted: `POST /v1/scrape` with `"formats": ["screenshot"]` returns a base64 PNG screenshot
- [ ] Self-hosted: `POST /v1/scrape` with `"formats": ["screenshot@fullPage"]` returns a full-page screenshot
- [ ] Self-hosted: `POST /v1/scrape` with `"formats": ["markdown", "screenshot"]` returns both markdown and screenshot
- [ ] Self-hosted: `POST /v1/scrape` with `"formats": ["markdown"]` (no screenshot) still works as before — no screenshot flag sent to microservice
- [ ] Cloud: No regression — Fire Engine engines still have higher quality scores and will be preferred over standalone Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables screenshot support for self-hosted Playwright. Requests with formats ["screenshot"] or ["screenshot@fullPage"] now return a base64 PNG.

- **New Features**
  - Playwright microservice: accepts screenshot and fullPageScreenshot, calls page.screenshot(), returns data:image/png;base64.
  - Playwright engine: detects screenshot formats, forwards flags, parses response, and includes screenshot in EngineScrapeResult.
  - Engine options: sets screenshot and screenshot@fullScreen to true so the standalone Playwright engine is selected for screenshot requests.

<sup>Written for commit 91d1a832720c722edc0184cd4479b75d01db3ab4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

