### PR TITLE
feat(scrape): forward pdf parser mode to fire-pdf + scope cache

### DIFF
--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -28,6 +28,7 @@ export async function savePdfResultToCache(
   pdfContent: string,
   result: CachedPdfResult,
   provider: PdfCacheProvider = "runpod",
+  variant?: string,
 ): Promise<string | null> {
   try {
     if (!config.GCS_BUCKET_NAME) {
@@ -36,8 +37,9 @@ export async function savePdfResultToCache(
 
     const prefix = PROVIDER_PREFIXES[provider];
     const cacheKey = createPdfCacheKey(pdfContent);
+    const objectKey = variant ? `${cacheKey}-${variant}` : cacheKey;
     const bucket = storage.bucket(config.GCS_BUCKET_NAME);
-    const blob = bucket.file(`${prefix}${cacheKey}.json`);
+    const blob = bucket.file(`${prefix}${objectKey}.json`);
 
     for (let i = 0; i < 3; i++) {
       try {
@@ -83,6 +85,7 @@ export async function savePdfResultToCache(
 export async function getPdfResultFromCache(
   pdfContent: string,
   provider: PdfCacheProvider = "runpod",
+  variant?: string,
 ): Promise<CachedPdfResult | null> {
   try {
     if (!config.GCS_BUCKET_NAME) {
@@ -91,8 +94,9 @@ export async function getPdfResultFromCache(
 
     const prefix = PROVIDER_PREFIXES[provider];
     const cacheKey = createPdfCacheKey(pdfContent);
+    const objectKey = variant ? `${cacheKey}-${variant}` : cacheKey;
     const bucket = storage.bucket(config.GCS_BUCKET_NAME);
-    const blob = bucket.file(`${prefix}${cacheKey}.json`);
+    const blob = bucket.file(`${prefix}${objectKey}.json`);
 
     const [content] = await blob.download();
     const result = JSON.parse(content.toString());

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -52,7 +52,11 @@ export async function scrapePDFWithFirePDF(
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {
     try {
-      const cached = await getPdfResultFromCache(base64Content, "firepdf");
+      const cached = await getPdfResultFromCache(
+        base64Content,
+        "firepdf",
+        mode,
+      );
       if (cached) {
         logger.info("Using cached FirePDF result", {
           scrapeId: meta.id,
@@ -158,7 +162,12 @@ export async function scrapePDFWithFirePDF(
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {
     try {
-      await savePdfResultToCache(base64Content, processorResult, "firepdf");
+      await savePdfResultToCache(
+        base64Content,
+        processorResult,
+        "firepdf",
+        mode,
+      );
     } catch (error) {
       logger.warn("Error saving FirePDF result to cache", { error });
     }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -3,6 +3,7 @@ import { config } from "../../../../config";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
 import type { PDFProcessorResult } from "./types";
+import type { PDFMode } from "../../../../controllers/v2/types";
 import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
   createPdfCacheKey,
@@ -45,6 +46,7 @@ export async function scrapePDFWithFirePDF(
   base64Content: string,
   maxPages?: number,
   pagesProcessed?: number,
+  mode?: PDFMode,
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
 
@@ -112,6 +114,7 @@ export async function scrapePDFWithFirePDF(
       pdf: base64Content,
       scrape_id: meta.id,
       ...(maxPages !== undefined && { max_pages: maxPages }),
+      ...(mode !== undefined && { mode }),
       // Enrichment for the fire-pdf jobs DB / dashboard. fire-pdf treats
       // these as optional — older fire-pdf builds will ignore unknown fields.
       team_id: meta.internalOptions.teamId,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -50,37 +50,52 @@ export async function scrapePDFWithFirePDF(
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
 
-  // Cache is scoped per parser mode because `auto` and `ocr` produce
-  // different markdown at fire-pdf: `auto` extracts text pages directly
-  // and only OCRs scanned pages, while `ocr` forces layout-mode OCR on
-  // every page. Cross-mode reuse would silently swap output styles.
-  // `fast` is bypassed entirely — it's a hard cost ceiling that must
-  // fail on scanned PDFs rather than serve a cached OCR result.
+  // Cache layout:
+  //   - `ocr` mode reads/writes a dedicated `…-ocr.json` bucket. ocr
+  //     requests explicitly want forced layout-mode OCR, so they must
+  //     not be served a base-cache entry that was written by `auto`.
+  //   - `auto` (and legacy undefined-mode) reads/writes the base
+  //     `firepdf-<sha>.json` bucket — same key main has always used,
+  //     so existing entries keep working. As a free upgrade, auto also
+  //     reads the ocr bucket as a fallback: if some prior `ocr` run
+  //     already produced markdown for this PDF, reuse it rather than
+  //     running fire-pdf again.
+  //   - `fast` is bypassed entirely (hard cost ceiling — must fail on
+  //     scanned PDFs, not serve a cached OCR result).
   const cacheable =
     mode !== "fast" && !maxPages && !meta.internalOptions.zeroDataRetention;
+  const ownVariant: string | undefined = mode === "ocr" ? "ocr" : undefined;
+  const lookupVariants: (string | undefined)[] =
+    mode === "ocr" ? ["ocr"] : [undefined, "ocr"];
 
   if (cacheable) {
-    try {
-      const cached = await getPdfResultFromCache(
-        base64Content,
-        "firepdf",
-        mode,
-      );
-      if (cached) {
-        logger.info("Using cached FirePDF result", {
-          scrapeId: meta.id,
-          mode,
+    for (const variant of lookupVariants) {
+      try {
+        const cached = await getPdfResultFromCache(
+          base64Content,
+          "firepdf",
+          variant,
+        );
+        if (cached) {
+          logger.info("Using cached FirePDF result", {
+            scrapeId: meta.id,
+            requestedMode: mode,
+            cacheVariant: variant ?? "base",
+          });
+          // Cache entries written before pagesProcessed existed don't carry
+          // the field. Fall back to the caller's pagesProcessed argument so
+          // billing on a stale hit doesn't silently regress to 0.
+          return {
+            ...cached,
+            pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
+          };
+        }
+      } catch (error) {
+        logger.warn("Error checking FirePDF cache, proceeding", {
+          error,
+          cacheVariant: variant ?? "base",
         });
-        // Cache entries written before pagesProcessed existed don't carry
-        // the field. Fall back to the caller's pagesProcessed argument so
-        // billing on a stale hit doesn't silently regress to 0.
-        return {
-          ...cached,
-          pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
-        };
       }
-    } catch (error) {
-      logger.warn("Error checking FirePDF cache, proceeding", { error });
     }
   }
 
@@ -176,7 +191,7 @@ export async function scrapePDFWithFirePDF(
         base64Content,
         processorResult,
         "firepdf",
-        mode,
+        ownVariant,
       );
     } catch (error) {
       logger.warn("Error saving FirePDF result to cache", { error });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -50,14 +50,20 @@ export async function scrapePDFWithFirePDF(
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
 
-  if (!maxPages && !meta.internalOptions.zeroDataRetention) {
+  // `fast` mode is a hard cost ceiling: it should fail fast on PDFs that
+  // need OCR rather than silently upgrading to a cached OCR result, and
+  // its outputs aren't worth caching since the path is cheap by design.
+  // Skip cache reads/writes entirely for fast mode.
+  const cacheable =
+    mode !== "fast" && !maxPages && !meta.internalOptions.zeroDataRetention;
+
+  if (cacheable) {
     // OCR is the highest-fidelity mode, so a prior `ocr` cache entry is a
-    // strict upgrade over rerunning `auto`/`fast`. Try OCR first for those
-    // modes; if missing, fall back to the cache scoped to the requested
-    // mode. (When mode itself is `ocr` or undefined, this is a single
-    // lookup against the same key.)
-    const lookupVariants =
-      mode === "auto" || mode === "fast" ? ["ocr", mode] : [mode];
+    // strict upgrade over rerunning `auto`. Try OCR first for `auto`; if
+    // missing, fall back to the cache scoped to the requested mode.
+    // (When mode itself is `ocr` or undefined, this is a single lookup
+    // against the same key.)
+    const lookupVariants = mode === "auto" ? ["ocr", mode] : [mode];
 
     for (const variant of lookupVariants) {
       try {
@@ -175,7 +181,7 @@ export async function scrapePDFWithFirePDF(
     pagesProcessed: pages,
   };
 
-  if (!maxPages && !meta.internalOptions.zeroDataRetention) {
+  if (cacheable) {
     try {
       await savePdfResultToCache(
         base64Content,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -50,29 +50,26 @@ export async function scrapePDFWithFirePDF(
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
 
-  // Cache policy: only OCR runs produce cache entries. OCR is the
-  // highest-fidelity output, so its result is safe to serve to later
-  // `auto` callers as a strict upgrade. `fast` is bypassed entirely
-  // (hard cost ceiling — must fail fast on scanned PDFs, not silently
-  // upgrade to OCR). `auto` reads the OCR cache but never writes;
-  // re-running `auto` is the user's stated trade-off vs storing
-  // lower-fidelity output.
-  const cacheReadable =
+  // Cache is scoped per parser mode because `auto` and `ocr` produce
+  // different markdown at fire-pdf: `auto` extracts text pages directly
+  // and only OCRs scanned pages, while `ocr` forces layout-mode OCR on
+  // every page. Cross-mode reuse would silently swap output styles.
+  // `fast` is bypassed entirely — it's a hard cost ceiling that must
+  // fail on scanned PDFs rather than serve a cached OCR result.
+  const cacheable =
     mode !== "fast" && !maxPages && !meta.internalOptions.zeroDataRetention;
-  const cacheWritable =
-    mode === "ocr" && !maxPages && !meta.internalOptions.zeroDataRetention;
 
-  if (cacheReadable) {
+  if (cacheable) {
     try {
       const cached = await getPdfResultFromCache(
         base64Content,
         "firepdf",
-        "ocr",
+        mode,
       );
       if (cached) {
-        logger.info("Using cached FirePDF OCR result", {
+        logger.info("Using cached FirePDF result", {
           scrapeId: meta.id,
-          requestedMode: mode,
+          mode,
         });
         // Cache entries written before pagesProcessed existed don't carry
         // the field. Fall back to the caller's pagesProcessed argument so
@@ -173,13 +170,13 @@ export async function scrapePDFWithFirePDF(
     pagesProcessed: pages,
   };
 
-  if (cacheWritable) {
+  if (cacheable) {
     try {
       await savePdfResultToCache(
         base64Content,
         processorResult,
         "firepdf",
-        "ocr",
+        mode,
       );
     } catch (error) {
       logger.warn("Error saving FirePDF result to cache", { error });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -50,48 +50,40 @@ export async function scrapePDFWithFirePDF(
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
 
-  // `fast` mode is a hard cost ceiling: it should fail fast on PDFs that
-  // need OCR rather than silently upgrading to a cached OCR result, and
-  // its outputs aren't worth caching since the path is cheap by design.
-  // Skip cache reads/writes entirely for fast mode.
-  const cacheable =
+  // Cache policy: only OCR runs produce cache entries. OCR is the
+  // highest-fidelity output, so its result is safe to serve to later
+  // `auto` callers as a strict upgrade. `fast` is bypassed entirely
+  // (hard cost ceiling — must fail fast on scanned PDFs, not silently
+  // upgrade to OCR). `auto` reads the OCR cache but never writes;
+  // re-running `auto` is the user's stated trade-off vs storing
+  // lower-fidelity output.
+  const cacheReadable =
     mode !== "fast" && !maxPages && !meta.internalOptions.zeroDataRetention;
+  const cacheWritable =
+    mode === "ocr" && !maxPages && !meta.internalOptions.zeroDataRetention;
 
-  if (cacheable) {
-    // OCR is the highest-fidelity mode, so a prior `ocr` cache entry is a
-    // strict upgrade over rerunning `auto`. Try OCR first for `auto`; if
-    // missing, fall back to the cache scoped to the requested mode.
-    // (When mode itself is `ocr` or undefined, this is a single lookup
-    // against the same key.)
-    const lookupVariants = mode === "auto" ? ["ocr", mode] : [mode];
-
-    for (const variant of lookupVariants) {
-      try {
-        const cached = await getPdfResultFromCache(
-          base64Content,
-          "firepdf",
-          variant,
-        );
-        if (cached) {
-          logger.info("Using cached FirePDF result", {
-            scrapeId: meta.id,
-            requestedMode: mode,
-            cacheVariant: variant,
-          });
-          // Cache entries written before pagesProcessed existed don't carry
-          // the field. Fall back to the caller's pagesProcessed argument so
-          // billing on a stale hit doesn't silently regress to 0.
-          return {
-            ...cached,
-            pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
-          };
-        }
-      } catch (error) {
-        logger.warn("Error checking FirePDF cache, proceeding", {
-          error,
-          cacheVariant: variant,
+  if (cacheReadable) {
+    try {
+      const cached = await getPdfResultFromCache(
+        base64Content,
+        "firepdf",
+        "ocr",
+      );
+      if (cached) {
+        logger.info("Using cached FirePDF OCR result", {
+          scrapeId: meta.id,
+          requestedMode: mode,
         });
+        // Cache entries written before pagesProcessed existed don't carry
+        // the field. Fall back to the caller's pagesProcessed argument so
+        // billing on a stale hit doesn't silently regress to 0.
+        return {
+          ...cached,
+          pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
+        };
       }
+    } catch (error) {
+      logger.warn("Error checking FirePDF cache, proceeding", { error });
     }
   }
 
@@ -181,13 +173,13 @@ export async function scrapePDFWithFirePDF(
     pagesProcessed: pages,
   };
 
-  if (cacheable) {
+  if (cacheWritable) {
     try {
       await savePdfResultToCache(
         base64Content,
         processorResult,
         "firepdf",
-        mode,
+        "ocr",
       );
     } catch (error) {
       logger.warn("Error saving FirePDF result to cache", { error });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -51,26 +51,41 @@ export async function scrapePDFWithFirePDF(
   const logger = meta.logger;
 
   if (!maxPages && !meta.internalOptions.zeroDataRetention) {
-    try {
-      const cached = await getPdfResultFromCache(
-        base64Content,
-        "firepdf",
-        mode,
-      );
-      if (cached) {
-        logger.info("Using cached FirePDF result", {
-          scrapeId: meta.id,
+    // OCR is the highest-fidelity mode, so a prior `ocr` cache entry is a
+    // strict upgrade over rerunning `auto`/`fast`. Try OCR first for those
+    // modes; if missing, fall back to the cache scoped to the requested
+    // mode. (When mode itself is `ocr` or undefined, this is a single
+    // lookup against the same key.)
+    const lookupVariants =
+      mode === "auto" || mode === "fast" ? ["ocr", mode] : [mode];
+
+    for (const variant of lookupVariants) {
+      try {
+        const cached = await getPdfResultFromCache(
+          base64Content,
+          "firepdf",
+          variant,
+        );
+        if (cached) {
+          logger.info("Using cached FirePDF result", {
+            scrapeId: meta.id,
+            requestedMode: mode,
+            cacheVariant: variant,
+          });
+          // Cache entries written before pagesProcessed existed don't carry
+          // the field. Fall back to the caller's pagesProcessed argument so
+          // billing on a stale hit doesn't silently regress to 0.
+          return {
+            ...cached,
+            pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
+          };
+        }
+      } catch (error) {
+        logger.warn("Error checking FirePDF cache, proceeding", {
+          error,
+          cacheVariant: variant,
         });
-        // Cache entries written before pagesProcessed existed don't carry
-        // the field. Fall back to the caller's pagesProcessed argument so
-        // billing on a stale hit doesn't silently regress to 0.
-        return {
-          ...cached,
-          pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
-        };
       }
-    } catch (error) {
-      logger.warn("Error checking FirePDF cache, proceeding", { error });
     }
   }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -410,6 +410,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             base64Content,
             maxPages,
             effectivePageCount,
+            mode,
           );
           effectivePageCount = reconcilePageCountWithFirePdf(
             effectivePageCount,


### PR DESCRIPTION
Threads the v2 PDF parser `mode` option (`fast` / `auto` / `ocr`) through `scrapePDFWithFirePDF` and into the fire-pdf `/ocr` request body, so callers' explicit mode selection is honored instead of fire-pdf silently applying its own default. Older fire-pdf builds remain compatible since they ignore unknown fields.

## What each mode does at fire-pdf

- `fast`: direct text extraction only; throws `PDFOCRRequiredError` on scanned/image-based PDFs.
- `auto`: per-page decision — direct extraction for text pages, OCR for scanned/image pages.
- `ocr`: forced layout-mode OCR on every page (used when the caller specifically wants layout reconstruction, e.g. tables).

## Cache layout

The FirePDF GCS cache is reorganized around what each mode produces:

| Mode | Reads | Writes |
|---|---|---|
| `ocr` | `…-ocr.json` only | `…-ocr.json` |
| `auto` / `undefined` | `firepdf-<sha>.json` (base) → `…-ocr.json` | `firepdf-<sha>.json` (base) |
| `fast` | none | none |

Notes:

- **Base key matches `main`.** auto/undefined callers continue reading the unsuffixed `firepdf-<sha>.json` key that main has always used, so pre-PR entries keep working — no deploy-day cold cache.
- **`ocr` is isolated.** Explicit ocr requests are guaranteed to get layout-mode output, never substituted with auto-style markdown from the base cache.
- **Auto reads the ocr bucket as a free fallback (intentional).** If a prior `ocr` run already cached a PDF, the next `auto` request reuses that markdown instead of running fire-pdf again. The trade-off is that the auto caller receives ocr-style (forced-layout) output in that case. Accepted as a cost-saving optimization — fire-pdf round trips on scanned PDFs are expensive.
- **`fast` is uncached by design.** It's a hard cost ceiling that must fail on scanned PDFs rather than silently serve cached OCR output. Both reads and writes are skipped.
- `maxPages` and `zeroDataRetention` continue to disable the cache entirely, as on main.