### PR TITLE
fix(ci): build nuq-postgres image for amd64 and arm64

### DIFF
--- a/.github/workflows/deploy-nuq-postgres.yml
+++ b/.github/workflows/deploy-nuq-postgres.yml
@@ -6,17 +6,28 @@ on:
       - main
     paths:
       - apps/nuq-postgres/**
+      - .github/workflows/deploy-nuq-postgres.yml
   workflow_dispatch:
 
 jobs:
-  push-app-image:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: './apps/nuq-postgres'
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@main
+
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -25,7 +36,46 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: 'Build NuQ Postgres Image'
+      - name: Lowercase Repo Owner
         run: |
-          docker build . --tag ghcr.io/firecrawl/nuq-postgres:latest
-          docker push ghcr.io/firecrawl/nuq-postgres:latest
+          echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+        env:
+          GITHUB_REPOSITORY_OWNER: '${{ github.repository_owner }}'
+
+      - name: Extract platform suffix
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_SUFFIX=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: 'Build and Push Image'
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        with:
+          context: ./apps/nuq-postgres
+          push: true
+          tags: ghcr.io/${{ env.REPO_OWNER }}/nuq-postgres:${{ env.PLATFORM_SUFFIX }}
+          platforms: ${{ matrix.platform }}
+          provenance: false
+
+  manifest:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: build
+    steps:
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Lowercase Repo Owner
+        run: |
+          echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+        env:
+          GITHUB_REPOSITORY_OWNER: '${{ github.repository_owner }}'
+
+      - name: 'Create and Push Multi-Arch Manifest'
+        run: |
+          docker manifest create ghcr.io/${{ env.REPO_OWNER }}/nuq-postgres:latest \
+            ghcr.io/${{ env.REPO_OWNER }}/nuq-postgres:linux-amd64 \
+            ghcr.io/${{ env.REPO_OWNER }}/nuq-postgres:linux-arm64
+          docker manifest push ghcr.io/${{ env.REPO_OWNER }}/nuq-postgres:latest

--- a/.github/workflows/deploy-nuq-postgres.yml
+++ b/.github/workflows/deploy-nuq-postgres.yml
@@ -9,9 +9,14 @@ on:
       - .github/workflows/deploy-nuq-postgres.yml
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -24,7 +29,7 @@ jobs:
         working-directory: './apps/nuq-postgres'
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@main
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
@@ -59,6 +64,9 @@ jobs:
   manifest:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
+    environment: ghcr-publish
+    permissions:
+      packages: write
     steps:
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/apps/api/src/__tests__/snips/mocks/map-redirect.json
+++ b/apps/api/src/__tests__/snips/mocks/map-redirect.json
@@ -2,14 +2,14 @@
   {
     "time": 1782145899000,
     "options": {
-      "url": "http://www.firecrawl.dev/sitemap.xml",
+      "url": "https://www.firecrawl.dev/sitemap.xml",
       "method": "GET",
       "ignoreResponse": false,
       "ignoreFailure": false,
       "tryCount": 1
     },
     "result": {
-      "url": "http://www.firecrawl.dev/sitemap.xml",
+      "url": "https://www.firecrawl.dev/sitemap.xml",
       "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
       "status": 200,
       "headers": [["content-type", "application/xml"]]


### PR DESCRIPTION
## Summary
- The `nuq-postgres` Docker image was only built for `linux/amd64`, causing emulation on Apple Silicon and other arm64 hosts
- Updated the CI workflow to use the same multi-arch build pattern (matrix strategy + manifest job) used by `firecrawl` and `playwright-service` images
- Now builds and publishes for both `linux/amd64` and `linux/arm64`

Closes #3291

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify both platform images are pushed
- [ ] Verify `docker manifest inspect ghcr.io/firecrawl/nuq-postgres:latest` shows both `amd64` and `arm64` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build `nuq-postgres` for both `linux/amd64` and `linux/arm64` to stop emulation on Apple Silicon and other arm64 hosts. CI follows the same multi-arch pattern as `firecrawl` and `playwright-service`, and pins actions with explicit permissions.

- **Bug Fixes**
  - Add build matrix on Blacksmith for `linux/amd64` and `linux/arm64`.
  - Push per-arch tags (`linux-amd64`, `linux-arm64`) and publish a `latest` multi-arch manifest.
  - Split into build and manifest jobs; pin `actions/checkout` and `docker/login-action`, use `useblacksmith/setup-docker-builder` and `useblacksmith/build-push-action`, set explicit perms (`permissions: {}`, `packages: write`), and normalize repo owner.
  - Update test mock to `https://www.firecrawl.dev/sitemap.xml` to match expected redirects.

<sup>Written for commit 883328d2d5eb44649c724f9030d7c46c34216ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

