### PR TITLE
fix(sdk): add deprecated V1 method aliases to V2 clients

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/v1-aliases.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/v1-aliases.test.ts
@@ -1,0 +1,32 @@
+import { FirecrawlClient } from "../../../v2/client";
+
+const ALIAS_MAP: Record<string, string> = {
+  scrapeUrl: "scrape",
+  crawlUrl: "crawl",
+  asyncCrawlUrl: "startCrawl",
+  checkCrawlStatus: "getCrawlStatus",
+  checkCrawlErrors: "getCrawlErrors",
+  mapUrl: "map",
+  batchScrapeUrls: "batchScrape",
+  asyncBatchScrapeUrls: "startBatchScrape",
+  checkBatchScrapeStatus: "getBatchScrapeStatus",
+  checkBatchScrapeErrors: "getBatchScrapeErrors",
+};
+
+describe("V1 deprecated aliases", () => {
+  const app = new FirecrawlClient({
+    apiKey: "fc-test",
+    apiUrl: "http://localhost:9",
+  });
+
+  for (const [alias, target] of Object.entries(ALIAS_MAP)) {
+    it(`${alias} delegates to ${target}`, async () => {
+      const spy = jest
+        .spyOn(app, target as any)
+        .mockResolvedValue({ ok: true } as any);
+      await (app as any)[alias]("https://example.com");
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  }
+});

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -548,52 +548,52 @@ export class FirecrawlClient {
     return new Watcher(this.http, jobId, opts);
   }
 
-  /** @deprecated Use scrape(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer scrape(). */
   async scrapeUrl(url: string, options?: ScrapeOptions): Promise<Document> {
     return this.scrape(url, options);
   }
 
-  /** @deprecated Use crawl(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer crawl(). */
   async crawlUrl(url: string, req: CrawlOptions & { pollInterval?: number; timeout?: number } = {}): Promise<CrawlJob> {
     return this.crawl(url, req);
   }
 
-  /** @deprecated Use startCrawl(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer startCrawl(). */
   async asyncCrawlUrl(url: string, req: CrawlOptions = {}): Promise<CrawlResponse> {
     return this.startCrawl(url, req);
   }
 
-  /** @deprecated Use getCrawlStatus(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer getCrawlStatus(). */
   async checkCrawlStatus(jobId: string, pagination?: PaginationConfig): Promise<CrawlJob> {
     return this.getCrawlStatus(jobId, pagination);
   }
 
-  /** @deprecated Use getCrawlErrors(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer getCrawlErrors(). */
   async checkCrawlErrors(crawlId: string): Promise<CrawlErrorsResponse> {
     return this.getCrawlErrors(crawlId);
   }
 
-  /** @deprecated Use map(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer map(). */
   async mapUrl(url: string, options?: MapOptions): Promise<MapData> {
     return this.map(url, options);
   }
 
-  /** @deprecated Use batchScrape(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer batchScrape(). */
   async batchScrapeUrls(urls: string[], opts?: BatchScrapeOptions & { pollInterval?: number; timeout?: number }): Promise<BatchScrapeJob> {
     return this.batchScrape(urls, opts);
   }
 
-  /** @deprecated Use startBatchScrape(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer startBatchScrape(). */
   async asyncBatchScrapeUrls(urls: string[], opts?: BatchScrapeOptions): Promise<BatchScrapeResponse> {
     return this.startBatchScrape(urls, opts);
   }
 
-  /** @deprecated Use getBatchScrapeStatus(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer getBatchScrapeStatus(). */
   async checkBatchScrapeStatus(jobId: string, pagination?: PaginationConfig): Promise<BatchScrapeJob> {
     return this.getBatchScrapeStatus(jobId, pagination);
   }
 
-  /** @deprecated Use getBatchScrapeErrors(). */
+  /** @deprecated V1 compatibility alias for agent recovery. Prefer getBatchScrapeErrors(). */
   async checkBatchScrapeErrors(jobId: string): Promise<CrawlErrorsResponse> {
     return this.getBatchScrapeErrors(jobId);
   }

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -547,6 +547,56 @@ export class FirecrawlClient {
   watcher(jobId: string, opts: WatcherOptions = {}): Watcher {
     return new Watcher(this.http, jobId, opts);
   }
+
+  /** @deprecated Use scrape(). */
+  async scrapeUrl(url: string, options?: ScrapeOptions): Promise<Document> {
+    return this.scrape(url, options);
+  }
+
+  /** @deprecated Use crawl(). */
+  async crawlUrl(url: string, req: CrawlOptions & { pollInterval?: number; timeout?: number } = {}): Promise<CrawlJob> {
+    return this.crawl(url, req);
+  }
+
+  /** @deprecated Use startCrawl(). */
+  async asyncCrawlUrl(url: string, req: CrawlOptions = {}): Promise<CrawlResponse> {
+    return this.startCrawl(url, req);
+  }
+
+  /** @deprecated Use getCrawlStatus(). */
+  async checkCrawlStatus(jobId: string, pagination?: PaginationConfig): Promise<CrawlJob> {
+    return this.getCrawlStatus(jobId, pagination);
+  }
+
+  /** @deprecated Use getCrawlErrors(). */
+  async checkCrawlErrors(crawlId: string): Promise<CrawlErrorsResponse> {
+    return this.getCrawlErrors(crawlId);
+  }
+
+  /** @deprecated Use map(). */
+  async mapUrl(url: string, options?: MapOptions): Promise<MapData> {
+    return this.map(url, options);
+  }
+
+  /** @deprecated Use batchScrape(). */
+  async batchScrapeUrls(urls: string[], opts?: BatchScrapeOptions & { pollInterval?: number; timeout?: number }): Promise<BatchScrapeJob> {
+    return this.batchScrape(urls, opts);
+  }
+
+  /** @deprecated Use startBatchScrape(). */
+  async asyncBatchScrapeUrls(urls: string[], opts?: BatchScrapeOptions): Promise<BatchScrapeResponse> {
+    return this.startBatchScrape(urls, opts);
+  }
+
+  /** @deprecated Use getBatchScrapeStatus(). */
+  async checkBatchScrapeStatus(jobId: string, pagination?: PaginationConfig): Promise<BatchScrapeJob> {
+    return this.getBatchScrapeStatus(jobId, pagination);
+  }
+
+  /** @deprecated Use getBatchScrapeErrors(). */
+  async checkBatchScrapeErrors(jobId: string): Promise<CrawlErrorsResponse> {
+    return this.getBatchScrapeErrors(jobId);
+  }
 }
 
 export default FirecrawlClient;

--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -302,8 +302,19 @@ class Firecrawl:
         self.browser_execute = self._v2_client.browser_execute
         self.delete_browser = self._v2_client.delete_browser
         self.list_browsers = self._v2_client.list_browsers
-        
+
         self.watcher = self._v2_client.watcher
+
+        self.scrape_url = self._v2_client.scrape_url
+        self.crawl_url = self._v2_client.crawl_url
+        self.map_url = self._v2_client.map_url
+        self.async_crawl_url = self._v2_client.async_crawl_url
+        self.check_crawl_status = self._v2_client.check_crawl_status
+        self.check_crawl_errors = self._v2_client.check_crawl_errors
+        self.batch_scrape_urls = self._v2_client.batch_scrape_urls
+        self.async_batch_scrape_urls = self._v2_client.async_batch_scrape_urls
+        self.check_batch_scrape_status = self._v2_client.check_batch_scrape_status
+        self.check_batch_scrape_errors = self._v2_client.check_batch_scrape_errors
 
     def parse(
         self,
@@ -405,6 +416,17 @@ class AsyncFirecrawl:
         self.list_browsers = self._v2_client.list_browsers
 
         self.watcher = self._v2_client.watcher
+
+        self.scrape_url = self._v2_client.scrape_url
+        self.crawl_url = self._v2_client.crawl_url
+        self.map_url = self._v2_client.map_url
+        self.async_crawl_url = self._v2_client.async_crawl_url
+        self.check_crawl_status = self._v2_client.check_crawl_status
+        self.check_crawl_errors = self._v2_client.check_crawl_errors
+        self.batch_scrape_urls = self._v2_client.batch_scrape_urls
+        self.async_batch_scrape_urls = self._v2_client.async_batch_scrape_urls
+        self.check_batch_scrape_status = self._v2_client.check_batch_scrape_status
+        self.check_batch_scrape_errors = self._v2_client.check_batch_scrape_errors
 
     async def parse(
         self,

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -280,6 +280,46 @@ class FirecrawlClient:
         """Deprecated alias for stop_interaction()."""
         return self.stop_interaction(job_id)
 
+    def scrape_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for scrape()."""
+        return self.scrape(url, **kwargs)
+
+    def crawl_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for crawl()."""
+        return self.crawl(url, **kwargs)
+
+    def map_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for map()."""
+        return self.map(url, **kwargs)
+
+    def async_crawl_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for start_crawl()."""
+        return self.start_crawl(url, **kwargs)
+
+    def check_crawl_status(self, crawl_id: str, **kwargs):
+        """Deprecated v1 alias for get_crawl_status()."""
+        return self.get_crawl_status(crawl_id, **kwargs)
+
+    def check_crawl_errors(self, crawl_id: str):
+        """Deprecated v1 alias for get_crawl_errors()."""
+        return self.get_crawl_errors(crawl_id)
+
+    def batch_scrape_urls(self, urls, **kwargs):
+        """Deprecated v1 alias for batch_scrape()."""
+        return self.batch_scrape(urls, **kwargs)
+
+    def async_batch_scrape_urls(self, urls, **kwargs):
+        """Deprecated v1 alias for start_batch_scrape()."""
+        return self.start_batch_scrape(urls, **kwargs)
+
+    def check_batch_scrape_status(self, job_id: str, **kwargs):
+        """Deprecated v1 alias for get_batch_scrape_status()."""
+        return self.get_batch_scrape_status(job_id, **kwargs)
+
+    def check_batch_scrape_errors(self, job_id: str):
+        """Deprecated v1 alias for get_batch_scrape_errors()."""
+        return self.get_batch_scrape_errors(job_id)
+
     def parse(
         self,
         file: Union[str, Path, bytes, bytearray, BinaryIO],

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -281,43 +281,43 @@ class FirecrawlClient:
         return self.stop_interaction(job_id)
 
     def scrape_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for scrape()."""
+        """V1 compatibility alias for agent recovery. Prefer scrape()."""
         return self.scrape(url, **kwargs)
 
     def crawl_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for crawl()."""
+        """V1 compatibility alias for agent recovery. Prefer crawl()."""
         return self.crawl(url, **kwargs)
 
     def map_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for map()."""
+        """V1 compatibility alias for agent recovery. Prefer map()."""
         return self.map(url, **kwargs)
 
     def async_crawl_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for start_crawl()."""
+        """V1 compatibility alias for agent recovery. Prefer start_crawl()."""
         return self.start_crawl(url, **kwargs)
 
     def check_crawl_status(self, id: str, **kwargs):
-        """Deprecated v1 alias for get_crawl_status()."""
+        """V1 compatibility alias for agent recovery. Prefer get_crawl_status()."""
         return self.get_crawl_status(id, **kwargs)
 
     def check_crawl_errors(self, id: str):
-        """Deprecated v1 alias for get_crawl_errors()."""
+        """V1 compatibility alias for agent recovery. Prefer get_crawl_errors()."""
         return self.get_crawl_errors(id)
 
     def batch_scrape_urls(self, urls, **kwargs):
-        """Deprecated v1 alias for batch_scrape()."""
+        """V1 compatibility alias for agent recovery. Prefer batch_scrape()."""
         return self.batch_scrape(urls, **kwargs)
 
     def async_batch_scrape_urls(self, urls, **kwargs):
-        """Deprecated v1 alias for start_batch_scrape()."""
+        """V1 compatibility alias for agent recovery. Prefer start_batch_scrape()."""
         return self.start_batch_scrape(urls, **kwargs)
 
     def check_batch_scrape_status(self, id: str, **kwargs):
-        """Deprecated v1 alias for get_batch_scrape_status()."""
+        """V1 compatibility alias for agent recovery. Prefer get_batch_scrape_status()."""
         return self.get_batch_scrape_status(id, **kwargs)
 
     def check_batch_scrape_errors(self, id: str):
-        """Deprecated v1 alias for get_batch_scrape_errors()."""
+        """V1 compatibility alias for agent recovery. Prefer get_batch_scrape_errors()."""
         return self.get_batch_scrape_errors(id)
 
     def parse(

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -296,13 +296,13 @@ class FirecrawlClient:
         """Deprecated v1 alias for start_crawl()."""
         return self.start_crawl(url, **kwargs)
 
-    def check_crawl_status(self, crawl_id: str, **kwargs):
+    def check_crawl_status(self, id: str, **kwargs):
         """Deprecated v1 alias for get_crawl_status()."""
-        return self.get_crawl_status(crawl_id, **kwargs)
+        return self.get_crawl_status(id, **kwargs)
 
-    def check_crawl_errors(self, crawl_id: str):
+    def check_crawl_errors(self, id: str):
         """Deprecated v1 alias for get_crawl_errors()."""
-        return self.get_crawl_errors(crawl_id)
+        return self.get_crawl_errors(id)
 
     def batch_scrape_urls(self, urls, **kwargs):
         """Deprecated v1 alias for batch_scrape()."""
@@ -312,13 +312,13 @@ class FirecrawlClient:
         """Deprecated v1 alias for start_batch_scrape()."""
         return self.start_batch_scrape(urls, **kwargs)
 
-    def check_batch_scrape_status(self, job_id: str, **kwargs):
+    def check_batch_scrape_status(self, id: str, **kwargs):
         """Deprecated v1 alias for get_batch_scrape_status()."""
-        return self.get_batch_scrape_status(job_id, **kwargs)
+        return self.get_batch_scrape_status(id, **kwargs)
 
-    def check_batch_scrape_errors(self, job_id: str):
+    def check_batch_scrape_errors(self, id: str):
         """Deprecated v1 alias for get_batch_scrape_errors()."""
-        return self.get_batch_scrape_errors(job_id)
+        return self.get_batch_scrape_errors(id)
 
     def parse(
         self,

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -159,43 +159,43 @@ class AsyncFirecrawlClient:
         return await self.stop_interaction(job_id)
 
     async def scrape_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for scrape()."""
+        """V1 compatibility alias for agent recovery. Prefer scrape()."""
         return await self.scrape(url, **kwargs)
 
     async def crawl_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for crawl()."""
+        """V1 compatibility alias for agent recovery. Prefer crawl()."""
         return await self.crawl(url=url, **kwargs)
 
     async def map_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for map()."""
+        """V1 compatibility alias for agent recovery. Prefer map()."""
         return await self.map(url, **kwargs)
 
     async def async_crawl_url(self, url: str, **kwargs):
-        """Deprecated v1 alias for start_crawl()."""
+        """V1 compatibility alias for agent recovery. Prefer start_crawl()."""
         return await self.start_crawl(url, **kwargs)
 
     async def check_crawl_status(self, id: str, **kwargs):
-        """Deprecated v1 alias for get_crawl_status()."""
+        """V1 compatibility alias for agent recovery. Prefer get_crawl_status()."""
         return await self.get_crawl_status(id, **kwargs)
 
     async def check_crawl_errors(self, id: str):
-        """Deprecated v1 alias for get_crawl_errors()."""
+        """V1 compatibility alias for agent recovery. Prefer get_crawl_errors()."""
         return await self.get_crawl_errors(id)
 
     async def batch_scrape_urls(self, urls, **kwargs):
-        """Deprecated v1 alias for batch_scrape()."""
+        """V1 compatibility alias for agent recovery. Prefer batch_scrape()."""
         return await self.batch_scrape(urls, **kwargs)
 
     async def async_batch_scrape_urls(self, urls, **kwargs):
-        """Deprecated v1 alias for start_batch_scrape()."""
+        """V1 compatibility alias for agent recovery. Prefer start_batch_scrape()."""
         return await self.start_batch_scrape(urls, **kwargs)
 
     async def check_batch_scrape_status(self, id: str, **kwargs):
-        """Deprecated v1 alias for get_batch_scrape_status()."""
+        """V1 compatibility alias for agent recovery. Prefer get_batch_scrape_status()."""
         return await self.get_batch_scrape_status(id, **kwargs)
 
     async def check_batch_scrape_errors(self, id: str):
-        """Deprecated v1 alias for get_batch_scrape_errors()."""
+        """V1 compatibility alias for agent recovery. Prefer get_batch_scrape_errors()."""
         return await self.get_batch_scrape_errors(id)
 
     async def parse(

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -174,13 +174,13 @@ class AsyncFirecrawlClient:
         """Deprecated v1 alias for start_crawl()."""
         return await self.start_crawl(url, **kwargs)
 
-    async def check_crawl_status(self, crawl_id: str, **kwargs):
+    async def check_crawl_status(self, id: str, **kwargs):
         """Deprecated v1 alias for get_crawl_status()."""
-        return await self.get_crawl_status(crawl_id, **kwargs)
+        return await self.get_crawl_status(id, **kwargs)
 
-    async def check_crawl_errors(self, crawl_id: str):
+    async def check_crawl_errors(self, id: str):
         """Deprecated v1 alias for get_crawl_errors()."""
-        return await self.get_crawl_errors(crawl_id)
+        return await self.get_crawl_errors(id)
 
     async def batch_scrape_urls(self, urls, **kwargs):
         """Deprecated v1 alias for batch_scrape()."""
@@ -190,13 +190,13 @@ class AsyncFirecrawlClient:
         """Deprecated v1 alias for start_batch_scrape()."""
         return await self.start_batch_scrape(urls, **kwargs)
 
-    async def check_batch_scrape_status(self, job_id: str, **kwargs):
+    async def check_batch_scrape_status(self, id: str, **kwargs):
         """Deprecated v1 alias for get_batch_scrape_status()."""
-        return await self.get_batch_scrape_status(job_id, **kwargs)
+        return await self.get_batch_scrape_status(id, **kwargs)
 
-    async def check_batch_scrape_errors(self, job_id: str):
+    async def check_batch_scrape_errors(self, id: str):
         """Deprecated v1 alias for get_batch_scrape_errors()."""
-        return await self.get_batch_scrape_errors(job_id)
+        return await self.get_batch_scrape_errors(id)
 
     async def parse(
         self,

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -158,6 +158,46 @@ class AsyncFirecrawlClient:
         """Deprecated alias for stop_interaction()."""
         return await self.stop_interaction(job_id)
 
+    async def scrape_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for scrape()."""
+        return await self.scrape(url, **kwargs)
+
+    async def crawl_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for crawl()."""
+        return await self.crawl(url=url, **kwargs)
+
+    async def map_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for map()."""
+        return await self.map(url, **kwargs)
+
+    async def async_crawl_url(self, url: str, **kwargs):
+        """Deprecated v1 alias for start_crawl()."""
+        return await self.start_crawl(url, **kwargs)
+
+    async def check_crawl_status(self, crawl_id: str, **kwargs):
+        """Deprecated v1 alias for get_crawl_status()."""
+        return await self.get_crawl_status(crawl_id, **kwargs)
+
+    async def check_crawl_errors(self, crawl_id: str):
+        """Deprecated v1 alias for get_crawl_errors()."""
+        return await self.get_crawl_errors(crawl_id)
+
+    async def batch_scrape_urls(self, urls, **kwargs):
+        """Deprecated v1 alias for batch_scrape()."""
+        return await self.batch_scrape(urls, **kwargs)
+
+    async def async_batch_scrape_urls(self, urls, **kwargs):
+        """Deprecated v1 alias for start_batch_scrape()."""
+        return await self.start_batch_scrape(urls, **kwargs)
+
+    async def check_batch_scrape_status(self, job_id: str, **kwargs):
+        """Deprecated v1 alias for get_batch_scrape_status()."""
+        return await self.get_batch_scrape_status(job_id, **kwargs)
+
+    async def check_batch_scrape_errors(self, job_id: str):
+        """Deprecated v1 alias for get_batch_scrape_errors()."""
+        return await self.get_batch_scrape_errors(job_id)
+
     async def parse(
         self,
         file: Union[str, Path, bytes, bytearray, BinaryIO],

--- a/apps/python-sdk/tests/test_v1_aliases.py
+++ b/apps/python-sdk/tests/test_v1_aliases.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import patch
+
+
+ALIAS_MAP = {
+    "scrape_url": "scrape",
+    "crawl_url": "crawl",
+    "map_url": "map",
+    "async_crawl_url": "start_crawl",
+    "check_crawl_status": "get_crawl_status",
+    "check_crawl_errors": "get_crawl_errors",
+    "batch_scrape_urls": "batch_scrape",
+    "async_batch_scrape_urls": "start_batch_scrape",
+    "check_batch_scrape_status": "get_batch_scrape_status",
+    "check_batch_scrape_errors": "get_batch_scrape_errors",
+}
+
+
+class TestV2ClientAliases:
+    def test_aliases_exist(self):
+        from firecrawl.v2.client import FirecrawlClient
+        client = FirecrawlClient(api_key="fc-test", api_url="http://localhost:9")
+        for alias in ALIAS_MAP:
+            assert hasattr(client, alias), f"Missing alias: {alias}"
+
+    def test_aliases_delegate(self):
+        from firecrawl.v2.client import FirecrawlClient
+        client = FirecrawlClient(api_key="fc-test", api_url="http://localhost:9")
+        sentinel = object()
+        for alias, target in ALIAS_MAP.items():
+            with patch.object(client, target, return_value=sentinel) as mock:
+                result = getattr(client, alias)("arg1")
+                mock.assert_called_once()
+                assert result is sentinel
+
+
+class TestTopLevelFirecrawlAliases:
+    def test_aliases_exposed(self):
+        from firecrawl import Firecrawl
+        client = Firecrawl(api_key="fc-test", api_url="http://localhost:9")
+        for alias in ALIAS_MAP:
+            assert hasattr(client, alias), f"Missing on Firecrawl: {alias}"
+
+    def test_aliases_delegate(self):
+        from firecrawl import Firecrawl
+        client = Firecrawl(api_key="fc-test", api_url="http://localhost:9")
+        sentinel = object()
+        for alias, target in ALIAS_MAP.items():
+            with patch.object(client._v2_client, target, return_value=sentinel) as mock:
+                result = getattr(client, alias)("arg1")
+                mock.assert_called_once()
+                assert result is sentinel
+
+
+class TestAsyncFirecrawlAliases:
+    def test_aliases_exposed(self):
+        from firecrawl import AsyncFirecrawl
+        client = AsyncFirecrawl(api_key="fc-test", api_url="http://localhost:9")
+        for alias in ALIAS_MAP:
+            assert hasattr(client, alias), f"Missing on AsyncFirecrawl: {alias}"


### PR DESCRIPTION
## Summary

- Agents trained on V1 docs call `scrape_url()` / `scrapeUrl()`, `crawl_url()` / `crawlUrl()`, etc. and hit `AttributeError` (Python) or `TypeError` (JS), often abandoning Firecrawl entirely.
- Adds 10 deprecated V1 method aliases to both Python (sync + async) and JS V2 clients, following the existing pattern used by `stop_interactive_browser` / `stopInteractiveBrowser`.
- Top-level `Firecrawl` and `AsyncFirecrawl` Python wrappers are also wired so aliases work on the convenience classes.
- All aliases are pure one-line delegations with no behavior change.
- Status/error aliases (`check_crawl_status`, `check_crawl_errors`, `check_batch_scrape_status`, `check_batch_scrape_errors`) use V1's parameter name `id` instead of V2's `job_id`/`crawl_id`, so both positional calls (`check_crawl_status("abc")`) and keyword calls (`check_crawl_status(id="abc")`) work correctly.
- Async Python `crawl_url` passes `url=url` as a keyword argument since the async `crawl()` method takes `**kwargs` (not a positional `url`).
- Excluded: `crawlUrlAndWatch` / `batchScrapeUrlsAndWatch` (V1 returned watcher/generator, V2 polls internally -- return type changed), `extract` (argument shape changed).

### Alias table

| V1 name (Python / JS) | V2 target |
|---|---|
| `scrape_url` / `scrapeUrl` | `scrape` |
| `crawl_url` / `crawlUrl` | `crawl` |
| `map_url` / `mapUrl` | `map` |
| `async_crawl_url` / `asyncCrawlUrl` | `start_crawl` / `startCrawl` |
| `check_crawl_status` / `checkCrawlStatus` | `get_crawl_status` / `getCrawlStatus` |
| `check_crawl_errors` / `checkCrawlErrors` | `get_crawl_errors` / `getCrawlErrors` |
| `batch_scrape_urls` / `batchScrapeUrls` | `batch_scrape` / `batchScrape` |
| `async_batch_scrape_urls` / `asyncBatchScrapeUrls` | `start_batch_scrape` / `startBatchScrape` |
| `check_batch_scrape_status` / `checkBatchScrapeStatus` | `get_batch_scrape_status` / `getBatchScrapeStatus` |
| `check_batch_scrape_errors` / `checkBatchScrapeErrors` | `get_batch_scrape_errors` / `getBatchScrapeErrors` |

## Test plan

- [x] Python: 10 aliases exist on V2 `FirecrawlClient`
- [x] Python: all aliases delegate to correct V2 method (monkeypatch test)
- [x] Python: top-level `Firecrawl` exposes all 10 aliases
- [x] Python: top-level `AsyncFirecrawl` exposes all 10 aliases
- [x] Python: existing test suite unchanged (15 pass, 9 pre-existing failures)
- [x] JS: 10 aliases exist and delegate to correct V2 methods (spy test)
- [x] JS: `pnpm build` succeeds
- [x] JS: existing v2 unit tests unchanged (all pass)