### PR TITLE
docs: fix NuQDB Docker command continuation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ docker build -t nuq-postgres .
 and then run:
 
 ```bash
-docker run --name nuqdb \          
+docker run --name nuqdb \
   -e POSTGRES_PASSWORD=postgres \
   -p 5433:5432 \
   -v nuq-data:/var/lib/postgresql/data \


### PR DESCRIPTION
CONTRIBUTING.md has trailing spaces after the line-continuation backslash in the NuQDB Docker command.

In shells, the spaces after `\` prevent the newline continuation from working when the command is copy/pasted. This removes the trailing spaces so the multi-line Docker command continues correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the NuQDB Docker command in CONTRIBUTING.md by removing trailing spaces after the line-continuation backslash so the multi-line command copies and runs correctly in shells.

<sup>Written for commit c129c570c263d22f4630bc169fe8643d4434ff70. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3588?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

