### PR TITLE
fix(python-sdk): fix async_batch_scrape_urls always raising exception

### DIFF
--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -4015,9 +4015,9 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             headers
         )
 
-        if response.get('status_code') == 200:
+        if response.get('success'):
             try:
-                return V1BatchScrapeResponse(**response.json())
+                return V1BatchScrapeResponse(**response)
             except:
                 raise Exception(f'Failed to parse Firecrawl response as JSON.')
         else:


### PR DESCRIPTION
## Summary

Fixes #3477

This PR fixes a critical bug in `AsyncV1FirecrawlApp.async_batch_scrape_urls` where the method always raises an exception, even on successful API responses.

## Problem

The `async_batch_scrape_urls` method treats the result of `_async_post_request` as a raw aiohttp response object, but the helper actually returns a parsed JSON `Dict[str, Any]`. This causes:

1. The success branch to be unreachable (`response.get('status_code')` is always `None`)
2. Every call to raise an exception, even with valid 200 responses
3. The error handler to crash when trying to call `.json()` on a dict

## Root Cause

Lines 4018-4020 were copy-pasted from the sync sibling `batch_scrape_urls` (line 1709), which uses `_post_request` and gets back a real `requests.Response` with `.status_code` and `.json()`. The async port forgot to adapt the result handling to the async helper's contract.

## Solution

Changed the response handling to match the pattern used by all other v1 async methods:

**Before:**
```python
if response.get('status_code') == 200:
    return V1BatchScrapeResponse(**response.json())
```

**After:**
```python
if response.get('success'):
    return V1BatchScrapeResponse(**response)
```

This matches the pattern in:
- `scrape_url` async (line 3738): `if response.get('success') and 'data' in response:`
- `async_crawl_url` (line 4072): `if response.get('success'):`
- All other v1 async methods

## Testing

### Reproduction (before fix):
```python
import asyncio
from firecrawl import AsyncV1FirecrawlApp

async def main():
    app = AsyncV1FirecrawlApp(api_key="fc-...")
    res = await app.async_batch_scrape_urls(["https://example.com"])
    print(res)

asyncio.run(main())
# Always raises - even with a valid key and successful 200 from server
```

### After fix:
The method now correctly returns `V1BatchScrapeResponse` on success.

## Changes

- `apps/python-sdk/firecrawl/v1/client.py` lines 4018-4020
  - Changed `response.get('status_code') == 200` to `response.get('success')`
  - Changed `response.json()` to `response` (dict is already parsed JSON)

## Impact

- Fixes a critical bug that made `async_batch_scrape_urls` completely unusable
- No breaking changes - the method signature and return type remain the same
- Aligns async method behavior with all other v1 async methods

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `AsyncV1FirecrawlApp.async_batch_scrape_urls` that always raised an exception. The method now returns `V1BatchScrapeResponse` on success and aligns with other v1 async methods.

- **Bug Fixes**
  - Check `response.get('success')` instead of `status_code` since `_async_post_request` returns a dict.
  - Pass the parsed `response` directly to `V1BatchScrapeResponse` instead of calling `.json()`.

<sup>Written for commit ef732754195136b2d126b7aef92774f0e8e46936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

