### PR TITLE
feat(lockdown): Update Lockdown Billing

### DIFF
--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -41,7 +41,8 @@ export async function calculateCreditsToBeBilled(
     // Bill for DNS resolution errors
     if (
       error instanceof TransportableError &&
-      error.code === "SCRAPE_DNS_RESOLUTION_ERROR"
+      (error.code === "SCRAPE_DNS_RESOLUTION_ERROR" ||
+        error.code === "SCRAPE_LOCKDOWN_CACHE_MISS")
     ) {
       creditsToBeBilled = 1;
     }
@@ -54,6 +55,11 @@ export async function calculateCreditsToBeBilled(
   }
 
   let creditsToBeBilled = 1; // Assuming 1 credit per document
+
+  if (options.lockdown) {
+    creditsToBeBilled += 4;
+  }
+
   const changeTrackingFormat = hasFormatOfType(
     options.formats,
     "changeTracking",

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -50,10 +50,6 @@ export async function calculateCreditsToBeBilled(
     return creditsToBeBilled;
   }
 
-  if (options.lockdown) {
-    return 5;
-  }
-
   let creditsToBeBilled = 1; // Assuming 1 credit per document
 
   if (options.lockdown) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Lockdown billing: +4 credits when `options.lockdown` is enabled; charge 1 for `SCRAPE_LOCKDOWN_CACHE_MISS` like DNS errors; remove dead code.

<sup>Written for commit e8e24cd296b5293ea1f6640caf6e0bc85d89ad40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

