### PR TITLE
Enable structured extraction on OpenAI-compatible local backends (opt-in)

### DIFF
--- a/apps/api/src/__tests__/openai-compatibility.test.ts
+++ b/apps/api/src/__tests__/openai-compatibility.test.ts
@@ -1,0 +1,132 @@
+describe("OpenAI Compatibility Mode", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  it("uses openai.responses by default when compatibility mode is off", () => {
+    jest.isolateModules(() => {
+      const { getModel } = require("../lib/generic-ai");
+      const model = getModel("gpt-4o", "openai");
+      expect(model.provider).toBe("openai.responses");
+    });
+  });
+
+  it("uses openai.chat when compatibility mode is enabled", () => {
+    jest.isolateModules(() => {
+      process.env.OPENAI_COMPATIBLE_MODE = "true";
+      const { getModel } = require("../lib/generic-ai");
+      const model = getModel("gpt-4o", "openai");
+      expect(model.provider).toBe("openai.chat");
+    });
+  });
+
+  it("preserves o3-mini forced chat completions regardless of compatibility mode", () => {
+    jest.isolateModules(() => {
+      process.env.OPENAI_COMPATIBLE_MODE = "false";
+      const { getModel } = require("../lib/generic-ai");
+      const model = getModel("o3-mini", "openai");
+      expect(model.provider).toBe("openai.chat");
+    });
+  });
+
+  it("passes structuredOutputs false to engpicker in compatibility mode", async () => {
+    process.env.OPENAI_COMPATIBLE_MODE = "true";
+
+    const generateObject = jest.fn().mockResolvedValue({
+      object: { is_successful: true },
+    });
+    const scrapeURL = jest.fn().mockResolvedValue({
+      success: true,
+      document: { markdown: "real page content" },
+    });
+
+    jest.doMock("ai", () => ({
+      generateObject,
+    }));
+    jest.doMock("../scraper/scrapeURL", () => ({
+      scrapeURL,
+    }));
+    jest.doMock("@mendable/firecrawl-rs", () => ({
+      computeEngpickerVerdict: jest.fn(),
+    }));
+
+    const { evaluateURL } = require("../lib/engpicker");
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      child: jest.fn(),
+    } as any;
+
+    const result = await evaluateURL(
+      "job-1",
+      "https://example.com",
+      "fire-engine;chrome-cdp",
+      false,
+      logger,
+    );
+
+    expect(result.result).toBe(true);
+    expect(generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          openai: {
+            structuredOutputs: false,
+          },
+        },
+      }),
+    );
+  });
+
+  it("degrades engpicker evaluation failures to unsuccessful instead of throwing", async () => {
+    process.env.OPENAI_COMPATIBLE_MODE = "true";
+
+    const generateObject = jest
+      .fn()
+      .mockRejectedValue(new Error("json_object parse failure"));
+    const scrapeURL = jest.fn().mockResolvedValue({
+      success: true,
+      document: { markdown: "real page content" },
+    });
+
+    jest.doMock("ai", () => ({
+      generateObject,
+    }));
+    jest.doMock("../scraper/scrapeURL", () => ({
+      scrapeURL,
+    }));
+    jest.doMock("@mendable/firecrawl-rs", () => ({
+      computeEngpickerVerdict: jest.fn(),
+    }));
+
+    const { evaluateURL } = require("../lib/engpicker");
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      child: jest.fn(),
+    } as any;
+
+    await expect(
+      evaluateURL(
+        "job-2",
+        "https://example.com",
+        "fire-engine;chrome-cdp",
+        false,
+        logger,
+      ),
+    ).resolves.toEqual({
+      engine: "fire-engine;chrome-cdp",
+      stealth: false,
+      markdown: "real page content",
+      result: false,
+    });
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -44,6 +44,7 @@ const configSchema = z.object({
   BULL_AUTH_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
+  OPENAI_COMPATIBLE_MODE: z.stringbool().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/apps/api/src/lib/branding/llm.ts
+++ b/apps/api/src/lib/branding/llm.ts
@@ -97,6 +97,14 @@ export async function enhanceBrandingWithLLM(
           // Prefer loose schema so we use whatever the LLM returns (avoids validation
           // failures on minor schema drift or when model omits optional fields).
           strictJsonSchema: false,
+          ...(config.OPENAI_COMPATIBLE_MODE
+            ? {
+                // When in OpenAI Compatible Mode, we disable strict 'structuredOutputs' (json_schema)
+                // because many local backends (e.g. Ollama) only support standard 'json_object' mode.
+                // Default behavior for official OpenAI remains unchanged.
+                structuredOutputs: false,
+              }
+            : {}),
         },
       },
       messages: [

--- a/apps/api/src/lib/engpicker.ts
+++ b/apps/api/src/lib/engpicker.ts
@@ -1,5 +1,6 @@
 import { generateObject } from "ai";
 import { z } from "zod";
+import { config } from "../config";
 import { scrapeOptions } from "../controllers/v2/types";
 import { scrapeURL } from "../scraper/scrapeURL";
 import type { Engine } from "../scraper/scrapeURL/engines";
@@ -22,7 +23,7 @@ type EngpickerJob = {
   created_at: string;
 };
 
-async function evaluateURL(
+export async function evaluateURL(
   id: string,
   url: string,
   engine: Engine,
@@ -63,16 +64,29 @@ async function evaluateURL(
 
   logger.info("Scrape completed, waiting for AI evaluation");
 
-  // Use GPT-4o-mini to evaluate if the scrape was actually successful
-  const evaluationResult = await generateObject({
-    model: getModel("gpt-4o-mini", "openai"),
-    schema: z.object({
-      is_successful: z.boolean(),
-    }),
-    messages: [
-      {
-        role: "system",
-        content: `You are a web scraping quality evaluator. Your job is to determine if a web scrape was successful based on the returned markdown content.
+  try {
+    // Use GPT-4o-mini to evaluate if the scrape was actually successful
+    const evaluationResult = await generateObject({
+      model: getModel("gpt-4o-mini", "openai"),
+      schema: z.object({
+        is_successful: z.boolean(),
+      }),
+      providerOptions: {
+        ...(config.OPENAI_COMPATIBLE_MODE
+          ? {
+              openai: {
+                // When in OpenAI Compatible Mode, we disable strict 'structuredOutputs' (json_schema)
+                // because many local backends (e.g. Ollama) only support standard 'json_object' mode.
+                // Default behavior for official OpenAI remains unchanged.
+                structuredOutputs: false,
+              },
+            }
+          : {}),
+      },
+      messages: [
+        {
+          role: "system",
+          content: `You are a web scraping quality evaluator. Your job is to determine if a web scrape was successful based on the returned markdown content.
 
 A scrape should be considered UNSUCCESSFUL if the content indicates any of the following:
 - Antibot/captcha challenges (e.g., Cloudflare, reCAPTCHA, hCaptcha, bot detection messages)
@@ -89,24 +103,39 @@ A scrape should be considered SUCCESSFUL if:
 A scrape may still be successful if:
 - Cookie consent walls block the actual content
 - Paywalls block the actual content`,
-      },
-      {
-        role: "user",
-        content: `Evaluate if this scraped markdown content represents a successful scrape:\n\n${markdown.slice(0, 4000)}`,
-      },
-    ],
-  });
+        },
+        {
+          role: "user",
+          content: `Evaluate if this scraped markdown content represents a successful scrape:\n\n${markdown.slice(0, 4000)}`,
+        },
+      ],
+    });
 
-  const isSuccess = evaluationResult.object.is_successful;
+    const isSuccess = evaluationResult.object.is_successful;
 
-  logger.info("AI evaluation completed", { isSuccess });
+    logger.info("AI evaluation completed", { isSuccess });
 
-  return {
-    engine,
-    stealth,
-    markdown,
-    result: isSuccess,
-  };
+    return {
+      engine,
+      stealth,
+      markdown,
+      result: isSuccess,
+    };
+  } catch (error) {
+    logger.warn("AI evaluation failed", {
+      error,
+      url,
+      engine,
+      compatibilityMode: config.OPENAI_COMPATIBLE_MODE,
+    });
+
+    return {
+      engine,
+      stealth,
+      markdown,
+      result: false,
+    };
+  }
 }
 
 export async function processEngpickerJob() {

--- a/apps/api/src/lib/extract/fire-0/llmExtract-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/llmExtract-f0.ts
@@ -13,6 +13,7 @@ import { generateObject, generateText, LanguageModel } from "ai";
 import { jsonSchema } from "ai";
 import { getModel } from "../../../lib/generic-ai";
 import { z } from "zod";
+import { config } from "../../../config";
 
 // Get max tokens from model prices
 const getModelLimits_F0 = (model: string) => {
@@ -387,6 +388,16 @@ export async function generateCompletions_F0({
             teamId: metadata.teamId,
           },
         },
+        ...(config.OPENAI_COMPATIBLE_MODE
+          ? {
+              openai: {
+                // When in OpenAI Compatible Mode, we disable strict 'structuredOutputs' (json_schema)
+                // because many local backends (e.g. Ollama) only support standard 'json_object' mode.
+                // Default behavior for official OpenAI remains unchanged.
+                structuredOutputs: false,
+              },
+            }
+          : {}),
       },
       experimental_telemetry: {
         isEnabled: true,

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -58,10 +58,17 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
     name = "gemini-2.5-pro";
   }
   const modelName = config.MODEL_NAME || name;
-  // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+
+  // The Responses API (/v1/responses) is proprietary to OpenAI and unsupported by local backends (e.g. Ollama).
+  // We force the standard Chat Completions path (/v1/chat/completions) for o3-mini (known bug)
+  // or when explicitly running in OpenAI Compatible Mode.
+  if (
+    provider === "openai" &&
+    (modelName.startsWith("o3-mini") || config.OPENAI_COMPATIBLE_MODE)
+  ) {
     return providerList.openai.chat(modelName);
   }
+
   return providerList[provider](modelName);
 }
 

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -25,6 +25,7 @@ import { extractData } from "../lib/extractSmartScrape";
 import { CostTracking } from "../../../lib/cost-tracking";
 import { isAgentExtractModelValid } from "../../../controllers/v1/types";
 import { hasFormatOfType } from "../../../lib/format-utils";
+import { config } from "../../../config";
 
 // Smart model selection based on schema
 function detectRecursiveSchema(schema: any): boolean {
@@ -313,6 +314,19 @@ export async function generateCompletions({
   totalUsage: TokenUsage;
   model: string;
 }> {
+  if (config.OPENAI_COMPATIBLE_MODE) {
+    providerOptions = {
+      ...(providerOptions || {}),
+      openai: {
+        ...((providerOptions as any)?.openai || {}),
+        // When in OpenAI Compatible Mode, we disable strict 'structuredOutputs' (json_schema)
+        // because many local backends (e.g. Ollama) only support standard 'json_object' mode.
+        // Default behavior for official OpenAI remains unchanged.
+        structuredOutputs: false,
+      },
+    } as any;
+  }
+
   let extract: any;
   let warning: string | undefined;
   let currentModel = model;


### PR DESCRIPTION
### Problem
Structured extraction workflows fail against self-hosted OpenAI-compatible backends such as Ollama and vLLM.

- Many of these backends do not implement the `/v1/responses` endpoint, which leads to 404s on the default OpenAI path.
- Many also do not support strict `json_schema` structured outputs, which leads to 400s on extraction-style calls.

### Root Cause
Firecrawl currently assumes the standard OpenAI Responses API path and strict structured output behavior for these flows. That assumption does not hold for many local OpenAI-compatible backends.

### Fix
This PR introduces an opt-in `OPENAI_COMPATIBLE_MODE`.

When enabled:
- OpenAI routing uses chat completions instead of the Responses API
- Structured extraction uses a compatibility path by disabling strict structured outputs where needed
- The compatibility behavior is applied across the relevant extraction surfaces:
  - `llmExtract`
  - `llmExtract-f0`
  - branding
  - engpicker

### Safety
- Opt-in only
- Default behavior for official OpenAI users is unchanged
- No base-URL inference or broad global behavior changes

### Tests
- Verifies default OpenAI routing still uses `openai.responses`
- Verifies compatibility mode switches OpenAI routing to `openai.chat`
- Verifies the existing `o3-mini` forced chat-completions path is preserved
- Verifies `engpicker` passes `structuredOutputs: false` in compatibility mode
- Verifies `engpicker` degrades safely when compatible-backend structured output generation fails

### Verification
Validated against a local OpenAI-compatible backend with compatibility mode enabled.

Observed behavior:
- requests route through the chat-completions path instead of `/v1/responses`
- structured extraction executes through the compatibility configuration instead of strict schema-constrained output mode

### Limitations
- Compatibility mode does not preserve strict `json_schema` guarantees
- Extraction fidelity still depends on the capabilities of the underlying backend/model