### PR TITLE
fix(python-sdk): add retry for TargetClosedError in interact() (Relat…

### DIFF
--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -229,16 +229,32 @@ class FirecrawlClient:
 
         Returns:
             BrowserExecuteResponse with execution result
+
+        Note:
+            Python (``language="python"``) can be flaky on scrape-bound sessions.
+            The page context may close before Python code runs. If you see
+            ``TargetClosedError``, retry the call (max 3 attempts).
         """
-        return scrape_module.interact(
-            self.http_client,
-            job_id,
-            code,
-            prompt=prompt,
-            language=language,
-            timeout=timeout,
-            origin=origin,
-        )
+        last_exc = None
+        for attempt in range(3):
+            try:
+                return scrape_module.interact(
+                    self.http_client,
+                    job_id,
+                    code,
+                    prompt=prompt,
+                    language=language,
+                    timeout=timeout,
+                    origin=origin,
+                )
+            except Exception as e:
+                if "TargetClosed" in str(e) and attempt < 2:
+                    import time
+                    time.sleep(1 * (attempt + 1))  # exponential backoff: 1s, 2s
+                    last_exc = e
+                    continue
+                raise
+        raise last_exc
 
     def stop_interaction(self, job_id: str):
         """


### PR DESCRIPTION
…ed to #3498)

## Problem
 fails ~2/3 of the time with:

The page object is injected into the Python sandbox, but it's already closed by the time Python code runs.
## Description
fix(python-sdk): add retry for TargetClosedError in interact() (Related to #3498)

## Problem
fails ~2/3 of the time with: `BrowserType.interact: TargetClosedError: Target page, context or browser has been closed`

The page object is injected into the Python sandbox, but it's already closed by the time Python code runs.

## Solution
Add retry logic (max 3 attempts) with exponential backoff (1s, 2s) when `TargetClosedError` is detected in the error message.

## Changes
- `apps/python-sdk/firecrawl/v2/client.py` — wrap `interact()` in retry loop for `TargetClosedError`
  - Retry up to 3 times with 1s, 2s delays
  - Re-raise if not `TargetClosedError` or retries exhausted

## Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [ ] Test: interact() with on scrape-bound session (should pass with retries)
- [x] Existing tests still pass
- [x] Branch rebased on upstream/main

## Related Issue
Related to #3498 (fixes the Python interact flakiness)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retry handling for `TargetClosedError` in the Python SDK’s `interact()` to reduce flaky failures on scrape-bound sessions. Retries up to 3 times with backoff for more reliable runs. Related to #3498.

- **Bug Fixes**
  - Wraps `interact()` in a retry loop (max 3 attempts; 1s, then 2s delay).
  - Retries only when the error message includes "TargetClosed"; otherwise re-raises.
  - No API changes; behavior is transparent to callers.

<sup>Written for commit c752ed9f8c86bec1b1d5902f1b19be00ea54de5a. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3558?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

