### PR TITLE
fix: add try/catch to execCell and correct stderr/stdout log labels

### DIFF
--- a/examples/scrape_and_analyze_airbnb_data_e2b/codeInterpreter.ts
+++ b/examples/scrape_and_analyze_airbnb_data_e2b/codeInterpreter.ts
@@ -8,17 +8,23 @@ export async function codeInterpret(
     `\n${'='.repeat(50)}\n> Running following AI-generated code:\n${code}\n${'='.repeat(50)}`
   )
 
-  const exec = await codeInterpreter.notebook.execCell(code, {
+  let exec
+  try {
+    exec = await codeInterpreter.notebook.execCell(code, {
     // You can stream logs from the code interpreter
-    // onStderr: (stderr: string) => console.log("\n[Code Interpreter stdout]", stderr),
-    // onStdout: (stdout: string) => console.log("\n[Code Interpreter stderr]", stdout),
+    // onStderr: (stderr: string) => console.log("\n[Code Interpreter stderr]", stderr),
+    // onStdout: (stdout: string) => console.log("\n[Code Interpreter stdout]", stdout),
     //
     // You can also stream additional results like charts, images, etc.
     // onResult: ...
   })
+  } catch (err) {
+    console.error('[Code Interpreter] execCell exception:', err)
+    return undefined
+  }
 
   if (exec.error) {
-    console.log('[Code Interpreter error]', exec.error) // Runtime error
+    console.error('[Code Interpreter error]', exec.error) // Runtime error
     return undefined
   }
 


### PR DESCRIPTION
Wrap execCell in a try/catch to handle network and API-level exceptions gracefully. Fix swapped stderr/stdout labels in commented-out stream handlers. Replace console.log with console.error for runtime error logging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a try/catch around `execCell` to handle network/API exceptions and prevent crashes. Also fixes stderr/stdout log labels and switches runtime error logs to `console.error`.

- **Bug Fixes**
  - Wrap `notebook.execCell` in try/catch; return `undefined` on exception.
  - Correct swapped labels in `onStderr`/`onStdout` comments.
  - Use `console.error` for runtime error logging.

<sup>Written for commit 6da423a815bd678b261eaa862d28626e75a9cf02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

