### PR TITLE
fix(js-sdk): add webhook option to startExtract and extract methods

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.28.2",
+  "version": "4.28.3",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/extract.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/extract.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "@jest/globals";
+import { startExtract } from "../../../v2/methods/extract";
+import type { WebhookConfig } from "../../../v2/types";
+
+describe("v2.extract unit", () => {
+  test("startExtract forwards string webhook in request payload", async () => {
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { id: "extract-job" },
+    });
+
+    await startExtract({ post } as any, {
+      urls: ["https://example.com"],
+      prompt: "Extract title",
+      webhook: "https://example.com/webhook",
+    });
+
+    expect(post).toHaveBeenCalledWith("/v2/extract", {
+      urls: ["https://example.com"],
+      prompt: "Extract title",
+      webhook: "https://example.com/webhook",
+    });
+  });
+
+  test("startExtract forwards object webhook in request payload", async () => {
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { id: "extract-job" },
+    });
+    const webhook: WebhookConfig = {
+      url: "https://example.com/webhook",
+      headers: { "x-signature": "secret" },
+    };
+
+    await startExtract({ post } as any, {
+      urls: ["https://example.com"],
+      prompt: "Extract title",
+      webhook,
+    });
+
+    expect(post).toHaveBeenCalledWith("/v2/extract", {
+      urls: ["https://example.com"],
+      prompt: "Extract title",
+      webhook,
+    });
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/extract.ts
@@ -1,4 +1,4 @@
-import { type ExtractResponse, type ScrapeOptions, type AgentOptions } from "../types";
+import { type ExtractResponse, type ScrapeOptions, type AgentOptions, type WebhookConfig } from "../types";
 import { HttpClient } from "../utils/httpClient";
 import { ensureValidScrapeOptions } from "../utils/validation";
 import { normalizeAxiosError, throwForBadResponse } from "../utils/errorHandler";
@@ -18,6 +18,7 @@ function prepareExtractPayload(args: {
   integration?: string;
   origin?: string;
   agent?: AgentOptions;
+  webhook?: string | WebhookConfig | null;
 }): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (args.urls) body.urls = args.urls;
@@ -33,6 +34,7 @@ function prepareExtractPayload(args: {
   if (args.integration && args.integration.trim()) body.integration = args.integration.trim();
   if (args.origin) body.origin = args.origin;
   if (args.agent) body.agent = args.agent;
+  if (args.webhook != null) body.webhook = args.webhook;
   if (args.scrapeOptions) {
     ensureValidScrapeOptions(args.scrapeOptions);
     body.scrapeOptions = args.scrapeOptions;


### PR DESCRIPTION
## Summary

Fixes #2582.

The `startExtract` and `extract` methods in the v2 JS SDK did not accept `webhook` configuration in their TypeScript type definitions, even though the Firecrawl API supports webhooks for extract jobs and other async methods (`crawl`, `batchScrape`) already include it.

- Added `webhook?: string | WebhookConfig | null` to `prepareExtractPayload()` parameter type
- Forward `webhook` to the request body, matching the pattern used in `crawl.ts` (line 39) and `batch.ts` (line 37)
- Types flow automatically to `startExtract()` and `extract()` via `Parameters<typeof prepareExtractPayload>[0]`

**Usage after fix:**
```ts
const result = await firecrawl.startExtract({
  urls: ['https://example.com'],
  schema: mySchema,
  prompt: 'Extract data',
  webhook: {
    url: 'https://example.com/webhook',
    metadata: { jobId: '123' },
    events: ['completed', 'failed'],
  },
});
```

## Test plan

- [x] Verified type signature matches `CrawlOptions.webhook` and `BatchScrapeOptions.webhook` patterns
- [x] Verified `webhook` is forwarded to request body using the same `if (args.webhook != null)` guard as `crawl.ts` and `batch.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds webhook support to `startExtract` and `extract` in the v2 `@mendable/firecrawl-js` SDK so extract jobs can send callbacks. Aligns extract with `crawl` and `batchScrape`.

- **Bug Fixes**
  - Accepts `webhook?: string | WebhookConfig | null` in `prepareExtractPayload`, with unit tests for string/object forwarding.
  - Forwards `webhook` to the request body when provided; bumps package to `4.28.3`.

<sup>Written for commit 0cd9d585c71d38ce1d3f8b4f31affb3f32c9af18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

