### PR TITLE
fix(api/pdf): replace pdf-parse with pdfjs-dist as last-resort PDF engine

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -56,7 +56,6 @@
     "@types/lodash": "^4.17.14",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.19.1",
-    "@types/pdf-parse": "^1.1.4",
     "@types/pg": "^8.15.5",
     "@types/qs": "^6.14.0",
     "@types/supertest": "^6.0.2",
@@ -130,7 +129,7 @@
     "ollama-ai-provider": "^1.2.0",
     "openai": "^5.20.2",
     "parse-diff": "^0.11.1",
-    "pdf-parse": "^1.1.1",
+    "pdfjs-dist": "^4.10.38",
     "pg": "^8.16.3",
     "prettier": "^3.6.2",
     "prom-client": "^15.1.3",
@@ -164,6 +163,9 @@
     "allowScripts": {
       "oxc-resolver": true
     },
+    "ignoredOptionalDependencies": [
+      "@napi-rs/canvas"
+    ],
     "onlyBuiltDependencies": [
       "@mendable/firecrawl-rs",
       "@sentry-internal/node-cpu-profiler",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -198,9 +198,9 @@ importers:
       parse-diff:
         specifier: ^0.11.1
         version: 0.11.1
-      pdf-parse:
-        specifier: ^1.1.1
-        version: 1.1.1
+      pdfjs-dist:
+        specifier: ^4.10.38
+        version: 4.10.38
       pg:
         specifier: ^8.16.3
         version: 8.16.3(pg-native@3.5.2)
@@ -307,9 +307,6 @@ importers:
       '@types/node':
         specifier: ^22.19.1
         version: 22.19.1
-      '@types/pdf-parse':
-        specifier: ^1.1.4
-        version: 1.1.4
       '@types/pg':
         specifier: ^8.15.5
         version: 8.15.5
@@ -2740,9 +2737,6 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
-  '@types/pdf-parse@1.1.4':
-    resolution: {integrity: sha512-+gbBHbNCVGGYw1S9lAIIvrHW47UYOhMIFUsJcMkMrzy1Jf0vulBN3XQIjPgnoOXveMuHnF3b57fXROnY/Or7eg==}
-
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
 
@@ -3464,14 +3458,6 @@ packages:
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -4714,9 +4700,6 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
-  node-ensure@0.0.0:
-    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -4927,9 +4910,9 @@ packages:
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
 
-  pdf-parse@1.1.1:
-    resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
-    engines: {node: '>=6.8.1'}
+  pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -5919,6 +5902,9 @@ packages:
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
+ignoredOptionalDependencies:
+  - '@napi-rs/canvas'
 
 snapshots:
 
@@ -8440,8 +8426,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/pdf-parse@1.1.4': {}
-
   '@types/pg-pool@2.0.6':
     dependencies:
       '@types/pg': 8.15.5
@@ -9164,10 +9148,6 @@ snapshots:
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
-
-  debug@3.2.7:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -10732,8 +10712,6 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-ensure@0.0.0: {}
-
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -10951,12 +10929,7 @@ snapshots:
     dependencies:
       through: 2.3.8
 
-  pdf-parse@1.1.1:
-    dependencies:
-      debug: 3.2.7
-      node-ensure: 0.0.0
-    transitivePeerDependencies:
-      - supports-color
+  pdfjs-dist@4.10.38: {}
 
   peberminta@0.9.0: {}
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/pdfParse.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/pdfParse.test.ts
@@ -1,0 +1,144 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Minimal valid PDF (one page, Helvetica, single text-showing operator). We
+// hand-craft one in the test rather than depending on test/data shipped by an
+// external package — that's exactly the sort of internal layout that broke in
+// production (pdf-parse's bundled pdf.js binary went missing from the docker
+// image, MODULE_NOT_FOUND, no working last-resort PDF engine).
+function buildMinimalPdf(text: string): Buffer {
+  const enc = (s: string) => Buffer.from(s, "binary");
+  const header = "%PDF-1.4\n%\xe2\xe3\xcf\xd3\n";
+  const obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+  const obj2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+  const obj3 =
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+    "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n";
+  const obj4 =
+    "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+  const stream = `BT /F1 24 Tf 72 720 Td (${text}) Tj ET\n`;
+  const obj5 = `5 0 obj\n<< /Length ${stream.length} >>\nstream\n${stream}endstream\nendobj\n`;
+
+  const parts = [header, obj1, obj2, obj3, obj4, obj5];
+  const offsets: number[] = [];
+  let cursor = 0;
+  for (const p of parts) {
+    offsets.push(cursor);
+    cursor += enc(p).length;
+  }
+  const pad = (n: number) => n.toString().padStart(10, "0");
+  let xref = "xref\n0 6\n0000000000 65535 f \n";
+  for (let i = 1; i <= 5; i++) xref += `${pad(offsets[i])} 00000 n \n`;
+  const trailer = "trailer\n<< /Size 6 /Root 1 0 R >>\n";
+  const startxrefStr = `startxref\n${cursor}\n%%EOF\n`;
+
+  return Buffer.concat([
+    ...parts.map(enc),
+    enc(xref),
+    enc(trailer),
+    enc(startxrefStr),
+  ]);
+}
+
+// pdfjs-dist is ESM-only and uses `import.meta.url`, so we can't load it
+// inside jest's CJS runtime. Run the actual extraction in a fresh `tsx` child
+// process — that's the configuration production uses anyway. Result is passed
+// via a tmp file because pdfjs prints unrelated warnings to stdout.
+function runExtractor(
+  pdfPath: string,
+  outPath: string,
+): { ok: true; markdown: string } | { ok: false; error: string } {
+  const apiRoot = resolve(__dirname, "../../../../../..");
+  const stub = `
+    const fs = require('node:fs');
+    const { scrapePDFWithParsePDF } = require('${apiRoot}/src/scraper/scrapeURL/engines/pdf/pdfParse.ts');
+    const meta = { logger: { debug() {}, info() {}, warn() {}, error() {} } };
+    const [pdfPath, outPath] = process.argv.slice(1);
+    scrapePDFWithParsePDF(meta, pdfPath).then(
+      r => fs.writeFileSync(outPath, JSON.stringify({ ok: true, ...r })),
+      e => {
+        fs.writeFileSync(outPath, JSON.stringify({ ok: false, error: String((e && e.message) || e) }));
+        process.exit(1);
+      }
+    );
+  `;
+  try {
+    execFileSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        "--input-type=commonjs",
+        "-e",
+        stub,
+        pdfPath,
+        outPath,
+      ],
+      {
+        cwd: apiRoot,
+        encoding: "utf8",
+        stdio: "ignore",
+        timeout: 30_000,
+      },
+    );
+  } catch {
+    // Failed exit — outPath should still contain the failure payload.
+  }
+  try {
+    const fs = require("node:fs") as typeof import("node:fs");
+    return JSON.parse(fs.readFileSync(outPath, "utf8"));
+  } catch {
+    return { ok: false, error: "no output written" };
+  }
+}
+
+describe("scrapePDFWithParsePDF", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "pdfparse-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("extracts text from a small valid PDF", async () => {
+    const pdfPath = join(tmp, "valid.pdf");
+    const outPath = join(tmp, "valid.out.json");
+    await writeFile(pdfPath, buildMinimalPdf("Hello, regression!"));
+
+    const result = runExtractor(pdfPath, outPath);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.markdown).toContain("Hello, regression!");
+    }
+  }, 60_000);
+
+  it("HTML-escapes characters that would otherwise be interpreted as markup", async () => {
+    const pdfPath = join(tmp, "escape.pdf");
+    const outPath = join(tmp, "escape.out.json");
+    await writeFile(pdfPath, buildMinimalPdf("<script>alert(1)</script>"));
+
+    const result = runExtractor(pdfPath, outPath);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.markdown).not.toContain("<script>");
+      expect(result.markdown).toContain("&lt;script&gt;");
+    }
+  }, 60_000);
+
+  it("rejects non-PDF input", async () => {
+    const garbagePath = join(tmp, "garbage.pdf");
+    const outPath = join(tmp, "garbage.out.json");
+    await writeFile(garbagePath, "this is definitely not a pdf");
+
+    const result = runExtractor(garbagePath, outPath);
+
+    expect(result.ok).toBe(false);
+  }, 60_000);
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/pdfParse.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/pdfParse.ts
@@ -1,8 +1,72 @@
 import { Meta } from "../..";
 import escapeHtml from "escape-html";
-import PdfParse from "pdf-parse";
 import { readFile } from "node:fs/promises";
 import type { PDFProcessorResult } from "./types";
+
+type TextItemLike = { str: string; transform: number[] };
+type TextMarkedContentLike = { type: string };
+
+function isTextItem(
+  item: TextItemLike | TextMarkedContentLike,
+): item is TextItemLike {
+  return typeof (item as TextItemLike).str === "string";
+}
+
+async function extractTextFromBuffer(
+  buffer: Buffer,
+): Promise<{ text: string; numPages: number }> {
+  // pdfjs-dist is ESM-only; dynamic import works from both CJS and ESM call sites.
+  // The legacy build avoids hard requirements on browser globals like DOMMatrix.
+  const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+
+  // pdfjs-dist mutates / detaches the buffer it's given. Pass an owned copy so
+  // we don't disturb anything else holding the same Buffer.
+  const data = new Uint8Array(buffer);
+
+  const loadingTask = pdfjs.getDocument({
+    data,
+    isEvalSupported: false,
+    useSystemFonts: false,
+    disableFontFace: true,
+    // Errors-only — silences the polyfill / font-data warnings pdfjs prints
+    // when it can't find @napi-rs/canvas or the standardFontDataUrl. Neither
+    // affects text extraction, which is all we need here.
+    verbosity: 0,
+  });
+
+  const doc = await loadingTask.promise;
+  try {
+    const numPages = doc.numPages;
+    let text = "";
+
+    for (let i = 1; i <= numPages; i++) {
+      const page = await doc.getPage(i);
+      try {
+        const content = await page.getTextContent();
+        let lastY: number | undefined;
+        let pageText = "";
+        for (const rawItem of content.items) {
+          const item = rawItem as TextItemLike | TextMarkedContentLike;
+          if (!isTextItem(item)) continue;
+          const y = item.transform[5];
+          if (lastY === undefined || lastY === y) {
+            pageText += item.str;
+          } else {
+            pageText += "\n" + item.str;
+          }
+          lastY = y;
+        }
+        text += `\n\n${pageText}`;
+      } finally {
+        page.cleanup();
+      }
+    }
+
+    return { text, numPages };
+  } finally {
+    await doc.destroy();
+  }
+}
 
 export async function scrapePDFWithParsePDF(
   meta: Meta,
@@ -12,14 +76,16 @@ export async function scrapePDFWithParsePDF(
 
   try {
     const startedAt = Date.now();
-    const result = await PdfParse(await readFile(tempFilePath));
+    const { text, numPages } = await extractTextFromBuffer(
+      await readFile(tempFilePath),
+    );
     const durationMs = Date.now() - startedAt;
-    const escaped = escapeHtml(result.text);
+    const escaped = escapeHtml(text);
 
     meta.logger.info("pdfParse succeeded", {
       durationMs,
       markdownLength: escaped.length,
-      numPages: result.numpages,
+      numPages,
     });
 
     return {

--- a/apps/api/src/types/pdfjs-dist.d.ts
+++ b/apps/api/src/types/pdfjs-dist.d.ts
@@ -1,0 +1,8 @@
+// pdfjs-dist's Node-side types reference `@napi-rs/canvas` for PDF rendering,
+// which we don't install (optional dep, ignored — see package.json's
+// `pnpm.ignoredOptionalDependencies`). We only call `getTextContent`, never
+// rasterize, so an empty Canvas type is enough to satisfy the compiler.
+declare module "@napi-rs/canvas" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Canvas {}
+}


### PR DESCRIPTION
## Summary

- pdfParse (the final fallback after fire-pdf and MinerU) was crashing in production with `MODULE_NOT_FOUND: './pdf.js/v1.10.100/build/pdf.js'`. pdf-parse@1.1.1 dynamic-requires its bundled pdf.js binary, and that file is missing from the deployed docker image.
- Replaced with `pdfjs-dist@^4.10.38` (mozilla/pdf.js, actively maintained). No more dynamic-require gymnastics, no bundled-binary fragility.
- Engine ordering is unchanged (Rust → fire-pdf → MinerU → pdfParse). Only the implementation of the last-resort engine swaps.

## Why this path (not bundling fix or removal)

Three options were on the table:

a) **Repair the docker bundling.** Smallest change, but the dynamic-require pattern is going to bite again the next time pnpm or the docker layout shifts. Brittle.

b) **Replace pdf-parse with pdfjs-dist.** Larger change, durable fix. ✅
c) **Drop pdfParse entirely.** Production logs show ~1 hit/24h *because* fire-pdf and MinerU are usually healthy. When they aren't, pdfParse is the only thing keeping scrapes alive — removing it removes a real safety net.

(b) preserves the safety net without the fragility.

## Implementation notes

- `pdfjs-dist` is ESM-only and uses `import.meta.url`, so the call site uses dynamic `import()`. The legacy build (`pdfjs-dist/legacy/build/pdf.mjs`) avoids hard requirements on browser globals.
- Buffer is copied with `new Uint8Array(buffer)` because pdfjs-dist detaches its input.
- Text reconstruction mirrors pdf-parse's old behaviour: items on the same Y coordinate are concatenated, line breaks inserted on Y change.
- `@napi-rs/canvas` is pdfjs-dist's optional canvas peer for rasterizing — we don't rasterize, so it's added to `pnpm.ignoredOptionalDependencies` and stubbed in `src/types/pdfjs-dist.d.ts`. pdfjs prints a one-time startup warning when it can't find canvas; harmless, text extraction unaffected.

## Regression test

Added `apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/pdfParse.test.ts` — hand-crafts a minimal one-page PDF and asserts end-to-end text extraction, HTML escaping, and rejection of non-PDF input. The test runs the extractor in a tsx subprocess because pdfjs-dist is ESM-only and jest's CJS runtime can't load it directly. Three tests, all green locally.

The existing `apps/api/src/__tests__/snips/v2/parsers.test.ts` exercises this same path end-to-end through the full scrape pipeline in CI's self-hosted mode (where fire-pdf and MinerU are unconfigured, so pdfParse is the active engine).

## Test plan

- [x] `pnpm test` on `__tests__/pdfParse.test.ts` — 3/3 passing
- [x] `pnpm test` on `engines/pdf/__tests__/` — 41/41 passing
- [x] `pnpm run build` — clean
- [x] `pnpm knip` — clean
- [ ] CI server test suite green (self-hosted mode exercises pdfParse via parsers.test.ts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the last-resort PDF engine from `pdf-parse` to `pdfjs-dist` to stop production crashes and restore reliable text extraction. Engine order is unchanged.

- **Bug Fixes**
  - Fixed `MODULE_NOT_FOUND` from `pdf-parse` by switching to `pdfjs-dist` (no dynamic require).
  - Implemented ESM dynamic import of `pdfjs-dist` legacy build; preserved line reconstruction (join same-Y text, newline on Y change).
  - Added regression tests that craft a minimal PDF and run the extractor via `tsx`; verify text, HTML escaping, and non‑PDF rejection.

- **Dependencies**
  - Replaced `pdf-parse` with `pdfjs-dist@^4.10.38`; removed `@types/pdf-parse`.
  - Ignored optional `@napi-rs/canvas` in `pnpm` and added a small type stub.

<sup>Written for commit 2473f4b004affbb747ebdc149a14340c8e20404c. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3454?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

