### PR TITLE
fix(go-html-to-md-service): emit nanosecond-precision log timestamps

### DIFF
--- a/apps/go-html-to-md-service/main.go
+++ b/apps/go-html-to-md-service/main.go
@@ -22,8 +22,13 @@ const (
 )
 
 func main() {
-	// Configure logging
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	// Configure logging.
+	// RFC3339Nano emits sub-second precision (and an unambiguous string format
+	// for Cloud Logging) so log entries from this service can be ordered
+	// correctly relative to other services. The previous TimeFormatUnix value
+	// produced second-level resolution, which collapsed many events into a
+	// single timestamp bucket and made cross-service log correlation flaky.
+	zerolog.TimeFieldFormat = time.RFC3339Nano
 
 	env := os.Getenv("ENV")
 


### PR DESCRIPTION
## Summary

- `zerolog.TimeFieldFormat` was set to `TimeFormatUnix`, which writes integer Unix-seconds. Cloud Logging then ingests every entry with second-level resolution.
- Under load this service emits hundreds of conversions per second per pod, so many distinct events collapse onto the same timestamp bucket and sort unpredictably against the Node app's logs (which use RFC3339 with nanosecond precision).
- Switching to `time.RFC3339Nano` preserves event ordering end-to-end and makes cross-service correlation in Logs Explorer reliable. RFC3339 is also the format Cloud Logging documents as canonical for the `time` field, so the `timestamp` GCP renders will match what the service emitted.

## Why we noticed

While debugging "HTML to Markdown conversion failed: socket hang up" tail errors on the Node app side, log entries for a single job appeared out-of-order in Logs Explorer — the go-html-to-md "conversion completed" line floated to the top of a job timeline because (a) it carried second-level granularity, and (b) the GCP logging agent received it later than the Node app's batched logs. Sub-second timestamps fix the in-second ordering; the receive-time skew is a viewer setting.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [ ] After deploy, spot-check a recent job in Logs Explorer and confirm `go-html-to-md` rows interleave with `app` rows in chronological order at sub-second granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use RFC3339Nano timestamps in go-html-to-md-service logs to preserve sub-second ordering in Cloud Logging and align with the Node app. Set `zerolog.TimeFieldFormat` to `time.RFC3339Nano` instead of Unix seconds.

<sup>Written for commit 6f048c37b129385c39459fd7feaccb9e40799d4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

