### PR TITLE
Add agent quickstart docs for 5 SDK languages

### DIFF
--- a/docs-agent-quickstart/elixir.mdx
+++ b/docs-agent-quickstart/elixir.mdx
@@ -1,0 +1,164 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` Elixir SDK source and the v2 OpenAPI spec. Function names and parameter keys are generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+{:firecrawl, "~> 1.4.0"}
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# or pass api_key per call
+{:ok, res} = Firecrawl.search_and_scrape([query: "example"], api_key: "fc-your-api-key")
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Returns relevant URLs you can then scrape or interact with.
+- **`scrape`**: use when you already have a URL and want page content in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a scrape job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query. Constrain results to a site with `site:` prefix, e.g. `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(query: "site:docs.firecrawl.dev webhook retries")
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Search query. Use `site:example.com` to scope to a domain. |
+| `sources` | `list` | Which sources to search. Values: `:web`, `:news`, `:images` (or string equivalents). |
+| `categories` | `list` | Filter results by category. Values: `:github`, `:research`, `:pdf` (or string equivalents). |
+| `limit` | `integer` | Max number of results. |
+| `tbs` | `string` | Time-based filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `location` | `string` | Location string for geo-targeted results. |
+| `country` | `string` | ISO 3166-1 alpha-2 country code (e.g. `"US"`). |
+| `include_domains` | `list[string]` | Domains to include. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list[string]` | Domains to exclude. Mutually exclusive with `include_domains`. |
+| `ignore_invalid_urls` | `boolean` | Drop URLs that cannot be scraped. |
+| `timeout` | `integer` | Request timeout in milliseconds. |
+| `enterprise` | `list[string]` | Enterprise search controls. Values: `"zdr"` (zero data retention), `"anon"` (anonymized). |
+| `scrape_options` | `keyword list` | Scrape each search result with these options (see Scrape parameters). |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: ["markdown"],
+  only_main_content: true
+)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | Target URL to scrape. |
+| `formats` | `list` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`. Map forms: `%{type: "json", prompt: ...}`, `%{type: "screenshot", fullPage: true, quality: 80}`, `%{type: "changeTracking", modes: ["git-diff"], tag: ...}`. |
+| `headers` | `map` | Custom HTTP headers. |
+| `include_tags` | `list[string]` | HTML tags to include. |
+| `exclude_tags` | `list[string]` | HTML tags to exclude. |
+| `only_main_content` | `boolean` | Strip nav, footer, and boilerplate. |
+| `timeout` | `integer` | Timeout in milliseconds. |
+| `wait_for` | `integer` | Wait for page to render (milliseconds). |
+| `mobile` | `boolean` | Use mobile viewport. |
+| `parsers` | `list` | Parser config. Values: `"pdf"`, `%{type: "pdf", mode: "fast" \| "auto" \| "ocr", maxPages: integer}`. |
+| `actions` | `list[map]` | Pre-scrape browser actions: `wait`, `click` (with optional `all`), `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `keyword list` | Geo and language targeting: `[country: "US", languages: ["en-US"]]`. |
+| `skip_tls_verification` | `boolean` | Skip TLS verification. |
+| `remove_base64_images` | `boolean` | Drop base64 images from markdown. |
+| `block_ads` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `atom \| string` | Proxy control. Values: `:basic`, `:enhanced`, `:auto`. |
+| `max_age` | `integer` | Accept cached data up to this age (milliseconds). |
+| `min_age` | `integer` | Accept cached data only if at least this old (milliseconds). |
+| `store_in_cache` | `boolean` | Cache the result. |
+| `lockdown` | `boolean` | Serve only previously cached results; never make outbound requests. |
+| `profile` | `keyword list` | Persistent browser profile: `[name: "my-session", save_changes: true]`. |
+| `zero_data_retention` | `boolean` | Enable zero data retention for this scrape. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for code execution and browser automation. Requires a scrape job ID from a prior scrape.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
+  "<scrapeJobId>",
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+
+# When done, stop the session
+{:ok, _} = Firecrawl.stop_interactive_scrape_browser_session("<scrapeJobId>")
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `string` | Scrape job ID. |
+| `code` | `string` | Code to run in the browser session. |
+| `language` | `atom \| string` | Runtime language. Values: `:python`, `:node`, `:bash`. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+| `origin` | `string` | Optional origin label for execution telemetry. |
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])` → ends the browser session. A bang variant `stop_interactive_scrape_browser_session!/2` is also available.
+
+## Notes
+
+- The Elixir client is **OpenAPI-shaped**: function names and parameter keys are generated from the spec, not manually named.
+- Each public function has a bang (`!`) variant that raises on error instead of returning `{:error, _}`.
+- This SDK exposes **code-based interactions only** (no `prompt` parameter on `interact_with_scrape_browser_session`).
+- Parameters can use atoms (`:web`) or strings (`"web"`) for values like sources and categories.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-agent-quickstart/java.mdx
+++ b/docs-agent-quickstart/java.mdx
@@ -1,0 +1,187 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl-java` SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.7.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.7.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Returns relevant URLs you can then scrape or interact with.
+- **`scrape`**: use when you already have a URL and want page content in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a scrape job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query. Constrain results to a site with `site:` prefix, e.g. `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+- `client.search(query)` → `SearchData`
+- `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchData;
+import java.util.List;
+import java.util.Map;
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries");
+List<Map<String, Object>> web = results.getWeb();
+```
+
+**Important:** Access results via `getWeb()`, `getNews()`, or `getImages()`. Do not treat `SearchData` as a directly iterable list.
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | Search query. Use `site:example.com` to scope to a domain. |
+| `options.sources` | `List<String \| Map>` | Which sources to search. Values: `"web"`, `"news"`, `"images"`. |
+| `options.categories` | `List<String \| Map>` | Filter results by category. Values: `"github"`, `"research"`, `"pdf"`. |
+| `options.limit` | `Integer` | Max number of results. |
+| `options.tbs` | `String` | Time-based filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `options.location` | `String` | Location string for geo-targeted results. |
+| `options.includeDomains` | `List<String>` | Domains to include. Mutually exclusive with `excludeDomains`. |
+| `options.excludeDomains` | `List<String>` | Domains to exclude. Mutually exclusive with `includeDomains`. |
+| `options.ignoreInvalidURLs` | `Boolean` | Drop URLs that cannot be scraped. |
+| `options.timeout` | `Integer` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each search result with these options (see Scrape parameters). |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+- `client.scrape(url)` → `Document`
+- `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown"))
+        .onlyMainContent(true)
+        .build()
+);
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | Target URL to scrape. |
+| `options.formats` | `List<Object>` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `JsonFormat.builder().prompt(...).schema(...).build()`, `Map.of("type", "screenshot", "fullPage", true)`, `Map.of("type", "changeTracking", "modes", List.of("git-diff"))`, `Map.of("type", "attributes", "selectors", List.of(...))`. |
+| `options.headers` | `Map<String, String>` | Custom HTTP headers. |
+| `options.includeTags` | `List<String>` | HTML tags to include. |
+| `options.excludeTags` | `List<String>` | HTML tags to exclude. |
+| `options.onlyMainContent` | `Boolean` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `Integer` | Timeout in milliseconds. |
+| `options.waitFor` | `Integer` | Wait for page to render (milliseconds). |
+| `options.mobile` | `Boolean` | Use mobile viewport. |
+| `options.parsers` | `List<Object>` | Parser config. Values: `"pdf"`, `Map.of("type", "pdf", "maxPages", 5)`. |
+| `options.actions` | `List<Map<String, Object>>` | Pre-scrape browser actions: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`. |
+| `options.location` | `LocationConfig` | Geo and language targeting. Fields: `country`, `languages`. |
+| `options.skipTlsVerification` | `Boolean` | Skip TLS verification. |
+| `options.removeBase64Images` | `Boolean` | Drop base64 images from markdown. |
+| `options.blockAds` | `Boolean` | Block ads and cookie popups. |
+| `options.proxy` | `String` | Proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom URL. |
+| `options.maxAge` | `Long` | Accept cached data up to this age (milliseconds). |
+| `options.storeInCache` | `Boolean` | Cache the result. |
+| `options.lockdown` | `Boolean` | Serve only previously cached results; never make outbound requests. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for code execution and Playwright-based browser automation. Requires a scrape job ID from a prior scrape.
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` → `BrowserExecuteResponse`
+- `client.interact(jobId, code, language, timeout)` → `BrowserExecuteResponse`
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+BrowserExecuteResponse result = client.interact(
+    "<scrapeJobId>",
+    "console.log(await page.title());",
+    "node",
+    60
+);
+
+// When done, stop the session
+client.stopInteractiveBrowser("<scrapeJobId>");
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | Scrape job ID. |
+| `code` | `String` | Code to run in the browser session (e.g. Playwright `page` usage). |
+| `language` | `String` | Runtime language. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Null uses API default (30 seconds). |
+| `origin` | `String` | Optional origin label for request attribution. |
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` → ends the browser session. Returns `BrowserDeleteResponse` with `isSuccess()`, `getSessionDurationMs()`, `getCreditsBilled()`, `getError()`.
+
+## Notes
+
+- **Deprecated aliases:** `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- The Java SDK exposes **code-based interactions only**: there is no `prompt` parameter on `interact` (unlike JS/TS, Python, and Rust SDKs).
+- Uses builder pattern for options: `ScrapeOptions.builder()...build()`, `SearchOptions.builder()...build()`.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-agent-quickstart/node.mdx
+++ b/docs-agent-quickstart/node.mdx
@@ -1,0 +1,170 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `@mendable/firecrawl-js` SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Returns relevant URLs you can then scrape or interact with.
+- **`scrape`**: use when you already have a URL and want page content in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query. Constrain results to a site with `site:` prefix, e.g. `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries");
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+**Important:** `search()` does not return `{ data: [...] }`. Access results via `results.web`, `results.news`, or `results.images`.
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Search query. Use `site:example.com` to scope to a domain. |
+| `options.sources` | `Array<"web" \| "news" \| "images">` | Which sources to search. |
+| `options.categories` | `Array<"github" \| "research" \| "pdf">` | Filter results by category. |
+| `options.includeDomains` | `string[]` | Domains to include. Mutually exclusive with `excludeDomains`. |
+| `options.excludeDomains` | `string[]` | Domains to exclude. Mutually exclusive with `includeDomains`. |
+| `options.limit` | `number` | Max number of results. |
+| `options.tbs` | `string` | Time-based filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `options.location` | `string` | Location string for geo-targeted results. |
+| `options.ignoreInvalidURLs` | `boolean` | Drop URLs that cannot be scraped. |
+| `options.timeout` | `number` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each search result with these options (see Scrape parameters). |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: ["markdown"],
+  onlyMainContent: true,
+});
+console.log(doc.markdown);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | Target URL to scrape. |
+| `options.formats` | `FormatOption[]` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors: [{ selector, attribute }] }`. Note: plain string `"json"` is rejected by the SDK — use the object form. |
+| `options.headers` | `Record<string, string>` | Custom HTTP headers. |
+| `options.includeTags` | `string[]` | HTML tags to include. |
+| `options.excludeTags` | `string[]` | HTML tags to exclude. |
+| `options.onlyMainContent` | `boolean` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `number` | Timeout in milliseconds. |
+| `options.waitFor` | `number` | Wait for page to render (milliseconds). |
+| `options.mobile` | `boolean` | Use mobile viewport. |
+| `options.parsers` | `Array<string \| { type: "pdf", mode?: "fast" \| "auto" \| "ocr", maxPages?: number }>` | Parser config for file types like PDF. |
+| `options.actions` | `ActionOption[]` | Pre-scrape browser actions: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`: `"up"` or `"down"`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf` (`format`, `landscape`, `scale`). |
+| `options.location` | `{ country?: string, languages?: string[] }` | Geo and language targeting. |
+| `options.skipTlsVerification` | `boolean` | Skip TLS verification. |
+| `options.removeBase64Images` | `boolean` | Drop base64 images from markdown. |
+| `options.fastMode` | `boolean` | Faster scrapes with reduced fidelity. |
+| `options.blockAds` | `boolean` | Block ads and cookie popups. |
+| `options.proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto" \| string` | Proxy control. |
+| `options.maxAge` | `number` | Accept cached data up to this age (milliseconds). |
+| `options.minAge` | `number` | Accept cached data only if at least this old (milliseconds). |
+| `options.storeInCache` | `boolean` | Cache the result. |
+| `options.lockdown` | `boolean` | Serve only previously cached results; never make outbound requests. |
+| `options.profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile shared across scrapes and interactions. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or natural-language browser instructions. Requires a `scrapeId` from a prior scrape response.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+
+// When done, stop the session
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | Scrape job ID from `document.metadata.scrapeId`. |
+| `args.code` | `string` | Code to run in the browser session (e.g. Playwright `page` usage). At least one of `code` or `prompt` required. |
+| `args.prompt` | `string` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` required. |
+| `args.language` | `"python" \| "node" \| "bash"` | Runtime language. Default: `"node"`. |
+| `args.timeout` | `number` | Execution timeout in seconds. |
+
+### Stop session
+
+`client.stopInteraction(jobId)` → ends the browser session. Returns `{ success, sessionDurationMs?, creditsBilled?, error? }`.
+
+## Notes
+
+- **Deprecated aliases:** `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`; `scrapeUrl` → `scrape`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed in `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-agent-quickstart/python.mdx
+++ b/docs-agent-quickstart/python.mdx
@@ -1,0 +1,167 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `firecrawl-py` SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Returns relevant URLs you can then scrape or interact with.
+- **`scrape`**: use when you already have a URL and want page content in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query. Constrain results to a site with `site:` prefix, e.g. `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search("site:docs.firecrawl.dev webhook retries")
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+**Important:** `search()` does not return `{ data: [...] }`. Access results via `results.web`, `results.news`, or `results.images`.
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | Search query. Use `site:example.com` to scope to a domain. |
+| `sources` | `list[str \| Source]` | Which sources to search. Values: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str \| Category]` | Filter results by category. Values: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Domains to include. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Domains to exclude. Mutually exclusive with `include_domains`. |
+| `limit` | `int` | Max number of results. Default: `5`. |
+| `tbs` | `str` | Time-based filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `location` | `str` | Location string for geo-targeted results. |
+| `ignore_invalid_urls` | `bool` | Drop URLs that cannot be scraped. |
+| `timeout` | `int` | Request timeout in milliseconds. Default: `300000`. |
+| `scrape_options` | `ScrapeOptions` | Scrape each search result with these options (see Scrape parameters). |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=["markdown"],
+    only_main_content=True,
+)
+print(doc.markdown)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | Target URL to scrape. |
+| `formats` | `list` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": [...], "tag": ...}`, `{"type": "attributes", "selectors": [{"selector": ..., "attribute": ...}]}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. |
+| `include_tags` | `list[str]` | HTML tags to include. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait for page to render (milliseconds). |
+| `mobile` | `bool` | Use mobile viewport. |
+| `parsers` | `list[str \| dict]` | Parser config for file types like PDF. Values: `"pdf"`, `{"type": "pdf", "mode": "fast" \| "auto" \| "ocr", "max_pages": int}`. |
+| `actions` | `list[dict]` | Pre-scrape browser actions: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`: `"up"` or `"down"`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf`. |
+| `location` | `dict` | Geo and language targeting: `{"country": "US", "languages": ["en-US"]}`. |
+| `skip_tls_verification` | `bool` | Skip TLS verification. |
+| `remove_base64_images` | `bool` | Drop base64 images from markdown. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Accept cached data up to this age (milliseconds). |
+| `store_in_cache` | `bool` | Cache the result. |
+| `lockdown` | `bool` | Serve only previously cached results; never make outbound requests. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "my-session", "save_changes": True}`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or natural-language browser instructions. Requires a `scrape_id` from a prior scrape response.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+`prompt` is keyword-only. At least one of `code` or `prompt` must be non-empty.
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+
+# When done, stop the session
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | Scrape job ID from `document.metadata.scrape_id`. |
+| `code` | `str` | Code to run in the browser session (positional). At least one of `code` or `prompt` required. |
+| `prompt` | `str` | Natural-language instruction for the browser agent (keyword-only). At least one of `code` or `prompt` required. |
+| `language` | `str` | Runtime language. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+### Stop session
+
+`client.stop_interaction(job_id)` → ends the browser session. Returns `BrowserDeleteResponse` with `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- **Deprecated aliases:** `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`; `scrape_url` → `scrape`.
+- `FirecrawlApp` is an alias for `Firecrawl`; `AsyncFirecrawlApp` for `AsyncFirecrawl`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- `min_age` exists on `ScrapeOptions` (for use in `scrape_options` passed to `search`) but is not a direct parameter on `client.scrape()`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-agent-quickstart/rust.mdx
+++ b/docs-agent-quickstart/rust.mdx
@@ -1,0 +1,185 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` crate source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Returns relevant URLs you can then scrape or interact with.
+- **`scrape`**: use when you already have a URL and want page content in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a scrape job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query. Constrain results to a site with `site:` prefix, e.g. `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::Client;
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", None)
+    .await?;
+
+if let Some(web) = results.data.web {
+    for item in web {
+        println!("{:?}", item);
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | Search query. Use `site:example.com` to scope to a domain. |
+| `options.sources` | `Vec<SearchSource>` | Which sources to search. Values: `Web`, `News`, `Images`. |
+| `options.categories` | `Vec<SearchCategory>` | Filter results by category. Values: `Github`, `Research`, `Pdf`. |
+| `options.limit` | `u32` | Max number of results. |
+| `options.tbs` | `String` | Time-based filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `options.location` | `String` | Location string for geo-targeted results. |
+| `options.ignore_invalid_urls` | `bool` | Drop URLs that cannot be scraped. |
+| `options.include_domains` | `Vec<String>` | Domains to include. Mutually exclusive with `exclude_domains`. |
+| `options.exclude_domains` | `Vec<String>` | Domains to exclude. Mutually exclusive with `include_domains`. |
+| `options.timeout` | `u32` | Request timeout in milliseconds. |
+| `options.scrape_options` | `ScrapeOptions` | Scrape each search result with these options (see Scrape parameters). |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        only_main_content: Some(true),
+        ..Default::default()
+    })
+    .await?;
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | Target URL to scrape. |
+| `options.formats` | `Vec<Format>` | Output formats. Values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`. |
+| `options.headers` | `HashMap<String, String>` | Custom HTTP headers. |
+| `options.include_tags` | `Vec<String>` | HTML tags to include. |
+| `options.exclude_tags` | `Vec<String>` | HTML tags to exclude. |
+| `options.only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `u32` | Timeout in milliseconds. |
+| `options.wait_for` | `u32` | Wait for page to render (milliseconds). |
+| `options.mobile` | `bool` | Use mobile viewport. |
+| `options.parsers` | `Vec<ParserConfig>` | Parser config. Values: `ParserConfig::Simple("pdf")`, `ParserConfig::Pdf { parser_type, max_pages }`. |
+| `options.actions` | `Vec<Action>` | Pre-scrape browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Screenshot`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `options.location` | `LocationConfig` | Geo and language targeting. Fields: `country`, `languages`. |
+| `options.skip_tls_verification` | `bool` | Skip TLS verification. |
+| `options.remove_base64_images` | `bool` | Drop base64 images from markdown. |
+| `options.fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `options.block_ads` | `bool` | Block ads and cookie popups. |
+| `options.proxy` | `ProxyType` | Proxy control. Values: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `options.max_age` | `u32` | Accept cached data up to this age (milliseconds). |
+| `options.min_age` | `u32` | Accept cached data only if at least this old (milliseconds). |
+| `options.store_in_cache` | `bool` | Cache the result. |
+| `options.lockdown` | `bool` | Serve only previously cached results; never make outbound requests. |
+| `options.profile` | `ProfileConfig` | Persistent browser profile. Fields: `name`, `save_changes`. |
+| `options.json_options` | `JsonOptions` | JSON extraction config. Fields: `schema`, `system_prompt`, `prompt`. |
+| `options.screenshot_options` | `ScreenshotOptions` | Screenshot config. Fields: `full_page`, `quality`, `viewport`. |
+| `options.change_tracking_options` | `ChangeTrackingOptions` | Change tracking config. Fields: `modes` (`GitDiff`, `Json`), `schema`, `prompt`, `tag`. |
+| `options.attribute_selectors` | `Vec<AttributeSelector>` | Attribute extraction. Fields: `selector`, `attribute`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or natural-language browser instructions. Requires a scrape job ID from a prior scrape.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions};
+
+let result = client
+    .interact(
+        "<scrapeJobId>",
+        ScrapeExecuteOptions {
+            prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+// When done, stop the session
+client.stop_interaction("<scrapeJobId>").await?;
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | Scrape job ID. |
+| `options.code` | `Option<String>` | Code to run in the browser session. At least one of `code` or `prompt` required. |
+| `options.prompt` | `Option<String>` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` required. |
+| `options.language` | `ScrapeExecuteLanguage` | Runtime language. Values: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `options.timeout` | `u32` | Execution timeout in seconds. |
+
+### Stop session
+
+`client.stop_interaction(job_id)` → ends the browser session. Returns `Result<ScrapeBrowserDeleteResponse, FirecrawlError>` with `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- **Deprecated aliases:** `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- `ScrapeOptions` uses dedicated sub-structs for complex format options: `json_options`, `screenshot_options`, `change_tracking_options`, `attribute_selectors`.
+- `search_and_scrape(query, limit)` is a convenience helper that calls `search` with default options and returns `Vec<Document>`.
+- All types are exported at the crate root: `use firecrawl::Client` (not `use firecrawl::v2::Client`).
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary\n\n- Adds canonical agent quickstart docs for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir** covering `search`, `scrape`, and `interact` endpoints\n- Each file includes install, auth, method signatures, working examples, complete parameter tables with descriptions, and language-specific notes\n- Generated from SDK source code and v2 OpenAPI spec as source of truth\n\n**Note:** These files are intended for `firecrawl-docs/agent-quickstart/` but are staged in `docs-agent-quickstart/` here due to write access constraints on `firecrawl-docs`. The files should be moved to `firecrawl-docs/agent-quickstart/` and the `docs.json` nav updated to include them under the \"Build with AI\" tab as an \"Agent Quickstarts\" group.\n\n## Files\n\n- `docs-agent-quickstart/node.mdx` → `firecrawl-docs/agent-quickstart/node.mdx`\n- `docs-agent-quickstart/python.mdx` → `firecrawl-docs/agent-quickstart/python.mdx`\n- `docs-agent-quickstart/rust.mdx` → `firecrawl-docs/agent-quickstart/rust.mdx`\n- `docs-agent-quickstart/java.mdx` → `firecrawl-docs/agent-quickstart/java.mdx`\n- `docs-agent-quickstart/elixir.mdx` → `firecrawl-docs/agent-quickstart/elixir.mdx`\n\n## Test plan\n\n- [ ] Verify each quickstart renders correctly in Mintlify\n- [ ] Confirm parameter tables match current SDK source\n- [ ] Move files to `firecrawl-docs/agent-quickstart/` and update `docs.json` navigation\n\nhttps://claude.ai/code/session_017ifpoboQnrZZDgXpqtWW3p

---
_Generated by [Claude Code](https://claude.ai/code/session_017ifpoboQnrZZDgXpqtWW3p)_