### PR TITLE
fix(api): make new crawl status immediately visible

### DIFF
--- a/apps/api/src/controllers/__tests__/crawl-status-utils.test.ts
+++ b/apps/api/src/controllers/__tests__/crawl-status-utils.test.ts
@@ -1,0 +1,81 @@
+// Avoid Jest ESM-parse issues on the transitive `uuid` import from NuQ.
+jest.mock("uuid", () => ({
+  v5: (value: string) => `normalized-${value}`,
+  validate: (value: string) => value.startsWith("uuid-"),
+}));
+
+import {
+  getCrawlStatusExpiresAt,
+  isCrawlStatusVisibleToTeam,
+} from "../crawl-status-utils";
+
+type TestGroup = Parameters<typeof isCrawlStatusVisibleToTeam>[0]["group"];
+
+function groupForTeam(
+  teamId: string,
+  overrides: Partial<TestGroup> = {},
+): TestGroup {
+  return {
+    id: "019b0000-0000-7000-8000-000000000001",
+    status: "active",
+    createdAt: new Date("2026-05-22T00:00:00.000Z"),
+    ownerId: `normalized-${teamId}`,
+    ttl: 24 * 60 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+describe("crawl status utilities", () => {
+  it("treats a crawl group owned by the team as visible before crawl metadata or child jobs are visible", () => {
+    expect(
+      isCrawlStatusVisibleToTeam({
+        group: groupForTeam("team_123"),
+        groupAnyJob: null,
+        storedCrawl: null,
+        teamId: "team_123",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats crawl metadata owned by the team as visible before the group is visible", () => {
+    expect(
+      isCrawlStatusVisibleToTeam({
+        group: null,
+        groupAnyJob: null,
+        storedCrawl: { team_id: "team_123" },
+        teamId: "team_123",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not expose a group owned by another team unless existing job/crawl checks pass", () => {
+    expect(
+      isCrawlStatusVisibleToTeam({
+        group: groupForTeam("team_123"),
+        groupAnyJob: null,
+        storedCrawl: null,
+        teamId: "team_other",
+      }),
+    ).toBe(false);
+
+    expect(
+      isCrawlStatusVisibleToTeam({
+        group: groupForTeam("team_123"),
+        groupAnyJob: null,
+        storedCrawl: { team_id: "team_other" },
+        teamId: "team_other",
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to the NuQ group expiry when crawl metadata is not visible yet", () => {
+    const group = groupForTeam("team_123", {
+      createdAt: new Date("2026-05-22T00:00:00.000Z"),
+      ttl: 60_000,
+    });
+
+    expect(
+      getCrawlStatusExpiresAt({ group, redisExpiry: null }).toISOString(),
+    ).toBe("2026-05-22T00:01:00.000Z");
+  });
+});

--- a/apps/api/src/controllers/crawl-status-utils.ts
+++ b/apps/api/src/controllers/crawl-status-utils.ts
@@ -1,0 +1,43 @@
+import type { StoredCrawl } from "../lib/crawl-redis";
+import { normalizeOwnerId } from "../services/worker/nuq";
+import type { NuQJobGroupInstance } from "../services/worker/nuq";
+
+export function isCrawlStatusVisibleToTeam(input: {
+  group: NuQJobGroupInstance | null;
+  groupAnyJob: unknown | null;
+  storedCrawl: Pick<StoredCrawl, "team_id"> | null;
+  teamId: string;
+}) {
+  if (input.storedCrawl?.team_id === input.teamId) {
+    return true;
+  }
+
+  if (!input.group) {
+    return false;
+  }
+
+  const normalizedTeamId = normalizeOwnerId(input.teamId);
+  if (normalizedTeamId && input.group.ownerId === normalizedTeamId) {
+    return true;
+  }
+
+  return Boolean(input.groupAnyJob);
+}
+
+export function getCrawlStatusExpiresAt(input: {
+  group: Pick<NuQJobGroupInstance, "createdAt" | "expiresAt" | "ttl"> | null;
+  redisExpiry: Date | null;
+}) {
+  if (input.redisExpiry && input.redisExpiry.getTime() > Date.now()) {
+    return input.redisExpiry;
+  }
+
+  if (!input.group) {
+    return new Date(Date.now() + 24 * 60 * 60 * 1000);
+  }
+
+  return (
+    input.group.expiresAt ??
+    new Date(input.group.createdAt.valueOf() + input.group.ttl)
+  );
+}

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -30,6 +30,10 @@ import {
   crawlGroup,
 } from "../../services/worker/nuq";
 import { ScrapeJobSingleUrls } from "../../types";
+import {
+  getCrawlStatusExpiresAt,
+  isCrawlStatusVisibleToTeam,
+} from "../crawl-status-utils";
 configDotenv();
 
 export type PseudoJob<T> = {
@@ -183,9 +187,22 @@ export async function crawlStatusController(
   );
   const sc = await getCrawl(req.params.jobId);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  if (
+    !isCrawlStatusVisibleToTeam({
+      group,
+      groupAnyJob,
+      storedCrawl: sc,
+      teamId: req.auth.team_id,
+    })
+  ) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
+
+  const statusExpiresAt = async () =>
+    getCrawlStatusExpiresAt({
+      group,
+      redisExpiry: sc ? await getCrawlExpiry(req.params.jobId) : null,
+    }).toISOString();
 
   const zeroDataRetention = !!(
     groupAnyJob?.data?.zeroDataRetention ?? sc?.zeroDataRetention
@@ -217,9 +234,9 @@ export async function crawlStatusController(
   } = {
     status: sc?.cancelled
       ? "cancelled"
-      : group.status === "active"
+      : group?.status === "active"
         ? "scraping"
-        : group.status,
+        : (group?.status ?? "scraping"),
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +
@@ -247,7 +264,7 @@ export async function crawlStatusController(
       completed: 0,
       total: 0,
       creditsUsed: outputBulkA.creditsUsed ?? 0,
-      expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
+      expiresAt: await statusExpiresAt(),
       data: [],
     });
   }
@@ -315,7 +332,7 @@ export async function crawlStatusController(
     completed: outputBulkA.completed ?? 0,
     total: outputBulkA.total ?? 0,
     creditsUsed: outputBulkA.creditsUsed ?? 0,
-    expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
+    expiresAt: await statusExpiresAt(),
     next: outputBulkB.next,
     data: outputBulkB.data,
   });

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -32,6 +32,10 @@ import {
 import { ScrapeJobSingleUrls } from "../../types";
 import { redisEvictConnection } from "../../../src/services/redis";
 import { isBaseDomain, extractBaseDomain } from "../../lib/url-utils";
+import {
+  getCrawlStatusExpiresAt,
+  isCrawlStatusVisibleToTeam,
+} from "../crawl-status-utils";
 configDotenv();
 
 export type PseudoJob<T> = {
@@ -203,9 +207,22 @@ export async function crawlStatusController(
   );
   const sc = await getCrawl(req.params.jobId);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  if (
+    !isCrawlStatusVisibleToTeam({
+      group,
+      groupAnyJob,
+      storedCrawl: sc,
+      teamId: req.auth.team_id,
+    })
+  ) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
+
+  const statusExpiresAt = async () =>
+    getCrawlStatusExpiresAt({
+      group,
+      redisExpiry: sc ? await getCrawlExpiry(req.params.jobId) : null,
+    }).toISOString();
 
   const zeroDataRetention = !!(
     groupAnyJob?.data?.zeroDataRetention ?? sc?.zeroDataRetention
@@ -237,9 +254,9 @@ export async function crawlStatusController(
   } = {
     status: sc?.cancelled
       ? "cancelled"
-      : group.status === "active"
+      : group?.status === "active"
         ? "scraping"
-        : group.status,
+        : (group?.status ?? "scraping"),
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +
@@ -267,7 +284,7 @@ export async function crawlStatusController(
       completed: 0,
       total: 0,
       creditsUsed: outputBulkA.creditsUsed ?? 0,
-      expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
+      expiresAt: await statusExpiresAt(),
       data: [],
     });
   }
@@ -376,7 +393,7 @@ export async function crawlStatusController(
     completed: outputBulkA.completed ?? 0,
     total: outputBulkA.total ?? 0,
     creditsUsed: outputBulkA.creditsUsed ?? 0,
-    expiresAt: (await getCrawlExpiry(req.params.jobId)).toISOString(),
+    expiresAt: await statusExpiresAt(),
     next: outputBulkB.next,
     data: outputBulkB.data,
     ...(warning && { warning }),

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -54,7 +54,9 @@ type NuQOptions = {
 
 // owner IDs can sometimes be non-UUID, so let's normalize it to avoid query breakage - mogery
 const normalizedUUIDNamespace = "0f38e00e-d7ee-4b77-8a7a-a787a3537ca2";
-function normalizeOwnerId(ownerId: string | undefined | null): string | null {
+export function normalizeOwnerId(
+  ownerId: string | undefined | null,
+): string | null {
   if (typeof ownerId !== "string") return null;
   if (isUUID(ownerId)) return ownerId;
   return uuidv5(ownerId, normalizedUUIDNamespace);


### PR DESCRIPTION
## Summary
- allow crawl status lookup when either the durable NuQ crawl group or Redis crawl metadata is visible for the requesting team
- return an initial scraping state with zero counts instead of Job not found before child crawl jobs are visible
- fall back to the NuQ group expiry while Redis crawl metadata is still catching up

Fixes #2662.

## Tests
- cd apps/api && pnpm exec jest src/controllers/__tests__/crawl-status-utils.test.ts --runInBand
- cd apps/api && pnpm exec prettier --check src/controllers/crawl-status-utils.ts src/controllers/__tests__/crawl-status-utils.test.ts src/controllers/v1/crawl-status.ts src/controllers/v2/crawl-status.ts src/services/worker/nuq.ts
- git diff --check

## Notes
- `pnpm exec tsc --noEmit --pretty false` still fails on this checkout because `@mendable/firecrawl-rs` native workspace types are not built/available; the failures are unrelated to this change and match the existing repository state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make new crawl statuses visible immediately by relaxing visibility checks and returning an initial "scraping" state instead of 404s. Also compute `expiresAt` early by falling back to the NuQ group TTL when Redis crawl metadata isn’t ready. Fixes #2662.

- **Bug Fixes**
  - Show status when either the NuQ crawl group owner matches the team or Redis crawl metadata matches.
  - For early reads, return "scraping" with zero counts instead of "Job not found".
  - Set `expiresAt` from Redis when available; otherwise fall back to NuQ group expiry.

- **Refactors**
  - Added `isCrawlStatusVisibleToTeam` and `getCrawlStatusExpiresAt`; used in both v1 and v2 controllers.
  - Exported `normalizeOwnerId` from `nuq` and added unit tests for visibility and expiry logic.

<sup>Written for commit 186630d891fea3f2f3da0631e95a0ef2e58bc0b4. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3582?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

