### PR TITLE
fix(go-sdk): embed jsonOptions into formats array for v2 scrape API

### DIFF
--- a/apps/go-sdk/firecrawl.go
+++ b/apps/go-sdk/firecrawl.go
@@ -93,6 +93,7 @@ func (c *Client) Scrape(ctx context.Context, url string, opts *ScrapeOptions) (*
 
 	body := map[string]interface{}{"url": url}
 	mergeOptions(body, opts)
+	restructureJSONFormats(body)
 
 	raw, err := c.http.post(ctx, "/v2/scrape", body, nil)
 	if err != nil {
@@ -782,6 +783,49 @@ func mergeOptions(body map[string]interface{}, opts interface{}) {
 	for k, v := range optsMap {
 		body[k] = v
 	}
+}
+
+// restructureJSONFormats moves jsonOptions into the formats array entries as
+// the v2 API expects. The v2 API rejects the top-level jsonOptions key (strict
+// schema) and instead requires JSON format options to be embedded directly in
+// the formats array: [{"type": "json", "schema": {...}, "prompt": "..."}].
+func restructureJSONFormats(body map[string]interface{}) {
+	formatsRaw, ok := body["formats"]
+	if !ok {
+		return
+	}
+	formats, ok := formatsRaw.([]interface{})
+	if !ok {
+		return
+	}
+
+	jsonOptsRaw, hasJsonOpts := body["jsonOptions"]
+	if !hasJsonOpts {
+		return
+	}
+	jsonOpts, ok := jsonOptsRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	newFormats := make([]interface{}, 0, len(formats))
+	for _, f := range formats {
+		fStr, isStr := f.(string)
+		if isStr && fStr == "json" {
+			entry := map[string]interface{}{"type": "json"}
+			if s, ok := jsonOpts["schema"]; ok {
+				entry["schema"] = s
+			}
+			if p, ok := jsonOpts["prompt"]; ok {
+				entry["prompt"] = p
+			}
+			newFormats = append(newFormats, entry)
+		} else {
+			newFormats = append(newFormats, f)
+		}
+	}
+	body["formats"] = newFormats
+	delete(body, "jsonOptions")
 }
 
 // extractDataAs extracts the "data" field from a raw API response and deserializes it.

--- a/apps/go-sdk/firecrawl.go
+++ b/apps/go-sdk/firecrawl.go
@@ -790,20 +790,22 @@ func mergeOptions(body map[string]interface{}, opts interface{}) {
 // schema) and instead requires JSON format options to be embedded directly in
 // the formats array: [{"type": "json", "schema": {...}, "prompt": "..."}].
 func restructureJSONFormats(body map[string]interface{}) {
+	jsonOptsRaw, hasJsonOpts := body["jsonOptions"]
+	if !hasJsonOpts {
+		return
+	}
+	defer delete(body, "jsonOptions")
+
+	jsonOpts, ok := jsonOptsRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+
 	formatsRaw, ok := body["formats"]
 	if !ok {
 		return
 	}
 	formats, ok := formatsRaw.([]interface{})
-	if !ok {
-		return
-	}
-
-	jsonOptsRaw, hasJsonOpts := body["jsonOptions"]
-	if !hasJsonOpts {
-		return
-	}
-	jsonOpts, ok := jsonOptsRaw.(map[string]interface{})
 	if !ok {
 		return
 	}

--- a/apps/go-sdk/firecrawl_test.go
+++ b/apps/go-sdk/firecrawl_test.go
@@ -1,0 +1,108 @@
+package firecrawl
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRestructureJSONFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]interface{}
+	}{
+		{
+			name: "restructures json format with schema and prompt",
+			input: map[string]interface{}{
+				"url":     "https://example.com",
+				"formats": []interface{}{"markdown", "json"},
+				"jsonOptions": map[string]interface{}{
+					"prompt": "extract data",
+					"schema": map[string]interface{}{"type": "object"},
+				},
+			},
+			want: map[string]interface{}{
+				"url": "https://example.com",
+				"formats": []interface{}{
+					"markdown",
+					map[string]interface{}{
+						"type":   "json",
+						"prompt": "extract data",
+						"schema": map[string]interface{}{"type": "object"},
+					},
+				},
+			},
+		},
+		{
+			name: "no jsonOptions leaves body unchanged",
+			input: map[string]interface{}{
+				"url":     "https://example.com",
+				"formats": []interface{}{"markdown", "html"},
+			},
+			want: map[string]interface{}{
+				"url":     "https://example.com",
+				"formats": []interface{}{"markdown", "html"},
+			},
+		},
+		{
+			name: "no formats key leaves body unchanged",
+			input: map[string]interface{}{
+				"url": "https://example.com",
+			},
+			want: map[string]interface{}{
+				"url": "https://example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restructureJSONFormats(tt.input)
+			gotJSON, _ := json.Marshal(tt.input)
+			wantJSON, _ := json.Marshal(tt.want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("restructureJSONFormats()\ngot:  %s\nwant: %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestMergeOptionsAndRestructure(t *testing.T) {
+	opts := &ScrapeOptions{
+		Formats: []string{"markdown", "json"},
+		JsonOptions: &JsonOptions{
+			Prompt: "extract the title",
+			Schema: map[string]interface{}{"type": "object"},
+		},
+	}
+
+	body := map[string]interface{}{"url": "https://example.com"}
+	mergeOptions(body, opts)
+	restructureJSONFormats(body)
+
+	if _, exists := body["jsonOptions"]; exists {
+		t.Error("jsonOptions key should be removed from body")
+	}
+
+	formats, ok := body["formats"].([]interface{})
+	if !ok {
+		t.Fatal("formats should be a slice")
+	}
+	if len(formats) != 2 {
+		t.Fatalf("expected 2 format entries, got %d", len(formats))
+	}
+	if formats[0].(string) != "markdown" {
+		t.Errorf("first format should be 'markdown', got %v", formats[0])
+	}
+
+	jsonFmt, ok := formats[1].(map[string]interface{})
+	if !ok {
+		t.Fatal("second format should be a map")
+	}
+	if jsonFmt["type"] != "json" {
+		t.Errorf("expected type 'json', got %v", jsonFmt["type"])
+	}
+	if jsonFmt["prompt"] != "extract the title" {
+		t.Errorf("expected prompt 'extract the title', got %v", jsonFmt["prompt"])
+	}
+}


### PR DESCRIPTION
The Go SDK sends `jsonOptions` as a separate top-level key alongside `formats: ["json"]`, but the v2 `/scrape` endpoint uses a strict schema that rejects unknown keys, causing a 400 error:

> Unrecognized key in body -- please review the v2 API documentation for request body changes

The v2 API expects JSON extraction options to be embedded directly in the formats array:

```json
"formats": [{"type": "json", "schema": {...}, "prompt": "..."}]
```

This adds a `restructureJSONFormats` helper that merges `jsonOptions` into the `"json"` format entry and removes the top-level key before the request is sent.

Fixes #3394

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors on the `/v2/scrape` API by embedding JSON extraction options into the `formats` array instead of sending a top-level `jsonOptions` key. Aligns the Go SDK with the v2 strict request schema and unblocks JSON extraction. Fixes #3394.

- **Bug Fixes**
  - Embed `jsonOptions` into the `"json"` entry in `formats` as `{"type":"json","schema":...,"prompt":...}`.
  - Remove the top-level `jsonOptions` key; keep non-JSON formats unchanged.
  - Add unit tests for the restructure helper and its integration with `mergeOptions`.

<sup>Written for commit 77021310512d8e1c7125e021d7af02804465866c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

