### PR TITLE
chore: add missing NUQ_DATABASE_URL to .env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,6 +9,9 @@ PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape
 ## To turn on DB authentication, you need to set up supabase.
 USE_DB_AUTHENTICATION=true
 
+## PostgreSQL connection for queuing — change if credentials, host, or DB differ
+NUQ_DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres
+
 # ===== Optional ENVS ======
 
 # SearchApi key. Head to https://searchapi.com/ to get your API key


### PR DESCRIPTION
This PR adds the missing `NUQ_DATABASE_URL` environment variable to `.env.example`. 

The project's setup documentation mentions configuring this variable for PostgreSQL queuing but the key value pair was missing from the template file which can cause confusion during initial local installation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing NUQ_DATABASE_URL to apps/api/.env.example so PostgreSQL queuing works by default and setup matches the docs. This avoids confusion during local setup.

- **Migration**
  - Add NUQ_DATABASE_URL to your .env if missing, or re-copy from .env.example.

<sup>Written for commit 4650fe3093411b645cc293627b7a5ae642d12c94. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3591?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

