### PR TITLE
feat(api/pdf): opt-in async fire-pdf client behind __experimental_firePdfAsync

### DIFF
--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -127,6 +127,38 @@ describe("/v2/parse", () => {
       },
       scrapeTimeout * 2,
     );
+
+    // The flag travels via baseScrapeOptions → parse request body →
+    // scrapeOptions → meta.options on the worker side, same path
+    // __forceFirePDF uses. Async path silently falls back to sync /ocr
+    // on any error, so an identically-shaped response is the contract
+    // we assert here.
+    it(
+      "accepts __experimental_firePdfAsync on parse uploads",
+      async () => {
+        expect(pdfFixture).not.toBeNull();
+
+        const result = await parse(
+          {
+            options: {
+              formats: ["markdown"],
+              parsers: [{ type: "pdf", mode: "ocr" }],
+              __experimental_firePdfAsync: true,
+            },
+            file: {
+              content: pdfFixture!,
+              filename: "upload.pdf",
+              contentType: "application/pdf",
+            },
+          },
+          identity,
+        );
+
+        expect(result.markdown).toContain("PDF Test File");
+        expect(result.metadata.numPages).toBeGreaterThan(0);
+      },
+      scrapeTimeout * 2,
+    );
   });
 
   it(

--- a/apps/api/src/__tests__/snips/v2/parsers.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parsers.test.ts
@@ -221,6 +221,33 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
     );
   });
 
+  // The async path silently falls back to sync /ocr on any error (404,
+  // 503, network, terminal failure, …), so this test verifies the
+  // user-visible contract: flag=true produces an identically-shaped
+  // response to the existing sync path. Whether the request actually
+  // traversed /jobs vs. /ocr depends on staging — both outcomes
+  // satisfy the acceptance criteria.
+  describe("__experimental_firePdfAsync (opt-in async fire-pdf)", () => {
+    it.concurrent(
+      "with mode 'ocr' returns markdown identical-shape to sync",
+      async () => {
+        const response = await scrape(
+          {
+            url: pdfUrl,
+            parsers: [{ type: "pdf", mode: "ocr" }],
+            __experimental_firePdfAsync: true,
+          },
+          identity,
+        );
+
+        expect(response.markdown).toBeDefined();
+        expect(response.markdown).toContain("PDF Test File");
+        expect(response.metadata.numPages).toBeGreaterThan(0);
+      },
+      scrapeTimeout * 2,
+    );
+  });
+
   describe("Default behavior", () => {
     it.concurrent(
       "parses PDF by default when parsers not specified",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -174,6 +174,7 @@ const configSchema = z.object({
   FIRE_PDF_PERCENT: z.coerce.number().min(0).max(100).default(10),
   FIRE_PDF_BASE_URL: z.string().optional(),
   FIRE_PDF_API_KEY: z.string().optional(),
+  GCS_FIRE_PDF_BUCKET_NAME: z.string().default("firecrawl-pdf-pipeline"),
 
   // RunPod
   RUNPOD_MU_API_KEY: z.string().optional(),

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -528,6 +528,7 @@ const baseScrapeOptions = z.strictObject({
   __experimental_omce: z.boolean().prefault(false).optional(),
   __experimental_omceDomain: z.string().optional(),
   __forceFirePDF: z.boolean().prefault(false).optional(),
+  __experimental_firePdfAsync: z.boolean().prefault(false).optional(),
 });
 
 const fire1RefineOpts = {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -610,6 +610,7 @@ const baseScrapeOptions = z.strictObject({
   __experimental_omceDomain: z.string().optional(),
   __experimental_engpicker: z.boolean().prefault(false).optional(),
   __forceFirePDF: z.boolean().prefault(false).optional(),
+  __experimental_firePdfAsync: z.boolean().prefault(false).optional(),
 });
 
 type ScrapeOptionsBase = z.infer<typeof baseScrapeOptions>;

--- a/apps/api/src/lib/fire-pdf-metrics.ts
+++ b/apps/api/src/lib/fire-pdf-metrics.ts
@@ -1,0 +1,45 @@
+import { Counter, Histogram } from "prom-client";
+
+export const firePdfAsyncSubmittedTotal = new Counter({
+  name: "firecrawl_fire_pdf_async_submitted_total",
+  help: "Fire-pdf /jobs submissions accepted (POST returned 200 or 202)",
+  labelNames: ["lane"],
+});
+
+export const firePdfAsyncCompletedTotal = new Counter({
+  name: "firecrawl_fire_pdf_async_completed_total",
+  help: "Fire-pdf async jobs that reached a terminal status via GET",
+  labelNames: ["terminal_status"],
+});
+
+// reason ∈ {http_404, http_503, http_429, http_5xx, http_4xx, network_error,
+//           terminal_failed, terminal_expired, terminal_cancelled,
+//           polling_timeout, gcs_upload_failed, gcs_download_failed}
+export const firePdfAsyncFallbackTotal = new Counter({
+  name: "firecrawl_fire_pdf_async_fallback_total",
+  help: "Fire-pdf async path fell back to sync /ocr",
+  labelNames: ["reason"],
+});
+
+export const firePdfAsyncTotalDurationSeconds = new Histogram({
+  name: "firecrawl_fire_pdf_async_total_duration_seconds",
+  help: "Seconds from 'decide to use async' to 'result available'",
+  buckets: [0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1200, 1800],
+});
+
+export const firePdfAsyncPollCount = new Histogram({
+  name: "firecrawl_fire_pdf_async_poll_count",
+  help: "Number of GET /jobs/<id> polls per async job",
+  buckets: [1, 2, 5, 10, 20, 50, 100, 200, 500],
+});
+
+// Lane assignment mirrors fire-pdf's server-side classification. Used as
+// the `lane` label on the submitted counter so we can see traffic mix
+// before fire-pdf reports it on its own metrics.
+export function laneForPages(pages: number | undefined): string {
+  if (pages === undefined) return "unknown";
+  if (pages <= 10) return "fast";
+  if (pages <= 100) return "standard";
+  if (pages <= 250) return "heavy";
+  return "xl";
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDFAsync.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDFAsync.ts
@@ -1,0 +1,427 @@
+import { Meta } from "../..";
+import { config } from "../../../../config";
+import { z } from "zod";
+import { fetch } from "undici";
+import type { PDFProcessorResult } from "./types";
+import type { PDFMode } from "../../../../controllers/v2/types";
+import { safeMarkdownToHtml } from "./markdownToHtml";
+import { createPdfCacheKey } from "../../../../lib/gcs-pdf-cache";
+import { storage } from "../../../../lib/gcs-jobs";
+import {
+  firePdfAsyncSubmittedTotal,
+  firePdfAsyncCompletedTotal,
+  firePdfAsyncFallbackTotal,
+  firePdfAsyncTotalDurationSeconds,
+  firePdfAsyncPollCount,
+  laneForPages,
+} from "../../../../lib/fire-pdf-metrics";
+import { scrapePDFWithFirePDF } from "./firePDF";
+import { AbortManagerThrownError } from "../../lib/abortManager";
+
+// Per /jobs validation: 5s < (deadline_at - now) < 30min.
+const MIN_DEADLINE_MS = 5_000;
+const MAX_DEADLINE_MS = 30 * 60 * 1000;
+const DEFAULT_DEADLINE_MS = 5 * 60 * 1000;
+
+// Polling cadence: floor from retry_after_ms, default 1s, cap 5s,
+// exponential growth up to the cap.
+const POLL_DEFAULT_MS = 1_000;
+const POLL_MAX_MS = 5_000;
+
+// After deadline_at passes the worker is supposed to write `expired`;
+// give it 30s of grace before we abandon the async path ourselves.
+const POLL_BUFFER_AFTER_DEADLINE_MS = 30_000;
+
+type FallbackReason =
+  | "http_404"
+  | "http_503"
+  | "http_429"
+  | "http_5xx"
+  | "http_4xx"
+  | "network_error"
+  | "terminal_failed"
+  | "terminal_expired"
+  | "terminal_cancelled"
+  | "polling_timeout"
+  | "gcs_upload_failed"
+  | "gcs_download_failed";
+
+class AsyncFallback extends Error {
+  reason: FallbackReason;
+  constructor(reason: FallbackReason) {
+    super(`fire-pdf async fallback: ${reason}`);
+    this.reason = reason;
+  }
+}
+
+function parseGcsUri(uri: string): { bucket: string; key: string } | null {
+  if (!uri.startsWith("gs://")) return null;
+  const rest = uri.slice("gs://".length);
+  const slash = rest.indexOf("/");
+  if (slash <= 0 || slash === rest.length - 1) return null;
+  return { bucket: rest.slice(0, slash), key: rest.slice(slash + 1) };
+}
+
+const submitResponseSchema = z.object({
+  scrape_id: z.string().optional(),
+  status: z.enum(["queued", "published", "done"]).optional(),
+  retry_after_ms: z.number().optional(),
+});
+
+const pollResponseSchema = z.object({
+  scrape_id: z.string().optional(),
+  status: z.enum([
+    "queued",
+    "published",
+    "running",
+    "done",
+    "failed",
+    "expired",
+    "cancelled",
+  ]),
+  result_gcs_uri: z.string().optional(),
+  pages_processed: z.number().optional(),
+  failed_pages: z.array(z.number()).nullable().optional(),
+  partial_pages: z.array(z.number()).nullable().optional(),
+});
+
+const resultJsonSchema = z.object({
+  markdown: z.string(),
+  failed_pages: z.array(z.number()).nullable().optional(),
+  pages_processed: z.number().optional(),
+});
+
+async function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  if (signal.aborted) {
+    throw (signal.reason as Error) ?? new Error("aborted");
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject((signal.reason as Error) ?? new Error("aborted"));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function runAsync(
+  meta: Meta,
+  base64Content: string,
+  maxPages: number | undefined,
+  pagesProcessed: number | undefined,
+  mode: PDFMode | undefined,
+): Promise<PDFProcessorResult> {
+  const logger = meta.logger;
+  const scrapeId = meta.id;
+  const signal = meta.abort.asSignal();
+
+  const inputBucket = config.GCS_FIRE_PDF_BUCKET_NAME;
+  const inputKey = `inputs/${scrapeId}.pdf`;
+  const inputUri = `gs://${inputBucket}/${inputKey}`;
+
+  const pdfBuffer = Buffer.from(base64Content, "base64");
+  const pdfSha256 = createPdfCacheKey(pdfBuffer);
+
+  // 1) Upload PDF to the input bucket. Fire-pdf workers read from here.
+  try {
+    const bucket = storage.bucket(inputBucket);
+    await bucket.file(inputKey).save(pdfBuffer, {
+      contentType: "application/pdf",
+      metadata: {
+        source: "firecrawl_fire_pdf_async",
+        scrape_id: scrapeId,
+        sha256: pdfSha256,
+      },
+    });
+  } catch (error) {
+    logger.warn("Fire-pdf async: GCS upload failed", { error, scrapeId });
+    throw new AsyncFallback("gcs_upload_failed");
+  }
+
+  meta.abort.throwIfAborted();
+
+  // 2) Compute deadline_at — fire-pdf requires 5s < delta < 30min.
+  const remainingMs = meta.abort.scrapeTimeout() ?? DEFAULT_DEADLINE_MS;
+  const clamped = Math.min(
+    MAX_DEADLINE_MS - 1000,
+    Math.max(MIN_DEADLINE_MS + 1000, Math.floor(remainingMs)),
+  );
+  const submitTime = Date.now();
+  const deadlineEpochMs = submitTime + clamped;
+  const deadlineAt = new Date(deadlineEpochMs).toISOString();
+
+  const lane = laneForPages(pagesProcessed);
+
+  const submitBody: Record<string, unknown> = {
+    scrape_id: scrapeId,
+    input_gcs_uri: inputUri,
+    input_sha256: pdfSha256,
+    source: "firecrawl",
+    zdr: false,
+    deadline_at: deadlineAt,
+    team_id: meta.internalOptions.teamId,
+    ...(meta.internalOptions.crawlId && {
+      crawl_id: meta.internalOptions.crawlId,
+    }),
+    options: {
+      ...(pagesProcessed !== undefined &&
+        pagesProcessed > 0 && { pages_estimate: pagesProcessed }),
+      ...(maxPages !== undefined && { max_pages: maxPages }),
+      ...(mode !== undefined && { mode }),
+    },
+  };
+
+  logger.info("Fire-pdf async: submitting job", {
+    scrapeId,
+    inputUri,
+    deadlineAt,
+    lane,
+    pagesEstimate: pagesProcessed,
+    maxPages,
+    mode,
+  });
+
+  // 3) POST /jobs
+  let submitResp;
+  try {
+    submitResp = await fetch(`${config.FIRE_PDF_BASE_URL}/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(config.FIRE_PDF_API_KEY
+          ? { Authorization: `Bearer ${config.FIRE_PDF_API_KEY}` }
+          : {}),
+      },
+      body: JSON.stringify(submitBody),
+      signal,
+    });
+  } catch (error) {
+    meta.abort.throwIfAborted();
+    if (error instanceof AbortManagerThrownError) throw error;
+    logger.warn("Fire-pdf async: POST /jobs network error", {
+      error,
+      scrapeId,
+    });
+    throw new AsyncFallback("network_error");
+  }
+
+  const submitStatus = submitResp.status;
+  if (submitStatus === 404) throw new AsyncFallback("http_404");
+  if (submitStatus === 503) throw new AsyncFallback("http_503");
+  if (submitStatus === 429) throw new AsyncFallback("http_429");
+  if (submitStatus >= 500) throw new AsyncFallback("http_5xx");
+  if (submitStatus !== 200 && submitStatus !== 202) {
+    let body = "";
+    try {
+      body = (await submitResp.text()).slice(0, 500);
+    } catch {
+      // body read may fail after abort; ignore — we're already falling back
+    }
+    logger.warn("Fire-pdf async: POST /jobs returned unexpected status", {
+      status: submitStatus,
+      body,
+      scrapeId,
+    });
+    throw new AsyncFallback("http_4xx");
+  }
+
+  let submitJson: z.infer<typeof submitResponseSchema>;
+  try {
+    submitJson = submitResponseSchema.parse(await submitResp.json());
+  } catch (error) {
+    logger.warn("Fire-pdf async: malformed POST /jobs response", {
+      error,
+      scrapeId,
+    });
+    throw new AsyncFallback("http_5xx");
+  }
+
+  firePdfAsyncSubmittedTotal.labels({ lane }).inc();
+
+  // 4) Poll GET /jobs/<scrape_id> until terminal.
+  let pollDelayMs = Math.max(
+    POLL_DEFAULT_MS,
+    Math.min(POLL_MAX_MS, submitJson.retry_after_ms ?? POLL_DEFAULT_MS),
+  );
+  let pollCount = 0;
+  let terminal: z.infer<typeof pollResponseSchema> | null = null;
+
+  while (terminal === null) {
+    if (Date.now() > deadlineEpochMs + POLL_BUFFER_AFTER_DEADLINE_MS) {
+      throw new AsyncFallback("polling_timeout");
+    }
+
+    await sleepWithAbort(pollDelayMs, signal);
+    meta.abort.throwIfAborted();
+    pollCount++;
+
+    let pollResp;
+    try {
+      pollResp = await fetch(
+        `${config.FIRE_PDF_BASE_URL}/jobs/${encodeURIComponent(scrapeId)}`,
+        {
+          method: "GET",
+          headers: {
+            ...(config.FIRE_PDF_API_KEY
+              ? { Authorization: `Bearer ${config.FIRE_PDF_API_KEY}` }
+              : {}),
+          },
+          signal,
+        },
+      );
+    } catch (error) {
+      meta.abort.throwIfAborted();
+      if (error instanceof AbortManagerThrownError) throw error;
+      logger.warn("Fire-pdf async: GET /jobs network error", {
+        error,
+        scrapeId,
+        pollCount,
+      });
+      throw new AsyncFallback("network_error");
+    }
+
+    const pollStatus = pollResp.status;
+    if (pollStatus === 404) throw new AsyncFallback("http_404");
+    if (pollStatus >= 500) throw new AsyncFallback("http_5xx");
+    if (pollStatus !== 200) throw new AsyncFallback("http_4xx");
+
+    let pollJson: z.infer<typeof pollResponseSchema>;
+    try {
+      pollJson = pollResponseSchema.parse(await pollResp.json());
+    } catch (error) {
+      logger.warn("Fire-pdf async: malformed GET /jobs response", {
+        error,
+        scrapeId,
+      });
+      throw new AsyncFallback("http_5xx");
+    }
+
+    switch (pollJson.status) {
+      case "done":
+        terminal = pollJson;
+        firePdfAsyncCompletedTotal.labels({ terminal_status: "done" }).inc();
+        break;
+      case "failed":
+        firePdfAsyncCompletedTotal.labels({ terminal_status: "failed" }).inc();
+        throw new AsyncFallback("terminal_failed");
+      case "expired":
+        firePdfAsyncCompletedTotal.labels({ terminal_status: "expired" }).inc();
+        throw new AsyncFallback("terminal_expired");
+      case "cancelled":
+        firePdfAsyncCompletedTotal
+          .labels({ terminal_status: "cancelled" })
+          .inc();
+        throw new AsyncFallback("terminal_cancelled");
+      default:
+        // queued / published / running — exponential backoff, capped.
+        pollDelayMs = Math.min(POLL_MAX_MS, Math.ceil(pollDelayMs * 1.5));
+        break;
+    }
+  }
+
+  firePdfAsyncPollCount.observe(pollCount);
+
+  // 5) Download the result JSON from GCS.
+  if (!terminal.result_gcs_uri) {
+    logger.warn("Fire-pdf async: terminal 'done' without result_gcs_uri", {
+      scrapeId,
+    });
+    throw new AsyncFallback("gcs_download_failed");
+  }
+  const parsed = parseGcsUri(terminal.result_gcs_uri);
+  if (!parsed) {
+    logger.warn("Fire-pdf async: malformed result_gcs_uri", {
+      scrapeId,
+      uri: terminal.result_gcs_uri,
+    });
+    throw new AsyncFallback("gcs_download_failed");
+  }
+
+  let resultJson: z.infer<typeof resultJsonSchema>;
+  try {
+    const [content] = await storage
+      .bucket(parsed.bucket)
+      .file(parsed.key)
+      .download();
+    resultJson = resultJsonSchema.parse(JSON.parse(content.toString()));
+  } catch (error) {
+    logger.warn("Fire-pdf async: GCS result download/parse failed", {
+      error,
+      scrapeId,
+    });
+    throw new AsyncFallback("gcs_download_failed");
+  }
+
+  const pages =
+    resultJson.pages_processed ?? terminal.pages_processed ?? pagesProcessed;
+
+  logger.info("Fire-pdf async: completed", {
+    scrapeId,
+    pollCount,
+    pagesProcessed: pages,
+    markdownLength: resultJson.markdown.length,
+    failedPages: resultJson.failed_pages,
+  });
+
+  return {
+    markdown: resultJson.markdown,
+    html: await safeMarkdownToHtml(resultJson.markdown, logger, scrapeId),
+    pagesProcessed: pages,
+  };
+}
+
+/**
+ * Async fire-pdf client (POST /jobs + poll + GCS result). Behavior contract:
+ *
+ *   - On success, returns a result indistinguishable from `scrapePDFWithFirePDF`.
+ *   - On any fallback condition (admission decline, terminal failure,
+ *     polling timeout, GCS error), silently falls back to the sync /ocr
+ *     path so the user never sees a failure they would not have seen
+ *     before. The reason is recorded on the fallback counter.
+ *   - Abort propagates as `AbortManagerThrownError` — we do NOT fall back
+ *     when the scrape-tier budget has been exhausted.
+ */
+export async function scrapePDFWithFirePDFAsync(
+  meta: Meta,
+  base64Content: string,
+  maxPages: number | undefined,
+  pagesProcessed: number | undefined,
+  mode: PDFMode | undefined,
+): Promise<PDFProcessorResult> {
+  const startedAt = Date.now();
+  try {
+    const result = await runAsync(
+      meta,
+      base64Content,
+      maxPages,
+      pagesProcessed,
+      mode,
+    );
+    firePdfAsyncTotalDurationSeconds.observe((Date.now() - startedAt) / 1000);
+    return result;
+  } catch (error) {
+    if (error instanceof AsyncFallback) {
+      firePdfAsyncFallbackTotal.labels({ reason: error.reason }).inc();
+      meta.logger.info("Fire-pdf async falling back to sync /ocr", {
+        scrapeId: meta.id,
+        reason: error.reason,
+        elapsedMs: Date.now() - startedAt,
+      });
+      const syncResult = await scrapePDFWithFirePDF(
+        meta,
+        base64Content,
+        maxPages,
+        pagesProcessed,
+        mode,
+      );
+      firePdfAsyncTotalDurationSeconds.observe((Date.now() - startedAt) / 1000);
+      return syncResult;
+    }
+    throw error;
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -34,6 +34,7 @@ import {
 import { withSpan, setSpanAttributes } from "../../../../lib/otel-tracer";
 import { scrapePDFWithRunPodMU } from "./runpodMU";
 import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
+import { scrapePDFWithFirePDFAsync } from "./firePDFAsync";
 import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
@@ -399,12 +400,23 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           Math.random() * 100 < config.FIRE_PDF_PERCENT);
 
       if (useFirePDF) {
+        // ZDR traffic must stay on sync /ocr — fire-pdf's /jobs handler
+        // requires zdr:false and we don't want PDF bytes parked in GCS
+        // for ZDR-flagged requests.
+        const useAsync =
+          !!meta.options.__experimental_firePdfAsync &&
+          !meta.internalOptions.zeroDataRetention;
         try {
-          result = await scrapePDFWithFirePDF(
+          const firePdfCall = useAsync
+            ? scrapePDFWithFirePDFAsync
+            : scrapePDFWithFirePDF;
+          result = await firePdfCall(
             {
               ...meta,
               logger: meta.logger.child({
-                method: "scrapePDF/firePDF",
+                method: useAsync
+                  ? "scrapePDF/firePDFAsync"
+                  : "scrapePDF/firePDF",
               }),
             },
             base64Content,


### PR DESCRIPTION
## Summary

- Adds a per-request flag `__experimental_firePdfAsync` (v1 + v2 scrape options, also available on `/v2/parse` since it extends the same base) that, when true and not ZDR, routes PDF parsing through fire-pdf's new `/jobs` async pipeline (GCS upload → POST /jobs → poll → GCS download) instead of the sync `/ocr` endpoint. Default false everywhere — zero behavior change for existing callers.
- On any failure of the async path (404, 503, 429, 5xx, network error, terminal `failed`/`expired`/`cancelled`, polling timeout, GCS upload/download error) the client silently falls back to the existing sync `scrapePDFWithFirePDF` so the user never sees a request fail that would have succeeded on sync. `AbortManagerThrownError` always propagates — we don't paper over a real scrape-budget exhaustion.
- ZDR requests never enter the async path (the `/jobs` handler requires `zdr:false`, and we don't park PDF bytes in GCS for ZDR traffic).
- New prom-client metrics in `apps/api/src/lib/fire-pdf-metrics.ts`: `firecrawl_fire_pdf_async_submitted_total{lane}`, `..._completed_total{terminal_status}`, `..._fallback_total{reason}`, `..._total_duration_seconds`, `..._poll_count`. Lane label mirrors fire-pdf's server-side classification (`fast`/`standard`/`heavy`/`xl`) based on `pages_estimate`.
- Bucket name is configurable via new env var `GCS_FIRE_PDF_BUCKET_NAME` (default `firecrawl-pdf-pipeline`).
- Out of scope (separate PRs): percentage rollout, shadow comparison, DELETE-on-cancellation, async-side admission enforcement.

### Prerequisites for production rollout
- Firecrawl needs GCS write IAM on `firecrawl-pdf-pipeline` (input bucket) and read on the results path.
- `FIRE_PDF_BASE_URL` must point to the fire-pdf API service that registers `/jobs`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in async fire-pdf path behind `__experimental_firePdfAsync`. When enabled (and not ZDR), PDFs go through `/jobs` (GCS upload → poll → download) with silent fallback to the sync `/ocr`. Default behavior is unchanged.

- **New Features**
  - Accepts `__experimental_firePdfAsync` in v1/v2 scrape options and `/v2/parse` uploads.
  - Async path submits to `/jobs`, polls for completion, and downloads results from GCS; supports `mode`, `max_pages`, and page estimates.
  - Adds `prom-client` metrics for async submissions, completions, fallbacks, total duration, and poll count.
  - New env var `GCS_FIRE_PDF_BUCKET_NAME` (default `firecrawl-pdf-pipeline`).

- **Migration**
  - Grant GCS write on the input bucket and read on results for Firecrawl.
  - Set `FIRE_PDF_BASE_URL` to the fire-pdf service that exposes `/jobs`.
  - Optionally override `GCS_FIRE_PDF_BUCKET_NAME`.

<sup>Written for commit d31efb5fc6e76d78e173f26ddac838b9a204bfb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

