### PR TITLE
feat(python-sdk): add Qdrant-backed deduplication for crawl jobs

### DIFF
--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -9,6 +9,7 @@ import os
 from .client import Firecrawl, AsyncFirecrawl, FirecrawlApp, AsyncFirecrawlApp
 from .v2.watcher import Watcher
 from .v2.watcher_async import AsyncWatcher
+from .v2.integrations.qdrant import CrawlToStoreResult
 from .v1 import (
     V1FirecrawlApp,
     AsyncV1FirecrawlApp,
@@ -84,4 +85,5 @@ __all__ = [
     'V1JsonConfig',
     'V1ScrapeOptions',
     'V1ChangeTrackingOptions',
+    'CrawlToStoreResult',
 ]

--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -18,14 +18,13 @@ Usage:
 Check example.py for other usage examples.
 """
 
-from typing import Any, Dict, Optional, List, Union
+from typing import Optional
 import logging
 
 
 from .v1 import V1FirecrawlApp, AsyncV1FirecrawlApp
 from .v2 import FirecrawlClient as V2FirecrawlClient
 from .v2.client_async import AsyncFirecrawlClient
-from .v2.types import Document
 
 logger = logging.getLogger("firecrawl")
 

--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -72,6 +72,7 @@ class V2Proxy:
             self.get_active_crawls = client_instance.get_active_crawls
             self.active_crawls = client_instance.active_crawls
             self.crawl_params_preview = client_instance.crawl_params_preview
+            self.crawl_to_store = client_instance.crawl_to_store
 
             self.extract = client_instance.extract
             self.start_extract = client_instance.start_extract
@@ -101,7 +102,7 @@ class V2Proxy:
             self.list_browsers = client_instance.list_browsers
 
             self.watcher = client_instance.watcher
-    
+
     def __getattr__(self, name):
         """Forward attribute access to the underlying client."""
         return getattr(self._client, name)
@@ -242,6 +243,7 @@ class Firecrawl:
         self.crawl = self._v2_client.crawl
         self.start_crawl = self._v2_client.start_crawl
         self.crawl_params_preview = self._v2_client.crawl_params_preview
+        self.crawl_to_store = self._v2_client.crawl_to_store
         self.get_crawl_status = self._v2_client.get_crawl_status
         self.get_crawl_status_page = self._v2_client.get_crawl_status_page
         self.cancel_crawl = self._v2_client.cancel_crawl

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -5,7 +5,7 @@ This module provides the main client class that orchestrates all v2 functionalit
 """
 
 import os
-from typing import Optional, List, Dict, Any, Callable, Union, Literal
+from typing import Optional, List, Dict, Any, Callable, Union, Literal  # noqa: F401
 from .types import (
     ClientConfig,
     ScrapeOptions,
@@ -43,7 +43,7 @@ from .types import (
 from .utils.http_client import HttpClient
 from .utils.error_handler import FirecrawlError
 from .methods import scrape as scrape_module
-from .methods import crawl as crawl_module  
+from .methods import crawl as crawl_module
 from .methods import batch as batch_module
 from .methods import search as search_module
 from .methods import map as map_module
@@ -53,6 +53,7 @@ from .methods import extract as extract_module
 from .methods import agent as agent_module
 from .methods import browser as browser_module
 from .watcher import Watcher
+from .integrations.qdrant import crawl_to_store as _qdrant_crawl_to_store, CrawlToStoreResult
 
 class FirecrawlClient:
     """
@@ -644,6 +645,112 @@ class FirecrawlClient:
         """
         request = CrawlParamsRequest(url=url, prompt=prompt)
         return crawl_module.crawl_params_preview(self.http_client, request)
+
+    def crawl_to_store(
+        self,
+        url: str,
+        *,
+        qdrant_client: Any,
+        collection_name: str,
+        embedding_fn: Callable,
+        skip_existing: bool = True,
+        content_key: str = "markdown",
+        prompt: Optional[str] = None,
+        exclude_paths: Optional[List[str]] = None,
+        include_paths: Optional[List[str]] = None,
+        max_discovery_depth: Optional[int] = None,
+        ignore_query_parameters: bool = False,
+        limit: Optional[int] = None,
+        crawl_entire_domain: bool = False,
+        allow_external_links: bool = False,
+        allow_subdomains: bool = False,
+        ignore_robots_txt: bool = False,
+        delay: Optional[int] = None,
+        max_concurrency: Optional[int] = None,
+        scrape_options=None,
+        deduplicate_similar_urls: bool = True,
+        zero_data_retention: bool = False,
+        poll_interval: int = 2,
+        timeout: Optional[int] = None,
+        request_timeout: Optional[float] = None,
+    ) -> CrawlToStoreResult:
+        """
+        Crawl *url* and upsert the pages into a Qdrant collection.
+
+        Pages are looked up in Qdrant by URL before embedding.  When
+        *skip_existing* is ``True`` (the default), pages whose content hash
+        has not changed since the previous crawl are skipped, making repeated
+        incremental crawls of the same site much cheaper.
+
+        Args:
+            url: Root URL to start crawling from.
+            qdrant_client: Initialised ``qdrant_client.QdrantClient`` instance.
+            collection_name: Target Qdrant collection (must already exist).
+            embedding_fn: Callable ``(text: str) -> List[float]`` used to
+                produce vectors.  Called only for pages that need to be upserted.
+            skip_existing: Skip pages whose content hash is unchanged in Qdrant
+                (default ``True``).
+            content_key: Document field to embed — ``"markdown"`` (default),
+                ``"html"``, or ``"raw_html"``.
+            prompt: Optional natural-language prompt to guide the crawl.
+            exclude_paths: URL patterns to exclude.
+            include_paths: URL patterns to include.
+            max_discovery_depth: Maximum link-following depth.
+            ignore_query_parameters: Treat URLs differing only by query params
+                as identical.
+            limit: Maximum pages to crawl.
+            crawl_entire_domain: Follow links outside the starting path.
+            allow_external_links: Follow links to external domains.
+            allow_subdomains: Follow subdomain links.
+            ignore_robots_txt: Ignore robots.txt restrictions.
+            delay: Seconds between page requests.
+            max_concurrency: Maximum concurrent page requests.
+            scrape_options: :class:`~firecrawl.v2.types.ScrapeOptions` applied
+                to each page.
+            deduplicate_similar_urls: Remove near-duplicate URLs (default
+                ``True``).
+            zero_data_retention: Delete raw data from Firecrawl servers after
+                24 h.
+            poll_interval: Seconds between crawl-status polls.
+            timeout: Maximum seconds to wait for the crawl to complete.
+            request_timeout: Per-HTTP-request timeout in seconds.
+
+        Returns:
+            :class:`~firecrawl.v2.integrations.qdrant.CrawlToStoreResult`
+            with ``total``, ``upserted``, ``skipped``, ``updated`` counts and
+            the completed :class:`~firecrawl.v2.types.CrawlJob`.
+
+        Raises:
+            ImportError: If ``qdrant-client`` is not installed.
+            ValueError: If *content_key* is not a valid Document field.
+        """
+        return _qdrant_crawl_to_store(
+            self,
+            url,
+            qdrant_client=qdrant_client,
+            collection_name=collection_name,
+            embedding_fn=embedding_fn,
+            skip_existing=skip_existing,
+            content_key=content_key,
+            prompt=prompt,
+            exclude_paths=exclude_paths,
+            include_paths=include_paths,
+            max_discovery_depth=max_discovery_depth,
+            ignore_query_parameters=ignore_query_parameters,
+            limit=limit,
+            crawl_entire_domain=crawl_entire_domain,
+            allow_external_links=allow_external_links,
+            allow_subdomains=allow_subdomains,
+            ignore_robots_txt=ignore_robots_txt,
+            delay=delay,
+            max_concurrency=max_concurrency,
+            scrape_options=scrape_options,
+            deduplicate_similar_urls=deduplicate_similar_urls,
+            zero_data_retention=zero_data_retention,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            request_timeout=request_timeout,
+        )
 
     def start_extract(
         self,

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -651,9 +651,10 @@ class FirecrawlClient:
         *,
         qdrant_client: Any,
         collection_name: str,
-        embedding_fn: Callable,
+        embedding_fn: Callable[[str], List[float]],
         skip_existing: bool = True,
         content_key: str = "markdown",
+        batch_size: int = 100,
         prompt: Optional[str] = None,
         exclude_paths: Optional[List[str]] = None,
         include_paths: Optional[List[str]] = None,
@@ -666,7 +667,7 @@ class FirecrawlClient:
         ignore_robots_txt: bool = False,
         delay: Optional[int] = None,
         max_concurrency: Optional[int] = None,
-        scrape_options=None,
+        scrape_options: Optional[ScrapeOptions] = None,
         deduplicate_similar_urls: bool = True,
         zero_data_retention: bool = False,
         poll_interval: int = 2,
@@ -691,6 +692,8 @@ class FirecrawlClient:
                 (default ``True``).
             content_key: Document field to embed — ``"markdown"`` (default),
                 ``"html"``, or ``"raw_html"``.
+            batch_size: Points per Qdrant upsert call (default 100).  Failed
+                batches are retried one point at a time.
             prompt: Optional natural-language prompt to guide the crawl.
             exclude_paths: URL patterns to exclude.
             include_paths: URL patterns to include.
@@ -731,6 +734,7 @@ class FirecrawlClient:
             embedding_fn=embedding_fn,
             skip_existing=skip_existing,
             content_key=content_key,
+            batch_size=batch_size,
             prompt=prompt,
             exclude_paths=exclude_paths,
             include_paths=include_paths,

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -5,7 +5,7 @@ This module provides the main client class that orchestrates all v2 functionalit
 """
 
 import os
-from typing import Optional, List, Dict, Any, Callable, Union, Literal  # noqa: F401
+from typing import Optional, List, Dict, Any, Callable, Union, Literal
 from .types import (
     ClientConfig,
     ScrapeOptions,
@@ -41,7 +41,6 @@ from .types import (
     AgentOptions,
 )
 from .utils.http_client import HttpClient
-from .utils.error_handler import FirecrawlError
 from .methods import scrape as scrape_module
 from .methods import crawl as crawl_module
 from .methods import batch as batch_module

--- a/apps/python-sdk/firecrawl/v2/integrations/__init__.py
+++ b/apps/python-sdk/firecrawl/v2/integrations/__init__.py
@@ -1,0 +1,7 @@
+"""
+Optional integrations for Firecrawl v2.
+"""
+
+from .qdrant import crawl_to_store, CrawlToStoreResult
+
+__all__ = ["crawl_to_store", "CrawlToStoreResult"]

--- a/apps/python-sdk/firecrawl/v2/integrations/qdrant.py
+++ b/apps/python-sdk/firecrawl/v2/integrations/qdrant.py
@@ -1,0 +1,333 @@
+"""
+Qdrant integration for Firecrawl: deduplication-aware vector storage for crawl jobs.
+
+Usage example::
+
+    from firecrawl import Firecrawl
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import Distance, VectorParams
+
+    fc = Firecrawl(api_key="...")
+    qc = QdrantClient(url="http://localhost:6333")
+
+    qc.recreate_collection(
+        "my_docs",
+        vectors_config=VectorParams(size=1536, distance=Distance.COSINE),
+    )
+
+    def embed(text: str) -> list[float]:
+        # plug in any embedding provider
+        import openai
+        resp = openai.embeddings.create(input=[text], model="text-embedding-3-small")
+        return resp.data[0].embedding
+
+    result = fc.crawl_to_store(
+        "https://docs.example.com",
+        qdrant_client=qc,
+        collection_name="my_docs",
+        embedding_fn=embed,
+        skip_existing=True,
+        limit=50,
+    )
+    print(f"Crawled {result.total} pages — {result.upserted} upserted, {result.skipped} skipped")
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ..types import CrawlJob, Document
+
+logger = logging.getLogger("firecrawl")
+
+
+@dataclass
+class CrawlToStoreResult:
+    """Result of a ``crawl_to_store`` operation.
+
+    Attributes:
+        total:      Total pages returned by the crawl.
+        upserted:   Pages inserted or updated in Qdrant.
+        skipped:    Pages skipped because an identical copy already existed.
+        updated:    Subset of *upserted* pages where content changed since last crawl.
+        crawl_job:  The completed :class:`~firecrawl.v2.types.CrawlJob`.
+        errors:     Any per-page errors encountered during upsert (url → error message).
+    """
+
+    total: int
+    upserted: int
+    skipped: int
+    updated: int
+    crawl_job: "CrawlJob"
+    errors: Dict[str, str] = field(default_factory=dict)
+
+
+def _content_hash(text: str) -> str:
+    """Return a hex SHA-256 digest of *text*."""
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _url_for_doc(doc: "Document") -> Optional[str]:
+    """Extract the canonical URL from a Document."""
+    if doc.metadata:
+        return doc.metadata.url or doc.metadata.source_url
+    return None
+
+
+def _get_content(doc: "Document", content_key: str) -> Optional[str]:
+    """Return the text content to embed/hash from *doc* using *content_key*."""
+    return getattr(doc, content_key, None)
+
+
+def _doc_to_payload(doc: "Document", content_key: str, content_hash: str) -> Dict[str, Any]:
+    """Build the Qdrant point payload for *doc*."""
+    payload: Dict[str, Any] = {
+        "content_hash": content_hash,
+        "scraped_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    url = _url_for_doc(doc)
+    if url:
+        payload["url"] = url
+
+    content = _get_content(doc, content_key)
+    if content:
+        payload["content"] = content
+
+    if doc.metadata:
+        if doc.metadata.title:
+            payload["title"] = doc.metadata.title
+        if doc.metadata.description:
+            payload["description"] = doc.metadata.description
+
+    return payload
+
+
+def _url_to_point_id(url: str) -> str:
+    """Derive a deterministic UUID from a URL so re-crawls update in-place."""
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, url))
+
+
+def _find_existing_point(qdrant_client: Any, collection_name: str, url: str):
+    """
+    Scroll Qdrant for a point whose payload ``url`` matches *url*.
+
+    Returns the first matching point or ``None``.
+    """
+    try:
+        from qdrant_client.models import Filter, FieldCondition, MatchValue
+    except ImportError:
+        raise ImportError(
+            "qdrant-client is required for Qdrant integration. "
+            "Install it with: pip install qdrant-client"
+        )
+
+    url_filter = Filter(
+        must=[FieldCondition(key="url", match=MatchValue(value=url))]
+    )
+
+    results, _ = qdrant_client.scroll(
+        collection_name=collection_name,
+        scroll_filter=url_filter,
+        limit=1,
+        with_payload=True,
+        with_vectors=False,
+    )
+    return results[0] if results else None
+
+
+def crawl_to_store(
+    firecrawl_client: Any,
+    url: str,
+    *,
+    qdrant_client: Any,
+    collection_name: str,
+    embedding_fn: Callable[[str], List[float]],
+    skip_existing: bool = True,
+    content_key: str = "markdown",
+    # ---- crawl kwargs forwarded verbatim ----
+    prompt: Optional[str] = None,
+    exclude_paths: Optional[List[str]] = None,
+    include_paths: Optional[List[str]] = None,
+    max_discovery_depth: Optional[int] = None,
+    ignore_query_parameters: bool = False,
+    limit: Optional[int] = None,
+    crawl_entire_domain: bool = False,
+    allow_external_links: bool = False,
+    allow_subdomains: bool = False,
+    ignore_robots_txt: bool = False,
+    delay: Optional[int] = None,
+    max_concurrency: Optional[int] = None,
+    scrape_options: Optional[Any] = None,
+    deduplicate_similar_urls: bool = True,
+    zero_data_retention: bool = False,
+    poll_interval: int = 2,
+    timeout: Optional[int] = None,
+    request_timeout: Optional[float] = None,
+) -> CrawlToStoreResult:
+    """
+    Crawl *url* and upsert the resulting pages into a Qdrant collection.
+
+    When *skip_existing* is ``True`` (the default) each page is looked up in
+    Qdrant by its URL before embedding.  Pages whose content hash has not
+    changed since the previous crawl are skipped entirely, making repeated
+    crawls of the same site dramatically cheaper.
+
+    Args:
+        firecrawl_client: A :class:`~firecrawl.v2.client.FirecrawlClient` (or
+            the unified :class:`~firecrawl.client.Firecrawl`) instance.
+        url: Root URL to crawl.
+        qdrant_client: An initialised ``qdrant_client.QdrantClient`` instance.
+        collection_name: Name of the target Qdrant collection.  The collection
+            must already exist with a vector size that matches the output of
+            *embedding_fn*.
+        embedding_fn: A callable that accepts a string and returns a list of
+            floats (the embedding vector).  Called once per page that needs to
+            be upserted.
+        skip_existing: When ``True`` (default), pages already stored in Qdrant
+            with an identical content hash are skipped.  Set to ``False`` to
+            always re-embed and overwrite.
+        content_key: Which :class:`~firecrawl.v2.types.Document` field to use
+            as the text for hashing and embedding.  Defaults to ``"markdown"``.
+            Accepted values: ``"markdown"``, ``"html"``, ``"raw_html"``.
+        prompt: Optional natural-language prompt to guide the crawl.
+        exclude_paths: URL path patterns to exclude.
+        include_paths: URL path patterns to include.
+        max_discovery_depth: Maximum link-following depth.
+        ignore_query_parameters: Treat URLs differing only in query params as
+            identical.
+        limit: Maximum number of pages to crawl.
+        crawl_entire_domain: Follow links outside the start path.
+        allow_external_links: Follow links to other domains.
+        allow_subdomains: Follow links to subdomains.
+        ignore_robots_txt: Skip robots.txt restrictions.
+        delay: Seconds to wait between page requests.
+        max_concurrency: Maximum simultaneous page requests.
+        scrape_options: :class:`~firecrawl.v2.types.ScrapeOptions` applied to
+            each page.
+        deduplicate_similar_urls: Remove near-duplicate URLs (default ``True``).
+        zero_data_retention: Delete raw data from Firecrawl servers after 24 h.
+        poll_interval: Seconds between crawl-status polls.
+        timeout: Maximum seconds to wait for the crawl to finish.
+        request_timeout: Per-HTTP-request timeout in seconds.
+
+    Returns:
+        :class:`CrawlToStoreResult` with counts and the completed
+        :class:`~firecrawl.v2.types.CrawlJob`.
+
+    Raises:
+        ImportError: If ``qdrant-client`` is not installed.
+        ValueError: If *content_key* is not a valid Document field.
+    """
+    try:
+        from qdrant_client.models import PointStruct
+    except ImportError:
+        raise ImportError(
+            "qdrant-client is required for Qdrant integration. "
+            "Install it with: pip install qdrant-client"
+        )
+
+    valid_content_keys = {"markdown", "html", "raw_html"}
+    if content_key not in valid_content_keys:
+        raise ValueError(
+            f"content_key must be one of {valid_content_keys!r}, got {content_key!r}"
+        )
+
+    # Run the crawl
+    crawl_job = firecrawl_client.crawl(
+        url,
+        prompt=prompt,
+        exclude_paths=exclude_paths,
+        include_paths=include_paths,
+        max_discovery_depth=max_discovery_depth,
+        ignore_query_parameters=ignore_query_parameters,
+        limit=limit,
+        crawl_entire_domain=crawl_entire_domain,
+        allow_external_links=allow_external_links,
+        allow_subdomains=allow_subdomains,
+        ignore_robots_txt=ignore_robots_txt,
+        delay=delay,
+        max_concurrency=max_concurrency,
+        scrape_options=scrape_options,
+        deduplicate_similar_urls=deduplicate_similar_urls,
+        zero_data_retention=zero_data_retention,
+        poll_interval=poll_interval,
+        timeout=timeout,
+        request_timeout=request_timeout,
+    )
+
+    documents = crawl_job.data or []
+    total = len(documents)
+    upserted = 0
+    skipped = 0
+    updated = 0
+    errors: Dict[str, str] = {}
+
+    for doc in documents:
+        doc_url = _url_for_doc(doc)
+        content = _get_content(doc, content_key)
+
+        if not content:
+            logger.debug("Skipping document with no %s content (url=%s)", content_key, doc_url)
+            skipped += 1
+            continue
+
+        if not doc_url:
+            logger.warning("Document has no URL in metadata; generating a random point ID.")
+
+        current_hash = _content_hash(content)
+
+        # Determine whether to upsert
+        is_update = False
+        if skip_existing and doc_url:
+            existing = _find_existing_point(qdrant_client, collection_name, doc_url)
+            if existing is not None:
+                existing_hash = (existing.payload or {}).get("content_hash")
+                if existing_hash == current_hash:
+                    skipped += 1
+                    logger.debug("Skipping unchanged page: %s", doc_url)
+                    continue
+                is_update = True
+                logger.debug("Updating changed page: %s", doc_url)
+
+        # Embed and upsert
+        try:
+            vector = embedding_fn(content)
+        except Exception as exc:
+            msg = f"Embedding failed: {exc}"
+            logger.warning("%s (url=%s)", msg, doc_url)
+            if doc_url:
+                errors[doc_url] = msg
+            continue
+
+        point_id = _url_to_point_id(doc_url) if doc_url else str(uuid.uuid4())
+        payload = _doc_to_payload(doc, content_key, current_hash)
+
+        try:
+            qdrant_client.upsert(
+                collection_name=collection_name,
+                points=[PointStruct(id=point_id, vector=vector, payload=payload)],
+            )
+            upserted += 1
+            if is_update:
+                updated += 1
+        except Exception as exc:
+            msg = f"Qdrant upsert failed: {exc}"
+            logger.warning("%s (url=%s)", msg, doc_url)
+            if doc_url:
+                errors[doc_url] = msg
+
+    return CrawlToStoreResult(
+        total=total,
+        upserted=upserted,
+        skipped=skipped,
+        updated=updated,
+        crawl_job=crawl_job,
+        errors=errors,
+    )

--- a/apps/python-sdk/firecrawl/v2/integrations/qdrant.py
+++ b/apps/python-sdk/firecrawl/v2/integrations/qdrant.py
@@ -39,12 +39,15 @@ import uuid
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from ..types import CrawlJob, Document
 
 logger = logging.getLogger("firecrawl")
+
+# Number of points sent to Qdrant in a single upsert call.
+_DEFAULT_BATCH_SIZE = 100
 
 
 @dataclass
@@ -54,10 +57,16 @@ class CrawlToStoreResult:
     Attributes:
         total:      Total pages returned by the crawl.
         upserted:   Pages inserted or updated in Qdrant.
-        skipped:    Pages skipped because an identical copy already existed.
-        updated:    Subset of *upserted* pages where content changed since last crawl.
+        skipped:    Pages not upserted — either because an identical copy
+                    already existed in Qdrant (``skip_existing=True``) or
+                    because the document had no usable content for the chosen
+                    ``content_key``.
+        updated:    Subset of *upserted* pages where content changed since the
+                    last crawl (existing point was overwritten).
         crawl_job:  The completed :class:`~firecrawl.v2.types.CrawlJob`.
-        errors:     Any per-page errors encountered during upsert (url → error message).
+        errors:     Per-page errors encountered during embedding or upsert
+                    (url → error message).  Pages with errors are not counted
+                    in *upserted* or *skipped*.
     """
 
     total: int
@@ -114,32 +123,67 @@ def _url_to_point_id(url: str) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_URL, url))
 
 
-def _find_existing_point(qdrant_client: Any, collection_name: str, url: str):
+def _retrieve_existing_point(qdrant_client: Any, collection_name: str, point_id: str):
     """
-    Scroll Qdrant for a point whose payload ``url`` matches *url*.
+    Fetch a single point by its deterministic *point_id* from Qdrant.
 
-    Returns the first matching point or ``None``.
+    Uses ``retrieve()`` (a direct O(1) key lookup) rather than a payload
+    filter scroll, so no payload index on ``url`` is required.
+
+    Returns the point record or ``None`` if not found.
     """
-    try:
-        from qdrant_client.models import Filter, FieldCondition, MatchValue
-    except ImportError:
-        raise ImportError(
-            "qdrant-client is required for Qdrant integration. "
-            "Install it with: pip install qdrant-client"
-        )
-
-    url_filter = Filter(
-        must=[FieldCondition(key="url", match=MatchValue(value=url))]
-    )
-
-    results, _ = qdrant_client.scroll(
+    results = qdrant_client.retrieve(
         collection_name=collection_name,
-        scroll_filter=url_filter,
-        limit=1,
+        ids=[point_id],
         with_payload=True,
         with_vectors=False,
     )
     return results[0] if results else None
+
+
+def _flush_batch(
+    qdrant_client: Any,
+    collection_name: str,
+    batch: List[Any],  # List[PointStruct]
+    batch_meta: List[Tuple[str, bool]],  # (url, is_update) per point
+    errors: Dict[str, str],
+) -> Tuple[int, int]:
+    """
+    Upsert *batch* into Qdrant and return ``(upserted_count, updated_count)``.
+
+    On batch failure every URL in the batch is individually retried so that a
+    single bad document does not silently discard the rest.  Per-URL errors are
+    recorded in *errors*.
+    """
+    if not batch:
+        return 0, 0
+
+    try:
+        qdrant_client.upsert(collection_name=collection_name, points=batch)
+        upserted = len(batch)
+        updated = sum(1 for _, is_upd in batch_meta if is_upd)
+        return upserted, updated
+    except Exception as batch_exc:
+        logger.warning(
+            "Batch upsert failed (%s), retrying individually: %s",
+            collection_name,
+            batch_exc,
+        )
+
+    upserted = updated = 0
+    for point, (url, is_update) in zip(batch, batch_meta):
+        try:
+            qdrant_client.upsert(collection_name=collection_name, points=[point])
+            upserted += 1
+            if is_update:
+                updated += 1
+        except Exception as exc:
+            msg = f"Qdrant upsert failed: {exc}"
+            logger.warning("%s (url=%s)", msg, url)
+            if url:
+                errors[url] = msg
+
+    return upserted, updated
 
 
 def crawl_to_store(
@@ -151,6 +195,7 @@ def crawl_to_store(
     embedding_fn: Callable[[str], List[float]],
     skip_existing: bool = True,
     content_key: str = "markdown",
+    batch_size: int = _DEFAULT_BATCH_SIZE,
     # ---- crawl kwargs forwarded verbatim ----
     prompt: Optional[str] = None,
     exclude_paths: Optional[List[str]] = None,
@@ -175,9 +220,18 @@ def crawl_to_store(
     Crawl *url* and upsert the resulting pages into a Qdrant collection.
 
     When *skip_existing* is ``True`` (the default) each page is looked up in
-    Qdrant by its URL before embedding.  Pages whose content hash has not
-    changed since the previous crawl are skipped entirely, making repeated
-    crawls of the same site dramatically cheaper.
+    Qdrant by its deterministic point ID before embedding.  Pages whose content
+    hash has not changed since the previous crawl are skipped entirely, making
+    repeated crawls of the same site dramatically cheaper.
+
+    Point IDs are derived from the page URL via UUID v5 so that every re-crawl
+    upserts to the same slot rather than creating duplicates.  Deduplication
+    checks use ``qdrant_client.retrieve()`` — a direct O(1) key lookup — so no
+    payload index on the ``url`` field is required.
+
+    Vectors are sent to Qdrant in batches (``batch_size`` points per request)
+    to minimise round-trips for large crawls.  If a batch fails it is retried
+    one point at a time so a single bad document does not drop the rest.
 
     Args:
         firecrawl_client: A :class:`~firecrawl.v2.client.FirecrawlClient` (or
@@ -187,15 +241,16 @@ def crawl_to_store(
         collection_name: Name of the target Qdrant collection.  The collection
             must already exist with a vector size that matches the output of
             *embedding_fn*.
-        embedding_fn: A callable that accepts a string and returns a list of
-            floats (the embedding vector).  Called once per page that needs to
-            be upserted.
+        embedding_fn: A callable ``(text: str) -> List[float]`` returning the
+            embedding vector.  Called once per page that needs to be upserted.
         skip_existing: When ``True`` (default), pages already stored in Qdrant
             with an identical content hash are skipped.  Set to ``False`` to
             always re-embed and overwrite.
         content_key: Which :class:`~firecrawl.v2.types.Document` field to use
             as the text for hashing and embedding.  Defaults to ``"markdown"``.
             Accepted values: ``"markdown"``, ``"html"``, ``"raw_html"``.
+        batch_size: Number of points sent to Qdrant in a single upsert call
+            (default 100).
         prompt: Optional natural-language prompt to guide the crawl.
         exclude_paths: URL path patterns to exclude.
         include_paths: URL path patterns to include.
@@ -239,6 +294,9 @@ def crawl_to_store(
             f"content_key must be one of {valid_content_keys!r}, got {content_key!r}"
         )
 
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size!r}")
+
     # Run the crawl
     crawl_job = firecrawl_client.crawl(
         url,
@@ -269,6 +327,22 @@ def crawl_to_store(
     updated = 0
     errors: Dict[str, str] = {}
 
+    # Pending batch accumulator: (PointStruct, url, is_update)
+    batch: List[Any] = []
+    batch_meta: List[Tuple[str, bool]] = []
+
+    def _flush() -> None:
+        nonlocal upserted, updated
+        if not batch:
+            return
+        # Pass copies so that clearing the accumulators below does not
+        # retroactively affect the snapshot sent to Qdrant (or to mocks).
+        u, upd = _flush_batch(qdrant_client, collection_name, list(batch), list(batch_meta), errors)
+        upserted += u
+        updated += upd
+        batch.clear()
+        batch_meta.clear()
+
     for doc in documents:
         doc_url = _url_for_doc(doc)
         content = _get_content(doc, content_key)
@@ -282,21 +356,26 @@ def crawl_to_store(
             logger.warning("Document has no URL in metadata; generating a random point ID.")
 
         current_hash = _content_hash(content)
+        point_id = _url_to_point_id(doc_url) if doc_url else str(uuid.uuid4())
 
-        # Determine whether to upsert
+        # Deduplication check via direct O(1) retrieve by deterministic point ID
         is_update = False
         if skip_existing and doc_url:
-            existing = _find_existing_point(qdrant_client, collection_name, doc_url)
+            existing = _retrieve_existing_point(qdrant_client, collection_name, point_id)
             if existing is not None:
                 existing_hash = (existing.payload or {}).get("content_hash")
                 if existing_hash == current_hash:
                     skipped += 1
                     logger.debug("Skipping unchanged page: %s", doc_url)
                     continue
+                # Content changed — overwrite the existing point in-place using
+                # its own ID (always equal to point_id since IDs are deterministic,
+                # but being explicit guards against any future ID scheme changes).
+                point_id = existing.id
                 is_update = True
                 logger.debug("Updating changed page: %s", doc_url)
 
-        # Embed and upsert
+        # Embed
         try:
             vector = embedding_fn(content)
         except Exception as exc:
@@ -306,22 +385,15 @@ def crawl_to_store(
                 errors[doc_url] = msg
             continue
 
-        point_id = _url_to_point_id(doc_url) if doc_url else str(uuid.uuid4())
         payload = _doc_to_payload(doc, content_key, current_hash)
+        batch.append(PointStruct(id=point_id, vector=vector, payload=payload))
+        batch_meta.append((doc_url or "", is_update))
 
-        try:
-            qdrant_client.upsert(
-                collection_name=collection_name,
-                points=[PointStruct(id=point_id, vector=vector, payload=payload)],
-            )
-            upserted += 1
-            if is_update:
-                updated += 1
-        except Exception as exc:
-            msg = f"Qdrant upsert failed: {exc}"
-            logger.warning("%s (url=%s)", msg, doc_url)
-            if doc_url:
-                errors[doc_url] = msg
+        if len(batch) >= batch_size:
+            _flush()
+
+    # Flush remaining points
+    _flush()
 
     return CrawlToStoreResult(
         total=total,

--- a/apps/python-sdk/tests/test_qdrant_integration.py
+++ b/apps/python-sdk/tests/test_qdrant_integration.py
@@ -15,12 +15,14 @@ from firecrawl.v2.integrations.qdrant import (
     _url_to_point_id,
     _url_for_doc,
     _get_content,
+    _retrieve_existing_point,
+    _flush_batch,
 )
 from firecrawl.v2.types import Document, DocumentMetadata
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Shared test helpers
 # ---------------------------------------------------------------------------
 
 def _make_doc(url: str, markdown: str = "hello world", title: str = "Test") -> Document:
@@ -30,7 +32,6 @@ def _make_doc(url: str, markdown: str = "hello world", title: str = "Test") -> D
 
 
 def _make_crawl_job(docs):
-    """Build a mock CrawlJob-like object."""
     job = MagicMock()
     job.data = docs
     job.status = "completed"
@@ -38,12 +39,27 @@ def _make_crawl_job(docs):
 
 
 def _make_qdrant_client(existing_point=None):
-    """Return a mock QdrantClient."""
+    """
+    Return a mock QdrantClient.
+
+    ``retrieve`` is the lookup path used by ``_retrieve_existing_point``.
+    ``scroll`` is kept on the mock but should NOT be called by the new code.
+    """
     qc = MagicMock()
-    # scroll returns (results, next_page_offset)
-    qc.scroll.return_value = ([existing_point] if existing_point else [], None)
+    qc.retrieve.return_value = [existing_point] if existing_point else []
     qc.upsert.return_value = MagicMock()
     return qc
+
+
+def _make_existing_point(url: str, content: str, custom_id: str = None) -> MagicMock:
+    """Build a mock Qdrant point record with the given URL and content hash."""
+    point = MagicMock()
+    point.id = custom_id or _url_to_point_id(url)
+    point.payload = {
+        "url": url,
+        "content_hash": _content_hash(content),
+    }
+    return point
 
 
 # ---------------------------------------------------------------------------
@@ -53,9 +69,7 @@ def _make_qdrant_client(existing_point=None):
 class TestHelpers(unittest.TestCase):
 
     def test_content_hash_deterministic(self):
-        h1 = _content_hash("hello")
-        h2 = _content_hash("hello")
-        self.assertEqual(h1, h2)
+        self.assertEqual(_content_hash("hello"), _content_hash("hello"))
 
     def test_content_hash_differs_for_different_text(self):
         self.assertNotEqual(_content_hash("hello"), _content_hash("world"))
@@ -66,9 +80,10 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(all(c in "0123456789abcdef" for c in h))
 
     def test_url_to_point_id_deterministic(self):
-        id1 = _url_to_point_id("https://example.com/page")
-        id2 = _url_to_point_id("https://example.com/page")
-        self.assertEqual(id1, id2)
+        self.assertEqual(
+            _url_to_point_id("https://example.com/page"),
+            _url_to_point_id("https://example.com/page"),
+        )
 
     def test_url_to_point_id_differs_for_different_urls(self):
         self.assertNotEqual(
@@ -78,12 +93,10 @@ class TestHelpers(unittest.TestCase):
 
     def test_url_to_point_id_is_valid_uuid_string(self):
         import uuid
-        result = _url_to_point_id("https://example.com")
-        uuid.UUID(result)  # raises if invalid
+        uuid.UUID(_url_to_point_id("https://example.com"))  # raises if invalid
 
     def test_url_for_doc_returns_metadata_url(self):
-        doc = _make_doc("https://example.com/page")
-        self.assertEqual(_url_for_doc(doc), "https://example.com/page")
+        self.assertEqual(_url_for_doc(_make_doc("https://example.com/page")), "https://example.com/page")
 
     def test_url_for_doc_falls_back_to_source_url(self):
         meta = DocumentMetadata(source_url="https://example.com/src")
@@ -91,20 +104,102 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(_url_for_doc(doc), "https://example.com/src")
 
     def test_url_for_doc_returns_none_without_metadata(self):
-        doc = Document(markdown="x")
-        self.assertIsNone(_url_for_doc(doc))
+        self.assertIsNone(_url_for_doc(Document(markdown="x")))
 
     def test_get_content_markdown(self):
-        doc = _make_doc("https://x.com", markdown="# Hi")
-        self.assertEqual(_get_content(doc, "markdown"), "# Hi")
+        self.assertEqual(_get_content(_make_doc("https://x.com", markdown="# Hi"), "markdown"), "# Hi")
 
     def test_get_content_html(self):
         doc = Document(html="<h1>Hi</h1>", metadata=DocumentMetadata(url="https://x.com"))
         self.assertEqual(_get_content(doc, "html"), "<h1>Hi</h1>")
 
     def test_get_content_missing_field_returns_none(self):
-        doc = Document(metadata=DocumentMetadata(url="https://x.com"))
-        self.assertIsNone(_get_content(doc, "markdown"))
+        self.assertIsNone(_get_content(Document(metadata=DocumentMetadata(url="https://x.com")), "markdown"))
+
+
+# ---------------------------------------------------------------------------
+# _retrieve_existing_point — uses retrieve(), not scroll()
+# ---------------------------------------------------------------------------
+
+class TestRetrieveExistingPoint(unittest.TestCase):
+
+    def test_returns_point_when_found(self):
+        point = MagicMock()
+        qc = MagicMock()
+        qc.retrieve.return_value = [point]
+        result = _retrieve_existing_point(qc, "my_col", "some-uuid")
+        self.assertIs(result, point)
+
+    def test_returns_none_when_not_found(self):
+        qc = MagicMock()
+        qc.retrieve.return_value = []
+        result = _retrieve_existing_point(qc, "my_col", "some-uuid")
+        self.assertIsNone(result)
+
+    def test_calls_retrieve_not_scroll(self):
+        qc = MagicMock()
+        qc.retrieve.return_value = []
+        _retrieve_existing_point(qc, "col", "id-123")
+        qc.retrieve.assert_called_once()
+        qc.scroll.assert_not_called()
+
+    def test_passes_point_id_to_retrieve(self):
+        qc = MagicMock()
+        qc.retrieve.return_value = []
+        _retrieve_existing_point(qc, "col", "target-id")
+        call_kwargs = qc.retrieve.call_args[1]
+        self.assertIn("target-id", call_kwargs["ids"])
+
+
+# ---------------------------------------------------------------------------
+# _flush_batch
+# ---------------------------------------------------------------------------
+
+class TestFlushBatch(unittest.TestCase):
+
+    def _make_point(self):
+        return MagicMock()
+
+    def test_successful_batch_returns_correct_counts(self):
+        qc = MagicMock()
+        batch = [self._make_point(), self._make_point(), self._make_point()]
+        meta = [("url1", False), ("url2", True), ("url3", False)]
+        errors = {}
+        u, upd = _flush_batch(qc, "col", batch, meta, errors)
+        self.assertEqual(u, 3)
+        self.assertEqual(upd, 1)
+        self.assertEqual(errors, {})
+
+    def test_batch_failure_retries_individually(self):
+        qc = MagicMock()
+        # First call (batch) fails; subsequent calls (individual) succeed
+        qc.upsert.side_effect = [Exception("batch fail"), None, None]
+        batch = [self._make_point(), self._make_point()]
+        meta = [("url1", False), ("url2", True)]
+        errors = {}
+        u, upd = _flush_batch(qc, "col", batch, meta, errors)
+        self.assertEqual(u, 2)
+        self.assertEqual(upd, 1)
+        self.assertEqual(errors, {})
+
+    def test_individual_failure_recorded_in_errors(self):
+        qc = MagicMock()
+        qc.upsert.side_effect = [Exception("batch fail"), Exception("item fail"), None]
+        batch = [self._make_point(), self._make_point()]
+        meta = [("url_bad", False), ("url_ok", False)]
+        errors = {}
+        u, upd = _flush_batch(qc, "col", batch, meta, errors)
+        self.assertEqual(u, 1)
+        self.assertIn("url_bad", errors)
+        self.assertNotIn("url_ok", errors)
+
+    def test_empty_batch_returns_zeros(self):
+        qc = MagicMock()
+        errors = {}
+        u, upd = _flush_batch(qc, "col", [], [], errors)
+        self.assertEqual(u, 0)
+        self.assertEqual(upd, 0)
+        qc.upsert.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -121,24 +216,20 @@ class TestCrawlToStoreNewPages(unittest.TestCase):
         self.crawl_job = _make_crawl_job(self.docs)
         self.fc = MagicMock()
         self.fc.crawl.return_value = self.crawl_job
-        self.qc = _make_qdrant_client(existing_point=None)  # no existing points
+        self.qc = _make_qdrant_client(existing_point=None)
         self.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     def test_returns_crawl_to_store_result(self):
         result = crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
         )
         self.assertIsInstance(result, CrawlToStoreResult)
 
     def test_all_new_pages_upserted(self):
         result = crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
         )
         self.assertEqual(result.total, 2)
         self.assertEqual(result.upserted, 2)
@@ -148,83 +239,118 @@ class TestCrawlToStoreNewPages(unittest.TestCase):
     def test_embedding_fn_called_once_per_page(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
         )
         self.assertEqual(self.embed.call_count, 2)
 
-    def test_qdrant_upsert_called_for_each_page(self):
+    def test_qdrant_upsert_called_in_single_batch(self):
+        """With 2 docs and default batch_size=100, only one upsert call is made."""
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
         )
-        self.assertEqual(self.qc.upsert.call_count, 2)
+        self.assertEqual(self.qc.upsert.call_count, 1)
+        points_sent = self.qc.upsert.call_args[1]["points"]
+        self.assertEqual(len(points_sent), 2)
 
     def test_point_payload_contains_url_and_hash(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
         )
-        first_call_kwargs = self.qc.upsert.call_args_list[0]
-        point = first_call_kwargs[1]["points"][0]
-        self.assertIn("url", point.payload)
-        self.assertIn("content_hash", point.payload)
+        points = self.qc.upsert.call_args[1]["points"]
+        for point in points:
+            self.assertIn("url", point.payload)
+            self.assertIn("content_hash", point.payload)
 
-    def test_crawl_called_with_url_and_kwargs(self):
+    def test_uses_retrieve_not_scroll_for_dedup(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            limit=50,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
+            skip_existing=True,
         )
-        self.fc.crawl.assert_called_once()
-        call_kwargs = self.fc.crawl.call_args[1]
-        self.assertEqual(call_kwargs["limit"], 50)
+        self.qc.retrieve.assert_called()
+        self.qc.scroll.assert_not_called()
 
     def test_crawl_job_attached_to_result(self):
         result = crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
+            qdrant_client=self.qc, collection_name="col", embedding_fn=self.embed,
         )
         self.assertIs(result.crawl_job, self.crawl_job)
 
 
 # ---------------------------------------------------------------------------
-# crawl_to_store — skip_existing=True, identical content
+# Batching behaviour
+# ---------------------------------------------------------------------------
+
+class TestBatching(unittest.TestCase):
+
+    def _run(self, n_docs, batch_size):
+        docs = [_make_doc(f"https://example.com/{i}", markdown=f"content {i}") for i in range(n_docs)]
+        fc = MagicMock()
+        fc.crawl.return_value = _make_crawl_job(docs)
+        qc = _make_qdrant_client()
+        embed = MagicMock(return_value=[0.1])
+        result = crawl_to_store(
+            fc, "https://example.com",
+            qdrant_client=qc, collection_name="col", embedding_fn=embed,
+            batch_size=batch_size,
+        )
+        return result, qc
+
+    def test_single_batch_when_docs_fit(self):
+        _, qc = self._run(n_docs=5, batch_size=10)
+        self.assertEqual(qc.upsert.call_count, 1)
+        self.assertEqual(len(qc.upsert.call_args[1]["points"]), 5)
+
+    def test_multiple_batches_when_docs_exceed_batch_size(self):
+        _, qc = self._run(n_docs=7, batch_size=3)
+        # ceil(7/3) = 3 upsert calls
+        self.assertEqual(qc.upsert.call_count, 3)
+        all_points = [p for call in qc.upsert.call_args_list for p in call[1]["points"]]
+        self.assertEqual(len(all_points), 7)
+
+    def test_exact_multiple_of_batch_size(self):
+        _, qc = self._run(n_docs=6, batch_size=3)
+        self.assertEqual(qc.upsert.call_count, 2)
+
+    def test_invalid_batch_size_raises(self):
+        docs = [_make_doc("https://x.com")]
+        fc = MagicMock()
+        fc.crawl.return_value = _make_crawl_job(docs)
+        with self.assertRaises(ValueError):
+            crawl_to_store(
+                fc, "https://x.com",
+                qdrant_client=MagicMock(), collection_name="col",
+                embedding_fn=MagicMock(return_value=[0.1]),
+                batch_size=0,
+            )
+
+    def test_all_upserted_correctly_counted_across_batches(self):
+        result, _ = self._run(n_docs=10, batch_size=3)
+        self.assertEqual(result.upserted, 10)
+
+
+# ---------------------------------------------------------------------------
+# skip_existing=True, identical content → skip
 # ---------------------------------------------------------------------------
 
 class TestCrawlToStoreSkipExisting(unittest.TestCase):
 
     def setUp(self):
         self.doc = _make_doc("https://example.com/a", markdown="unchanged content")
-        self.crawl_job = _make_crawl_job([self.doc])
         self.fc = MagicMock()
-        self.fc.crawl.return_value = self.crawl_job
-        self.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
-
-        # Build an existing Qdrant point with matching hash
-        existing = MagicMock()
-        existing.payload = {
-            "url": "https://example.com/a",
-            "content_hash": _content_hash("unchanged content"),
-        }
+        self.fc.crawl.return_value = _make_crawl_job([self.doc])
+        self.embed = MagicMock(return_value=[0.1])
+        existing = _make_existing_point("https://example.com/a", "unchanged content")
         self.qc = _make_qdrant_client(existing_point=existing)
 
     def test_unchanged_page_is_skipped(self):
         result = crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=True,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=True,
         )
         self.assertEqual(result.skipped, 1)
         self.assertEqual(result.upserted, 0)
@@ -232,110 +358,103 @@ class TestCrawlToStoreSkipExisting(unittest.TestCase):
     def test_embedding_not_called_for_skipped_page(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=True,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=True,
         )
         self.embed.assert_not_called()
 
     def test_qdrant_not_upserted_for_skipped_page(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=True,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=True,
         )
         self.qc.upsert.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# crawl_to_store — skip_existing=True, changed content → update
+# skip_existing=True, changed content → update using existing.id
 # ---------------------------------------------------------------------------
 
 class TestCrawlToStoreUpdateChanged(unittest.TestCase):
 
     def setUp(self):
-        self.doc = _make_doc("https://example.com/a", markdown="NEW content")
-        self.crawl_job = _make_crawl_job([self.doc])
+        self.url = "https://example.com/a"
+        self.doc = _make_doc(self.url, markdown="NEW content")
         self.fc = MagicMock()
-        self.fc.crawl.return_value = self.crawl_job
+        self.fc.crawl.return_value = _make_crawl_job([self.doc])
         self.embed = MagicMock(return_value=[0.5, 0.6])
 
-        # Existing point has a DIFFERENT hash (stale content)
-        existing = MagicMock()
-        existing.payload = {
-            "url": "https://example.com/a",
-            "content_hash": _content_hash("OLD content"),
-        }
+        # Existing point has stale content AND a custom ID (simulates external insertion)
+        self.custom_existing_id = "custom-id-from-another-process"
+        existing = _make_existing_point(self.url, "OLD content", custom_id=self.custom_existing_id)
         self.qc = _make_qdrant_client(existing_point=existing)
 
     def test_changed_page_is_updated(self):
         result = crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=True,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=True,
         )
         self.assertEqual(result.upserted, 1)
         self.assertEqual(result.updated, 1)
         self.assertEqual(result.skipped, 0)
 
+    def test_uses_existing_point_id_for_update(self):
+        """When updating, the existing point's own ID is used to overwrite in-place."""
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=True,
+        )
+        points = self.qc.upsert.call_args[1]["points"]
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].id, self.custom_existing_id)
+
     def test_embedding_called_for_updated_page(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=True,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=True,
         )
         self.embed.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# crawl_to_store — skip_existing=False always upserts
+# skip_existing=False → always upsert, never call retrieve
 # ---------------------------------------------------------------------------
 
 class TestCrawlToStoreNoSkip(unittest.TestCase):
 
     def setUp(self):
         self.doc = _make_doc("https://example.com/a", markdown="same content")
-        self.crawl_job = _make_crawl_job([self.doc])
         self.fc = MagicMock()
-        self.fc.crawl.return_value = self.crawl_job
+        self.fc.crawl.return_value = _make_crawl_job([self.doc])
         self.embed = MagicMock(return_value=[0.1])
-
-        # Even though a point exists with same hash…
-        existing = MagicMock()
-        existing.payload = {"url": "https://example.com/a", "content_hash": _content_hash("same content")}
+        existing = _make_existing_point("https://example.com/a", "same content")
         self.qc = _make_qdrant_client(existing_point=existing)
 
     def test_page_upserted_even_if_unchanged(self):
         result = crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=False,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=False,
         )
         self.assertEqual(result.upserted, 1)
         self.assertEqual(result.skipped, 0)
 
-    def test_qdrant_scroll_not_called_when_skip_false(self):
+    def test_retrieve_not_called_when_skip_false(self):
         crawl_to_store(
             self.fc, "https://example.com",
-            qdrant_client=self.qc,
-            collection_name="test_col",
-            embedding_fn=self.embed,
-            skip_existing=False,
+            qdrant_client=self.qc, collection_name="col",
+            embedding_fn=self.embed, skip_existing=False,
         )
+        self.qc.retrieve.assert_not_called()
         self.qc.scroll.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# crawl_to_store — edge cases / failure paths
+# Edge cases and failure paths
 # ---------------------------------------------------------------------------
 
 class TestCrawlToStoreEdgeCases(unittest.TestCase):
@@ -346,117 +465,114 @@ class TestCrawlToStoreEdgeCases(unittest.TestCase):
         return fc
 
     def test_empty_crawl_returns_zeros(self):
-        fc = self._base_fc([])
-        qc = _make_qdrant_client()
         result = crawl_to_store(
-            fc, "https://example.com",
-            qdrant_client=qc,
-            collection_name="col",
+            self._base_fc([]), "https://example.com",
+            qdrant_client=_make_qdrant_client(), collection_name="col",
             embedding_fn=MagicMock(),
         )
         self.assertEqual(result.total, 0)
         self.assertEqual(result.upserted, 0)
         self.assertEqual(result.skipped, 0)
 
-    def test_doc_with_no_content_is_skipped(self):
-        doc = Document(metadata=DocumentMetadata(url="https://x.com"))  # no markdown
-        fc = self._base_fc([doc])
-        qc = _make_qdrant_client()
-        embed = MagicMock()
+    def test_doc_with_no_content_counted_in_skipped(self):
+        """Missing content is counted in skipped (documented behaviour)."""
+        doc = Document(metadata=DocumentMetadata(url="https://x.com"))
         result = crawl_to_store(
-            fc, "https://example.com",
-            qdrant_client=qc,
-            collection_name="col",
-            embedding_fn=embed,
+            self._base_fc([doc]), "https://example.com",
+            qdrant_client=_make_qdrant_client(), collection_name="col",
+            embedding_fn=MagicMock(),
         )
         self.assertEqual(result.skipped, 1)
+        self.assertEqual(result.upserted, 0)
+
+    def test_doc_with_no_content_does_not_call_embed(self):
+        doc = Document(metadata=DocumentMetadata(url="https://x.com"))
+        embed = MagicMock()
+        crawl_to_store(
+            self._base_fc([doc]), "https://example.com",
+            qdrant_client=_make_qdrant_client(), collection_name="col",
+            embedding_fn=embed,
+        )
         embed.assert_not_called()
 
     def test_invalid_content_key_raises_value_error(self):
-        fc = self._base_fc([_make_doc("https://x.com")])
         with self.assertRaises(ValueError):
             crawl_to_store(
-                fc, "https://example.com",
-                qdrant_client=MagicMock(),
-                collection_name="col",
-                embedding_fn=MagicMock(),
-                content_key="invalid_key",
+                self._base_fc([_make_doc("https://x.com")]), "https://example.com",
+                qdrant_client=MagicMock(), collection_name="col",
+                embedding_fn=MagicMock(), content_key="invalid_key",
             )
 
     def test_missing_qdrant_client_import_raises(self):
-        """When qdrant_client package is not installed, a clear ImportError is raised."""
         doc = _make_doc("https://example.com/a")
-        fc = self._base_fc([doc])
-        qc = MagicMock()
-
         with patch.dict("sys.modules", {"qdrant_client": None, "qdrant_client.models": None}):
             with self.assertRaises((ImportError, TypeError)):
                 crawl_to_store(
-                    fc, "https://example.com",
-                    qdrant_client=qc,
-                    collection_name="col",
+                    self._base_fc([doc]), "https://example.com",
+                    qdrant_client=MagicMock(), collection_name="col",
                     embedding_fn=MagicMock(return_value=[0.1]),
                 )
 
     def test_embedding_error_recorded_not_raised(self):
         doc = _make_doc("https://example.com/a", markdown="content")
-        fc = self._base_fc([doc])
-        qc = _make_qdrant_client()
         embed = MagicMock(side_effect=RuntimeError("embed failed"))
-
         result = crawl_to_store(
-            fc, "https://example.com",
-            qdrant_client=qc,
-            collection_name="col",
+            self._base_fc([doc]), "https://example.com",
+            qdrant_client=_make_qdrant_client(), collection_name="col",
             embedding_fn=embed,
         )
         self.assertEqual(result.upserted, 0)
         self.assertIn("https://example.com/a", result.errors)
 
-    def test_qdrant_upsert_error_recorded_not_raised(self):
+    def test_qdrant_upsert_error_falls_back_to_individual_retry(self):
+        """Batch failure triggers per-item retry; individual success still counted."""
         doc = _make_doc("https://example.com/a", markdown="content")
-        fc = self._base_fc([doc])
         qc = _make_qdrant_client()
-        qc.upsert.side_effect = Exception("connection refused")
-
+        # First call is the batch attempt (fails), second is the individual retry (succeeds)
+        qc.upsert.side_effect = [Exception("batch fail"), None]
         result = crawl_to_store(
-            fc, "https://example.com",
-            qdrant_client=qc,
-            collection_name="col",
+            self._base_fc([doc]), "https://example.com",
+            qdrant_client=qc, collection_name="col",
+            embedding_fn=MagicMock(return_value=[0.1]),
+        )
+        self.assertEqual(result.upserted, 1)
+        self.assertEqual(result.errors, {})
+
+    def test_qdrant_individual_retry_failure_recorded(self):
+        doc = _make_doc("https://example.com/a", markdown="content")
+        qc = _make_qdrant_client()
+        qc.upsert.side_effect = Exception("always fails")
+        result = crawl_to_store(
+            self._base_fc([doc]), "https://example.com",
+            qdrant_client=qc, collection_name="col",
             embedding_fn=MagicMock(return_value=[0.1]),
         )
         self.assertEqual(result.upserted, 0)
         self.assertIn("https://example.com/a", result.errors)
 
     def test_deterministic_point_id_same_across_runs(self):
-        """Re-crawling the same URL produces the same point ID so upsert is idempotent."""
-        doc = _make_doc("https://example.com/stable")
-        fc1 = self._base_fc([doc])
-        fc2 = self._base_fc([_make_doc("https://example.com/stable", markdown="v2")])
+        url = "https://example.com/stable"
+        docs_v1 = [_make_doc(url, markdown="v1")]
+        docs_v2 = [_make_doc(url, markdown="v2")]
+
+        fc1, fc2 = self._base_fc(docs_v1), self._base_fc(docs_v2)
         qc = _make_qdrant_client()
         embed = MagicMock(return_value=[0.1])
 
         crawl_to_store(fc1, "https://example.com", qdrant_client=qc, collection_name="c", embedding_fn=embed)
         crawl_to_store(fc2, "https://example.com", qdrant_client=qc, collection_name="c", embedding_fn=embed)
 
-        ids = [
-            qc.upsert.call_args_list[i][1]["points"][0].id
-            for i in range(2)
-        ]
+        ids = [qc.upsert.call_args_list[i][1]["points"][0].id for i in range(2)]
         self.assertEqual(ids[0], ids[1])
 
     def test_html_content_key(self):
         doc = Document(html="<p>hi</p>", metadata=DocumentMetadata(url="https://x.com"))
-        fc = self._base_fc([doc])
         qc = _make_qdrant_client()
         embed = MagicMock(return_value=[0.1])
-
         result = crawl_to_store(
-            fc, "https://x.com",
-            qdrant_client=qc,
-            collection_name="col",
-            embedding_fn=embed,
-            content_key="html",
+            self._base_fc([doc]), "https://x.com",
+            qdrant_client=qc, collection_name="col",
+            embedding_fn=embed, content_key="html",
         )
         self.assertEqual(result.upserted, 1)
         embed.assert_called_once_with("<p>hi</p>")
@@ -464,44 +580,64 @@ class TestCrawlToStoreEdgeCases(unittest.TestCase):
     def test_crawl_kwargs_forwarded(self):
         doc = _make_doc("https://example.com/page")
         fc = self._base_fc([doc])
-        qc = _make_qdrant_client()
-
         crawl_to_store(
             fc, "https://example.com",
-            qdrant_client=qc,
-            collection_name="col",
+            qdrant_client=_make_qdrant_client(), collection_name="col",
             embedding_fn=MagicMock(return_value=[0.1]),
-            limit=10,
-            max_discovery_depth=3,
-            allow_subdomains=True,
+            limit=10, max_discovery_depth=3, allow_subdomains=True,
         )
+        kw = fc.crawl.call_args[1]
+        self.assertEqual(kw["limit"], 10)
+        self.assertEqual(kw["max_discovery_depth"], 3)
+        self.assertTrue(kw["allow_subdomains"])
 
-        call_kwargs = fc.crawl.call_args[1]
-        self.assertEqual(call_kwargs["limit"], 10)
-        self.assertEqual(call_kwargs["max_discovery_depth"], 3)
-        self.assertTrue(call_kwargs["allow_subdomains"])
+    def test_mixed_new_skip_update_counts(self):
+        """Three docs: one new, one unchanged (skip), one changed (update)."""
+        new_doc = _make_doc("https://x.com/new", markdown="new content")
+        same_doc = _make_doc("https://x.com/same", markdown="same content")
+        changed_doc = _make_doc("https://x.com/changed", markdown="new version")
+
+        def _retrieve_side(collection_name, ids, **kwargs):
+            if ids[0] == _url_to_point_id("https://x.com/new"):
+                return []
+            if ids[0] == _url_to_point_id("https://x.com/same"):
+                return [_make_existing_point("https://x.com/same", "same content")]
+            if ids[0] == _url_to_point_id("https://x.com/changed"):
+                return [_make_existing_point("https://x.com/changed", "old version")]
+            return []
+
+        fc = self._base_fc([new_doc, same_doc, changed_doc])
+        qc = MagicMock()
+        qc.retrieve.side_effect = _retrieve_side
+        embed = MagicMock(return_value=[0.1])
+
+        result = crawl_to_store(
+            fc, "https://x.com",
+            qdrant_client=qc, collection_name="col",
+            embedding_fn=embed, skip_existing=True,
+        )
+        self.assertEqual(result.total, 3)
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(result.upserted, 2)  # new + changed
+        self.assertEqual(result.updated, 1)   # only changed
 
 
 # ---------------------------------------------------------------------------
-# FirecrawlClient integration — method is accessible on the client
+# Client-level accessibility
 # ---------------------------------------------------------------------------
 
 class TestFirecrawlClientIntegration(unittest.TestCase):
 
     def test_crawl_to_store_on_firecrawl_client(self):
-        """crawl_to_store is reachable via FirecrawlClient."""
         from firecrawl.v2.client import FirecrawlClient
         self.assertTrue(callable(FirecrawlClient.crawl_to_store))
 
     def test_crawl_to_store_on_unified_client(self):
-        """crawl_to_store is reachable via the unified Firecrawl client."""
         from firecrawl import Firecrawl
-        # Instantiate without API key (self-hosted mode)
         fc = Firecrawl(api_key="test", api_url="http://localhost:3002")
         self.assertTrue(callable(fc.crawl_to_store))
 
     def test_crawl_to_store_result_exported(self):
-        """CrawlToStoreResult is importable from the top-level package."""
         from firecrawl import CrawlToStoreResult  # noqa: F401
 
 

--- a/apps/python-sdk/tests/test_qdrant_integration.py
+++ b/apps/python-sdk/tests/test_qdrant_integration.py
@@ -1,0 +1,509 @@
+"""
+Unit tests for the Qdrant crawl_to_store integration.
+
+All external calls (Firecrawl API + Qdrant client) are mocked so no live
+services are required.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from firecrawl.v2.integrations.qdrant import (
+    crawl_to_store,
+    CrawlToStoreResult,
+    _content_hash,
+    _url_to_point_id,
+    _url_for_doc,
+    _get_content,
+)
+from firecrawl.v2.types import Document, DocumentMetadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_doc(url: str, markdown: str = "hello world", title: str = "Test") -> Document:
+    """Build a minimal Document for testing."""
+    meta = DocumentMetadata(url=url, title=title)
+    return Document(markdown=markdown, metadata=meta)
+
+
+def _make_crawl_job(docs):
+    """Build a mock CrawlJob-like object."""
+    job = MagicMock()
+    job.data = docs
+    job.status = "completed"
+    return job
+
+
+def _make_qdrant_client(existing_point=None):
+    """Return a mock QdrantClient."""
+    qc = MagicMock()
+    # scroll returns (results, next_page_offset)
+    qc.scroll.return_value = ([existing_point] if existing_point else [], None)
+    qc.upsert.return_value = MagicMock()
+    return qc
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+class TestHelpers(unittest.TestCase):
+
+    def test_content_hash_deterministic(self):
+        h1 = _content_hash("hello")
+        h2 = _content_hash("hello")
+        self.assertEqual(h1, h2)
+
+    def test_content_hash_differs_for_different_text(self):
+        self.assertNotEqual(_content_hash("hello"), _content_hash("world"))
+
+    def test_content_hash_is_64_hex_chars(self):
+        h = _content_hash("test")
+        self.assertEqual(len(h), 64)
+        self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_url_to_point_id_deterministic(self):
+        id1 = _url_to_point_id("https://example.com/page")
+        id2 = _url_to_point_id("https://example.com/page")
+        self.assertEqual(id1, id2)
+
+    def test_url_to_point_id_differs_for_different_urls(self):
+        self.assertNotEqual(
+            _url_to_point_id("https://example.com/a"),
+            _url_to_point_id("https://example.com/b"),
+        )
+
+    def test_url_to_point_id_is_valid_uuid_string(self):
+        import uuid
+        result = _url_to_point_id("https://example.com")
+        uuid.UUID(result)  # raises if invalid
+
+    def test_url_for_doc_returns_metadata_url(self):
+        doc = _make_doc("https://example.com/page")
+        self.assertEqual(_url_for_doc(doc), "https://example.com/page")
+
+    def test_url_for_doc_falls_back_to_source_url(self):
+        meta = DocumentMetadata(source_url="https://example.com/src")
+        doc = Document(markdown="x", metadata=meta)
+        self.assertEqual(_url_for_doc(doc), "https://example.com/src")
+
+    def test_url_for_doc_returns_none_without_metadata(self):
+        doc = Document(markdown="x")
+        self.assertIsNone(_url_for_doc(doc))
+
+    def test_get_content_markdown(self):
+        doc = _make_doc("https://x.com", markdown="# Hi")
+        self.assertEqual(_get_content(doc, "markdown"), "# Hi")
+
+    def test_get_content_html(self):
+        doc = Document(html="<h1>Hi</h1>", metadata=DocumentMetadata(url="https://x.com"))
+        self.assertEqual(_get_content(doc, "html"), "<h1>Hi</h1>")
+
+    def test_get_content_missing_field_returns_none(self):
+        doc = Document(metadata=DocumentMetadata(url="https://x.com"))
+        self.assertIsNone(_get_content(doc, "markdown"))
+
+
+# ---------------------------------------------------------------------------
+# crawl_to_store — happy path: all pages are new
+# ---------------------------------------------------------------------------
+
+class TestCrawlToStoreNewPages(unittest.TestCase):
+
+    def setUp(self):
+        self.docs = [
+            _make_doc("https://example.com/a", markdown="page a content"),
+            _make_doc("https://example.com/b", markdown="page b content"),
+        ]
+        self.crawl_job = _make_crawl_job(self.docs)
+        self.fc = MagicMock()
+        self.fc.crawl.return_value = self.crawl_job
+        self.qc = _make_qdrant_client(existing_point=None)  # no existing points
+        self.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+    def test_returns_crawl_to_store_result(self):
+        result = crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+        )
+        self.assertIsInstance(result, CrawlToStoreResult)
+
+    def test_all_new_pages_upserted(self):
+        result = crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+        )
+        self.assertEqual(result.total, 2)
+        self.assertEqual(result.upserted, 2)
+        self.assertEqual(result.skipped, 0)
+        self.assertEqual(result.updated, 0)
+
+    def test_embedding_fn_called_once_per_page(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+        )
+        self.assertEqual(self.embed.call_count, 2)
+
+    def test_qdrant_upsert_called_for_each_page(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+        )
+        self.assertEqual(self.qc.upsert.call_count, 2)
+
+    def test_point_payload_contains_url_and_hash(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+        )
+        first_call_kwargs = self.qc.upsert.call_args_list[0]
+        point = first_call_kwargs[1]["points"][0]
+        self.assertIn("url", point.payload)
+        self.assertIn("content_hash", point.payload)
+
+    def test_crawl_called_with_url_and_kwargs(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            limit=50,
+        )
+        self.fc.crawl.assert_called_once()
+        call_kwargs = self.fc.crawl.call_args[1]
+        self.assertEqual(call_kwargs["limit"], 50)
+
+    def test_crawl_job_attached_to_result(self):
+        result = crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+        )
+        self.assertIs(result.crawl_job, self.crawl_job)
+
+
+# ---------------------------------------------------------------------------
+# crawl_to_store — skip_existing=True, identical content
+# ---------------------------------------------------------------------------
+
+class TestCrawlToStoreSkipExisting(unittest.TestCase):
+
+    def setUp(self):
+        self.doc = _make_doc("https://example.com/a", markdown="unchanged content")
+        self.crawl_job = _make_crawl_job([self.doc])
+        self.fc = MagicMock()
+        self.fc.crawl.return_value = self.crawl_job
+        self.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+        # Build an existing Qdrant point with matching hash
+        existing = MagicMock()
+        existing.payload = {
+            "url": "https://example.com/a",
+            "content_hash": _content_hash("unchanged content"),
+        }
+        self.qc = _make_qdrant_client(existing_point=existing)
+
+    def test_unchanged_page_is_skipped(self):
+        result = crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=True,
+        )
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(result.upserted, 0)
+
+    def test_embedding_not_called_for_skipped_page(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=True,
+        )
+        self.embed.assert_not_called()
+
+    def test_qdrant_not_upserted_for_skipped_page(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=True,
+        )
+        self.qc.upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# crawl_to_store — skip_existing=True, changed content → update
+# ---------------------------------------------------------------------------
+
+class TestCrawlToStoreUpdateChanged(unittest.TestCase):
+
+    def setUp(self):
+        self.doc = _make_doc("https://example.com/a", markdown="NEW content")
+        self.crawl_job = _make_crawl_job([self.doc])
+        self.fc = MagicMock()
+        self.fc.crawl.return_value = self.crawl_job
+        self.embed = MagicMock(return_value=[0.5, 0.6])
+
+        # Existing point has a DIFFERENT hash (stale content)
+        existing = MagicMock()
+        existing.payload = {
+            "url": "https://example.com/a",
+            "content_hash": _content_hash("OLD content"),
+        }
+        self.qc = _make_qdrant_client(existing_point=existing)
+
+    def test_changed_page_is_updated(self):
+        result = crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=True,
+        )
+        self.assertEqual(result.upserted, 1)
+        self.assertEqual(result.updated, 1)
+        self.assertEqual(result.skipped, 0)
+
+    def test_embedding_called_for_updated_page(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=True,
+        )
+        self.embed.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# crawl_to_store — skip_existing=False always upserts
+# ---------------------------------------------------------------------------
+
+class TestCrawlToStoreNoSkip(unittest.TestCase):
+
+    def setUp(self):
+        self.doc = _make_doc("https://example.com/a", markdown="same content")
+        self.crawl_job = _make_crawl_job([self.doc])
+        self.fc = MagicMock()
+        self.fc.crawl.return_value = self.crawl_job
+        self.embed = MagicMock(return_value=[0.1])
+
+        # Even though a point exists with same hash…
+        existing = MagicMock()
+        existing.payload = {"url": "https://example.com/a", "content_hash": _content_hash("same content")}
+        self.qc = _make_qdrant_client(existing_point=existing)
+
+    def test_page_upserted_even_if_unchanged(self):
+        result = crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=False,
+        )
+        self.assertEqual(result.upserted, 1)
+        self.assertEqual(result.skipped, 0)
+
+    def test_qdrant_scroll_not_called_when_skip_false(self):
+        crawl_to_store(
+            self.fc, "https://example.com",
+            qdrant_client=self.qc,
+            collection_name="test_col",
+            embedding_fn=self.embed,
+            skip_existing=False,
+        )
+        self.qc.scroll.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# crawl_to_store — edge cases / failure paths
+# ---------------------------------------------------------------------------
+
+class TestCrawlToStoreEdgeCases(unittest.TestCase):
+
+    def _base_fc(self, docs):
+        fc = MagicMock()
+        fc.crawl.return_value = _make_crawl_job(docs)
+        return fc
+
+    def test_empty_crawl_returns_zeros(self):
+        fc = self._base_fc([])
+        qc = _make_qdrant_client()
+        result = crawl_to_store(
+            fc, "https://example.com",
+            qdrant_client=qc,
+            collection_name="col",
+            embedding_fn=MagicMock(),
+        )
+        self.assertEqual(result.total, 0)
+        self.assertEqual(result.upserted, 0)
+        self.assertEqual(result.skipped, 0)
+
+    def test_doc_with_no_content_is_skipped(self):
+        doc = Document(metadata=DocumentMetadata(url="https://x.com"))  # no markdown
+        fc = self._base_fc([doc])
+        qc = _make_qdrant_client()
+        embed = MagicMock()
+        result = crawl_to_store(
+            fc, "https://example.com",
+            qdrant_client=qc,
+            collection_name="col",
+            embedding_fn=embed,
+        )
+        self.assertEqual(result.skipped, 1)
+        embed.assert_not_called()
+
+    def test_invalid_content_key_raises_value_error(self):
+        fc = self._base_fc([_make_doc("https://x.com")])
+        with self.assertRaises(ValueError):
+            crawl_to_store(
+                fc, "https://example.com",
+                qdrant_client=MagicMock(),
+                collection_name="col",
+                embedding_fn=MagicMock(),
+                content_key="invalid_key",
+            )
+
+    def test_missing_qdrant_client_import_raises(self):
+        """When qdrant_client package is not installed, a clear ImportError is raised."""
+        doc = _make_doc("https://example.com/a")
+        fc = self._base_fc([doc])
+        qc = MagicMock()
+
+        with patch.dict("sys.modules", {"qdrant_client": None, "qdrant_client.models": None}):
+            with self.assertRaises((ImportError, TypeError)):
+                crawl_to_store(
+                    fc, "https://example.com",
+                    qdrant_client=qc,
+                    collection_name="col",
+                    embedding_fn=MagicMock(return_value=[0.1]),
+                )
+
+    def test_embedding_error_recorded_not_raised(self):
+        doc = _make_doc("https://example.com/a", markdown="content")
+        fc = self._base_fc([doc])
+        qc = _make_qdrant_client()
+        embed = MagicMock(side_effect=RuntimeError("embed failed"))
+
+        result = crawl_to_store(
+            fc, "https://example.com",
+            qdrant_client=qc,
+            collection_name="col",
+            embedding_fn=embed,
+        )
+        self.assertEqual(result.upserted, 0)
+        self.assertIn("https://example.com/a", result.errors)
+
+    def test_qdrant_upsert_error_recorded_not_raised(self):
+        doc = _make_doc("https://example.com/a", markdown="content")
+        fc = self._base_fc([doc])
+        qc = _make_qdrant_client()
+        qc.upsert.side_effect = Exception("connection refused")
+
+        result = crawl_to_store(
+            fc, "https://example.com",
+            qdrant_client=qc,
+            collection_name="col",
+            embedding_fn=MagicMock(return_value=[0.1]),
+        )
+        self.assertEqual(result.upserted, 0)
+        self.assertIn("https://example.com/a", result.errors)
+
+    def test_deterministic_point_id_same_across_runs(self):
+        """Re-crawling the same URL produces the same point ID so upsert is idempotent."""
+        doc = _make_doc("https://example.com/stable")
+        fc1 = self._base_fc([doc])
+        fc2 = self._base_fc([_make_doc("https://example.com/stable", markdown="v2")])
+        qc = _make_qdrant_client()
+        embed = MagicMock(return_value=[0.1])
+
+        crawl_to_store(fc1, "https://example.com", qdrant_client=qc, collection_name="c", embedding_fn=embed)
+        crawl_to_store(fc2, "https://example.com", qdrant_client=qc, collection_name="c", embedding_fn=embed)
+
+        ids = [
+            qc.upsert.call_args_list[i][1]["points"][0].id
+            for i in range(2)
+        ]
+        self.assertEqual(ids[0], ids[1])
+
+    def test_html_content_key(self):
+        doc = Document(html="<p>hi</p>", metadata=DocumentMetadata(url="https://x.com"))
+        fc = self._base_fc([doc])
+        qc = _make_qdrant_client()
+        embed = MagicMock(return_value=[0.1])
+
+        result = crawl_to_store(
+            fc, "https://x.com",
+            qdrant_client=qc,
+            collection_name="col",
+            embedding_fn=embed,
+            content_key="html",
+        )
+        self.assertEqual(result.upserted, 1)
+        embed.assert_called_once_with("<p>hi</p>")
+
+    def test_crawl_kwargs_forwarded(self):
+        doc = _make_doc("https://example.com/page")
+        fc = self._base_fc([doc])
+        qc = _make_qdrant_client()
+
+        crawl_to_store(
+            fc, "https://example.com",
+            qdrant_client=qc,
+            collection_name="col",
+            embedding_fn=MagicMock(return_value=[0.1]),
+            limit=10,
+            max_discovery_depth=3,
+            allow_subdomains=True,
+        )
+
+        call_kwargs = fc.crawl.call_args[1]
+        self.assertEqual(call_kwargs["limit"], 10)
+        self.assertEqual(call_kwargs["max_discovery_depth"], 3)
+        self.assertTrue(call_kwargs["allow_subdomains"])
+
+
+# ---------------------------------------------------------------------------
+# FirecrawlClient integration — method is accessible on the client
+# ---------------------------------------------------------------------------
+
+class TestFirecrawlClientIntegration(unittest.TestCase):
+
+    def test_crawl_to_store_on_firecrawl_client(self):
+        """crawl_to_store is reachable via FirecrawlClient."""
+        from firecrawl.v2.client import FirecrawlClient
+        self.assertTrue(callable(FirecrawlClient.crawl_to_store))
+
+    def test_crawl_to_store_on_unified_client(self):
+        """crawl_to_store is reachable via the unified Firecrawl client."""
+        from firecrawl import Firecrawl
+        # Instantiate without API key (self-hosted mode)
+        fc = Firecrawl(api_key="test", api_url="http://localhost:3002")
+        self.assertTrue(callable(fc.crawl_to_store))
+
+    def test_crawl_to_store_result_exported(self):
+        """CrawlToStoreResult is importable from the top-level package."""
+        from firecrawl import CrawlToStoreResult  # noqa: F401
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `crawl_to_store()` to `FirecrawlClient` and the unified `Firecrawl` client. The method runs a crawl and upserts resulting pages into a Qdrant collection. When `skip_existing=True` (default) each page is looked up by URL payload before embedding; pages whose SHA-256 content hash is unchanged since the last crawl are skipped entirely, making incremental re-crawls of the same site dramatically cheaper.

- New `firecrawl/v2/integrations/qdrant.py` module with core logic
- Deterministic point IDs derived from URL (UUID v5) so re-crawls update in-place rather than creating duplicate vectors
- Payload stores `url`, `content_hash`, `title`, `description`, `content`, and `scraped_at` for rich metadata filtering
- `qdrant-client` is an optional dependency; a clear `ImportError` is raised when it is missing
- Returns `CrawlToStoreResult` with `total`, `upserted`, `skipped`, `updated` counts and the completed `CrawlJob`