### PR TITLE
fix(js-sdk): convert seconds→ms when mirroring interact/browser-execute timeout to Axios

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/httpClient.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/httpClient.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { HttpClient } from "../../../v2/utils/httpClient";
+
+function buildClientWithSpy() {
+  const client = new HttpClient({
+    apiKey: "test-key",
+    apiUrl: "https://api.firecrawl.dev",
+  });
+  const request = jest.fn(async (cfg: any) => ({
+    status: 200,
+    data: {},
+    config: cfg,
+  }));
+  // Replace the internal axios instance with a spy so we can inspect
+  // the config that would be sent on the wire.
+  (client as any).instance = { request };
+  return { client, request };
+}
+
+describe("HttpClient body-timeout override", () => {
+  test("preserves ms-based timeout for /v2/scrape (adds 5s buffer)", async () => {
+    const { client, request } = buildClientWithSpy();
+    await client.post("/v2/scrape", { timeout: 30000 });
+    const cfg = (request.mock.calls[0] as any[])[0];
+    expect(cfg.timeout).toBe(35000);
+  });
+
+  test("preserves ms-based timeout for /v2/map (adds 5s buffer)", async () => {
+    const { client, request } = buildClientWithSpy();
+    await client.post("/v2/map", { timeout: 60000 });
+    const cfg = (request.mock.calls[0] as any[])[0];
+    expect(cfg.timeout).toBe(65000);
+  });
+
+  test("converts seconds to ms for /v2/scrape/:id/interact (API cap 300s)", async () => {
+    const { client, request } = buildClientWithSpy();
+    await client.post("/v2/scrape/job-123/interact", { timeout: 150 });
+    const cfg = (request.mock.calls[0] as any[])[0];
+    // Without the conversion this would have been 5150 ms and the Axios
+    // client would give up long before the 150-second API call returned.
+    expect(cfg.timeout).toBe(155000);
+  });
+
+  test("converts seconds to ms for /v2/browser/:id/execute (API cap 300s)", async () => {
+    const { client, request } = buildClientWithSpy();
+    await client.post("/v2/browser/sess-abc/execute", { timeout: 300 });
+    const cfg = (request.mock.calls[0] as any[])[0];
+    expect(cfg.timeout).toBe(305000);
+  });
+
+  test("does not set cfg.timeout when body has no numeric timeout", async () => {
+    const { client, request } = buildClientWithSpy();
+    await client.post("/v2/scrape", { formats: ["markdown"] });
+    const cfg = (request.mock.calls[0] as any[])[0];
+    expect(cfg.timeout).toBeUndefined();
+  });
+
+  test("seconds-conversion does not match unrelated URLs containing 'interact'", async () => {
+    const { client, request } = buildClientWithSpy();
+    // e.g. a future /v2/scrape endpoint taking a body with a `timeout` (ms)
+    // that happens to have the word 'interact' nowhere near the URL should
+    // keep ms semantics.
+    await client.post("/v2/scrape", { timeout: 30000, prompt: "interact with page" });
+    const cfg = (request.mock.calls[0] as any[])[0];
+    expect(cfg.timeout).toBe(35000);
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts
@@ -66,9 +66,20 @@ export class HttpClient {
           const data = (cfg.data ?? {}) as Record<string, unknown>;
           cfg.data = { ...data, origin: typeof data.origin === "string" && data.origin.includes("mcp") ? data.origin : `js-sdk@${version}` };
 
-          // If timeout is specified in the body, use it to override the request timeout
+          // If timeout is specified in the body, use it to override the request timeout.
+          // Most endpoints accept the timeout in milliseconds (matching Axios' cfg.timeout),
+          // but the interact and browser-execute endpoints take seconds (API cap 300s) — see
+          // `apps/api/src/controllers/v2/scrape-browser.ts` and `.../browser.ts`. Convert those
+          // so the Axios client doesn't give up ~5s into a long-running operation.
           if (typeof data.timeout === "number") {
-            cfg.timeout = data.timeout + 5000;
+            const url = typeof cfg.url === "string" ? cfg.url : "";
+            const timeoutInSeconds =
+              /\/v2\/scrape\/[^/]+\/interact(?:\/|$|\?)/.test(url) ||
+              /\/v2\/browser\/[^/]+\/execute(?:\/|$|\?)/.test(url);
+            const apiTimeoutMs = timeoutInSeconds
+              ? data.timeout * 1000
+              : data.timeout;
+            cfg.timeout = apiTimeoutMs + 5000;
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes #3407 — `client.interact(jobId, { timeout: 150 })` failed with `timeout of 5150ms exceeded`.

`HttpClient.request` mirrors a numeric `body.timeout` onto Axios' `cfg.timeout` so the HTTP client doesn't give up before the API does:

```ts
// before
if (typeof data.timeout === "number") {
  cfg.timeout = data.timeout + 5000;
}
```

That assumes the body timeout is already in milliseconds. It is for most v2 endpoints (`/v2/scrape`, `/v2/map` — schema `z.int().positive().min(1000)`), but **not** for `/v2/scrape/:id/interact` and `/v2/browser/:id/execute`, whose schemas are `z.number().min(1).max(300)` — i.e. **seconds**. A valid 150 s interact timeout came through as a 5 150 ms Axios timeout, so Axios aborted within seconds.

## Fix

URL-sniff the two seconds-based endpoints and multiply their timeouts by 1 000 before applying the existing 5 s buffer. All other endpoints keep the ms-based behaviour unchanged.

```ts
// after
if (typeof data.timeout === "number") {
  const url = typeof cfg.url === "string" ? cfg.url : "";
  const timeoutInSeconds =
    /\/v2\/scrape\/[^/]+\/interact(?:\/|$|\?)/.test(url) ||
    /\/v2\/browser\/[^/]+\/execute(?:\/|$|\?)/.test(url);
  const apiTimeoutMs = timeoutInSeconds
    ? data.timeout * 1000
    : data.timeout;
  cfg.timeout = apiTimeoutMs + 5000;
}
```

I considered making the mirroring opt-in from each method instead, but that's a larger refactor touching scrape/map/search/interact — the URL check is surgical and the endpoint set is small and known (the schemas that use seconds are at `apps/api/src/controllers/v2/scrape-browser.ts:80` and `apps/api/src/controllers/v2/browser.ts:69`).

## Changes

- `apps/js-sdk/firecrawl/src/v2/utils/httpClient.ts` — unit-aware mirroring.
- `apps/js-sdk/firecrawl/src/__tests__/unit/v2/httpClient.unit.test.ts` — new unit test file covering both unit regimes, a no-op case, and a negative case.

## Test plan

- [x] `pnpm test:unit` passes (52/52, including 6 new `HttpClient body-timeout override` tests).
- [x] Verified no regression on existing ms-based scrape/map paths (`preserves ms-based timeout for /v2/scrape (adds 5s buffer)` passes unchanged).
- [ ] Verified the new seconds→ms conversion turns `timeout: 150` into Axios `timeout: 155000` (was 5 150) and `timeout: 300` into `305000` (was 5 300).

Pre-existing TypeScript errors in `src/v2/utils/validation.ts` are unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix premature timeouts in the JS SDK by converting seconds-based `timeout` values to milliseconds for `/v2/scrape/:id/interact` and `/v2/browser/:id/execute`, so long runs (e.g., 150s) no longer fail early in `axios`. Keeps the existing +5s buffer and leaves ms-based endpoints unchanged.

- **Bug Fixes**
  - Mirror `body.timeout` to `axios` with unit-aware logic: seconds→ms for the two endpoints above; ms for others.
  - Preserve the universal +5s buffer on the computed timeout.
  - Add unit tests for both unit regimes, a no-timeout case, and a negative URL match case.

<sup>Written for commit 1687356a7383221ec0b131a15d7c10b5b1f72ca7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

