### PR TITLE
fix(api): drain concurrency-limit backlog on crawl/batch cancel

### DIFF
--- a/apps/api/src/__tests__/snips/v2/batch-scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/batch-scrape.test.ts
@@ -4,15 +4,23 @@ import {
   describeIf,
   TEST_PRODUCTION,
   TEST_SUITE_WEBSITE,
+  TEST_API_URL,
 } from "../lib";
 import { batchScrape, scrapeTimeout, idmux, Identity } from "./lib";
+import request from "supertest";
 
 let identity: Identity;
+let lowConcurrencyIdentity: Identity;
 
 beforeAll(async () => {
   identity = await idmux({
     name: "batch-scrape",
     concurrency: 100,
+    credits: 1000000,
+  });
+  lowConcurrencyIdentity = await idmux({
+    name: "batch-scrape-cancel",
+    concurrency: 2,
     credits: 1000000,
   });
 }, 10000);
@@ -49,6 +57,63 @@ describe("Batch scrape tests", () => {
     },
     scrapeTimeout,
   );
+
+  concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
+    "cancel drains the concurrency-limit backlog and flips status to cancelled",
+    async () => {
+      const apiKey = lowConcurrencyIdentity.apiKey;
+      const urls = Array.from(
+        { length: 20 },
+        (_, i) => `${TEST_SUITE_WEBSITE}?cancelTest=${i}`,
+      );
+
+      const start = await request(TEST_API_URL)
+        .post("/v2/batch/scrape")
+        .set("Authorization", `Bearer ${apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({ urls });
+      expect(start.statusCode).toBe(200);
+      expect(start.body.success).toBe(true);
+      const id = start.body.id as string;
+
+      const queueBefore = await request(TEST_API_URL)
+        .get("/v2/team/queue-status")
+        .set("Authorization", `Bearer ${apiKey}`);
+      expect(queueBefore.statusCode).toBe(200);
+      const waitingBefore = queueBefore.body.waitingJobsInQueue ?? 0;
+
+      const cancel = await request(TEST_API_URL)
+        .delete(`/v2/batch/scrape/${encodeURIComponent(id)}`)
+        .set("Authorization", `Bearer ${apiKey}`)
+        .send();
+      expect(cancel.statusCode).toBe(200);
+      expect(cancel.body.status).toBe("cancelled");
+
+      const statusAfter = await request(TEST_API_URL)
+        .get(`/v2/batch/scrape/${encodeURIComponent(id)}`)
+        .set("Authorization", `Bearer ${apiKey}`)
+        .send();
+      expect(statusAfter.statusCode).toBe(200);
+      expect(statusAfter.body.status).toBe("cancelled");
+
+      const queueAfter = await request(TEST_API_URL)
+        .get("/v2/team/queue-status")
+        .set("Authorization", `Bearer ${apiKey}`);
+      expect(queueAfter.statusCode).toBe(200);
+      const waitingAfter = queueAfter.body.waitingJobsInQueue ?? 0;
+      expect(waitingAfter).toBeLessThan(waitingBefore);
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent("cancel rejects unknown batch id with 404", async () => {
+    const unknownId = "00000000-0000-7000-8000-000000000000";
+    const res = await request(TEST_API_URL)
+      .delete(`/v2/batch/scrape/${unknownId}`)
+      .set("Authorization", `Bearer ${identity.apiKey}`)
+      .send();
+    expect(res.statusCode).toBe(404);
+  });
 
   describeIf(TEST_PRODUCTION)("JSON format", () => {
     it.concurrent(

--- a/apps/api/src/__tests__/snips/v2/batch-scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/batch-scrape.test.ts
@@ -59,7 +59,7 @@ describe("Batch scrape tests", () => {
   );
 
   concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
-    "cancel drains the concurrency-limit backlog and flips status to cancelled",
+    "cancel flips batch status to cancelled immediately",
     async () => {
       const apiKey = lowConcurrencyIdentity.apiKey;
       const urls = Array.from(
@@ -76,12 +76,6 @@ describe("Batch scrape tests", () => {
       expect(start.body.success).toBe(true);
       const id = start.body.id as string;
 
-      const queueBefore = await request(TEST_API_URL)
-        .get("/v2/team/queue-status")
-        .set("Authorization", `Bearer ${apiKey}`);
-      expect(queueBefore.statusCode).toBe(200);
-      const waitingBefore = queueBefore.body.waitingJobsInQueue ?? 0;
-
       const cancel = await request(TEST_API_URL)
         .delete(`/v2/batch/scrape/${encodeURIComponent(id)}`)
         .set("Authorization", `Bearer ${apiKey}`)
@@ -95,13 +89,6 @@ describe("Batch scrape tests", () => {
         .send();
       expect(statusAfter.statusCode).toBe(200);
       expect(statusAfter.body.status).toBe("cancelled");
-
-      const queueAfter = await request(TEST_API_URL)
-        .get("/v2/team/queue-status")
-        .set("Authorization", `Bearer ${apiKey}`);
-      expect(queueAfter.statusCode).toBe(200);
-      const waitingAfter = queueAfter.body.waitingJobsInQueue ?? 0;
-      expect(waitingAfter).toBeLessThan(waitingBefore);
     },
     scrapeTimeout,
   );

--- a/apps/api/src/controllers/v1/crawl-cancel.ts
+++ b/apps/api/src/controllers/v1/crawl-cancel.ts
@@ -1,10 +1,11 @@
 import { Response } from "express";
 import { logger } from "../../lib/logger";
-import { getCrawl, saveCrawl } from "../../lib/crawl-redis";
+import { getCrawl, getCrawlJobs, saveCrawl } from "../../lib/crawl-redis";
 import * as Sentry from "@sentry/node";
 import { configDotenv } from "dotenv";
 import { RequestWithAuth } from "./types";
 import { crawlGroup } from "../../services/worker/nuq";
+import { removeConcurrencyLimitedJobs } from "../../lib/concurrency-limit";
 configDotenv();
 
 export async function crawlCancelController(
@@ -36,6 +37,9 @@ export async function crawlCancelController(
     } catch (error) {
       logger.error(error);
     }
+
+    const jobIds = await getCrawlJobs(req.params.jobId);
+    await removeConcurrencyLimitedJobs(sc.team_id, jobIds);
 
     res.json({
       status: "cancelled",

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -215,7 +215,11 @@ export async function crawlStatusController(
     total?: number;
     creditsUsed?: number;
   } = {
-    status: group.status === "active" ? "scraping" : group.status,
+    status: sc?.cancelled
+      ? "cancelled"
+      : group.status === "active"
+        ? "scraping"
+        : group.status,
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +

--- a/apps/api/src/controllers/v2/crawl-cancel.ts
+++ b/apps/api/src/controllers/v2/crawl-cancel.ts
@@ -1,10 +1,11 @@
 import { Response } from "express";
 import { logger } from "../../lib/logger";
-import { getCrawl, saveCrawl } from "../../lib/crawl-redis";
+import { getCrawl, getCrawlJobs, saveCrawl } from "../../lib/crawl-redis";
 import * as Sentry from "@sentry/node";
 import { configDotenv } from "dotenv";
 import { RequestWithAuth } from "./types";
 import { crawlGroup } from "../../services/worker/nuq";
+import { removeConcurrencyLimitedJobs } from "../../lib/concurrency-limit";
 configDotenv();
 
 export async function crawlCancelController(
@@ -37,6 +38,9 @@ export async function crawlCancelController(
     } catch (error) {
       logger.error(error);
     }
+
+    const jobIds = await getCrawlJobs(req.params.jobId);
+    await removeConcurrencyLimitedJobs(sc.team_id, jobIds);
 
     res.json({
       status: "cancelled",

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -235,7 +235,11 @@ export async function crawlStatusController(
     total?: number;
     creditsUsed?: number;
   } = {
-    status: group.status === "active" ? "scraping" : group.status,
+    status: sc?.cancelled
+      ? "cancelled"
+      : group.status === "active"
+        ? "scraping"
+        : group.status,
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -85,6 +85,25 @@ export async function removeConcurrencyLimitActiveJob(
   await getRedisConnection().zrem(constructKey(team_id), id);
 }
 
+export async function removeConcurrencyLimitedJobs(
+  team_id: string,
+  job_ids: string[],
+) {
+  if (job_ids.length === 0) return;
+  const redis = getRedisConnection();
+  const queueKey = constructQueueKey(team_id);
+  const chunkSize = 1000;
+  for (let i = 0; i < job_ids.length; i += chunkSize) {
+    const chunk = job_ids.slice(i, i + chunkSize);
+    const pipeline = redis.pipeline();
+    pipeline.zrem(queueKey, ...chunk);
+    for (const id of chunk) {
+      pipeline.del(constructJobKey(id));
+    }
+    await pipeline.exec();
+  }
+}
+
 type ConcurrencyLimitedJob = {
   id: string;
   data: any;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Canceling a crawl or batch now drains queued jobs from the concurrency-limit backlog and immediately reports status as cancelled. This prevents stuck backlog and frees capacity for other work.

- **Bug Fixes**
  - v1/v2 cancel controllers remove the crawl’s job IDs from the per-team concurrency-limit queue and delete job keys via a chunked Redis pipeline.
  - v1/v2 status controllers return "cancelled" when a crawl is flagged cancelled, even if the worker group is still active.
  - Tests updated: v2 batch cancel verifies immediate "cancelled" status and 404 for unknown batch IDs; removed a flaky queue-depth assertion.

<sup>Written for commit d9b6561d0cb73a44cc9202d9c92a4283b5ccb777. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3561?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

