### PR TITLE
fix(api): deduplicate adjacent repeated words in markdown output

### DIFF
--- a/apps/api/src/lib/html-to-markdown.ts
+++ b/apps/api/src/lib/html-to-markdown.ts
@@ -76,6 +76,7 @@ export async function parseMarkdown(
         zeroDataRetention,
       });
       markdownContent = await postProcessMarkdown(markdownContent);
+      markdownContent = deduplicateAdjacentWords(markdownContent);
       return markdownContent;
     } catch (error) {
       contextLogger.error(
@@ -96,6 +97,7 @@ export async function parseMarkdown(
       const converter = await GoMarkdownConverter.getInstance();
       let markdownContent = await converter.convertHTMLToMarkdown(html);
       markdownContent = await postProcessMarkdown(markdownContent);
+      markdownContent = deduplicateAdjacentWords(markdownContent);
       return markdownContent;
     }
   } catch (error) {
@@ -144,6 +146,7 @@ export async function parseMarkdown(
   try {
     let markdownContent = await turndownService.turndown(html);
     markdownContent = await postProcessMarkdown(markdownContent);
+    markdownContent = deduplicateAdjacentWords(markdownContent);
 
     return markdownContent;
   } catch (error) {
@@ -182,4 +185,13 @@ function removeSkipToContentLinks(markdownContent: string): string {
     "",
   );
   return newMarkdownContent;
+
+/**
+ * Fix word repetition bug where adjacent HTML elements produce
+ * duplicated adjacent words (e.g. "FunktionalFunktional" instead of
+ * "Funktional\nFunktional").
+ */
+function deduplicateAdjacentWords(markdownContent: string): string {
+  return markdownContent.replace(/(\b\w{3,}+)\1\b/g, "$1\n$1");
+}
 }


### PR DESCRIPTION
The Go/Rust HTML-to-Markdown converter can produce concatenated identical words at block-level element boundaries (e.g. "Funktional- Funktional" rendered as "FunktionalFunktional").

Add deduplicateAdjacentWords() post-processing step after every postProcessMarkdown() call to detect and fix this pattern.

Fixes #3583
## Description

### Problem

The `markdown` format produced by Firecrawl's `/v1/scrape` endpoint contains **duplicated adjacent words** with no separating whitespace or newline — e.g. `FunktionalFunktional` instead of `Funktional\nFunktional` or `Funktional Funktional`.

This occurs at **boundaries where two HTML elements with the same visible text are rendered next to each other** (common with cookie-consent banners that have duplicate "Accept"/"Deny" labels in different DOM nodes). The Go/Rust HTML→Markdown converter does not insert a separator between these tokens, corrupting the output for downstream LLM consumption.

**Reproduction steps:**
1. Call the Firecrawl scrape endpoint against a page with a cookie consent banner (German CMP widgets like Cookiebot/Usercentrics reliably reproduce this).
2. Request the `markdown` format: `POST /v1/scrape` with `{ "url": "<page>", "formats": ["markdown"] }`.
3. Inspect the returned `markdown` field around the consent section.
4. Observe: `FunktionalFunktional\nAlways active` (concatenated tokens).

### Solution

Add a `deduplicateAdjacentWords()` post-processing step that runs **after every `postProcessMarkdown()` call** (3 call sites in `html-to-markdown.ts`):

```ts
function deduplicateAdjacentWords(markdownContent: string): string {
  // Detect a word (≥3 chars) immediately followed by the same word
  return markdownContent.replace(/(\b\w{3,}+)\1\b/g, "$1\n$1");
}
```

This inserts a newline between the duplicated tokens so the markdown renders as **distinct tokens** for the LLM, which is the correct semantic output.

### Impact

- ✅ No change to the Go/Rust converter itself — pure JS post-processing
- ✅ Applied consistently at all 3 `postProcessMarkdown()` call sites
- ✅ Downstream LLM consumers receive properly separated tokens
- ✅ No performance impact — regex runs once on the final string

### Verification

```bash
# Run existing html-to-markdown tests
pnpm test -- --filter @firecrawl/apps/api
```

Fixes #3583


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concatenated duplicate words in markdown at HTML element boundaries by deduplicating adjacent repeats. Adds a post-processing step after `postProcessMarkdown()` to insert a newline between duplicates (e.g., "FunktionalFunktional" -> "Funktional\nFunktional"). Fixes #3583

- **Bug Fixes**
  - Add `deduplicateAdjacentWords()` and run it after every `postProcessMarkdown()` call.
  - Use a regex to detect back-to-back identical words (≥3 chars) and insert a newline.
  - No changes to Go/Rust converters; negligible runtime cost.

<sup>Written for commit 1f62b5b6d590b77d0a0d7d8ad15241e14cc906f0. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3586?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

