### PR TITLE
fix: proxy billing for cached scrapes

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -404,7 +404,7 @@ export async function scrapeURLWithIndex(
 
     postprocessorsUsed: doc.postprocessorsUsed,
 
-    proxyUsed: doc.proxyUsed ?? "basic",
+    proxyUsed: meta.featureFlags.has("stealthProxy") ? "stealth" : "basic",
   };
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -102,6 +102,7 @@ export async function sendDocumentToIndex(meta: Meta, document: Document) {
               : undefined,
           contentType: document.metadata.contentType,
           postprocessorsUsed: document.metadata.postprocessorsUsed,
+          proxyUsed: document.metadata.proxyUsed,
         });
       } catch (error) {
         meta.logger.error("Failed to save document to index", {
@@ -404,7 +405,9 @@ export async function scrapeURLWithIndex(
 
     postprocessorsUsed: doc.postprocessorsUsed,
 
-    proxyUsed: meta.featureFlags.has("stealthProxy") ? "stealth" : "basic",
+    proxyUsed:
+      doc.proxyUsed ??
+      (meta.featureFlags.has("stealthProxy") ? "stealth" : "basic"), // this can be dropped after june 2026, it's here to backfill proxyUsed for older index entries that don't have it
   };
 }
 

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -165,6 +165,7 @@ export async function saveIndexToGCS(
     pdfMetadata?: PdfMetadata;
     contentType?: string;
     postprocessorsUsed?: string[];
+    proxyUsed?: "basic" | "stealth";
   },
 ): Promise<void> {
   return await withSpan("firecrawl-index-save-to-gcs", async span => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes proxy billing for cached scrapes by deriving the proxy type from the `stealthProxy` feature flag at runtime and persisting it in index metadata. Ensures stealth proxy usage is billed correctly now and on future reads.

- **Bug Fixes**
  - Backfill `proxyUsed` during cached reads: use `doc.proxyUsed` if present, otherwise derive from `meta.featureFlags` (`stealth` vs `basic`).
  - Persist `proxyUsed` to document metadata and GCS index to carry the correct proxy type forward.

<sup>Written for commit ed94b6a57bff5f270fa1aea301bc8eca59eb05aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

