### PR TITLE
fix(pdf): raise Fire PDF cap to 30MB and compare raw bytes

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -365,19 +365,21 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     // unless we explicitly routed to MinerU via MINERU_PERCENT.
     const skipOCR = rustEnabled && mode === "fast" && !routeToMinerU;
     if (!result && !skipOCR) {
-      const base64Content = (await readFile(tempFilePath)).toString("base64");
+      const pdfBuffer = await readFile(tempFilePath);
+      const fileSizeBytes = pdfBuffer.length;
+      const base64Content = pdfBuffer.toString("base64");
 
       if (
         !routeToMinerU &&
         config.FIRE_PDF_ENABLE &&
         config.FIRE_PDF_BASE_URL &&
-        base64Content.length >= FIRE_PDF_MAX_FILE_SIZE
+        fileSizeBytes >= FIRE_PDF_MAX_FILE_SIZE
       ) {
         meta.logger.warn("PDF skipped by Fire PDF: exceeds size cap", {
           method: "scrapePDF",
           event: "pdf_skipped_size",
           engine: "firepdf",
-          base64_size_bytes: base64Content.length,
+          file_size_bytes: fileSizeBytes,
           max_size_bytes: FIRE_PDF_MAX_FILE_SIZE,
           scrape_id: meta.id,
           team_id: meta.internalOptions.teamId,
@@ -392,7 +394,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         (!routeToMinerU &&
           config.FIRE_PDF_ENABLE &&
           config.FIRE_PDF_BASE_URL &&
-          base64Content.length < FIRE_PDF_MAX_FILE_SIZE &&
+          fileSizeBytes < FIRE_PDF_MAX_FILE_SIZE &&
           Math.random() * 100 < config.FIRE_PDF_PERCENT);
 
       if (useFirePDF) {
@@ -448,7 +450,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       if (
         !result &&
         !forceFirePDF &&
-        base64Content.length >= MAX_FILE_SIZE &&
+        fileSizeBytes >= MAX_FILE_SIZE &&
         config.RUNPOD_MU_API_KEY &&
         config.RUNPOD_MU_POD_ID
       ) {
@@ -456,7 +458,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           method: "scrapePDF",
           event: "pdf_skipped_size",
           engine: "mineru",
-          base64_size_bytes: base64Content.length,
+          file_size_bytes: fileSizeBytes,
           max_size_bytes: MAX_FILE_SIZE,
           scrape_id: meta.id,
           team_id: meta.internalOptions.teamId,
@@ -466,7 +468,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       if (
         !result &&
         !forceFirePDF &&
-        base64Content.length < MAX_FILE_SIZE &&
+        fileSizeBytes < MAX_FILE_SIZE &&
         config.RUNPOD_MU_API_KEY &&
         config.RUNPOD_MU_POD_ID
       ) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -21,7 +21,11 @@ import {
 } from "../../../../controllers/v2/types";
 import type { PDFMode } from "../../../../controllers/v2/types";
 import { processPdf, detectPdf } from "@mendable/firecrawl-rs";
-import { MAX_FILE_SIZE, MILLISECONDS_PER_PAGE } from "./types";
+import {
+  FIRE_PDF_MAX_FILE_SIZE,
+  MAX_FILE_SIZE,
+  MILLISECONDS_PER_PAGE,
+} from "./types";
 import type { PDFProcessorResult } from "./types";
 import {
   emitNativeLogs,
@@ -371,7 +375,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         (!routeToMinerU &&
           config.FIRE_PDF_ENABLE &&
           config.FIRE_PDF_BASE_URL &&
-          base64Content.length < MAX_FILE_SIZE &&
+          base64Content.length < FIRE_PDF_MAX_FILE_SIZE &&
           Math.random() * 100 < config.FIRE_PDF_PERCENT);
 
       if (useFirePDF) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -370,6 +370,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       const base64Content = pdfBuffer.toString("base64");
 
       if (
+        !forceFirePDF &&
         !routeToMinerU &&
         config.FIRE_PDF_ENABLE &&
         config.FIRE_PDF_BASE_URL &&

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -367,6 +367,23 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     if (!result && !skipOCR) {
       const base64Content = (await readFile(tempFilePath)).toString("base64");
 
+      if (
+        !routeToMinerU &&
+        config.FIRE_PDF_ENABLE &&
+        config.FIRE_PDF_BASE_URL &&
+        base64Content.length >= FIRE_PDF_MAX_FILE_SIZE
+      ) {
+        meta.logger.warn("PDF skipped by Fire PDF: exceeds size cap", {
+          method: "scrapePDF",
+          event: "pdf_skipped_size",
+          engine: "firepdf",
+          base64_size_bytes: base64Content.length,
+          max_size_bytes: FIRE_PDF_MAX_FILE_SIZE,
+          scrape_id: meta.id,
+          team_id: meta.internalOptions.teamId,
+        });
+      }
+
       // Route a percentage of traffic to Fire PDF instead of MinerU.
       // forceFirePDF always wins; skip percentage-based Fire PDF when
       // we explicitly routed to MinerU via MINERU_PERCENT.
@@ -426,6 +443,24 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             ).slice(0, 500),
           });
         }
+      }
+
+      if (
+        !result &&
+        !forceFirePDF &&
+        base64Content.length >= MAX_FILE_SIZE &&
+        config.RUNPOD_MU_API_KEY &&
+        config.RUNPOD_MU_POD_ID
+      ) {
+        meta.logger.warn("PDF skipped by RunPod MU: exceeds size cap", {
+          method: "scrapePDF",
+          event: "pdf_skipped_size",
+          engine: "mineru",
+          base64_size_bytes: base64Content.length,
+          max_size_bytes: MAX_FILE_SIZE,
+          scrape_id: meta.id,
+          team_id: meta.internalOptions.teamId,
+        });
       }
 
       if (

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -2,5 +2,6 @@ export type PDFProcessorResult = { html: string; markdown?: string };
 
 export type PdfMetadata = { numPages: number; title?: string };
 
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+export const MAX_FILE_SIZE = 19 * 1024 * 1024; // 19MB
+export const FIRE_PDF_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 export const MILLISECONDS_PER_PAGE = 150;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -3,5 +3,5 @@ export type PDFProcessorResult = { html: string; markdown?: string };
 export type PdfMetadata = { numPages: number; title?: string };
 
 export const MAX_FILE_SIZE = 19 * 1024 * 1024; // 19MB
-export const FIRE_PDF_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+export const FIRE_PDF_MAX_FILE_SIZE = 30 * 1024 * 1024; // 30MB
 export const MILLISECONDS_PER_PAGE = 150;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -2,5 +2,5 @@ export type PDFProcessorResult = { html: string; markdown?: string };
 
 export type PdfMetadata = { numPages: number; title?: string };
 
-export const MAX_FILE_SIZE = 19 * 1024 * 1024; // 19MB
+export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 export const MILLISECONDS_PER_PAGE = 150;


### PR DESCRIPTION
Adds a 30MB Fire PDF file-size cap (separate from MinerU's 19MB), switches the size checks from base64 character length to raw file bytes so caps apply correctly, and emits warn logs when a PDF is skipped by either engine for exceeding its cap.