### PR TITLE
Fix embedded-PDF URLs misclassified as raw PDFs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/contentTypeHeuristics.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/contentTypeHeuristics.test.ts
@@ -1,0 +1,36 @@
+import { shouldRemovePdfFeatureForContentType } from "../contentTypeHeuristics";
+
+describe("shouldRemovePdfFeatureForContentType", () => {
+  it("does not remove PDF feature for application/pdf", () => {
+    expect(shouldRemovePdfFeatureForContentType("application/pdf")).toBe(false);
+    expect(
+      shouldRemovePdfFeatureForContentType("application/pdf; charset=binary"),
+    ).toBe(false);
+  });
+
+  it("does not remove PDF feature for application/octet-stream", () => {
+    expect(
+      shouldRemovePdfFeatureForContentType("application/octet-stream"),
+    ).toBe(false);
+  });
+
+  it("removes PDF feature for html responses", () => {
+    expect(shouldRemovePdfFeatureForContentType("text/html")).toBe(true);
+    expect(
+      shouldRemovePdfFeatureForContentType("text/html; charset=UTF-8"),
+    ).toBe(true);
+    expect(shouldRemovePdfFeatureForContentType("application/xhtml+xml")).toBe(
+      true,
+    );
+  });
+
+  it("removes PDF feature for non-html text responses", () => {
+    expect(shouldRemovePdfFeatureForContentType("text/plain")).toBe(true);
+  });
+
+  it("does not remove when content type is missing", () => {
+    expect(shouldRemovePdfFeatureForContentType(null)).toBe(false);
+    expect(shouldRemovePdfFeatureForContentType(undefined)).toBe(false);
+    expect(shouldRemovePdfFeatureForContentType("")).toBe(false);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/contentTypeHeuristics.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/contentTypeHeuristics.ts
@@ -1,0 +1,28 @@
+export function shouldRemovePdfFeatureForContentType(
+  contentType: string | null | undefined,
+): boolean {
+  if (!contentType) {
+    return false;
+  }
+
+  const normalized = contentType.split(";")[0].trim().toLowerCase();
+
+  // Valid (or ambiguous-but-common) PDF download types should keep PDF parsing enabled.
+  if (normalized === "application/pdf") {
+    return false;
+  }
+  if (normalized === "application/octet-stream") {
+    return false;
+  }
+
+  // HTML/text responses on .pdf URLs are typically embedded viewers or error pages.
+  // In this case we should remove the pdf feature and let HTML engines handle it.
+  if (normalized.startsWith("text/")) {
+    return true;
+  }
+  if (normalized === "application/xhtml+xml") {
+    return true;
+  }
+
+  return false;
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -12,7 +12,6 @@ import {
   EngineUnsuccessfulError,
 } from "../../error";
 import { open, readFile, unlink } from "node:fs/promises";
-import type { Response } from "undici";
 import { AbortManagerThrownError } from "../../lib/abortManager";
 import {
   shouldParsePDF,
@@ -28,6 +27,7 @@ import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
+import { shouldRemovePdfFeatureForContentType } from "./contentTypeHeuristics";
 
 /** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
 function getIneligibleReason(
@@ -70,6 +70,14 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         },
       );
 
+      if (
+        shouldRemovePdfFeatureForContentType(
+          file.response.headers.get("content-type"),
+        )
+      ) {
+        throw new RemoveFeatureError(["pdf"]);
+      }
+
       if (!isPdfBuffer(file.buffer)) {
         // downloaded content isn't a valid PDF
         if (meta.pdfPrefetch === undefined) {
@@ -109,6 +117,14 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             signal: meta.abort.asSignal(),
           },
         );
+
+  const contentType =
+    "headers" in response
+      ? response.headers.get("content-type")
+      : response.contentType;
+  if (shouldRemovePdfFeatureForContentType(contentType)) {
+    throw new RemoveFeatureError(["pdf"]);
+  }
 
   try {
     // Validate the downloaded file is actually a PDF by checking magic bytes

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -118,15 +118,15 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           },
         );
 
-  const contentType =
-    "headers" in response
-      ? response.headers.get("content-type")
-      : response.contentType;
-  if (shouldRemovePdfFeatureForContentType(contentType)) {
-    throw new RemoveFeatureError(["pdf"]);
-  }
-
   try {
+    const contentType =
+      "headers" in response
+        ? response.headers.get("content-type")
+        : response.contentType;
+    if (shouldRemovePdfFeatureForContentType(contentType)) {
+      throw new RemoveFeatureError(["pdf"]);
+    }
+
     // Validate the downloaded file is actually a PDF by checking magic bytes
     const header = Buffer.alloc(PDF_SNIFF_WINDOW);
     const fh = await open(tempFilePath, "r");


### PR DESCRIPTION
## Summary
Fixes #839 by preventing `.pdf` URL suffixes from forcing PDF parsing when the response is actually HTML/text (embedded viewer pages).

## What changed
- added `shouldRemovePdfFeatureForContentType` heuristic for PDF engine inputs
- in PDF engine paths, when content-type is clearly HTML/text (`text/*`, `application/xhtml+xml`), throw `RemoveFeatureError(["pdf"])`
- this makes the scrape loop drop the `pdf` feature and retry with regular HTML-capable engines
- added focused tests for content-type heuristics

## Why this helps
Some URLs end with `.pdf` but return HTML pages that embed a PDF viewer. Previously this could reach PDF parsing and fail with errors like `Invalid PDF structure`. Now those responses are treated as non-PDF early and routed through the normal HTML flow.

## Validation
- `pnpm test -- src/scraper/scrapeURL/engines/pdf/__tests__/contentTypeHeuristics.test.ts`
- `pnpm test -- src/scraper/scrapeURL/engines/pdf/__tests__/isPdfBuffer.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `.pdf` URLs with HTML/text responses from being parsed as PDFs, so embedded viewer pages go through the normal HTML flow. Fixes #839 and avoids errors like “Invalid PDF structure.”

- **Bug Fixes**
  - Added a content-type heuristic: keep PDF for `application/pdf` and `application/octet-stream`; treat `text/*` and `application/xhtml+xml` as HTML.
  - In the PDF engine, run the check early (inside try/finally) and throw `RemoveFeatureError(["pdf"])` so temp files are deleted and we retry with HTML-capable engines.
  - Added tests for the heuristic.

<sup>Written for commit 3f0bffb6b562842a2c9a08755be61ceb8c0d9793. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

