### PR TITLE
docs: add canonical agent quickstart guides for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,204 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Elixir SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add `firecrawl` to your `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.4"}
+  ]
+end
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Authenticate
+
+Configure your API key in `config/config.exs`:
+
+```elixir
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+```
+
+Or pass the key per-request via the options keyword list:
+
+```elixir
+Firecrawl.search_and_scrape([query: "test"], api_key: "fc-YOUR-API-KEY")
+```
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages across the web
+- **scrape** — you already have a URL and want its content (markdown, HTML, structured JSON, screenshot, etc.)
+- **interact** — the page needs clicks, form fills, or other post-scrape browser actions
+
+## Search
+
+### Why use it
+
+Search the web and optionally scrape every result in one call. Use it when you need discovery — you have a question or topic but no specific URL.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping",
+  limit: 5
+)
+
+for result <- response.body["data"]["web"] do
+  IO.puts("#{result["title"]} #{result["url"]}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list (first argument). Keys use snake_case.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `:string` | Yes | The search query. |
+| `limit` | `:integer` | No | Maximum number of results to return. |
+| `sources` | `list` | No | Result types to include: `"web"`, `"news"`, `"images"`. Defaults to `["web"]`. |
+| `categories` | `list` | No | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list(string)` | No | Restrict results to these domains. |
+| `exclude_domains` | `list(string)` | No | Exclude results from these domains. |
+| `tbs` | `:string` | No | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `:string` | No | Geographic location for search results. |
+| `country` | `:string` | No | ISO country code for geo-targeting (e.g. `"US"`). |
+| `ignore_invalid_urls` | `:boolean` | No | Skip invalid URLs instead of failing. |
+| `timeout` | `:integer` | No | Request timeout in milliseconds. |
+| `scrape_options` | `:keyword_list` | No | Scrape each result page. Same parameters as `scrape_and_extract_from_url`. |
+| `enterprise` | `list(string)` | No | Enterprise ZDR options: `["zdr"]` or `["anon"]`. |
+
+## Scrape
+
+### Why use it
+
+Fetch the content of a single URL in the format you need — markdown, HTML, structured JSON, screenshot, and more. Use it when you already know which page to read.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | `:string` | Yes | The URL to scrape. |
+| `formats` | `list` | No | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"audio"`, `"video"`. Objects for advanced formats: `%{type: "json", schema: ..., prompt: ...}`, `%{type: "question", question: "..."}`, `%{type: "highlights", query: "..."}`. |
+| `headers` | `:any` | No | Custom HTTP headers. |
+| `include_tags` | `list(string)` | No | HTML tags to include. |
+| `exclude_tags` | `list(string)` | No | HTML tags to exclude. |
+| `only_main_content` | `:boolean` | No | Extract only the main content area. |
+| `timeout` | `:integer` | No | Timeout in milliseconds (1000–300000). |
+| `wait_for` | `:integer` | No | Wait this many milliseconds before scraping. |
+| `mobile` | `:boolean` | No | Emulate a mobile device. |
+| `parsers` | `list` | No | Parser config (e.g. `["pdf"]` or `[%{type: "pdf", mode: "auto", max_pages: 10}]`). |
+| `actions` | `list` | No | Browser actions as maps: `[%{type: "click", selector: "#btn"}]`. |
+| `location` | `:keyword_list` | No | Geographic location: `[country: "US", languages: ["en-US"]]`. |
+| `skip_tls_verification` | `:boolean` | No | Skip TLS certificate verification. |
+| `remove_base64_images` | `:boolean` | No | Remove base64-encoded images from output. |
+| `block_ads` | `:boolean` | No | Block ads and cookie popups. |
+| `proxy` | `:atom` | No | Proxy mode: `:basic`, `:enhanced`, or `:auto`. |
+| `max_age` | `:integer` | No | Use cached result if younger than this many milliseconds. |
+| `min_age` | `:integer` | No | Minimum cache age; only checks cache. |
+| `store_in_cache` | `:boolean` | No | Store the result in cache. |
+| `lockdown` | `:boolean` | No | Only serve cached results. |
+| `profile` | `:keyword_list` | No | Persistent browser profile: `[name: "my-profile", save_changes: true]`. |
+| `zero_data_retention` | `:boolean` | No | Enable zero data retention for this scrape. |
+
+## Interact
+
+### Why use it
+
+Control a live browser session attached to a previous scrape. Use it when the page requires clicks, form fills, navigation, or code execution after the initial scrape.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://www.amazon.com",
+  formats: ["markdown"]
+)
+
+scrape_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(scrape_id,
+  code: ~s|document.querySelector('#twotabsearchtextbox').value = 'iPhone 16 Pro Max';|,
+  language: :node
+)
+
+IO.puts(response.body["stdout"])
+
+Firecrawl.stop_interactive_scrape_browser_session(scrape_id)
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `job_id` | `String.t()` | Yes | The scrape job ID (first positional argument). |
+| `code` | `:string` | Yes | Code to execute in the browser sandbox. |
+| `language` | `:atom` | No | Language for code execution: `:python`, `:node`, `:bash`. Defaults to `:node`. |
+| `timeout` | `:integer` | No | Execution timeout in seconds. |
+| `origin` | `:string` | No | Origin label for telemetry. |
+
+### Stopping a session
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(scrape_id)
+```
+
+## Notes
+
+- **Naming style**: all parameters use snake_case keyword lists. The SDK converts them to camelCase JSON keys for the API.
+- **OpenAPI-generated surface**: the Elixir SDK is generated from the OpenAPI spec. Function names match the operation IDs directly (`scrape_and_extract_from_url`, `search_and_scrape`, `interact_with_scrape_browser_session`).
+- **interact only supports `code`**: unlike the JS/TS, Python, and Rust SDKs, the Elixir SDK does not support the `prompt` parameter for natural language interaction. Pass executable code instead.
+- **Bang variants**: all functions have `!` versions (e.g. `search_and_scrape!`) that raise on error instead of returning `{:error, ...}`.
+- **Batch scraping**: use `Firecrawl.scrape_and_extract_from_urls/2` for scraping multiple URLs in one call.
+- **Parameter validation**: the SDK validates all parameters using NimbleOptions before sending.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,209 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Java SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+<Tabs>
+  <Tab title="Gradle (Kotlin DSL)">
+```kotlin
+dependencies {
+    implementation("com.firecrawl:firecrawl-java:1.7.0")
+}
+```
+  </Tab>
+  <Tab title="Maven">
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.7.0</version>
+</dependency>
+```
+  </Tab>
+</Tabs>
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// Option 1: pass the key directly
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR-API-KEY")
+    .build();
+
+// Option 2: read from FIRECRAWL_API_KEY env var or firecrawl.apiKey system property
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages across the web
+- **scrape** — you already have a URL and want its content (markdown, HTML, structured JSON, screenshot, etc.)
+- **interact** — the page needs clicks, form fills, or other post-scrape browser actions
+
+## Search
+
+### Why use it
+
+Search the web and optionally scrape every result in one call. Use it when you need discovery — you have a question or topic but no specific URL.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("firecrawl web scraping",
+    SearchOptions.builder().limit(5).build());
+
+for (var result : results.getWeb()) {
+    System.out.println(result.get("title") + " " + result.get("url"));
+}
+```
+
+### Parameters
+
+`SearchOptions.builder()` (all optional):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `limit` | `Integer` | Maximum number of results to return. |
+| `sources` | `List<Object>` | Result types to include: `"web"`, `"news"`, `"images"`. |
+| `categories` | `List<Object>` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Geographic location for search results. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs instead of failing. |
+| `timeout` | `Integer` | Request timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result page. Same options as `client.scrape()`. |
+| `integration` | `String` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Fetch the content of a single URL in the format you need — markdown, HTML, structured JSON, screenshot, and more. Use it when you already know which page to read.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+`ScrapeOptions.builder()` (all optional):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Objects: `JsonFormat.builder().prompt("...").schema(map).build()`, `QuestionFormat.builder().question("...").build()`, `HighlightsFormat.builder().query("...").build()`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent` | `Boolean` | Extract only the main content area. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `waitFor` | `Integer` | Wait this many milliseconds before scraping. |
+| `mobile` | `Boolean` | Emulate a mobile device. |
+| `parsers` | `List<Object>` | Parser config (e.g. `"pdf"` or `Map.of("type", "pdf", "maxPages", 10)`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions as maps: `Map.of("type", "click", "selector", "#btn")`. |
+| `location` | `LocationConfig` | Geographic location: `LocationConfig.builder().country("US").languages(List.of("en-US")).build()`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `Boolean` | Remove base64-encoded images from output. |
+| `blockAds` | `Boolean` | Block ads. |
+| `proxy` | `String` | Proxy mode: `"basic"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Use cached result if younger than this many milliseconds. |
+| `storeInCache` | `Boolean` | Store the result in cache. |
+| `lockdown` | `Boolean` | Only serve cached results. |
+| `integration` | `String` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control a live browser session attached to a previous scrape. Use it when the page requires clicks, form fills, navigation, or code execution after the initial scrape.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape("https://www.amazon.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+
+String scrapeId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse response = client.interact(scrapeId,
+    "document.querySelector('#twotabsearchtextbox').value = 'iPhone 16 Pro Max';" +
+    "document.querySelector('#nav-search-submit-button').click();");
+
+System.out.println(response.getStdout());
+
+client.stopInteractiveBrowser(scrapeId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `String` (required) | The scrape job ID from a previous `scrape()` call. |
+| `code` | `String` (required) | Code to execute in the browser sandbox. |
+| `language` | `String` | Language for code execution: `"python"`, `"node"`, `"bash"`. Defaults to `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Defaults to 30. |
+| `origin` | `String` | Origin tag for request attribution. |
+
+### Stopping a session
+
+```java
+client.stopInteractiveBrowser(scrapeId);
+```
+
+## Notes
+
+- **Naming style**: all parameters use camelCase, matching the API wire format.
+- **interact only supports `code`**: unlike the JS/TS, Python, and Rust SDKs, the Java SDK does not support the `prompt` parameter for natural language interaction. Pass executable code instead.
+- **Builder pattern**: `ScrapeOptions`, `SearchOptions`, `JsonFormat`, `QuestionFormat`, `HighlightsFormat`, and `LocationConfig` all use `.builder()...build()`.
+- **Async variants**: all methods have async versions returning `CompletableFuture<T>` (e.g. `searchAsync`, `scrapeAsync`, `interactAsync`).
+- **Deprecated aliases**: `scrapeExecute()` is deprecated — use `interact()`. `deleteScrapeBrowser()` is deprecated — use `stopInteractiveBrowser()`.
+- **Retries**: the client retries failed requests up to 3 times by default with exponential backoff.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,183 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Node.js/TypeScript SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+// Option 1: pass the key directly
+const client = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+
+// Option 2: set the FIRECRAWL_API_KEY environment variable
+const client = new Firecrawl();
+```
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages across the web
+- **scrape** — you already have a URL and want its content (markdown, HTML, structured JSON, screenshot, etc.)
+- **interact** — the page needs clicks, form fills, or other post-scrape browser actions
+
+## Search
+
+### Why use it
+
+Search the web and optionally scrape every result in one call. Use it when you need discovery — you have a question or topic but no specific URL.
+
+### Preferred SDK method
+
+```typescript
+client.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await client.search("firecrawl web scraping", { limit: 5 });
+
+for (const result of results.web ?? []) {
+  console.log(result.title, result.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` (required) | The search query. |
+| `limit` | `number` | Maximum number of results to return. |
+| `sources` | `Array<"web" \| "news" \| "images">` | Which result types to include. Defaults to `["web"]`. |
+| `categories` | `Array<"github" \| "research" \| "pdf">` | Filter results by category. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Mutually exclusive with `includeDomains`. |
+| `tbs` | `string` | Time-based search filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `location` | `string` | Geographic location for search results (e.g. `"San Francisco,California,United States"`). |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs instead of failing. |
+| `timeout` | `number` | Request timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result page. Accepts the same options as `client.scrape()`. |
+| `integration` | `string` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Fetch the content of a single URL in the format you need — markdown, HTML, structured JSON, screenshot, and more. Use it when you already know which page to read.
+
+### Preferred SDK method
+
+```typescript
+client.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+
+console.log(doc.markdown);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` (required) | The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats. Simple strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"audio"`, `"video"`. Objects for advanced formats: `{ type: "json", schema?, prompt? }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "question", question }`, `{ type: "highlights", query }`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send with the request. |
+| `includeTags` | `string[]` | HTML tags to include in output. |
+| `excludeTags` | `string[]` | HTML tags to exclude from output. |
+| `onlyMainContent` | `boolean` | Extract only the main content area. |
+| `timeout` | `number` | Scrape timeout in seconds. |
+| `waitFor` | `number` | Wait this many milliseconds before scraping. |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `parsers` | `Array<string \| { type: "pdf", mode?: "fast" \| "auto" \| "ocr", maxPages?: number }>` | Parser configuration (e.g. PDF parsing). |
+| `actions` | `ActionOption[]` | Browser actions to execute before scraping. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string, languages?: string[] }` | Geographic location and language settings. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64-encoded images from output. |
+| `fastMode` | `boolean` | Use fast scraping mode. |
+| `blockAds` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy mode. `"basic"` is fast, `"enhanced"` handles advanced anti-bot (5 credits), `"auto"` retries with enhanced. |
+| `maxAge` | `number` | Use cached result if younger than this many seconds. |
+| `minAge` | `number` | Minimum cache age; only checks cache, never scrapes fresh. |
+| `storeInCache` | `boolean` | Store the result in cache. |
+| `lockdown` | `boolean` | Only serve cached results; return 404 on cache miss. |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile for shared session state. |
+| `integration` | `string` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control a live browser session attached to a previous scrape. Use it when the page requires clicks, form fills, navigation, or code execution after the initial scrape.
+
+### Preferred SDK method
+
+```typescript
+client.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://www.amazon.com", {
+  formats: ["markdown"],
+});
+const scrapeId = doc.metadata?.scrapeId;
+
+const response = await client.interact(scrapeId, {
+  prompt: "Search for iPhone 16 Pro Max",
+});
+console.log(response.output);
+
+await client.stopInteraction(scrapeId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `string` (required) | The scrape job ID from a previous `scrape()` call (available as `metadata.scrapeId`). |
+| `code` | `string` | Code to execute in the browser sandbox. Either `code` or `prompt` must be provided. |
+| `prompt` | `string` | Natural language instruction for the browser agent. Either `code` or `prompt` must be provided. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Defaults to `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds (1–300). |
+
+### Stopping a session
+
+```typescript
+await client.stopInteraction(scrapeId);
+```
+
+Returns `{ success, sessionDurationMs?, creditsBilled? }`.
+
+## Notes
+
+- **Naming style**: all parameters use camelCase.
+- **Deprecated aliases**: `scrapeExecute()` is deprecated — use `interact()`. `stopInteractiveBrowser()` and `deleteScrapeBrowser()` are deprecated — use `stopInteraction()`.
+- **Error handling**: the SDK throws `SdkError` with optional `jobId`, `code`, `status`, and `details` properties.
+- **Origin tracking**: requests automatically include `origin: "js-sdk@<version>"` unless overridden.
+- **Retries**: the client retries failed requests up to 3 times by default with exponential backoff (configurable via `maxRetries` and `backoffFactor`).
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,180 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Python SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+# Option 1: pass the key directly
+client = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+# Option 2: set the FIRECRAWL_API_KEY environment variable
+client = Firecrawl()
+```
+
+An async client is also available:
+
+```python
+from firecrawl import AsyncFirecrawl
+
+client = AsyncFirecrawl(api_key="fc-YOUR-API-KEY")
+```
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages across the web
+- **scrape** — you already have a URL and want its content (markdown, HTML, structured JSON, screenshot, etc.)
+- **interact** — the page needs clicks, form fills, or other post-scrape browser actions
+
+## Search
+
+### Why use it
+
+Search the web and optionally scrape every result in one call. Use it when you need discovery — you have a question or topic but no specific URL.
+
+### Preferred SDK method
+
+```python
+client.search(query, **kwargs)
+```
+
+### Example
+
+```python
+results = client.search("firecrawl web scraping", limit=5)
+
+for result in results.web or []:
+    print(result.title, result.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` (required) | The search query. |
+| `limit` | `int` | Maximum number of results to return. |
+| `sources` | `list[str]` | Which result types to include: `"web"`, `"news"`, `"images"`. Defaults to `["web"]`. |
+| `categories` | `list[str]` | Filter results by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Mutually exclusive with `include_domains`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `str` | Geographic location for search results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs instead of failing. |
+| `timeout` | `int` | Request timeout in milliseconds. |
+| `scrape_options` | `ScrapeOptions` | Scrape each result page. Accepts the same options as `client.scrape()`. |
+| `integration` | `str` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Fetch the content of a single URL in the format you need — markdown, HTML, structured JSON, screenshot, and more. Use it when you already know which page to read.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **kwargs)
+```
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+
+print(doc.markdown)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` (required) | The URL to scrape. |
+| `formats` | `list[FormatOption]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"audio"`, `"video"`. Objects for advanced formats: `{"type": "json", "schema": ..., "prompt": ...}`, `{"type": "screenshot", "fullPage": True}`, `{"type": "question", "question": "..."}`, `{"type": "highlights", "query": "..."}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers to send with the request. |
+| `include_tags` | `list[str]` | HTML tags to include in output. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from output. |
+| `only_main_content` | `bool` | Extract only the main content area. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait this many milliseconds before scraping. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list` | Parser configuration. Use `"pdf"` or `PDFParser(type="pdf", mode="auto", max_pages=10)`. |
+| `actions` | `list` | Browser actions to execute before scraping. Types: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Geographic location: `Location(country="US", languages=["en-US"])`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64-encoded images from output. |
+| `fast_mode` | `bool` | Use fast scraping mode. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, or `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this many seconds. |
+| `store_in_cache` | `bool` | Store the result in cache. |
+| `lockdown` | `bool` | Only serve cached results; return 404 on cache miss. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "my-profile", "saveChanges": True}`. |
+| `integration` | `str` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control a live browser session attached to a previous scrape. Use it when the page requires clicks, form fills, navigation, or code execution after the initial scrape.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)
+```
+
+### Example
+
+```python
+doc = client.scrape("https://www.amazon.com", formats=["markdown"])
+scrape_id = doc.metadata.scrape_id
+
+response = client.interact(scrape_id, prompt="Search for iPhone 16 Pro Max")
+print(response.output)
+
+client.stop_interaction(scrape_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `str` (required) | The scrape job ID from a previous `scrape()` call (available as `metadata.scrape_id`). |
+| `code` | `str` | Code to execute in the browser sandbox. Either `code` or `prompt` must be provided. |
+| `prompt` | `str` | Natural language instruction for the browser agent. Either `code` or `prompt` must be provided. |
+| `language` | `Literal["python", "node", "bash"]` | Language for code execution. Defaults to `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+### Stopping a session
+
+```python
+client.stop_interaction(scrape_id)
+```
+
+## Notes
+
+- **Naming style**: all parameters use snake_case.
+- **Deprecated aliases**: `scrape_execute()` is deprecated — use `interact()`. `delete_scrape_browser()` is deprecated — use `stop_interaction()`.
+- **Async**: all methods are available on `AsyncFirecrawl` with the same signatures.
+- **Retries**: the client retries failed requests up to 3 times by default with exponential backoff (configurable via `max_retries` and `backoff_factor`).
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/methods/scrape.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/methods/search.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,234 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Rust SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+// Option 1: pass the key directly
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+// Option 2: self-hosted instance (API key optional)
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR-API-KEY"))?;
+```
+
+## When To Use What
+
+- **search** — start with a query and discover relevant pages across the web
+- **scrape** — you already have a URL and want its content (markdown, HTML, structured JSON, screenshot, etc.)
+- **interact** — the page needs clicks, form fills, or other post-scrape browser actions
+
+## Search
+
+### Why use it
+
+Search the web and optionally scrape every result in one call. Use it when you need discovery — you have a question or topic but no specific URL.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR-API-KEY")?;
+
+    let response = client
+        .search("firecrawl web scraping", SearchOptions { limit: Some(5), ..Default::default() })
+        .await?;
+
+    if let Some(web) = response.data.web {
+        for result in web {
+            println!("{:?}", result);
+        }
+    }
+
+    Ok(())
+}
+```
+
+A convenience method is also available:
+
+```rust
+let docs = client.search_and_scrape("firecrawl", 5).await?;
+```
+
+### Parameters
+
+`SearchOptions` (all fields `Option`, default is `None`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `limit` | `u32` | Maximum number of results to return. |
+| `sources` | `Vec<SearchSource>` | Result types to include: `SearchSource::Web`, `News`, `Images`. |
+| `categories` | `Vec<SearchCategory>` | Filter by category: `SearchCategory::Github`, `Research`, `Pdf`. |
+| `include_domains` | `Vec<String>` | Restrict results to these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `Vec<String>` | Exclude results from these domains. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Geographic location for search results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs instead of failing. |
+| `timeout` | `u32` | Request timeout in milliseconds. |
+| `scrape_options` | `ScrapeOptions` | Scrape each result page. Same options as `client.scrape()`. |
+| `integration` | `String` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Fetch the content of a single URL in the format you need — markdown, HTML, structured JSON, screenshot, and more. Use it when you already know which page to read.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let doc = client
+    .scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    })
+    .await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+A convenience method for JSON extraction:
+
+```rust
+let json_value = client.scrape_with_schema("https://example.com", schema, Some("extract product info")).await?;
+```
+
+### Parameters
+
+`ScrapeOptions` (all fields `Option`, default is `None`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `formats` | `Vec<Format>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `Json`, `ChangeTracking`, `Branding`, `Audio`, `Video`. Also `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `headers` | `HashMap<String, String>` | Custom HTTP headers. |
+| `include_tags` | `Vec<String>` | HTML tags to include. |
+| `exclude_tags` | `Vec<String>` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Extract only the main content area. |
+| `timeout` | `u32` | Timeout in milliseconds. |
+| `wait_for` | `u32` | Wait this many milliseconds before scraping. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `Vec<ParserConfig>` | Parser config (e.g. PDF): `ParserConfig::Simple("pdf")` or `ParserConfig::Pdf { mode, max_pages }`. |
+| `actions` | `Vec<Action>` | Browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `LocationConfig` | Geographic location: `LocationConfig { country, languages }`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64-encoded images from output. |
+| `fast_mode` | `bool` | Use fast scraping mode. |
+| `block_ads` | `bool` | Block ads. |
+| `proxy` | `ProxyType` | Proxy mode: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `u32` | Use cached result if younger than this many seconds. |
+| `min_age` | `u32` | Minimum cache age; only checks cache. |
+| `store_in_cache` | `bool` | Store the result in cache. |
+| `lockdown` | `bool` | Only serve cached results. |
+| `profile` | `ProfileConfig` | Persistent browser profile: `ProfileConfig { name, save_changes }`. |
+| `integration` | `String` | Integration identifier. |
+| `json_options` | `JsonOptions` | JSON extraction config: `JsonOptions { schema, system_prompt, prompt }`. |
+| `screenshot_options` | `ScreenshotOptions` | Screenshot config: `ScreenshotOptions { full_page, quality, viewport }`. |
+| `change_tracking_options` | `ChangeTrackingOptions` | Change tracking config: `ChangeTrackingOptions { modes, schema, prompt, tag }`. |
+| `attribute_selectors` | `Vec<AttributeSelector>` | Attribute extraction: `AttributeSelector { selector, attribute }`. |
+
+## Interact
+
+### Why use it
+
+Control a live browser session attached to a previous scrape. Use it when the page requires clicks, form fills, navigation, or code execution after the initial scrape.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let doc = client.scrape("https://www.amazon.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let scrape_id = doc.metadata.as_ref().and_then(|m| m.scrape_id.as_ref()).unwrap();
+
+let response = client.interact(scrape_id, ScrapeExecuteOptions {
+    prompt: Some("Search for iPhone 16 Pro Max".into()),
+    ..Default::default()
+}).await?;
+
+println!("{}", response.output.unwrap_or_default());
+
+client.stop_interaction(scrape_id).await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | `Option<String>` | Code to execute in the browser sandbox. Either `code` or `prompt` must be provided. |
+| `prompt` | `Option<String>` | Natural language instruction for the browser agent. Either `code` or `prompt` must be provided. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Language for code execution: `Python`, `Node`, `Bash`. Defaults to `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds (1–300). |
+| `origin` | `Option<String>` | Origin tag for request attribution. |
+
+### Stopping a session
+
+```rust
+client.stop_interaction(scrape_id).await?;
+```
+
+Returns `ScrapeBrowserDeleteResponse { success, session_duration_ms, credits_billed }`.
+
+## Notes
+
+- **Naming style**: all struct fields use snake_case (serialized to camelCase for the API).
+- **Async**: all methods are async and return `Result<T, FirecrawlError>`.
+- **Deprecated aliases**: `scrape_execute()` is deprecated — use `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` are deprecated — use `stop_interaction()`.
+- **Convenience methods**: `search_and_scrape(query, limit)` searches and scrapes all results. `scrape_with_schema(url, schema, prompt)` scrapes and extracts JSON.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one self-contained agent quickstart document per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file covers `search`, `scrape`, and `interact` with every confirmed parameter, realistic examples, and language-specific notes
- Generated from SDK source code and the OpenAPI spec (`v2-openapi.json`) — no invented parameters or behavior

## Note on target repo

These files are intended for `firecrawl-docs/agent-quickstart/` and should be moved to the `firecrawl-docs` repo along with the corresponding `docs.json` navigation update. Write access to `firecrawl-docs` was not available in this environment, so they are staged here temporarily.

The `docs.json` change needed is adding an "Agent Quickstarts" group after the existing "Quickstarts" group:

```json
{
  "group": "Agent Quickstarts",
  "pages": [
    "agent-quickstart/node",
    "agent-quickstart/python",
    "agent-quickstart/rust",
    "agent-quickstart/java",
    "agent-quickstart/elixir"
  ]
}
```

## What each file covers

- **Install** — exact package name and install command
- **Authenticate** — minimal auth example with API key
- **When To Use What** — decision guide for search vs scrape vs interact
- **Search / Scrape / Interact** — each with why, preferred method, example, and full parameter table
- **Notes** — language-specific caveats (naming conventions, deprecated aliases, async support)
- **Source Of Truth** — exact SDK source files used

## Key language differences documented

- JS/TS, Python, Rust: `interact` supports both `code` and `prompt` (natural language)
- Java, Elixir: `interact` only supports `code`
- Elixir: function names match OpenAPI operation IDs (`scrape_and_extract_from_url`, `search_and_scrape`, `interact_with_scrape_browser_session`)

## Test plan

- [ ] Verify each quickstart renders cleanly as a Mintlify docs page
- [ ] Confirm parameter tables match SDK source
- [ ] Move files to `firecrawl-docs` repo and add `docs.json` nav entry

https://claude.ai/code/session_01WNxPhdJYm3WMQVfzGYczcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNxPhdJYm3WMQVfzGYczcc)_