### PR TITLE
chore(deps): bump langsmith to fix GHSA-rr7j-v2q5-chgv

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -122,7 +122,7 @@
     "joplin-turndown-plugin-gfm": "^1.0.12",
     "jsdom": "^26.0.0",
     "koffi": "^2.9.0",
-    "langsmith": "^0.5.18",
+    "langsmith": "^0.5.19",
     "lodash": "^4.18.0",
     "marked": "^14.1.2",
     "ollama-ai-provider": "^1.2.0",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -178,8 +178,8 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       langsmith:
-        specifier: ^0.5.18
-        version: 0.5.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@5.20.2(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: ^0.5.19
+        version: 0.5.20(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@5.20.2(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       lodash:
         specifier: ^4.18.0
         version: 4.18.1
@@ -4420,8 +4420,8 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
-  langsmith@0.5.18:
-    resolution: {integrity: sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==}
+  langsmith@0.5.20:
+    resolution: {integrity: sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -10449,7 +10449,7 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langsmith@0.5.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@5.20.2(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  langsmith@0.5.20(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@5.20.2(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       p-queue: 6.6.2
       uuid: 10.0.0


### PR DESCRIPTION
## Summary

### `apps/api`
- `langsmith` `^0.5.18` -> `^0.5.19` (installed resolution: `0.5.20`, released `2026-04-15`) -> addresses [GHSA-rr7j-v2q5-chgv](https://github.com/advisories/GHSA-rr7j-v2q5-chgv) (moderate; LangSmith SDK streaming token events bypassed the output redaction pipeline; patched in npm `langsmith@0.5.19`).

No overrides were required. All other audited workspaces (`apps/api`, `apps/playwright-service-ts`, `apps/js-sdk`, `apps/js-sdk/firecrawl`, `apps/test-suite`, `apps/ui/ingestion-ui`, `apps/test-site`) were already clean and remain clean after this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `langsmith` in `apps/api` to apply the security fix for GHSA-rr7j-v2q5-chgv so streaming token events are properly redacted.

- **Dependencies**
  - `langsmith` `^0.5.18` → `^0.5.19` (resolved `0.5.20`); no other workspaces changed.

<sup>Written for commit a24aeeb63cb125450208cc22e9f0c1c134d311e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

