### PR TITLE
fire-pdf: send explicit {timeout, created_at} for deadline contract

### DIFF
--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -11,7 +11,7 @@ const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {
   firepdf: "pdf-cache-firepdf/",
 };
 
-function createPdfCacheKey(pdfContent: string | Buffer): string {
+export function createPdfCacheKey(pdfContent: string | Buffer): string {
   return crypto.createHash("sha256").update(pdfContent).digest("hex");
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { PDFProcessorResult } from "./types";
 import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
+  createPdfCacheKey,
   getPdfResultFromCache,
   savePdfResultToCache,
 } from "../../../../lib/gcs-pdf-cache";
@@ -42,6 +43,9 @@ export async function scrapePDFWithFirePDF(
     pagesProcessed,
   });
 
+  const zdr = meta.internalOptions.zeroDataRetention === true;
+  const pdfSha256 = createPdfCacheKey(base64Content);
+
   const resp = await robustFetch({
     url: `${config.FIRE_PDF_BASE_URL}/ocr`,
     method: "POST",
@@ -52,6 +56,16 @@ export async function scrapePDFWithFirePDF(
       pdf: base64Content,
       scrape_id: meta.id,
       ...(maxPages !== undefined && { max_pages: maxPages }),
+      // Enrichment for the fire-pdf jobs DB / dashboard. fire-pdf treats
+      // these as optional — older fire-pdf builds will ignore unknown fields.
+      team_id: meta.internalOptions.teamId,
+      ...(meta.internalOptions.crawlId && {
+        crawl_id: meta.internalOptions.crawlId,
+      }),
+      ...(zdr ? {} : { url: meta.rewrittenUrl ?? meta.url }),
+      pdf_sha256: pdfSha256,
+      source: "firecrawl",
+      zdr,
     },
     logger,
     schema: z.object({

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -46,6 +46,26 @@ export async function scrapePDFWithFirePDF(
   const zdr = meta.internalOptions.zeroDataRetention === true;
   const pdfSha256 = createPdfCacheKey(base64Content);
 
+  // Explicit deadline contract with fire-pdf (mirrors mineru-api):
+  //   timeout    — remaining scrape-tier budget in ms (from AbortManager)
+  //   created_at — epoch ms when we handed the budget over to fire-pdf
+  //
+  // fire-pdf computes remaining = timeout - (now - created_at) and can
+  // return 503 if the budget is spent. Previously it only saw the abort
+  // signal from the HTTP connection, which it didn't observe — so work
+  // kept running past the caller's timeout and the user got a late
+  // failure instead of a fast deadline-exceeded response.
+  //
+  // scrapeTimeout() returns undefined if no scrape-tier deadline is set
+  // (e.g., internal tests, CLI). Don't send timeout in that case so
+  // fire-pdf applies its own default.
+  const fireScrapeTimeout = meta.abort.scrapeTimeout();
+  const deadlineFields: { timeout?: number; created_at?: number } = {};
+  if (fireScrapeTimeout !== undefined && fireScrapeTimeout > 0) {
+    deadlineFields.timeout = Math.floor(fireScrapeTimeout);
+    deadlineFields.created_at = Date.now();
+  }
+
   const resp = await robustFetch({
     url: `${config.FIRE_PDF_BASE_URL}/ocr`,
     method: "POST",
@@ -66,6 +86,7 @@ export async function scrapePDFWithFirePDF(
       pdf_sha256: pdfSha256,
       source: "firecrawl",
       zdr,
+      ...deadlineFields,
     },
     logger,
     schema: z.object({

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -409,8 +409,17 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             team_id: meta.internalOptions.teamId,
             from_engine: "firepdf",
             to_engine: "mineru",
-            error_class: (error as Error)?.name,
-            error_message: ((error as Error)?.message ?? "").slice(0, 500),
+            // Coerce both to strings defensively — if someone throws a
+            // non-Error (e.g. a plain object or primitive), `.name` /
+            // `.message` could be undefined or non-string, and `.slice` would
+            // throw inside the fallback logger, masking the original failure.
+            error_class:
+              (error as { name?: unknown })?.name != null
+                ? String((error as { name?: unknown }).name)
+                : undefined,
+            error_message: String(
+              (error as { message?: unknown })?.message ?? "",
+            ).slice(0, 500),
           });
         }
       }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -404,6 +404,13 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           meta.logger.warn("FirePDF failed -- falling back to MinerU", {
             method: "scrapePDF/firePDF",
             error,
+            event: "pdf_engine_fallback",
+            scrape_id: meta.id,
+            team_id: meta.internalOptions.teamId,
+            from_engine: "firepdf",
+            to_engine: "mineru",
+            error_class: (error as Error)?.name,
+            error_message: ((error as Error)?.message ?? "").slice(0, 500),
           });
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send an explicit deadline (`timeout`, `created_at`) to `fire-pdf` and enrich the POST payload for better observability. Improves timeout behavior and makes fallbacks and jobs easier to trace.

- **New Features**
  - Include `timeout` and `created_at` in `fire-pdf` POST body to enforce caller deadlines; expired requests return 503. Omit when no scrape-tier deadline so service default applies.
  - Send job metadata: `team_id`, `crawl_id`, `url` (omitted with zero data retention), `pdf_sha256`, `source`, and `zdr` for the jobs dashboard.
  - Export `createPdfCacheKey` and use it to compute `pdf_sha256`.
  - Log structured `event=pdf_engine_fallback` with IDs and error details when falling back from FirePDF to MinerU.

- **Bug Fixes**
  - Coerce `error_class` and `error_message` to strings in fallback logs to prevent logger errors when non-Error values are thrown.

<sup>Written for commit 6bbdf295dfd793094c2db09814ca72d16d7001fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

