### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,223 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` Hex package source and the v2 OpenAPI spec. The Elixir SDK is auto-generated from the OpenAPI spec, so function names follow the spec operation IDs rather than short aliases.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.4"}
+  ]
+end
+```
+
+## Authenticate
+
+Configure via application config:
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+```
+
+Or pass per-request:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"], api_key: "fc-your-api-key")
+```
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages. Optionally scrape each result.
+- **scrape** — you already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, form fills, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Discover pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+```
+Firecrawl.search_and_scrape(params, opts) → {:ok, Req.Response.t()} | {:error, term()}
+```
+
+Bang variant: `Firecrawl.search_and_scrape!(params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  limit: 5,
+  scrape_options: [
+    formats: ["markdown"],
+    only_main_content: true
+  ]
+)
+
+for hit <- response.body["data"]["web"] || [] do
+  IO.puts("#{hit["url"]} #{String.slice(hit["markdown"] || "", 0, 200)}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. The SDK converts `snake_case` keys to `camelCase` for the API.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Search query. Use `site:example.com` to scope results. **Required.** |
+| `sources` | `list` | Source indices: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list` | Category filters: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list(string)` | Restrict results to these domains. |
+| `exclude_domains` | `list(string)` | Exclude results from these domains. |
+| `limit` | `integer` | Maximum results per source type. |
+| `tbs` | `string` | Time-based filter, e.g. `"qdr:d"` (past day). |
+| `location` | `string` | Geographic location for results. |
+| `country` | `string` | ISO country code, e.g. `"US"`. |
+| `ignore_invalid_urls` | `boolean` | Drop URLs that cannot be scraped. |
+| `timeout` | `integer` | Request timeout in milliseconds. |
+| `scrape_options` | `keyword` | Scrape each search result (nested keyword list with scrape params). |
+
+### Return value
+
+`{:ok, %Req.Response{}}` where `response.body["data"]` contains `"web"`, `"news"`, `"images"` lists.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats — markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```
+Firecrawl.scrape_and_extract_from_url(params, opts) → {:ok, Req.Response.t()} | {:error, term()}
+```
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    %{"type" => "json", "prompt" => "Extract plan names and prices."}
+  ],
+  only_main_content: true,
+  timeout: 30_000
+)
+
+IO.puts(response.body["data"]["markdown"])
+IO.inspect(response.body["data"]["json"])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | The URL to scrape. **Required.** |
+| `formats` | `list` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Maps for structured formats: `%{"type" => "json", "prompt" => ..., "schema" => ...}`, `%{"type" => "question", "question" => ...}`, `%{"type" => "highlights", "query" => ...}`. |
+| `headers` | `map` | Custom HTTP headers. |
+| `include_tags` | `list(string)` | HTML tags to include. |
+| `exclude_tags` | `list(string)` | HTML tags to exclude. |
+| `only_main_content` | `boolean` | Strip nav, footer, and boilerplate. |
+| `timeout` | `integer` | Request timeout in milliseconds. Min: 1000, max: 300000. |
+| `wait_for` | `integer` | Wait for the page to render (milliseconds). |
+| `mobile` | `boolean` | Emulate a mobile viewport. |
+| `parsers` | `list` | File parsing controls. E.g. `["pdf"]` or `[%{"type" => "pdf", "mode" => "auto", "maxPages" => 10}]`. |
+| `actions` | `list(map)` | Browser actions before scraping. |
+| `location` | `keyword` | Geo and language settings. Keys: `country`, `languages`. |
+| `skip_tls_verification` | `boolean` | Skip TLS certificate verification. |
+| `remove_base64_images` | `boolean` | Remove base64 images from markdown. |
+| `block_ads` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `atom \| string` | Proxy type: `:basic`, `:enhanced`, `:auto`. |
+| `max_age` | `integer` | Use cached result if younger than this (milliseconds). Default: 172800000. |
+| `min_age` | `integer` | Only return cached data. Set to `1` for any cached data. |
+| `store_in_cache` | `boolean` | Cache the result in Firecrawl. |
+| `lockdown` | `boolean` | Serve only cached results. |
+| `profile` | `keyword` | Persistent browser profile. Keys: `name`, `save_changes`. |
+| `zero_data_retention` | `boolean` | Enable zero data retention. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows — filling forms, clicking through pages, or running code in the browser sandbox.
+
+### Preferred SDK method
+
+```
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts) → {:ok, Req.Response.t()} | {:error, term()}
+```
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "document.querySelector('button').click()",
+  language: :node
+)
+
+IO.puts(result.body["stdout"])
+
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | Scrape job ID from the scrape response metadata. **Required (path param).** |
+| `code` | `string` | Code to execute in the browser sandbox. **Required.** |
+| `language` | `atom` | Runtime: `:python`, `:node`, `:bash`. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+| `origin` | `string` | Optional origin tag for telemetry. |
+
+### Return value
+
+`{:ok, %Req.Response{}}` where `response.body` contains `"success"`, `"stdout"`, `"result"`, `"stderr"`, `"exitCode"`, `"killed"`, `"error"`.
+
+### Stop session
+
+```
+Firecrawl.stop_interactive_scrape_browser_session(job_id, opts)
+```
+
+## Notes
+
+- The Elixir SDK is auto-generated from the OpenAPI spec, so function names are long and spec-derived (e.g. `scrape_and_extract_from_url` instead of `scrape`).
+- Parameters use `snake_case` keyword lists; the SDK converts to `camelCase` JSON.
+- Atoms (e.g. `:basic`, `:node`) are converted to strings for the API.
+- Return values are raw `Req.Response` structs — access data via `response.body`.
+- Error handling uses `{:ok, _} | {:error, _}` tuples; bang variants raise `Firecrawl.Error`.
+- Batch scrape available via `Firecrawl.scrape_and_extract_from_urls/2`.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,244 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `firecrawl-java` SDK source and the v2 OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.6.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.6.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+// Or from environment directly:
+// FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+The builder reads `FIRECRAWL_API_KEY` from the environment if `apiKey` is not set. An API key is required for the cloud service.
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages. Optionally scrape each result.
+- **scrape** — you already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, form fills, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Discover pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+```
+client.search(query, options) → SearchData
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries",
+    SearchOptions.builder()
+        .limit(5)
+        .scrapeOptions(ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .onlyMainContent(true)
+            .build())
+        .build());
+
+for (Map<String, Object> hit : results.getWeb()) {
+    System.out.println(hit.get("url") + " " + hit.get("markdown"));
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | Search query. Use `site:example.com` to scope results. |
+| `options.sources` | `List<Object>` | Source indices: `"web"`, `"news"`, `"images"`. |
+| `options.categories` | `List<Object>` | Category filters: `"github"`, `"research"`, `"pdf"`. |
+| `options.includeDomains` | `List<String>` | Restrict results to these domains. |
+| `options.excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `options.limit` | `Integer` | Maximum results per source type. |
+| `options.tbs` | `String` | Time-based filter, e.g. `"qdr:d"` (past day). |
+| `options.location` | `String` | Geographic location for results. |
+| `options.ignoreInvalidURLs` | `Boolean` | Drop URLs that cannot be scraped. |
+| `options.timeout` | `Integer` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each search result with these options. |
+| `options.integration` | `String` | Integration identifier for tracking. |
+
+### Return value
+
+`SearchData` has `getWeb()`, `getNews()`, `getImages()` — each returns `List<Map<String, Object>>`.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats — markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```
+client.scrape(url, options) → Document
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of(
+            "markdown",
+            JsonFormat.builder()
+                .prompt("Extract plan names and prices.")
+                .build()
+        ))
+        .onlyMainContent(true)
+        .timeout(30000)
+        .build());
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | The URL to scrape. |
+| `options.formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Objects: `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `options.headers` | `Map<String, String>` | Custom HTTP headers. |
+| `options.includeTags` | `List<String>` | HTML tags to include. |
+| `options.excludeTags` | `List<String>` | HTML tags to exclude. |
+| `options.onlyMainContent` | `Boolean` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `Integer` | Request timeout in milliseconds. |
+| `options.waitFor` | `Integer` | Wait for the page to render (milliseconds). |
+| `options.mobile` | `Boolean` | Emulate a mobile viewport. |
+| `options.parsers` | `List<Object>` | File parsing controls. E.g. `"pdf"` or `Map.of("type", "pdf", "maxPages", 10)`. |
+| `options.actions` | `List<Map<String, Object>>` | Browser actions before scraping. |
+| `options.location` | `LocationConfig` | Geo and language-aware scraping. Fields: `country`, `languages`. |
+| `options.skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `options.removeBase64Images` | `Boolean` | Remove base64 images from markdown. |
+| `options.blockAds` | `Boolean` | Block ads and cookie popups. |
+| `options.proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom URL. |
+| `options.maxAge` | `Long` | Use cached result if younger than this (milliseconds). |
+| `options.storeInCache` | `Boolean` | Cache the result. |
+| `options.lockdown` | `Boolean` | Serve only cached results. |
+| `options.integration` | `String` | Integration identifier. |
+
+### Format objects
+
+```java
+// JSON extraction
+JsonFormat.builder().prompt("...").schema(Map.of(...)).build()
+
+// Question answering
+QuestionFormat.builder().question("What is the pricing?").build()
+
+// Text highlights
+HighlightsFormat.builder().query("pricing plans").build()
+```
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows — filling forms, clicking through pages, or running code in the browser sandbox.
+
+### Preferred SDK method
+
+```
+client.interact(jobId, code) → BrowserExecuteResponse
+client.interact(jobId, code, language, timeout) → BrowserExecuteResponse
+client.interact(jobId, code, language, timeout, origin) → BrowserExecuteResponse
+```
+
+### Example
+
+```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+System.out.println(result.getStdout());
+
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | Scrape job ID from `document.getMetadata().get("scrapeId")`. |
+| `code` | `String` | Code to run in the browser session. |
+| `language` | `String` | Runtime: `"python"`, `"node"`, or `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: 30. |
+| `origin` | `String` | Optional origin tag for telemetry. |
+
+### Return value
+
+`BrowserExecuteResponse` fields: `isSuccess()`, `getStdout()`, `getStderr()`, `getResult()`, `getExitCode()`, `getKilled()`, `getError()`.
+
+### Stop session
+
+```
+client.stopInteractiveBrowser(jobId) → BrowserDeleteResponse
+```
+
+## Notes
+
+- Java SDK uses `camelCase` for all parameter names (matching the JSON API).
+- All options classes use the builder pattern.
+- Async variants available for all methods via `searchAsync`, `scrapeAsync`, `interactAsync` returning `CompletableFuture`.
+- Client builder also accepts `apiUrl`, `timeoutMs`, `maxRetries`, `backoffFactor`, `asyncExecutor`.
+- Requires Java 11+.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,205 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `@mendable/firecrawl-js` SDK source and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+The client reads `FIRECRAWL_API_KEY` from the environment if `apiKey` is not passed. An API key is required for the cloud service.
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages. Optionally scrape each result.
+- **scrape** — you already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, form fills, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Discover pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+```
+client.search(query, options?) → Promise<SearchData>
+```
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true,
+  },
+});
+
+for (const hit of results.web ?? []) {
+  console.log(hit.url, hit.markdown?.slice(0, 200));
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Search query. Use `site:example.com` to scope results. |
+| `options.sources` | `("web" \| "news" \| "images")[]` | Which source indices to search. |
+| `options.categories` | `("github" \| "research" \| "pdf")[]` | Category filters for results. |
+| `options.includeDomains` | `string[]` | Restrict results to these domains. |
+| `options.excludeDomains` | `string[]` | Exclude results from these domains. |
+| `options.limit` | `number` | Maximum results per source type. |
+| `options.tbs` | `string` | Time-based filter, e.g. `"qdr:d"` (past day), `"qdr:w"` (past week). |
+| `options.location` | `string` | Geographic location for results, e.g. `"San Francisco,California,United States"`. |
+| `options.ignoreInvalidURLs` | `boolean` | Drop URLs that cannot be scraped. |
+| `options.timeout` | `number` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each search result with these options. |
+| `options.integration` | `string` | Integration identifier for tracking. |
+
+### Return value
+
+`SearchData` contains optional arrays:
+
+- `web` — web results (lightweight result or full `Document` when `scrapeOptions` is set)
+- `news` — news results
+- `images` — image results
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats — markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```
+client.scrape(url, options?) → Promise<Document>
+```
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+  timeout: 30000,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | The URL to scrape. |
+| `options.formats` | `FormatOption[]` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{ type: "json", prompt?, schema? }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`, `{ type: "question", question }`, `{ type: "highlights", query }`. |
+| `options.headers` | `Record<string, string>` | Custom HTTP headers for the request. |
+| `options.includeTags` | `string[]` | HTML tags to include. |
+| `options.excludeTags` | `string[]` | HTML tags to exclude. |
+| `options.onlyMainContent` | `boolean` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `number` | Request timeout in milliseconds. |
+| `options.waitFor` | `number` | Wait for the page to render (milliseconds). |
+| `options.mobile` | `boolean` | Emulate a mobile viewport. |
+| `options.parsers` | `(string \| PdfParser)[]` | File parsing controls. E.g. `"pdf"` or `{ type: "pdf", mode: "auto", maxPages: 10 }`. |
+| `options.actions` | `ActionOption[]` | Browser actions before scraping. Types: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`. |
+| `options.location` | `{ country?, languages? }` | Geo and language-aware scraping. |
+| `options.skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `options.removeBase64Images` | `boolean` | Remove base64 images from markdown. |
+| `options.fastMode` | `boolean` | Faster scrapes with reduced fidelity. |
+| `options.blockAds` | `boolean` | Block ads and cookie popups. |
+| `options.proxy` | `string` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom URL. |
+| `options.maxAge` | `number` | Use cached result if younger than this (milliseconds). |
+| `options.minAge` | `number` | Only return cached data at least this old (milliseconds). |
+| `options.storeInCache` | `boolean` | Cache the result in Firecrawl. |
+| `options.lockdown` | `boolean` | Serve only cached results; never make outbound requests. |
+| `options.profile` | `{ name, saveChanges? }` | Persistent browser profile shared across scrapes and interactions. |
+| `options.integration` | `string` | Integration identifier for tracking. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows that go beyond quick pre-scrape actions — filling forms, clicking through pages, or running code in the browser sandbox.
+
+### Preferred SDK method
+
+```
+client.interact(jobId, args) → Promise<ScrapeExecuteResponse>
+```
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.scrapeId;
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+console.log(result.output);
+
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | Scrape job ID from `document.metadata.scrapeId`. |
+| `args.code` | `string` | Code to run in the browser session. At least one of `code` or `prompt` is required. |
+| `args.prompt` | `string` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` is required. |
+| `args.language` | `string` | Runtime: `"python"`, `"node"`, or `"bash"`. Default: `"node"`. |
+| `args.timeout` | `number` | Execution timeout in seconds (1–300). |
+
+### Return value
+
+`ScrapeExecuteResponse` fields: `success`, `output`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `liveViewUrl`, `interactiveLiveViewUrl`, `error`.
+
+### Stop session
+
+```
+client.stopInteraction(jobId) → Promise<ScrapeBrowserDeleteResponse>
+```
+
+Returns `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`, `stopInteractiveBrowser` / `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client.
+- Zod schemas passed in `formats` for `json` or `changeTracking` are converted to JSON Schema by the SDK.
+- The package declares Node.js >= 22 in `engines`.
+- Client constructor also accepts `apiUrl`, `timeoutMs`, `maxRetries`, `backoffFactor`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,199 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `firecrawl-py` SDK source and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+The client reads `FIRECRAWL_API_KEY` from the environment if `api_key` is not passed. An API key is required for the cloud service.
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages. Optionally scrape each result.
+- **scrape** — you already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, form fills, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Discover pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+```
+client.search(query, **kwargs) → SearchData
+```
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    limit=5,
+    scrape_options=ScrapeOptions(
+        formats=["markdown"],
+        only_main_content=True,
+    ),
+)
+
+for hit in results.web or []:
+    print(hit.url, getattr(hit, "markdown", "")[:200])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | Search query. Use `site:example.com` to scope results. |
+| `sources` | `list[str]` | Which source indices to search: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str]` | Category filters: `"github"`, `"research"`, `"pdf"`. |
+| `limit` | `int` | Maximum results per source type. |
+| `tbs` | `str` | Time-based filter, e.g. `"qdr:d"` (past day), `"qdr:w"` (past week). |
+| `location` | `str` | Geographic location for results. |
+| `ignore_invalid_urls` | `bool` | Drop URLs that cannot be scraped. |
+| `timeout` | `int` | Request timeout in milliseconds. |
+| `scrape_options` | `ScrapeOptions` | Scrape each search result with these options. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+### Return value
+
+`SearchData` contains optional lists:
+
+- `web` — web results (lightweight result or full `Document` when `scrape_options` is set)
+- `news` — news results
+- `images` — image results
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats — markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```
+client.scrape(url, **kwargs) → Document
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+    timeout=30000,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | The URL to scrape. |
+| `formats` | `list` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": [...]}`, `{"type": "attributes", "selectors": [...]}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers for the request. |
+| `include_tags` | `list[str]` | HTML tags to include. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `timeout` | `int` | Request timeout in milliseconds. |
+| `wait_for` | `int` | Wait for the page to render (milliseconds). |
+| `mobile` | `bool` | Emulate a mobile viewport. |
+| `parsers` | `list` | File parsing controls. E.g. `"pdf"` or `{"type": "pdf", "mode": "auto", "max_pages": 10}`. |
+| `actions` | `list` | Browser actions before scraping. Types: `WaitAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScreenshotAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Geo and language-aware scraping. Fields: `country`, `languages`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this (milliseconds). |
+| `store_in_cache` | `bool` | Cache the result in Firecrawl. |
+| `lockdown` | `bool` | Serve only cached results; never make outbound requests. |
+| `profile` | `dict` | Persistent browser profile. Keys: `name`, `saveChanges`. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows — filling forms, clicking through pages, or running code in the browser sandbox.
+
+### Preferred SDK method
+
+```
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None) → BrowserExecuteResponse
+```
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("scrapeId") if doc.metadata else None
+
+result = client.interact(
+    job_id,
+    prompt="Click the pricing tab and summarize the plans.",
+)
+print(result.output)
+
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | Scrape job ID from `document.metadata["scrapeId"]`. |
+| `code` | `str` | Code to run in the browser session. At least one of `code` or `prompt` is required. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` is required. |
+| `language` | `str` | Runtime: `"python"`, `"node"`, or `"bash"`. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+| `origin` | `str` | Optional origin tag for telemetry. |
+
+### Return value
+
+`BrowserExecuteResponse` fields: `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+### Stop session
+
+```
+client.stop_interaction(job_id)
+```
+
+## Notes
+
+- Python SDK uses `snake_case` for all parameter names.
+- Deprecated aliases: `scrape_execute` → `interact`, `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`.
+- Import the v2 client directly: `from firecrawl import Firecrawl`.
+- Client constructor also accepts `api_url`, `timeout`, `max_retries`, `backoff_factor`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,238 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` crate source and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+Crate: **`firecrawl`** on crates.io.
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+`Client::new` requires an API key for the cloud service. `Client::new_selfhosted` allows an optional key.
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages. Optionally scrape each result.
+- **scrape** — you already have a URL and want page content in one or more formats.
+- **interact** — the page needs clicks, form fills, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Discover pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+```
+client.search(query, options) → Result<SearchResponse, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let response = client.search("site:docs.firecrawl.dev webhook retries", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        only_main_content: Some(true),
+        ..Default::default()
+    }),
+    ..Default::default()
+}).await?;
+
+for hit in response.data.web.unwrap_or_default() {
+    println!("{:?}", hit);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | Search query. |
+| `options.limit` | `Option<u32>` | Maximum results. Default: 5, max: 20. |
+| `options.sources` | `Option<Vec<SearchSource>>` | Source indices: `Web`, `News`, `Images`. |
+| `options.categories` | `Option<Vec<SearchCategory>>` | Category filters: `Github`, `Research`, `Pdf`. |
+| `options.include_domains` | `Option<Vec<String>>` | Restrict results to these domains. |
+| `options.exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `options.tbs` | `Option<String>` | Time-based filter, e.g. `"qdr:d"`. |
+| `options.location` | `Option<String>` | Geographic location for results. |
+| `options.ignore_invalid_urls` | `Option<bool>` | Drop URLs that cannot be scraped. |
+| `options.timeout` | `Option<u32>` | Request timeout in milliseconds. |
+| `options.scrape_options` | `Option<ScrapeOptions>` | Scrape each search result with these options. |
+| `options.integration` | `Option<String>` | Integration identifier for tracking. |
+
+### Return value
+
+`SearchResponse` contains `success`, `data` (`SearchData`), and `warning`. `SearchData` has:
+
+- `web` — `Option<Vec<SearchResultOrDocument>>` (can be `WebResult` or full `Document`)
+- `news` — `Option<Vec<SearchResultNews>>`
+- `images` — `Option<Vec<SearchResultImage>>`
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats — markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```
+client.scrape(url, options) → Result<Document, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client.scrape("https://example.com/pricing", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Json]),
+    json_options: Some(JsonOptions {
+        prompt: Some("Extract plan names and prices.".into()),
+        ..Default::default()
+    }),
+    only_main_content: Some(true),
+    timeout: Some(30000),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+println!("{:?}", doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | The URL to scrape. |
+| `options.formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `options.headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `options.include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `options.exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `options.only_main_content` | `Option<bool>` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `Option<u32>` | Request timeout in milliseconds. |
+| `options.wait_for` | `Option<u32>` | Wait for the page to render (milliseconds). |
+| `options.mobile` | `Option<bool>` | Emulate a mobile viewport. |
+| `options.parsers` | `Option<Vec<ParserConfig>>` | File parsing: `Simple("pdf".into())` or `Pdf { mode, max_pages, .. }`. |
+| `options.actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Screenshot`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `options.location` | `Option<LocationConfig>` | Geo and language-aware scraping. Fields: `country`, `languages`. |
+| `options.skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. |
+| `options.remove_base64_images` | `Option<bool>` | Remove base64 images from markdown. |
+| `options.fast_mode` | `Option<bool>` | Faster scrapes with reduced fidelity. |
+| `options.block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `options.proxy` | `Option<ProxyType>` | Proxy: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `options.max_age` | `Option<u32>` | Use cached result if younger than this (seconds). |
+| `options.min_age` | `Option<u32>` | Only return cached data at least this old (seconds). |
+| `options.store_in_cache` | `Option<bool>` | Cache the result. |
+| `options.lockdown` | `Option<bool>` | Serve only cached results. |
+| `options.profile` | `Option<ProfileConfig>` | Persistent browser profile. Fields: `name`, `save_changes`. |
+| `options.json_options` | `Option<JsonOptions>` | JSON extraction: `schema`, `system_prompt`, `prompt`. |
+| `options.screenshot_options` | `Option<ScreenshotOptions>` | Screenshot options: `full_page`, `quality`, `viewport`. |
+| `options.change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking: `modes`, `schema`, `prompt`, `tag`. |
+| `options.attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `selector`, `attribute`. |
+| `options.integration` | `Option<String>` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows — filling forms, clicking through pages, or running code in the browser sandbox.
+
+### Preferred SDK method
+
+```
+client.interact(job_id, options) → Result<ScrapeExecuteResponse, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_deref())
+    .expect("Missing scrapeId");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    prompt: Some("Click the pricing tab and summarize the plans.".into()),
+    ..Default::default()
+}).await?;
+
+println!("{}", result.output.unwrap_or_default());
+
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | Scrape job ID from document metadata. |
+| `options.code` | `Option<String>` | Code to run in the browser session. At least one of `code` or `prompt` is required. |
+| `options.prompt` | `Option<String>` | Natural-language instruction for the browser agent. |
+| `options.language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `options.timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `options.origin` | `Option<String>` | Optional origin tag for telemetry. |
+
+### Return value
+
+`ScrapeExecuteResponse` fields: `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+### Stop session
+
+```
+client.stop_interaction(job_id) → Result<ScrapeBrowserDeleteResponse, FirecrawlError>
+```
+
+Returns `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- All options structs derive `Default`, so use `..Default::default()` for unneeded fields.
+- Deprecated aliases: `scrape_execute` → `interact`, `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`.
+- Convenience method: `client.scrape_with_schema(url, schema, prompt)` for JSON extraction.
+- Convenience method: `client.search_and_scrape(query, limit)` returns `Vec<Document>`.
+- The Rust SDK uses `snake_case` for all struct fields.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart doc per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each quickstart covers `search`, `scrape`, and `interact` with full parameter tables, realistic examples, and language-specific notes
- Generated from SDK source code and the v2 OpenAPI spec — no invented parameters or behavior

## Details

Files are placed under `docs/agent-quickstart/` in this repo. They are intended for the `firecrawl-docs` repo under `agent-quickstart/` and should be moved there (the docs repo did not have push permissions in this session).

Each file follows a consistent structure:
- Install / Authenticate
- When To Use What (search vs scrape vs interact)
- Per-endpoint sections with: why use it, preferred SDK method, example, full parameter table, return value
- Language-specific notes and deprecated alias migration info
- Source of truth references

## Test plan

- [ ] Review each quickstart file for accuracy against SDK source
- [ ] Move files to `firecrawl-docs/agent-quickstart/` and add navigation entries to `docs.json`
- [ ] Verify Mintlify rendering

https://claude.ai/code/session_01J5y4pFhpi7afbrDL4vWgnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5y4pFhpi7afbrDL4vWgnx)_