### PR TITLE
fix: return creditsUsed during agent job processing

### DIFF
--- a/apps/api/src/controllers/v2/agent-status.ts
+++ b/apps/api/src/controllers/v2/agent-status.ts
@@ -87,6 +87,6 @@ export async function agentStatusController(
       new Date(agent?.created_at ?? agentRequest.created_at).getTime() +
         1000 * 60 * 60 * 24,
     ).toISOString(),
-    creditsUsed: agent?.credits_cost,
+    creditsUsed: agent?.credits_cost ?? 0,
   });
 }

--- a/apps/api/src/controllers/v2/extract-status.ts
+++ b/apps/api/src/controllers/v2/extract-status.ts
@@ -66,7 +66,7 @@ export async function extractStatusController(
           new Date(agent?.created_at ?? extractRequest.created_at).getTime() +
             1000 * 60 * 60 * 24,
         ).toISOString(),
-        creditsUsed: agent?.credits_cost,
+        creditsUsed: agent?.credits_cost ?? 0,
       });
     }
   }


### PR DESCRIPTION
## Summary

This fix ensures that the `creditsUsed` attribute is always returned in the agent status endpoint response, even during job processing. Previously, `creditsUsed` was only returned when the agent job completed because the value was read from the agents table which is only populated after completion.

## Changes

- Modified `apps/api/src/controllers/v2/agent-status.ts` to return `creditsUsed: 0` when the agent is still processing
- Modified `apps/api/src/controllers/v2/extract-status.ts` to return `creditsUsed: 0` for agent jobs that are still processing

## Testing

The fix was verified by reviewing the code changes. The changes are minimal and follow the existing code patterns:
- When `agent` is null (job processing), `agent?.credits_cost ?? 0` returns `0`
- When `agent` exists (job completed/failed), `agent?.credits_cost ?? 0` returns the actual credits cost

Note: Running tests was not possible due to disk space constraints on the build environment.

Fixes firecrawl/firecrawl#2891

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return `creditsUsed` in v2 agent and extract status responses, using 0 while jobs are processing. Fixes firecrawl/firecrawl#2891 and keeps the schema stable for polling clients.

- **Bug Fixes**
  - v2/agent-status: set `creditsUsed` to `agent?.credits_cost ?? 0`.
  - v2/extract-status: set `creditsUsed` to `agent?.credits_cost ?? 0`.

<sup>Written for commit 4e735d3c642a6b9acfb4ea8ad5910b67b567b267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

