### PR TITLE
feat(api): add session id 

### DIFF
--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -35,6 +35,7 @@ import { fromV0ScrapeOptions } from "../v2/types";
 import { isSelfHosted } from "../../lib/deployment";
 import { crawlGroup } from "../../services/worker/nuq";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 export async function crawlController(req: Request, res: Response) {
@@ -63,6 +64,7 @@ export async function crawlController(req: Request, res: Response) {
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: req.body.url ?? "",
+      session_id: getSessionId(req),
       zeroDataRetention: false, // not supported on v0
       api_key_id: chunk?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v0/scrape.ts
+++ b/apps/api/src/controllers/v0/scrape.ts
@@ -25,6 +25,7 @@ import { ScrapeJobTimeoutError } from "../../lib/error";
 import { scrapeQueue } from "../../services/worker/nuq";
 import { getErrorContactMessage } from "../../lib/deployment";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 async function scrapeHelper(
@@ -208,6 +209,7 @@ export async function scrapeController(req: Request, res: Response) {
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: req.body.url ?? "",
+      session_id: getSessionId(req),
       zeroDataRetention: false, // not supported on v0
       api_key_id: chunk?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -6,6 +6,7 @@ import {
 import { authenticateUser } from "../auth";
 import { RateLimiterMode, ScrapeJobSingleUrls } from "../../types";
 import { logSearch, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { PageOptions, SearchOptions } from "../../lib/entities";
 import { search } from "../../search";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
@@ -201,6 +202,7 @@ export async function searchController(req: Request, res: Response) {
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: req.body.query ?? "",
+      session_id: getSessionId(req),
       zeroDataRetention: false, // not supported on v0
       api_key_id: chunk?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -28,6 +28,7 @@ import { fromV1ScrapeOptions } from "../v2/types";
 import { checkPermissions } from "../../lib/permissions";
 import { crawlGroup } from "../../services/worker/nuq";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 export async function batchScrapeController(
@@ -130,6 +131,7 @@ export async function batchScrapeController(
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: urls[0] ?? "",
+      session_id: getSessionId(req),
       zeroDataRetention: zeroDataRetention || false,
       api_key_id: req.acuc?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -20,6 +20,7 @@ import { fromV1ScrapeOptions } from "../v2/types";
 import { checkPermissions } from "../../lib/permissions";
 import { crawlGroup } from "../../services/worker/nuq";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 export async function crawlController(
@@ -66,6 +67,7 @@ export async function crawlController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.url,
+    session_id: getSessionId(req),
     zeroDataRetention: zeroDataRetention || false,
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v1/deep-research.ts
+++ b/apps/api/src/controllers/v1/deep-research.ts
@@ -6,6 +6,7 @@ import * as Sentry from "@sentry/node";
 import { saveDeepResearch } from "../../lib/deep-research/deep-research-redis";
 import { z } from "zod";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 const deepResearchRequestSchema = z
@@ -101,6 +102,7 @@ export async function deepResearchController(
     team_id: req.auth.team_id,
     origin: "api",
     target_hint: req.body.query ?? "",
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for deep research
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -20,6 +20,7 @@ import {
 } from "../v2/types";
 import { createWebhookSender, WebhookEvent } from "../../services/webhook";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 import { config } from "../../config";
@@ -153,6 +154,7 @@ export async function extractController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.urls?.[0] ?? "",
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for extract
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v1/generate-llmstxt.ts
+++ b/apps/api/src/controllers/v1/generate-llmstxt.ts
@@ -10,6 +10,7 @@ import { getGenerateLlmsTxtQueue } from "../../services/queue-service";
 import * as Sentry from "@sentry/node";
 import { saveGeneratedLlmsTxt } from "../../lib/generate-llmstxt/generate-llmstxt-redis";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 type GenerateLLMsTextResponse =
@@ -48,6 +49,7 @@ export async function generateLLMsTextController(
     team_id: req.auth.team_id,
     origin: "api", // no origin field for llmstxt
     target_hint: req.body.url,
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for llmstxt
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -20,6 +20,7 @@ import {
 import { fireEngineMap } from "../../search/fireEngine";
 import { billTeam } from "../../services/billing/credit_billing";
 import { logMap, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { performCosineSimilarity } from "../../lib/map-cosine";
 import { logger } from "../../lib/logger";
 import Redis from "ioredis";
@@ -406,6 +407,7 @@ export async function mapController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.url,
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for map
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -20,6 +20,7 @@ import { processJobInternal } from "../../services/worker/scrape-worker";
 import { ScrapeJobData } from "../../types";
 import { AbortManagerThrownError } from "../../scraper/scrapeURL/lib/abortManager";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getErrorContactMessage } from "../../lib/deployment";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
@@ -76,6 +77,7 @@ export async function scrapeController(
     origin: req.body.origin,
     integration: req.body.integration,
     target_hint: req.body.url,
+    session_id: getSessionId(req),
     zeroDataRetention: zeroDataRetention || false,
     api_key_id: req.acuc?.api_key_id ?? null,
   }).catch(err =>

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -10,6 +10,7 @@ import {
 import { billTeam } from "../../services/billing/credit_billing";
 import { v7 as uuidv7 } from "uuid";
 import { logSearch, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { search } from "../../search";
 import { logger as _logger } from "../../lib/logger";
 import type { Logger } from "winston";
@@ -130,6 +131,7 @@ export async function searchController(
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: req.body.query,
+      session_id: getSessionId(req),
       zeroDataRetention: false,
       api_key_id: req.acuc?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v1/x402-search.ts
+++ b/apps/api/src/controllers/v1/x402-search.ts
@@ -12,6 +12,7 @@ import {
 import { v7 as uuidv7 } from "uuid";
 import { addScrapeJob, waitForJob } from "../../services/queue-jobs";
 import { logSearch, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { search } from "../../search";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { UNSUPPORTED_SITE_MESSAGE } from "../../lib/strings";
@@ -234,6 +235,7 @@ export async function x402SearchController(
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: req.body.query,
+      session_id: getSessionId(req),
       zeroDataRetention: false, // not supported for x402 search
       api_key_id: req.acuc?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v2/agent.ts
+++ b/apps/api/src/controllers/v2/agent.ts
@@ -8,6 +8,7 @@ import {
 } from "./types";
 import { logger as _logger } from "../../lib/logger";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { config } from "../../config";
 import { supabase_service } from "../../services/supabase";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
@@ -85,6 +86,7 @@ export async function agentController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.urls?.[0] ?? req.body.prompt ?? "",
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for agent
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -28,6 +28,7 @@ import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { checkPermissions } from "../../lib/permissions";
 import { crawlGroup } from "../../services/worker/nuq";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import type { BillingMetadata } from "../../services/billing/types";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
@@ -51,7 +52,8 @@ export async function batchScrapeController(
   }
 
   const zeroDataRetention =
-    getScrapeZDR(req.acuc?.flags) === "forced" || (req.body.zeroDataRetention ?? false);
+    getScrapeZDR(req.acuc?.flags) === "forced" ||
+    (req.body.zeroDataRetention ?? false);
 
   if (
     req.body.__agentInterop &&
@@ -150,6 +152,7 @@ export async function batchScrapeController(
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: urls[0] ?? "",
+      session_id: getSessionId(req),
       zeroDataRetention: zeroDataRetention || false,
       api_key_id: req.acuc?.api_key_id ?? null,
     });

--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -26,6 +26,7 @@ import { RequestWithAuth } from "./types";
 import { billTeam } from "../../services/billing/credit_billing";
 import { enqueueBrowserSessionActivity } from "../../lib/browser-session-activity";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { integrationSchema } from "../../utils/integration";
 import {
   BROWSER_CREDITS_PER_HOUR,
@@ -334,6 +335,7 @@ export async function browserCreateController(
       api_version: "v2",
       team_id: req.auth.team_id,
       target_hint: "Browser session",
+      session_id: getSessionId(req),
       origin: "api",
       integration: integration ?? null,
       zeroDataRetention: false,

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -22,6 +22,7 @@ import { checkPermissions } from "../../lib/permissions";
 import { buildPromptWithWebsiteStructure } from "../../lib/map-utils";
 import { crawlGroup } from "../../services/worker/nuq";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
 export async function crawlController(
@@ -68,6 +69,7 @@ export async function crawlController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.url,
+    session_id: getSessionId(req),
     zeroDataRetention: zeroDataRetention || false,
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v2/extract.ts
+++ b/apps/api/src/controllers/v2/extract.ts
@@ -12,6 +12,7 @@ import { UNSUPPORTED_SITE_MESSAGE } from "../../lib/strings";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { logger as _logger } from "../../lib/logger";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { config } from "../../config";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
 
@@ -82,6 +83,7 @@ export async function extractController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.urls?.[0] ?? "",
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for extract
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -8,6 +8,7 @@ import {
 import { configDotenv } from "dotenv";
 import { billTeam } from "../../services/billing/credit_billing";
 import { logMap, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { logger as _logger } from "../../lib/logger";
 import { MapTimeoutError, MapFailedError } from "../../lib/error";
 import { checkPermissions } from "../../lib/permissions";
@@ -65,6 +66,7 @@ export async function mapController(
     origin: req.body.origin ?? "api",
     integration: req.body.integration,
     target_hint: req.body.url,
+    session_id: getSessionId(req),
     zeroDataRetention: false, // not supported for map
     api_key_id: req.acuc?.api_key_id ?? null,
   });

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -22,6 +22,7 @@ import { ScrapeJobData } from "../../types";
 import { teamConcurrencySemaphore } from "../../services/worker/team-semaphore";
 import { getJobPriority } from "../../lib/job-priority";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getErrorContactMessage } from "../../lib/deployment";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
 import type { BillingMetadata } from "../../services/billing/types";
@@ -377,6 +378,7 @@ export async function parseController(
           origin: req.body.origin ?? "api",
           integration: req.body.integration,
           target_hint: req.body.file.filename,
+          session_id: getSessionId(req),
           zeroDataRetention: zeroDataRetention || false,
           api_key_id: req.acuc?.api_key_id ?? null,
         }).catch(err =>

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -46,6 +46,7 @@ import { RequestWithAuth, ScrapeOptions } from "./types";
 import { billTeam } from "../../services/billing/credit_billing";
 import { enqueueBrowserSessionActivity } from "../../lib/browser-session-activity";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { integrationSchema } from "../../utils/integration";
 import { supabaseGetScrapeById } from "../../lib/supabase-jobs";
 import {
@@ -712,6 +713,7 @@ async function createSessionForScrape(
       api_version: "v2",
       team_id: req.auth.team_id,
       target_hint: "Interact session",
+      session_id: getSessionId(req),
       origin: req.body?.origin ?? "api",
       integration: integration ?? null,
       zeroDataRetention: false,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -20,6 +20,7 @@ import { ScrapeJobData } from "../../types";
 import { teamConcurrencySemaphore } from "../../services/worker/team-semaphore";
 import { getJobPriority } from "../../lib/job-priority";
 import { logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { getErrorContactMessage } from "../../lib/deployment";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
 import type { BillingMetadata } from "../../services/billing/types";
@@ -141,6 +142,7 @@ export async function scrapeController(
           origin: req.body.origin ?? "api",
           integration: req.body.integration,
           target_hint: req.body.url,
+          session_id: getSessionId(req),
           zeroDataRetention: zeroDataRetention || false,
           api_key_id: req.acuc?.api_key_id ?? null,
         }).catch(err =>

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -9,6 +9,7 @@ import {
 import { billTeam } from "../../services/billing/credit_billing";
 import { v7 as uuidv7 } from "uuid";
 import { logSearch, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { logger as _logger } from "../../lib/logger";
 import { ScrapeJobTimeoutError } from "../../lib/error";
 import { z } from "zod";
@@ -111,6 +112,7 @@ export async function searchController(
         origin: req.body.origin ?? "api",
         integration: req.body.integration,
         target_hint: req.body.query,
+        session_id: getSessionId(req),
         zeroDataRetention: isZDROrAnon ?? false,
         api_key_id: req.acuc?.api_key_id ?? null,
       });

--- a/apps/api/src/controllers/v2/x402-search.ts
+++ b/apps/api/src/controllers/v2/x402-search.ts
@@ -12,6 +12,7 @@ import {
 import { v7 as uuidv7 } from "uuid";
 import { addScrapeJob, waitForJob } from "../../services/queue-jobs";
 import { logSearch, logRequest } from "../../services/logging/log_job";
+import { getSessionId } from "../../lib/session-tracking";
 import { search } from "../../search/v2";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { logger as _logger } from "../../lib/logger";
@@ -265,6 +266,7 @@ export async function x402SearchController(
       origin: req.body.origin ?? "api",
       integration: req.body.integration,
       target_hint: req.body.query,
+      session_id: getSessionId(req),
       zeroDataRetention: false, // not supported for x402 search
       api_key_id: req.acuc?.api_key_id ?? null,
     });

--- a/apps/api/src/lib/session-tracking.ts
+++ b/apps/api/src/lib/session-tracking.ts
@@ -1,18 +1,12 @@
 import type { Request } from "express";
 
-const HEADERS = [
-  "x-firecrawl-session-id",
-  "x-firecrawl-mcp-session-id",
-  "mcp-session-id",
-];
+const SESSION_ID_HEADER = "x-firecrawl-session-id";
 
 export function getSessionId(req: Request): string | null {
-  for (const name of HEADERS) {
-    const raw = req.headers[name];
-    const value = Array.isArray(raw) ? raw[0] : raw;
-    if (typeof value === "string" && value.trim()) {
-      return value.trim().slice(0, 128);
-    }
-  }
-  return null;
+  const raw = req.headers[SESSION_ID_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 128);
 }

--- a/apps/api/src/lib/session-tracking.ts
+++ b/apps/api/src/lib/session-tracking.ts
@@ -1,0 +1,18 @@
+import type { Request } from "express";
+
+const HEADERS = [
+  "x-firecrawl-session-id",
+  "x-firecrawl-mcp-session-id",
+  "mcp-session-id",
+];
+
+export function getSessionId(req: Request): string | null {
+  for (const name of HEADERS) {
+    const raw = req.headers[name];
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof value === "string" && value.trim()) {
+      return value.trim().slice(0, 128);
+    }
+  }
+  return null;
+}

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -165,6 +165,7 @@ type LoggedRequest = {
   target_hint: string;
   zeroDataRetention: boolean;
   api_key_id?: number | null;
+  session_id?: string | null;
 };
 
 export async function logRequest(request: LoggedRequest) {
@@ -200,6 +201,7 @@ export async function logRequest(request: LoggedRequest) {
         ? new Date(Date.now() + 24 * 60 * 60 * 1000)
         : null,
       api_key_id: request.api_key_id ?? null,
+      session_id: request.session_id ?? null,
     },
     true,
     logger,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds session ID tracking across API endpoints by reading the `x-firecrawl-session-id` header and logging it with each request. This helps MCP and CLI correlate related calls.

- **New Features**
  - Added `getSessionId(req)` to parse the `x-firecrawl-session-id` header (trims, null if empty, max 128 chars).
  - Extended `logRequest` to accept and store `session_id`.
  - Wired session logging into v0/v1/v2 controllers (scrape, crawl, search, map, extract, parse, agent, browser, batch-scrape, deep-research, x402, llmstxt).

- **Migration**
  - Optional: clients can send `x-firecrawl-session-id` to group logs; no API changes required.
  - Keep IDs <= 128 chars; absence of the header leaves logs unchanged.

<sup>Written for commit 2f2b39eb255e7b01b8bcb61e79d041ee4c975b51. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3590?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

