### PR TITLE
feat(playwright): expose timezone in scrape result and allow specifying timezone

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -19,6 +19,7 @@ export async function scrapeURLWithPlaywright(
       timeout: meta.abort.scrapeTimeout(),
       headers: meta.options.headers,
       skip_tls_verification: meta.options.skipTlsVerification,
+      timezone: meta.options.location?.timezone,
     },
     method: "POST",
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),
@@ -27,6 +28,7 @@ export async function scrapeURLWithPlaywright(
       pageStatusCode: z.number(),
       pageError: z.string().optional(),
       contentType: z.string().optional(),
+      timezone: z.string().optional(),
     }),
     mock: meta.mock,
     abort: meta.abort.asSignal(),
@@ -42,7 +44,7 @@ export async function scrapeURLWithPlaywright(
     statusCode: response.pageStatusCode,
     error: response.pageError,
     contentType: response.contentType,
-
+    timezone: response.timezone,
     proxyUsed: "basic",
   };
 }

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -80,6 +80,7 @@ interface UrlModel {
   headers?: { [key: string]: string };
   check_selector?: string;
   skip_tls_verification?: boolean;
+  timezone?: string;
 }
 
 let browser: Browser;
@@ -99,7 +100,16 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
+const isValidTimezone = (tz: string): boolean => {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const createContext = async (skipTlsVerification: boolean = false, timezone?: string) => {
   const userAgent = new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
@@ -107,6 +117,7 @@ const createContext = async (skipTlsVerification: boolean = false) => {
     userAgent,
     viewport,
     ignoreHTTPSErrors: skipTlsVerification,
+    ...(timezone && { timezoneId: timezone }), 
   };
 
   if (PROXY_SERVER && PROXY_USERNAME && PROXY_PASSWORD) {
@@ -219,8 +230,7 @@ app.get('/health', async (req: Request, res: Response) => {
 });
 
 app.post('/scrape', async (req: Request, res: Response) => {
-  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false }: UrlModel = req.body;
-
+  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false, timezone }: UrlModel = req.body;
   console.log(`================= Scrape Request =================`);
   console.log(`URL: ${url}`);
   console.log(`Wait After Load: ${wait_after_load}`);
@@ -228,6 +238,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   console.log(`Headers: ${headers ? JSON.stringify(headers) : 'None'}`);
   console.log(`Check Selector: ${check_selector ? check_selector : 'None'}`);
   console.log(`Skip TLS Verification: ${skip_tls_verification}`);
+  console.log(`Timezone: ${timezone ?? 'None (browser default)'}`);
   console.log(`==================================================`);
 
   if (!url) {
@@ -236,6 +247,10 @@ app.post('/scrape', async (req: Request, res: Response) => {
 
   if (!isValidUrl(url)) {
     return res.status(400).json({ error: 'Invalid URL' });
+  }
+
+  if (timezone && !isValidTimezone(timezone)) {
+      return res.status(400).json({ error: `Invalid timezone: '${timezone}'. Use IANA format e.g. 'America/New_York'` });
   }
 
   if (!PROXY_SERVER) {
@@ -252,7 +267,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, timezone);
     page = await requestContext.newPage();
 
     if (headers) {
@@ -261,7 +276,8 @@ app.post('/scrape', async (req: Request, res: Response) => {
 
     const result = await scrapePage(page, url, 'load', wait_after_load, timeout, check_selector);
     const pageError = result.status !== 200 ? getError(result.status) : undefined;
-
+    const actualTimezone = await page.evaluate(() =>
+      Intl.DateTimeFormat().resolvedOptions().timeZone);
     if (!pageError) {
       console.log(`✅ Scrape successful!`);
     } else {
@@ -272,6 +288,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
       content: result.content,
       pageStatusCode: result.status,
       contentType: result.contentType,
+      timezone: actualTimezone,
       ...(pageError && { pageError })
     });
 


### PR DESCRIPTION
## Summary
Fixes #2383

Adds timezone support to the self-hosted Playwright scraping path.

## Changes
- `playwright-service-ts/api.ts`: Added `timezone` field to `UrlModel`, passes `timezoneId` to Playwright browser context, returns actual browser timezone in response
- `engines/playwright/index.ts`: Forwards `meta.options.location.timezone` to playwright microservice request body, adds `timezone` to response schema and return value

## How to test
```json
POST /scrape
{
  "url": "https://www.timeanddate.com/worldclock/",
  "location": {
    "country": "US",
    "timezone": "America/New_York"
  }
}
```
Response will include `"timezone": "America/New_York"`

## Notes
- Fire-engine path already handled timezone separately
- This fix closes the gap for self-hosted Playwright users
- Falls back gracefully if timezone not specified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds timezone support to the self-hosted Playwright scraper so clients can set an IANA timezone and receive the resolved timezone in the response. Closes #2383.

- **New Features**
  - API: Accepts location.timezone in scrape requests and forwards it to the Playwright service.
  - Playwright service: Validates the timezone, sets it as timezoneId in the browser context, and includes the resolved timezone in the response.
  - Optional field; if not provided, the browser default timezone is used.

<sup>Written for commit c2e800b4d2631b22a689a5c0d43a310bc006e71f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

