### PR TITLE
chore(api): update lockdown billing

### DIFF
--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -49,6 +49,10 @@ export async function calculateCreditsToBeBilled(
     return creditsToBeBilled;
   }
 
+  if (options.lockdown) {
+    return 5;
+  }
+
   let creditsToBeBilled = 1; // Assuming 1 credit per document
   const changeTrackingFormat = hasFormatOfType(
     options.formats,


### PR DESCRIPTION
Tweaks credit accounting for the lockdown scrape path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bill a flat 5 credits for lockdown scrape requests to standardize accounting. If `options.lockdown` is true, billing returns 5 and skips other format-based logic.

<sup>Written for commit c59ffa62f4818010967868b15844597ad58cfa6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

