### PR TITLE
fix(docker): wait for nuq-postgres before starting api

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,6 +111,8 @@ services:
         condition: service_started
       rabbitmq:
         condition: service_healthy
+      nuq-postgres:
+        condition: service_healthy
     ports:
       - "${PORT:-3002}:${INTERNAL_PORT:-3002}"
     volumes:
@@ -166,6 +168,16 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -h 127.0.0.1 -p 5432 -U \"$${POSTGRES_USER:-postgres}\" -d \"$${POSTGRES_DB:-postgres}\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     networks:
       - backend
     logging:


### PR DESCRIPTION
## Current-head update — 2026-08-23

This PR has been rebased onto the live `firecrawl/main` at `ca0be9b7d91e` and remains a single commit. Current head: `4e25a3c3ebaa`.

The latest rendered-Compose validation and the distinction from the broader open #3673 are in the most recent PR comment. The older validation references below describe the pre-rebase head and should be read as historical context only.

### Summary

Adds a `pg_isready` healthcheck to `nuq-postgres` and makes `api` wait for `condition: service_healthy` instead of only waiting for the container to start.

The probe has a 30-second `start_period` before five 5-second retries, so cold database initialization has room without delaying an already-healthy server. `POSTGRES_USER` / `POSTGRES_DB` expand from the container environment at runtime.

### Why

Compose still starts the API with `POSTGRES_HOST=nuq-postgres`, but current `main` only waits for redis, playwright, and a healthy RabbitMQ. `nuq-postgres` has no healthcheck, so the API/harness can race a cold Postgres start.

This follows the RabbitMQ readiness pattern already on `main`.

### Scope

- One file: `docker-compose.yaml`
- Does not change the experimental FoundationDB services or introduce an FDB-only profile. Current `main` still starts both backends; this PR only gates the PostgreSQL path the API already depends on.
- #3673 is a broader Compose/Docker Desktop change and is not a substitute for this focused gate.

### Verification

Rebased onto current `main` (`b304eff46`).

- `docker compose --env-file /dev/null config --quiet` — passed
- Rendered config: `api.depends_on.nuq-postgres.condition == service_healthy`
- Healthcheck: `pg_isready` with 5s interval/timeout, 5 retries, `start_period=30s`
- Runtime `POSTGRES_USER` / `POSTGRES_DB` remain escaped for container-side expansion
- `git diff --check` — passed