### PR TITLE
feat(js-sdk): include creditsUsed in v2 search() response (#3351)

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { search } from "../../../v2/methods/search";
+
+describe("JS SDK v2 search creditsUsed", () => {
+  function makeHttp(postImpl: (url: string, data: any) => any) {
+    return { post: jest.fn(async (u: string, d: any) => postImpl(u, d)) } as any;
+  }
+
+  test("forwards creditsUsed from API response (#3351)", async () => {
+    const mockResponse = {
+      status: 200,
+      data: {
+        success: true,
+        creditsUsed: 2,
+        data: {
+          web: [{ url: "https://example.com", title: "Example", description: "desc" }],
+        },
+      },
+    };
+
+    const http = makeHttp(() => mockResponse);
+    const result = await search(http, { query: "example" });
+
+    expect(result.creditsUsed).toBe(2);
+    expect(result.web).toBeDefined();
+    expect((result.web || []).length).toBe(1);
+  });
+
+  test("omits creditsUsed when API response does not include it", async () => {
+    const mockResponse = {
+      status: 200,
+      data: {
+        success: true,
+        data: {
+          web: [{ url: "https://example.com" }],
+        },
+      },
+    };
+
+    const http = makeHttp(() => mockResponse);
+    const result = await search(http, { query: "example" });
+
+    expect(result.creditsUsed).toBeUndefined();
+  });
+
+  test("forwards creditsUsed=0 from API response", async () => {
+    const mockResponse = {
+      status: 200,
+      data: {
+        success: true,
+        creditsUsed: 0,
+        data: {},
+      },
+    };
+
+    const http = makeHttp(() => mockResponse);
+    const result = await search(http, { query: "example" });
+
+    expect(result.creditsUsed).toBe(0);
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -54,7 +54,7 @@ function transformArray<ResultType>(arr: any[]): Array<ResultType | Document> {
 export async function search(http: HttpClient, request: SearchRequest): Promise<SearchData> {
   const payload = prepareSearchPayload(request);
   try {
-    const res = await http.post<{ success: boolean; data?: Record<string, unknown>; error?: string }>("/v2/search", payload);
+    const res = await http.post<{ success: boolean; data?: Record<string, unknown>; creditsUsed?: number; error?: string }>("/v2/search", payload);
     if (res.status !== 200 || !res.data?.success) {
       throwForBadResponse(res, "search");
     }
@@ -63,6 +63,7 @@ export async function search(http: HttpClient, request: SearchRequest): Promise<
     if (data.web) out.web = transformArray<SearchResultWeb>(data.web);
     if (data.news) out.news = transformArray<SearchResultNews>(data.news);
     if (data.images) out.images = transformArray<SearchResultImages>(data.images);
+    if (typeof res.data.creditsUsed === "number") out.creditsUsed = res.data.creditsUsed;
     return out;
   } catch (err: any) {
     if (err?.isAxiosError) return normalizeAxiosError(err, "search");

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -448,6 +448,7 @@ export interface SearchData {
   web?: Array<SearchResultWeb | Document>;
   news?: Array<SearchResultNews | Document>;
   images?: Array<SearchResultImages | Document>;
+  creditsUsed?: number;
 }
 
 export interface CategoryOption {


### PR DESCRIPTION
## Summary

Fixes #3351.

The `/v2/search` API returns `creditsUsed` in the top-level response, but the JS SDK's `search()` method was dropping it when building `SearchData`. Callers who wanted to track per-request credit consumption through the SDK had no accurate way to do so — they were stuck estimating from the pricing page.

This PR forwards the field through, matching what `scrape`, `crawl`, and the other v2 methods already expose.

## Changes

- `src/v2/types.ts` — add optional `creditsUsed?: number` to the `SearchData` interface (same shape as existing `creditsUsed?` fields on `Document`, `CrawlJob`, `ScrapeData`, etc.)
- `src/v2/methods/search.ts` — forward `res.data.creditsUsed` onto the returned `SearchData` when the API includes it
- `src/__tests__/unit/v2/search.test.ts` — new unit tests covering:
  - populated `creditsUsed` is surfaced
  - missing `creditsUsed` leaves the field `undefined` (no breaking type change)
  - `creditsUsed: 0` is still forwarded (no truthy-check bug)

Kept the field optional rather than defaulted-to-0 so the SDK's output reflects exactly what the API sent — and so this isn't a breaking type change for existing consumers.

## Test plan

- [x] `pnpm test:unit` — all 47 tests pass (3 new + 44 existing)
- [x] `pnpm build` — DTS + CJS + ESM all emit cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `creditsUsed` from `/v2/search` in the JS SDK’s `search()` response so apps can track per-request credit usage. Aligns `search()` with other v2 methods like `scrape` and `crawl`.

- **Bug Fixes**
  - Added optional `creditsUsed?: number` to `SearchData` (no breaking change).
  - Forwarded `res.data.creditsUsed` to the returned `SearchData`, including when it is `0`.
  - Added unit tests for present, absent, and zero cases.

<sup>Written for commit 1874ae6c8a9f227b444e807029ca0d7f95d82208. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->