### PR TITLE
fix(api/pdf): propagate fire-pdf pages_processed to billing

### DIFF
--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -6,6 +6,15 @@ import { storage } from "./gcs-jobs";
 
 type PdfCacheProvider = "runpod" | "firepdf";
 
+// Cache shape — markdown/html are required; pagesProcessed is optional so
+// pre-existing entries (written before the field existed) round-trip cleanly
+// and the caller can fall back to its own page-count signal on a stale hit.
+type CachedPdfResult = {
+  markdown: string;
+  html: string;
+  pagesProcessed?: number;
+};
+
 const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {
   runpod: "pdf-cache-v2/",
   firepdf: "pdf-cache-firepdf/",
@@ -17,7 +26,7 @@ export function createPdfCacheKey(pdfContent: string | Buffer): string {
 
 export async function savePdfResultToCache(
   pdfContent: string,
-  result: { markdown: string; html: string },
+  result: CachedPdfResult,
   provider: PdfCacheProvider = "runpod",
 ): Promise<string | null> {
   try {
@@ -74,7 +83,7 @@ export async function savePdfResultToCache(
 export async function getPdfResultFromCache(
   pdfContent: string,
   provider: PdfCacheProvider = "runpod",
-): Promise<{ markdown: string; html: string } | null> {
+): Promise<CachedPdfResult | null> {
   try {
     if (!config.GCS_BUCKET_NAME) {
       return null;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDF.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDF.test.ts
@@ -1,0 +1,43 @@
+import { reconcilePageCountWithFirePdf } from "../firePDF";
+
+describe("reconcilePageCountWithFirePdf", () => {
+  it("uses fire-pdf's count when the upstream pass left it at 0", () => {
+    // The original regression: processPdf threw "Invalid PDF structure" on a
+    // malformed-but-still-renderable PDF, so effectivePageCount stayed 0.
+    // fire-pdf processes it successfully and reports 15 pages. Billing must
+    // see 15, not 0.
+    expect(reconcilePageCountWithFirePdf(0, { pagesProcessed: 15 })).toBe(15);
+  });
+
+  it("never shrinks a count that an upstream pass already established", () => {
+    // detectPdf / processPdf saw 20 pages; fire-pdf was called with
+    // max_pages=10 and processed 10. We must keep 20 — fire-pdf's value
+    // reflects its own cap, not the true PDF length.
+    expect(reconcilePageCountWithFirePdf(20, { pagesProcessed: 10 })).toBe(20);
+  });
+
+  it("keeps current when both agree", () => {
+    expect(reconcilePageCountWithFirePdf(15, { pagesProcessed: 15 })).toBe(15);
+  });
+
+  it("ignores undefined pagesProcessed (older fire-pdf or stale cache)", () => {
+    // No signal — preserve whatever the upstream pass set, even if 0.
+    expect(
+      reconcilePageCountWithFirePdf(0, { pagesProcessed: undefined }),
+    ).toBe(0);
+    expect(reconcilePageCountWithFirePdf(7, {})).toBe(7);
+  });
+
+  it("ignores null/undefined result (fire-pdf didn't run)", () => {
+    expect(reconcilePageCountWithFirePdf(7, null)).toBe(7);
+    expect(reconcilePageCountWithFirePdf(7, undefined)).toBe(7);
+  });
+
+  it("treats fire-pdf's 0 as a real value (no special-casing)", () => {
+    // If fire-pdf legitimately reports 0 (empty PDF that still rendered),
+    // the max() semantic preserves whatever was already there. We only
+    // skip when the field is *missing*, not when it's zero.
+    expect(reconcilePageCountWithFirePdf(0, { pagesProcessed: 0 })).toBe(0);
+    expect(reconcilePageCountWithFirePdf(5, { pagesProcessed: 0 })).toBe(5);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -10,6 +10,36 @@ import {
   savePdfResultToCache,
 } from "../../../../lib/gcs-pdf-cache";
 
+/**
+ * Reconcile an existing page count with what fire-pdf reported.
+ *
+ * Used after `scrapePDFWithFirePDF` returns. The original bug: when Rust
+ * extraction (`processPdf`) threw on a malformed-but-still-renderable PDF,
+ * `effectivePageCount` stayed at 0; fire-pdf would then process the PDF
+ * fine but its `pages_processed` value was dropped on the floor, so
+ * `pdfMetadata.numPages` shipped as 0 and billing under-counted.
+ *
+ * Semantics:
+ *   - If fire-pdf didn't report a count (older fire-pdf builds, or stale
+ *     cache hits), keep the current value — no signal to act on.
+ *   - Otherwise take the max — never shrink a count that an upstream pass
+ *     (detectPdf / processPdf) already established. fire-pdf can be
+ *     called with `max_pages` capping its own processing below the true
+ *     PDF length, and the upstream count is the authoritative one when
+ *     both succeeded.
+ *
+ * Pure / synchronous so it's trivially unit-testable; the integration in
+ * `index.ts` is just `effectivePageCount = reconcilePageCountWithFirePdf(...)`.
+ */
+export function reconcilePageCountWithFirePdf(
+  current: number,
+  firePdfResult: { pagesProcessed?: number } | null | undefined,
+): number {
+  const fromFirePdf = firePdfResult?.pagesProcessed;
+  if (fromFirePdf === undefined) return current;
+  return Math.max(current, fromFirePdf);
+}
+
 export async function scrapePDFWithFirePDF(
   meta: Meta,
   base64Content: string,
@@ -25,7 +55,13 @@ export async function scrapePDFWithFirePDF(
         logger.info("Using cached FirePDF result", {
           scrapeId: meta.id,
         });
-        return cached;
+        // Cache entries written before pagesProcessed existed don't carry
+        // the field. Fall back to the caller's pagesProcessed argument so
+        // billing on a stale hit doesn't silently regress to 0.
+        return {
+          ...cached,
+          pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
+        };
       }
     } catch (error) {
       logger.warn("Error checking FirePDF cache, proceeding", { error });
@@ -111,9 +147,10 @@ export async function scrapePDFWithFirePDF(
     perPageMs: pages ? Math.round(durationMs / pages) : undefined,
   });
 
-  const processorResult = {
+  const processorResult: PDFProcessorResult & { markdown: string } = {
     markdown: resp.markdown,
     html: await safeMarkdownToHtml(resp.markdown, logger, meta.id),
+    pagesProcessed: pages,
   };
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -33,7 +33,7 @@ import {
 } from "../../../../lib/native-logging";
 import { withSpan, setSpanAttributes } from "../../../../lib/otel-tracer";
 import { scrapePDFWithRunPodMU } from "./runpodMU";
-import { scrapePDFWithFirePDF } from "./firePDF";
+import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
 import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
@@ -410,6 +410,10 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             base64Content,
             maxPages,
             effectivePageCount,
+          );
+          effectivePageCount = reconcilePageCountWithFirePdf(
+            effectivePageCount,
+            result,
           );
         } catch (error) {
           if (

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -1,4 +1,15 @@
-export type PDFProcessorResult = { html: string; markdown?: string };
+export type PDFProcessorResult = {
+  html: string;
+  markdown?: string;
+  /**
+   * Pages the underlying engine actually processed for this request.
+   * Currently populated only by fire-pdf (via OcrSuccessBody.pages_processed).
+   * Optional because older fire-pdf builds and the runpodMU / pdf-parse
+   * engines don't report it. Consumers must treat undefined as "no signal"
+   * and fall back to whatever upstream metadata pass set.
+   */
+  pagesProcessed?: number;
+};
 
 export type PdfMetadata = { numPages: number; title?: string };
 


### PR DESCRIPTION
Alternative to #3451 — same fix, different test approach. Closing notes vs that PR at the bottom.

## Summary
Propagates fire-pdf's `pages_processed` into `pdfMetadata.numPages` so billing reflects actual processed pages when `processPdf` (Rust) throws but fire-pdf succeeds.

- Extracts a small pure helper `reconcilePageCountWithFirePdf(current, firePdfResult)` in `firePDF.ts` so the page-count reconciliation is unit-testable.
- `index.ts` calls the helper after `scrapePDFWithFirePDF` returns: `effectivePageCount = reconcilePageCountWithFirePdf(effectivePageCount, result)`.
- `PDFProcessorResult` gains `pagesProcessed?: number`.
- `gcs-pdf-cache.ts` extends its cached shape to round-trip the field; `firePDF.ts` falls back to the caller's argument when a stale entry lacks it (pre-fix entries don't regress).

## The bug
Repro: scrape_id `019dcf02-87ec-7405-8d4b-0ddce64c344a` on https://bogota.gov.co/sites/default/files/inline-files/decreto_4741_de_2005.pdf. Malformed xref/trailer. `@mendable/firecrawl-rs` `processPdf` throws "Invalid PDF structure" and the catch leaves `effectivePageCount = 0` (the comment in `index.ts` even calls this out). fire-pdf renders all 15 pages via mupdf and returns 200 + `pages_processed: 15`. But `scrapePDFWithFirePDF` only used that for a log line — never returned it — so `pdfMetadata.numPages` shipped as 0 and billing under-counted.

## Why a unit test instead of an integration test
The integration test in #3451 uses `__forceFirePDF: true`, which routes through the `detectPdf` branch in `index.ts`:

```ts
if (!rustEnabled || mode === "ocr" || forceFirePDF || routeToMinerU) {
  // detectPdf runs and sets effectivePageCount = detection.pageCount
}
```

`detectPdf` populates `effectivePageCount` independently of fire-pdf. The test would pass on `main` even with the propagation logic reverted.

To actually pin the regression you'd need either:
- A fixture PDF where both `processPdf` *and* `detectPdf` throw (binary in the repo, fragile), or
- A live URL test (flaky), or
- A unit test on the reconciliation logic itself.

This PR takes the third path. The helper covers six cases:

```
✓ uses fire-pdf's count when the upstream pass left it at 0
✓ never shrinks a count that an upstream pass already established
✓ keeps current when both agree
✓ ignores undefined pagesProcessed (older fire-pdf or stale cache)
✓ ignores null/undefined result (fire-pdf didn't run)
✓ treats fire-pdf's 0 as a real value (no special-casing)
```

## Edge cases worth noting (same as #3451)
- Pre-fix cache entries for the bogota.gov.co class will still serve `numPages=0` on cache hit — the entry has no `pagesProcessed` and the caller's argument was 0 in that exact failure path. The data was never recorded; the fix can't synthesize it. SHA256 cache keys mean those entries roll naturally; one-time purge of `pdf-cache-firepdf/` is also an option if you want a clean slate.
- `runpodMU.ts` left alone — that engine doesn't surface a per-engine page count, so no field to propagate.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec jest src/scraper/scrapeURL/engines/pdf/__tests__ src/lib/gcs-pdf-cache` — 38/38 pass (6 new in `firePDF.test.ts`)
- [ ] After deploy, re-scrape the bogota.gov.co URL and confirm `pdfMetadata.numPages > 0`

## Closing #3451 if this lands
If this PR is preferred, #3451 can be closed without merging — same fix logic in both, this one just adds the targeted unit test. If you'd rather keep #3451's structure, either close this one or pull just the `__tests__/firePDF.test.ts` file across.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes under-counted pages in PDF billing by reconciling `pdfMetadata.numPages` with FirePDF’s `pages_processed`. Ensures actual processed pages are billed even when Rust `processPdf` fails.

- **Bug Fixes**
  - Reconcile page counts using a new helper so we take the max of the existing count and FirePDF’s `pages_processed`.
  - Add `pagesProcessed?: number` to `PDFProcessorResult` and return it in the FirePDF path.
  - Store `pagesProcessed` in `gcs-pdf-cache`; fall back to the caller’s count when old cache entries lack it.
  - Add unit tests that cover zero/undefined values and “never shrink” behavior.

<sup>Written for commit ac8ebd6b41838cc3ed556405a95b08895e7f27bd. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

