### PR TITLE
Add agent quickstart docs for 5 SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,207 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Elixir SDK. It is generated from SDK source plus OpenAPI.
+
+## Install
+
+Add to your `mix.exs` dependencies:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.5"}
+  ]
+end
+```
+
+## Authenticate
+
+Set the API key in your application config:
+
+```elixir
+config :firecrawl, api_key: "fc-YOUR-API-KEY"
+```
+
+Or pass it per-request via the `opts` keyword list:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(
+  [url: "https://example.com"],
+  api_key: "fc-YOUR-API-KEY"
+)
+```
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract its page content.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via a live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news articles, and images from a query. Results can optionally include scraped page content.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+A bang variant `Firecrawl.search_and_scrape!/2` is also available that raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping",
+  limit: 5
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+All parameters are passed as a keyword list.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | **Required.** The search query. |
+| `limit` | `integer` | Maximum number of results to return. |
+| `sources` | `list` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list` | Categories to filter by: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list(string)` | Only return results from these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list(string)` | Exclude results from these domains. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `string` | Geographic location string (e.g. `"San Francisco,California,United States"`). |
+| `country` | `string` | ISO country code for geo-targeting (e.g. `"US"`). |
+| `ignore_invalid_urls` | `boolean` | Skip invalid URLs in results. |
+| `timeout` | `integer` | Request timeout in milliseconds. |
+| `scrape_options` | `keyword` | When provided, each result page is scraped with these options. |
+| `enterprise` | `list(string)` | Enterprise ZDR options: `["zdr"]` or `["anon"]`. |
+
+Parameters are automatically converted from snake_case to camelCase for the API.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL. Supports multiple output formats, browser actions, proxies, caching, and more.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+A bang variant `Firecrawl.scrape_and_extract_from_url!/2` is also available.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+IO.inspect(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `list` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"audio"`, `"video"`. Also accepts format objects for `json`, `question`, `highlights`. |
+| `headers` | `any` | Custom HTTP headers. |
+| `include_tags` | `list(string)` | HTML tags to include. |
+| `exclude_tags` | `list(string)` | HTML tags to exclude. |
+| `only_main_content` | `boolean` | Only extract the main content area. |
+| `timeout` | `integer` | Request timeout in milliseconds (1000–300000). Default: `60000`. |
+| `wait_for` | `integer` | Milliseconds to wait after page load before scraping. |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `parsers` | `list` | Parser configs. Default: `["pdf"]`. |
+| `actions` | `list` | Browser actions to perform before scraping. |
+| `location` | `keyword` | Geographic location config. Default: `"US"`. |
+| `skip_tls_verification` | `boolean` | Skip TLS certificate verification. |
+| `remove_base64_images` | `boolean` | Remove base64-encoded images. |
+| `block_ads` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `atom \| string` | Proxy type: `:basic`, `:enhanced`, `:auto`. |
+| `max_age` | `integer` | Return cached version if younger than this (milliseconds). Default: `172800000` (2 days). |
+| `min_age` | `integer` | Only check cache, never trigger fresh scrape. |
+| `store_in_cache` | `boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `boolean` | Serve only from cache; returns 404 on cache miss. |
+| `profile` | `keyword` | Persistent browser profile with `name` and `save_changes`. |
+| `zero_data_retention` | `boolean` | Enable zero data retention. |
+
+Parameters are automatically converted from snake_case to camelCase for the API.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in a live browser session tied to a previous scrape. Use it for clicking buttons, filling forms, navigating pages, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])
+```
+
+A bang variant `Firecrawl.interact_with_scrape_browser_session!/3` is also available.
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://www.amazon.com",
+  formats: ["markdown"]
+)
+
+scrape_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(
+  scrape_id,
+  code: "document.querySelector('input[name=field-keywords]').value = 'iPhone 16 Pro Max';",
+  language: :node,
+  timeout: 30
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+The `job_id` is the first positional argument. All other parameters are passed as a keyword list.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `String.t()` | **Required.** The scrape job ID from a previous scrape (first argument). |
+| `code` | `string` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `atom` | Language for code execution: `:python`, `:node`, `:bash`. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+| `origin` | `string` | Optional origin label for telemetry. |
+
+## Notes
+
+- **snake_case parameters** — All Elixir parameters use snake_case; they are automatically converted to camelCase for the API.
+- **OpenAPI-shaped client** — The Elixir SDK is generated from the OpenAPI spec, so function names match the OpenAPI operation IDs rather than friendlier aliases.
+- **Function names differ from other SDKs** — `scrape_and_extract_from_url` (not `scrape`), `search_and_scrape` (not `search`), `interact_with_scrape_browser_session` (not `interact`).
+- **Code only for interact** — Unlike the Python, Node.js, and Rust SDKs, the Elixir SDK's interact function only accepts `code`, not a natural-language `prompt`.
+- **Bang variants** — Every function has a `!` variant that raises on error instead of returning `{:error, _}`.
+- **Req-based** — HTTP is handled by the `Req` library. Additional `Req` options can be passed through `opts`.
+- **Batch scrape** — `Firecrawl.scrape_and_extract_from_urls/2` is available for scraping multiple URLs in one call.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,190 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Java SDK. It is generated from SDK source plus OpenAPI.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.8.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.8.0'
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR-API-KEY")
+    .build();
+```
+
+Or set the `FIRECRAWL_API_KEY` environment variable and use:
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract its page content.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via a live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news articles, and images from a query. Results can optionally include scraped page content.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+### Example
+
+```java
+SearchData results = client.search("firecrawl web scraping");
+
+for (Map<String, Object> result : results.getWeb()) {
+    System.out.println(result.get("title") + " " + result.get("url"));
+}
+```
+
+### Parameters (`SearchOptions`)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `String` | **Required.** The search query (passed as first argument). |
+| `sources` | `List<Object>` | Sources to search: `"web"`, `"news"`, `"images"`. |
+| `categories` | `List<Object>` | Categories to filter by: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Only return results from these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `limit` | `Integer` | Maximum number of results to return. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Geographic location string for localized results. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs in results. |
+| `timeout` | `Integer` | Request timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | When provided, each result page is scraped with these options. |
+| `integration` | `String` | Integration identifier. |
+
+Results contain `.getWeb()`, `.getNews()`, `.getImages()` lists.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL. Supports multiple output formats, browser actions, proxies, caching, and more.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+Document doc = client.scrape("https://example.com");
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters (`ScrapeOptions`)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `String` | **Required.** The URL to scrape (passed as first argument). |
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Also accepts format objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent` | `Boolean` | Only extract the main content area. |
+| `timeout` | `Integer` | Request timeout in milliseconds. |
+| `waitFor` | `Integer` | Milliseconds to wait after page load. |
+| `mobile` | `Boolean` | Emulate a mobile device. |
+| `parsers` | `List<Object>` | Parser configs (e.g. `"pdf"` or `{"type": "pdf", "maxPages": 10}`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions to perform before scraping. |
+| `location` | `LocationConfig` | Geographic location with country and languages. |
+| `skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `Boolean` | Remove base64-encoded images. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Return cached version if younger than this (milliseconds). |
+| `storeInCache` | `Boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `Boolean` | Serve only from cache; returns 404 on cache miss. |
+| `integration` | `String` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in a live browser session tied to a previous scrape. Use it for clicking buttons, filling forms, navigating pages, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+Document doc = client.scrape("https://www.amazon.com");
+String scrapeId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse response = client.interact(
+    scrapeId,
+    "document.querySelector('input[name=field-keywords]').value = 'iPhone 16 Pro Max';"
+);
+System.out.println(response.getStdout());
+
+client.stopInteractiveBrowser(scrapeId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `String` | **Required.** The scrape job ID from a previous scrape. |
+| `code` | `String` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `String` | Language for code execution: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: `30`. |
+| `origin` | `String` | Optional origin tag for request attribution. |
+
+Call `client.stopInteractiveBrowser(jobId)` to end the browser session.
+
+## Notes
+
+- **camelCase parameters** — All parameter names use camelCase.
+- **Code only for interact** — Unlike the Python, Node.js, and Rust SDKs, the Java SDK's `interact` method only accepts `code`, not a natural-language `prompt`. Use `code` to drive the browser.
+- **Async variants** — All methods have async variants returning `CompletableFuture`: `scrapeAsync()`, `searchAsync()`, `interactAsync()`.
+- **Builder pattern** — `ScrapeOptions` and `SearchOptions` use builder pattern for construction.
+- **Deprecated aliases** — `scrapeExecute()` is deprecated; use `interact()`. `deleteScrapeBrowser()` is deprecated; use `stopInteractiveBrowser()`.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,182 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Node.js/TypeScript SDK. It is generated from SDK source plus OpenAPI.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+```
+
+Or set the `FIRECRAWL_API_KEY` environment variable and omit the `apiKey` option.
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract its page content.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via a live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news articles, and images from a query. Results can optionally include scraped page content.
+
+### Preferred SDK method
+
+```typescript
+client.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await client.search("firecrawl web scraping", {
+  limit: 5,
+  sources: ["web"],
+});
+
+for (const result of results.web ?? []) {
+  console.log(result.title, result.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | **Required.** The search query. |
+| `limit` | `number` | Maximum number of results to return per source type. |
+| `sources` | `Array<"web" \| "news" \| "images" \| { type: string }>` | Which sources to search. |
+| `categories` | `Array<"github" \| "research" \| "pdf">` | Categories to filter results by. |
+| `includeDomains` | `string[]` | Only return results from these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Mutually exclusive with `includeDomains`. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `string` | Geographic location string for localized results. |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs in results instead of failing. |
+| `timeout` | `number` | Request timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | When provided, each result page is scraped with these options. |
+| `integration` | `string` | Integration identifier for tracking. |
+| `origin` | `string` | Request origin header. |
+
+Results are grouped by source: `results.web`, `results.news`, `results.images`.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL. Supports multiple output formats, browser actions, proxies, caching, and more.
+
+### Preferred SDK method
+
+```typescript
+client.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+
+console.log(doc.markdown);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"audio"`, `"video"`. Also accepts objects for `json`, `screenshot`, `changeTracking`, `question`, `highlights`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send with the request. |
+| `includeTags` | `string[]` | HTML tags to include in output. |
+| `excludeTags` | `string[]` | HTML tags to exclude from output. |
+| `onlyMainContent` | `boolean` | Only extract the main content area of the page. |
+| `timeout` | `number` | Request timeout in milliseconds. |
+| `waitFor` | `number` | Milliseconds to wait after page load before scraping. |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `parsers` | `Array<string \| { type: "pdf"; mode?: "fast" \| "auto" \| "ocr"; maxPages?: number }>` | Parser configurations (e.g. for PDFs). |
+| `actions` | `ActionOption[]` | Browser actions to perform before scraping: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string; languages?: string[] }` | Geographic location for proxy routing. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64-encoded images from output. |
+| `fastMode` | `boolean` | Enable faster scraping with potentially reduced accuracy. |
+| `blockAds` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. `enhanced` costs up to 5 credits. `auto` retries with enhanced on failure. |
+| `maxAge` | `number` | Return cached version if younger than this age in milliseconds. |
+| `minAge` | `number` | Only check cache, never trigger fresh scrape. |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `boolean` | Serve only from cache; returns 404 on cache miss. |
+| `profile` | `{ name: string; saveChanges?: boolean }` | Persistent browser profile for maintaining state across sessions. |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Request origin header. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language prompts in a live browser session tied to a previous scrape. Use it for clicking buttons, filling forms, navigating pages, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```typescript
+client.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://www.amazon.com", {
+  formats: ["markdown"],
+});
+
+const scrapeId = doc.metadata?.scrapeId;
+
+const response = await client.interact(scrapeId, {
+  prompt: "Search for iPhone 16 Pro Max",
+});
+console.log(response.output);
+
+await client.stopInteraction(scrapeId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `string` | **Required.** The scrape job ID from a previous scrape. |
+| `code` | `string` | Code to execute in the browser sandbox. Provide `code` or `prompt` (at least one). |
+| `prompt` | `string` | Natural-language instruction for the browser agent. Provide `code` or `prompt` (at least one). |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in milliseconds. |
+| `origin` | `string` | Request origin header. |
+
+Call `client.stopInteraction(jobId)` to end the browser session.
+
+## Notes
+
+- **camelCase parameters** — All parameter names use camelCase.
+- **Zod schema support** — The `json` format accepts Zod schemas directly; they are converted to JSON Schema automatically.
+- **Search result grouping** — Search results are grouped under `.web`, `.news`, `.images`. Accessing `.data` throws an error.
+- **Deprecated aliases** — `scrapeUrl()` is deprecated; use `scrape()`. `scrapeExecute()` is deprecated; use `interact()`. `deleteScrapeBrowser()` and `stopInteractiveBrowser()` are deprecated; use `stopInteraction()`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,173 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Python SDK. It is generated from SDK source plus OpenAPI.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-YOUR-API-KEY")
+```
+
+Or set the `FIRECRAWL_API_KEY` environment variable and omit the `api_key` argument.
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract its page content.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via a live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news articles, and images from a query. Results can optionally include scraped page content.
+
+### Preferred SDK method
+
+```python
+client.search(query, **options)
+```
+
+### Example
+
+```python
+results = client.search("firecrawl web scraping", limit=5)
+
+for result in results.web:
+    print(result.title, result.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | **Required.** The search query. |
+| `limit` | `int` | Maximum number of results to return. Default: `5`. |
+| `sources` | `list[str]` | Sources to search: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str]` | Categories to filter by: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Only return results from these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Mutually exclusive with `include_domains`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `str` | Geographic location string for localized results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs instead of failing. |
+| `timeout` | `int` | Request timeout in milliseconds. Default: `300000`. |
+| `scrape_options` | `ScrapeOptions` | When provided, each result page is scraped with these options. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+Results are grouped by source: `results.web`, `results.news`, `results.images`.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL. Supports multiple output formats, browser actions, proxies, caching, and more.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+
+print(doc.markdown)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` | **Required.** The URL to scrape. |
+| `formats` | `list[str]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"audio"`, `"video"`. Also accepts format objects for `json`, `screenshot`, `changeTracking`, `question`, `highlights`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers to send with the request. |
+| `include_tags` | `list[str]` | HTML tags to include in output. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from output. |
+| `only_main_content` | `bool` | Only extract the main content area. |
+| `timeout` | `int` | Request timeout in milliseconds. |
+| `wait_for` | `int` | Milliseconds to wait after page load before scraping. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list` | Parser configurations (e.g. `["pdf"]` or `[{"type": "pdf", "mode": "ocr"}]`). |
+| `actions` | `list` | Browser actions to perform before scraping: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Geographic location config with `country` and `languages`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64-encoded images from output. |
+| `fast_mode` | `bool` | Enable faster scraping mode. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. `enhanced` costs up to 5 credits. |
+| `max_age` | `int` | Return cached version if younger than this age in seconds. |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. |
+| `lockdown` | `bool` | Serve only from cache; returns 404 on cache miss. |
+| `profile` | `dict` | Persistent browser profile, e.g. `{"name": "my-profile", "saveChanges": True}`. |
+| `integration` | `str` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language prompts in a live browser session tied to a previous scrape. Use it for clicking buttons, filling forms, navigating pages, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, **options)
+```
+
+### Example
+
+```python
+doc = client.scrape("https://www.amazon.com", formats=["markdown"])
+scrape_id = doc.metadata.scrape_id
+
+client.interact(scrape_id, prompt="Search for iPhone 16 Pro Max")
+response = client.interact(
+    scrape_id,
+    prompt="Click on the first result and tell me the price",
+)
+print(response.output)
+
+client.stop_interaction(scrape_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `str` | **Required.** The scrape job ID from a previous scrape. |
+| `code` | `str` | Code to execute in the browser sandbox. Provide `code` or `prompt` (at least one). |
+| `prompt` | `str` | Natural-language instruction for the browser agent. Provide `code` or `prompt` (at least one). |
+| `language` | `Literal["python", "node", "bash"]` | Language for code execution. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+| `origin` | `str` | Optional origin tag for request attribution. |
+
+Call `client.stop_interaction(job_id)` to end the browser session.
+
+## Notes
+
+- **snake_case parameters** — All Python parameter names use snake_case.
+- **Keyword-only arguments** — All parameters after the first positional argument are keyword-only.
+- **Pydantic v2 models** — All request/response types use Pydantic v2 for validation.
+- **Async support** — An `AsyncFirecrawl` client is available at `from firecrawl import AsyncFirecrawl`.
+- **Deprecated aliases** — `scrape_url()` is deprecated; use `scrape()`. `scrape_execute()` is deprecated; use `interact()`. `delete_scrape_browser()` is deprecated; use `stop_interaction()`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,217 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Rust SDK. It is generated from SDK source plus OpenAPI.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("http://localhost:3000", Some("fc-YOUR-API-KEY"))?;
+```
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract its page content.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via a live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news articles, and images from a query. Results can optionally include scraped page content.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let response = client.search("firecrawl web scraping", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters (`SearchOptions`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `limit` | `Option<u32>` | Maximum number of results to return. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources to search: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Categories to filter by: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Only return results from these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `Option<String>` | Geographic location string for localized results. |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs in results. |
+| `timeout` | `Option<u32>` | Request timeout in milliseconds. |
+| `scrape_options` | `Option<ScrapeOptions>` | When provided, each result page is scraped with these options. |
+| `integration` | `Option<String>` | Integration identifier. |
+
+All fields serialize to camelCase for the API. `SearchOptions` implements `Default`.
+
+A convenience method `client.search_and_scrape(query, limit)` is available that automatically scrapes all results and returns `Vec<Document>`.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL. Supports multiple output formats, browser actions, proxies, caching, and more.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+if let Some(markdown) = doc.markdown {
+    println!("{}", markdown);
+}
+```
+
+### Parameters (`ScrapeOptions`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `Json`, `ChangeTracking`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `only_main_content` | `Option<bool>` | Only extract the main content area. |
+| `timeout` | `Option<u32>` | Request timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Milliseconds to wait after page load. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configs (e.g. PDF with mode and maxPages). |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Geographic location with `country` and `languages`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. |
+| `remove_base64_images` | `Option<bool>` | Remove base64-encoded images. |
+| `fast_mode` | `Option<bool>` | Enable faster scraping mode. |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Return cached version if younger than this (seconds). |
+| `min_age` | `Option<u32>` | Only check cache, never trigger fresh scrape. |
+| `store_in_cache` | `Option<bool>` | Store result in Firecrawl cache. |
+| `lockdown` | `Option<bool>` | Serve only from cache; returns 404 on cache miss. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile with `name` and `save_changes`. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction options with `schema`, `system_prompt`, `prompt`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot options with `full_page`, `quality`, `viewport`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking with `modes`, `schema`, `prompt`, `tag`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction with `selector` and `attribute`. |
+
+All fields serialize to camelCase for the API. `ScrapeOptions` implements `Default`.
+
+A convenience method `client.scrape_with_schema(url, schema, prompt)` is available for JSON extraction.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language prompts in a live browser session tied to a previous scrape. Use it for clicking buttons, filling forms, navigating pages, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let doc = client.scrape("https://www.amazon.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let scrape_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_ref())
+    .expect("scrape_id required for interact");
+
+let response = client.interact(scrape_id, ScrapeExecuteOptions {
+    prompt: Some("Search for iPhone 16 Pro Max".into()),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", response.output);
+
+client.stop_interaction(scrape_id).await?;
+```
+
+### Parameters (`ScrapeExecuteOptions`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | `Option<String>` | Code to execute in the browser sandbox. Provide `code` or `prompt` (at least one). |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. Provide `code` or `prompt` (at least one). |
+| `language` | `Option<ScrapeExecuteLanguage>` | Language for code execution: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `origin` | `Option<String>` | Optional origin tag. |
+
+Call `client.stop_interaction(job_id).await` to end the browser session.
+
+## Notes
+
+- **snake_case fields** — Struct fields use snake_case; they serialize to camelCase for the API automatically via serde.
+- **Async** — All methods are async and return `Result<T, FirecrawlError>`.
+- **Default trait** — `ScrapeOptions`, `SearchOptions`, and `ScrapeExecuteOptions` implement `Default` for easy construction with struct update syntax.
+- **Deprecated aliases** — `scrape_execute()` is deprecated; use `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` are deprecated; use `stop_interaction()`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary\n\n- Adds canonical agent quickstart docs for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir** covering `search`, `scrape`, and `interact` endpoints\n- Each file includes install, auth, method signatures, realistic examples, complete parameter tables with descriptions, and language-specific notes\n- Generated from SDK source code and the v2 OpenAPI spec — no invented parameters or behavior\n\n## Note on placement\n\nThese files are intended for `firecrawl-docs/agent-quickstart/` but are staged in `docs/agent-quickstart/` here because the current integration lacks write access to `firecrawl/firecrawl-docs`. To complete the deployment:\n\n1. Copy `docs/agent-quickstart/*.mdx` to `firecrawl-docs/agent-quickstart/`\n2. Add an \"Agent Quickstarts\" nav group to the \"Build with AI\" tab in `docs.json`:\n\n```json\n{\n  \"group\": \"Agent Quickstarts\",\n  \"pages\": [\n    \"agent-quickstart/node\",\n    \"agent-quickstart/python\",\n    \"agent-quickstart/rust\",\n    \"agent-quickstart/java\",\n    \"agent-quickstart/elixir\"\n  ]\n}\n```\n\n## What each doc covers\n\n- **When to use what** — search vs scrape vs interact decision guide\n- **Search** — method, example, all confirmed parameters with descriptions\n- **Scrape** — method, example, all confirmed parameters including formats, actions, proxies, caching\n- **Interact** — method, example, all confirmed parameters (notes which SDKs support `prompt` vs `code` only)\n- **Language-specific notes** — naming conventions, deprecated aliases, async support, quirks\n\n## Test plan\n\n- [ ] Verify each `.mdx` file renders correctly in Mintlify\n- [ ] Cross-check parameter tables against SDK source and OpenAPI spec\n- [ ] Confirm examples use current SDK API surface (no deprecated methods)\n\nhttps://claude.ai/code/session_018i94osUxy9qXZXz2wgYK6b

---
_Generated by [Claude Code](https://claude.ai/code/session_018i94osUxy9qXZXz2wgYK6b)_