### PR TITLE
fix(api/pdf): propagate fire-pdf pages_processed to billing

### DIFF
--- a/apps/api/src/__tests__/snips/lib.ts
+++ b/apps/api/src/__tests__/snips/lib.ts
@@ -24,6 +24,7 @@ export const TEST_PRODUCTION = !TEST_SELF_HOST;
 // TODO: do we want to run AI tests when users run this command locally? It may lead to increased spending for them, depending on configuration
 export const HAS_AI = !!(config.OPENAI_API_KEY || config.OLLAMA_BASE_URL);
 export const HAS_FIRE_ENGINE = !!config.FIRE_ENGINE_BETA_URL;
+export const HAS_FIRE_PDF = !!config.FIRE_PDF_BASE_URL;
 export const HAS_PLAYWRIGHT = !!config.PLAYWRIGHT_MICROSERVICE_URL;
 export const HAS_PROXY = !!config.PROXY_SERVER;
 

--- a/apps/api/src/__tests__/snips/v2/parsers.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parsers.test.ts
@@ -1,6 +1,7 @@
 import {
   ALLOW_TEST_SUITE_WEBSITE,
   describeIf,
+  HAS_FIRE_PDF,
   TEST_SUITE_WEBSITE,
 } from "../lib";
 import { scrape, scrapeRaw, scrapeTimeout, idmux, Identity } from "./lib";
@@ -419,6 +420,29 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
         // Should bill based on limited pages (1 page = 1 credit)
         expect(response.metadata.creditsUsed).toBe(1);
         expect(response.metadata.numPages).toBe(1);
+      },
+      scrapeTimeout * 2,
+    );
+  });
+
+  describeIf(HAS_FIRE_PDF)("Fire PDF page count (regression)", () => {
+    // Guards against the billing regression where fire-pdf processed pages but
+    // pdfMetadata.numPages stayed 0 because scrapePDFWithFirePDF dropped the
+    // pages_processed value on the floor.
+    it.concurrent(
+      "reports numPages when fire-pdf is forced",
+      async () => {
+        const response = await scrape(
+          {
+            url: pdfUrl,
+            __forceFirePDF: true,
+          },
+          identity,
+        );
+
+        expect(response.markdown).toBeDefined();
+        expect(response.markdown).toContain("PDF Test File");
+        expect(response.metadata.numPages).toBeGreaterThan(0);
       },
       scrapeTimeout * 2,
     );

--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -3,8 +3,14 @@ import { logger } from "./logger";
 import { config } from "../config";
 import crypto from "crypto";
 import { storage } from "./gcs-jobs";
+import type { PDFProcessorResult } from "../scraper/scrapeURL/engines/pdf/types";
 
 type PdfCacheProvider = "runpod" | "firepdf";
+
+type CachedPdfResult = Pick<
+  PDFProcessorResult,
+  "markdown" | "html" | "pagesProcessed"
+> & { markdown: string };
 
 const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {
   runpod: "pdf-cache-v2/",
@@ -17,7 +23,7 @@ export function createPdfCacheKey(pdfContent: string | Buffer): string {
 
 export async function savePdfResultToCache(
   pdfContent: string,
-  result: { markdown: string; html: string },
+  result: CachedPdfResult,
   provider: PdfCacheProvider = "runpod",
 ): Promise<string | null> {
   try {
@@ -74,7 +80,7 @@ export async function savePdfResultToCache(
 export async function getPdfResultFromCache(
   pdfContent: string,
   provider: PdfCacheProvider = "runpod",
-): Promise<{ markdown: string; html: string } | null> {
+): Promise<CachedPdfResult | null> {
   try {
     if (!config.GCS_BUCKET_NAME) {
       return null;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -25,7 +25,13 @@ export async function scrapePDFWithFirePDF(
         logger.info("Using cached FirePDF result", {
           scrapeId: meta.id,
         });
-        return cached;
+        // Cache entries written before fire-pdf reported page counts won't
+        // carry pagesProcessed — fall back to the caller's value so billing
+        // doesn't regress on cache hits.
+        return {
+          ...cached,
+          pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
+        };
       }
     } catch (error) {
       logger.warn("Error checking FirePDF cache, proceeding", { error });
@@ -111,9 +117,10 @@ export async function scrapePDFWithFirePDF(
     perPageMs: pages ? Math.round(durationMs / pages) : undefined,
   });
 
-  const processorResult = {
+  const processorResult: PDFProcessorResult & { markdown: string } = {
     markdown: resp.markdown,
     html: await safeMarkdownToHtml(resp.markdown, logger, meta.id),
+    ...(pages !== undefined && { pagesProcessed: pages }),
   };
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -411,6 +411,16 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             maxPages,
             effectivePageCount,
           );
+          // When processPdf threw (e.g. malformed xref/trailer),
+          // effectivePageCount was left at 0 and billing under-counts. Use
+          // fire-pdf's reported pages_processed to fill the gap, but never
+          // shrink a count that an upstream step already established.
+          if (
+            result?.pagesProcessed !== undefined &&
+            result.pagesProcessed > effectivePageCount
+          ) {
+            effectivePageCount = result.pagesProcessed;
+          }
         } catch (error) {
           if (
             error instanceof RemoveFeatureError ||

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -1,4 +1,8 @@
-export type PDFProcessorResult = { html: string; markdown?: string };
+export type PDFProcessorResult = {
+  html: string;
+  markdown?: string;
+  pagesProcessed?: number;
+};
 
 export type PdfMetadata = { numPages: number; title?: string };
 


### PR DESCRIPTION
Surfaces fire-pdf's pages_processed value so pdfMetadata.numPages reflects the true page count when Rust extraction fails but fire-pdf succeeds, fixing a billing under-count for PDFs in that fallback path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates `fire-pdf` pages_processed to `pdfMetadata.numPages` and billing to fix 0-page undercounts when Rust extraction fails but `fire-pdf` succeeds. Adds cache support and a regression test to prevent this from recurring.

- **Bug Fixes**
  - Raise `effectivePageCount` using `pagesProcessed` from `fire-pdf` (never decrease), so `pdfMetadata.numPages` reflects actual processed pages.
  - Carry `pagesProcessed` through cache reads/writes and backfill from the caller for old cache entries; update `PDFProcessorResult` and GCS cache types.
  - Add a regression test that forces `fire-pdf` and asserts `metadata.numPages > 0`, gated by `HAS_FIRE_PDF`.

<sup>Written for commit 6d87bbb8662999495aca873d83c36fdfc60f2d09. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3451?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

