### PR TITLE
feat(sdk): add searchRaw for metadata and forward missing search options

### DIFF
--- a/apps/js-sdk/firecrawl/src/v1/index.ts
+++ b/apps/js-sdk/firecrawl/src/v1/index.ts
@@ -656,7 +656,7 @@ export default class FirecrawlApp {
       if (typeof process !== 'undefined' && process.env && process.env.npm_package_version) {
         return process.env.npm_package_version as string;
       }
-      const packageJson = await import('../../package.json', { assert: { type: 'json' } });
+      const packageJson = await import('../../package.json', { with: { type: 'json' } });
       return packageJson.default.version;
     } catch (error) {
       // Suppress noisy logs under test environments

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -5,7 +5,7 @@ import {
   stopInteraction as stopInteractionMethod,
 } from "./methods/scrape";
 import { parse as parseMethod } from "./methods/parse";
-import { search } from "./methods/search";
+import { search, searchRaw } from "./methods/search";
 import { map as mapMethod } from "./methods/map";
 import {
   startCrawl,
@@ -39,6 +39,7 @@ import type {
   ScrapeOptions,
   SearchData,
   SearchRequest,
+  SearchResponse,
   MapData,
   MapOptions,
   CrawlResponse,
@@ -207,6 +208,17 @@ export class FirecrawlClient {
    */
   async search(query: string, req: Omit<SearchRequest, "query"> = {}): Promise<SearchData> {
     return search(this.http, { query, ...req });
+  }
+
+  /**
+   * Search the web and optionally scrape each result.
+   * Returns the full response metadata including ID and credits used.
+   * @param query Search query string.
+   * @param req Additional search options (sources, limit, scrapeOptions, etc.).
+   * @returns Search response with metadata.
+   */
+  async searchRaw(query: string, req: Omit<SearchRequest, "query"> = {}): Promise<SearchResponse> {
+    return searchRaw(this.http, { query, ...req });
   }
 
   // Map

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -2,6 +2,7 @@ import {
   type Document,
   type SearchData,
   type SearchRequest,
+  type SearchResponse,
   type SearchResultWeb,
   type ScrapeOptions,
   type SearchResultNews,
@@ -28,6 +29,8 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.limit != null) payload.limit = req.limit;
   if (req.tbs != null) payload.tbs = req.tbs;
   if (req.location != null) payload.location = req.location;
+  if (req.country != null) payload.country = req.country;
+  if (req.enterprise != null) payload.enterprise = req.enterprise;
   if (req.ignoreInvalidURLs != null)
     payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
   if (req.timeout != null) payload.timeout = req.timeout;
@@ -66,16 +69,19 @@ function transformArray<ResultType>(arr: any[]): Array<ResultType | Document> {
   return results;
 }
 
-export async function search(
+export async function searchRaw(
   http: HttpClient,
   request: SearchRequest,
-): Promise<SearchData> {
+): Promise<SearchResponse> {
   const payload = prepareSearchPayload(request);
   try {
     const res = await http.post<{
       success: boolean;
       data?: Record<string, unknown>;
       error?: string;
+      id?: string;
+      creditsUsed?: number;
+      warning?: string | null;
     }>(
       "/v2/search",
       payload,
@@ -92,9 +98,22 @@ export async function search(
     if (data.news) out.news = transformArray<SearchResultNews>(data.news);
     if (data.images)
       out.images = transformArray<SearchResultImages>(data.images);
-    return out;
+    return {
+      data: out,
+      id: res.data.id,
+      creditsUsed: res.data.creditsUsed,
+      warning: res.data.warning,
+    };
   } catch (err: any) {
     if (err?.isAxiosError) return normalizeAxiosError(err, "search");
     throw err;
   }
+}
+
+export async function search(
+  http: HttpClient,
+  request: SearchRequest,
+): Promise<SearchData> {
+  const response = await searchRaw(http, request);
+  return response.data;
 }

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -498,6 +498,13 @@ export interface SearchData {
   images?: Array<SearchResultImages | Document>;
 }
 
+export interface SearchResponse {
+  data: SearchData;
+  id?: string;
+  creditsUsed?: number;
+  warning?: string | null;
+}
+
 export interface CategoryOption {
   type: 'github' | 'research' | 'pdf';
 }
@@ -511,6 +518,8 @@ export interface SearchRequest {
   limit?: number;
   tbs?: string;
   location?: string;
+  country?: string;
+  enterprise?: Array<'default' | 'anon' | 'zdr'>;
   ignoreInvalidURLs?: boolean;
   timeout?: number; // ms
   scrapeOptions?: ScrapeOptions;


### PR DESCRIPTION
Fixes #3437 and #3438 by updating the Node SDK v2 search method to forward all documented request fields (country, enterprise) and exposing a new `searchRaw` method that provides the complete response envelope including the search ID, warning, and credits used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `searchRaw` to the v2 SDK to return full search metadata (id, credits used, warnings) and forwards missing `country` and `enterprise` options. No breaking changes; `search` still returns `SearchData`.

- New Features
  - New `client.searchRaw(query, options)` returns `{ data, id, creditsUsed, warning }`.
  - `search` now forwards `country` and `enterprise` to the API and calls `searchRaw` under the hood.

<sup>Written for commit 3dda348ca693af14502f0defb14bebb20a26a190. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

