### PR TITLE
Forward documented v2 search country and enterprise fields

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.unit.test.ts
@@ -1,0 +1,36 @@
+import { jest } from "@jest/globals";
+import { FirecrawlClient } from "../../../v2/client";
+
+describe("v2.search unit", () => {
+  test("forwards documented country and enterprise search fields", async () => {
+    const client = new FirecrawlClient({ apiUrl: "http://localhost:3000" });
+    const post = jest.fn(async () => ({
+      status: 200,
+      data: {
+        success: true,
+        data: {
+          web: [],
+        },
+      },
+    }));
+
+    (client as any).http = { post };
+
+    await client.search("restaurants", {
+      country: "DE",
+      enterprise: ["zdr"],
+      limit: 5,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      "/v2/search",
+      expect.objectContaining({
+        query: "restaurants",
+        country: "DE",
+        enterprise: ["zdr"],
+        limit: 5,
+      }),
+      {},
+    );
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -34,9 +34,11 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.limit != null) payload.limit = req.limit;
   if (req.tbs != null) payload.tbs = req.tbs;
   if (req.location != null) payload.location = req.location;
+  if (req.country != null) payload.country = req.country;
   if (req.ignoreInvalidURLs != null)
     payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
   if (req.timeout != null) payload.timeout = req.timeout;
+  if (req.enterprise != null) payload.enterprise = req.enterprise;
   if (req.integration && req.integration.trim())
     payload.integration = req.integration.trim();
   if (req.origin) payload.origin = req.origin;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -544,8 +544,10 @@ export interface SearchRequest {
   limit?: number;
   tbs?: string;
   location?: string;
+  country?: string;
   ignoreInvalidURLs?: boolean;
   timeout?: number; // ms
+  enterprise?: Array<"default" | "anon" | "zdr">;
   scrapeOptions?: ScrapeOptions;
   integration?: string;
   origin?: string;


### PR DESCRIPTION
## Summary

- Adds `country` and `enterprise` to the JS SDK v2 `SearchRequest` type.
- Forwards both documented fields in the `/v2/search` payload.
- Adds a unit test covering `client.search()` payload forwarding for `country` and `enterprise`.

## Context

Fixes #3437. The public `/v2/search` API documents `country` and `enterprise`, but the JS SDK v2 request type and payload preparation did not expose or forward those options.

## Validation

- `git diff --check`
- `$env:NODE_OPTIONS='--experimental-vm-modules'; npx.cmd jest --verbose src/__tests__/unit/v2/search.unit.test.ts` from `apps/js-sdk/firecrawl`

Note: `npm.cmd run test:unit -- search.unit.test.ts` is not directly runnable on Windows because the package script uses POSIX-style `NODE_OPTIONS=...` assignment, so I ran the equivalent command with `NODE_OPTIONS` set in PowerShell.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes and forwards the documented country and enterprise fields in JS SDK v2 search requests to align with the /v2/search API. Adds a unit test verifying client.search() includes these fields in the payload.

<sup>Written for commit 13d8155786c807a42ac014c8c110cb56472c5a14. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3580?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

