### PR TITLE
feat(docker): expose HARNESS_STARTUP_TIMEOUT_MS via docker-compose env

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,6 +95,7 @@ services:
       EXTRACT_WORKER_PORT: ${EXTRACT_WORKER_PORT:-3004}
       WORKER_PORT: ${WORKER_PORT:-3005}
       NUQ_RABBITMQ_URL: amqp://rabbitmq:5672
+      HARNESS_STARTUP_TIMEOUT_MS: ${HARNESS_STARTUP_TIMEOUT_MS:-60000}
       ENV: local
     depends_on:
       redis:


### PR DESCRIPTION
## Summary

Expose the existing `HARNESS_STARTUP_TIMEOUT_MS` env var through `docker-compose.yaml`'s `api` service `environment:` block. Default unchanged (60 000 ms). One-line diff. No application code change.

## Why

The api harness already reads `HARNESS_STARTUP_TIMEOUT_MS` from the environment (`apps/api/src/config.ts:139`) and uses it to gate startup waits on Postgres + RabbitMQ readiness (`apps/api/src/harness.ts:174,468,587`). The default of 60 000 ms is fine on warm machines but races on cold starts:

- Apple Silicon / VirtioFS dev machines where docker volumes ping-pong through the hypervisor
- Hardened workstation tmpfs / encrypted-volume setups
- CI runners on slow shared storage

In those conditions, RabbitMQ's first-boot metadata initialization can exceed 60 s, the api harness's port wait fires before RabbitMQ binds, the api container exits with zombie workers, and `localhost:3002` never accepts connections. The fix today requires either editing the compose file in a fork or using a `docker-compose.override.yaml` workaround.

This change just plumbs the env var through to compose. Operators who hit cold-start issues can now bump it without forking:

```bash
# .env (in compose dir)
HARNESS_STARTUP_TIMEOUT_MS=180000

# or one-shot
HARNESS_STARTUP_TIMEOUT_MS=300000 docker compose up -d
```

## Out of scope

- Bumping the default. Worth a separate discussion — keeping defaults stable here so this change is purely additive.
- Threading the same env var into other services (worker, extract-worker). The harness's `HARNESS_STARTUP_TIMEOUT_MS` consumer lives in `apps/api/src` only; if the worker images grow a similar wait, that's a follow-up.
- Documenting the env var in `SELF_HOST.md`. Happy to add a sentence in a follow-up commit on this PR if reviewers want it.

## Verification

- `docker compose config` shows `HARNESS_STARTUP_TIMEOUT_MS: "60000"` in the merged config (the default).
- `HARNESS_STARTUP_TIMEOUT_MS=300000 docker compose config` shows `"300000"`.
- No behavior change for existing users (env var unset → harness reads `config.ts` default of 60 000 → identical to today).

## Origin

Surfaced during a research-pipeline run that called the self-hosted firecrawl from parallel agents on a cold M-series macOS machine; 1 of 4 agents hit the zombie-worker condition before RabbitMQ finished metadata init. Local workaround was a `docker-compose.override.yaml` patching this exact env var; upstreaming so other operators don't need to discover the same workaround.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `HARNESS_STARTUP_TIMEOUT_MS` in `docker-compose.yaml` for the `api` service so you can increase startup wait for Postgres/RabbitMQ on slow or cold machines. Default stays 60000 ms; no app code changes and no behavior change unless you set the env var.

<sup>Written for commit e431df90d8ea2c50d79204cbe43bb0d9f24556e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

