### PR TITLE
fix(sdk): add country and enterprise fields to SearchRequest

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "@jest/globals";
+import type { SearchRequest } from "../../../v2/types";
+
+describe("v2 types: SearchRequest", () => {
+  test("accepts country field", () => {
+    const req: SearchRequest = {
+      query: "restaurants",
+      country: "DE",
+    };
+    expect(req.country).toBe("DE");
+  });
+
+  test("country is optional", () => {
+    const req: SearchRequest = { query: "test" };
+    expect(req.country).toBeUndefined();
+  });
+
+  test("accepts enterprise field with valid values", () => {
+    const req: SearchRequest = {
+      query: "sensitive topic",
+      enterprise: ["zdr"],
+    };
+    expect(req.enterprise).toEqual(["zdr"]);
+  });
+
+  test("enterprise accepts all documented values", () => {
+    const req: SearchRequest = {
+      query: "test",
+      enterprise: ["default", "anon", "zdr"],
+    };
+    expect(req.enterprise).toHaveLength(3);
+  });
+
+  test("enterprise is optional", () => {
+    const req: SearchRequest = { query: "test" };
+    expect(req.enterprise).toBeUndefined();
+  });
+
+  test("accepts both country and enterprise together", () => {
+    const req: SearchRequest = {
+      query: "test",
+      country: "US",
+      enterprise: ["default"],
+    };
+    expect(req.country).toBe("US");
+    expect(req.enterprise).toEqual(["default"]);
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -34,9 +34,11 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.limit != null) payload.limit = req.limit;
   if (req.tbs != null) payload.tbs = req.tbs;
   if (req.location != null) payload.location = req.location;
+  if (req.country != null) payload.country = req.country;
   if (req.ignoreInvalidURLs != null)
     payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
   if (req.timeout != null) payload.timeout = req.timeout;
+  if (req.enterprise != null) payload.enterprise = req.enterprise;
   if (req.integration && req.integration.trim())
     payload.integration = req.integration.trim();
   if (req.origin) payload.origin = req.origin;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -544,8 +544,10 @@ export interface SearchRequest {
   limit?: number;
   tbs?: string;
   location?: string;
+  country?: string;
   ignoreInvalidURLs?: boolean;
   timeout?: number; // ms
+  enterprise?: Array<"default" | "anon" | "zdr">;
   scrapeOptions?: ScrapeOptions;
   integration?: string;
   origin?: string;


### PR DESCRIPTION
## Problem

The `/v2/search` API supports `country` for geo-targeting and `enterprise` for Search ZDR options, but the Node.js SDK `SearchRequest` type was missing both fields. Additionally, `prepareSearchPayload` did not forward them to the API, so callers had no way to use these documented features.

Closes #3437

## Solution

- Added `country?: string` to `SearchRequest` in `src/v2/types.ts`
- Added `enterprise?: Array<"default" | "anon" | "zdr">` to `SearchRequest` in `src/v2/types.ts`
- Added forwarding for both fields in `prepareSearchPayload` in `src/v2/methods/search.ts`

## Testing

- Added `src/__tests__/unit/v2/search.unit.test.ts` covering type acceptance of both new fields
- All 60 unit tests pass (`pnpm test:unit`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `country` and `enterprise` in SDK search requests so users can enable geo-targeting and ZDR modes with `/v2/search`.

- **Bug Fixes**
  - Added `country?: string` and `enterprise?: Array<"default" | "anon" | "zdr">` to `SearchRequest`.
  - Forward both fields in `prepareSearchPayload` for `/v2/search`.
  - Added unit tests covering the new fields.

<sup>Written for commit 8e8964c50c692b8fc122be647ed18df3d3ac58fc. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3568?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

