### PR TITLE
ci(rust-sdk): add publish workflow for crates.io

### DIFF
--- a/.github/scripts/check_version_has_incremented.py
+++ b/.github/scripts/check_version_has_incremented.py
@@ -82,18 +82,19 @@ def get_maven_central_version(package_name: str) -> str:
         return version_match.group(1).strip()
     return "0.0.0"
 
-# def get_rust_version(file_path: str) -> str:
-#     """Extract version string from Cargo.toml."""
-#     cargo_toml = toml.load(file_path)
-#     if 'package' in cargo_toml and 'version' in cargo_toml['package']:
-#         return cargo_toml['package']['version'].strip()
-#     raise RuntimeError("Unable to find version string in Cargo.toml.")
+def get_rust_version(file_path: str) -> str:
+    """Extract version string from Cargo.toml."""
+    import toml
+    cargo_toml = toml.load(file_path)
+    if 'package' in cargo_toml and 'version' in cargo_toml['package']:
+        return cargo_toml['package']['version'].strip()
+    raise RuntimeError("Unable to find version string in Cargo.toml.")
 
-# def get_crates_version(package_name: str) -> str:
-#     """Get latest version of Rust package from crates.io."""
-#     response = requests.get(f"https://crates.io/api/v1/crates/{package_name}")
-#     version = response.json()['crate']['newest_version']
-#     return version.strip()
+def get_crates_version(package_name: str) -> str:
+    """Get latest version of Rust package from crates.io."""
+    response = requests.get(f"https://crates.io/api/v1/crates/{package_name}")
+    version = response.json()['crate']['newest_version']
+    return version.strip()
 
 def is_version_incremented(local_version: str, published_version: str) -> bool:
     """Compare local and published versions."""
@@ -121,14 +122,14 @@ if __name__ == "__main__":
         current_version = get_gradle_version(os.path.join(package_path, 'build.gradle.kts'))
         # Get published version from Maven Central
         published_version = get_maven_central_version(package_name)
-    # if package_type == "rust":
-    #     # Get current version from Cargo.toml
-    #     current_version = get_rust_version(os.path.join(package_path, 'Cargo.toml'))
-    #     # Get published version from crates.io
-    #     published_version = get_crates_version(package_name)
+    elif package_type == "rust":
+        # Get current version from Cargo.toml
+        current_version = get_rust_version(os.path.join(package_path, 'Cargo.toml'))
+        # Get published version from crates.io
+        published_version = get_crates_version(package_name)
 
     else:
-        raise ValueError("Invalid package type. Use 'python', 'js', or 'java'.")
+        raise ValueError("Invalid package type. Use 'python', 'js', 'java', or 'rust'.")
 
     # Print versions for debugging
     # print(f"Local version: {current_version}")

--- a/.github/scripts/check_version_has_incremented.py
+++ b/.github/scripts/check_version_has_incremented.py
@@ -93,6 +93,9 @@ def get_rust_version(file_path: str) -> str:
 def get_crates_version(package_name: str) -> str:
     """Get latest version of Rust package from crates.io."""
     response = requests.get(f"https://crates.io/api/v1/crates/{package_name}")
+    if response.status_code == 404:
+        return "0.0.0"
+    response.raise_for_status()
     version = response.json()['crate']['newest_version']
     return version.strip()
 

--- a/.github/workflows/publish-rust-sdk.yml
+++ b/.github/workflows/publish-rust-sdk.yml
@@ -1,0 +1,74 @@
+name: Publish Rust SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/rust-sdk/**'
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install requests packaging toml
+
+      - name: Run version check script
+        id: version_check
+        run: |
+          VERSION_INCREMENTED=$(python .github/scripts/check_version_has_incremented.py rust ./apps/rust-sdk firecrawl)
+          echo "VERSION_INCREMENTED=$VERSION_INCREMENTED" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo registry
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/rust-sdk/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('apps/rust-sdk/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        working-directory: ./apps/rust-sdk
+        run: cargo fmt --check
+
+      - name: Run clippy
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        working-directory: ./apps/rust-sdk
+        run: cargo clippy --all-targets -- -D warnings -A clippy::needless_borrows_for_generic_args -A clippy::redundant_closure -A clippy::large_enum_variant -A clippy::extra_unused_lifetimes
+
+      - name: Run unit tests
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        working-directory: ./apps/rust-sdk
+        run: cargo test --lib
+
+      - name: Dry-run publish
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        working-directory: ./apps/rust-sdk
+        run: cargo publish --dry-run
+
+      - name: Publish to crates.io
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        working-directory: ./apps/rust-sdk
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish


### PR DESCRIPTION
The Rust SDK has no automated publish workflow, unlike the Python and JS SDKs. This adds one following the same pattern: trigger on pushes to main that touch apps/rust-sdk/**, check the local Cargo.toml version against crates.io, and only proceed if the version has been incremented.

The version check script already had Rust support commented out, so this uncomments it and wires up the "rust" branch. The toml import is done inline so existing workflows that don't install the toml package aren't affected.

Before publishing, the workflow re-runs fmt, clippy, and unit tests (since the test workflow only runs on PRs), then does a cargo publish --dry-run to catch packaging errors before the real publish. All steps after the version check are gated on the version having actually changed, so no-op pushes skip the Rust toolchain install entirely.

Uses the CRATES_IO_TOKEN secret for authentication with crates.io.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automated workflow to publish the Rust SDK to `crates.io` on a `Cargo.toml` version bump, with Rust support and handling for unpublished crates in the version check.

- **New Features**
  - Workflow triggers on pushes to `main` that touch `apps/rust-sdk/**`, checks local `Cargo.toml` against `crates.io`, and runs only on version bump.
  - `.github/scripts/check_version_has_incremented.py` adds Rust support with inline `toml`; treats 404/unpublished crates as `0.0.0` so first publish proceeds.
  - On bump: runs `cargo fmt --check`, `cargo clippy`, `cargo test --lib`, then `cargo publish --dry-run` and `cargo publish`; caches Cargo dirs; uses `CRATES_IO_TOKEN` for auth.

<sup>Written for commit a3b711d0770e0c2f5efa897851f16f3373c8fc6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

