### PR TITLE
fix(api): wire USE_RESPONSES_ENDPOINT for self-hosted AI

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -61,6 +61,9 @@ USE_DB_AUTHENTICATION=false
 # Experimental: Use any OpenAI-compatible API
 # OPENAI_BASE_URL=https://example.com/v1
 # OPENAI_API_KEY=
+# Set this to false when your provider does not support the Responses API.
+# Examples include many OpenAI-compatible self-hosted gateways and proxies.
+# USE_RESPONSES_ENDPOINT=false
 
 ## === Proxy ===
 # PROXY_SERVER can be a full URL (e.g. http://0.1.2.3:1234) or just an IP and port combo (e.g. 0.1.2.3:1234)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -48,6 +48,8 @@ RATE_LIMIT_TEST_API_KEY_CRAWL=
 SCRAPING_BEE_API_KEY=
 # add for LLM dependent features (image alt generation, etc.)
 OPENAI_API_KEY=
+# set this if you're using an OpenAI-compatible API that only supports /chat/completions
+# USE_RESPONSES_ENDPOINT=false
 BULL_AUTH_KEY=@
 # set if you have a llamaparse key you'd like to use to parse pdfs
 LLAMAPARSE_API_KEY=

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -46,6 +46,7 @@ const configSchema = z.object({
   BULL_AUTH_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
+  USE_RESPONSES_ENDPOINT: z.stringbool().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),

--- a/apps/api/src/lib/generic-ai.test.ts
+++ b/apps/api/src/lib/generic-ai.test.ts
@@ -1,0 +1,141 @@
+describe("generic-ai", () => {
+  const createOpenAISpy = jest.fn();
+  const openaiDefaultModelSpy = jest.fn();
+  const openaiChatModelSpy = jest.fn();
+  const openaiEmbeddingSpy = jest.fn();
+  const createOllamaSpy = jest.fn();
+  const ollamaModelSpy = jest.fn();
+  const ollamaEmbeddingSpy = jest.fn();
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    createOpenAISpy.mockReset();
+    openaiDefaultModelSpy.mockReset();
+    openaiChatModelSpy.mockReset();
+    openaiEmbeddingSpy.mockReset();
+    createOllamaSpy.mockReset();
+    ollamaModelSpy.mockReset();
+    ollamaEmbeddingSpy.mockReset();
+
+    createOpenAISpy.mockReturnValue(
+      Object.assign(openaiDefaultModelSpy, {
+        chat: openaiChatModelSpy,
+        embedding: openaiEmbeddingSpy,
+      }),
+    );
+
+    createOllamaSpy.mockReturnValue(
+      Object.assign(ollamaModelSpy, {
+        embedding: ollamaEmbeddingSpy,
+      }),
+    );
+
+    jest.doMock("@ai-sdk/openai", () => ({
+      createOpenAI: createOpenAISpy,
+    }));
+    jest.doMock("ollama-ai-provider", () => ({
+      createOllama: createOllamaSpy,
+    }));
+    jest.doMock("@ai-sdk/anthropic", () => ({
+      anthropic: jest.fn(),
+    }));
+    jest.doMock("@ai-sdk/groq", () => ({
+      groq: jest.fn(),
+    }));
+    jest.doMock("@ai-sdk/google", () => ({
+      google: jest.fn(),
+    }));
+    jest.doMock("@openrouter/ai-sdk-provider", () => ({
+      createOpenRouter: jest.fn(() => jest.fn()),
+    }));
+    jest.doMock("@ai-sdk/fireworks", () => ({
+      fireworks: jest.fn(),
+    }));
+    jest.doMock("@ai-sdk/deepinfra", () => ({
+      deepinfra: jest.fn(),
+    }));
+    jest.doMock("@ai-sdk/google-vertex", () => ({
+      createVertex: jest.fn(() =>
+        Object.assign(jest.fn(), {
+          embedding: jest.fn(),
+        }),
+      ),
+    }));
+  });
+
+  afterEach(() => {
+    jest.dontMock("@ai-sdk/openai");
+    jest.dontMock("ollama-ai-provider");
+    jest.dontMock("@ai-sdk/anthropic");
+    jest.dontMock("@ai-sdk/groq");
+    jest.dontMock("@ai-sdk/google");
+    jest.dontMock("@openrouter/ai-sdk-provider");
+    jest.dontMock("@ai-sdk/fireworks");
+    jest.dontMock("@ai-sdk/deepinfra");
+    jest.dontMock("@ai-sdk/google-vertex");
+    jest.dontMock("../config");
+  });
+
+  function mockConfig(overrides: Record<string, unknown> = {}) {
+    jest.doMock("../config", () => ({
+      config: {
+        OPENAI_API_KEY: "test-openai-key",
+        OPENAI_BASE_URL: "https://example-openai.test/v1",
+        OPENROUTER_API_KEY: undefined,
+        OLLAMA_BASE_URL: undefined,
+        MODEL_NAME: undefined,
+        MODEL_EMBEDDING_NAME: undefined,
+        VERTEX_CREDENTIALS: undefined,
+        ...overrides,
+      },
+    }));
+  }
+
+  it("uses the default OpenAI model path when USE_RESPONSES_ENDPOINT is unset", () => {
+    mockConfig();
+
+    const { getModel } = require("./generic-ai");
+    getModel("gpt-4.1", "openai");
+
+    expect(openaiDefaultModelSpy).toHaveBeenCalledWith("gpt-4.1");
+    expect(openaiChatModelSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses chat completions when USE_RESPONSES_ENDPOINT is false", () => {
+    mockConfig({
+      USE_RESPONSES_ENDPOINT: false,
+    });
+
+    const { getModel } = require("./generic-ai");
+    getModel("gpt-4.1", "openai");
+
+    expect(openaiChatModelSpy).toHaveBeenCalledWith("gpt-4.1");
+    expect(openaiDefaultModelSpy).not.toHaveBeenCalled();
+  });
+
+  it("still forces chat completions for o3-mini when responses are enabled", () => {
+    mockConfig({
+      USE_RESPONSES_ENDPOINT: true,
+    });
+
+    const { getModel } = require("./generic-ai");
+    getModel("o3-mini", "openai");
+
+    expect(openaiChatModelSpy).toHaveBeenCalledWith("o3-mini");
+    expect(openaiDefaultModelSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses the configured MODEL_NAME when switching OpenAI-compatible endpoints", () => {
+    mockConfig({
+      MODEL_NAME: "qianfan-compatible-model",
+      USE_RESPONSES_ENDPOINT: false,
+    });
+
+    const { getModel } = require("./generic-ai");
+    getModel("ignored-model-name", "openai");
+
+    expect(openaiChatModelSpy).toHaveBeenCalledWith("qianfan-compatible-model");
+    expect(openaiDefaultModelSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -53,13 +53,21 @@ const providerList: Record<Provider, any> = {
   }),
 };
 
+function shouldUseOpenAIChatCompletions(modelName: string) {
+  if (modelName.startsWith("o3-mini")) {
+    return true;
+  }
+
+  return config.USE_RESPONSES_ENDPOINT === false;
+}
+
 export function getModel(name: string, provider: Provider = defaultProvider) {
   if (name === "gemini-2.5-pro") {
     name = "gemini-2.5-pro";
   }
   const modelName = config.MODEL_NAME || name;
   // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+  if (provider === "openai" && shouldUseOpenAIChatCompletions(modelName)) {
     return providerList.openai.chat(modelName);
   }
   return providerList[provider](modelName);


### PR DESCRIPTION
## Summary

This PR wires up `USE_RESPONSES_ENDPOINT` for self-hosted OpenAI-compatible providers.

Today Firecrawl always uses the default OpenAI provider model path, which maps to the Responses API in AI SDK v5+. That breaks self-hosted setups that point `OPENAI_BASE_URL` at providers which only implement the Chat Completions API.

With this change:

- `USE_RESPONSES_ENDPOINT=false` forces Firecrawl to use the Chat Completions path for the OpenAI provider
- existing default behavior is preserved when the env var is unset
- `o3-mini` keeps its existing forced chat-completions behavior

## Why

This unblocks self-hosted users running Firecrawl against OpenAI-compatible gateways and proxies that do not support the Responses API.

When `USE_RESPONSES_ENDPOINT=false`, requests use the Chat Completions path (`/chat/completions`) relative to the configured `OPENAI_BASE_URL`. For example, if `OPENAI_BASE_URL` points to `https://qianfan.baidubce.com/v2`, Firecrawl will call `https://qianfan.baidubce.com/v2/chat/completions`.

## Changes

- add `USE_RESPONSES_ENDPOINT` to the API config schema
- route OpenAI model selection through `.chat(...)` when `USE_RESPONSES_ENDPOINT=false`
- keep the existing `o3-mini` override in place
- document the new self-hosted setting in `SELF_HOST.md`
- add a note to `.env.example`
- add focused unit tests for the model routing behavior

## Validation

Ran:

- `./node_modules/.bin/jest --runTestsByPath src/lib/generic-ai.test.ts --config jest.config.ts`

Passed:

- 4 focused tests covering:
  - default OpenAI path when `USE_RESPONSES_ENDPOINT` is unset
  - chat-completions path when `USE_RESPONSES_ENDPOINT=false`
  - existing `o3-mini` override
  - `MODEL_NAME` override with chat-completions routing

Notes:

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` currently fails in this repo due to existing `@mendable/firecrawl-rs` type resolution errors unrelated to this PR.
