### PR TITLE
fix(api/scrape-worker): skip per-URL webhook on crawl cancellation

### DIFF
--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -741,7 +741,13 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
             : new Error(JSON.stringify(error)),
     };
 
-    if (job.data.crawl_id) {
+    // Cancellation is a parent-job operation, not a per-URL failure. Emitting
+    // a CRAWL_PAGE/BATCH_SCRAPE_PAGE webhook for every queued URL after a
+    // crawl is cancelled floods consumers with spurious failure events that
+    // are indistinguishable from real per-URL errors. Skip the per-URL
+    // webhook on cancellation; the terminal CRAWL_COMPLETED event still fires
+    // from finishCrawlSuper.
+    if (job.data.crawl_id && !isCancelled) {
       const sender = await createWebhookSender({
         teamId: job.data.team_id,
         jobId: (job.data.crawl_id ?? job.id) as string,


### PR DESCRIPTION
## Summary

Fixes #3614.

When a crawl is cancelled via `DELETE /v1/crawl/{id}` (or the SDK), every URL that was still queued runs through the scrape worker, throws `JobCancelledError`, and triggers a per-URL `CRAWL_PAGE` (or `BATCH_SCRAPE_PAGE`) webhook with `success: false`. Subscribers see this as a flood of failure deliveries that are indistinguishable from real per-URL errors.

## Change

Guard the per-URL webhook send in `processJob`'s catch block with `!isCancelled`:

```ts
if (job.data.crawl_id && !isCancelled) {
  // emit CRAWL_PAGE / BATCH_SCRAPE_PAGE
}
```

Cancellation is a parent-job operation, not a per-URL failure. The terminal `CRAWL_COMPLETED` webhook still fires from `finishCrawlSuper` once the queue drains, so consumers still get a clean signal that the job ended. All other failure paths (timeouts, redirect race, robots block, generic error) are untouched.

## Files

- `apps/api/src/services/worker/scrape-worker.ts` — one boolean guard + comment.

## Test plan

- [ ] Start a crawl with a webhook subscribed to `crawl.page` / `batch_scrape.page`.
- [ ] Cancel mid-flight with `DELETE /v1/crawl/{id}`.
- [ ] Confirm no per-URL `CRAWL_PAGE`/`BATCH_SCRAPE_PAGE` events fire for the queued URLs after cancellation.
- [ ] Confirm the terminal `CRAWL_COMPLETED` event still fires.
- [ ] Confirm non-cancellation failures (timeouts, etc.) still emit per-URL webhooks.

## Notes

The reporter also suggested an alternative: keep emitting per-URL events but tag them with `reason: "cancelled"` so consumers can filter. That keeps existing payload shape but adds metadata complexity. This PR takes the simpler "stop the flood" path; happy to switch to the tagged-payload approach if maintainers prefer — the same `isCancelled` check can branch into a tagged payload instead of being skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips per-URL `CRAWL_PAGE`/`BATCH_SCRAPE_PAGE` webhooks when a crawl is cancelled to prevent a flood of false failure events. Cancellation is reported via the terminal `CRAWL_COMPLETED` webhook; all non-cancellation failures still emit per-URL events.

<sup>Written for commit a39bddabdadd0af3bede116d2708734208fbda21. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3615?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

