### PR TITLE
ci(rust-sdk): allow dirty Cargo.lock when publishing

### DIFF
--- a/.github/workflows/publish-rust-sdk.yml
+++ b/.github/workflows/publish-rust-sdk.yml
@@ -61,4 +61,4 @@ jobs:
         working-directory: ./apps/rust-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish
+        run: cargo publish --allow-dirty


### PR DESCRIPTION
Pass `--allow-dirty` to `cargo publish` so the workflow doesn't fail when the release build updates Cargo.lock in the working directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow dirty Cargo.lock in the Rust SDK publish workflow to prevent release failures when the build updates the lockfile. Adds `--allow-dirty` to `cargo publish` in `.github/workflows/publish-rust-sdk.yml`.

<sup>Written for commit 71d4babf130212b75e829a7ade069ce08948ce46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

