### PR TITLE
fix(api): wire up USE_RESPONSES_ENDPOINT env var for OpenAI-compatible proxies

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -44,6 +44,10 @@ const configSchema = z.object({
   BULL_AUTH_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
+  USE_RESPONSES_ENDPOINT: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((val) => val !== "false"),
   OPENROUTER_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -44,10 +44,7 @@ const configSchema = z.object({
   BULL_AUTH_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
-  USE_RESPONSES_ENDPOINT: z
-    .enum(["true", "false"])
-    .optional()
-    .transform((val) => val !== "false"),
+  USE_RESPONSES_ENDPOINT: z.stringbool().default(true),
   OPENROUTER_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -58,8 +58,11 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
     name = "gemini-2.5-pro";
   }
   const modelName = config.MODEL_NAME || name;
-  // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+  // Use Chat Completions API when the Responses API is disabled or unsupported
+  if (
+    provider === "openai" &&
+    (modelName.startsWith("o3-mini") || !config.USE_RESPONSES_ENDPOINT)
+  ) {
     return providerList.openai.chat(modelName);
   }
   return providerList[provider](modelName);


### PR DESCRIPTION
## Summary

Fixes #3169.

Self-hosted users with OpenAI-compatible proxies (Azure OpenAI, LiteLLM, vLLM) get **404 errors** because `@ai-sdk/openai` v2+ defaults to the Responses API (`/v1/responses`), which most proxies don't implement.

### Changes

1. **`apps/api/src/config.ts`** — Added `USE_RESPONSES_ENDPOINT` env var to the config schema. Defaults to `true` (preserving current behavior). Set to `"false"` to force Chat Completions API.

2. **`apps/api/src/lib/generic-ai.ts`** — Extended the existing `o3-mini` special case: when `USE_RESPONSES_ENDPOINT` is `false`, all OpenAI provider calls use `.chat(modelName)` to force the Chat Completions API (`/v1/chat/completions`).

### Usage

```env
# Force Chat Completions API for OpenAI-compatible proxies
USE_RESPONSES_ENDPOINT=false
OPENAI_BASE_URL=https://your-proxy.example.com/v1
OPENAI_API_KEY=your-key
```

## Test plan

- [x] Default behavior unchanged (`USE_RESPONSES_ENDPOINT` defaults to `true`)
- [x] `o3-mini` still uses Chat Completions regardless of the setting
- [x] Setting `USE_RESPONSES_ENDPOINT=false` forces `.chat()` for all OpenAI models

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `USE_RESPONSES_ENDPOINT` env flag to switch from the OpenAI Responses API to Chat Completions, fixing 404s with proxies that don’t support `/v1/responses`. Defaults to true; set it to false to force `/v1/chat/completions`.

- **Bug Fixes**
  - Config adds `USE_RESPONSES_ENDPOINT` with `z.stringbool().default(true)` (accepts "true"/"false").
  - When false, all OpenAI calls use `.chat()` and hit `/v1/chat/completions`; `o3-mini` remains forced.

- **Migration**
  - For Azure OpenAI, `LiteLLM`, or `vLLM`, set `USE_RESPONSES_ENDPOINT=false`.
  - No action needed for OpenAI’s standard API.

<sup>Written for commit 523c160d877b7eb039fc88d4bfe59ff8b3d85434. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

