### PR TITLE
fix(docker): drop explicit pnpm cache id for Railway Metal builder co…

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -40,7 +40,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY . .
 
 # Install dependencies
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+RUN --mount=type=cache,target=/pnpm/store \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/native/target \
     pnpm install --frozen-lockfile


### PR DESCRIPTION
…mpat

Railway's Metal builder requires BuildKit cache mount ids to carry a namespacing prefix so caches are scoped per service. Removing the explicit `id=pnpm` lets BuildKit derive the id from the target path, which Railway accepts and preserves caching behavior in local builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the explicit `id=pnpm` from the BuildKit cache mount in the API Dockerfile to fix Railway Metal builder compatibility. BuildKit now infers the cache id from `/pnpm/store`, keeping local caching and allowing Railway to scope caches per service.

<sup>Written for commit c017d5f2ef9f55621d1af5c6cc208eee351059d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

