### PR TITLE
fix(sdk): helpful error when agents access SearchData.data

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-data-property.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-data-property.test.ts
@@ -1,0 +1,66 @@
+import { search } from "../../../v2/methods/search";
+
+const fakeHttp = {
+  post: jest.fn(),
+} as any;
+
+describe("SearchData .data helpful error", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("throws with available sources when .data is accessed", async () => {
+    fakeHttp.post.mockResolvedValue({
+      status: 200,
+      data: {
+        success: true,
+        data: {
+          web: [{ title: "Test", url: "http://a.com" }],
+        },
+      },
+    });
+
+    const result = await search(fakeHttp, { query: "test" });
+    expect(result.web).toHaveLength(1);
+    expect(() => (result as any).data).toThrow(
+      /SearchData has no '\.data'.*\.web \(1 results\)/,
+    );
+  });
+
+  it("throws with multiple sources listed", async () => {
+    fakeHttp.post.mockResolvedValue({
+      status: 200,
+      data: {
+        success: true,
+        data: {
+          web: [{ title: "W", url: "http://a.com" }],
+          news: [{ title: "N", url: "http://b.com" }],
+        },
+      },
+    });
+
+    const result = await search(fakeHttp, { query: "test" });
+    expect(() => (result as any).data).toThrow(/\.web.*\.news/);
+  });
+
+  it("throws with generic message when empty", async () => {
+    fakeHttp.post.mockResolvedValue({
+      status: 200,
+      data: { success: true, data: {} },
+    });
+
+    const result = await search(fakeHttp, { query: "test" });
+    expect(() => (result as any).data).toThrow("grouped by source");
+  });
+
+  it("does not show .data in Object.keys", async () => {
+    fakeHttp.post.mockResolvedValue({
+      status: 200,
+      data: {
+        success: true,
+        data: { web: [{ title: "T", url: "http://a.com" }] },
+      },
+    });
+
+    const result = await search(fakeHttp, { query: "test" });
+    expect(Object.keys(result)).not.toContain("data");
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -98,6 +98,20 @@ export async function search(
     if (data.news) out.news = transformArray<SearchResultNews>(data.news);
     if (data.images)
       out.images = transformArray<SearchResultImages>(data.images);
+    Object.defineProperty(out, "data", {
+      get() {
+        const parts: string[] = [];
+        if (out.web?.length) parts.push(`.web (${out.web.length} results)`);
+        if (out.news?.length) parts.push(`.news (${out.news.length} results)`);
+        if (out.images?.length) parts.push(`.images (${out.images.length} results)`);
+        const available = parts.length ? parts.join(", ") : ".web, .news, or .images";
+        throw new Error(
+          `SearchData has no '.data'. Results are grouped by source: ${available}`,
+        );
+      },
+      enumerable: false,
+      configurable: true,
+    });
     return out;
   } catch (err: any) {
     if (err?.isAxiosError) return normalizeAxiosError(err, "search");

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1362,6 +1362,20 @@ class SearchData(BaseModel):
     news: Optional[List[Union[SearchResultNews, Document]]] = None
     images: Optional[List[Union[SearchResultImages, Document]]] = None
 
+    @property
+    def data(self):
+        parts = []
+        if self.web:
+            parts.append(f".web ({len(self.web)} results)")
+        if self.news:
+            parts.append(f".news ({len(self.news)} results)")
+        if self.images:
+            parts.append(f".images ({len(self.images)} results)")
+        available = ", ".join(parts) if parts else ".web, .news, or .images"
+        raise AttributeError(
+            f"SearchData has no '.data'. Results are grouped by source: {available}"
+        )
+
 
 class SearchResponse(BaseResponse[SearchData]):
     """Response from search operation."""

--- a/apps/python-sdk/tests/test_search_data_property.py
+++ b/apps/python-sdk/tests/test_search_data_property.py
@@ -1,0 +1,27 @@
+import pytest
+from firecrawl.v2.types import SearchData, SearchResultWeb, SearchResultNews
+
+
+class TestSearchDataDotData:
+    def test_raises_with_web_results(self):
+        sd = SearchData(web=[SearchResultWeb(title="T", url="http://a.com")])
+        with pytest.raises(AttributeError, match=r"\.web \(1 results\)"):
+            sd.data
+
+    def test_raises_with_multiple_sources(self):
+        sd = SearchData(
+            web=[SearchResultWeb(title="T", url="http://a.com")],
+            news=[SearchResultNews(title="N", url="http://b.com")],
+        )
+        with pytest.raises(AttributeError, match=r"\.web.*\.news"):
+            sd.data
+
+    def test_raises_with_empty_response(self):
+        sd = SearchData()
+        with pytest.raises(AttributeError, match="grouped by source"):
+            sd.data
+
+    def test_web_still_works(self):
+        sd = SearchData(web=[SearchResultWeb(title="T", url="http://a.com")])
+        assert len(sd.web) == 1
+        assert sd.web[0].title == "T"


### PR DESCRIPTION
## Summary
- LLM agents consistently hallucinate `.data` on search results instead of `.web`/`.news`/`.images`
- Tested in 4 Claude Code scenarios: agents without docs always use `.data`; with docs they use `.web`
- Python: `@property` on `SearchData` that raises `AttributeError` with available sources and counts
- JS: `Object.defineProperty` on the search result object (non-enumerable, throws on access)

Error message example:
```
SearchData has no '.data'. Results are grouped by source: .web (10 results), .news (3 results)
```

Companion to firecrawl/firecrawl-docs#980 (docs callout for search response shape).

## Test plan
- [x] Python: 4 unit tests in `tests/test_search_data_property.py`
- [x] JS: 4 unit tests in `src/__tests__/unit/v2/search-data-property.test.ts`
- [x] `.web`/`.news`/`.images` access unaffected
- [x] `.data` not visible in `Object.keys()` (JS)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provide a clear error when `SearchData.data` is accessed, telling users to use `.web`, `.news`, or `.images` and listing available counts. Applies to both Python and JS SDKs to reduce `.data` hallucinations.

- **Bug Fixes**
  - JS: Add non-enumerable `.data` getter on search results that throws with available sources; not shown in `Object.keys`.
  - Python: Add `SearchData.data` property that raises `AttributeError` listing available sources.
  - Tests: Unit tests ensure helpful messaging and no impact on `.web`/`.news`/`.images`.

<sup>Written for commit 645613fae407c2b5ff96242dedbe49380c60389a. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3579?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

