### PR TITLE
fix(api): accept zeroDataRetention in /v2/search scrapeOptions

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -89,7 +89,7 @@ export async function searchController(
     const isZDROrAnon = isZDR || isAnon;
     const scrapeOptionsZDR = req.body.scrapeOptions?.zeroDataRetention ?? false;
     zeroDataRetention = (isZDROrAnon ?? false) || scrapeOptionsZDR;
-    applyZdrScope(isZDROrAnon ?? false);
+    applyZdrScope(zeroDataRetention);
 
     // Verify the team has searchZDR enabled before allowing enterprise ZDR/anon
     if (isZDROrAnon) {
@@ -112,7 +112,7 @@ export async function searchController(
         origin: req.body.origin ?? "api",
         integration: req.body.integration,
         target_hint: req.body.query,
-        zeroDataRetention: isZDROrAnon ?? false,
+        zeroDataRetention: zeroDataRetention,
         api_key_id: req.acuc?.api_key_id ?? null,
       });
     }
@@ -141,7 +141,7 @@ export async function searchController(
         jobId,
         apiVersion: "v2",
         bypassBilling: !shouldBill,
-        zeroDataRetention: isZDROrAnon,
+        zeroDataRetention: zeroDataRetention,
         billing,
         agentIndexOnly: (req as any).agentIndexOnly ?? false,
       },
@@ -179,7 +179,7 @@ export async function searchController(
         team_id: req.auth.team_id,
         options: req.body,
         credits_cost: shouldBill ? result.searchCredits : 0,
-        zeroDataRetention: isZDROrAnon ?? false,
+        zeroDataRetention: zeroDataRetention,
       },
       false,
     );

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -87,7 +87,8 @@ export async function searchController(
     const isZDR = req.body.enterprise?.includes("zdr");
     const isAnon = req.body.enterprise?.includes("anon");
     const isZDROrAnon = isZDR || isAnon;
-    zeroDataRetention = isZDROrAnon ?? false;
+    const scrapeOptionsZDR = req.body.scrapeOptions?.zeroDataRetention ?? false;
+    zeroDataRetention = (isZDROrAnon ?? false) || scrapeOptionsZDR;
     applyZdrScope(isZDROrAnon ?? false);
 
     // Verify the team has searchZDR enabled before allowing enterprise ZDR/anon

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1780,6 +1780,7 @@ export const searchRequestSchema = z
           .refine(x => {
             return x.filter(f => f.type === "screenshot").length <= 1;
           }, "You may only specify one screenshot format"),
+        zeroDataRetention: z.boolean().optional(),
       })
       .optional(),
     __agentInterop: z


### PR DESCRIPTION
Fixes #3441

## Problem

The `/v2/search` endpoint rejects requests containing `scrapeOptions.zeroDataRetention` with a `400 Invalid request body` error, even though the documentation explicitly describes using `scrapeOptions.zeroDataRetention` to enable scrape-side zero data retention when combining search with content scraping.

The root cause is that the `searchRequestSchema`'s `scrapeOptions` field is built from `baseScrapeOptions.extend({ formats: ... })` but does not include `zeroDataRetention`, while other endpoints (scrape, batch scrape, crawl) do include it in their top-level schema.

## Solution

1. **`apps/api/src/controllers/v2/types.ts`**: Add `zeroDataRetention: z.boolean().optional()` to the `scrapeOptions` extension in `searchRequestSchema` so the field is accepted by Zod validation.

2. **`apps/api/src/controllers/v2/search.ts`**: Update the controller to also apply `scrapeOptions.zeroDataRetention` to the `zeroDataRetention` context flag, enabling scrape-side ZDR when the caller passes it via `scrapeOptions`.

## Testing

The fix can be verified by sending a `/v2/search` request with `scrapeOptions.zeroDataRetention: true` — it should no longer return `400 Invalid request body`.

```bash
curl -X POST https://api.firecrawl.dev/v2/search \
  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "query": "Firecrawl Search docs",
    "limit": 1,
    "scrapeOptions": {
      "formats": ["markdown"],
      "zeroDataRetention": true
    }
  }'
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts and fully applies `scrapeOptions.zeroDataRetention` in `/v2/search`, fixing the 400 error and ensuring scrape-side zero data retention is enforced end-to-end.

- **Bug Fixes**
  - Add `zeroDataRetention: z.boolean().optional()` to `searchRequestSchema.scrapeOptions`.
  - Propagate the combined ZDR flag to scope and downstream calls (applyZdrScope, request logging, `executeSearch`, search logging).

<sup>Written for commit b63bda1e0bb1e2c07e9c1a0fc0e0df5da225fe97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

