### PR TITLE
Add agent quickstart docs for all 5 SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,210 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `:firecrawl` Hex package v1.4.0 source and the v2 OpenAPI spec. Function names and parameters match the SDK public API. The Elixir client is auto-generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.4.0"}
+  ]
+end
+```
+
+## Authenticate
+
+Set the API key in your application config:
+
+```elixir
+config :firecrawl, api_key: "fc-your-api-key"
+```
+
+Or pass `api_key:` as an option on each call:
+
+```elixir
+Firecrawl.search_and_scrape([query: "..."], api_key: "fc-your-api-key")
+```
+
+## When To Use What
+
+- **search_and_scrape** — start with a query and need to discover relevant pages.
+- **scrape_and_extract_from_url** — already have a URL and want page content in one or more formats.
+- **interact_with_scrape_browser_session** — the page needs code execution in the browser session after a scrape.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params, opts)` → `{:ok, response} | {:error, exception}`
+
+Bang variant: `Firecrawl.search_and_scrape!(params, opts)` → `Req.Response.t()` (raises on error)
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  limit: 5
+)
+
+for hit <- response.body["data"]["web"] || [] do
+  IO.puts("#{hit["url"]} #{hit["title"]}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Validated by `NimbleOptions`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | Search query. **Required.** |
+| `sources` | `list(any)` | Sources: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list(any)` | Categories to filter by. Default: `[]`. |
+| `include_domains` | `list(string)` | Restrict to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `list(string)` | Exclude these domains. |
+| `limit` | `integer` | Max results. |
+| `tbs` | `string` | Time-based filter (e.g. `"qdr:d"` for past day). Supports `qdr:h`, `qdr:d`, `qdr:w`, `qdr:m`, `qdr:y`, custom ranges, and `sbd:1` sort. |
+| `location` | `string` | Location for geo-targeted results (e.g. `"San Francisco,California,United States"`). |
+| `country` | `string` | ISO country code for geo-targeting (e.g. `"US"`). |
+| `ignore_invalid_urls` | `boolean` | Skip invalid URLs in results. |
+| `timeout` | `integer` | Timeout in milliseconds. |
+| `scrape_options` | `keyword_list` | Scrape each result (same fields as scrape). |
+| `enterprise` | `list(string)` | Enterprise options: `["zdr"]` or `["anon"]` for zero data retention. Must be enabled. |
+
+### Return value
+
+`{:ok, %Req.Response{}}` where `response.body` contains `"data"` with `"web"`, `"news"`, `"images"` arrays.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params, opts)` → `{:ok, response} | {:error, exception}`
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts)` → `Req.Response.t()`
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: ["markdown", %{type: "json", prompt: "Extract plan names and prices."}],
+  only_main_content: true
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | URL to scrape. **Required.** |
+| `formats` | `list(any)` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"branding"`, `"audio"`, `"video"`. Objects: `%{type: "json", schema: ..., prompt: ...}`, `%{type: "question", question: ...}`, `%{type: "highlights", query: ...}`. |
+| `headers` | `any` | Custom HTTP headers. |
+| `include_tags` | `list(string)` | HTML tags to include. |
+| `exclude_tags` | `list(string)` | HTML tags to exclude. |
+| `only_main_content` | `boolean` | Strip nav, footer, boilerplate. |
+| `timeout` | `integer` | Timeout in milliseconds. Min: 1000, max: 300000. |
+| `wait_for` | `integer` | Wait before scraping (milliseconds). |
+| `mobile` | `boolean` | Emulate mobile viewport. |
+| `parsers` | `list(any)` | File parsing controls (e.g. `["pdf"]` or `[%{type: "pdf", mode: "auto", maxPages: 5}]`). |
+| `actions` | `list(any)` | Browser actions before scraping (wait, click, write, press, scroll, screenshot, scrape, executeJavascript, pdf). |
+| `location` | `keyword_list` | Geo and language settings (e.g. `[country: "US", languages: ["en"]]`). |
+| `skip_tls_verification` | `boolean` | Skip TLS verification. |
+| `remove_base64_images` | `boolean` | Remove base64 images from markdown. |
+| `block_ads` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy mode. |
+| `max_age` | `integer` | Return cached data up to this age (milliseconds). Default: 2 days. |
+| `min_age` | `integer` | Cache-only mode. Set to `1` to accept any cached data. |
+| `store_in_cache` | `boolean` | Cache the result. |
+| `lockdown` | `boolean` | Serve from cache only; never make outbound requests. |
+| `profile` | `keyword_list` | Persistent browser profile (e.g. `[name: "my-session", saveChanges: true]`). |
+| `zero_data_retention` | `boolean` | Enable zero data retention. |
+
+## Interact
+
+### Why use it
+
+Use `interact_with_scrape_browser_session` to execute code in the browser session tied to a scrape job.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params, opts)` → `{:ok, response} | {:error, exception}`
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)` → `Req.Response.t()`
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+
+IO.puts(result.body["stdout"])
+
+# Stop the session when done:
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+`job_id` is a path parameter (first argument). Remaining parameters are a keyword list.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `String.t()` | Scrape job ID. **Required** (first argument). |
+| `code` | `string` | Code to execute in the browser sandbox. **Required.** |
+| `language` | `:python \| :node \| :bash` | Runtime for code execution. Use `:node` for JavaScript. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+| `origin` | `string` | Origin label for execution telemetry. |
+
+### Return value
+
+`{:ok, %Req.Response{}}` where `response.body` contains execution results (`"stdout"`, `"stderr"`, `"exitCode"`, etc).
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts)` → `{:ok, response} | {:error, exception}`
+
+## Notes
+
+- The Elixir SDK is auto-generated from the OpenAPI spec. Function names match the OpenAPI operation IDs, not friendlier aliases.
+- The Elixir SDK `interact_with_scrape_browser_session` only accepts `code`, not `prompt`. For natural-language browser control, use the Node.js or Python SDKs.
+- Parameters use snake_case in Elixir and are mapped to camelCase for the JSON request body.
+- Languages for `interact` are atoms (`:python`, `:node`, `:bash`), not strings.
+- Proxy values are atoms (`:basic`, `:enhanced`, `:auto`), not strings.
+- Errors are returned as `{:error, %Firecrawl.Error{status: ..., body: ...}}` for HTTP errors.
+- All functions accept a second options keyword list for per-call overrides (`api_key:`, `base_url:`, and any `Req` options).
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs` (v1.4.0)
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,235 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `com.firecrawl:firecrawl-java` v1.6.0 SDK source and the v2 OpenAPI spec. Method names and parameters match the SDK public API.
+
+## Install
+
+**Gradle:**
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.6.0'
+```
+
+**Maven:**
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.6.0</version>
+</dependency>
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// From environment variable (FIRECRAWL_API_KEY)
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+// Or with explicit key
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-your-api-key")
+    .build();
+```
+
+Optional builder methods: `apiUrl(String)`, `timeoutMs(long)` (default 300000), `maxRetries(int)` (default 3), `backoffFactor(double)` (default 0.5), `asyncExecutor(Executor)`, `httpClient(OkHttpClient)`.
+
+## When To Use What
+
+- **search** — start with a query and need to discover relevant pages.
+- **scrape** — already have a URL and want page content in one or more formats.
+- **interact** — the page needs code execution in the browser session after a scrape.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries",
+    SearchOptions.builder()
+        .limit(5)
+        .build()
+);
+
+for (var hit : results.getWeb()) {
+    System.out.println(hit.get("url") + " " + hit.get("title"));
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are optional. Build via `SearchOptions.builder()`.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `sources(List<Object>)` | `List` | Sources: `"web"`, `"news"`, `"images"`. |
+| `categories(List<Object>)` | `List` | Categories: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains(List<String>)` | `List<String>` | Restrict to these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains(List<String>)` | `List<String>` | Exclude these domains. |
+| `limit(Integer)` | `Integer` | Max results. |
+| `tbs(String)` | `String` | Time-based filter (e.g. `"qdr:d"`). |
+| `location(String)` | `String` | Location for geo-targeted results. |
+| `ignoreInvalidURLs(Boolean)` | `Boolean` | Drop URLs that cannot be scraped. |
+| `timeout(Integer)` | `Integer` | Timeout in milliseconds. |
+| `scrapeOptions(ScrapeOptions)` | `ScrapeOptions` | Scrape each result (same fields as `scrape`). |
+| `integration(String)` | `String` | Integration identifier. |
+
+### Return value
+
+`SearchData` with `getWeb()`, `getNews()`, `getImages()` returning `List<Map<String, Object>>`.
+
+### Async variant
+
+`client.searchAsync(query, options)` → `CompletableFuture<SearchData>`
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import java.util.List;
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are optional. Build via `ScrapeOptions.builder()`.
+
+| Method | Type | Description |
+|--------|------|-------------|
+| `formats(List<Object>)` | `List` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`, `"video"`, etc. Object forms supported for `json`, `question`, `highlights`, etc. |
+| `headers(Map<String, String>)` | `Map` | Custom HTTP headers. |
+| `includeTags(List<String>)` | `List<String>` | HTML tags to include. |
+| `excludeTags(List<String>)` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent(Boolean)` | `Boolean` | Strip nav, footer, boilerplate. |
+| `timeout(Integer)` | `Integer` | Timeout in milliseconds. |
+| `waitFor(Integer)` | `Integer` | Wait before scraping (milliseconds). |
+| `mobile(Boolean)` | `Boolean` | Emulate mobile viewport. |
+| `parsers(List<Object>)` | `List` | File parsing controls (e.g. `"pdf"` or `Map.of("type", "pdf", "maxPages", 10)`). |
+| `actions(List<Map<String, Object>>)` | `List` | Browser actions before scraping (wait, click, write, press, scroll, screenshot, scrape, executeJavascript, pdf). |
+| `location(LocationConfig)` | `LocationConfig` | Geo and language settings. |
+| `skipTlsVerification(Boolean)` | `Boolean` | Skip TLS verification. |
+| `removeBase64Images(Boolean)` | `Boolean` | Remove base64 images from markdown. |
+| `blockAds(Boolean)` | `Boolean` | Block ads and cookie popups. |
+| `proxy(String)` | `String` | `"basic"`, `"stealth"`, `"enhanced"`, or `"auto"`. |
+| `maxAge(Long)` | `Long` | Return cached data up to this age (milliseconds). |
+| `storeInCache(Boolean)` | `Boolean` | Cache the result. |
+| `lockdown(Boolean)` | `Boolean` | Serve from cache only. |
+| `integration(String)` | `String` | Integration identifier. |
+
+### Async variant
+
+`client.scrapeAsync(url, options)` → `CompletableFuture<Document>`
+
+## Interact
+
+### Why use it
+
+Use `interact` to execute code in the browser session tied to a scrape job. For multi-step browser flows, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, code)` → `BrowserExecuteResponse`
+
+Overloads:
+- `client.interact(jobId, code)`
+- `client.interact(jobId, code, language, timeout)`
+- `client.interact(jobId, code, language, timeout, origin)`
+
+### Example
+
+```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build()
+);
+
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+System.out.println(result.getStdout());
+
+// Stop the session when done:
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `String` | Scrape job ID from `document.getMetadata().get("scrapeId")`. **Required.** |
+| `code` | `String` | Code to execute in the browser session. **Required.** |
+| `language` | `String` | `"python"`, `"node"`, or `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: 30. Nullable. |
+| `origin` | `String` | Origin tag for request attribution. Nullable. |
+
+### Return value
+
+`BrowserExecuteResponse` with: `isSuccess()`, `getStdout()`, `getStderr()`, `getResult()`, `getExitCode()`, `getKilled()`, `getError()`.
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` → `BrowserDeleteResponse`
+
+### Async variants
+
+- `client.interactAsync(jobId, code)` → `CompletableFuture<BrowserExecuteResponse>`
+- `client.interactAsync(jobId, code, language, timeout)` → `CompletableFuture<BrowserExecuteResponse>`
+- `client.interactAsync(jobId, code, language, timeout, origin)` → `CompletableFuture<BrowserExecuteResponse>`
+- `client.stopInteractiveBrowserAsync(jobId)` → `CompletableFuture<BrowserDeleteResponse>`
+
+## Notes
+
+- The Java SDK `interact` method only accepts `code`, not `prompt`. For natural-language browser control, use the Node.js or Python SDKs.
+- All parameter names use camelCase (Java convention).
+- Deprecated aliases: `scrapeExecute()` → `interact()`; `deleteScrapeBrowser()` → `stopInteractiveBrowser()`.
+- Async methods use `CompletableFuture` and run on a configurable `Executor` (default: `ForkJoinPool.commonPool()`).
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts` (v1.6.0)
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,199 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `@mendable/firecrawl-js` v4.23.0 SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Requires Node.js >= 22.
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+The client reads `FIRECRAWL_API_KEY` and optionally `FIRECRAWL_API_URL` from the environment. You can also pass `apiUrl`, `timeoutMs`, `maxRetries`, and `backoffFactor` to the constructor.
+
+## When To Use What
+
+- **search** — start with a query and need to discover relevant pages.
+- **scrape** — already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, forms, or other browser actions after a scrape has created a session. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const hit of results.web ?? []) {
+  console.log(hit.url, hit.title);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | Search query. Use `site:example.com` to limit results to a domain. **Required.** |
+| `options.sources` | `("web" \| "news" \| "images")[]` | Sources to search. Default: `["web"]`. |
+| `options.categories` | `("github" \| "research" \| "pdf")[]` | Filter results by category. |
+| `options.includeDomains` | `string[]` | Restrict results to these domains. Cannot combine with `excludeDomains`. |
+| `options.excludeDomains` | `string[]` | Exclude these domains. Cannot combine with `includeDomains`. |
+| `options.limit` | `number` | Max results to return. Must be positive. |
+| `options.tbs` | `string` | Time-based filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week, `"sbd:1,qdr:m"`). |
+| `options.location` | `string` | Location string for geo-targeted results. |
+| `options.ignoreInvalidURLs` | `boolean` | Drop URLs that cannot be scraped by other endpoints. |
+| `options.timeout` | `number` | Request timeout in milliseconds. Must be positive. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each result with these options (same fields as `scrape`). |
+
+### Return value
+
+`SearchData` with optional arrays keyed by source type:
+
+- `web` — web results (lightweight objects or full `Document` when `scrapeOptions` is set)
+- `news` — news results
+- `images` — image results
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | URL to scrape. **Required.** |
+| `options.formats` | `FormatOption[]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Objects: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`. Note: plain `"json"` string is rejected by the SDK — use the object form. |
+| `options.headers` | `Record<string, string>` | Custom HTTP headers. |
+| `options.includeTags` | `string[]` | HTML tags to include. |
+| `options.excludeTags` | `string[]` | HTML tags to exclude. |
+| `options.onlyMainContent` | `boolean` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `number` | Timeout in milliseconds. |
+| `options.waitFor` | `number` | Wait time in milliseconds before scraping. |
+| `options.mobile` | `boolean` | Emulate mobile viewport. |
+| `options.parsers` | `ParserConfig[]` | File parsing controls (e.g. `[{ type: "pdf", mode: "auto", maxPages: 5 }]`). |
+| `options.actions` | `ActionOption[]` | Browser actions before scraping. Types: `wait` (milliseconds or selector), `screenshot`, `click` (selector), `write` (text), `press` (key), `scroll` (direction, selector?), `scrape`, `executeJavascript` (script), `pdf` (format?, landscape?, scale?). |
+| `options.location` | `{ country?: string, languages?: string[] }` | Geo and language settings. |
+| `options.skipTlsVerification` | `boolean` | Skip TLS verification. |
+| `options.removeBase64Images` | `boolean` | Remove base64 images from markdown. |
+| `options.fastMode` | `boolean` | Faster scrapes with reduced fidelity. |
+| `options.blockAds` | `boolean` | Block ads and cookie popups. |
+| `options.proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy mode. `"auto"` retries with enhanced on failure. |
+| `options.maxAge` | `number` | Return cached data up to this age (milliseconds). |
+| `options.minAge` | `number` | Cache-only mode; returns 404 on cache miss. Set to `1` to accept any cached data. |
+| `options.storeInCache` | `boolean` | Cache the result. |
+| `options.lockdown` | `boolean` | Serve from cache only; never make outbound requests. |
+| `options.profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile for shared state across sessions. |
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. The SDK requires at least one of `code` or `prompt`. For flows beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+console.log(result.output);
+
+// Or use code directly:
+const codeResult = await client.interact(jobId, {
+  code: "console.log(await page.title());",
+  language: "node",
+  timeout: 60,
+});
+console.log(codeResult.stdout);
+
+// Stop the session when done:
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `string` | Scrape job ID from `document.metadata.scrapeId`. **Required.** |
+| `args.code` | `string` | Code to execute in the browser session. At least one of `code` or `prompt` is required. |
+| `args.prompt` | `string` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` is required. |
+| `args.language` | `"python" \| "node" \| "bash"` | Runtime for code execution. Default: `"node"`. |
+| `args.timeout` | `number` | Execution timeout in seconds (1–300). |
+
+### Return value
+
+`ScrapeExecuteResponse` with fields: `success`, `output`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `liveViewUrl`, `interactiveLiveViewUrl`, `error`.
+
+### Stop session
+
+`client.stopInteraction(jobId)` → `Promise<ScrapeBrowserDeleteResponse>` with `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- All parameter names use camelCase.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json` (v4.23.0)
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,192 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl-py` v4.26.0 SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="your-api-key")
+# Or set the FIRECRAWL_API_KEY environment variable and omit api_key.
+```
+
+Optional constructor parameters: `api_url`, `timeout`, `max_retries` (default 3), `backoff_factor` (default 0.5).
+
+For async usage, use `AsyncFirecrawl` with the same interface.
+
+## When To Use What
+
+- **search** — start with a query and need to discover relevant pages.
+- **scrape** — already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query, **kwargs)` → `SearchData`
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for hit in results.web or []:
+    print(hit.url, hit.title)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | Search query. **Required.** |
+| `sources` | `list[str]` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list[str]` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `limit` | `int` | Max results. Default: 5, max: 100. |
+| `tbs` | `str` | Time-based filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `str` | Location string for geo-targeted results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs in results. |
+| `timeout` | `int` | Request timeout in milliseconds. Default: 300000, max: 300000. |
+| `scrape_options` | `ScrapeOptions` | Scrape each result with these options (same fields as `scrape`). |
+| `integration` | `str` | Integration identifier. |
+
+### Return value
+
+`SearchData` with optional lists keyed by source type:
+
+- `web` — `SearchResultWeb` or `Document` objects
+- `news` — `SearchResultNews` or `Document` objects
+- `images` — `SearchResultImages` or `Document` objects
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **kwargs)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` | URL to scrape. **Required.** |
+| `formats` | `list[FormatOption]` | Output formats. Strings: `"markdown"`, `"html"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"change_tracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Objects: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "change_tracking", "modes": [...], "schema": ..., "prompt": ..., "tag": ...}`, `{"type": "attributes", "selectors": [...]}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. |
+| `include_tags` | `list[str]` | HTML tags to include. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait time in milliseconds before scraping. |
+| `mobile` | `bool` | Emulate mobile viewport. |
+| `parsers` | `list` | File parsing controls (e.g. `[{"type": "pdf", "mode": "auto", "max_pages": 5}]`). |
+| `actions` | `list[Action]` | Browser actions before scraping. Types: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | `Location(country="US", languages=["en"])` for geo and language settings. |
+| `skip_tls_verification` | `bool` | Skip TLS verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy mode. |
+| `max_age` | `int` | Return cached data up to this age (milliseconds). |
+| `min_age` | `int` | Cache-only mode; returns 404 on cache miss. Set to `1` to accept any cached data. |
+| `store_in_cache` | `bool` | Cache the result. |
+| `lockdown` | `bool` | Serve from cache only; never make outbound requests. |
+| `profile` | `dict` | Persistent browser profile (e.g. `{"name": "my-session", "saveChanges": True}`). |
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. Either `code` or `prompt` must be provided. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)` → `BrowserExecuteResponse`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+print(result.output)
+
+# Or use code directly:
+code_result = client.interact(job_id, code="console.log(await page.title());", language="node", timeout=60)
+print(code_result.stdout)
+
+# Stop the session when done:
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `str` | Scrape job ID from `document.metadata.scrape_id`. **Required.** |
+| `code` | `str` | Code to execute in the browser session. At least one of `code` or `prompt` is required. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Runtime for code execution. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+### Return value
+
+`BrowserExecuteResponse` with fields: `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+### Stop session
+
+`client.stop_interaction(job_id)` → `BrowserDeleteResponse` with `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- All parameter names use snake_case per Python convention.
+- Deprecated aliases: `scrape_execute()` → `interact()`; `delete_scrape_browser()` and `stop_interactive_browser()` → `stop_interaction()`.
+- Full async support via `AsyncFirecrawl` with the same method signatures.
+- Pydantic v2+ is used for type validation.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/__init__.py` (v4.26.0)
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,227 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` crate v2.5.0 source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2.5.0"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::FirecrawlClient;
+
+// Cloud (requires API key)
+let client = FirecrawlClient::new("fc-your-api-key")?;
+
+// Self-hosted (API key optional)
+let client = FirecrawlClient::new_selfhosted("https://your-instance.com", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- **search** — start with a query and need to discover relevant pages.
+- **scrape** — already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{FirecrawlClient, SearchOptions};
+
+let client = FirecrawlClient::new("fc-your-api-key")?;
+
+let results = client.search("site:docs.firecrawl.dev webhook retries", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+for hit in results.data.web.unwrap_or_default() {
+    println!("{}", hit.url());
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are optional. Uses `#[serde(rename_all = "camelCase")]`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `limit` | `Option<u32>` | Max results. Default: 5, max: 20. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Categories: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude these domains. |
+| `tbs` | `Option<String>` | Time-based filter (e.g. `"qdr:d"`). |
+| `location` | `Option<String>` | Location for geo-targeted results. |
+| `ignore_invalid_urls` | `Option<bool>` | Drop URLs that cannot be scraped. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape each result (same fields as `scrape`). |
+| `integration` | `Option<String>` | Integration identifier. |
+
+### Return value
+
+`SearchResponse` with `success`, `data` (`SearchData`), and optional `warning`. `SearchData` has:
+
+- `web` — `Vec<SearchResultOrDocument>` (either `WebResult` or `Document`)
+- `news` — `Vec<SearchResultNews>`
+- `images` — `Vec<SearchResultImage>`
+
+Convenience method: `client.search_and_scrape(query, limit)` returns only `Vec<Document>`.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{FirecrawlClient, ScrapeOptions, Format};
+
+let client = FirecrawlClient::new("fc-your-api-key")?;
+
+let doc = client.scrape("https://example.com/pricing", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are optional. Uses `#[serde(rename_all = "camelCase")]`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `only_main_content` | `Option<bool>` | Strip nav, footer, boilerplate. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Wait before scraping (milliseconds). |
+| `mobile` | `Option<bool>` | Emulate mobile viewport. |
+| `parsers` | `Option<Vec<ParserConfig>>` | File parsing controls (e.g. PDF: `ParserConfig::Pdf { ... }`). |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | `LocationConfig { country, languages }`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images from markdown. |
+| `fast_mode` | `Option<bool>` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `proxy` | `Option<ProxyType>` | `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Return cached data up to this age (seconds). |
+| `min_age` | `Option<u32>` | Cache-only mode. |
+| `store_in_cache` | `Option<bool>` | Cache the result. |
+| `lockdown` | `Option<bool>` | Serve from cache only. |
+| `profile` | `Option<ProfileConfig>` | `ProfileConfig { name, save_changes }`. |
+| `json_options` | `Option<JsonOptions>` | `JsonOptions { schema, system_prompt, prompt }`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | `ScreenshotOptions { full_page, quality, viewport }`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | `ChangeTrackingOptions { modes, schema, prompt, tag }`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | `AttributeSelector { selector, attribute }`. |
+| `integration` | `Option<String>` | Integration identifier. |
+
+Convenience method: `client.scrape_with_schema(url, schema, prompt)` returns extracted JSON directly.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. At least one of `code` or `prompt` must be non-empty.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{FirecrawlClient, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = FirecrawlClient::new("fc-your-api-key")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.scrape_id.as_ref())
+    .expect("scrape_id required");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some("console.log(await page.title());".into()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(60),
+    ..Default::default()
+}).await?;
+
+println!("{}", result.stdout.unwrap_or_default());
+
+// Stop the session when done:
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields (all optional, but at least `code` or `prompt` must be set):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | `Option<String>` | Code to execute. At least one of `code` or `prompt` required. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. |
+| `language` | `Option<ScrapeExecuteLanguage>` | `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `origin` | `Option<String>` | Origin tag for request attribution. |
+
+### Return value
+
+`ScrapeExecuteResponse` with: `success`, `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error`.
+
+### Stop session
+
+`client.stop_interaction(job_id)` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>` with `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- All structs use `#[serde(rename_all = "camelCase")]` for JSON serialization. Rust field names are snake_case.
+- String parameters use `impl AsRef<str>` to accept both `&str` and `String`.
+- Deprecated aliases: `scrape_execute()` → `interact()`; `stop_interactive_browser()` and `delete_scrape_browser()` → `stop_interaction()`.
+- Errors use a custom `FirecrawlError` enum with variants for API errors, HTTP errors, and parse errors.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml` (v2.5.0)
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file covers `search`, `scrape`, and `interact` endpoints with every confirmed parameter from SDK source and the v2 OpenAPI spec
- Documents language-specific differences (e.g. Java/Elixir `interact` only supports `code`, not `prompt`; Elixir uses atoms for enums; naming conventions per language)

### Files

- `docs/agent-quickstart/node.mdx` — @mendable/firecrawl-js v4.23.0
- `docs/agent-quickstart/python.mdx` — firecrawl-py v4.26.0
- `docs/agent-quickstart/rust.mdx` — firecrawl crate v2.5.0
- `docs/agent-quickstart/java.mdx` — firecrawl-java v1.6.0
- `docs/agent-quickstart/elixir.mdx` — :firecrawl Hex v1.4.0

### Note

These files are intended for `firecrawl-docs/agent-quickstart/` but write access to the `firecrawl-docs` repo was unavailable during this session. Please move them to firecrawl-docs when merging.

## Test plan

- [ ] Verify each quickstart renders correctly as Mintlify MDX
- [ ] Confirm parameter lists match current SDK source
- [ ] Check examples compile/run against latest SDK versions
- [ ] Move files to firecrawl-docs/agent-quickstart/ for production deployment

https://claude.ai/code/session_011Li76GnDwtrcPXPhKVr6Za

---
_Generated by [Claude Code](https://claude.ai/code/session_011Li76GnDwtrcPXPhKVr6Za)_