### PR TITLE
fix(audio): Use tlsclient for audio

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -325,6 +325,19 @@ async function buildMetaObject(
     }
   }
 
+  // HACK(hotfix): audio format should go through tlsclient.
+  if (
+    internalOptions.forceEngine === undefined &&
+    hasFormatOfType(options.formats, "audio")
+  ) {
+    internalOptions = Object.assign(internalOptions, {
+      forceEngine: [
+        "fire-engine;tlsclient",
+        "fire-engine;tlsclient;stealth",
+      ] as Engine[],
+    });
+  }
+
   const logger = _logger.child({
     module: "ScrapeURL",
     scrapeId: id,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route audio scrapes through the tlsclient engine to improve success rates and avoid blocks.
When audio is detected and `forceEngine` is unset, set it to `['fire-engine;tlsclient', 'fire-engine;tlsclient;stealth']`.

<sup>Written for commit ce9935a71e5faae746cfd3590c79396f5433a663. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

