### PR TITLE
fix: use user-agent from headers if provided in scrape request

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, headers?: Record<string, string>) => {
+  const userAgent = headers?.['user-agent'] ?? new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,7 +252,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    requestContext = await createContext(skip_tls_verification, headers);
     page = await requestContext.newPage();
 
     if (headers) {

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -100,7 +100,7 @@ const initializeBrowser = async () => {
 };
 
 const createContext = async (skipTlsVerification: boolean = false, headers?: Record<string, string>) => {
-  const userAgent = headers?.['user-agent'] ?? new UserAgent().toString();
+  const userAgent = Object.entries(headers ?? {}).find(([key]) => key.toLowerCase() === 'user-agent')?.[1] ?? new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {


### PR DESCRIPTION
When user-agent is passed in headers to the scrape endpoint, it was being ignored because Playwright sets the context's user-agent first (from UserAgent package), then extra HTTP headers are applied. Playwright ignores user-agent in extra headers if it's already set on the context.

This fix checks if headers['user-agent'] is provided and uses that for the context's userAgent instead of the derived UserAgent package value.

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the user-agent from scrape request headers when provided, so Playwright uses the requested UA instead of the generated default. Fixes cases where the header user-agent was being ignored.

- **Bug Fixes**
  - Pass headers to createContext and set the context userAgent from a case-insensitive "user-agent" header when available.
  - Prevent Playwright from overriding the header UA by setting it at context creation.

<sup>Written for commit a0df5d176fa9b548722cb35691322b02d7e882b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

