### PR TITLE
fix(js-sdk): expose V2 methods on top-level Firecrawl prototype

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/prototype-discoverability.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/prototype-discoverability.test.ts
@@ -1,4 +1,4 @@
-import { Firecrawl } from "../../../index";
+import { Firecrawl, FirecrawlClient } from "../../../index";
 
 describe("V2 prototype discoverability", () => {
   const app = new Firecrawl({ apiKey: "fc-test", apiUrl: "http://localhost:9" });
@@ -29,14 +29,17 @@ describe("V2 prototype discoverability", () => {
     expect(desc!.get).toBeDefined();
   });
 
-  it("exposed methods are callable with correct this binding", async () => {
-    const spy = jest
-      .spyOn(app, "scrape")
-      .mockResolvedValue({ markdown: "ok" } as any);
-    await app.scrape("https://example.com", { formats: ["markdown"] });
-    expect(spy).toHaveBeenCalledWith("https://example.com", {
-      formats: ["markdown"],
-    });
-    spy.mockRestore();
+  it("copied descriptors are identical to V2 prototype originals", () => {
+    for (const name of ["scrape", "search", "crawl", "map", "startCrawl"]) {
+      const firecrawlDesc = Object.getOwnPropertyDescriptor(Firecrawl.prototype, name);
+      const v2Desc = Object.getOwnPropertyDescriptor(FirecrawlClient.prototype, name);
+      expect(firecrawlDesc).toBeDefined();
+      expect(firecrawlDesc!.value).toBe(v2Desc!.value);
+    }
+  });
+
+  it("copied method resolves this to the Firecrawl instance", async () => {
+    const method = Object.getOwnPropertyDescriptor(Firecrawl.prototype, "scrape")!.value;
+    await expect(method.call(app, "https://example.com")).rejects.toThrow();
   });
 });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/prototype-discoverability.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/prototype-discoverability.test.ts
@@ -1,0 +1,42 @@
+import { Firecrawl } from "../../../index";
+
+describe("V2 prototype discoverability", () => {
+  const app = new Firecrawl({ apiKey: "fc-test", apiUrl: "http://localhost:9" });
+
+  it("exposes V2 methods on immediate Firecrawl prototype", () => {
+    const names = Object.getOwnPropertyNames(Object.getPrototypeOf(app));
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "scrape",
+        "search",
+        "map",
+        "crawl",
+        "startCrawl",
+        "getCrawlStatus",
+        "batchScrape",
+        "v1",
+      ])
+    );
+  });
+
+  it("preserves v1 getter on Firecrawl prototype", () => {
+    const desc = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(app),
+      "v1"
+    );
+    expect(desc).toBeDefined();
+    expect(desc!.get).toBeDefined();
+  });
+
+  it("exposed methods are callable with correct this binding", async () => {
+    const spy = jest
+      .spyOn(app, "scrape")
+      .mockResolvedValue({ markdown: "ok" } as any);
+    await app.scrape("https://example.com", { formats: ["markdown"] });
+    expect(spy).toHaveBeenCalledWith("https://example.com", {
+      formats: ["markdown"],
+    });
+    spy.mockRestore();
+  });
+});

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -43,5 +43,16 @@ export class Firecrawl extends V2 {
   }
 }
 
+// Copy V2 method descriptors onto Firecrawl.prototype so that
+// Object.getOwnPropertyNames(Object.getPrototypeOf(app)) includes them.
+(function exposeV2MethodsOnTopLevel() {
+  for (const name of Object.getOwnPropertyNames(V2.prototype)) {
+    if (name === "constructor") continue;
+    if (Object.prototype.hasOwnProperty.call(Firecrawl.prototype, name)) continue;
+    const desc = Object.getOwnPropertyDescriptor(V2.prototype, name);
+    if (desc) Object.defineProperty(Firecrawl.prototype, name, desc);
+  }
+})();
+
 export default Firecrawl;
 


### PR DESCRIPTION
## Summary
- Agents that introspect `Object.getPrototypeOf(app)` only see `["constructor", "v1"]` - V2 methods like `scrape`, `search`, `crawl` live on the parent `FirecrawlClient` prototype and are invisible to runtime discovery
- Copies V2 method descriptors onto `Firecrawl.prototype` at module load using `Object.defineProperty`
- Skips `constructor` and existing own properties (preserves `v1` getter)
- Auto-exposes future V2 methods without maintenance

## Risk / alternatives
- **Chosen:** Descriptor copy loop at module load. No per-instance overhead, auto-exposes future methods.
- **Rejected:** `declare` keyword (TypeScript-only, no JS emit). Explicit stubs (maintenance when V2 adds methods).
- **Fallback:** Static `methods()` helper (if prototype manipulation is undesirable).

## Test plan
- [x] `Object.getPrototypeOf(app)` includes `scrape`, `search`, `crawl`, `map`, `startCrawl`, `getCrawlStatus`, `batchScrape`
- [x] `v1` getter preserved and returns V1 instance
- [x] Methods callable with correct `this` binding (`jest.spyOn` works)
- [x] `pnpm build` succeeds
- [x] All v2 unit tests pass (11/11 suites)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose V2 methods on the top-level Firecrawl prototype so runtime introspection can find them (e.g., `scrape`, `search`, `crawl`). Copies descriptors at module load and preserves the `v1` getter.

- **Bug Fixes**
  - Copy V2 method descriptors onto `Firecrawl.prototype` at module load, skipping `constructor` and existing properties.
  - Strengthen tests: verify discoverability via `Object.getPrototypeOf(app)`, descriptor identity with `FirecrawlClient.prototype`, and correct `this` binding via direct calls.

<sup>Written for commit 83a8653058fd6102117949839a2a3998d64e477c. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

