### PR TITLE
fix(api): reject AVIF/HEIF/MP4 served as application/octet-stream

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/utils/__tests__/detectIsobmffMime.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/__tests__/detectIsobmffMime.test.ts
@@ -1,0 +1,76 @@
+import { detectIsobmffMime } from "../specialtyHandler";
+
+// Builds a minimal 24-byte ISOBMFF "ftyp" box with the given major brand,
+// matching what real AVIF/HEIC/MP4 files have at byte offset 0.
+function ftypBox(brand: string): Buffer {
+  const head = Buffer.alloc(24);
+  head.writeUInt32BE(24, 0); // box size
+  head.write("ftyp", 4, "ascii");
+  head.write(brand, 8, "ascii");
+  // bytes 12-15: minor version (zeros)
+  head.write(brand, 16, "ascii"); // one compatible brand
+  // bytes 20-23: padding (zeros)
+  return head;
+}
+
+describe("detectIsobmffMime", () => {
+  it("detects AVIF (avif brand)", () => {
+    expect(detectIsobmffMime(ftypBox("avif"))).toBe("image/avif");
+  });
+
+  it("detects animated AVIF (avis brand)", () => {
+    expect(detectIsobmffMime(ftypBox("avis"))).toBe("image/avif");
+  });
+
+  it("detects HEIC (heic brand)", () => {
+    expect(detectIsobmffMime(ftypBox("heic"))).toBe("image/heic");
+  });
+
+  it("detects HEIF (mif1 brand)", () => {
+    expect(detectIsobmffMime(ftypBox("mif1"))).toBe("image/heif");
+  });
+
+  it("detects MP4 (isom brand)", () => {
+    expect(detectIsobmffMime(ftypBox("isom"))).toBe("video/mp4");
+  });
+
+  it("detects QuickTime (qt brand with trailing spaces)", () => {
+    expect(detectIsobmffMime(ftypBox("qt  "))).toBe("video/quicktime");
+  });
+
+  it("returns null for an unknown ftyp brand", () => {
+    expect(detectIsobmffMime(ftypBox("zzzz"))).toBeNull();
+  });
+
+  it("rejects buffers shorter than 12 bytes", () => {
+    expect(detectIsobmffMime(Buffer.alloc(0))).toBeNull();
+    expect(
+      detectIsobmffMime(
+        Buffer.from([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x61]),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects HTML content", () => {
+    expect(
+      detectIsobmffMime(
+        Buffer.from("<!DOCTYPE html><html><body>not an image</body></html>"),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects PDF content", () => {
+    expect(detectIsobmffMime(Buffer.from("%PDF-1.4 rest of file..."))).toBeNull();
+  });
+
+  it("rejects a ZIP archive", () => {
+    expect(
+      detectIsobmffMime(
+        Buffer.from([
+          0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00,
+          0x00, 0x00, 0x00,
+        ]),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -6,6 +6,34 @@ import os from "os";
 import { writeFile } from "fs/promises";
 import { Meta } from "../..";
 
+// Some CDNs serve image/video files with Content-Type: application/octet-stream
+// rather than image/* or video/*, which bypasses the prefix-based rejection in
+// specialtyScrapeCheck. Detect ISOBMFF-family files (AVIF/HEIF/HEIC, MP4, MOV)
+// by the "ftyp" box at byte offset 4 so they can still be rejected.
+const ISOBMFF_BRAND_TO_MIME: Record<string, string> = {
+  avif: "image/avif",
+  avis: "image/avif",
+  heic: "image/heic",
+  heix: "image/heic",
+  hevc: "image/heic",
+  hevx: "image/heic",
+  mif1: "image/heif",
+  msf1: "image/heif",
+  mp41: "video/mp4",
+  mp42: "video/mp4",
+  isom: "video/mp4",
+  iso2: "video/mp4",
+  "M4V ": "video/mp4",
+  "qt  ": "video/quicktime",
+};
+
+export function detectIsobmffMime(buf: Buffer): string | null {
+  if (buf.length < 12) return null;
+  if (buf.toString("ascii", 4, 8) !== "ftyp") return null;
+  const brand = buf.toString("ascii", 8, 12);
+  return ISOBMFF_BRAND_TO_MIME[brand] ?? null;
+}
+
 async function feResToFilePrefetch(
   logger: Logger,
   feRes: FireEngineCheckStatusSuccess | undefined,
@@ -154,6 +182,17 @@ export async function specialtyScrapeCheck(
       feRes?.content.startsWith("%PDF-"))
   ) {
     throw new AddFeatureError(["pdf"], await feResToPdfPrefetch(logger, feRes));
+  }
+
+  // Check for octet-stream with ISOBMFF signature (AVIF/HEIF/HEIC, MP4, MOV).
+  // Some CDNs label these as application/octet-stream rather than image/* or
+  // video/*, which would otherwise slip past the prefix check below.
+  if (isOctetStream && feRes?.file?.content) {
+    const head = Buffer.from(feRes.file.content.slice(0, 32), "base64");
+    const isobmffMime = detectIsobmffMime(head);
+    if (isobmffMime) {
+      throw new UnsupportedFileError(isobmffMime);
+    }
   }
 
   // Reject unsupported binary content types (images, video, audio, archives, etc.)


### PR DESCRIPTION
Hey friends,

Thanks for the most excellent service.

While using `https://api.firecrawl.dev/v1/scrape?format=markdown` we observed the endpoint returns binary content if the user provided a video URL.

Since we're asking for `markdown` format, I think it makes more sense to get back an `UnsupportedFileError`.

This PR adds detection for these sorts of files and rejects them.

I've tried to do this in a way that is consistent with the existing codebase.

Thanks!

🙏 🙏 🙏 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects AVIF/HEIF/HEIC and MP4/MOV files served as `application/octet-stream` so `format=markdown` no longer returns binary mojibake and instead fails with a clear `UnsupportedFileError`.

- **Bug Fixes**
  - Detects ISOBMFF files by the `ftyp` box at byte offset 4 (brands for AVIF/HEIF/HEIC, MP4, QuickTime) when the response is `application/octet-stream`.
  - Throws `UnsupportedFileError` with the inferred MIME instead of passing binary through to markdown.
  - Adds `detectIsobmffMime` helper and unit tests.

<sup>Written for commit e55280fb6cb5d537b5f25f7d2a3b7da87a951267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

