### PR TITLE
fix(python-sdk): repair dead code path in v1 async_batch_scrape_urls

### DIFF
--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -3951,9 +3951,9 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             headers
         )
 
-        if response.get('status_code') == 200:
+        if response.get('success'):
             try:
-                return V1BatchScrapeResponse(**response.json())
+                return V1BatchScrapeResponse(**response)
             except:
                 raise Exception(f'Failed to parse Firecrawl response as JSON.')
         else:


### PR DESCRIPTION
## Summary

Fixes #3477.

`AsyncV1FirecrawlApp.async_batch_scrape_urls` was treating the result of `_async_post_request` as a raw aiohttp response (checking `response.get('status_code') == 200` and calling `response.json()`), but that helper returns a parsed JSON `Dict[str, Any]`. Result: the success branch was unreachable and every call raised — even on a successful 200.

This block was a copy-paste from the sync sibling `batch_scrape_urls` (line 1709), which uses `_post_request` and does get back a real `requests.Response`. The async port forgot to adapt the result handling.

## Diff

```diff
--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -3951,9 +3951,9 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             headers
         )
 
-        if response.get('status_code') == 200:
+        if response.get('success'):
             try:
-                return V1BatchScrapeResponse(**response.json())
+                return V1BatchScrapeResponse(**response)
             except:
                 raise Exception(f'Failed to parse Firecrawl response as JSON.')
         else:
```

## Why this pattern

Aligns with the three other v1 async methods in the same file that already do exactly this:

- `scrape_url` async — line 3674
- `async_batch_scrape_urls` polling variant — line 3812
- `async_crawl_url` — line 4072

All check `response.get('success')` on the dict and pass `**response` directly to their pydantic response model. `V1BatchScrapeResponse` (line 233) defines `id / url / success / error / invalidURLs` — exactly the shape returned by `POST /v1/batch/scrape`.

## v2

Not affected — v2's async HTTP helper returns a real httpx-style response with a `.status_code` attribute. This is a v1-only fix.

## Test plan

- [x] Verified the bug reproduces on `firecrawl==4.3.6` against a live API key — every call to `async_batch_scrape_urls` raised before this patch.
- [x] After patch: success path returns a populated `V1BatchScrapeResponse` and downstream code (`response.id`, `response.success`, etc.) works as expected.
- [ ] Maintainers may want to add a unit test covering the success path; happy to push one in a follow-up if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repair v1 `AsyncV1FirecrawlApp.async_batch_scrape_urls` so successful calls return a valid `V1BatchScrapeResponse` instead of raising. The method now treats `_async_post_request` as a parsed JSON dict (checks `success`, passes `**response`), aligning with other v1 async methods; v2 is unaffected.

<sup>Written for commit f5dd3906b7d53617f6f0ec627721a95435ed004a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

