### PR TITLE
fix(api): wrap monitor webhook data in array

### DIFF
--- a/apps/api/src/services/monitoring/results.ts
+++ b/apps/api/src/services/monitoring/results.ts
@@ -46,15 +46,17 @@ async function sendMonitorPageWebhook(params: {
 
     await sender?.send(WebhookEvent.MONITOR_PAGE, {
       success: params.status !== "error",
-      data: {
-        monitorId: params.monitorId,
-        checkId: params.checkId,
-        url: params.url,
-        status: params.status,
-        previousScrapeId: params.previousScrapeId ?? null,
-        currentScrapeId: params.currentScrapeId ?? null,
-        error: params.error ?? null,
-      },
+      data: [
+        {
+          monitorId: params.monitorId,
+          checkId: params.checkId,
+          url: params.url,
+          status: params.status,
+          previousScrapeId: params.previousScrapeId ?? null,
+          currentScrapeId: params.currentScrapeId ?? null,
+          error: params.error ?? null,
+        },
+      ],
       error: params.error ?? undefined,
     });
   } catch (error) {

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -585,7 +585,7 @@ async function sendNotifications(params: {
     try {
       const result = await sender?.send(WebhookEvent.MONITOR_CHECK_COMPLETED, {
         success: params.check.status === "completed",
-        data: payload,
+        data: [payload],
         error: params.check.error ?? undefined,
         awaitWebhook: true,
       });

--- a/apps/api/src/services/webhook/types.ts
+++ b/apps/api/src/services/webhook/types.ts
@@ -129,7 +129,7 @@ interface MonitorPageData extends BaseWebhookData {
     previousScrapeId?: string | null;
     currentScrapeId?: string | null;
     error?: string | null;
-  };
+  }[];
   error?: string;
 }
 
@@ -147,6 +147,6 @@ interface MonitorCheckCompletedData extends BaseWebhookData {
       removed: number;
       error: number;
     };
-  };
+  }[];
   error?: string;
 }


### PR DESCRIPTION
Rust webhook-dispatcher declares `data: Vec<serde_json::Value>`, so object payloads from monitor.page and monitor.check.completed were dead-lettered as malformed_json. Wrap the single payload in an array to match the existing crawl/batch shape and the dispatcher's contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap monitoring webhook data in an array to match the Rust dispatcher contract and stop malformed_json dead-lettering for `monitor.page` and `monitor.check.completed`. Aligns the payload shape with existing crawl/batch webhooks.

- **Bug Fixes**
  - Send array `data` for `monitor.page` and `monitor.check.completed`.
  - Update webhook TypeScript types to `data: object[]`.

<sup>Written for commit b44cad6fd265ec60115c1bf22b7c72794399c670. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

