### PR TITLE
fix(ci): add multi-arch (amd64+arm64) build for nuq-postgres image (i…

### DIFF
--- a/.github/workflows/deploy-nuq-postgres.yml
+++ b/.github/workflows/deploy-nuq-postgres.yml
@@ -8,15 +8,22 @@ on:
       - apps/nuq-postgres/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   push-app-image:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    defaults:
-      run:
-        working-directory: './apps/nuq-postgres'
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@main
+
+      - name: 'Set up QEMU (for multi-arch builds)'
+        uses: docker/setup-qemu-action@v3
+
+      - name: 'Set up Docker Buildx'
+        uses: docker/setup-buildx-action@v3
 
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -25,7 +32,10 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: 'Build NuQ Postgres Image'
-        run: |
-          docker build . --tag ghcr.io/firecrawl/nuq-postgres:latest
-          docker push ghcr.io/firecrawl/nuq-postgres:latest
+      - name: 'Build and Push Multi-Arch NuQ Postgres Image'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/nuq-postgres
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: ghcr.io/firecrawl/nuq-postgres:latest


### PR DESCRIPTION
## Summary

Fixes [#3291](https://github.com/mendableai/firecrawl/issues/3291) — `ghcr.io/firecrawl/nuq-postgres:latest` is only published for `linux/amd64`, unlike the other Firecrawl images (`firecrawl`, `playwright-service`) which both support `linux/arm64`. This forces Apple Silicon (M1–M4) and other arm64 users to run the container under QEMU emulation.

## Root Cause

`.github/workflows/deploy-nuq-postgres.yml` used a bare `docker build` + `docker push`, which only builds for the runner's native architecture. The other service images already use `docker/build-push-action` with `platforms: linux/amd64,linux/arm64`.

## Changes

### `.github/workflows/deploy-nuq-postgres.yml`
- Added `permissions: contents: read` + `packages: write` (required for GHCR push)
- Added `docker/setup-qemu-action@v3` step (QEMU emulation for cross-arch builds)
- Added `docker/setup-buildx-action@v3` step (multi-arch builder)
- Replaced the `docker build` + `docker push` run step with `docker/build-push-action@v6`
- Set `platforms: linux/amd64, linux/arm64` so the image is pushed as a proper multi-arch manifest

### `apps/nuq-postgres/Dockerfile`
- No changes needed — the base image `postgres:17` already supports both `linux/amd64` and `linux/arm64` natively. The multi-arch manifest is created at push time by `build-push-action`.

## Testing

After this CI runs, verify with:

```bash
docker manifest inspect ghcr.io/firecrawl/nuq-postgres:latest | grep architecture
# Expected: both "amd64" and "arm64" entries
```

Local dry-run (on an arm64 or amd64 host):

```bash
cd apps/nuq-postgres
docker buildx build --platform linux/amd64,linux/arm64 -t test-nuq .
```

## PR Checklist

- [x] Scope isolated — only `deploy-nuq-postgres.yml` is modified
- [x] No `Dockerfile` changes needed (confirmed `postgres:17` is multi-arch)
- [ ] CI passes (pending)

## Context

> The `ghcr.io/firecrawl/nuq-postgres:latest` image is only published for `linux/amd64`, unlike `ghcr.io/firecrawl/firecrawl:latest` and `ghcr.io/firecrawl/playwright-service:latest` which both support multi-arch (including `linux/arm64`). This causes the self-hosted Docker Compose setup to run the `nuq-postgres` container through emulation (Rosetta on Apple Silicon, QEMU on other arm64 hosts), which is slower and less reliable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-arch builds for the `ghcr.io/firecrawl/nuq-postgres` image so it runs natively on `linux/amd64` and `linux/arm64` (Apple Silicon), matching the other Firecrawl images.

- **Bug Fixes**
  - Switched to `docker/build-push-action@v6` with `platforms: linux/amd64,linux/arm64` and `context: ./apps/nuq-postgres`.
  - Added `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` for cross-arch builds.
  - Set GHCR permissions (`contents: read`, `packages: write`) and replaced manual `docker build/push`.
  - No `Dockerfile` changes needed; `postgres:17` is already multi-arch.

<sup>Written for commit 9d66fa8ee6387606b040eee716a1298f787ce261. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3571?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

