### PR TITLE
ci(audit): schedule daily audit run and tag reviewers on remediation PR

### DIFF
--- a/.github/workflows/npm-audit-claude-remediation.yml
+++ b/.github/workflows/npm-audit-claude-remediation.yml
@@ -115,6 +115,20 @@ jobs:
 
           gh pr edit "$PR_NUMBER" --body-file "$UPDATED_BODY_FILE"
 
+      - name: Request code review
+        if: ${{ steps.scan.outputs.has_uncovered == 'true' && steps.claude.outputs.branch_name != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ steps.claude.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::No open PR for ${BRANCH_NAME}; cannot request reviewers."
+            exit 0
+          fi
+          gh pr edit "$PR_NUMBER" --add-reviewer abimaelmartell,mogery
+
       - name: Notify Slack about remediation PR
         if: ${{ steps.remediation_pr.outputs.pr_url != '' && env.NPM_AUDIT_CLAUDE_SLACK_WEBHOOK_URL != '' }}
         env:

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 17 * * *"  # 9am PST / 10am PDT
+  workflow_dispatch:
 
 jobs:
   audit:


### PR DESCRIPTION
## Summary

- Add a daily `schedule` trigger (`0 17 * * *` — 9am PST / 10am PDT) to `Audit NPM Packages` so vulnerabilities surface even without PR activity. The remediation workflow already chains off this via `workflow_run`, so scheduled audit failures flow through to Claude remediation automatically.
- Add `workflow_dispatch` so the audit can be run manually from the Actions tab.
- Request review from @abimaelmartell and @mogery on the auto-opened remediation PR.

Slack notification on the remediation PR is unchanged — it still posts via the `NPM_AUDIT_CLAUDE_SLACK_WEBHOOK_URL` secret.

Note on cron offset: GitHub Actions cron is UTC and doesn't follow DST. `0 17 * * *` is anchored to PST (9am in winter, 10am in summer).

## Test plan

- [ ] Merge and confirm the workflow appears under the daily schedule in the Actions tab
- [ ] Manually trigger via `workflow_dispatch` to validate the scheduled path end-to-end
- [ ] On the next remediation PR, verify both reviewers are auto-requested and Slack still posts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Schedules a daily npm audit and auto-requests reviewers on remediation PRs so vulnerabilities surface without PR activity and get reviewed faster. Also adds a manual trigger from the Actions tab.

- **New Features**
  - Run `npm-audit` daily at 17:00 UTC (9am PST / 10am PDT).
  - Add `workflow_dispatch` to run audits manually.
  - Auto-request review from @abimaelmartell and @mogery on remediation PRs; Slack notifications via `NPM_AUDIT_CLAUDE_SLACK_WEBHOOK_URL` remain unchanged.

<sup>Written for commit 04ddf0ea9a5ef8e533e303e7461d1b9b7ce62f30. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3557?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

