### PR TITLE
Add agent quickstart docs for all five SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,311 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+Canonical Firecrawl Elixir quickstart for external agents. Aligned with the `firecrawl` hex package **v1.3.1** and the v2 OpenAPI spec. Function names, parameters, and types match the SDK public API. The Elixir client is auto-generated from the OpenAPI spec, so function names follow the spec operation names.
+
+## Install
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:firecrawl, "~> 1.3"}
+  ]
+end
+```
+
+## Authenticate
+
+```elixir
+# In config/config.exs:
+config :firecrawl, api_key: "fc-YOUR-API-KEY"
+
+# Or pass api_key as an option to any function call:
+Firecrawl.scrape_and_extract_from_url(url: "https://example.com", api_key: "fc-YOUR-API-KEY")
+```
+
+## When To Use What
+
+- `search_and_scrape`: use when you start with a query and need discovery.
+- `scrape_and_extract_from_url`: use when you already have a URL and want page content.
+- `interact_with_scrape_browser_session`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(opts)` &rarr; `{:ok, Req.Response.t()} | {:error, Exception.t() | Firecrawl.Error.t()}`
+
+Bang variant: `Firecrawl.search_and_scrape!(opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  limit: 5,
+  sources: ["web"]
+)
+
+for hit <- response.body["data"]["web"] || [] do
+  IO.puts("#{hit["title"]} #{hit["url"]}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Only `query` is required.
+
+- `query`
+  - Type: string (required)
+  - The search query.
+
+- `limit`
+  - Type: integer
+  - Use when: you want to cap the number of results.
+
+- `sources`
+  - Type: list of any
+  - Use when: you want to control which source types are searched.
+  - Values: `"web"`, `"news"`, `"images"`, or maps like `%{"type" => "web"}`.
+
+- `categories`
+  - Type: list of any
+  - Use when: you want category-filtered results.
+  - Values: `"github"`, `"research"`, `"pdf"`.
+
+- `include_domains`
+  - Type: list of strings
+  - Use when: you want to restrict results to specific domains.
+
+- `exclude_domains`
+  - Type: list of strings
+  - Use when: you want to exclude specific domains from results.
+
+- `tbs`
+  - Type: string
+  - Use when: you need a time-based filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week).
+
+- `location`
+  - Type: string
+  - Use when: you want localized results (e.g. `"San Francisco,California,United States"`).
+
+- `country`
+  - Type: string
+  - Use when: you want geo-targeted results (ISO country code, e.g. `"US"`).
+
+- `ignore_invalid_urls`
+  - Type: boolean
+  - Use when: you want to drop URLs that cannot be scraped by other Firecrawl endpoints.
+
+- `timeout`
+  - Type: integer
+  - Use when: you need a request timeout in milliseconds.
+
+- `scrape_options`
+  - Type: keyword list
+  - Use when: you want to scrape each search result inline. Accepts the same fields as the Scrape parameters below.
+
+- `enterprise`
+  - Type: list of strings
+  - Use when: you need Zero Data Retention. Values: `["zdr"]` or `["anon"]`.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(opts)` &rarr; `{:ok, Req.Response.t()} | {:error, Exception.t() | Firecrawl.Error.t()}`
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: ["markdown", "links"],
+  only_main_content: true,
+  timeout: 30000
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Only `url` is required.
+
+- `url`
+  - Type: string (required)
+  - The URL to scrape.
+
+- `formats`
+  - Type: list of any
+  - Use when: you want specific output formats.
+  - String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`
+  - Object formats: `%{"type" => "json", "schema" => %{...}}`, `%{"type" => "question", "question" => "..."}`, `%{"type" => "highlights", "query" => "..."}`.
+
+- `headers`
+  - Type: any
+  - Use when: you need custom HTTP headers.
+
+- `include_tags`
+  - Type: list of strings
+  - Use when: you want to include only specific HTML tags.
+
+- `exclude_tags`
+  - Type: list of strings
+  - Use when: you want to exclude specific HTML tags.
+
+- `only_main_content`
+  - Type: boolean
+  - Use when: you want to strip nav, footer, and other boilerplate.
+
+- `timeout`
+  - Type: integer
+  - Use when: you need a request timeout in milliseconds. Range: 1000-300000. Default: 60000.
+
+- `wait_for`
+  - Type: integer
+  - Use when: you need to wait for the page to render (milliseconds).
+
+- `mobile`
+  - Type: boolean
+  - Use when: you want a mobile viewport.
+
+- `parsers`
+  - Type: list of any
+  - Use when: you need file parsing controls. E.g. `"pdf"` or `%{"type" => "pdf", "mode" => "auto", "maxPages" => 10}`.
+
+- `actions`
+  - Type: list of any
+  - Use when: you need pre-scrape browser actions. Each item is a map with a `"type"` key.
+
+- `location`
+  - Type: keyword list
+  - Use when: you need geo or language-aware scraping. Keys: `country`, `languages`.
+
+- `skip_tls_verification`
+  - Type: boolean
+  - Use when: you need to skip TLS certificate verification.
+
+- `remove_base64_images`
+  - Type: boolean
+  - Use when: you want to remove base64 images from output.
+
+- `block_ads`
+  - Type: boolean
+  - Use when: you want ad and cookie popup blocking.
+
+- `proxy`
+  - Type: atom
+  - Use when: you need proxy control.
+  - Values: `:basic`, `:enhanced`, `:auto`.
+
+- `max_age`
+  - Type: integer
+  - Use when: you want cached data up to a maximum age (milliseconds). Default: 172800000 (2 days).
+
+- `min_age`
+  - Type: integer
+  - Use when: you only want cached data at least this old (milliseconds).
+
+- `store_in_cache`
+  - Type: boolean
+  - Use when: you want Firecrawl to cache the result.
+
+- `lockdown`
+  - Type: boolean
+  - Use when: you only want cached results and never want outbound requests.
+
+- `profile`
+  - Type: keyword list
+  - Use when: you want a persistent browser profile. Keys: `name`, `save_changes`.
+
+- `zero_data_retention`
+  - Type: boolean
+  - Use when: you need zero data retention for this scrape.
+
+## Interact
+
+### Why use it
+
+Use `interact_with_scrape_browser_session` to run code in the browser session tied to a scrape job. The Elixir SDK accepts code to execute (not a natural-language prompt).
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, opts)` &rarr; `{:ok, Req.Response.t()} | {:error, Exception.t() | Firecrawl.Error.t()}`
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+IO.puts(result.body["stdout"])
+
+# Stop the session when done:
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+The first argument is the `job_id` (string). Remaining parameters are a keyword list.
+
+- `code`
+  - Type: string (required)
+  - The code to execute in the browser sandbox.
+
+- `language`
+  - Type: atom
+  - Use when: you need a specific runtime. Default: `:node`.
+  - Values: `:python`, `:node`, `:bash`.
+
+- `timeout`
+  - Type: integer
+  - Use when: you need an execution timeout in seconds.
+
+- `origin`
+  - Type: string
+  - Use when: you need to tag the request for attribution.
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id)` or bang variant `Firecrawl.stop_interactive_scrape_browser_session!(job_id)`
+
+## Notes
+
+- The Elixir client is auto-generated from the OpenAPI spec. Function names match OpenAPI operation names (e.g. `scrape_and_extract_from_url` instead of `scrape`).
+- The `interact` function only accepts `code`, not a `prompt` parameter. This differs from the JS and Python SDKs.
+- Proxy values are atoms (`:basic`, `:enhanced`, `:auto`), not strings.
+- All parameters use `snake_case` in Elixir and are mapped to `camelCase` for the JSON API body.
+- Every function has a bang (`!`) variant that raises instead of returning error tuples.
+- Parameters are validated by `NimbleOptions` before sending.
+- The base URL defaults to `https://api.firecrawl.dev/v2` and can be overridden with `base_url:` option.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs` (hex package: `firecrawl`)
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,329 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+Canonical Firecrawl Java quickstart for external agents. Aligned with `com.firecrawl:firecrawl-java` **v1.5.1** and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.5.1</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.5.1'
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// Builder pattern
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR-API-KEY")
+    .build();
+
+// Or from environment variable FIRECRAWL_API_KEY
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` &rarr; `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries",
+    SearchOptions.builder()
+        .limit(5)
+        .sources(List.of("web"))
+        .build()
+);
+
+for (var hit : results.getWeb()) {
+    System.out.println(hit.get("title") + " " + hit.get("url"));
+}
+```
+
+### Parameters
+
+`SearchOptions` fields (all optional, set via builder):
+
+- `sources`
+  - Type: `List<Object>`
+  - Use when: you want to control which source types are searched.
+  - Values: `"web"`, `"news"`, `"images"`, or maps like `Map.of("type", "web")`.
+
+- `categories`
+  - Type: `List<Object>`
+  - Use when: you want category-filtered results.
+  - Values: `"github"`, `"research"`, `"pdf"`.
+
+- `includeDomains`
+  - Type: `List<String>`
+  - Use when: you want to restrict results to specific domains.
+
+- `excludeDomains`
+  - Type: `List<String>`
+  - Use when: you want to exclude specific domains from results.
+
+- `limit`
+  - Type: `Integer`
+  - Use when: you want to cap the number of results.
+
+- `tbs`
+  - Type: `String`
+  - Use when: you need a time-based filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week).
+
+- `location`
+  - Type: `String`
+  - Use when: you want localized results.
+
+- `ignoreInvalidURLs`
+  - Type: `Boolean`
+  - Use when: you want to drop URLs that cannot be scraped by other Firecrawl endpoints.
+
+- `timeout`
+  - Type: `Integer`
+  - Use when: you need a request timeout in milliseconds.
+
+- `scrapeOptions`
+  - Type: `ScrapeOptions`
+  - Use when: you want to scrape each search result inline. Accepts the same fields as the Scrape parameters below.
+
+- `integration`
+  - Type: `String`
+  - Use when: you need to tag the request for integration tracking.
+
+### Async variant
+
+`client.searchAsync(query, options)` &rarr; `CompletableFuture<SearchData>`
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` &rarr; `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .timeout(30000)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all optional, set via builder):
+
+- `formats`
+  - Type: `List<Object>`
+  - Use when: you want specific output formats.
+  - String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`.
+  - Format config objects are also supported for structured extraction.
+
+- `headers`
+  - Type: `Map<String, String>`
+  - Use when: you need custom HTTP headers.
+
+- `includeTags`
+  - Type: `List<String>`
+  - Use when: you want to include only specific HTML tags.
+
+- `excludeTags`
+  - Type: `List<String>`
+  - Use when: you want to exclude specific HTML tags.
+
+- `onlyMainContent`
+  - Type: `Boolean`
+  - Use when: you want to strip nav, footer, and other boilerplate.
+
+- `timeout`
+  - Type: `Integer`
+  - Use when: you need a request timeout in milliseconds. Default: 60000.
+
+- `waitFor`
+  - Type: `Integer`
+  - Use when: you need to wait for the page to render (milliseconds).
+
+- `mobile`
+  - Type: `Boolean`
+  - Use when: you want a mobile viewport.
+
+- `parsers`
+  - Type: `List<Object>`
+  - Use when: you need file parsing controls. E.g. `"pdf"` or `Map.of("type", "pdf", "maxPages", 10)`.
+
+- `actions`
+  - Type: `List<Map<String, Object>>`
+  - Use when: you need pre-scrape browser actions. Each map has a `"type"` key and action-specific fields.
+
+- `location`
+  - Type: `LocationConfig`
+  - Use when: you need geo or language-aware scraping. Fields: `country`, `languages`.
+
+- `skipTlsVerification`
+  - Type: `Boolean`
+  - Use when: you need to skip TLS certificate verification.
+
+- `removeBase64Images`
+  - Type: `Boolean`
+  - Use when: you want to remove base64 images from output.
+
+- `blockAds`
+  - Type: `Boolean`
+  - Use when: you want ad and cookie popup blocking.
+
+- `proxy`
+  - Type: `String`
+  - Use when: you need proxy control.
+  - Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL.
+
+- `maxAge`
+  - Type: `Long`
+  - Use when: you want cached data up to a maximum age (milliseconds).
+
+- `storeInCache`
+  - Type: `Boolean`
+  - Use when: you want Firecrawl to cache the result.
+
+- `lockdown`
+  - Type: `Boolean`
+  - Use when: you only want cached results and never want outbound requests.
+
+- `integration`
+  - Type: `String`
+  - Use when: you need to tag the request for integration tracking.
+
+### Async variant
+
+`client.scrapeAsync(url, options)` &rarr; `CompletableFuture<Document>`
+
+## Interact
+
+### Why use it
+
+Use `interact` to run code in the browser session tied to a scrape job. The Java SDK accepts code to execute (not a natural-language prompt).
+
+### Preferred SDK method
+
+`client.interact(jobId, code)` &rarr; `BrowserExecuteResponse`
+
+Overloads:
+- `client.interact(jobId, code)`
+- `client.interact(jobId, code, language, timeout)`
+- `client.interact(jobId, code, language, timeout, origin)`
+
+### Example
+
+```java
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build()
+);
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60,
+    null
+);
+System.out.println(result.getStdout());
+
+// Stop the session when done:
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+- `jobId`
+  - Type: `String` (required)
+  - The scrape job ID from `document.getMetadata().get("scrapeId")`.
+
+- `code`
+  - Type: `String` (required)
+  - The code to execute in the browser sandbox.
+
+- `language`
+  - Type: `String`
+  - Use when: you need a specific runtime. Default: `"node"`.
+  - Values: `"python"`, `"node"`, `"bash"`.
+
+- `timeout`
+  - Type: `Integer`
+  - Use when: you need an execution timeout in seconds (1-300). Default: 30.
+
+- `origin`
+  - Type: `String`
+  - Use when: you need to tag the request for attribution.
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` &rarr; `BrowserDeleteResponse`
+
+Response fields: `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+### Async variants
+
+- `client.interactAsync(jobId, code)`
+- `client.interactAsync(jobId, code, language, timeout)`
+- `client.interactAsync(jobId, code, language, timeout, origin)`
+- `client.stopInteractiveBrowserAsync(jobId)`
+
+All return `CompletableFuture`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` &rarr; `interact`; `deleteScrapeBrowser` &rarr; `stopInteractiveBrowser`. Async variants follow the same pattern.
+- The Java SDK `interact` method accepts only `code`, not a `prompt` parameter. This differs from the JS and Python SDKs.
+- All options classes use an immutable builder pattern.
+- Client builder also accepts `apiUrl`, `timeoutMs` (default: 300000), `maxRetries` (default: 3), `backoffFactor` (default: 0.5), `asyncExecutor`, and `httpClient`.
+- Requires Java 11+.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts` (artifact: `com.firecrawl:firecrawl-java`)
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,317 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+Canonical Firecrawl Node.js quickstart for external agents. Aligned with `@mendable/firecrawl-js` **v4.22.2** and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+  // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL or cloud default
+});
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` &rarr; `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true,
+  },
+});
+
+for (const hit of results.web ?? []) {
+  console.log(hit.title, hit.url);
+}
+```
+
+### Parameters
+
+- `query`
+  - Type: string (required)
+  - The search query. Use `site:example.com` to scope results to a domain.
+
+- `options.sources`
+  - Type: array of `"web"` | `"news"` | `"images"` or `{ type: "web" | "news" | "images" }`
+  - Use when: you want to control which source types are searched.
+
+- `options.categories`
+  - Type: array of `"github"` | `"research"` | `"pdf"` or `{ type: "github" | "research" | "pdf" }`
+  - Use when: you want category-filtered results.
+
+- `options.limit`
+  - Type: number
+  - Use when: you want to cap the number of results.
+
+- `options.tbs`
+  - Type: string
+  - Use when: you need a time-based filter (`qdr:d` for past day, `qdr:w` for past week, `qdr:m` for past month, `sbd:1` to sort by date).
+
+- `options.location`
+  - Type: string
+  - Use when: you want localized results (e.g. `"San Francisco,California,United States"`).
+
+- `options.includeDomains`
+  - Type: array of strings
+  - Use when: you want to restrict results to specific domains.
+
+- `options.excludeDomains`
+  - Type: array of strings
+  - Use when: you want to exclude specific domains from results.
+
+- `options.ignoreInvalidURLs`
+  - Type: boolean
+  - Use when: you want to drop URLs that cannot be scraped by other Firecrawl endpoints.
+
+- `options.timeout`
+  - Type: number
+  - Use when: you need a request timeout in milliseconds.
+
+- `options.scrapeOptions`
+  - Type: `ScrapeOptions`
+  - Use when: you want to scrape each search result inline. Accepts the same fields as the Scrape parameters below.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` &rarr; `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    "links",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+  timeout: 30000,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+- `url`
+  - Type: string (required)
+  - The URL to scrape.
+
+- `options.formats`
+  - Type: array of format strings or format objects
+  - Use when: you want specific output formats.
+  - Plain string formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`
+  - Object-only formats:
+    - `{ type: "json", prompt?: string, schema?: JSON schema or Zod schema }`: at least one of `prompt` or `schema` required.
+    - `{ type: "question", question: string }`: question-answer extraction.
+    - `{ type: "highlights", query: string }`: relevant source-text extraction.
+    - `{ type: "screenshot", fullPage?: boolean, quality?: number, viewport?: { width, height } }`: screenshot with options.
+    - `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?, prompt?, tag? }`: `modes` is required.
+    - `{ type: "attributes", selectors: Array<{ selector, attribute }> }`: attribute extraction.
+
+- `options.headers`
+  - Type: `Record<string, string>`
+  - Use when: you need custom HTTP headers (cookies, user-agent, etc.).
+
+- `options.includeTags`
+  - Type: array of strings
+  - Use when: you want to include only specific HTML tags.
+
+- `options.excludeTags`
+  - Type: array of strings
+  - Use when: you want to exclude specific HTML tags.
+
+- `options.onlyMainContent`
+  - Type: boolean
+  - Use when: you want to strip nav, footer, and other boilerplate. Default: true (per OpenAPI).
+
+- `options.timeout`
+  - Type: number
+  - Use when: you need a request timeout in milliseconds. Default: 60000. Range: 1000-300000.
+
+- `options.waitFor`
+  - Type: number
+  - Use when: you need to wait for the page to render (milliseconds).
+
+- `options.mobile`
+  - Type: boolean
+  - Use when: you want a mobile viewport.
+
+- `options.parsers`
+  - Type: array of parser names or objects
+  - Use when: you need file parsing controls.
+  - Values: `"pdf"` or `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`.
+
+- `options.actions`
+  - Type: array of action objects
+  - Use when: you need pre-scrape browser actions.
+  - Action types:
+    - `{ type: "wait", milliseconds: number }` or `{ type: "wait", selector: string }`
+    - `{ type: "click", selector: string }`
+    - `{ type: "write", text: string }`
+    - `{ type: "press", key: string }`
+    - `{ type: "scroll", direction?: "up" | "down", selector?: string }`
+    - `{ type: "screenshot", fullPage?, quality?, viewport? }`
+    - `{ type: "scrape" }`
+    - `{ type: "executeJavascript", script: string }`
+    - `{ type: "pdf", format?: string, landscape?: boolean, scale?: number }`
+
+- `options.location`
+  - Type: `{ country?: string, languages?: string[] }`
+  - Use when: you need geo or language-aware scraping. Default country: `"US"`.
+
+- `options.skipTlsVerification`
+  - Type: boolean
+  - Use when: you need to skip TLS certificate verification.
+
+- `options.removeBase64Images`
+  - Type: boolean
+  - Use when: you want to remove base64 images from markdown output.
+
+- `options.fastMode`
+  - Type: boolean
+  - Use when: you want faster scrapes with reduced fidelity.
+
+- `options.blockAds`
+  - Type: boolean
+  - Use when: you want ad and cookie popup blocking.
+
+- `options.proxy`
+  - Type: string
+  - Use when: you need proxy control.
+  - Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL.
+
+- `options.maxAge`
+  - Type: number
+  - Use when: you want cached data up to a maximum age (milliseconds). Default: 172800000 (2 days).
+
+- `options.minAge`
+  - Type: number
+  - Use when: you only want cached data at least this old (milliseconds). Returns 404 on cache miss.
+
+- `options.storeInCache`
+  - Type: boolean
+  - Use when: you want Firecrawl to cache the result.
+
+- `options.lockdown`
+  - Type: boolean
+  - Use when: you only want cached results and never want outbound requests. Returns 404 on cache miss.
+
+- `options.profile`
+  - Type: `{ name: string, saveChanges?: boolean }`
+  - Use when: you want a persistent browser profile shared across scrapes and interactions.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrapeId`). The SDK requires at least one of `code` or `prompt`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` &rarr; `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+console.log(result.output);
+
+// Or with code:
+const codeResult = await client.interact(jobId, {
+  code: "console.log(await page.title());",
+  language: "node",
+  timeout: 60,
+});
+console.log(codeResult.stdout);
+
+// Stop the session when done:
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+- `jobId`
+  - Type: string (required)
+  - The scrape job ID from `document.metadata.scrapeId`.
+
+- `args.code`
+  - Type: string
+  - Use when: you want to run code in the browser sandbox (e.g. Playwright `page` usage in `node` runtime).
+
+- `args.prompt`
+  - Type: string
+  - Use when: you want the browser agent to follow a natural-language instruction.
+
+- At least one of `args.code` or `args.prompt` must be non-empty.
+
+- `args.language`
+  - Type: `"python"` | `"node"` | `"bash"`
+  - Use when: you need a specific runtime. Default: `"node"`.
+
+- `args.timeout`
+  - Type: number
+  - Use when: you need an execution timeout in seconds (1-300).
+
+### Stop session
+
+`client.stopInteraction(jobId)` &rarr; `Promise<ScrapeBrowserDeleteResponse>`
+
+Response fields: `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` &rarr; `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` &rarr; `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+- Client constructor also accepts `timeoutMs`, `maxRetries`, and `backoffFactor`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json` (package name: `@mendable/firecrawl-js`)
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,323 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+Canonical Firecrawl Python quickstart for external agents. Aligned with `firecrawl-py` and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-YOUR-API-KEY")
+# Or use the FIRECRAWL_API_KEY environment variable:
+client = Firecrawl()
+```
+
+An async client is also available:
+
+```python
+from firecrawl import AsyncFirecrawl
+
+client = AsyncFirecrawl()
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` &rarr; `SearchData`
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    limit=5,
+    scrape_options={"formats": ["markdown"], "only_main_content": True},
+)
+
+for hit in results.web or []:
+    print(hit.title, hit.url)
+```
+
+### Parameters
+
+- `query`
+  - Type: str (required)
+  - The search query. Use `site:example.com` to scope results to a domain.
+
+- `sources`
+  - Type: list of source names or source objects
+  - Use when: you want to control which source types are searched.
+  - Values: `"web"`, `"news"`, `"images"`, or `{"type": "web"}` etc.
+
+- `categories`
+  - Type: list of category names or category objects
+  - Use when: you want category-filtered results.
+  - Values: `"github"`, `"research"`, `"pdf"`, or `{"type": "github"}` etc.
+
+- `limit`
+  - Type: int
+  - Use when: you want to cap the number of results. Default: 5.
+
+- `tbs`
+  - Type: str
+  - Use when: you need a time-based filter (`qdr:d` for past day, `qdr:w` for past week, `qdr:m` for past month, `sbd:1` to sort by date).
+
+- `location`
+  - Type: str
+  - Use when: you want localized results (e.g. `"San Francisco,California,United States"`).
+
+- `include_domains`
+  - Type: list of str
+  - Use when: you want to restrict results to specific domains.
+
+- `exclude_domains`
+  - Type: list of str
+  - Use when: you want to exclude specific domains from results.
+
+- `ignore_invalid_urls`
+  - Type: bool
+  - Use when: you want to drop URLs that cannot be scraped by other Firecrawl endpoints.
+
+- `timeout`
+  - Type: int
+  - Use when: you need a request timeout in milliseconds. Default: 300000.
+
+- `scrape_options`
+  - Type: ScrapeOptions or dict
+  - Use when: you want to scrape each search result inline. Accepts the same fields as the Scrape parameters below (using snake_case).
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` &rarr; `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        "links",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+    timeout=30000,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+- `url`
+  - Type: str (required)
+  - The URL to scrape.
+
+- `formats`
+  - Type: list of format strings or format dicts
+  - Use when: you want specific output formats.
+  - Plain string formats: `"markdown"`, `"html"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"change_tracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`
+  - Object-only formats:
+    - `{"type": "json", "prompt": str, "schema": dict}`: at least one of `prompt` or `schema` required.
+    - `{"type": "question", "question": str}`: question-answer extraction.
+    - `{"type": "highlights", "query": str}`: relevant source-text extraction.
+    - `{"type": "screenshot", "full_page": bool, "quality": int, "viewport": {"width": int, "height": int}}`: screenshot with options.
+    - `{"type": "changeTracking", "modes": list, "schema": dict, "prompt": str, "tag": str}`: `modes` required.
+    - `{"type": "attributes", "selectors": [{"selector": str, "attribute": str}]}`: attribute extraction.
+
+- `headers`
+  - Type: dict of str to str
+  - Use when: you need custom HTTP headers (cookies, user-agent, etc.).
+
+- `include_tags`
+  - Type: list of str
+  - Use when: you want to include only specific HTML tags.
+
+- `exclude_tags`
+  - Type: list of str
+  - Use when: you want to exclude specific HTML tags.
+
+- `only_main_content`
+  - Type: bool
+  - Use when: you want to strip nav, footer, and other boilerplate. Default: true (per OpenAPI).
+
+- `timeout`
+  - Type: int
+  - Use when: you need a request timeout in milliseconds. Default: 60000. Range: 1000-300000.
+
+- `wait_for`
+  - Type: int
+  - Use when: you need to wait for the page to render (milliseconds).
+
+- `mobile`
+  - Type: bool
+  - Use when: you want a mobile viewport.
+
+- `parsers`
+  - Type: list of parser names or dicts
+  - Use when: you need file parsing controls.
+  - Values: `"pdf"` or `{"type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": int}`.
+
+- `actions`
+  - Type: list of action dicts
+  - Use when: you need pre-scrape browser actions.
+  - Action types:
+    - `{"type": "wait", "milliseconds": int}` or `{"type": "wait", "selector": str}`
+    - `{"type": "click", "selector": str}`
+    - `{"type": "write", "text": str}`
+    - `{"type": "press", "key": str}`
+    - `{"type": "scroll", "direction": "up" | "down", "selector": str}`
+    - `{"type": "screenshot", "full_page": bool, "quality": int, "viewport": dict}`
+    - `{"type": "scrape"}`
+    - `{"type": "executeJavascript", "script": str}`
+    - `{"type": "pdf", "format": str, "landscape": bool, "scale": float}`
+
+- `location`
+  - Type: Location or dict with `country` and `languages`
+  - Use when: you need geo or language-aware scraping. Default country: `"US"`.
+
+- `skip_tls_verification`
+  - Type: bool
+  - Use when: you need to skip TLS certificate verification.
+
+- `remove_base64_images`
+  - Type: bool
+  - Use when: you want to remove base64 images from markdown output.
+
+- `fast_mode`
+  - Type: bool
+  - Use when: you want faster scrapes with reduced fidelity.
+
+- `block_ads`
+  - Type: bool
+  - Use when: you want ad and cookie popup blocking.
+
+- `proxy`
+  - Type: str
+  - Use when: you need proxy control.
+  - Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL.
+
+- `max_age`
+  - Type: int
+  - Use when: you want cached data up to a maximum age (milliseconds). Default: 172800000 (2 days).
+
+- `min_age`
+  - Type: int
+  - Use when: you only want cached data at least this old (milliseconds). Returns 404 on cache miss.
+
+- `store_in_cache`
+  - Type: bool
+  - Use when: you want Firecrawl to cache the result.
+
+- `lockdown`
+  - Type: bool
+  - Use when: you only want cached results and never want outbound requests. Returns 404 on cache miss.
+
+- `profile`
+  - Type: dict with `name` (str) and optional `save_changes` (bool)
+  - Use when: you want a persistent browser profile shared across scrapes and interactions.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrape_id`). The SDK requires at least one of `code` or `prompt`.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)` &rarr; `BrowserExecuteResponse`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id
+
+result = client.interact(
+    job_id,
+    prompt="Click the pricing tab and summarize the plans.",
+)
+print(result.output)
+
+# Or with code:
+code_result = client.interact(
+    job_id,
+    code="console.log(await page.title());",
+    language="node",
+    timeout=60,
+)
+print(code_result.stdout)
+
+# Stop the session when done:
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+- `job_id`
+  - Type: str (required)
+  - The scrape job ID from `document.metadata.scrape_id`.
+
+- `code`
+  - Type: str
+  - Use when: you want to run code in the browser sandbox.
+
+- `prompt`
+  - Type: str
+  - Use when: you want the browser agent to follow a natural-language instruction.
+
+- At least one of `code` or `prompt` must be provided.
+
+- `language`
+  - Type: `"python"` | `"node"` | `"bash"`
+  - Use when: you need a specific runtime. Default: `"node"`.
+
+- `timeout`
+  - Type: int
+  - Use when: you need an execution timeout in seconds (1-300).
+
+### Stop session
+
+`client.stop_interaction(job_id)` &rarr; `BrowserDeleteResponse`
+
+Response fields: `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` &rarr; `interact`; `delete_scrape_browser` and `stop_interactive_browser` &rarr; `stop_interaction`.
+- `Firecrawl` is also exported as `FirecrawlApp`; `AsyncFirecrawl` is also exported as `AsyncFirecrawlApp`.
+- Client constructor accepts `api_url` (default: `"https://api.firecrawl.dev"`), `timeout` (seconds), `max_retries` (default: 3), and `backoff_factor` (default: 0.5).
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,345 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+Canonical Firecrawl Rust quickstart for external agents. Aligned with the `firecrawl` crate **v2.4.1** and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::FirecrawlClient;
+
+// Cloud service (API key required)
+let client = FirecrawlClient::new("fc-YOUR-API-KEY")?;
+
+// Self-hosted (API key optional)
+let client = FirecrawlClient::new_selfhosted(
+    "https://your-instance.com",
+    Some("fc-YOUR-API-KEY"),
+)?;
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query, options)` &rarr; `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::search::SearchOptions;
+
+let response = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    SearchOptions {
+        limit: Some(5),
+        ..Default::default()
+    },
+).await?;
+
+for hit in response.data.web.unwrap_or_default() {
+    println!("{}", hit.url);
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option` and default to `None`:
+
+- `limit`
+  - Type: `Option<u32>`
+  - Use when: you want to cap the number of results. Default: 5, max: 20.
+
+- `sources`
+  - Type: `Option<Vec<SearchSource>>`
+  - Use when: you want to control which source types are searched.
+  - Values: `SearchSource::Web`, `SearchSource::News`, `SearchSource::Images`.
+
+- `categories`
+  - Type: `Option<Vec<SearchCategory>>`
+  - Use when: you want category-filtered results.
+  - Values: `SearchCategory::Github`, `SearchCategory::Research`, `SearchCategory::Pdf`.
+
+- `include_domains`
+  - Type: `Option<Vec<String>>`
+  - Use when: you want to restrict results to specific domains.
+
+- `exclude_domains`
+  - Type: `Option<Vec<String>>`
+  - Use when: you want to exclude specific domains from results.
+
+- `tbs`
+  - Type: `Option<String>`
+  - Use when: you need a time-based filter (e.g. `"qdr:d"` for past day).
+
+- `location`
+  - Type: `Option<String>`
+  - Use when: you want localized results.
+
+- `ignore_invalid_urls`
+  - Type: `Option<bool>`
+  - Use when: you want to drop URLs that cannot be scraped by other Firecrawl endpoints.
+
+- `timeout`
+  - Type: `Option<u32>`
+  - Use when: you need a request timeout in milliseconds.
+
+- `scrape_options`
+  - Type: `Option<ScrapeOptions>`
+  - Use when: you want to scrape each search result inline. Accepts the same fields as the Scrape parameters below.
+
+- `integration`
+  - Type: `Option<String>`
+  - Use when: you need to tag the request for integration tracking.
+
+### Convenience method
+
+`client.search_and_scrape(query, limit)` &rarr; `Result<Vec<Document>, FirecrawlError>`
+
+Automatically applies scraping to search results and returns only documents.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` &rarr; `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::scrape::{ScrapeOptions, Format};
+
+let doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Links]),
+        only_main_content: Some(true),
+        timeout: Some(30000),
+        ..Default::default()
+    },
+).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option` and default to `None`:
+
+- `formats`
+  - Type: `Option<Vec<Format>>`
+  - Use when: you want specific output formats.
+  - Enum values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`, `Query(QueryFormat)`.
+
+- `headers`
+  - Type: `Option<HashMap<String, String>>`
+  - Use when: you need custom HTTP headers.
+
+- `include_tags`
+  - Type: `Option<Vec<String>>`
+  - Use when: you want to include only specific HTML tags.
+
+- `exclude_tags`
+  - Type: `Option<Vec<String>>`
+  - Use when: you want to exclude specific HTML tags.
+
+- `only_main_content`
+  - Type: `Option<bool>`
+  - Use when: you want to strip nav, footer, and other boilerplate.
+
+- `timeout`
+  - Type: `Option<u32>`
+  - Use when: you need a request timeout in milliseconds.
+
+- `wait_for`
+  - Type: `Option<u32>`
+  - Use when: you need to wait for the page to render (milliseconds).
+
+- `mobile`
+  - Type: `Option<bool>`
+  - Use when: you want a mobile viewport.
+
+- `parsers`
+  - Type: `Option<Vec<ParserConfig>>`
+  - Use when: you need file parsing controls. `ParserConfig` has `type` (`"pdf"`), optional `mode` (`"fast"`, `"auto"`, `"ocr"`), optional `max_pages`.
+
+- `actions`
+  - Type: `Option<Vec<Action>>`
+  - Use when: you need pre-scrape browser actions.
+  - Variants: `Wait { milliseconds, selector }`, `Click { selector }`, `Write { text }`, `Press { key }`, `Scroll { direction, selector }`, `Screenshot { full_page, quality, viewport }`, `Scrape`, `ExecuteJavascript { script }`, `Pdf { format, landscape, scale }`.
+
+- `location`
+  - Type: `Option<LocationConfig>`
+  - Use when: you need geo or language-aware scraping. Fields: `country` (ISO 3166-1), `languages`.
+
+- `skip_tls_verification`
+  - Type: `Option<bool>`
+  - Use when: you need to skip TLS certificate verification.
+
+- `remove_base64_images`
+  - Type: `Option<bool>`
+  - Use when: you want to remove base64 images from output.
+
+- `fast_mode`
+  - Type: `Option<bool>`
+  - Use when: you want faster scrapes with reduced fidelity.
+
+- `block_ads`
+  - Type: `Option<bool>`
+  - Use when: you want ad and cookie popup blocking.
+
+- `proxy`
+  - Type: `Option<ProxyType>`
+  - Use when: you need proxy control.
+  - Values: `ProxyType::Basic`, `ProxyType::Stealth`, `ProxyType::Enhanced`, `ProxyType::Auto`.
+
+- `max_age`
+  - Type: `Option<u32>`
+  - Use when: you want cached data up to a maximum age (seconds).
+
+- `min_age`
+  - Type: `Option<u32>`
+  - Use when: you only want cached data at least this old (seconds).
+
+- `store_in_cache`
+  - Type: `Option<bool>`
+  - Use when: you want Firecrawl to cache the result.
+
+- `lockdown`
+  - Type: `Option<bool>`
+  - Use when: you only want cached results and never want outbound requests.
+
+- `profile`
+  - Type: `Option<ProfileConfig>`
+  - Use when: you want a persistent browser profile. Fields: `name` (1-128 chars), `save_changes`.
+
+- `json_options`
+  - Type: `Option<JsonOptions>`
+  - Use when: you want JSON extraction. Fields: `schema`, `system_prompt`, `prompt`.
+
+- `screenshot_options`
+  - Type: `Option<ScreenshotOptions>`
+  - Use when: you want screenshot configuration. Fields: `full_page`, `quality` (1-100), `viewport`.
+
+- `change_tracking_options`
+  - Type: `Option<ChangeTrackingOptions>`
+  - Use when: you want change tracking. Fields: `modes` (`GitDiff`/`Json`), `schema`, `prompt`, `tag`.
+
+- `integration`
+  - Type: `Option<String>`
+  - Use when: you need to tag the request for integration tracking.
+
+### Convenience method
+
+`client.scrape_with_schema(url, schema, prompt)` &rarr; `Result<Value, FirecrawlError>`
+
+Combines scraping with JSON schema extraction in one call.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. The SDK requires at least one of `code` or `prompt` to be non-empty.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` &rarr; `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::scrape::ScrapeExecuteOptions;
+
+let doc = client.scrape("https://example.com", None).await?;
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_ref())
+    .expect("Missing scrapeId");
+
+let result = client.interact(
+    job_id,
+    ScrapeExecuteOptions {
+        code: Some("console.log(await page.title());".into()),
+        language: Some(ScrapeExecuteLanguage::Node),
+        timeout: Some(60),
+        ..Default::default()
+    },
+).await?;
+
+println!("{}", result.stdout.unwrap_or_default());
+
+// Stop the session when done:
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields:
+
+- `code`
+  - Type: `Option<String>`
+  - Use when: you want to run code in the browser sandbox.
+
+- `prompt`
+  - Type: `Option<String>`
+  - Use when: you want the browser agent to follow a natural-language instruction.
+
+- At least one of `code` or `prompt` must be non-empty.
+
+- `language`
+  - Type: `Option<ScrapeExecuteLanguage>`
+  - Use when: you need a specific runtime. Default: `Node`.
+  - Values: `ScrapeExecuteLanguage::Python`, `ScrapeExecuteLanguage::Node`, `ScrapeExecuteLanguage::Bash`.
+
+- `timeout`
+  - Type: `Option<u32>`
+  - Use when: you need an execution timeout in seconds.
+
+- `origin`
+  - Type: `Option<String>`
+  - Use when: you need to tag the request for attribution.
+
+### Stop session
+
+`client.stop_interaction(job_id)` &rarr; `Result<ScrapeBrowserDeleteResponse, FirecrawlError>`
+
+Response fields: `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` &rarr; `interact`; `stop_interactive_browser` and `delete_scrape_browser` &rarr; `stop_interaction`.
+- All client methods are async and require a Tokio runtime.
+- The crate uses `serde` for serialization; struct fields use `snake_case` but serialize to `camelCase` for the API.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml` (crate name: `firecrawl`)
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language (Node.js, Python, Rust, Java, Elixir) in `docs/agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with full parameter documentation
- All content generated from SDK source code and the v2 OpenAPI spec — no invented parameters or defaults

### What each quickstart includes
- Install instructions and auth pattern
- When-to-use-what decision guide
- Preferred SDK method names with realistic examples
- Every confirmed parameter with type, description, and usage guidance
- Language-specific differences (e.g. Java/Elixir `interact` takes only `code`, not `prompt`)
- Deprecated alias migration notes
- Source-of-truth file references

### Note on placement
These files are intended for `firecrawl-docs/agent-quickstart/` but are staged in the main repo's `docs/` directory because the GitHub integration lacks write access to the `firecrawl-docs` repository. They should be moved to `firecrawl-docs` for production use, along with a `docs.json` navigation entry for the "Agent Quickstarts" group.

## Test plan

- [ ] Review each `.mdx` file renders correctly in Mintlify
- [ ] Verify parameter lists match current SDK source
- [ ] Confirm examples compile/run against latest SDK versions
- [ ] Move files to `firecrawl-docs/agent-quickstart/` and add navigation entry

https://claude.ai/code/session_015fiUgbv2NpSjJsRiGESeFB

---
_Generated by [Claude Code](https://claude.ai/code/session_015fiUgbv2NpSjJsRiGESeFB)_