### PR TITLE
refactor: move httpx2 from httpx

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_ensure_async.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_ensure_async.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-import httpx
+import httpx2
 import pytest
 
 from firecrawl.v2.client_async import AsyncFirecrawlClient
@@ -13,7 +13,7 @@ from firecrawl.v2.methods.aio import batch as aio_batch
 async def test_scrape_concurrency(monkeypatch):
     async def fake_post(self, endpoint, data, headers=None, timeout=None):
         await asyncio.sleep(0.1)
-        return httpx.Response(200, json={"success": True, "data": {}})
+        return httpx2.Response(200, json={"success": True, "data": {}})
 
     monkeypatch.setattr(AsyncHttpClient, "post", fake_post)
 
@@ -43,7 +43,7 @@ async def test_event_loop_not_blocked(monkeypatch):
 
     async def fake_post(self, endpoint, data, headers=None, timeout=None):
         await asyncio.sleep(0.2)
-        return httpx.Response(200, json={"success": True, "data": {}})
+        return httpx2.Response(200, json={"success": True, "data": {}})
 
     monkeypatch.setattr(AsyncHttpClient, "post", fake_post)
 
@@ -99,7 +99,7 @@ async def test_async_transport_used_no_threads(monkeypatch):
         max_active = max(max_active, active)
         try:
             await asyncio.sleep(0.1)
-            return httpx.Response(200, json={"success": True, "data": {}})
+            return httpx2.Response(200, json={"success": True, "data": {}})
         finally:
             active -= 1
 

--- a/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
@@ -1,5 +1,5 @@
 import asyncio
-import httpx
+import httpx2
 from typing import Optional, Dict, Any
 from .get_version import get_version
 
@@ -26,10 +26,10 @@ class AsyncHttpClient:
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        self._client = httpx.AsyncClient(
+        self._client = httpx2.AsyncClient(
             base_url=api_url,
             headers=headers,
-            limits=httpx.Limits(max_keepalive_connections=0),
+            limits=httpx2.Limits(max_keepalive_connections=0),
         )
 
     async def close(self) -> None:
@@ -49,7 +49,7 @@ class AsyncHttpClient:
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff_factor: Optional[float] = None,
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         if timeout is None:
             timeout = self.timeout
         if retries is None:
@@ -76,7 +76,7 @@ class AsyncHttpClient:
                         await asyncio.sleep(backoff_factor * (2 ** attempt))
                         continue
                 return response
-            except httpx.HTTPError as e:
+            except httpx2.HTTPError as e:
                 last_exception = e
                 if attempt == num_attempts - 1:
                     raise e
@@ -93,7 +93,7 @@ class AsyncHttpClient:
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff_factor: Optional[float] = None,
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         if timeout is None:
             timeout = self.timeout
         if retries is None:
@@ -118,7 +118,7 @@ class AsyncHttpClient:
                         await asyncio.sleep(backoff_factor * (2 ** attempt))
                         continue
                 return response
-            except httpx.HTTPError as e:
+            except httpx2.HTTPError as e:
                 last_exception = e
                 if attempt == num_attempts - 1:
                     raise e
@@ -133,7 +133,7 @@ class AsyncHttpClient:
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff_factor: Optional[float] = None,
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         if timeout is None:
             timeout = self.timeout
         if retries is None:
@@ -156,7 +156,7 @@ class AsyncHttpClient:
                         await asyncio.sleep(backoff_factor * (2 ** attempt))
                         continue
                 return response
-            except httpx.HTTPError as e:
+            except httpx2.HTTPError as e:
                 last_exception = e
                 if attempt == num_attempts - 1:
                     raise e
@@ -171,7 +171,7 @@ class AsyncHttpClient:
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff_factor: Optional[float] = None,
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         if timeout is None:
             timeout = self.timeout
         if retries is None:
@@ -194,7 +194,7 @@ class AsyncHttpClient:
                         await asyncio.sleep(backoff_factor * (2 ** attempt))
                         continue
                 return response
-            except httpx.HTTPError as e:
+            except httpx2.HTTPError as e:
                 last_exception = e
                 if attempt == num_attempts - 1:
                     raise e
@@ -210,7 +210,7 @@ class AsyncHttpClient:
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff_factor: Optional[float] = None,
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         if timeout is None:
             timeout = self.timeout
         if retries is None:
@@ -236,7 +236,7 @@ class AsyncHttpClient:
                     await asyncio.sleep(backoff_factor * (2 ** attempt))
                     continue
                 return response
-            except httpx.HTTPError as e:
+            except httpx2.HTTPError as e:
                 last_exception = e
                 if attempt == num_attempts - 1:
                     raise e

--- a/apps/python-sdk/pyproject.toml
+++ b/apps/python-sdk/pyproject.toml
@@ -10,7 +10,7 @@ readme = {file="README.md", content-type = "text/markdown"}
 requires-python = ">=3.8"
 dependencies = [
     "requests",
-    "httpx",
+    "httpx2",
     "python-dotenv",
     "websockets",
     "nest-asyncio",

--- a/apps/python-sdk/requirements.txt
+++ b/apps/python-sdk/requirements.txt
@@ -1,5 +1,5 @@
 requests
-httpx
+httpx2
 pytest
 pytest-asyncio
 python-dotenv


### PR DESCRIPTION
use pydantic's httpx2 instead of old httpx package because it is no longer maintained

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Python SDK to `httpx2` and drop `httpx` to keep the async HTTP client on a maintained library. Updated imports, response/exception types, and tests; no behavior changes.

- **Refactors**
  - Update async client to `httpx2` (`AsyncClient`, `Limits`, `Response`, `HTTPError`).
  - Update unit tests to use `httpx2.Response` and keep concurrency tests intact.

- **Dependencies**
  - Replace `httpx` with `httpx2` in `pyproject.toml` and `requirements.txt`.

<sup>Written for commit 39577cc3df3e7dbea7f3638efecb1f55c50d0675. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3595?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

