### PR TITLE
feat(api): opt-in main-content extraction via @firecrawl/html-extractor

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -86,6 +86,7 @@
     "@bull-board/express": "^6.14.0",
     "@clickhouse/client": "^1.8.1",
     "@dqbd/tiktoken": "^1.0.22",
+    "@firecrawl/html-extractor": "0.1.1",
     "@google-cloud/storage": "^7.19.0",
     "@mendable/firecrawl-rs": "workspace:*",
     "@openrouter/ai-sdk-provider": "^0.4.5",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@dqbd/tiktoken':
         specifier: ^1.0.22
         version: 1.0.22
+      '@firecrawl/html-extractor':
+        specifier: 0.1.1
+        version: 0.1.1
       '@google-cloud/storage':
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
@@ -1096,6 +1099,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@firecrawl/html-extractor@0.1.1':
+    resolution: {integrity: sha512-OjvBkeSD+3l+9HbsFynuqCnmm+ScsRbiSR1TQB5mzFioL4Uw8XC5sS89L+Xdc+d2TgkjnHRi4Al9bJ9IAotk9w==}
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -6564,6 +6570,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.2':
     optional: true
+
+  '@firecrawl/html-extractor@0.1.1': {}
 
   '@google-cloud/paginator@5.0.2':
     dependencies:

--- a/apps/api/src/__tests__/snips/v2/scrape-html-extractor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-html-extractor.test.ts
@@ -1,0 +1,78 @@
+import {
+  describeIf,
+  concurrentIf,
+  ALLOW_TEST_SUITE_WEBSITE,
+  TEST_SUITE_WEBSITE,
+} from "../lib";
+import { Identity, idmux, scrape, scrapeRaw, scrapeTimeout } from "./lib";
+
+describeIf(ALLOW_TEST_SUITE_WEBSITE)("V2 Scrape html-extractor", () => {
+  let identity: Identity;
+
+  beforeAll(async () => {
+    identity = await idmux({
+      name: "v2-scrape-html-extractor",
+      concurrency: 100,
+      credits: 1000000,
+    });
+  }, 10000);
+
+  concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
+    "returns markdown via html-extractor when __experimental_htmlExtractor is set",
+    async () => {
+      const response = await scrape(
+        {
+          url: TEST_SUITE_WEBSITE,
+          __experimental_htmlExtractor: true,
+        },
+        identity,
+      );
+
+      expect(response.markdown).toBeDefined();
+      expect(typeof response.markdown).toBe("string");
+      expect(response.markdown!.length).toBeGreaterThan(0);
+      expect(response.markdown).toContain("Firecrawl");
+
+      // Live path attaches these fields from the extractor result.
+      expect(typeof response.extractionQuality).toBe("number");
+      expect(typeof response.pageType).toBe("string");
+    },
+    scrapeTimeout,
+  );
+
+  concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
+    "does not run html-extractor when flag is omitted",
+    async () => {
+      const response = await scrape(
+        {
+          url: TEST_SUITE_WEBSITE,
+        },
+        identity,
+      );
+
+      expect(response.markdown).toBeDefined();
+      expect(response.markdown).toContain("Firecrawl");
+      expect(response.extractionQuality).toBeUndefined();
+      expect(response.pageType).toBeUndefined();
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
+    "rejects __experimental_htmlExtractor with a non-boolean value",
+    async () => {
+      const raw = await scrapeRaw(
+        {
+          url: TEST_SUITE_WEBSITE,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          __experimental_htmlExtractor: "yes" as any,
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).toBe(400);
+      expect(raw.body.success).toBe(false);
+    },
+    scrapeTimeout,
+  );
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -64,7 +64,11 @@ const configSchema = z.object({
   SEARCH_PREVIEW_TOKEN: z.string().optional(),
   SEARCH_SERVICE_API_SECRET: z.string().optional(),
   SEARCH_FEEDBACK_MAX_AGE_SEC: z.coerce.number().int().positive().default(120),
-  SEARCH_FEEDBACK_DAILY_CAP_CREDITS: z.coerce.number().int().nonnegative().default(100),
+  SEARCH_FEEDBACK_DAILY_CAP_CREDITS: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(100),
 
   // OAuth token introspection
   OAUTH_INTROSPECT_URL: z.string().optional(),
@@ -203,6 +207,8 @@ const configSchema = z.object({
   FIRECRAWL_LOG_TO_FILE: z.stringbool().optional(),
   FIRECRAWL_SAVE_MOCKS: z.stringbool().optional(),
   FIRECRAWL_INDEX_WRITE_ONLY: z.stringbool().optional(),
+  FIRECRAWL_USE_HTML_EXTRACTOR: z.stringbool().optional(),
+  FIRECRAWL_HTML_EXTRACTOR_SHADOW: z.stringbool().optional(),
   DISABLE_BLOCKLIST: z.stringbool().optional(),
   FORCED_ENGINE_DOMAINS: z.string().optional(),
   DEBUG_BRANDING: z.stringbool().optional(),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -208,7 +208,11 @@ const configSchema = z.object({
   FIRECRAWL_SAVE_MOCKS: z.stringbool().optional(),
   FIRECRAWL_INDEX_WRITE_ONLY: z.stringbool().optional(),
   FIRECRAWL_USE_HTML_EXTRACTOR: z.stringbool().optional(),
-  FIRECRAWL_HTML_EXTRACTOR_SHADOW: z.stringbool().optional(),
+  FIRECRAWL_HTML_EXTRACTOR_SHADOW_PERCENT: z.coerce
+    .number()
+    .min(0)
+    .max(100)
+    .default(5),
   DISABLE_BLOCKLIST: z.stringbool().optional(),
   FORCED_ENGINE_DOMAINS: z.string().optional(),
   DEBUG_BRANDING: z.stringbool().optional(),

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -625,6 +625,7 @@ const baseScrapeOptions = z.strictObject({
   __experimental_omce: z.boolean().prefault(false).optional(),
   __experimental_omceDomain: z.string().optional(),
   __experimental_engpicker: z.boolean().prefault(false).optional(),
+  __experimental_htmlExtractor: z.boolean().prefault(false).optional(),
   __forceFirePDF: z.boolean().prefault(false).optional(),
 });
 

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1111,6 +1111,8 @@ export type Document = {
   markdown?: string;
   html?: string;
   rawHtml?: string;
+  extractionQuality?: number;
+  pageType?: string;
   links?: string[];
   images?: string[];
   screenshot?: string;

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -486,6 +486,7 @@ export type InternalOptions = {
   isPreCrawl?: boolean; // Whether this scrape is part of a precrawl job
   agentIndexOnly?: boolean; // Pre-confirmation agent key: serve from index only, never touch web/Fire Engine
   isParse?: boolean; // Whether this scrape originated from /v2/parse
+  useHtmlExtractor?: boolean; // Use @firecrawl/html-extractor for main-content; per-request override of FIRECRAWL_USE_HTML_EXTRACTOR env var
   uploadedFile?: {
     buffer: Buffer;
     filename: string;

--- a/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
@@ -9,7 +9,10 @@ export async function performHtmlExtractor(
   meta: Meta,
   document: Document,
 ): Promise<Document> {
-  const live = ENV_LIVE || meta.internalOptions.useHtmlExtractor === true;
+  const live =
+    ENV_LIVE ||
+    meta.internalOptions.useHtmlExtractor === true ||
+    meta.options.__experimental_htmlExtractor === true;
   const shadow = !live && ENV_SHADOW;
 
   if (!live && !shadow) return document;
@@ -56,8 +59,7 @@ export async function performHtmlExtractor(
       rawHtmlBytes: document.rawHtml.length,
       legacyMarkdownBytes: legacyBytes,
       newMarkdownBytes: result.markdown.length,
-      sizeRatio:
-        legacyBytes > 0 ? result.markdown.length / legacyBytes : null,
+      sizeRatio: legacyBytes > 0 ? result.markdown.length / legacyBytes : null,
       pageType: result.pageType,
       extractionQuality: result.extractionQuality,
       durationMs,

--- a/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
@@ -1,19 +1,17 @@
 import { extract } from "@firecrawl/html-extractor";
 import { Meta } from "..";
+import { config } from "../../../config";
 import { Document } from "../../../controllers/v2/types";
-
-const ENV_LIVE = process.env.FIRECRAWL_USE_HTML_EXTRACTOR === "1";
-const ENV_SHADOW = process.env.FIRECRAWL_HTML_EXTRACTOR_SHADOW === "1";
 
 export async function performHtmlExtractor(
   meta: Meta,
   document: Document,
 ): Promise<Document> {
   const live =
-    ENV_LIVE ||
+    config.FIRECRAWL_USE_HTML_EXTRACTOR === true ||
     meta.internalOptions.useHtmlExtractor === true ||
     meta.options.__experimental_htmlExtractor === true;
-  const shadow = !live && ENV_SHADOW;
+  const shadow = !live && config.FIRECRAWL_HTML_EXTRACTOR_SHADOW === true;
 
   if (!live && !shadow) return document;
   if (document.rawHtml === undefined) return document;

--- a/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
@@ -11,7 +11,10 @@ export async function performHtmlExtractor(
     config.FIRECRAWL_USE_HTML_EXTRACTOR === true ||
     meta.internalOptions.useHtmlExtractor === true ||
     meta.options.__experimental_htmlExtractor === true;
-  const shadow = !live && config.FIRECRAWL_HTML_EXTRACTOR_SHADOW === true;
+  const shadow =
+    !live &&
+    config.FIRECRAWL_HTML_EXTRACTOR_SHADOW_PERCENT > 0 &&
+    Math.random() * 100 < config.FIRECRAWL_HTML_EXTRACTOR_SHADOW_PERCENT;
 
   if (!live && !shadow) return document;
   if (document.rawHtml === undefined) return document;

--- a/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/htmlExtractor.ts
@@ -1,0 +1,68 @@
+import { extract } from "@firecrawl/html-extractor";
+import { Meta } from "..";
+import { Document } from "../../../controllers/v2/types";
+
+const ENV_LIVE = process.env.FIRECRAWL_USE_HTML_EXTRACTOR === "1";
+const ENV_SHADOW = process.env.FIRECRAWL_HTML_EXTRACTOR_SHADOW === "1";
+
+export async function performHtmlExtractor(
+  meta: Meta,
+  document: Document,
+): Promise<Document> {
+  const live = ENV_LIVE || meta.internalOptions.useHtmlExtractor === true;
+  const shadow = !live && ENV_SHADOW;
+
+  if (!live && !shadow) return document;
+  if (document.rawHtml === undefined) return document;
+
+  const url =
+    document.metadata.url ??
+    document.metadata.sourceURL ??
+    meta.rewrittenUrl ??
+    meta.url;
+
+  const start = Date.now();
+  let result: Awaited<ReturnType<typeof extract>>;
+  try {
+    result = await extract(document.rawHtml, { url });
+  } catch (err) {
+    meta.logger.warn("html-extractor failed; falling back", {
+      module: "html-extractor",
+      mode: live ? "live" : "shadow",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return document;
+  }
+  const durationMs = Date.now() - start;
+
+  if (live) {
+    document.markdown = result.markdown;
+    document.extractionQuality = result.extractionQuality;
+    document.pageType = result.pageType;
+    meta.logger.info("html-extractor live", {
+      module: "html-extractor",
+      mode: "live",
+      rawHtmlBytes: document.rawHtml.length,
+      markdownBytes: result.markdown.length,
+      pageType: result.pageType,
+      extractionQuality: result.extractionQuality,
+      durationMs,
+    });
+  } else {
+    const legacyBytes = document.markdown?.length ?? 0;
+    meta.logger.info("html-extractor shadow", {
+      module: "html-extractor",
+      mode: "shadow",
+      rawHtmlBytes: document.rawHtml.length,
+      legacyMarkdownBytes: legacyBytes,
+      newMarkdownBytes: result.markdown.length,
+      sizeRatio:
+        legacyBytes > 0 ? result.markdown.length / legacyBytes : null,
+      pageType: result.pageType,
+      extractionQuality: result.extractionQuality,
+      durationMs,
+    });
+  }
+
+  return document;
+}

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -14,6 +14,7 @@ import { performQuery } from "./query";
 import { uploadScreenshot } from "./uploadScreenshot";
 import { removeBase64Images } from "./removeBase64Images";
 import { performAgent } from "./agent";
+import { performHtmlExtractor } from "./htmlExtractor";
 import { performAttributes } from "./performAttributes";
 
 import { deriveDiff } from "./diff";
@@ -552,6 +553,7 @@ function coerceFieldsToFormats(meta: Meta, document: Document): Document {
 const transformerStack: Transformer[] = [
   deriveHTMLFromRawHTML,
   deriveMarkdownFromHTML,
+  performHtmlExtractor,
   performCleanContent,
   deriveLinksFromHTML,
   deriveImagesFromHTML,


### PR DESCRIPTION
Adds an opt-in main-content extraction path using [`@firecrawl/html-extractor`](https://github.com/firecrawl/html-extractor) (fast Rust-based, page-type aware) as a new transformer that overrides `document.markdown` after the legacy HTML→MD step, with default behavior unchanged. The path is gated three ways: `FIRECRAWL_USE_HTML_EXTRACTOR=1` (env, worker-wide live), `internalOptions.useHtmlExtractor=true` (per-request override), or `FIRECRAWL_HTML_EXTRACTOR_SHADOW=1` (runs the new extractor alongside the legacy path and logs a size/quality comparison via Winston without changing customer-visible output) — all default off, and extraction errors fall through to the legacy path silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in main-content extraction using `@firecrawl/html-extractor` for cleaner markdown and page-type awareness. Default output is unchanged; enable via env, the `__experimental_htmlExtractor` request flag, or an internal option, with a sampled shadow mode for logging only.

- New Features
  - New transformer runs after legacy HTML→MD; in live mode it overrides `document.markdown`.
  - Enable with `FIRECRAWL_USE_HTML_EXTRACTOR=1`, request flag `__experimental_htmlExtractor=true`, or `internalOptions.useHtmlExtractor=true`; shadow sampling via `FIRECRAWL_HTML_EXTRACTOR_SHADOW_PERCENT` (0–100, default 5). Env flags are read via the parsed config schema; the request flag is boolean-validated (400 on invalid) and covered by a new CI snip.
  - Errors silently fall back to the legacy path.
  - Added `extractionQuality` and `pageType` to Document; logs include mode, sizes, size ratio (shadow), duration, and page type.

- Dependencies
  - Added `@firecrawl/html-extractor@0.1.1`.

<sup>Written for commit dd80112c9514c9e4e4feeea07b02cb99da650b85. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3566?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

