### PR TITLE
Set GOPROXY in Dockerfiles and add update script

### DIFF
--- a/apps/add_proxy_to_dockerfile.sh
+++ b/apps/add_proxy_to_dockerfile.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# 查找 apps 目录下所有名为 Dockerfile 的文件
+find apps -name "Dockerfile" | while read -r df; do
+    echo "正在处理: $df"
+    
+    # 逻辑说明：
+    # 1. 匹配包含 'go mod download' 的行
+    # 2. 在该行之前插入环境变量设置
+    # 3. 使用 -i 直接修改文件内容
+    
+    # 针对 Go 代理的通用插入
+    sed -i '/go mod download/i \    export GOPROXY=https://goproxy.cn,direct && \\' "$df"
+    
+    # 顺便处理可能存在的 pnpm/npm 慢的问题（可选）
+    sed -i '/pnpm install/i \    RUN pnpm config set registry https://registry.npmmirror.com && \\' "$df"
+done
+
+echo "所有 Dockerfile 代理配置已更新！"

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 COPY sharedLibs/go-html-to-md ./sharedLibs/go-html-to-md
 
 RUN cd sharedLibs/go-html-to-md && \
+    export GOPROXY=https://goproxy.cn,direct && \
     go mod download && \
     go build -o libhtml-to-markdown.so -buildmode=c-shared html-to-markdown.go
 

--- a/apps/go-html-to-md-service/Dockerfile
+++ b/apps/go-html-to-md-service/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN export GOPROXY=https://goproxy.cn,direct && go mod download
 
 # Copy source code
 COPY . .


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configure Go Docker builds to use the `GOPROXY` mirror to speed up `go mod download` and reduce build flakiness. Adds a helper script to apply this across `apps/*` and optionally set a faster `pnpm` registry.

- **New Features**
  - Added `apps/add_proxy_to_dockerfile.sh` to insert `export GOPROXY=https://goproxy.cn,direct` before `go mod download`; also injects `pnpm config set registry https://registry.npmmirror.com` before `pnpm install` when present.
  - Updated `apps/api/Dockerfile` and `apps/go-html-to-md-service/Dockerfile` to use the proxy during module downloads.

<sup>Written for commit b694dc7ea8b98eb6581fbd8fd4fa38da002ddbef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

