### PR TITLE
fix(lockdown): treat lockdown requests as zero data retention

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-lockdown.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-lockdown.test.ts
@@ -1,5 +1,7 @@
 import { describeIf, TEST_PRODUCTION } from "../lib";
 import { Identity, idmux, scrapeTimeout, scrape, scrapeRaw } from "./lib";
+import { expectScrapeIsCleanedUp } from "../zdr-helpers";
+import { getJobFromGCS } from "../../../lib/gcs-jobs";
 import crypto from "crypto";
 
 describeIf(TEST_PRODUCTION)("V2 Scrape Lockdown Mode", () => {
@@ -68,6 +70,31 @@ describeIf(TEST_PRODUCTION)("V2 Scrape Lockdown Mode", () => {
       expect(response.body.code).toBe("SCRAPE_LOCKDOWN_CACHE_MISS");
     },
     scrapeTimeout,
+  );
+
+  test(
+    "should treat lockdown as ZDR — no URL in DB, no GCS blob",
+    async () => {
+      const id = crypto.randomUUID();
+      const url = "https://firecrawl.dev/?lockdownZdr=" + id;
+
+      const seed = await scrape({ url }, identity);
+      expect(seed).toBeDefined();
+      expect(seed.metadata.cacheState).toBe("miss");
+
+      await new Promise(resolve => setTimeout(resolve, 20000));
+
+      const data = await scrape({ url, lockdown: true }, identity);
+      expect(data).toBeDefined();
+      expect(data.metadata.cacheState).toBe("hit");
+
+      const scrapeId = data.metadata.scrapeId!;
+      await expectScrapeIsCleanedUp(scrapeId);
+
+      const gcsJob = await getJobFromGCS(scrapeId);
+      expect(gcsJob).toBeNull();
+    },
+    scrapeTimeout * 2 + 20000,
   );
 
   test(

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -84,7 +84,9 @@ export async function scrapeController(
       }
 
       const zeroDataRetention =
-        getScrapeZDR(req.acuc?.flags) === "forced" || (req.body.zeroDataRetention ?? false);
+        getScrapeZDR(req.acuc?.flags) === "forced" ||
+        (req.body.zeroDataRetention ?? false) ||
+        (req.body.lockdown ?? false);
       const billing: BillingMetadata = req.body.__agentInterop
         ? { endpoint: "agent" as const, jobId }
         : { endpoint: "scrape" as const, jobId };


### PR DESCRIPTION
Lockdown mode exists to keep a scrape fully cache-only, so the threat model already lines up with zero data retention — any persisted URL, log line, or telemetry blob is still a potential leak vector. This change folds `lockdown: true` into the same derivation used for `zeroDataRetention` in the v2 scrape controller, so a single enforcement point covers Sentry, winston, Supabase redaction, analytics, GCS, and the search index without scattering parallel checks across emit sites. A snips test seeds the cache, runs a lockdown scrape, and asserts the observable ZDR outcome: no URL in the scrapes row and no GCS blob.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats lockdown scrapes as zero data retention so cache-only runs leave no traces. Centralizes enforcement in the v2 scrape controller to block persistence across logs, telemetry, storage, and index.

- **Bug Fixes**
  - When `lockdown` is true, derive zero data retention via the single enforcement path (covers Sentry, winston, analytics, Supabase redaction, GCS, search index).
  - Added a snips test that seeds the cache, runs a lockdown scrape, and verifies no URL in DB and no GCS blob.

<sup>Written for commit 552ac06c6024f842ec537ce6c09fa1c918f762ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

