### PR TITLE
fix(js-sdk): add missing country and enterprise fields to v2 SearchRequest

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -15,8 +15,10 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.limit != null) payload.limit = req.limit;
   if (req.tbs != null) payload.tbs = req.tbs;
   if (req.location != null) payload.location = req.location;
+  if (req.country != null) payload.country = req.country;
   if (req.ignoreInvalidURLs != null) payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
   if (req.timeout != null) payload.timeout = req.timeout;
+  if (req.enterprise != null) payload.enterprise = req.enterprise;
   if (req.integration && req.integration.trim()) payload.integration = req.integration.trim();
   if (req.origin) payload.origin = req.origin;
   if (req.scrapeOptions) {

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -509,8 +509,10 @@ export interface SearchRequest {
   limit?: number;
   tbs?: string;
   location?: string;
+  country?: string;
   ignoreInvalidURLs?: boolean;
   timeout?: number; // ms
+  enterprise?: Array<'default' | 'anon' | 'zdr'>;
   scrapeOptions?: ScrapeOptions;
   integration?: string;
   origin?: string;


### PR DESCRIPTION

## Summary

The Node SDK v2 `SearchRequest` type was missing two fields that are documented in the public `/v2/search` API:

1. **`country?: string`** — for geo-targeting search results
2. **`enterprise?: Array<"default" | "anon" | "zdr">`** — for Search ZDR options

The `prepareSearchPayload` function also did not forward these fields to the API.

## Changes

### `apps/js-sdk/firecrawl/src/v2/types.ts`
Added two new optional fields to `SearchRequest`:
```ts
country?: string;
enterprise?: Array<default | anon | zdr>;
```

### `apps/js-sdk/firecrawl/src/v2/methods/search.ts`
Added forwarding in `prepareSearchPayload`:
```ts
if (req.country != null) payload.country = req.country;
if (req.enterprise != null) payload.enterprise = req.enterprise;
```

## Fixes

Fixes #3437 — **Bug: Node SDK v2 search does not forward all documented `/v2/search` request fields**

## Testing

TypeScript users can now use these documented parameters without type errors, and the SDK will correctly forward them to the API.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing `country` and `enterprise` fields to v2 `SearchRequest` and forwarded them in `prepareSearchPayload`, so `/v2/search` can use geo-targeting and ZDR options without TypeScript errors.

- **Bug Fixes**
  - Added `country?: string` and `enterprise?: Array<'default' | 'anon' | 'zdr'>` to `SearchRequest`.
  - Forwarded `country` and `enterprise` in `prepareSearchPayload` to the API.

<sup>Written for commit 2caf9485e13e5f5312b2e5f44f7b6fadf9279541. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

