### PR TITLE
fix: handle HTML pages with embedded PDFs when URL ends in .pdf

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/embeddedPdf.integration.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/embeddedPdf.integration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration test for the embedded-PDF fix (issue #839).
+ *
+ * Strategy: mock the heavy I/O dependencies (downloadFile, fetchFileToBuffer,
+ * native pdf bindings) so we can exercise the real detection + re-fetch logic
+ * inside scrapePDF without needing a running server or ESM-incompatible deps.
+ */
+
+import { writeFile, unlink } from "node:fs/promises";
+import os from "os";
+import path from "path";
+import { randomUUID } from "crypto";
+
+// ---------------------------------------------------------------------------
+// Minimal valid 1-page PDF bytes
+// ---------------------------------------------------------------------------
+const MINIMAL_PDF = Buffer.from(
+  "255044462d312e340a312030206f626a0a3c3c202f54797065202f436174616c6f670a202020202f50616765732032203020520a3e3e0a656e646f626a0a322030206f626a0a3c3c202f54797065202f50616765730a202020202f4b696473205b332030205d0a202020202f436f756e7420310a3e3e0a656e646f626a0a332030206f626a0a3c3c202f54797065202f506167650a202020202f506172656e742032203020520a202020202f4d65646961426f78205b302030203631322037393220200a202020205d0a3e3e0a656e646f626a0a787265660a302034200a303030303030303030302036353533352066200a303030303030303030392030303030302066200a303030303030303034332030303030302066200a303030303030303039382030303030302066200a747261696c65720a3c3c202f53697a6520340a202020202f526f6f742031203020520a3e3e0a7374617274787265660a3139380a2525454f46",
+  "hex",
+);
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that pull the real modules
+// ---------------------------------------------------------------------------
+jest.mock("../../../engines/utils/downloadFile", () => ({
+  downloadFile: jest.fn(),
+  fetchFileToBuffer: jest.fn(),
+}));
+
+jest.mock("pdf-parse", () =>
+  jest.fn().mockResolvedValue({ text: "Hello from PDF", numpages: 1 }),
+);
+
+jest.mock("@mendable/firecrawl-rs", () => ({
+  processPdf: jest.fn(() => ({
+    pdfType: "TextBased",
+    pageCount: 1,
+    confidence: 0.99,
+    isComplex: false,
+    markdown: "Hello from PDF",
+    logs: [],
+  })),
+  detectPdf: jest.fn(() => ({ pdfType: "TextBased", pageCount: 1, logs: [] })),
+}));
+
+// ---------------------------------------------------------------------------
+// Now import the module under test
+// ---------------------------------------------------------------------------
+import { scrapePDF } from "../index";
+import {
+  downloadFile,
+  fetchFileToBuffer,
+} from "../../../engines/utils/downloadFile";
+
+const mockDownloadFile = downloadFile as jest.MockedFunction<
+  typeof downloadFile
+>;
+const mockFetchFileToBuffer = fetchFileToBuffer as jest.MockedFunction<
+  typeof fetchFileToBuffer
+>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeMeta(url: string, htmlTempPath: string) {
+  return {
+    id: randomUUID(),
+    url,
+    rewrittenUrl: undefined,
+    options: {
+      formats: [{ type: "markdown" }],
+      parsers: [],
+      skipTlsVerification: false,
+      onlyMainContent: true,
+      waitFor: 0,
+      mobile: false,
+      fastMode: false,
+      blockAds: true,
+      proxy: "basic",
+      __forceFirePDF: false,
+    },
+    internalOptions: { teamId: "test-team", zeroDataRetention: false },
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      child: () => ({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(),
+      }),
+    },
+    abort: {
+      asSignal: () => undefined,
+      throwIfAborted: () => {},
+      scrapeTimeout: () => undefined,
+      child: () => ({ dispose: jest.fn() }),
+    },
+    featureFlags: new Set(["pdf"]),
+    mock: null,
+    // pdfPrefetch points to the HTML file (simulates what downloadFile produced)
+    pdfPrefetch: {
+      filePath: htmlTempPath,
+      url,
+      status: 200,
+      proxyUsed: "basic",
+    },
+    documentPrefetch: undefined,
+    fetchPrefetch: undefined,
+    costTracking: { add: jest.fn(), get: jest.fn(() => 0) },
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("scrapePDF — embedded PDF in HTML page (issue #839)", () => {
+  let htmlTempPath: string;
+  let pdfTempPath: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (htmlTempPath) await unlink(htmlTempPath).catch(() => {});
+  });
+
+  it("re-fetches and processes the real PDF found inside an HTML embed tag (shouldParse=true path)", async () => {
+    const embeddedPdfUrl = "https://example.com/real.pdf";
+
+    // Write HTML with embedded PDF to a temp file
+    htmlTempPath = path.join(os.tmpdir(), `test-html-${randomUUID()}`);
+    await writeFile(
+      htmlTempPath,
+      `<html><body><embed src="${embeddedPdfUrl}" type="application/pdf"></body></html>`,
+    );
+
+    // Write the real PDF to another temp file (returned by downloadFile re-fetch)
+    const pdfTempPath = path.join(os.tmpdir(), `test-pdf-${randomUUID()}`);
+    await writeFile(pdfTempPath, MINIMAL_PDF);
+
+    mockDownloadFile.mockResolvedValue({
+      response: { url: embeddedPdfUrl, status: 200 } as any,
+      tempFilePath: pdfTempPath,
+    });
+
+    // Use parsers so shouldParse=true, triggering the isPdfBuffer check path
+    const meta = {
+      ...makeMeta("https://example.com/fake.pdf", htmlTempPath),
+      options: {
+        ...makeMeta("https://example.com/fake.pdf", htmlTempPath).options,
+        parsers: [{ type: "pdf" }],
+      },
+    } as any;
+
+    const result = await scrapePDF(meta);
+
+    expect(result.contentType).toBe("application/pdf");
+    expect(result.statusCode).toBe(200);
+    // downloadFile must have been called with the embedded URL
+    expect(mockDownloadFile).toHaveBeenCalledWith(
+      expect.any(String),
+      embeddedPdfUrl,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("returns HTML as base64 when no embedded PDF is found (no-parse path)", async () => {
+    // When shouldParse=false and no embedded PDF is found, the code returns
+    // the raw content as base64 — it does NOT throw. This is the existing
+    // behaviour for non-PDF URLs that reach the pdf engine.
+    htmlTempPath = path.join(os.tmpdir(), `test-html-${randomUUID()}`);
+    const htmlContent = `<html><body><p>No PDF here</p></body></html>`;
+    await writeFile(htmlTempPath, htmlContent);
+
+    const meta = makeMeta("https://example.com/fake.pdf", htmlTempPath);
+    const result = await scrapePDF(meta);
+
+    // Content is returned as base64 of the HTML
+    expect(result.contentType).toBe("application/pdf");
+    expect(Buffer.from(result.markdown ?? "", "base64").toString()).toBe(
+      htmlContent,
+    );
+    // fetchFileToBuffer should NOT have been called (no URL to re-fetch)
+    expect(mockFetchFileToBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/extractEmbeddedPdfUrl.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/extractEmbeddedPdfUrl.test.ts
@@ -24,13 +24,15 @@ describe("extractEmbeddedPdfUrl", () => {
     );
   });
 
-  it("returns null when no embedded PDF is present", () => {
-    const html = `<html><body><p>No PDF here</p></body></html>`;
-    expect(extractEmbeddedPdfUrl(html, BASE)).toBeNull();
+  it("finds a URL without .pdf extension (e.g. viewer or download endpoint)", () => {
+    const html = `<iframe src="/viewer?id=12345"></iframe>`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBe(
+      "https://www.example.com/viewer?id=12345",
+    );
   });
 
-  it("returns null for an iframe pointing to a non-PDF URL", () => {
-    const html = `<iframe src="https://example.com/page.html"></iframe>`;
+  it("returns null when no embedded src is present", () => {
+    const html = `<html><body><p>No PDF here</p></body></html>`;
     expect(extractEmbeddedPdfUrl(html, BASE)).toBeNull();
   });
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/extractEmbeddedPdfUrl.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/extractEmbeddedPdfUrl.test.ts
@@ -1,0 +1,55 @@
+import { extractEmbeddedPdfUrl } from "../pdfUtils";
+
+const BASE = "https://www.example.com/page";
+
+describe("extractEmbeddedPdfUrl", () => {
+  it("finds a PDF in an <iframe src>", () => {
+    const html = `<html><body><iframe src="/assets/doc.pdf"></iframe></body></html>`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBe(
+      "https://www.example.com/assets/doc.pdf",
+    );
+  });
+
+  it("finds a PDF in an <embed src>", () => {
+    const html = `<embed src="https://cdn.example.com/file.pdf" type="application/pdf">`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBe(
+      "https://cdn.example.com/file.pdf",
+    );
+  });
+
+  it("finds a PDF in an <object data>", () => {
+    const html = `<object data="/files/report.pdf?v=2" type="application/pdf"></object>`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBe(
+      "https://www.example.com/files/report.pdf?v=2",
+    );
+  });
+
+  it("returns null when no embedded PDF is present", () => {
+    const html = `<html><body><p>No PDF here</p></body></html>`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBeNull();
+  });
+
+  it("returns null for an iframe pointing to a non-PDF URL", () => {
+    const html = `<iframe src="https://example.com/page.html"></iframe>`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBeNull();
+  });
+
+  it("resolves relative URLs against the base", () => {
+    const html = `<iframe src="../docs/manual.pdf"></iframe>`;
+    expect(extractEmbeddedPdfUrl(html, BASE)).toBe(
+      "https://www.example.com/docs/manual.pdf",
+    );
+  });
+
+  it("rejects non-http/https protocols (SSRF prevention)", () => {
+    expect(
+      extractEmbeddedPdfUrl(`<embed src="file:///etc/passwd.pdf">`, BASE),
+    ).toBeNull();
+    expect(
+      extractEmbeddedPdfUrl(
+        `<embed src="data:application/pdf;base64,abc.pdf">`,
+        BASE,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -36,7 +36,11 @@ import { scrapePDFWithRunPodMU } from "./runpodMU";
 import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
 import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
-import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
+import {
+  isPdfBuffer,
+  PDF_SNIFF_WINDOW,
+  extractEmbeddedPdfUrl,
+} from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
 
 /** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
@@ -82,6 +86,32 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       );
 
       if (!isPdfBuffer(file.buffer)) {
+        // Check if it's an HTML page with an embedded PDF
+        const embeddedUrl = extractEmbeddedPdfUrl(
+          file.buffer.toString("utf8", 0, Math.min(file.buffer.length, 8192)),
+          meta.rewrittenUrl ?? meta.url,
+        );
+        if (embeddedUrl) {
+          meta.logger.info("Found embedded PDF in HTML page, re-fetching", {
+            embeddedUrl,
+          });
+          const pdfFile = await fetchFileToBuffer(
+            embeddedUrl,
+            meta.options.skipTlsVerification,
+            { headers: meta.options.headers, signal: meta.abort.asSignal() },
+          );
+          if (isPdfBuffer(pdfFile.buffer)) {
+            const content = pdfFile.buffer.toString("base64");
+            return {
+              url: embeddedUrl,
+              statusCode: pdfFile.response.status,
+              html: content,
+              markdown: content,
+              contentType: "application/pdf",
+              proxyUsed: "basic",
+            };
+          }
+        }
         // downloaded content isn't a valid PDF
         if (meta.pdfPrefetch === undefined) {
           // for non-PDF URLs, this is expected, not anti-bot
@@ -139,6 +169,63 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     }
 
     if (!isPdfBuffer(header.subarray(0, headerBytesRead))) {
+      // Check if it's an HTML page with an embedded PDF
+      const htmlSnippet = await readFile(tempFilePath, {
+        encoding: "utf8",
+        flag: "r",
+      })
+        .then(s => s.slice(0, 8192))
+        .catch(() => "");
+      const embeddedUrl = extractEmbeddedPdfUrl(
+        htmlSnippet,
+        meta.rewrittenUrl ?? meta.url,
+      );
+      if (embeddedUrl) {
+        meta.logger.info("Found embedded PDF in HTML page, re-downloading", {
+          embeddedUrl,
+        });
+        // Replace the temp file with the real PDF
+        const { response: embeddedResponse, tempFilePath: embeddedTempPath } =
+          await downloadFile(
+            meta.id,
+            embeddedUrl,
+            meta.options.skipTlsVerification,
+            { headers: meta.options.headers, signal: meta.abort.asSignal() },
+          );
+        // Swap the temp file path by unlinking the HTML file and using the new one
+        await unlink(tempFilePath);
+        // Re-enter the function logic with the real PDF by updating the reference
+        // We do this by recursively calling with a patched meta
+        const pdfHeader = Buffer.alloc(PDF_SNIFF_WINDOW);
+        const pdfFh = await open(embeddedTempPath, "r");
+        let pdfHeaderBytesRead: number;
+        try {
+          ({ bytesRead: pdfHeaderBytesRead } = await pdfFh.read(
+            pdfHeader,
+            0,
+            PDF_SNIFF_WINDOW,
+            0,
+          ));
+        } finally {
+          await pdfFh.close();
+        }
+        if (isPdfBuffer(pdfHeader.subarray(0, pdfHeaderBytesRead))) {
+          // Patch meta to use the embedded PDF's prefetch info and recurse
+          return await scrapePDF({
+            ...meta,
+            url: embeddedUrl,
+            rewrittenUrl: embeddedUrl,
+            pdfPrefetch: {
+              ...embeddedResponse,
+              filePath: embeddedTempPath,
+              url: embeddedUrl,
+              status: embeddedResponse.status,
+              proxyUsed: "basic" as const,
+            },
+          });
+        }
+        await unlink(embeddedTempPath).catch(() => {});
+      }
       if (meta.pdfPrefetch === undefined) {
         if (!meta.featureFlags.has("pdf")) {
           throw new EngineUnsuccessfulError("pdf");

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/pdfUtils.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/pdfUtils.ts
@@ -9,8 +9,9 @@ export function isPdfBuffer(buf: Buffer): boolean {
 }
 
 /**
- * Given an HTML string, returns the first PDF URL found in an <iframe>,
+ * Given an HTML string, returns the first URL found in an <iframe>,
  * <embed>, or <object> tag, or null if none is found.
+ * The caller is responsible for verifying the fetched content is a PDF.
  */
 export function extractEmbeddedPdfUrl(
   html: string,
@@ -18,7 +19,7 @@ export function extractEmbeddedPdfUrl(
 ): string | null {
   // Match src/data attributes in <iframe>, <embed>, <object> tags
   const pattern =
-    /<(?:iframe|embed|object)[^>]+(?:src|data)=["']([^"']+\.pdf(?:[?#][^"']*)?)["']/gi;
+    /<(?:iframe|embed|object)[^>]+(?:src|data)=["']([^"']+)["']/gi;
   const match = pattern.exec(html);
   if (!match) return null;
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/pdfUtils.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/pdfUtils.ts
@@ -7,3 +7,29 @@ export function isPdfBuffer(buf: Buffer): boolean {
   const window = buf.subarray(0, Math.min(buf.length, PDF_SNIFF_WINDOW));
   return window.includes(PDF_MAGIC);
 }
+
+/**
+ * Given an HTML string, returns the first PDF URL found in an <iframe>,
+ * <embed>, or <object> tag, or null if none is found.
+ */
+export function extractEmbeddedPdfUrl(
+  html: string,
+  baseUrl: string,
+): string | null {
+  // Match src/data attributes in <iframe>, <embed>, <object> tags
+  const pattern =
+    /<(?:iframe|embed|object)[^>]+(?:src|data)=["']([^"']+\.pdf(?:[?#][^"']*)?)["']/gi;
+  const match = pattern.exec(html);
+  if (!match) return null;
+
+  const found = match[1];
+  try {
+    const resolved = new URL(found, baseUrl);
+    if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+      return null;
+    }
+    return resolved.href;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
**## Description**
When a URL ends in `.pdf` but the server returns an HTML page with the
PDF embedded via `<iframe>`, `<embed>`, or `<object>`, Firecrawl was
throwing "Invalid PDF structure" instead of extracting the content.

**## Changes**
- Added `extractEmbeddedPdfUrl()` in `pdfUtils.ts` to detect embedded
  PDF URLs in HTML pages (with SSRF protection — only http/https allowed)
- Updated `scrapePDF()` in `engines/pdf/index.ts` to re-fetch the real
  PDF when the downloaded content is HTML with an embedded PDF
- Added unit tests for `extractEmbeddedPdfUrl`
- Added integration tests for the full `scrapePDF` fix

**## Fixes**
Closes firecrawl/firecrawl#839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PDF scraping when a URL ends with .pdf but the server returns HTML with an embedded PDF. We now detect and fetch the actual PDF (even when the embedded URL doesn’t end with .pdf) instead of throwing "Invalid PDF structure".

- **Bug Fixes**
  - Added `extractEmbeddedPdfUrl()` to detect PDFs in `<iframe>`, `<embed>`, and `<object>`; supports viewer/download URLs without a `.pdf` suffix; http/https only.
  - Updated `scrapePDF` to re-fetch and process the embedded PDF for both buffer and temp-file paths; verifies PDF signature; returns base64 HTML when no PDF is found and parsing isn’t requested.
  - Added unit and integration tests for detection and end-to-end flow.
  - Fixes #839.

<sup>Written for commit 26ddb19d68f910e92467683dd4950d095af63199. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

