### PR TITLE
fix(go-sdk): embed jsonOptions into formats array for v2 scrape API

### DIFF
--- a/apps/go-sdk/firecrawl.go
+++ b/apps/go-sdk/firecrawl.go
@@ -93,6 +93,7 @@ func (c *Client) Scrape(ctx context.Context, url string, opts *ScrapeOptions) (*
 
 	body := map[string]interface{}{"url": url}
 	mergeOptions(body, opts)
+	restructureJSONFormats(body)
 
 	raw, err := c.http.post(ctx, "/v2/scrape", body, nil)
 	if err != nil {
@@ -288,6 +289,7 @@ func (c *Client) StartBatchScrape(ctx context.Context, urls []string, opts *Batc
 				}
 			}
 		}
+		restructureJSONFormats(body)
 	}
 
 	raw, err := c.http.post(ctx, "/v2/batch/scrape", body, extraHeaders)
@@ -782,6 +784,48 @@ func mergeOptions(body map[string]interface{}, opts interface{}) {
 	for k, v := range optsMap {
 		body[k] = v
 	}
+}
+
+// restructureJSONFormats moves jsonOptions into the formats array as the v2 API
+// expects. The v2 API rejects a top-level "jsonOptions" key (strict schema) and
+// instead requires JSON format options to be embedded directly in the formats
+// array: [{"type": "json", "schema": {...}, "prompt": "..."}].
+func restructureJSONFormats(body map[string]interface{}) {
+	jsonOptsRaw, hasJsonOpts := body["jsonOptions"]
+	if !hasJsonOpts {
+		return
+	}
+	jsonOpts, ok := jsonOptsRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+	formatsRaw, ok := body["formats"]
+	if !ok {
+		delete(body, "jsonOptions")
+		return
+	}
+	formats, ok := formatsRaw.([]interface{})
+	if !ok {
+		delete(body, "jsonOptions")
+		return
+	}
+	newFormats := make([]interface{}, 0, len(formats))
+	for _, f := range formats {
+		if fStr, isStr := f.(string); isStr && fStr == "json" {
+			entry := map[string]interface{}{"type": "json"}
+			if s, ok := jsonOpts["schema"]; ok {
+				entry["schema"] = s
+			}
+			if p, ok := jsonOpts["prompt"]; ok {
+				entry["prompt"] = p
+			}
+			newFormats = append(newFormats, entry)
+		} else {
+			newFormats = append(newFormats, f)
+		}
+	}
+	body["formats"] = newFormats
+	delete(body, "jsonOptions")
 }
 
 // extractDataAs extracts the "data" field from a raw API response and deserializes it.

--- a/apps/go-sdk/firecrawl_test.go
+++ b/apps/go-sdk/firecrawl_test.go
@@ -1,0 +1,131 @@
+package firecrawl
+
+import (
+	"testing"
+)
+
+func TestRestructureJSONFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]interface{}
+	}{
+		{
+			name: "embeds jsonOptions with schema and prompt into formats array",
+			input: map[string]interface{}{
+				"url":     "https://example.com",
+				"formats": []interface{}{"markdown", "json"},
+				"jsonOptions": map[string]interface{}{
+					"prompt": "extract data",
+					"schema": map[string]interface{}{"type": "object"},
+				},
+			},
+			want: map[string]interface{}{
+				"url": "https://example.com",
+				"formats": []interface{}{
+					"markdown",
+					map[string]interface{}{
+						"type":   "json",
+						"prompt": "extract data",
+						"schema": map[string]interface{}{"type": "object"},
+					},
+				},
+			},
+		},
+		{
+			name: "embeds jsonOptions with schema only",
+			input: map[string]interface{}{
+				"formats": []interface{}{"json"},
+				"jsonOptions": map[string]interface{}{
+					"schema": map[string]interface{}{"type": "object"},
+				},
+			},
+			want: map[string]interface{}{
+				"formats": []interface{}{
+					map[string]interface{}{
+						"type":   "json",
+						"schema": map[string]interface{}{"type": "object"},
+					},
+				},
+			},
+		},
+		{
+			name: "no-op when jsonOptions is absent",
+			input: map[string]interface{}{
+				"url":     "https://example.com",
+				"formats": []interface{}{"markdown"},
+			},
+			want: map[string]interface{}{
+				"url":     "https://example.com",
+				"formats": []interface{}{"markdown"},
+			},
+		},
+		{
+			name: "removes jsonOptions when formats has no json entry",
+			input: map[string]interface{}{
+				"formats":     []interface{}{"markdown"},
+				"jsonOptions": map[string]interface{}{"prompt": "test"},
+			},
+			want: map[string]interface{}{
+				"formats": []interface{}{"markdown"},
+			},
+		},
+		{
+			name: "no-op when jsonOptions is absent, formats is empty",
+			input: map[string]interface{}{
+				"formats": []interface{}{},
+			},
+			want: map[string]interface{}{
+				"formats": []interface{}{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restructureJSONFormats(tc.input)
+
+			// Check that jsonOptions is always removed
+			if _, exists := tc.input["jsonOptions"]; exists {
+				t.Errorf("jsonOptions should have been removed from body")
+			}
+
+			// Check formats match expected
+			gotFormats, _ := tc.input["formats"].([]interface{})
+			wantFormats, _ := tc.want["formats"].([]interface{})
+
+			if len(gotFormats) != len(wantFormats) {
+				t.Errorf("formats length mismatch: got %d, want %d", len(gotFormats), len(wantFormats))
+				return
+			}
+
+			for i, gotEntry := range gotFormats {
+				wantEntry := wantFormats[i]
+				switch wantVal := wantEntry.(type) {
+				case string:
+					if gotVal, ok := gotEntry.(string); !ok || gotVal != wantVal {
+						t.Errorf("formats[%d]: got %v, want %q", i, gotEntry, wantVal)
+					}
+				case map[string]interface{}:
+					gotMap, ok := gotEntry.(map[string]interface{})
+					if !ok {
+						t.Errorf("formats[%d]: expected map, got %T", i, gotEntry)
+						continue
+					}
+					for k, wantV := range wantVal {
+						gotV, exists := gotMap[k]
+						if !exists {
+							t.Errorf("formats[%d][%q] missing", i, k)
+							continue
+						}
+						if wantS, ok := wantV.(string); ok {
+							if gotS, ok := gotV.(string); !ok || gotS != wantS {
+								t.Errorf("formats[%d][%q]: got %v, want %q", i, k, gotV, wantS)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3394

## Problem

The Go SDK's `ScrapeOptions` struct serialises `JsonOptions` as a top-level `jsonOptions` key alongside `formats: ["json"]`:

```json
{
  "formats": ["json"],
  "jsonOptions": { "schema": {...}, "prompt": "..." }
}
```

The v2 `/scrape` API rejects this with a 400 Bad Request:

> Unrecognized key in body — please review the v2 API documentation for request body changes

The v2 API expects JSON format options embedded in the formats array:

```json
{
  "formats": [{ "type": "json", "schema": {...}, "prompt": "..." }]
}
```

## Solution

Add a `restructureJSONFormats()` helper that post-processes the request body after `mergeOptions()`. It finds any `"json"` string entry in the `formats` slice, replaces it with an object `{"type": "json", ...jsonOptions}`, and removes the top-level `jsonOptions` key.

The same fix is applied in `StartBatchScrape()`, where scrape options are already flattened to the top level before the POST.

## Testing

- Added `TestRestructureJSONFormats` in `apps/go-sdk/firecrawl_test.go` covering:
  - Embedding both schema and prompt into the formats array
  - Embedding schema-only options
  - No-op when `jsonOptions` is absent
  - Cleanup of `jsonOptions` when formats has no `"json"` string entry
- All existing SDK tests continue to pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400s from the v2 `/scrape` API by embedding JSON format options inside the `formats` array for both single and batch scrape requests.

- **Bug Fixes**
  - Move `jsonOptions` into `formats` as `{ "type": "json", ... }` and remove the top-level key in `Scrape` and `StartBatchScrape`.
  - Add tests covering embedding (schema and prompt), schema-only, no-op, and cleanup cases.

<sup>Written for commit 2ef6cc0ddda95a2f3e3ead1f74081e10132aae95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

