### PR TITLE
fix(lockdown): don't double-bill ZDR cost on lockdown scrapes

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-lockdown.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-lockdown.test.ts
@@ -47,6 +47,7 @@ describeIf(TEST_PRODUCTION)("V2 Scrape Lockdown Mode", () => {
       expect(data).toBeDefined();
       expect(data.metadata.cacheState).toBe("hit");
       expect(data.metadata.cachedAt).toBeDefined();
+      expect(data.metadata.creditsUsed).toBe(5);
     },
     scrapeTimeout * 2 + 20000,
   );

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -82,7 +82,7 @@ export async function calculateCreditsToBeBilled(
     creditsToBeBilled += 4;
   }
 
-  if (internalOptions.zeroDataRetention) {
+  if (internalOptions.zeroDataRetention && !options.lockdown) {
     creditsToBeBilled += flags?.zdrCost ?? 1;
   }
 


### PR DESCRIPTION
Lockdown scrapes were billing 6 credits instead of the documented 5 because lockdown now forces `zeroDataRetention` internally, which caused the ZDR add-on cost to stack on top of the lockdown price.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lockdown scrape billing so they always cost exactly 5 credits by skipping the ZDR add-on when lockdown is enabled.

- **Bug Fixes**
  - Skip ZDR cost when `lockdown` is true in `calculateCreditsToBeBilled`.
  - Update test to assert `creditsUsed` is 5.

<sup>Written for commit 7451993c8a9d1145fc3d39bc5219542f65dc977b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

