### PR TITLE
Fix agent no-auth mode ACUC crash

### DIFF
--- a/apps/api/src/controllers/__tests__/auth.noauth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.noauth.test.ts
@@ -1,0 +1,39 @@
+jest.mock("uuid", () => ({
+  validate: jest.fn(() => true),
+}));
+
+import { authenticateUser } from "../auth";
+import { config } from "../../config";
+import { RateLimiterMode } from "../../types";
+
+describe("authenticateUser without DB authentication", () => {
+  let originalUseDbAuthentication: typeof config.USE_DB_AUTHENTICATION;
+
+  beforeEach(() => {
+    originalUseDbAuthentication = config.USE_DB_AUTHENTICATION;
+    config.USE_DB_AUTHENTICATION = false;
+  });
+
+  afterEach(() => {
+    config.USE_DB_AUTHENTICATION = originalUseDbAuthentication;
+  });
+
+  it("returns a mock ACUC chunk so shared auth middleware can populate req.acuc", async () => {
+    const auth = await authenticateUser(
+      { headers: {}, socket: {} },
+      {},
+      RateLimiterMode.ExtractAgentPreview,
+    );
+
+    expect(auth.success).toBe(true);
+    if (!auth.success) {
+      throw new Error("Expected authentication to succeed");
+    }
+    expect(auth.team_id).toBe("bypass");
+    expect(auth.chunk).toBeDefined();
+    expect(auth.chunk?.api_key).toBe("bypass");
+    expect(auth.chunk?.api_key_id).toBe(0);
+    expect(auth.chunk?.team_id).toBe("bypass");
+    expect(auth.chunk?.is_extract).toBe(true);
+  });
+});

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -4,7 +4,6 @@ import { validate } from "uuid";
 import { config } from "../config";
 import { logger } from "../lib/logger";
 import { parseApi } from "../lib/parseApi";
-import { withAuth } from "../lib/withAuth";
 import { getAgentSponsorStatus } from "../services/agent-sponsor";
 import { getRedisConnection } from "../services/queue-service";
 import { getRateLimiter } from "../services/rate-limiter";
@@ -478,12 +477,23 @@ export async function authenticateUser(
   res,
   mode?: RateLimiterMode,
 ): Promise<AuthResponse> {
-  return withAuth(supaAuthenticateUser, {
-    success: true,
-    chunk: null,
-    team_id: "bypass",
-    org_id: null,
-  })(req, res, mode);
+  if (config.USE_DB_AUTHENTICATION !== true) {
+    const isExtract =
+      mode === RateLimiterMode.Extract ||
+      mode === RateLimiterMode.ExtractStatus ||
+      mode === RateLimiterMode.ExtractAgentPreview;
+    const chunk = mockACUC();
+    chunk.is_extract = isExtract;
+
+    return {
+      success: true,
+      chunk,
+      team_id: chunk.team_id,
+      org_id: null,
+    };
+  }
+
+  return supaAuthenticateUser(req, res, mode);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Return the existing mock ACUC chunk from `authenticateUser` when `USE_DB_AUTHENTICATION` is disabled.
- Preserve the Supabase-backed auth path unchanged when DB authentication is enabled.
- Add a focused regression test covering no-auth `authenticateUser` behavior for agent/extract mode.

Fixes #3553

## Validation
- `pnpm exec jest src/controllers/__tests__/auth.noauth.test.ts --runInBand`
- `pnpm exec prettier --check src/controllers/auth.ts src/controllers/__tests__/auth.noauth.test.ts`
- Attempted `pnpm exec tsc --noEmit --pretty false`, but this isolated install fails on missing `@mendable/firecrawl-rs` native workspace module before completing full typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate a mock ACUC chunk in `authenticateUser` when `USE_DB_AUTHENTICATION` is disabled to prevent agent/extract no-auth crashes and keep middleware working. The Supabase-backed path remains unchanged when DB auth is on. Fixes #3553.

- **Bug Fixes**
  - Return mock ACUC with `"bypass"` values when `USE_DB_AUTHENTICATION` is false and set `is_extract` for `Extract`, `ExtractStatus`, and `ExtractAgentPreview`.
  - Preserve `supaAuthenticateUser` path when DB auth is enabled.
  - Add a regression test for the no-auth agent/extract flow.

<sup>Written for commit 7807baf3a4a243da80ad04195ff3f49794381a7a. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3581?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

