### PR TITLE
feat(monitoring): default timeout to 5000 to mitigate false positives on load

### DIFF
--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -62,6 +62,8 @@ const poll = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 export { isMonitorCheckStale, MONITOR_CHECK_STALE_TIMEOUT_MS };
 
 const MONITOR_DEFAULT_WAIT_FOR_MS = 5000;
+const MONITOR_MAX_WAIT_FOR_MS = 60000;
+const MONITOR_MAX_TIMEOUT_MS = MONITOR_MAX_WAIT_FOR_MS * 2;
 
 type PageResult = MonitorCheckPageInsert & {
   emailStatus?: string;
@@ -122,10 +124,14 @@ function withMonitorScrapeDefaults(
     typeof options.waitFor === "number"
       ? options.waitFor
       : MONITOR_DEFAULT_WAIT_FOR_MS;
+  const timeout =
+    typeof options.timeout === "number"
+      ? Math.min(Math.max(options.timeout, waitFor * 2), MONITOR_MAX_TIMEOUT_MS)
+      : Math.min(waitFor * 2, MONITOR_MAX_TIMEOUT_MS);
 
   return {
     maxAge: 0,
-    ...withMarkdownFormat({ ...options, formats, waitFor }),
+    ...withMarkdownFormat({ ...options, formats, waitFor, timeout }),
   };
 }
 

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -61,6 +61,8 @@ const logger = _logger.child({ module: "monitoring-runner" });
 const poll = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 export { isMonitorCheckStale, MONITOR_CHECK_STALE_TIMEOUT_MS };
 
+const MONITOR_DEFAULT_WAIT_FOR_MS = 5000;
+
 type PageResult = MonitorCheckPageInsert & {
   emailStatus?: string;
 };
@@ -116,9 +118,14 @@ function withMonitorScrapeDefaults(
   const formats = Array.isArray(options.formats)
     ? normalizeMonitorFormats(options.formats)
     : options.formats;
+  const waitFor =
+    typeof options.waitFor === "number"
+      ? options.waitFor
+      : MONITOR_DEFAULT_WAIT_FOR_MS;
+
   return {
     maxAge: 0,
-    ...withMarkdownFormat({ ...options, formats }),
+    ...withMarkdownFormat({ ...options, formats, waitFor }),
   };
 }
 
@@ -351,7 +358,7 @@ async function runCrawlTarget(params: {
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
-    scrapeOptions: withMarkdownFormat(params.target.scrapeOptions ?? {}),
+    scrapeOptions: withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
     origin: "monitor",
   }) as CrawlRequest;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set a 5s default wait and safe timeout for monitoring scrapes to reduce false positives while pages load. Defaults apply unless `waitFor`/`timeout` are provided.

- **Bug Fixes**
  - Default `waitFor` to 5s and set `timeout` to 2×`waitFor`, clamping custom timeouts up to 120s (`MONITOR_DEFAULT_WAIT_FOR_MS`, `MONITOR_MAX_WAIT_FOR_MS`, `MONITOR_MAX_TIMEOUT_MS`).
  - Use `withMonitorScrapeDefaults` in `runCrawlTarget` and pass `waitFor`/`timeout` through `withMarkdownFormat`.

<sup>Written for commit 10643acab2fbe3e33c1ea61390e1cbd4d57daeb1. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3612?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

