### PR TITLE
fix: use user-provided user-agent header in playwright scrape

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -99,8 +99,8 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false) => {
-  const userAgent = new UserAgent().toString();
+const createContext = async (skipTlsVerification: boolean = false, customUserAgent?: string) => {
+  const userAgent = customUserAgent || new UserAgent().toString();
   const viewport = { width: 1280, height: 800 };
 
   const contextOptions: any = {
@@ -252,7 +252,8 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    requestContext = await createContext(skip_tls_verification);
+    const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 
     if (headers) {

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -252,7 +252,9 @@ app.post('/scrape', async (req: Request, res: Response) => {
   let page: Page | null = null;
 
   try {
-    const customUserAgent = headers?.['user-agent'] || headers?.['User-Agent'];
+    const customUserAgent = headers
+      ? Object.entries(headers).find(([key]) => key.toLowerCase() === 'user-agent')?.[1]
+      : undefined;
     requestContext = await createContext(skip_tls_verification, customUserAgent);
     page = await requestContext.newPage();
 


### PR DESCRIPTION
## Summary

This fix ensures that when a user-agent header is provided in the scrape request headers, it is properly used by playwright instead of being ignored.

## Changes

- Modified user-agent handling in apps/playwright-service-ts/api.ts to prioritize user-provided headers
- The user-agent from request headers now takes precedence over the default UserAgent package value

## Testing

- Verified the fix preserves backward compatibility (default behavior unchanged when no user-agent header is provided)
- Tested that explicit user-agent headers are now respected

Fixes #2802

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the user-provided `user-agent` header in the `playwright` scrape endpoint, falling back to a generated `UserAgent` only when none is provided. Header lookup is now case-insensitive, and the value is applied at browser context creation so all requests use the exact agent clients specify.

<sup>Written for commit 1a3470b0751379e31051a263f109e365e0d34b0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

