### PR TITLE
feat(monitoring): Add hashed shard to GCS monitor diff object names

### DIFF
--- a/apps/api/src/lib/gcs-monitoring.test.ts
+++ b/apps/api/src/lib/gcs-monitoring.test.ts
@@ -1,0 +1,118 @@
+const mockSave = jest.fn();
+const mockDownload = jest.fn();
+const mockFile = jest.fn(() => ({
+  save: mockSave,
+  download: mockDownload,
+}));
+const mockBucket = jest.fn(() => ({
+  file: mockFile,
+}));
+const mockConfig: { GCS_BUCKET_NAME?: string } = {};
+
+jest.mock("../config", () => ({
+  config: mockConfig,
+}));
+
+jest.mock("./gcs-jobs", () => ({
+  storage: {
+    bucket: mockBucket,
+  },
+}));
+
+import { monitorDiffGcsKey, saveMonitorDiffArtifact } from "./gcs-monitoring";
+
+const artifact = {
+  kind: "markdown" as const,
+  url: "https://example.com",
+  previousScrapeId: "previous",
+  currentScrapeId: "current",
+  generatedAt: "2026-05-24T00:00:00.000Z",
+  text: "diff text",
+  json: { changed: true },
+};
+
+beforeEach(() => {
+  mockConfig.GCS_BUCKET_NAME = undefined;
+  mockSave.mockReset();
+  mockDownload.mockReset();
+  mockFile.mockClear();
+  mockBucket.mockClear();
+  jest.spyOn(Math, "random").mockReturnValue(0);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("monitorDiffGcsKey", () => {
+  const params = {
+    teamId: "team-123",
+    monitorId: "monitor-456",
+    checkId: "check-789",
+    pageId: "page-abc",
+  };
+
+  it("places a stable hash shard before tenant-specific identifiers", () => {
+    const key = monitorDiffGcsKey(params);
+
+    expect(key).toMatch(
+      /^monitors\/diffs\/v2\/[0-9a-f]{4}\/team-123\/monitor-456\/check-789\/page-abc\.diff\.json$/,
+    );
+    expect(key).toBe(monitorDiffGcsKey(params));
+    expect(key).not.toBe(
+      "monitors/team-123/monitor-456/check-789/page-abc.diff.json",
+    );
+  });
+
+  it("changes shards when the page id changes", () => {
+    const first = monitorDiffGcsKey(params).split("/")[3];
+    const second = monitorDiffGcsKey({
+      ...params,
+      pageId: "page-def",
+    }).split("/")[3];
+
+    expect(second).not.toBe(first);
+  });
+});
+
+describe("saveMonitorDiffArtifact", () => {
+  it("returns artifact sizes without writing when GCS is not configured", async () => {
+    const result = await saveMonitorDiffArtifact("key", artifact);
+
+    expect(result).toEqual({
+      textBytes: Buffer.byteLength(artifact.text),
+      jsonBytes: Buffer.byteLength(JSON.stringify(artifact.json)),
+    });
+    expect(mockBucket).not.toHaveBeenCalled();
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it("retries retryable GCS write failures with jitter", async () => {
+    mockConfig.GCS_BUCKET_NAME = "monitor-bucket";
+    mockSave
+      .mockRejectedValueOnce({ code: 429 })
+      .mockRejectedValueOnce({ statusCode: 503 })
+      .mockResolvedValueOnce(undefined);
+
+    await expect(saveMonitorDiffArtifact("key", artifact)).resolves.toEqual({
+      textBytes: Buffer.byteLength(artifact.text),
+      jsonBytes: Buffer.byteLength(JSON.stringify(artifact.json)),
+    });
+
+    expect(mockBucket).toHaveBeenCalledWith("monitor-bucket");
+    expect(mockFile).toHaveBeenCalledWith("key");
+    expect(mockSave).toHaveBeenCalledTimes(3);
+    expect(Math.random).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable GCS write failures", async () => {
+    mockConfig.GCS_BUCKET_NAME = "monitor-bucket";
+    const error = { code: 400 };
+    mockSave.mockRejectedValueOnce(error);
+
+    await expect(saveMonitorDiffArtifact("key", artifact)).rejects.toBe(error);
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(Math.random).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/gcs-monitoring.ts
+++ b/apps/api/src/lib/gcs-monitoring.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { config } from "../config";
 import { storage } from "./gcs-jobs";
 
@@ -33,6 +34,9 @@ export type MonitorDiffArtifact =
     });
 
 const contentType = "application/json";
+const monitorDiffGcsSaveMaxAttempts = 4;
+const monitorDiffGcsRetryBaseMs = 250;
+const monitorDiffGcsRetryMaxMs = 4_000;
 
 export function monitorDiffGcsKey(params: {
   teamId: string;
@@ -40,7 +44,16 @@ export function monitorDiffGcsKey(params: {
   checkId: string;
   pageId: string;
 }): string {
-  return `monitors/${params.teamId}/${params.monitorId}/${params.checkId}/${params.pageId}.diff.json`;
+  const shard = createHash("sha256")
+    .update(
+      `${params.teamId}:${params.monitorId}:${params.checkId}:${params.pageId}`,
+    )
+    .digest("hex")
+    .slice(0, 4);
+
+  // Keep the random shard before tenant/check identifiers so high-volume
+  // monitor diff writes distribute across GCS object-name key ranges.
+  return `monitors/diffs/v2/${shard}/${params.teamId}/${params.monitorId}/${params.checkId}/${params.pageId}.diff.json`;
 }
 
 function artifactBytes(artifact: MonitorDiffArtifact): {
@@ -59,6 +72,69 @@ function artifactBytes(artifact: MonitorDiffArtifact): {
   return { textBytes, jsonBytes };
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function monitorDiffGcsRetryDelayMs(attempt: number): number {
+  const cap = Math.min(
+    monitorDiffGcsRetryMaxMs,
+    monitorDiffGcsRetryBaseMs * 2 ** attempt,
+  );
+  return Math.floor(Math.random() * cap);
+}
+
+function errorStatusCode(error: unknown): number | undefined {
+  const value = error as {
+    code?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown };
+    error?: { code?: unknown };
+  };
+  const status =
+    value.statusCode ??
+    value.code ??
+    value.response?.status ??
+    value.error?.code;
+  if (typeof status === "number") return status;
+  if (typeof status === "string") {
+    const parsed = Number(status);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function isRetryableGcsWriteError(error: unknown): boolean {
+  const status = errorStatusCode(error);
+  if (status === 408 || status === 429) return true;
+  if (status !== undefined && status >= 500 && status < 600) return true;
+
+  const value = error as {
+    message?: unknown;
+    errors?: Array<{ reason?: unknown }>;
+    error?: { errors?: Array<{ reason?: unknown }> };
+  };
+  const message =
+    typeof value.message === "string" ? value.message.toLowerCase() : "";
+  if (
+    message.includes("retry limit exceeded") ||
+    message.includes("ratelimitexceeded")
+  ) {
+    return true;
+  }
+
+  const nestedErrors = value.errors ?? value.error?.errors ?? [];
+  return nestedErrors.some(entry => {
+    const reason =
+      typeof entry.reason === "string" ? entry.reason.toLowerCase() : "";
+    return (
+      reason === "ratelimitexceeded" ||
+      reason === "backenderror" ||
+      reason === "internalerror"
+    );
+  });
+}
+
 export async function saveMonitorDiffArtifact(
   key: string,
   artifact: MonitorDiffArtifact,
@@ -69,10 +145,25 @@ export async function saveMonitorDiffArtifact(
   }
 
   const bucket = storage.bucket(config.GCS_BUCKET_NAME);
-  await bucket.file(key).save(payload, {
-    contentType,
-    resumable: false,
-  });
+  const file = bucket.file(key);
+
+  for (let attempt = 0; attempt < monitorDiffGcsSaveMaxAttempts; attempt++) {
+    try {
+      await file.save(payload, {
+        contentType,
+        resumable: false,
+      });
+      break;
+    } catch (error) {
+      if (
+        attempt === monitorDiffGcsSaveMaxAttempts - 1 ||
+        !isRetryableGcsWriteError(error)
+      ) {
+        throw error;
+      }
+      await sleep(monitorDiffGcsRetryDelayMs(attempt));
+    }
+  }
 
   return artifactBytes(artifact);
 }


### PR DESCRIPTION
Prefix monitor diff object names with a stable 4-hex shard derived from a sha256 hash of the identifiers and move keys under monitors/diffs/v2. This spreads high-volume monitor-diff writes across GCS object-name key ranges to reduce hot-spotting. Also add a unit test verifying the shard is stable, placed before tenant identifiers, and changes when pageId changes. Imported createHash and updated monitorDiffGcsKey accordingly.

Was running into; 

**{"error":{"code":429,"message":"Your request distribution is too uneven across the key-ranges in your
  bucket. Please follow the guidance at https://cloud.google.com/storage/docs/conformance#naming-convention in order to avoid temporary limits on the
  bucket.","errors":[{"message":"Your request distribution is too uneven across the key-ranges in your bucket. Please follow the guidance at
  https://cloud.google.com/storage/docs/conformance#naming-convention in order to avoid temporary limits on the
  bucket.","domain":"usageLimits","reason":"rateLimitExceeded"}]}}**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shards GCS monitor diff object names with a stable 4-hex hash and moves them under `monitors/diffs/v2` to spread writes and prevent key-range hot-spotting. Also adds retries for transient GCS write failures.

- Bug Fixes
  - New key format: `monitors/diffs/v2/<4-hex-shard>/<teamId>/<monitorId>/<checkId>/<pageId>.diff.json` using a sha256 of the identifiers.
  - Retries 408/429 and 5xx saves with jittered backoff (up to 4 attempts); no retry for non-retryable errors.
  - Tests for shard stability and placement, shard change on `pageId` updates, retry behavior, and no-op writes when `GCS_BUCKET_NAME` is unset.

<sup>Written for commit 0cc91f81bccb553a443973925724948f3c1521ec. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3601?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

