### PR TITLE
fix(js-sdk): accept string API key in constructor

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/clientOptions.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/clientOptions.test.ts
@@ -1,4 +1,4 @@
-import { Firecrawl, type FirecrawlClientOptions } from '../../../index';
+import { Firecrawl, FirecrawlClient, type FirecrawlClientOptions } from '../../../index';
 
 describe('Firecrawl v2 Client Options', () => {
   it('should accept v2 options including timeoutMs, maxRetries, and backoffFactor', () => {
@@ -51,5 +51,29 @@ describe('Firecrawl v2 Client Options', () => {
 
     expect(options.timeoutMs).toBe(300);
     expect(options.apiKey).toBe('test-key');
+  });
+
+  it('should accept a string API key in Firecrawl constructor', () => {
+    const client = new Firecrawl('test-key');
+
+    expect(client).toBeDefined();
+    expect(client).toBeInstanceOf(Firecrawl);
+  });
+
+  it('should accept a string API key in FirecrawlClient constructor', () => {
+    const client = new FirecrawlClient('test-key');
+
+    expect(client).toBeDefined();
+    expect(client).toBeInstanceOf(FirecrawlClient);
+  });
+
+  it('should throw for empty string API key on cloud', () => {
+    expect(() => new Firecrawl('')).toThrow('API key is required');
+  });
+
+  it('should provide v1 accessor when constructed with string', () => {
+    const client = new Firecrawl('test-key');
+
+    expect(client.v1).toBeDefined();
   });
 });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/clientOptions.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/clientOptions.test.ts
@@ -71,6 +71,10 @@ describe('Firecrawl v2 Client Options', () => {
     expect(() => new Firecrawl('')).toThrow('API key is required');
   });
 
+  it('should throw for whitespace-only string API key on cloud', () => {
+    expect(() => new Firecrawl('   ')).toThrow('API key is required');
+  });
+
   it('should provide v1 accessor when constructed with string', () => {
     const client = new Firecrawl('test-key');
 

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -15,11 +15,11 @@ export { Watcher, type WatcherOptions } from "./v2/watcher";
 export { default as FirecrawlAppV1 } from "./v1";
 
 import V1 from "./v1";
-import { FirecrawlClient as V2, type FirecrawlClientOptions } from "./v2/client";
+import { FirecrawlClient as V2, type FirecrawlClientOptions, type FirecrawlClientInput } from "./v2/client";
 import type { FirecrawlAppConfig } from "./v1";
 
 // Re-export v2 client options for convenience
-export type { FirecrawlClientOptions } from "./v2/client";
+export type { FirecrawlClientOptions, FirecrawlClientInput } from "./v2/client";
 
 /** Unified client: extends v2 and adds `.v1` for backward compatibility. */
 export class Firecrawl extends V2 {
@@ -27,12 +27,14 @@ export class Firecrawl extends V2 {
   private _v1?: V1;
   private _v1Opts: FirecrawlAppConfig;
 
-  /** @param opts API credentials and base URL. */
-  constructor(opts: FirecrawlClientOptions = {}) {
-    super(opts);
+  /** @param opts API key string or credentials object. */
+  constructor(opts: FirecrawlClientInput = {}) {
+    const resolved: FirecrawlClientOptions =
+      typeof opts === "string" ? { apiKey: opts } : opts;
+    super(resolved);
     this._v1Opts = {
-      apiKey: opts.apiKey,
-      apiUrl: opts.apiUrl,
+      apiKey: resolved.apiKey,
+      apiUrl: resolved.apiUrl,
     };
   }
 

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -110,6 +110,9 @@ export interface FirecrawlClientOptions {
   backoffFactor?: number;
 }
 
+/** Accepts a plain API key string or a full options object. */
+export type FirecrawlClientInput = FirecrawlClientOptions | string;
+
 /**
  * Firecrawl v2 client. Provides typed access to all v2 endpoints and utilities.
  */
@@ -123,11 +126,14 @@ export class FirecrawlClient {
 
   /**
    * Create a v2 client.
-   * @param options Transport configuration (API key, base URL, timeouts, retries).
+   * @param options API key string or transport configuration object.
    */
-  constructor(options: FirecrawlClientOptions = {}) {
-    const apiKey = options.apiKey ?? process.env.FIRECRAWL_API_KEY ?? "";
-    const apiUrl = (options.apiUrl ?? process.env.FIRECRAWL_API_URL ?? "https://api.firecrawl.dev").replace(/\/$/, "");
+  constructor(options: FirecrawlClientInput = {}) {
+    const opts: FirecrawlClientOptions =
+      typeof options === "string" ? { apiKey: options } : options;
+
+    const apiKey = opts.apiKey ?? process.env.FIRECRAWL_API_KEY ?? "";
+    const apiUrl = (opts.apiUrl ?? process.env.FIRECRAWL_API_URL ?? "https://api.firecrawl.dev").replace(/\/$/, "");
 
     if (this.isCloudService(apiUrl) && !apiKey) {
       throw new Error("API key is required for the cloud API. Set FIRECRAWL_API_KEY env or pass apiKey.");
@@ -136,9 +142,9 @@ export class FirecrawlClient {
     this.http = new HttpClient({
       apiKey,
       apiUrl,
-      timeoutMs: options.timeoutMs,
-      maxRetries: options.maxRetries,
-      backoffFactor: options.backoffFactor,
+      timeoutMs: opts.timeoutMs,
+      maxRetries: opts.maxRetries,
+      backoffFactor: opts.backoffFactor,
     });
   }
 

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -132,7 +132,7 @@ export class FirecrawlClient {
     const opts: FirecrawlClientOptions =
       typeof options === "string" ? { apiKey: options } : options;
 
-    const apiKey = opts.apiKey ?? process.env.FIRECRAWL_API_KEY ?? "";
+    const apiKey = (opts.apiKey ?? process.env.FIRECRAWL_API_KEY ?? "").trim();
     const apiUrl = (opts.apiUrl ?? process.env.FIRECRAWL_API_URL ?? "https://api.firecrawl.dev").replace(/\/$/, "");
 
     if (this.isCloudService(apiUrl) && !apiKey) {


### PR DESCRIPTION
## Summary
- Agents commonly try `new Firecrawl("fc-key")` because passing a string to a constructor is a standard SDK pattern (Stripe, OpenAI, etc.).
- The current constructor requires `new Firecrawl({ apiKey: "fc-key" })`. When a string is passed, `options.apiKey` is `undefined` and the error misleadingly says "API key is required" instead of indicating the wrong constructor shape.
- This PR adds a type guard: if `typeof options === "string"`, it's treated as `{ apiKey: options }`. Both forms now work.
- Applied to both `FirecrawlClient` (v2) and the top-level `Firecrawl` class.

## Test plan
- [x] `new Firecrawl("fc-key")` succeeds and can scrape (verified with real API key)
- [x] `new Firecrawl({ apiKey: "fc-key" })` still works (backward compat, verified with real API)
- [x] `new FirecrawlClient("fc-key")` also works
- [x] `new Firecrawl("")` throws "API key is required" for cloud
- [x] `new Firecrawl()` throws "API key is required" for cloud
- [x] `.v1` accessor works with string constructor
- [x] `app.search(...)` works with string-constructed client
- [x] `pnpm build` succeeds
- [x] `FirecrawlClientInput` type exported for external consumers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept a plain API key string in the JS SDK constructor to match common SDK patterns and avoid misleading errors. Both `new Firecrawl("...")` and `new Firecrawl({ apiKey: "..." })` now work for the top-level client and v2, with whitespace-only keys rejected.

- **Bug Fixes**
  - Constructors for `Firecrawl` and `FirecrawlClient` accept a string API key; object form remains supported. Exported `FirecrawlClientInput`.
  - Trim API keys and throw a clear "API key is required" error for empty or whitespace-only values on cloud; added unit tests for string constructors, `.v1` accessor, and empty/whitespace-only rejection.

<sup>Written for commit 6eefd0f8225d74ba328bb20f7e11c7b0ee7a4534. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

