### PR TITLE
fix(deps): bump axios to 1.15.2 to resolve audit-ci advisories

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -103,7 +103,7 @@
     "amqplib": "^0.10.9",
     "async-mutex": "^0.5.0",
     "autumn-js": "1.2.13",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "body-parser": "^1.20.3",
     "bullmq": "^5.56.7",
     "cacheable-lookup": "^6.1.0",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: 1.2.13
         version: 1.2.13(express@4.22.0)(react@18.3.1)
       axios:
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^1.15.2
+        version: 1.16.0
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
@@ -3145,8 +3145,8 @@ packages:
     peerDependencies:
       axios: 0.x || 1.x
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   babel-jest@30.2.0:
     resolution: {integrity: sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==}
@@ -5715,6 +5715,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@13.0.0:
@@ -5723,10 +5724,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6346,8 +6349,8 @@ snapshots:
       '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.8.3)(zod@3.25.76)
-      axios: 1.15.0
-      axios-retry: 4.5.0(axios@1.15.0)
+      axios: 1.16.0
+      axios-retry: 4.5.0(axios@1.16.0)
       jose: 6.0.12
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -8820,12 +8823,12 @@ snapshots:
       express: 4.22.0
       react: 18.3.1
 
-  axios-retry@4.5.0(axios@1.15.0):
+  axios-retry@4.5.0(axios@1.16.0):
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       is-retry-allowed: 2.2.0
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -26,7 +26,7 @@
   "author": "Mendable.ai",
   "license": "MIT",
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "firecrawl": "4.16.0",
     "typescript-event-target": "^1.1.1",
     "zod": "^3.23.8",
@@ -70,7 +70,7 @@
       "picomatch@<4.0.4": ">=4.0.4",
       "handlebars": ">=4.7.9",
       "brace-expansion": ">=5.0.5",
-      "axios@<1.15.0": "1.15.0",
+      "axios@<1.15.2": "1.15.2",
       "follow-redirects@<1.16.0": ">=1.16.0 <2.0.0"
     }
   }

--- a/apps/js-sdk/firecrawl/pnpm-lock.yaml
+++ b/apps/js-sdk/firecrawl/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   picomatch@<4.0.4: '>=4.0.4'
   handlebars: '>=4.7.9'
   brace-expansion: '>=5.0.5'
-  axios@<1.15.0: 1.15.0
+  axios@<1.15.2: 1.15.2
   follow-redirects@<1.16.0: '>=1.16.0 <2.0.0'
 
 importers:
@@ -19,8 +19,8 @@ importers:
   .:
     dependencies:
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       firecrawl:
         specifier: 4.16.0
         version: 4.16.0
@@ -884,8 +884,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-jest@30.2.0:
     resolution: {integrity: sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==}
@@ -2797,7 +2797,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -3090,7 +3090,7 @@ snapshots:
 
   firecrawl@4.16.0:
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.2
       typescript-event-target: 1.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)

--- a/apps/js-sdk/package.json
+++ b/apps/js-sdk/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@mendable/firecrawl-js": "^4.3.4",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "firecrawl": "^4.3.4",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"

--- a/apps/js-sdk/pnpm-lock.yaml
+++ b/apps/js-sdk/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^4.3.4
         version: 4.11.1
       axios:
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^1.15.2
+        version: 1.16.0
       firecrawl:
         specifier: ^4.3.4
         version: 4.11.1
@@ -247,8 +247,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -512,7 +512,7 @@ snapshots:
 
   '@mendable/firecrawl-js@4.11.1':
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       typescript-event-target: 1.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
@@ -541,7 +541,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -616,7 +616,7 @@ snapshots:
 
   firecrawl@4.11.1:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       typescript-event-target: 1.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)


### PR DESCRIPTION
## Summary

Bumps `axios` to `1.15.2` (released 2026-04-21) across affected apps to clear all axios security advisories flagged by `audit-ci` in CI (`.github/workflows/npm-audit.yml`). The `<1.15.2` advisories include GHSA-3w6x-2g7m-8v23 and GHSA-q8qp-cvcw-x6jj, while the `<1.15.1` advisories include the 11 axios prototype-pollution / CRLF / token-leakage gadgets.

### `apps/api`
- `axios` `^1.15.0` → `^1.15.2` (lockfile resolves to `axios@1.16.0`, released 2026-05-02) — addresses:
  - GHSA-3w6x-2g7m-8v23, GHSA-445q-vr5w-6q77, GHSA-5c9x-8gcm-mpgx, GHSA-62hf-57xw-28j9, GHSA-6chq-wfr3-2hj9, GHSA-m7pr-hjqh-92cm, GHSA-pf86-5x62-jrwf, GHSA-pmwg-cvhr-8vh7, GHSA-q8qp-cvcw-x6jj, GHSA-vf2m-468p-8v99, GHSA-w9j2-pvgh-6h63, GHSA-xhjh-pmcv-23jw, GHSA-xx6v-rp6x-q39c

### `apps/js-sdk`
- `axios` `^1.15.0` → `^1.15.2` (lockfile resolves to `axios@1.16.0`, released 2026-05-02) — addresses the same 13 advisories as above.

### `apps/js-sdk/firecrawl`
- `axios` `1.15.0` → `1.15.2` (resolved version: `1.15.2`, released 2026-04-21)
- pnpm override `axios@<1.15.0` → `1.15.0` updated to `axios@<1.15.2` → `1.15.2` to keep transitive deps off vulnerable versions
  - Major bound: the override selector is constrained to `<1.15.2` and the replacement is the exact patched version `1.15.2`, so it cannot drift to a higher major.
- Addresses the same 13 axios advisories as above.

CI-equivalent local verification: ran every audit step from `.github/workflows/npm-audit.yml` (`apps/api`, `apps/playwright-service-ts`, `apps/js-sdk`, `apps/js-sdk/firecrawl`, `apps/test-suite`, `apps/ui/ingestion-ui`, `apps/test-site`) and all seven now pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `axios` to 1.15.2+ across affected apps to resolve all `audit-ci` security advisories and restore green CI. Lockfiles update accordingly; no runtime changes.

- **Dependencies**
  - `apps/api`: `axios` `^1.15.2` (lockfile → `1.16.0`)
  - `apps/js-sdk`: `axios` `^1.15.2` (lockfile → `1.16.0`)
  - `apps/js-sdk/firecrawl`: `axios` `1.15.2`; pnpm override `axios@<1.15.2` → `1.15.2`

<sup>Written for commit 8f2b7571a7529856e6c16b91676ec9b5e27038b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

