### PR TITLE
Normalize map cosine ranking for decoded search terms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+Firecrawl is a web scraper API. The directory you have access to is a monorepo:
+ - `apps/api` has the actual API and worker code
+ - `apps/js-sdk`, `apps/python-sdk`, `apps/rust-sdk` and `apps/java-sdk` are various SDKs
+
+When making changes to the API, here are the general steps you should take:
+1. Write some end-to-end tests that assert your win conditions, if they don't already exist
+  - 1 happy path (more is encouraged if there are multiple happy paths with significantly different code paths taken)
+  - 1+ failure path(s)
+  - Generally, E2E (called `snips` in the API) is always preferred over unit testing.
+  - In the API, always use `scrapeTimeout` from `./lib` to set the timeout you use for scrapes.
+  - These tests will be ran on a variety of configurations. You should gate tests in the following manner:
+    - If it requires fire-engine: `!process.env.TEST_SUITE_SELF_HOSTED`
+    - If it requires AI: `!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL`
+2. Write code to achieve your win conditions
+3. Run your tests using `pnpm harness jest ...`
+  - `pnpm harness` is a command that gets the API server and workers up for you to run the tests. Don't try to `pnpm start` manually.
+  - The full test suite takes a long time to run, so you should try to only execute the relevant tests locally, and let CI run the full test suite.
+4. Push to a branch, open a PR, and let CI run to verify your win condition.
+Keep these steps in mind while building your TODO list.

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -291,8 +291,7 @@ export async function getMapResults({
 
     // Perform cosine similarity between the search query and the list of links
     if (search) {
-      const searchQuery = search.toLowerCase();
-      links = performCosineSimilarity(links, searchQuery);
+      links = performCosineSimilarity(links, search);
     }
 
     links = links

--- a/apps/api/src/lib/map-cosine.test.ts
+++ b/apps/api/src/lib/map-cosine.test.ts
@@ -1,0 +1,42 @@
+import {
+  performCosineSimilarity,
+  performCosineSimilarityV2,
+} from "./map-cosine";
+import { MapDocument } from "../controllers/v2/types";
+
+describe("performCosineSimilarity", () => {
+  it("keeps umlaut terms intact when ranking links", () => {
+    const links = [
+      "https://example.com/reisen-nach-munchen",
+      "https://example.com/reisen-nach-m%C3%BCnchen",
+      "https://example.com/berlin",
+    ];
+
+    const ranked = performCosineSimilarity(links, "münchen");
+    expect(ranked[0]).toBe("https://example.com/reisen-nach-m%C3%BCnchen");
+  });
+
+  it("returns original order for symbol-only queries", () => {
+    const links = [
+      "https://example.com/foo",
+      "https://example.com/bar",
+      "https://example.com/baz",
+    ];
+
+    const ranked = performCosineSimilarity(links, "++--??");
+    expect(ranked).toEqual(links);
+  });
+});
+
+describe("performCosineSimilarityV2", () => {
+  it("supports umlaut queries for map document ranking", () => {
+    const links: MapDocument[] = [
+      { url: "https://example.com/reisen-nach-munchen" },
+      { url: "https://example.com/reisen-nach-m%C3%BCnchen" },
+      { url: "https://example.com/berlin" },
+    ];
+
+    const ranked = performCosineSimilarityV2(links, "münchen");
+    expect(ranked[0].url).toBe("https://example.com/reisen-nach-m%C3%BCnchen");
+  });
+});

--- a/apps/api/src/lib/map-cosine.ts
+++ b/apps/api/src/lib/map-cosine.ts
@@ -1,45 +1,73 @@
 import { logger } from "./logger";
 import { MapDocument } from "../controllers/v2/types";
 
+const TOKEN_REGEX = /[\p{L}\p{N}]+/gu;
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function tokenize(value: string): string[] {
+  return (
+    safeDecodeURIComponent(value)
+      .toLowerCase()
+      .normalize("NFC")
+      .match(TOKEN_REGEX) ?? []
+  );
+}
+
+function termFrequency(tokens: string[]): Map<string, number> {
+  const frequencies = new Map<string, number>();
+  for (const token of tokens) {
+    frequencies.set(token, (frequencies.get(token) ?? 0) + 1);
+  }
+  return frequencies;
+}
+
+function cosineSimilarity(vec1: number[], vec2: number[]): number {
+  if (vec1.length !== vec2.length || vec1.length === 0) return 0;
+
+  const dotProduct = vec1.reduce((sum, val, i) => sum + val * vec2[i], 0);
+  const magnitude1 = Math.sqrt(vec1.reduce((sum, val) => sum + val * val, 0));
+  const magnitude2 = Math.sqrt(vec2.reduce((sum, val) => sum + val * val, 0));
+  if (magnitude1 === 0 || magnitude2 === 0) return 0;
+  return dotProduct / (magnitude1 * magnitude2);
+}
+
+function rankByCosine<T>(
+  items: T[],
+  searchQuery: string,
+  toText: (item: T) => string,
+): T[] {
+  const queryTokens = tokenize(searchQuery);
+  if (queryTokens.length === 0) {
+    return items;
+  }
+
+  const queryFrequency = termFrequency(queryTokens);
+  const vocabulary = Array.from(queryFrequency.keys());
+  const searchVector = vocabulary.map(token => queryFrequency.get(token) ?? 0);
+
+  return items
+    .map(item => {
+      const itemFrequency = termFrequency(tokenize(toText(item)));
+      const itemVector = vocabulary.map(token => itemFrequency.get(token) ?? 0);
+      return {
+        item,
+        score: cosineSimilarity(itemVector, searchVector),
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .map(result => result.item);
+}
+
 export function performCosineSimilarity(links: string[], searchQuery: string) {
   try {
-    // Function to calculate cosine similarity
-    const cosineSimilarity = (vec1: number[], vec2: number[]): number => {
-      const dotProduct = vec1.reduce((sum, val, i) => sum + val * vec2[i], 0);
-      const magnitude1 = Math.sqrt(
-        vec1.reduce((sum, val) => sum + val * val, 0),
-      );
-      const magnitude2 = Math.sqrt(
-        vec2.reduce((sum, val) => sum + val * val, 0),
-      );
-      if (magnitude1 === 0 || magnitude2 === 0) return 0;
-      return dotProduct / (magnitude1 * magnitude2);
-    };
-
-    // Function to convert text to vector
-    const textToVector = (text: string): number[] => {
-      const words = searchQuery.toLowerCase().split(/\W+/);
-      return words.map(word => {
-        const count = (text.toLowerCase().match(new RegExp(word, "g")) || [])
-          .length;
-        return count / text.length;
-      });
-    };
-
-    // Calculate similarity scores
-    const similarityScores = links.map(link => {
-      const linkVector = textToVector(link);
-      const searchVector = textToVector(searchQuery);
-      return cosineSimilarity(linkVector, searchVector);
-    });
-
-    // Sort links based on similarity scores and print scores
-    const a = links
-      .map((link, index) => ({ link, score: similarityScores[index] }))
-      .sort((a, b) => b.score - a.score);
-
-    links = a.map(item => item.link);
-    return links;
+    return rankByCosine(links, searchQuery, link => link);
   } catch (error) {
     logger.error(`Error performing cosine similarity: ${error}`);
     return links;
@@ -51,43 +79,7 @@ export function performCosineSimilarityV2(
   searchQuery: string,
 ) {
   try {
-    // Function to calculate cosine similarity
-    const cosineSimilarity = (vec1: number[], vec2: number[]): number => {
-      const dotProduct = vec1.reduce((sum, val, i) => sum + val * vec2[i], 0);
-      const magnitude1 = Math.sqrt(
-        vec1.reduce((sum, val) => sum + val * val, 0),
-      );
-      const magnitude2 = Math.sqrt(
-        vec2.reduce((sum, val) => sum + val * val, 0),
-      );
-      if (magnitude1 === 0 || magnitude2 === 0) return 0;
-      return dotProduct / (magnitude1 * magnitude2);
-    };
-
-    // Function to convert text to vector
-    const textToVector = (text: string): number[] => {
-      const words = searchQuery.toLowerCase().split(/\W+/);
-      return words.map(word => {
-        const count = (text.toLowerCase().match(new RegExp(word, "g")) || [])
-          .length;
-        return count / text.length;
-      });
-    };
-
-    // Calculate similarity scores
-    const similarityScores = links.map(link => {
-      const linkVector = textToVector(link.url); // TODO: we can use title/description here as well!
-      const searchVector = textToVector(searchQuery);
-      return cosineSimilarity(linkVector, searchVector);
-    });
-
-    // Sort links based on similarity scores and print scores
-    const a = links
-      .map((link, index) => ({ link, score: similarityScores[index] }))
-      .sort((a, b) => b.score - a.score);
-
-    links = a.map(item => item.link);
-    return links;
+    return rankByCosine(links, searchQuery, link => link.url);
   } catch (error) {
     logger.error(`Error performing cosine similarity: ${error}`);
     return links;

--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -305,8 +305,7 @@ export async function getMapResults({
     }
 
     if (search) {
-      const searchQuery = search.toLowerCase();
-      mapResults = performCosineSimilarityV2(mapResults, searchQuery);
+      mapResults = performCosineSimilarityV2(mapResults, search);
     }
   }
 


### PR DESCRIPTION
- Preserve Unicode and percent-encoded search terms when ranking map links
- Replace the ad hoc lowercase-only handling with tokenized cosine ranking
- Add tests for umlaut queries and symbol-only search input