### PR TITLE
fix: force cache miss for stale screenshot signed URLs

### DIFF
--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -97,6 +97,19 @@ export async function getIndexFromGCS(
               ) *
                 1000;
           }
+          // TODO: remove on Apr 26 -- Approximate signing time: expiresAt minus the 7-day TTL used when signing.
+          // Cache entries signed before this cutoff are treated as stale.
+          const SCREENSHOT_CACHE_VALID_AFTER = new Date(
+            "2026-04-19T21:00:00Z",
+          ).getTime();
+          const signedAt = expiresAt - 1000 * 60 * 60 * 24 * 7;
+          if (
+            screenshotUrl.hostname === "storage.googleapis.com" &&
+            signedAt < SCREENSHOT_CACHE_VALID_AFTER
+          ) {
+            logger?.info("Stale screenshot cache, forcing miss");
+            return null;
+          }
           if (
             screenshotUrl.hostname === "storage.googleapis.com" &&
             expiresAt < Date.now()


### PR DESCRIPTION
## Summary
- Screenshot signed URLs cached before 2026-04-19T21:00:00Z are now treated as a cache miss, forcing a fresh scrape with a valid signed URL
- Stale URLs were still within their 7-day TTL so the existing re-sign-on-expiry path wasn't catching them

## TODO
Remove the `SCREENSHOT_CACHE_VALID_AFTER` block on Apr 26 once all pre-rotation cache entries have naturally expired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force a cache miss for screenshot signed URLs cached before 2026-04-19T21:00:00Z to ensure a fresh scrape with a valid URL. Fixes stale screenshots that were still within their 7-day TTL and bypassed the normal expiry path.

- **Bug Fixes**
  - For `storage.googleapis.com` screenshot URLs, infer sign time as expiresAt minus 7 days; if before the cutoff, return null to bypass cache and fetch anew. Temporary guard to be removed on Apr 26.

<sup>Written for commit 397b74f71a8cc14994a7d73ec2dcaacaa63615aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

