### PR TITLE
feat: add v2 monitor API prototype with SDK support

### DIFF
--- a/apps/api/requests/v2/monitor.local-test-server.cjs
+++ b/apps/api/requests/v2/monitor.local-test-server.cjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+const http = require("node:http");
+const { URL } = require("node:url");
+
+const PORT = Number(process.env.MONITOR_DEMO_PORT || 8788);
+
+let content = "# Monitor demo\n\nCurrent value: v1";
+const webhookEvents = [];
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload, null, 2);
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendHtml(res, statusCode, body) {
+  res.writeHead(statusCode, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", chunk => chunks.push(chunk));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(new Error("Body must be valid JSON"));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function buildContentPage() {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Monitor local demo</title>
+  </head>
+  <body>
+    <main>
+      <h1>Monitor local demo page</h1>
+      <pre id="content">${content}</pre>
+    </main>
+  </body>
+</html>`;
+}
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = new URL(req.url || "/", `http://${req.headers.host}`);
+  const method = req.method || "GET";
+
+  try {
+    if (method === "GET" && requestUrl.pathname === "/health") {
+      sendJson(res, 200, { ok: true });
+      return;
+    }
+
+    if (method === "GET" && requestUrl.pathname === "/content") {
+      sendHtml(res, 200, buildContentPage());
+      return;
+    }
+
+    if (method === "POST" && requestUrl.pathname === "/content") {
+      const body = await readRequestBody(req);
+      if (typeof body.content !== "string" || body.content.length === 0) {
+        sendJson(res, 400, {
+          ok: false,
+          error: "Expected JSON body with non-empty string field `content`",
+        });
+        return;
+      }
+
+      content = body.content;
+      sendJson(res, 200, { ok: true, content });
+      return;
+    }
+
+    if (method === "POST" && requestUrl.pathname === "/content/toggle") {
+      content = content.includes("v1")
+        ? "# Monitor demo\n\nCurrent value: v2"
+        : "# Monitor demo\n\nCurrent value: v1";
+      sendJson(res, 200, { ok: true, content });
+      return;
+    }
+
+    if (method === "POST" && requestUrl.pathname === "/webhook") {
+      const body = await readRequestBody(req);
+      webhookEvents.push({
+        receivedAt: new Date().toISOString(),
+        body,
+      });
+      sendJson(res, 200, { ok: true, received: webhookEvents.length });
+      return;
+    }
+
+    if (method === "GET" && requestUrl.pathname === "/webhooks") {
+      sendJson(res, 200, {
+        count: webhookEvents.length,
+        events: webhookEvents,
+      });
+      return;
+    }
+
+    if (method === "DELETE" && requestUrl.pathname === "/webhooks") {
+      webhookEvents.length = 0;
+      sendJson(res, 200, { ok: true });
+      return;
+    }
+
+    sendJson(res, 404, { ok: false, error: "Not found" });
+  } catch (error) {
+    sendJson(res, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`monitor-local-test-server listening on http://127.0.0.1:${PORT}`);
+  console.log("Endpoints:");
+  console.log("  GET    /health");
+  console.log("  GET    /content");
+  console.log("  POST   /content         {\"content\":\"...\"}");
+  console.log("  POST   /content/toggle");
+  console.log("  POST   /webhook");
+  console.log("  GET    /webhooks");
+  console.log("  DELETE /webhooks");
+});

--- a/apps/api/requests/v2/monitor.quick-test.ts
+++ b/apps/api/requests/v2/monitor.quick-test.ts
@@ -1,0 +1,385 @@
+import { config as loadEnv } from "dotenv";
+
+type MonitorChangedPage = {
+  metadata?: {
+    sourceURL?: string;
+    url?: string;
+  };
+  changeTracking?: {
+    changeStatus?: string;
+    previousScrapeAt?: string | null;
+  };
+};
+
+type MonitorStatusResponse = {
+  success: boolean;
+  id: string;
+  status: "active" | "cancelled";
+  interval: string;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  latestData: Array<{
+    source: string;
+    pages: MonitorChangedPage[];
+  }>;
+  lastError: string | null;
+};
+
+type MonitorCreateResponse = {
+  success: boolean;
+  id: string;
+  url: string;
+};
+
+type MonitorCancelResponse = {
+  success: boolean;
+  status: "cancelled";
+};
+
+type CliOptions = {
+  baseUrl: string;
+  targetUrl: string;
+  interval: string;
+  pollMs: number;
+  token?: string;
+  keep: boolean;
+  waitSecondRun: boolean;
+};
+
+function parseIntervalToMs(interval: string): number {
+  const normalized = interval.trim().toLowerCase();
+  const match = normalized.match(/^(\d+)([mh])$/);
+  if (!match) {
+    throw new Error(
+      "Interval must match formats like 5m, 30m, 1h, or 24h (example: --interval 5m)",
+    );
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2];
+  const multiplier = unit === "m" ? 60_000 : 3_600_000;
+  return value * multiplier;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    baseUrl: "http://localhost:3102",
+    targetUrl: "https://firecrawl.dev",
+    interval: "5m",
+    pollMs: 5_000,
+    keep: false,
+    waitSecondRun: true,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if ((arg === "--base-url" || arg === "-b") && next) {
+      options.baseUrl = next;
+      i++;
+      continue;
+    }
+    if ((arg === "--target" || arg === "-t") && next) {
+      options.targetUrl = next;
+      i++;
+      continue;
+    }
+    if ((arg === "--interval" || arg === "-i") && next) {
+      options.interval = next;
+      i++;
+      continue;
+    }
+    if (arg === "--poll-ms" && next) {
+      options.pollMs = Number(next);
+      i++;
+      continue;
+    }
+    if (arg === "--token" && next) {
+      options.token = next;
+      i++;
+      continue;
+    }
+    if (arg === "--keep") {
+      options.keep = true;
+      continue;
+    }
+    if (arg === "--no-wait-second-run") {
+      options.waitSecondRun = false;
+      continue;
+    }
+  }
+
+  if (!Number.isFinite(options.pollMs) || options.pollMs <= 0) {
+    throw new Error("--poll-ms must be a positive number");
+  }
+
+  // Validate early so bad intervals fail fast.
+  parseIntervalToMs(options.interval);
+
+  return options;
+}
+
+function maskToken(token: string): string {
+  if (token.length <= 10) {
+    return "***";
+  }
+  return `${token.slice(0, 6)}...${token.slice(-4)}`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function requestJson<T>(
+  url: string,
+  init?: RequestInit,
+  retries = 3,
+): Promise<{
+  status: number;
+  data: T;
+}> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, init);
+      const rawText = await res.text();
+      let parsed: T;
+      try {
+        parsed = (rawText ? JSON.parse(rawText) : {}) as T;
+      } catch {
+        throw new Error(`Non-JSON response (${res.status}) from ${url}: ${rawText}`);
+      }
+      return { status: res.status, data: parsed };
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await sleep(750);
+      }
+    }
+  }
+
+  const message =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(`Request failed after ${retries} attempts (${url}): ${message}`);
+}
+
+async function waitForStatus(
+  opts: CliOptions,
+  token: string,
+  monitorId: string,
+  predicate: (status: MonitorStatusResponse) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<MonitorStatusResponse> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const statusRes = await requestJson<MonitorStatusResponse>(
+      `${opts.baseUrl}/v2/monitor/${monitorId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    if (statusRes.status !== 200 || !statusRes.data.success) {
+      throw new Error(
+        `Failed monitor status check (${statusRes.status}): ${JSON.stringify(statusRes.data)}`,
+      );
+    }
+
+    if (predicate(statusRes.data)) {
+      return statusRes.data;
+    }
+
+    await sleep(opts.pollMs);
+  }
+
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function printChangeSummary(status: MonitorStatusResponse): void {
+  if (!Array.isArray(status.latestData) || status.latestData.length === 0) {
+    console.log("No changed pages in latestData.");
+    return;
+  }
+
+  const firstGroup = status.latestData[0];
+  const firstPage = firstGroup.pages?.[0];
+  const pageUrl =
+    firstPage?.metadata?.sourceURL ?? firstPage?.metadata?.url ?? "unknown";
+  const changeStatus = firstPage?.changeTracking?.changeStatus ?? "unknown";
+  const previousScrapeAt = firstPage?.changeTracking?.previousScrapeAt ?? null;
+
+  console.log(`Changed source: ${firstGroup.source}`);
+  console.log(`Changed page:   ${pageUrl}`);
+  console.log(`Change status:  ${changeStatus}`);
+  console.log(`Previous run:   ${previousScrapeAt}`);
+}
+
+async function main() {
+  loadEnv({ path: ".env.local" });
+  loadEnv({ path: ".env" });
+
+  const opts = parseArgs(process.argv.slice(2));
+  const token =
+    opts.token ||
+    process.env.MONITOR_TEST_TOKEN ||
+    process.env.PREVIEW_TOKEN ||
+    process.env.TEST_API_KEY;
+
+  if (!token) {
+    throw new Error(
+      "Missing token. Set PREVIEW_TOKEN/TEST_API_KEY in env, or pass --token.",
+    );
+  }
+
+  const intervalMs = parseIntervalToMs(opts.interval);
+  const firstRunTimeoutMs = 3 * 60_000;
+  const secondRunTimeoutMs = intervalMs + 3 * 60_000;
+
+  console.log("Monitor quick test");
+  console.log("------------------");
+  console.log(`Base URL:    ${opts.baseUrl}`);
+  console.log(`Target URL:  ${opts.targetUrl}`);
+  console.log(`Interval:    ${opts.interval}`);
+  console.log(`Auth token:  ${maskToken(token)}`);
+  console.log("");
+
+  let monitorId: string | null = null;
+
+  try {
+    console.log("[1/5] Creating monitor...");
+    const createRes = await requestJson<MonitorCreateResponse>(
+      `${opts.baseUrl}/v2/monitor`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          urls: [opts.targetUrl],
+          interval: opts.interval,
+          scrapeOptions: {
+            formats: [
+              "markdown",
+              {
+                type: "changeTracking",
+                modes: ["git-diff"],
+              },
+            ],
+            onlyMainContent: true,
+          },
+        }),
+      },
+    );
+
+    if (createRes.status !== 200 || !createRes.data.success) {
+      throw new Error(
+        `Create monitor failed (${createRes.status}): ${JSON.stringify(createRes.data)}`,
+      );
+    }
+
+    monitorId = createRes.data.id;
+    console.log(`✓ Monitor created: ${monitorId}`);
+    console.log(`  URL: ${createRes.data.url}`);
+    console.log("");
+
+    console.log("[2/5] Waiting for first run (baseline)...");
+    const firstRun = await waitForStatus(
+      opts,
+      token,
+      monitorId,
+      status => Boolean(status.lastRunAt),
+      firstRunTimeoutMs,
+      "first run",
+    );
+    console.log(`✓ First run completed at: ${firstRun.lastRunAt}`);
+    console.log(`  latestData groups: ${firstRun.latestData.length}`);
+    console.log(`  lastError: ${firstRun.lastError ?? "null"}`);
+    console.log("");
+
+    if (!opts.waitSecondRun) {
+      console.log(
+        "[3/5] Skipping second-run wait (--no-wait-second-run was set).",
+      );
+      console.log("");
+    } else {
+      console.log(
+        `[3/5] Waiting for second run (~${opts.interval}) to check for changes...`,
+      );
+      const firstRunAt = firstRun.lastRunAt;
+      const secondRun = await waitForStatus(
+        opts,
+        token,
+        monitorId,
+        status => Boolean(status.lastRunAt && status.lastRunAt !== firstRunAt),
+        secondRunTimeoutMs,
+        "second run",
+      );
+      console.log(`✓ Second run completed at: ${secondRun.lastRunAt}`);
+      console.log(`  latestData groups: ${secondRun.latestData.length}`);
+      console.log(`  lastError: ${secondRun.lastError ?? "null"}`);
+      printChangeSummary(secondRun);
+      console.log("");
+    }
+
+    if (opts.keep) {
+      console.log("[4/5] Keeping monitor active (--keep set).");
+      console.log(`Done. Monitor ID: ${monitorId}`);
+      return;
+    }
+
+    console.log("[4/5] Cancelling monitor...");
+    const cancelRes = await requestJson<MonitorCancelResponse>(
+      `${opts.baseUrl}/v2/monitor/${monitorId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    if (cancelRes.status !== 200 || cancelRes.data.status !== "cancelled") {
+      throw new Error(
+        `Cancel monitor failed (${cancelRes.status}): ${JSON.stringify(cancelRes.data)}`,
+      );
+    }
+    console.log("✓ Monitor cancelled");
+    console.log("");
+    console.log("[5/5] Done.");
+  } catch (error) {
+    console.error("");
+    console.error("Monitor quick test failed.");
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+
+    if (monitorId && !opts.keep) {
+      try {
+        await requestJson<MonitorCancelResponse>(
+          `${opts.baseUrl}/v2/monitor/${monitorId}`,
+          {
+            method: "DELETE",
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+        console.error(`Cleanup: cancelled monitor ${monitorId}`);
+      } catch {
+        console.error(`Cleanup: failed to cancel monitor ${monitorId}`);
+      }
+    }
+
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/apps/api/requests/v2/monitor.requests.http
+++ b/apps/api/requests/v2/monitor.requests.http
@@ -1,0 +1,158 @@
+# Manual playground for /v2/monitor
+#
+# Local prerequisites:
+# 1) Start API/workers (one option):
+#    pnpm harness jest apps/api/src/__tests__/snips/v2/scrape.test.ts --runInBand
+# 2) Start the demo webhook/content server (for webhook inspection and optional demo flow):
+#    node apps/api/requests/v2/monitor.local-test-server.cjs
+#
+# Tip:
+# - For local API, PREVIEW_TOKEN usually works.
+# - For hosted/staging API, switch to TEST_API_KEY.
+
+# Local API (use the port where monitor route is running):
+@baseUrl = http://localhost:3102
+# @baseUrl = http://localhost:3002
+# Hosted API:
+# @baseUrl = https://api.firecrawl.dev
+
+# Pick one auth token source:
+@authToken = {{$dotenv PREVIEW_TOKEN}}
+# @authToken = {{$dotenv TEST_API_KEY}}
+
+@demoBase = http://127.0.0.1:8788
+@firecrawlUrl = https://firecrawl.dev
+
+# Optional local demo target (must be public):
+# Monitor target URLs are fetched by the scraping engine, so localhost/127.0.0.1
+# is not reachable as a monitor target.
+# Use a tunnel URL:
+# - cloudflared tunnel --url http://127.0.0.1:8788
+# - or ngrok http 8788
+# @demoPublicBase = https://your-subdomain.trycloudflare.com
+# @demoPublicBase = https://your-subdomain.ngrok-free.app
+@demoPublicBase = {{demoBase}}
+@demoContentUrl = {{demoPublicBase}}/content
+
+# Fill these after creating jobs:
+@quickMonitorId = 019caa44-d17b-73ce-9753-040c1b1424b2
+@demoMonitorId = REPLACE_WITH_DEMO_MONITOR_ID
+
+### Demo server health
+GET {{demoBase}}/health HTTP/1.1
+
+################################################################################
+# Quick flow (default): use firecrawl.dev
+################################################################################
+
+### Q1) Reset webhook log
+DELETE {{demoBase}}/webhooks HTTP/1.1
+
+### Q2) Create monitor for firecrawl.dev
+# First run should build baseline and not emit monitor.changed.
+POST {{baseUrl}}/v2/monitor HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+{
+  "urls": ["{{firecrawlUrl}}"],
+  "interval": "5m",
+  "scrapeOptions": {
+    "formats": [
+      "markdown",
+      {
+        "type": "changeTracking",
+        "modes": ["git-diff"]
+      }
+    ],
+    "onlyMainContent": true
+  },
+  "webhook": {
+    "url": "{{demoBase}}/webhook",
+    "events": ["started", "changed", "error"]
+  }
+}
+
+### Q3) Get status (paste id into @quickMonitorId first)
+GET {{baseUrl}}/v2/monitor/{{quickMonitorId}} HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+### Q4) Check webhook events (expect monitor.started after first run)
+GET {{demoBase}}/webhooks HTTP/1.1
+
+### Q5) After one interval, check status again
+GET {{baseUrl}}/v2/monitor/{{quickMonitorId}} HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+### Q6) Check webhook events again (monitor.changed may appear if content differs)
+GET {{demoBase}}/webhooks HTTP/1.1
+
+### Q7) Cancel quick monitor
+DELETE {{baseUrl}}/v2/monitor/{{quickMonitorId}} HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+### Q8) Verify cancelled state
+GET {{baseUrl}}/v2/monitor/{{quickMonitorId}} HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+################################################################################
+# Optional deterministic demo flow (requires public demo tunnel URL)
+################################################################################
+
+### D1) Set demo content baseline (v1)
+POST {{demoBase}}/content HTTP/1.1
+content-type: application/json
+
+{
+  "content": "# Monitor demo\n\nCurrent value: v1"
+}
+
+### D2) Create monitor for demo content
+POST {{baseUrl}}/v2/monitor HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+{
+  "urls": ["{{demoContentUrl}}"],
+  "interval": "5m",
+  "scrapeOptions": {
+    "formats": [
+      "markdown",
+      {
+        "type": "changeTracking",
+        "modes": ["git-diff"]
+      }
+    ],
+    "onlyMainContent": true
+  },
+  "webhook": {
+    "url": "{{demoBase}}/webhook",
+    "events": ["started", "changed", "error"]
+  }
+}
+
+### D3) Get status (paste id into @demoMonitorId first)
+GET {{baseUrl}}/v2/monitor/{{demoMonitorId}} HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+
+### D4) Update demo content to v2
+POST {{demoBase}}/content HTTP/1.1
+content-type: application/json
+
+{
+  "content": "# Monitor demo\n\nCurrent value: v2"
+}
+
+### D5) Check webhook events
+GET {{demoBase}}/webhooks HTTP/1.1
+
+### D6) Cancel demo monitor
+DELETE {{baseUrl}}/v2/monitor/{{demoMonitorId}} HTTP/1.1
+Authorization: Bearer {{authToken}}
+content-type: application/json
+

--- a/apps/api/src/controllers/v2/monitor-cancel.ts
+++ b/apps/api/src/controllers/v2/monitor-cancel.ts
@@ -1,0 +1,26 @@
+import { Response } from "express";
+import { ErrorResponse, RequestWithAuth } from "./types";
+import { MonitorCancelResponse } from "./monitor-types";
+import { cancelMonitorJob } from "../../services/monitor/service";
+
+export async function monitorCancelController(
+  req: RequestWithAuth<
+    { jobId: string },
+    MonitorCancelResponse | ErrorResponse,
+    undefined
+  >,
+  res: Response<MonitorCancelResponse | ErrorResponse>,
+) {
+  const cancelled = cancelMonitorJob(req.params.jobId, req.auth.team_id);
+  if (!cancelled) {
+    return res.status(404).json({
+      success: false,
+      error: "Monitor job not found",
+    });
+  }
+
+  return res.status(200).json({
+    success: true,
+    status: "cancelled",
+  });
+}

--- a/apps/api/src/controllers/v2/monitor-status.ts
+++ b/apps/api/src/controllers/v2/monitor-status.ts
@@ -1,0 +1,38 @@
+import { Response } from "express";
+import { ErrorResponse, RequestWithAuth } from "./types";
+import { MonitorStatusResponse } from "./monitor-types";
+import { getMonitorJob } from "../../services/monitor/service";
+
+export async function monitorStatusController(
+  req: RequestWithAuth<
+    { jobId: string },
+    MonitorStatusResponse | ErrorResponse,
+    undefined
+  >,
+  res: Response<MonitorStatusResponse | ErrorResponse>,
+) {
+  const monitor = getMonitorJob(req.params.jobId, req.auth.team_id);
+  if (!monitor) {
+    return res.status(404).json({
+      success: false,
+      error: "Monitor job not found",
+    });
+  }
+
+  return res.status(200).json({
+    success: true,
+    id: monitor.id,
+    status: monitor.status,
+    urls: monitor.urls,
+    resolvedUrls: monitor.resolvedUrls,
+    interval: monitor.interval,
+    intervalMs: monitor.intervalMs,
+    createdAt: monitor.createdAt,
+    updatedAt: monitor.updatedAt,
+    nextRunAt: monitor.nextRunAt,
+    lastRunAt: monitor.lastRunAt,
+    latestData: monitor.latestData,
+    latestDataAt: monitor.latestDataAt,
+    lastError: monitor.lastError,
+  });
+}

--- a/apps/api/src/controllers/v2/monitor-types.ts
+++ b/apps/api/src/controllers/v2/monitor-types.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+import { scrapeOptions, Document } from "./types";
+import { createWebhookSchema } from "../../services/webhook/schema";
+import { checkUrl, protocolIncluded } from "../../lib/validateUrl";
+
+export const monitorWebhookSchema = createWebhookSchema([
+  "started",
+  "changed",
+  "error",
+]);
+
+const monitorIntervalRegex = /^(\d+)([mh])$/i;
+
+function normalizeMonitorUrl(input: string): string {
+  const value = input.trim();
+  const withProtocol = protocolIncluded(value) ? value : `http://${value}`;
+
+  if (withProtocol.includes("*")) {
+    if (!withProtocol.endsWith("/*")) {
+      throw new Error("Only trailing /* wildcard patterns are supported");
+    }
+
+    const baseUrl = withProtocol.slice(0, -2);
+    checkUrl(baseUrl);
+
+    return `${baseUrl.replace(/\/+$/, "")}/*`;
+  }
+
+  checkUrl(withProtocol);
+  return withProtocol;
+}
+
+export function parseMonitorIntervalToMs(interval: string): number {
+  const normalized = interval.trim().toLowerCase();
+  const match = normalized.match(monitorIntervalRegex);
+  if (!match) {
+    throw new Error("Interval must match formats like 5m, 30m, 1h, or 24h");
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2];
+  const multiplier = unit === "m" ? 60_000 : 3_600_000;
+  const milliseconds = value * multiplier;
+  if (milliseconds < 5 * 60_000) {
+    throw new Error("Interval must be at least 5m");
+  }
+
+  return milliseconds;
+}
+
+const monitorIntervalSchema = z
+  .string()
+  .trim()
+  .refine(value => {
+    try {
+      parseMonitorIntervalToMs(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }, "Interval must be at least 5m and match formats like 5m, 30m, 1h, or 24h");
+
+function hasChangeTrackingFormat(formats?: unknown[]): boolean {
+  if (!Array.isArray(formats)) {
+    return false;
+  }
+
+  return formats.some(format => {
+    if (typeof format === "string") {
+      return format === "changeTracking";
+    }
+
+    if (format && typeof format === "object") {
+      return (format as { type?: string }).type === "changeTracking";
+    }
+
+    return false;
+  });
+}
+
+export const monitorRequestSchema = z.strictObject({
+  urls: z
+    .array(
+      z
+        .string()
+        .min(1)
+        .transform(value => normalizeMonitorUrl(value)),
+    )
+    .min(1),
+  interval: monitorIntervalSchema.default("1h"),
+  scrapeOptions: scrapeOptions.refine(
+    value => hasChangeTrackingFormat(value.formats),
+    "scrapeOptions.formats must include changeTracking",
+  ),
+  webhook: monitorWebhookSchema.optional(),
+  origin: z.string().optional(),
+  integration: z.string().nullable().optional(),
+});
+
+export type MonitorRequest = z.infer<typeof monitorRequestSchema>;
+
+export type MonitorStatus = "active" | "cancelled";
+
+export type MonitorChangedGroup = {
+  source: string;
+  pages: Document[];
+};
+
+export interface MonitorResponse {
+  success: boolean;
+  id: string;
+  url: string;
+}
+
+export interface MonitorStatusResponse {
+  success: boolean;
+  id: string;
+  status: MonitorStatus;
+  urls: string[];
+  resolvedUrls: string[];
+  interval: string;
+  intervalMs: number;
+  createdAt: string;
+  updatedAt: string;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  latestData: MonitorChangedGroup[];
+  latestDataAt: string | null;
+  lastError: string | null;
+}
+
+export interface MonitorCancelResponse {
+  success: boolean;
+  status: "cancelled";
+}

--- a/apps/api/src/controllers/v2/monitor.ts
+++ b/apps/api/src/controllers/v2/monitor.ts
@@ -1,0 +1,46 @@
+import { Response } from "express";
+import { ErrorResponse, RequestWithAuth } from "./types";
+import {
+  MonitorRequest,
+  MonitorResponse,
+  monitorRequestSchema,
+} from "./monitor-types";
+import { checkPermissions } from "../../lib/permissions";
+import { createMonitorJob } from "../../services/monitor/service";
+
+export async function monitorController(
+  req: RequestWithAuth<{}, MonitorResponse | ErrorResponse, MonitorRequest>,
+  res: Response<MonitorResponse | ErrorResponse>,
+) {
+  req.body = monitorRequestSchema.parse(req.body);
+
+  const permissions = checkPermissions(
+    { scrapeOptions: req.body.scrapeOptions },
+    req.acuc?.flags,
+  );
+  if (permissions.error) {
+    return res.status(403).json({
+      success: false,
+      error: permissions.error,
+    });
+  }
+
+  const monitor = await createMonitorJob({
+    teamId: req.auth.team_id,
+    urls: req.body.urls,
+    interval: req.body.interval,
+    scrapeOptions: req.body.scrapeOptions,
+    webhook: req.body.webhook,
+    origin: req.body.origin,
+    integration: req.body.integration,
+    apiKeyId: req.acuc?.api_key_id ?? null,
+    zeroDataRetention: req.acuc?.flags?.forceZDR || false,
+    teamFlags: req.acuc?.flags ?? null,
+  });
+
+  return res.status(200).json({
+    success: true,
+    id: monitor.id,
+    url: `${req.protocol}://${req.get("host")}/v2/monitor/${monitor.id}`,
+  });
+}

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -9,6 +9,9 @@ import { batchScrapeController } from "../controllers/v2/batch-scrape";
 import { crawlController } from "../controllers/v2/crawl";
 import { crawlParamsPreviewController } from "../controllers/v2/crawl-params-preview";
 import { crawlStatusController } from "../controllers/v2/crawl-status";
+import { monitorController } from "../controllers/v2/monitor";
+import { monitorStatusController } from "../controllers/v2/monitor-status";
+import { monitorCancelController } from "../controllers/v2/monitor-cancel";
 import { mapController } from "../controllers/v2/map";
 import { crawlErrorsController } from "../controllers/v2/crawl-errors";
 import { ongoingCrawlsController } from "../controllers/v2/crawl-ongoing";
@@ -223,6 +226,28 @@ v2Router.post(
   blocklistMiddleware,
   idempotencyMiddleware,
   wrap(crawlController),
+);
+
+v2Router.post(
+  "/monitor",
+  authMiddleware(RateLimiterMode.Crawl),
+  countryCheck,
+  idempotencyMiddleware,
+  wrap(monitorController),
+);
+
+v2Router.get(
+  "/monitor/:jobId",
+  authMiddleware(RateLimiterMode.CrawlStatus),
+  validateJobIdParam,
+  wrap(monitorStatusController),
+);
+
+v2Router.delete(
+  "/monitor/:jobId",
+  authMiddleware(RateLimiterMode.CrawlStatus),
+  validateJobIdParam,
+  wrap(monitorCancelController),
 );
 
 v2Router.post(

--- a/apps/api/src/services/monitor/service.ts
+++ b/apps/api/src/services/monitor/service.ts
@@ -1,0 +1,495 @@
+import { v7 as uuidv7 } from "uuid";
+import { config } from "../../config";
+import { logger as _logger } from "../../lib/logger";
+import { getMapResults } from "../../lib/map-utils";
+import { ScrapeJobData } from "../../types";
+import { createWebhookSender, WebhookEvent } from "../webhook";
+import { NuQJob } from "../worker/nuq";
+import { processJobInternal } from "../worker/scrape-worker";
+import { Document, ScrapeOptions, TeamFlags } from "../../controllers/v2/types";
+import {
+  MonitorChangedGroup,
+  MonitorStatus,
+  parseMonitorIntervalToMs,
+} from "../../controllers/v2/monitor-types";
+
+type ChangeStatus = "new" | "same" | "changed" | "removed";
+
+type MonitorSnapshot = {
+  markdown: string;
+  statusCode: number | null;
+  scrapedAt: string;
+};
+
+type MonitorSnapshots = Map<string, MonitorSnapshot>;
+
+export type StoredMonitorJob = {
+  id: string;
+  teamId: string;
+  status: MonitorStatus;
+  urls: string[];
+  resolvedUrls: string[];
+  interval: string;
+  intervalMs: number;
+  scrapeOptions: ScrapeOptions;
+  webhook?: {
+    url: string;
+    headers: Record<string, string>;
+    metadata: Record<string, string>;
+    events: string[];
+  };
+  hasBaseline: boolean;
+  createdAt: string;
+  updatedAt: string;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  latestData: MonitorChangedGroup[];
+  latestDataAt: string | null;
+  lastError: string | null;
+  origin: string;
+  integration: string | null;
+  apiKeyId: number | null;
+  zeroDataRetention: boolean;
+  teamFlags: TeamFlags | null;
+};
+
+type CreateMonitorInput = {
+  teamId: string;
+  urls: string[];
+  interval: string;
+  scrapeOptions: ScrapeOptions;
+  webhook?: StoredMonitorJob["webhook"];
+  origin?: string;
+  integration?: string | null;
+  apiKeyId: number | null;
+  zeroDataRetention: boolean;
+  teamFlags: TeamFlags | null;
+};
+
+const monitorJobs = new Map<string, StoredMonitorJob>();
+const monitorSnapshots = new Map<string, MonitorSnapshots>();
+const activeRunLocks = new Set<string>();
+let schedulerLoop: NodeJS.Timeout | null = null;
+let schedulerSweepInProgress = false;
+
+const MONITOR_SCHEDULER_TICK_MS = 5_000;
+const MONITOR_MAP_LIMIT = 1_000;
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function ensureSchedulerStarted() {
+  if (schedulerLoop) {
+    return;
+  }
+
+  schedulerLoop = setInterval(() => {
+    void runDueMonitorChecks();
+  }, MONITOR_SCHEDULER_TICK_MS);
+
+  if (typeof schedulerLoop.unref === "function") {
+    schedulerLoop.unref();
+  }
+
+  _logger.info("Started monitor scheduler loop", {
+    module: "monitor",
+    tickMs: MONITOR_SCHEDULER_TICK_MS,
+  });
+}
+
+export function stopMonitorScheduler() {
+  if (!schedulerLoop) {
+    return;
+  }
+
+  clearInterval(schedulerLoop);
+  schedulerLoop = null;
+}
+
+function deriveSourceHost(document: Document): string {
+  const candidate =
+    document.metadata?.sourceURL ?? document.metadata?.url ?? "unknown";
+  try {
+    return new URL(candidate).hostname;
+  } catch {
+    return "unknown";
+  }
+}
+
+function deriveDocumentUrl(document: Document, fallbackUrl: string): string {
+  return document.metadata?.sourceURL ?? document.metadata?.url ?? fallbackUrl;
+}
+
+function inferChangeStatus(
+  document: Document,
+  previous: MonitorSnapshot | undefined,
+): ChangeStatus {
+  const fromChangeTracking = (
+    document.changeTracking as { changeStatus?: ChangeStatus } | undefined
+  )?.changeStatus;
+  if (
+    fromChangeTracking &&
+    ["new", "same", "changed", "removed"].includes(fromChangeTracking)
+  ) {
+    return fromChangeTracking;
+  }
+
+  const currentStatusCode = document.metadata?.statusCode ?? null;
+  if (currentStatusCode === 404) {
+    return previous ? "removed" : "new";
+  }
+
+  if (!previous) {
+    return "new";
+  }
+
+  if (previous.markdown !== (document.markdown ?? "")) {
+    return "changed";
+  }
+
+  if (previous.statusCode !== currentStatusCode) {
+    return "changed";
+  }
+
+  return "same";
+}
+
+function withChangeTracking(
+  document: Document,
+  previous: MonitorSnapshot | undefined,
+  changeStatus: ChangeStatus,
+): Document {
+  const existing =
+    (document.changeTracking as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...document,
+    changeTracking: {
+      ...existing,
+      previousScrapeAt: previous?.scrapedAt ?? null,
+      changeStatus,
+      visibility:
+        (existing.visibility as "visible" | "hidden" | undefined) ?? "visible",
+    },
+  };
+}
+
+function buildSingleScrapeJob(
+  monitorJob: StoredMonitorJob,
+  url: string,
+): NuQJob<ScrapeJobData> {
+  return {
+    id: uuidv7(),
+    status: "active",
+    createdAt: new Date(),
+    priority: 10,
+    data: {
+      mode: "single_urls",
+      url,
+      team_id: monitorJob.teamId,
+      scrapeOptions: monitorJob.scrapeOptions,
+      internalOptions: {
+        teamId: monitorJob.teamId,
+        disableSmartWaitCache: true,
+        bypassBilling: true,
+        saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
+        zeroDataRetention: monitorJob.zeroDataRetention,
+        teamFlags: monitorJob.teamFlags ?? undefined,
+      },
+      origin: monitorJob.origin,
+      integration: monitorJob.integration,
+      skipNuq: true,
+      startTime: Date.now(),
+      zeroDataRetention: monitorJob.zeroDataRetention,
+      apiKeyId: monitorJob.apiKeyId,
+    },
+  };
+}
+
+async function resolveMonitorUrls(job: StoredMonitorJob): Promise<string[]> {
+  const resolved = new Set<string>();
+
+  for (const sourceUrl of job.urls) {
+    if (!sourceUrl.endsWith("/*")) {
+      resolved.add(sourceUrl);
+      continue;
+    }
+
+    const baseUrl = sourceUrl.slice(0, -2);
+    try {
+      const map = await getMapResults({
+        url: baseUrl,
+        limit: MONITOR_MAP_LIMIT,
+        includeSubdomains: true,
+        crawlerOptions: { sitemap: "include" },
+        teamId: job.teamId,
+        allowExternalLinks: false,
+        filterByPath: true,
+        flags: job.teamFlags,
+        useIndex: true,
+        ignoreCache: true,
+      });
+
+      for (const entry of map.mapResults) {
+        resolved.add(entry.url);
+      }
+
+      if (map.mapResults.length === 0) {
+        resolved.add(baseUrl);
+      }
+    } catch (error) {
+      _logger.warn("Failed to resolve wildcard monitor URL", {
+        module: "monitor",
+        monitorId: job.id,
+        sourceUrl,
+        error,
+      });
+      resolved.add(baseUrl);
+    }
+  }
+
+  return Array.from(resolved);
+}
+
+async function sendMonitorWebhook<T extends WebhookEvent>(
+  job: StoredMonitorJob,
+  event: T,
+  payload: any,
+) {
+  const sender = await createWebhookSender({
+    teamId: job.teamId,
+    jobId: job.id,
+    webhook: job.webhook as any,
+    v0: false,
+  });
+  if (!sender) {
+    return;
+  }
+
+  try {
+    await sender.send(event, payload);
+  } catch (error) {
+    _logger.warn("Monitor webhook delivery failed", {
+      module: "monitor",
+      monitorId: job.id,
+      event,
+      error,
+    });
+  }
+}
+
+async function runMonitorCheck(jobId: string) {
+  const monitorJob = monitorJobs.get(jobId);
+  if (!monitorJob || monitorJob.status !== "active") {
+    return;
+  }
+
+  const logger = _logger.child({
+    module: "monitor",
+    method: "runMonitorCheck",
+    monitorId: jobId,
+    teamId: monitorJob.teamId,
+  });
+
+  const now = new Date().toISOString();
+  const snapshots = monitorSnapshots.get(jobId) ?? new Map<string, MonitorSnapshot>();
+
+  let resolvedUrls: string[] = [];
+  const changedDocuments: Document[] = [];
+  const errors: string[] = [];
+
+  try {
+    resolvedUrls = await resolveMonitorUrls(monitorJob);
+
+    for (const resolvedUrl of resolvedUrls) {
+      try {
+        const scrapeJob = buildSingleScrapeJob(monitorJob, resolvedUrl);
+        const scraped = await processJobInternal(scrapeJob);
+        if (!scraped) {
+          continue;
+        }
+
+        const document = scraped as Document;
+        const canonicalUrl = deriveDocumentUrl(document, resolvedUrl);
+        const previous = snapshots.get(canonicalUrl);
+        const changeStatus = inferChangeStatus(document, previous);
+        const normalizedDocument = withChangeTracking(
+          document,
+          previous,
+          changeStatus,
+        );
+
+        snapshots.set(canonicalUrl, {
+          markdown: normalizedDocument.markdown ?? "",
+          statusCode: normalizedDocument.metadata?.statusCode ?? null,
+          scrapedAt: now,
+        });
+
+        if (monitorJob.hasBaseline && changeStatus !== "same") {
+          changedDocuments.push(normalizedDocument);
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown monitor scrape error";
+        errors.push(`${resolvedUrl}: ${message}`);
+      }
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown monitor cycle error";
+    errors.push(message);
+    logger.warn("Monitor check failed", { error });
+  }
+
+  const groupedBySource = new Map<string, Document[]>();
+  for (const doc of changedDocuments) {
+    const source = deriveSourceHost(doc);
+    const group = groupedBySource.get(source) ?? [];
+    group.push(doc);
+    groupedBySource.set(source, group);
+  }
+
+  const groupedChanges: MonitorChangedGroup[] = Array.from(
+    groupedBySource.entries(),
+  ).map(([source, pages]) => ({
+    source,
+    pages,
+  }));
+
+  monitorJob.hasBaseline = true;
+  monitorJob.lastRunAt = now;
+  monitorJob.nextRunAt =
+    monitorJob.status === "active"
+      ? new Date(Date.now() + monitorJob.intervalMs).toISOString()
+      : null;
+  monitorJob.updatedAt = now;
+  monitorJob.resolvedUrls = resolvedUrls;
+  monitorJob.lastError = errors.length > 0 ? errors.join("; ") : null;
+
+  if (groupedChanges.length > 0) {
+    monitorJob.latestData = groupedChanges;
+    monitorJob.latestDataAt = now;
+  }
+
+  monitorSnapshots.set(jobId, snapshots);
+  monitorJobs.set(jobId, monitorJob);
+
+  if (groupedChanges.length > 0) {
+    for (const groupedChange of groupedChanges) {
+      await sendMonitorWebhook(monitorJob, WebhookEvent.MONITOR_CHANGED, {
+        success: true,
+        data: [groupedChange],
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    await sendMonitorWebhook(monitorJob, WebhookEvent.MONITOR_ERROR, {
+      success: false,
+      error: "One or more monitor URLs failed during this check",
+      data: errors.map(error => ({ error })),
+    });
+  }
+}
+
+async function runDueMonitorChecks() {
+  if (schedulerSweepInProgress) {
+    return;
+  }
+
+  schedulerSweepInProgress = true;
+  const now = Date.now();
+
+  try {
+    for (const monitorJob of monitorJobs.values()) {
+      if (monitorJob.status !== "active" || !monitorJob.nextRunAt) {
+        continue;
+      }
+
+      if (new Date(monitorJob.nextRunAt).getTime() > now) {
+        continue;
+      }
+
+      if (activeRunLocks.has(monitorJob.id)) {
+        continue;
+      }
+
+      activeRunLocks.add(monitorJob.id);
+      void runMonitorCheck(monitorJob.id).finally(() => {
+        activeRunLocks.delete(monitorJob.id);
+      });
+    }
+  } finally {
+    schedulerSweepInProgress = false;
+  }
+}
+
+export async function createMonitorJob(
+  input: CreateMonitorInput,
+): Promise<StoredMonitorJob> {
+  ensureSchedulerStarted();
+
+  const now = new Date().toISOString();
+  const id = uuidv7();
+  const intervalMs = parseMonitorIntervalToMs(input.interval);
+
+  const job: StoredMonitorJob = {
+    id,
+    teamId: input.teamId,
+    status: "active",
+    urls: input.urls,
+    resolvedUrls: [],
+    interval: input.interval,
+    intervalMs,
+    scrapeOptions: input.scrapeOptions,
+    webhook: input.webhook,
+    hasBaseline: false,
+    createdAt: now,
+    updatedAt: now,
+    nextRunAt: now,
+    lastRunAt: null,
+    latestData: [],
+    latestDataAt: null,
+    lastError: null,
+    origin: input.origin ?? "api",
+    integration: input.integration ?? null,
+    apiKeyId: input.apiKeyId,
+    zeroDataRetention: input.zeroDataRetention,
+    teamFlags: input.teamFlags,
+  };
+
+  monitorJobs.set(id, job);
+  monitorSnapshots.set(id, new Map());
+
+  await sendMonitorWebhook(job, WebhookEvent.MONITOR_STARTED, {
+    success: true,
+  });
+
+  return clone(job);
+}
+
+export function getMonitorJob(
+  id: string,
+  teamId: string,
+): StoredMonitorJob | null {
+  const job = monitorJobs.get(id);
+  if (!job || job.teamId !== teamId) {
+    return null;
+  }
+
+  return clone(job);
+}
+
+export function cancelMonitorJob(id: string, teamId: string): boolean {
+  const job = monitorJobs.get(id);
+  if (!job || job.teamId !== teamId) {
+    return false;
+  }
+
+  const now = new Date().toISOString();
+  job.status = "cancelled";
+  job.updatedAt = now;
+  job.nextRunAt = null;
+  monitorJobs.set(id, job);
+  return true;
+}

--- a/apps/api/src/services/webhook/config.ts
+++ b/apps/api/src/services/webhook/config.ts
@@ -24,7 +24,7 @@ export async function getWebhookConfig(
         url: selfHostedUrl,
         headers: {},
         metadata: {},
-        events: ["completed", "failed", "page", "started"],
+        events: ["completed", "failed", "page", "started", "changed", "error"],
       },
       secret: config.SELF_HOSTED_WEBHOOK_HMAC_SECRET,
     };

--- a/apps/api/src/services/webhook/schema.ts
+++ b/apps/api/src/services/webhook/schema.ts
@@ -32,4 +32,6 @@ export const webhookSchema = createWebhookSchema([
   "failed",
   "page",
   "started",
+  "changed",
+  "error",
 ]);

--- a/apps/api/src/services/webhook/types.ts
+++ b/apps/api/src/services/webhook/types.ts
@@ -13,6 +13,9 @@ export enum WebhookEvent {
   EXTRACT_STARTED = "extract.started",
   EXTRACT_COMPLETED = "extract.completed",
   EXTRACT_FAILED = "extract.failed",
+  MONITOR_STARTED = "monitor.started",
+  MONITOR_CHANGED = "monitor.changed",
+  MONITOR_ERROR = "monitor.error",
 }
 
 export type WebhookEventDataMap = {
@@ -25,6 +28,9 @@ export type WebhookEventDataMap = {
   [WebhookEvent.EXTRACT_STARTED]: ExtractStartedData;
   [WebhookEvent.EXTRACT_COMPLETED]: ExtractCompletedData;
   [WebhookEvent.EXTRACT_FAILED]: ExtractFailedData;
+  [WebhookEvent.MONITOR_STARTED]: MonitorStartedData;
+  [WebhookEvent.MONITOR_CHANGED]: MonitorChangedData;
+  [WebhookEvent.MONITOR_ERROR]: MonitorErrorData;
 };
 
 export type WebhookConfig = z.infer<typeof webhookSchema>;
@@ -112,4 +118,25 @@ interface ExtractCompletedData extends BaseWebhookData {
 interface ExtractFailedData extends BaseWebhookData {
   success: false;
   error: string;
+}
+
+// monitor
+interface MonitorStartedData extends BaseWebhookData {
+  success: true;
+}
+
+type MonitorChangedPageGroup = {
+  source: string;
+  pages: Document[];
+};
+
+interface MonitorChangedData extends BaseWebhookData {
+  success: true;
+  data: MonitorChangedPageGroup[];
+}
+
+interface MonitorErrorData extends BaseWebhookData {
+  success: false;
+  error: string;
+  data: Array<Record<string, string>>;
 }

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -12,6 +12,11 @@ import {
   crawlParamsPreview,
 } from "./methods/crawl";
 import {
+  startMonitor,
+  getMonitorStatus,
+  cancelMonitor,
+} from "./methods/monitor";
+import {
   startBatchScrape,
   getBatchScrapeStatus,
   getBatchScrapeErrors,
@@ -50,6 +55,9 @@ import type {
   BrowserExecuteResponse,
   BrowserDeleteResponse,
   BrowserListResponse,
+  MonitorJob,
+  MonitorOptions,
+  MonitorResponse,
 } from "./types";
 import { Watcher } from "./watcher";
 import type { WatcherOptions } from "./watcher";
@@ -198,6 +206,55 @@ export class FirecrawlClient {
    */
   async getActiveCrawls(): Promise<ActiveCrawlsResponse> {
     return getActiveCrawls(this.http);
+  }
+
+  // Monitor
+  /**
+   * Start a long-lived monitor job (async).
+   * @param req Monitor configuration (urls, interval, scrapeOptions, webhook).
+   * @returns Monitor job id and status URL.
+   */
+  async startMonitor(req: MonitorOptions): Promise<MonitorResponse> {
+    return startMonitor(this.http, req);
+  }
+  /**
+   * Get monitor status and latest change payload.
+   * @param jobId Monitor job id.
+   */
+  async getMonitor(jobId: string): Promise<MonitorJob> {
+    return getMonitorStatus(this.http, jobId);
+  }
+  /**
+   * Cancel a monitor job.
+   * @param jobId Monitor job id.
+   * @returns True if cancelled.
+   */
+  async cancelMonitor(jobId: string): Promise<boolean> {
+    return cancelMonitor(this.http, jobId);
+  }
+  /**
+   * Convenience alias for starting monitor jobs.
+   * @param req Monitor configuration.
+   * @returns Monitor job id and status URL.
+   */
+  async monitor(req: MonitorOptions): Promise<MonitorResponse> {
+    return startMonitor(this.http, req);
+  }
+  /**
+   * Convenience alias for monitor status checks.
+   * @param jobId Monitor job id.
+   * @returns Monitor status payload.
+   */
+  async monitorGet(jobId: string): Promise<MonitorJob> {
+    return getMonitorStatus(this.http, jobId);
+  }
+  /**
+   * Convenience alias for monitor cancellation.
+   * @param jobId Monitor job id.
+   * @returns True if cancelled.
+   */
+  async monitorStop(jobId: string): Promise<boolean> {
+    return cancelMonitor(this.http, jobId);
   }
   /**
    * Preview normalized crawl parameters produced by a natural-language prompt.

--- a/apps/js-sdk/firecrawl/src/v2/methods/monitor.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/monitor.ts
@@ -1,0 +1,137 @@
+import type {
+  MonitorJob,
+  MonitorOptions,
+  MonitorResponse,
+  ScrapeOptions,
+} from "../types";
+import { HttpClient } from "../utils/httpClient";
+import { ensureValidScrapeOptions } from "../utils/validation";
+import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
+
+function hasChangeTrackingFormat(scrapeOptions: ScrapeOptions): boolean {
+  if (!Array.isArray(scrapeOptions.formats)) {
+    return false;
+  }
+
+  return scrapeOptions.formats.some(format => {
+    if (typeof format === "string") {
+      return format === "changeTracking";
+    }
+
+    return (format as { type?: string }).type === "changeTracking";
+  });
+}
+
+function prepareMonitorPayload(request: MonitorOptions): Record<string, unknown> {
+  if (!Array.isArray(request.urls) || request.urls.length === 0) {
+    throw new Error("urls must be a non-empty array");
+  }
+
+  if (!request.scrapeOptions) {
+    throw new Error("scrapeOptions is required");
+  }
+
+  ensureValidScrapeOptions(request.scrapeOptions);
+
+  if (!hasChangeTrackingFormat(request.scrapeOptions)) {
+    throw new Error("scrapeOptions.formats must include changeTracking");
+  }
+
+  const payload: Record<string, unknown> = {
+    urls: request.urls,
+    scrapeOptions: request.scrapeOptions,
+  };
+
+  if (request.interval != null) {
+    payload.interval = request.interval;
+  }
+  if (request.webhook != null) {
+    payload.webhook = request.webhook;
+  }
+  if (request.origin != null) {
+    payload.origin = request.origin;
+  }
+  if (request.integration != null) {
+    payload.integration = request.integration;
+  }
+
+  return payload;
+}
+
+export async function startMonitor(
+  http: HttpClient,
+  request: MonitorOptions,
+): Promise<MonitorResponse> {
+  try {
+    const payload = prepareMonitorPayload(request);
+    const res = await http.post<{ success: boolean; id: string; url: string }>(
+      "/v2/monitor",
+      payload,
+    );
+    if (res.status !== 200 || !res.data?.success) {
+      throwForBadResponse(res, "start monitor");
+    }
+
+    return {
+      id: res.data.id,
+      url: res.data.url,
+    };
+  } catch (err: any) {
+    if (err?.isAxiosError) return normalizeAxiosError(err, "start monitor");
+    throw err;
+  }
+}
+
+export async function getMonitorStatus(
+  http: HttpClient,
+  jobId: string,
+): Promise<MonitorJob> {
+  try {
+    const res = await http.get<
+      MonitorJob & {
+        success: boolean;
+      }
+    >(`/v2/monitor/${jobId}`);
+    if (res.status !== 200 || !res.data?.success) {
+      throwForBadResponse(res, "get monitor status");
+    }
+
+    return {
+      id: res.data.id,
+      status: res.data.status,
+      urls: res.data.urls || [],
+      resolvedUrls: res.data.resolvedUrls || [],
+      interval: res.data.interval,
+      intervalMs: res.data.intervalMs,
+      createdAt: res.data.createdAt,
+      updatedAt: res.data.updatedAt,
+      nextRunAt: res.data.nextRunAt,
+      lastRunAt: res.data.lastRunAt,
+      latestData: res.data.latestData || [],
+      latestDataAt: res.data.latestDataAt,
+      lastError: res.data.lastError,
+    };
+  } catch (err: any) {
+    if (err?.isAxiosError) return normalizeAxiosError(err, "get monitor status");
+    throw err;
+  }
+}
+
+export async function cancelMonitor(
+  http: HttpClient,
+  jobId: string,
+): Promise<boolean> {
+  try {
+    const res = await http.delete<{ success?: boolean; status?: string }>(
+      `/v2/monitor/${jobId}`,
+    );
+    if (res.status !== 200) {
+      throwForBadResponse(res, "cancel monitor");
+    }
+
+    return res.data?.status === "cancelled";
+  } catch (err: any) {
+    if (err?.isAxiosError) return normalizeAxiosError(err, "cancel monitor");
+    throw err;
+  }
+}

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -164,7 +164,9 @@ export interface WebhookConfig {
   url: string;
   headers?: Record<string, string>;
   metadata?: Record<string, string>;
-  events?: Array<'completed' | 'failed' | 'page' | 'started'>;
+  events?: Array<
+    "completed" | "failed" | "page" | "started" | "changed" | "error"
+  >;
 }
 
 // Agent webhook events differ from crawl: has 'action' and 'cancelled', no 'page'
@@ -631,6 +633,41 @@ export interface ActiveCrawl {
 export interface ActiveCrawlsResponse {
   success: boolean;
   crawls: ActiveCrawl[];
+}
+
+export interface MonitorOptions {
+  urls: string[];
+  interval?: string;
+  scrapeOptions: ScrapeOptions;
+  webhook?: WebhookConfig;
+  origin?: string;
+  integration?: string | null;
+}
+
+export interface MonitorResponse {
+  id: string;
+  url: string;
+}
+
+export interface MonitorChangedGroup {
+  source: string;
+  pages: Document[];
+}
+
+export interface MonitorJob {
+  id: string;
+  status: "active" | "cancelled";
+  urls: string[];
+  resolvedUrls: string[];
+  interval: string;
+  intervalMs: number;
+  createdAt: string;
+  updatedAt: string;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  latestData: MonitorChangedGroup[];
+  latestDataAt: string | null;
+  lastError: string | null;
 }
 
 export interface ErrorDetails {

--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -67,6 +67,12 @@ class V2Proxy:
             self.get_active_crawls = client_instance.get_active_crawls
             self.active_crawls = client_instance.active_crawls
             self.crawl_params_preview = client_instance.crawl_params_preview
+            self.start_monitor = client_instance.start_monitor
+            self.get_monitor = client_instance.get_monitor
+            self.cancel_monitor = client_instance.cancel_monitor
+            self.monitor = client_instance.monitor
+            self.monitor_get = client_instance.monitor_get
+            self.monitor_stop = client_instance.monitor_stop
 
             self.extract = client_instance.extract
             self.start_extract = client_instance.start_extract
@@ -140,6 +146,12 @@ class AsyncV2Proxy:
             self.get_active_crawls = client_instance.get_active_crawls
             self.active_crawls = client_instance.active_crawls
             self.crawl_params_preview = client_instance.crawl_params_preview
+            self.start_monitor = client_instance.start_monitor
+            self.get_monitor = client_instance.get_monitor
+            self.cancel_monitor = client_instance.cancel_monitor
+            self.monitor = client_instance.monitor
+            self.monitor_get = client_instance.monitor_get
+            self.monitor_stop = client_instance.monitor_stop
 
             self.extract = client_instance.extract
             self.start_extract = client_instance.start_extract
@@ -233,6 +245,12 @@ class Firecrawl:
         self.get_crawl_errors = self._v2_client.get_crawl_errors
         self.get_active_crawls = self._v2_client.get_active_crawls
         self.active_crawls = self._v2_client.active_crawls
+        self.start_monitor = self._v2_client.start_monitor
+        self.get_monitor = self._v2_client.get_monitor
+        self.cancel_monitor = self._v2_client.cancel_monitor
+        self.monitor = self._v2_client.monitor
+        self.monitor_get = self._v2_client.monitor_get
+        self.monitor_stop = self._v2_client.monitor_stop
 
         self.start_batch_scrape = self._v2_client.start_batch_scrape
         self.get_batch_scrape_status = self._v2_client.get_batch_scrape_status
@@ -304,6 +322,12 @@ class AsyncFirecrawl:
         self.get_crawl_errors = self._v2_client.get_crawl_errors
         self.active_crawls = self._v2_client.active_crawls
         self.crawl_params_preview = self._v2_client.crawl_params_preview
+        self.start_monitor = self._v2_client.start_monitor
+        self.get_monitor = self._v2_client.get_monitor
+        self.cancel_monitor = self._v2_client.cancel_monitor
+        self.monitor = self._v2_client.monitor
+        self.monitor_get = self._v2_client.monitor_get
+        self.monitor_stop = self._v2_client.monitor_stop
 
         self.start_batch_scrape = self._v2_client.start_batch_scrape
         self.get_batch_scrape_status = self._v2_client.get_batch_scrape_status

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -24,6 +24,9 @@ from .types import (
     AgentWebhookConfig,
     CrawlErrorsResponse,
     ActiveCrawlsResponse,
+    MonitorRequest,
+    MonitorResponse,
+    MonitorJob,
     MapOptions,
     MapData,
     FormatOption,
@@ -47,6 +50,7 @@ from .methods import crawl as crawl_module
 from .methods import batch as batch_module
 from .methods import search as search_module
 from .methods import map as map_module
+from .methods import monitor as monitor_module
 from .methods import batch as batch_methods
 from .methods import usage as usage_methods
 from .methods import extract as extract_module
@@ -494,6 +498,58 @@ class FirecrawlClient:
             ActiveCrawlsResponse containing the list of active crawl jobs
         """
         return self.get_active_crawls()
+
+    def start_monitor(
+        self,
+        urls: List[str],
+        *,
+        scrape_options: ScrapeOptions,
+        interval: Optional[str] = None,
+        webhook: Optional[WebhookConfig] = None,
+        origin: Optional[str] = None,
+        integration: Optional[str] = None,
+    ) -> MonitorResponse:
+        request = MonitorRequest(
+            urls=urls,
+            scrape_options=scrape_options,
+            interval=interval,
+            webhook=webhook,
+            origin=origin,
+            integration=integration,
+        )
+        return monitor_module.start_monitor(self.http_client, request)
+
+    def get_monitor(self, job_id: str) -> MonitorJob:
+        return monitor_module.get_monitor_status(self.http_client, job_id)
+
+    def cancel_monitor(self, job_id: str) -> bool:
+        return monitor_module.cancel_monitor(self.http_client, job_id)
+
+    # Convenience aliases for prototype naming parity
+    def monitor(
+        self,
+        urls: List[str],
+        *,
+        scrape_options: ScrapeOptions,
+        interval: Optional[str] = None,
+        webhook: Optional[WebhookConfig] = None,
+        origin: Optional[str] = None,
+        integration: Optional[str] = None,
+    ) -> MonitorResponse:
+        return self.start_monitor(
+            urls,
+            scrape_options=scrape_options,
+            interval=interval,
+            webhook=webhook,
+            origin=origin,
+            integration=integration,
+        )
+
+    def monitor_get(self, job_id: str) -> MonitorJob:
+        return self.get_monitor(job_id)
+
+    def monitor_stop(self, job_id: str) -> bool:
+        return self.cancel_monitor(job_id)
 
     def map(
         self,

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -20,6 +20,9 @@ from .types import (
     CrawlParamsData,
     CrawlErrorsResponse,
     ActiveCrawlsResponse,
+    MonitorRequest,
+    MonitorResponse,
+    MonitorJob,
     MapOptions,
     MapData,
     FormatOption,
@@ -47,6 +50,7 @@ from .methods.aio import usage as async_usage # type: ignore[attr-defined]
 from .methods.aio import extract as async_extract  # type: ignore[attr-defined]
 from .methods.aio import agent as async_agent  # type: ignore[attr-defined]
 from .methods.aio import browser as async_browser  # type: ignore[attr-defined]
+from .methods.aio import monitor as async_monitor  # type: ignore[attr-defined]
 
 from .watcher_async import AsyncWatcher
 
@@ -235,6 +239,58 @@ class AsyncFirecrawlClient:
 
     async def active_crawls(self) -> ActiveCrawlsResponse:
         return await self.get_active_crawls()
+
+    async def start_monitor(
+        self,
+        urls: List[str],
+        *,
+        scrape_options: ScrapeOptions,
+        interval: Optional[str] = None,
+        webhook: Optional[WebhookConfig] = None,
+        origin: Optional[str] = None,
+        integration: Optional[str] = None,
+    ) -> MonitorResponse:
+        request = MonitorRequest(
+            urls=urls,
+            scrape_options=scrape_options,
+            interval=interval,
+            webhook=webhook,
+            origin=origin,
+            integration=integration,
+        )
+        return await async_monitor.start_monitor(self.async_http_client, request)
+
+    async def get_monitor(self, job_id: str) -> MonitorJob:
+        return await async_monitor.get_monitor_status(self.async_http_client, job_id)
+
+    async def cancel_monitor(self, job_id: str) -> bool:
+        return await async_monitor.cancel_monitor(self.async_http_client, job_id)
+
+    # Convenience aliases for prototype naming parity
+    async def monitor(
+        self,
+        urls: List[str],
+        *,
+        scrape_options: ScrapeOptions,
+        interval: Optional[str] = None,
+        webhook: Optional[WebhookConfig] = None,
+        origin: Optional[str] = None,
+        integration: Optional[str] = None,
+    ) -> MonitorResponse:
+        return await self.start_monitor(
+            urls,
+            scrape_options=scrape_options,
+            interval=interval,
+            webhook=webhook,
+            origin=origin,
+            integration=integration,
+        )
+
+    async def monitor_get(self, job_id: str) -> MonitorJob:
+        return await self.get_monitor(job_id)
+
+    async def monitor_stop(self, job_id: str) -> bool:
+        return await self.cancel_monitor(job_id)
 
     # Map
     async def map(

--- a/apps/python-sdk/firecrawl/v2/methods/aio/monitor.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/monitor.py
@@ -1,0 +1,139 @@
+from typing import Any, Dict, List
+from ...types import Document, MonitorJob, MonitorRequest, MonitorResponse
+from ...utils.error_handler import handle_response_error
+from ...utils.validation import prepare_scrape_options, validate_scrape_options
+from ...utils.http_client_async import AsyncHttpClient
+from ...utils.normalize import normalize_document_input
+
+
+def _normalize_monitor_webhook_events(webhook: Dict[str, Any]) -> None:
+    events = webhook.get("events")
+    if not isinstance(events, list):
+        return
+
+    normalized: List[str] = []
+    for event in events:
+        if isinstance(event, str) and event.startswith("monitor."):
+            normalized.append(event.split(".", 1)[1])
+        else:
+            normalized.append(event)
+    webhook["events"] = normalized
+
+
+def _has_change_tracking(scrape_options: Any) -> bool:
+    formats = getattr(scrape_options, "formats", None)
+
+    def has_change_tracking_item(item: Any) -> bool:
+        if isinstance(item, str):
+            return item in ("changeTracking", "change_tracking")
+        if isinstance(item, dict):
+            return item.get("type") in ("changeTracking", "change_tracking")
+        item_type = getattr(item, "type", None)
+        return item_type in ("changeTracking", "change_tracking")
+
+    if isinstance(formats, list):
+        return any(has_change_tracking_item(item) for item in formats)
+
+    if formats is None:
+        return False
+
+    if getattr(formats, "change_tracking", False):
+        return True
+
+    nested = getattr(formats, "formats", None)
+    if isinstance(nested, list):
+        return any(has_change_tracking_item(item) for item in nested)
+
+    return False
+
+
+def _prepare_monitor_request(request: MonitorRequest) -> Dict[str, Any]:
+    if not request.urls:
+        raise ValueError("urls must be a non-empty list")
+
+    validate_scrape_options(request.scrape_options)
+    if not _has_change_tracking(request.scrape_options):
+        raise ValueError("scrape_options.formats must include changeTracking")
+
+    payload: Dict[str, Any] = {
+        "urls": request.urls,
+        "scrapeOptions": prepare_scrape_options(request.scrape_options),
+    }
+
+    if request.interval is not None:
+        payload["interval"] = request.interval
+    if request.origin is not None:
+        payload["origin"] = request.origin
+    if request.integration is not None:
+        payload["integration"] = request.integration
+    if request.webhook is not None:
+        webhook_payload = request.webhook.model_dump(exclude_none=True)
+        _normalize_monitor_webhook_events(webhook_payload)
+        payload["webhook"] = webhook_payload
+
+    return payload
+
+
+async def start_monitor(
+    client: AsyncHttpClient, request: MonitorRequest
+) -> MonitorResponse:
+    payload = _prepare_monitor_request(request)
+    response = await client.post("/v2/monitor", payload)
+    if response.status_code >= 400:
+        handle_response_error(response, "start monitor")
+
+    body = response.json()
+    if not body.get("success"):
+        raise Exception(body.get("error", "Unknown error occurred"))
+
+    return MonitorResponse(id=body.get("id"), url=body.get("url"))
+
+
+async def get_monitor_status(client: AsyncHttpClient, job_id: str) -> MonitorJob:
+    response = await client.get(f"/v2/monitor/{job_id}")
+    if response.status_code >= 400:
+        handle_response_error(response, "get monitor status")
+
+    body = response.json()
+    if not body.get("success"):
+        raise Exception(body.get("error", "Unknown error occurred"))
+
+    latest_data = []
+    for group in body.get("latestData", []) or []:
+        pages = []
+        for page in group.get("pages", []) or []:
+            if isinstance(page, dict):
+                pages.append(Document(**normalize_document_input(page)))
+        latest_data.append(
+            {
+                "source": group.get("source"),
+                "pages": pages,
+            }
+        )
+
+    normalized = {
+        "id": body.get("id"),
+        "status": body.get("status"),
+        "urls": body.get("urls", []),
+        "resolved_urls": body.get("resolvedUrls", []),
+        "interval": body.get("interval"),
+        "interval_ms": body.get("intervalMs"),
+        "created_at": body.get("createdAt"),
+        "updated_at": body.get("updatedAt"),
+        "next_run_at": body.get("nextRunAt"),
+        "last_run_at": body.get("lastRunAt"),
+        "latest_data": latest_data,
+        "latest_data_at": body.get("latestDataAt"),
+        "last_error": body.get("lastError"),
+    }
+
+    return MonitorJob(**normalized)
+
+
+async def cancel_monitor(client: AsyncHttpClient, job_id: str) -> bool:
+    response = await client.delete(f"/v2/monitor/{job_id}")
+    if response.status_code >= 400:
+        handle_response_error(response, "cancel monitor")
+
+    body = response.json()
+    return body.get("status") == "cancelled"

--- a/apps/python-sdk/firecrawl/v2/methods/monitor.py
+++ b/apps/python-sdk/firecrawl/v2/methods/monitor.py
@@ -1,0 +1,144 @@
+"""
+Monitor functionality for Firecrawl v2 API.
+"""
+
+from typing import Any, Dict, List
+from ..types import Document, MonitorJob, MonitorRequest, MonitorResponse
+from ..utils import (
+    HttpClient,
+    handle_response_error,
+    prepare_scrape_options,
+    validate_scrape_options,
+)
+from ..utils.normalize import normalize_document_input
+
+
+def _normalize_monitor_webhook_events(webhook: Dict[str, Any]) -> None:
+    events = webhook.get("events")
+    if not isinstance(events, list):
+        return
+
+    normalized: List[str] = []
+    for event in events:
+        if isinstance(event, str) and event.startswith("monitor."):
+            normalized.append(event.split(".", 1)[1])
+        else:
+            normalized.append(event)
+    webhook["events"] = normalized
+
+
+def _has_change_tracking(scrape_options: Any) -> bool:
+    formats = getattr(scrape_options, "formats", None)
+
+    def has_change_tracking_item(item: Any) -> bool:
+        if isinstance(item, str):
+            return item in ("changeTracking", "change_tracking")
+        if isinstance(item, dict):
+            return item.get("type") in ("changeTracking", "change_tracking")
+        item_type = getattr(item, "type", None)
+        return item_type in ("changeTracking", "change_tracking")
+
+    if isinstance(formats, list):
+        return any(has_change_tracking_item(item) for item in formats)
+
+    if formats is None:
+        return False
+
+    if getattr(formats, "change_tracking", False):
+        return True
+
+    nested = getattr(formats, "formats", None)
+    if isinstance(nested, list):
+        return any(has_change_tracking_item(item) for item in nested)
+
+    return False
+
+
+def _prepare_monitor_request(request: MonitorRequest) -> Dict[str, Any]:
+    if not request.urls:
+        raise ValueError("urls must be a non-empty list")
+
+    validate_scrape_options(request.scrape_options)
+    if not _has_change_tracking(request.scrape_options):
+        raise ValueError("scrape_options.formats must include changeTracking")
+
+    payload: Dict[str, Any] = {
+        "urls": request.urls,
+        "scrapeOptions": prepare_scrape_options(request.scrape_options),
+    }
+
+    if request.interval is not None:
+        payload["interval"] = request.interval
+    if request.origin is not None:
+        payload["origin"] = request.origin
+    if request.integration is not None:
+        payload["integration"] = request.integration
+    if request.webhook is not None:
+        webhook_payload = request.webhook.model_dump(exclude_none=True)
+        _normalize_monitor_webhook_events(webhook_payload)
+        payload["webhook"] = webhook_payload
+
+    return payload
+
+
+def start_monitor(client: HttpClient, request: MonitorRequest) -> MonitorResponse:
+    payload = _prepare_monitor_request(request)
+    response = client.post("/v2/monitor", payload)
+    if not response.ok:
+        handle_response_error(response, "start monitor")
+
+    body = response.json()
+    if not body.get("success"):
+        raise Exception(body.get("error", "Unknown error occurred"))
+
+    return MonitorResponse(id=body.get("id"), url=body.get("url"))
+
+
+def get_monitor_status(client: HttpClient, job_id: str) -> MonitorJob:
+    response = client.get(f"/v2/monitor/{job_id}")
+    if not response.ok:
+        handle_response_error(response, "get monitor status")
+
+    body = response.json()
+    if not body.get("success"):
+        raise Exception(body.get("error", "Unknown error occurred"))
+
+    latest_data = []
+    for group in body.get("latestData", []) or []:
+        pages = []
+        for page in group.get("pages", []) or []:
+            if isinstance(page, dict):
+                pages.append(Document(**normalize_document_input(page)))
+        latest_data.append(
+            {
+                "source": group.get("source"),
+                "pages": pages,
+            }
+        )
+
+    normalized = {
+        "id": body.get("id"),
+        "status": body.get("status"),
+        "urls": body.get("urls", []),
+        "resolved_urls": body.get("resolvedUrls", []),
+        "interval": body.get("interval"),
+        "interval_ms": body.get("intervalMs"),
+        "created_at": body.get("createdAt"),
+        "updated_at": body.get("updatedAt"),
+        "next_run_at": body.get("nextRunAt"),
+        "last_run_at": body.get("lastRunAt"),
+        "latest_data": latest_data,
+        "latest_data_at": body.get("latestDataAt"),
+        "last_error": body.get("lastError"),
+    }
+
+    return MonitorJob(**normalized)
+
+
+def cancel_monitor(client: HttpClient, job_id: str) -> bool:
+    response = client.delete(f"/v2/monitor/{job_id}")
+    if not response.ok:
+        handle_response_error(response, "cancel monitor")
+
+    body = response.json()
+    return body.get("status") == "cancelled"

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -317,7 +317,9 @@ class WebhookConfig(BaseModel):
     url: str
     headers: Optional[Dict[str, str]] = None
     metadata: Optional[Dict[str, str]] = None
-    events: Optional[List[Literal["completed", "failed", "page", "started"]]] = None
+    events: Optional[
+        List[Literal["completed", "failed", "page", "started", "changed", "error"]]
+    ] = None
 
 
 class AgentWebhookConfig(BaseModel):
@@ -1180,6 +1182,49 @@ class ActiveCrawlsResponse(BaseModel):
 
     success: bool = True
     crawls: List[ActiveCrawl]
+
+
+class MonitorRequest(BaseModel):
+    """Request for starting a monitor job."""
+
+    urls: List[str]
+    interval: Optional[str] = None
+    scrape_options: ScrapeOptions
+    webhook: Optional[WebhookConfig] = None
+    origin: Optional[str] = None
+    integration: Optional[str] = None
+
+
+class MonitorResponse(BaseModel):
+    """Response from monitor start endpoint."""
+
+    id: str
+    url: str
+
+
+class MonitorChangeGroup(BaseModel):
+    """Grouped monitor changes for a single source host."""
+
+    source: str
+    pages: List[Document]
+
+
+class MonitorJob(BaseModel):
+    """Monitor job status and latest data snapshot."""
+
+    id: str
+    status: Literal["active", "cancelled"]
+    urls: List[str]
+    resolved_urls: List[str]
+    interval: str
+    interval_ms: int
+    created_at: str
+    updated_at: str
+    next_run_at: Optional[str] = None
+    last_run_at: Optional[str] = None
+    latest_data: List[MonitorChangeGroup] = Field(default_factory=list)
+    latest_data_at: Optional[str] = None
+    last_error: Optional[str] = None
 
 
 class ActiveCrawlsRequest(BaseModel):


### PR DESCRIPTION
## Summary
- Add `/v2/monitor` create/get/cancel endpoints with an in-memory scheduler and snapshot-based change detection for prototype monitoring.
- Extend webhook support for `monitor.started`, `monitor.changed`, and `monitor.error` events, and wire monitor payload types.
- Add JS and Python SDK monitor methods plus local playground tooling (`monitor.quick-test.ts` and monitor request/demo scripts).

## Test plan
- [x] Build API (`pnpm --dir apps/api build`)
- [x] Manual local API smoke test for create/get/cancel monitor flow
- [x] Baseline suppression validation (first run emits no `monitor.changed`)
- [x] Follow-up run validation (later run can emit `monitor.changed`)
- [x] Quick script run: `pnpm --dir apps/api tsx requests/v2/monitor.quick-test.ts --no-wait-second-run`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a prototype v2 Monitor API with an in-memory scheduler for URL change tracking, plus JS/Python SDK methods and new webhook events to create, query, and cancel monitors.

- **New Features**
  - API: POST /v2/monitor, GET /v2/monitor/:id, DELETE /v2/monitor/:id with snapshot-based change detection, baseline suppression on first run, and optional wildcard support via /*.
  - Webhooks: added monitor.started, monitor.changed, monitor.error events; schema and self-hosted defaults updated.
  - SDKs: JS startMonitor/getMonitor/cancelMonitor (+aliases); Python sync/async equivalents.
  - Tooling: local demo server, HTTP request collection, and a quick test script to exercise the flow.

- **Migration**
  - scrapeOptions.formats must include changeTracking.
  - interval must be ≥5m and match 5m/30m/1h/24h.
  - Wildcards require a trailing /*; expanded via sitemap/map.
  - Prototype stores state in memory; monitors reset on server restarts.

<sup>Written for commit adec05790d9a6b12e3268b722efb19c769702114. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

