### PR TITLE
chore(python-sdk): drop Python 3.8/3.9 support and require 3.10+

### DIFF
--- a/.github/archive/python-sdk.yml
+++ b/.github/archive/python-sdk.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404  
     strategy:  
       matrix:  
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       redis:
         image: redis

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-python-sdk.yml
+++ b/.github/workflows/test-python-sdk.yml
@@ -1,0 +1,43 @@
+name: Python SDK Test Suite
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - apps/python-sdk/**
+      - .github/workflows/test-python-sdk.yml
+  push:
+    branches:
+      - main
+    paths:
+      - apps/python-sdk/**
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Install dependencies
+        working-directory: ./apps/python-sdk
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run unit tests
+        working-directory: ./apps/python-sdk
+        run: python -m pytest firecrawl/__tests__/unit tests/ -q

--- a/apps/python-sdk/pyproject.toml
+++ b/apps/python-sdk/pyproject.toml
@@ -7,7 +7,7 @@ dynamic = ["version"]
 name = "firecrawl-py"
 description = "Python SDK for Firecrawl API"
 readme = {file="README.md", content-type = "text/markdown"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "requests",
     "httpx",
@@ -30,9 +30,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",

--- a/apps/python-sdk/setup.py
+++ b/apps/python-sdk/setup.py
@@ -36,7 +36,7 @@ setup(
         'pydantic>=2.0',
         'aiohttp'
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -46,9 +46,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Internet",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",


### PR DESCRIPTION
Raise the minimum supported version to 3.10 and declare support for 3.10–3.14. Add a CI matrix to run unit tests across those versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop Python 3.8/3.9 support for the `firecrawl-py` SDK and require Python 3.10+. Declares support for 3.10–3.14, adds a CI test matrix for these versions, and sets the publish workflow to Python 3.12.

- **Migration**
  - Python 3.10+ is required. Projects on 3.8/3.9 must upgrade to install and use the SDK.

<sup>Written for commit 701015bcfc101a30ba50b441c0b2558789702bcf. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

