### PR TITLE
docs: add agent quickstart files for all SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,178 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` Hex package SDK source and the v2 OpenAPI spec. Function names are auto-generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+{:firecrawl, "~> 1.5"}
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# or pass api_key per call
+{:ok, res} = Firecrawl.search_and_scrape([query: "example"], api_key: "fc-your-api-key")
+```
+
+## When To Use What
+
+- `search` — use when you start with a query and need discovery.
+- `scrape` — use when you already have a URL and want page content.
+- `interact` — use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  sources: [:web],
+  limit: 5,
+  scrape_options: [
+    formats: ["markdown"],
+    only_main_content: true
+  ]
+)
+```
+
+### Parameters
+
+- `query` (string, required) — search query. Use `site:example.com` to limit to a domain.
+- `sources` (list) — which sources to search. Values: `:web`, `:news`, `:images` (or string equivalents).
+- `categories` (list) — filter by category. Values: `:github`, `:research`, `:pdf` (or string equivalents).
+- `limit` (integer) — cap number of results.
+- `tbs` (string) — time-based filter, e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`.
+- `location` (string) — localized results, e.g. `"San Francisco,California,United States"`.
+- `country` (string) — ISO 3166-1 alpha-2 code for geo-targeting, e.g. `"US"`.
+- `include_domains` (list of strings) — restrict to these domains.
+- `exclude_domains` (list of strings) — exclude these domains.
+- `ignore_invalid_urls` (boolean) — drop URLs that cannot be scraped.
+- `timeout` (integer) — request timeout in milliseconds.
+- `enterprise` (list of strings) — enterprise ZDR options. Values: `"zdr"`, `"anon"`.
+- `scrape_options` (keyword list) — scrape each result. See Scrape parameters.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    %{type: "json", prompt: "Extract plan names and prices."}
+  ],
+  only_main_content: true,
+  timeout: 30000
+)
+```
+
+### Parameters
+
+- `url` (string, required) — URL to scrape.
+- `formats` (list) — output formats. String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`. Format maps:
+  - `%{type: "json", prompt: str, schema: map}` — JSON extraction
+  - `%{type: "screenshot", fullPage: bool, quality: int, viewport: %{width: int, height: int}}`
+  - `%{type: "changeTracking", modes: ["git-diff" | "json"], tag: str}`
+  - `%{type: "attributes", selectors: [%{selector: str, attribute: str}]}`
+- `headers` (map) — custom request headers.
+- `include_tags` (list of strings) — HTML tags to include.
+- `exclude_tags` (list of strings) — HTML tags to exclude.
+- `only_main_content` (boolean) — strip nav, footer, and boilerplate.
+- `timeout` (integer) — timeout in milliseconds. Default: `60000`.
+- `wait_for` (integer) — wait for page to render (milliseconds).
+- `mobile` (boolean) — use mobile viewport.
+- `parsers` (list) — file parsing. Values: `"pdf"` or `%{type: "pdf", mode: "fast" | "auto" | "ocr", maxPages: integer}`.
+- `actions` (list of maps) — pre-scrape browser actions. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`.
+- `location` (keyword list) — `[country: "US", languages: ["en-US"]]` for geo-aware scraping.
+- `skip_tls_verification` (boolean) — skip TLS verification.
+- `remove_base64_images` (boolean) — drop base64 images from markdown.
+- `block_ads` (boolean) — block ads and cookie popups.
+- `proxy` (atom) — proxy control. Values: `:basic`, `:enhanced`, `:auto`.
+- `max_age` (integer) — use cached data up to this age (milliseconds).
+- `min_age` (integer) — use cached data only if at least this old (milliseconds).
+- `store_in_cache` (boolean) — cache the result.
+- `lockdown` (boolean) — serve only from cache.
+- `profile` (keyword list) — `[name: "session-name", save_changes: true]` for persistent browser profile.
+- `zero_data_retention` (boolean) — enable zero data retention.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job via code execution. The Elixir SDK exposes code-based interactions only — there is no `prompt` parameter.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, scrape_res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_res.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+
+{:ok, _} = Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+- `job_id` (string, required) — scrape job ID.
+- `code` (string, required) — code to run in the browser session.
+- `language` (atom) — runtime. Values: `:python`, `:node`, `:bash`.
+- `timeout` (integer) — execution timeout in seconds.
+
+Stop session: `Firecrawl.stop_interactive_scrape_browser_session(job_id)` tears down the browser session.
+
+## Notes
+
+- The Elixir client is auto-generated from the OpenAPI spec. Function names like `scrape_and_extract_from_url` and `interact_with_scrape_browser_session` are spec-derived — do not rename them.
+- Each public function has a bang (`!`) variant that raises on error instead of returning `{:error, _}`.
+- Parameters use **snake_case** in Elixir; they are automatically converted to camelCase for the API.
+- The Elixir SDK does not support the `prompt` parameter on interact — use `code` only.
+- Dependencies: `req` (~> 0.5) for HTTP, `nimble_options` (~> 1.1) for parameter validation.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,206 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `firecrawl-java` SDK source and the v2 OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.8.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.8.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+```
+
+## When To Use What
+
+- `search` — use when you start with a query and need discovery.
+- `scrape` — use when you already have a URL and want page content.
+- `interact` — use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import java.util.List;
+import java.util.Map;
+
+SearchOptions options = SearchOptions.builder()
+    .sources(List.of("web"))
+    .limit(5)
+    .scrapeOptions(
+        ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .onlyMainContent(true)
+            .build()
+    )
+    .build();
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries", options);
+List<Map<String, Object>> web = results.getWeb();
+```
+
+Return value: `SearchData`. Read result buckets with `getWeb()`, `getNews()`, `getImages()` (each is `List<Map<String, Object>>` and may be null). Do not treat `SearchData` as a directly iterable list.
+
+### Parameters
+
+- `query` (String, required) — search query. Use `site:example.com` to limit to a domain.
+- `options.sources` (List) — which sources to search. Values: `"web"`, `"news"`, `"images"`.
+- `options.categories` (List) — filter by category. Values: `"github"`, `"research"`, `"pdf"`.
+- `options.limit` (Integer) — cap number of results.
+- `options.tbs` (String) — time-based filter, e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`.
+- `options.location` (String) — localized results.
+- `options.includeDomains` (`List<String>`) — restrict results to these domains.
+- `options.excludeDomains` (`List<String>`) — exclude these domains from results.
+- `options.ignoreInvalidURLs` (Boolean) — drop URLs that cannot be scraped.
+- `options.timeout` (Integer) — request timeout in milliseconds.
+- `options.scrapeOptions` (`ScrapeOptions`) — scrape each result. See Scrape parameters.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
+
+ScrapeOptions options = ScrapeOptions.builder()
+    .formats(List.of(
+        "markdown",
+        JsonFormat.builder().prompt("Extract plan names and prices.").build()
+    ))
+    .onlyMainContent(true)
+    .build();
+
+Document doc = client.scrape("https://example.com/pricing", options);
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+- `url` (String, required) — URL to scrape.
+- `options.formats` (List) — output formats. String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Format object fields:
+  - `type` — one of the format strings above
+  - `prompt`, `schema` — JSON extraction options for `type: "json"`
+  - `modes`, `schema`, `prompt`, `tag` — change tracking options for `type: "changeTracking"`
+  - `fullPage`, `quality`, `viewport` — screenshot options for `type: "screenshot"`
+  - `selectors` — array of `{selector, attribute}` for `type: "attributes"`
+- `options.headers` (`Map<String, String>`) — custom request headers.
+- `options.includeTags` (`List<String>`) — HTML tags to include.
+- `options.excludeTags` (`List<String>`) — HTML tags to exclude.
+- `options.onlyMainContent` (Boolean) — strip nav, footer, and boilerplate.
+- `options.timeout` (Integer) — timeout in milliseconds.
+- `options.waitFor` (Integer) — wait for page to render (milliseconds).
+- `options.mobile` (Boolean) — use mobile viewport.
+- `options.parsers` (`List<Object>`) — file parsing. Values: `"pdf"` or `{type: "pdf", maxPages: number}`.
+- `options.actions` (`List<Map<String, Object>>`) — pre-scrape browser actions. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`.
+- `options.location` (`LocationConfig`) — `{ country, languages }` for geo-aware scraping.
+- `options.skipTlsVerification` (Boolean) — skip TLS verification.
+- `options.removeBase64Images` (Boolean) — drop base64 images from markdown.
+- `options.blockAds` (Boolean) — block ads and cookie popups.
+- `options.proxy` (String) — proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`.
+- `options.maxAge` (Long) — use cached data up to this age (milliseconds).
+- `options.storeInCache` (Boolean) — cache the result.
+- `options.lockdown` (Boolean) — serve only from cache, never make outbound requests.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job via code execution. The Java SDK exposes code-based interactions only — there is no `prompt` parameter.
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` — uses default language `node`
+- `client.interact(jobId, code, language, timeout)` — `timeout` in seconds (1–300), or null for API default (30s)
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+System.out.println(result.getStdout());
+
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+- `jobId` (String, required) — scrape job ID.
+- `code` (String, required) — code to run in the browser session.
+- `language` (String) — runtime. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+- `timeout` (Integer) — execution timeout in seconds (1–300). Null uses API default.
+
+Response: `BrowserExecuteResponse` with `isSuccess()`, `getStdout()`, `getStderr()`, `getResult()`, `getError()`, `getExitCode()`, `getKilled()`.
+
+Stop session: `client.stopInteractiveBrowser(jobId)` → `BrowserDeleteResponse` with `isSuccess()`, `getSessionDurationMs()`, `getCreditsBilled()`, `getError()`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- The Java SDK uses **camelCase** for all parameter names (matching JSON field names directly).
+- The Java SDK does not support the `prompt` parameter on `interact` — use `code` only.
+- Format objects use `JsonFormat.builder()` for JSON extraction; other format objects use raw `Map<String, Object>`.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,193 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `@mendable/firecrawl-js` SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+Client options:
+
+- `apiKey` — falls back to `FIRECRAWL_API_KEY` env var
+- `apiUrl` — falls back to `FIRECRAWL_API_URL` or `https://api.firecrawl.dev`
+- `timeoutMs` — per-request timeout in milliseconds
+- `maxRetries` — auto-retry transient failures
+- `backoffFactor` — exponential backoff multiplier
+
+## When To Use What
+
+- `search` — use when you start with a query and need discovery.
+- `scrape` — use when you already have a URL and want page content.
+- `interact` — use when the page needs clicks, forms, or post-scrape browser actions. Prefer `interact` over scrape-time `actions` for multi-step flows.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  sources: ["web"],
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true,
+  },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+Return value: `SearchData` has optional arrays `web`, `news`, `images`. Each entry is a lightweight result or a full `Document` when `scrapeOptions` hydrated it. Do **not** access `result.data` — results are in `result.web`, `result.news`, `result.images`.
+
+### Parameters
+
+- `query` (string, required) — search query. Use `site:example.com` to limit to a domain.
+- `options.sources` (array) — which sources to search. Values: `"web"`, `"news"`, `"images"`, or `{ type: "web" | "news" | "images" }`.
+- `options.categories` (array) — filter by category. Values: `"github"`, `"research"`, `"pdf"`, or `{ type: "github" | "research" | "pdf" }`.
+- `options.limit` (number) — cap number of results.
+- `options.tbs` (string) — time-based filter, e.g. `"qdr:d"` (past day), `"qdr:w"` (past week), `"qdr:m"` (past month).
+- `options.location` (string) — localized results, e.g. `"San Francisco,California,United States"`.
+- `options.includeDomains` (string[]) — restrict results to these domains.
+- `options.excludeDomains` (string[]) — exclude these domains from results.
+- `options.ignoreInvalidURLs` (boolean) — drop URLs that cannot be scraped by other endpoints.
+- `options.timeout` (number) — request timeout in milliseconds.
+- `options.scrapeOptions` (`ScrapeOptions`) — scrape each search result. See Scrape parameters.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+  timeout: 30000,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+- `url` (string, required) — URL to scrape.
+- `options.formats` (array) — output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object-only formats:
+  - `{ type: "json", prompt?: string, schema?: object }` — at least one of `prompt` or `schema` required. Plain string `"json"` is rejected by the SDK.
+  - `{ type: "question", question: string }` — question-answer extraction.
+  - `{ type: "highlights", query: string }` — relevant source-text extraction.
+  - `{ type: "screenshot", fullPage?: boolean, quality?: number, viewport?: { width, height } }`
+  - `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?: object, prompt?: string, tag?: string }` — `modes` is required.
+  - `{ type: "attributes", selectors: { selector: string, attribute: string }[] }`
+- `options.headers` (Record\<string, string\>) — custom request headers.
+- `options.includeTags` (string[]) — HTML tags to include.
+- `options.excludeTags` (string[]) — HTML tags to exclude.
+- `options.onlyMainContent` (boolean) — strip nav, footer, and boilerplate.
+- `options.timeout` (number) — timeout in milliseconds.
+- `options.waitFor` (number) — wait for page to render (milliseconds).
+- `options.mobile` (boolean) — use mobile viewport.
+- `options.parsers` (array) — file parsing controls. Values: `"pdf"` or `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`.
+- `options.actions` (array) — pre-scrape browser actions. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`.
+- `options.location` (object) — `{ country?: string, languages?: string[] }` for geo-aware scraping.
+- `options.skipTlsVerification` (boolean) — skip TLS verification.
+- `options.removeBase64Images` (boolean) — drop base64 images from markdown.
+- `options.fastMode` (boolean) — faster scrapes with reduced fidelity.
+- `options.blockAds` (boolean) — block ads and cookie popups.
+- `options.proxy` (string) — proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`.
+- `options.maxAge` (number) — use cached data up to this age (milliseconds).
+- `options.minAge` (number) — use cached data only if at least this old (milliseconds).
+- `options.storeInCache` (boolean) — cache the result.
+- `options.lockdown` (boolean) — serve only from cache, never make outbound requests.
+- `options.profile` (object) — `{ name: string, saveChanges?: boolean }` for persistent browser profile.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job via code or natural language. The SDK requires at least one of `code` or `prompt`. For flows beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId from scrape response");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+console.log(result.output);
+
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+- `jobId` (string, required) — scrape job ID from `document.metadata.scrapeId`.
+- `args.code` (string) — code to run in the browser session.
+- `args.prompt` (string) — natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty (SDK throws otherwise).
+- `args.language` (string) — runtime language. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+- `args.timeout` (number) — execution timeout in seconds.
+
+Response fields: `success`, `output`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `liveViewUrl`, `interactiveLiveViewUrl`, `error`.
+
+Stop session: `client.stopInteraction(jobId)` ends the browser session. Returns `{ success, sessionDurationMs?, creditsBilled?, error? }`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json`
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,190 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from `firecrawl-py` SDK source and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client in `firecrawl/v2/client.py`.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+Client options:
+
+- `api_key` — falls back to `FIRECRAWL_API_KEY` env var
+- `api_url` — defaults to `https://api.firecrawl.dev`
+- `timeout` — per-request timeout
+- `max_retries` — default `3`
+- `backoff_factor` — default `0.5`
+
+An async client is also available: `from firecrawl import AsyncFirecrawl`.
+
+## When To Use What
+
+- `search` — use when you start with a query and need discovery.
+- `scrape` — use when you already have a URL and want page content.
+- `interact` — use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    sources=["web"],
+    limit=5,
+    scrape_options=ScrapeOptions(
+        formats=["markdown"],
+        only_main_content=True,
+    ),
+)
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+Return value: `SearchData` has optional lists `web`, `news`, `images`. Each entry is a `SearchResultWeb`/`SearchResultNews`/`SearchResultImages` or a full `Document` when `scrape_options` hydrated it. Do **not** access `result.data` — results are in `result.web`, `result.news`, `result.images`.
+
+### Parameters
+
+- `query` (str, required) — search query. Use `site:example.com` to limit to a domain.
+- `sources` (list) — which sources to search. Values: `"web"`, `"news"`, `"images"`, or `Source(type=...)`.
+- `categories` (list) — filter by category. Values: `"github"`, `"research"`, `"pdf"`, or `Category(type=...)`.
+- `limit` (int) — cap number of results. Default: `5`.
+- `tbs` (str) — time-based filter, e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`.
+- `location` (str) — localized results, e.g. `"San Francisco,California,United States"`.
+- `include_domains` (list[str]) — restrict results to these domains.
+- `exclude_domains` (list[str]) — exclude these domains. Mutually exclusive with `include_domains`.
+- `ignore_invalid_urls` (bool) — drop URLs that cannot be scraped.
+- `timeout` (int) — request timeout in milliseconds. Default: `300000`.
+- `scrape_options` (`ScrapeOptions`) — scrape each result. See Scrape parameters.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+    timeout=30000,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+- `url` (str, required) — URL to scrape.
+- `formats` (list) — output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"` or `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` or `"change_tracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object-only formats:
+  - `{"type": "json", "prompt": str, "schema": dict}` — at least one of `prompt` or `schema` required. Do not use plain string `"json"`.
+  - `{"type": "question", "question": str}` — question-answer extraction.
+  - `{"type": "highlights", "query": str}` — relevant source-text extraction.
+  - `{"type": "screenshot", "full_page": bool, "quality": int, "viewport": {"width": int, "height": int}}`
+  - `{"type": "changeTracking", "modes": ["git-diff" | "json"], "schema": dict, "prompt": str, "tag": str}` — `modes` is required.
+  - `{"type": "attributes", "selectors": [{"selector": str, "attribute": str}]}`
+- `headers` (dict) — custom request headers.
+- `include_tags` (list[str]) — HTML tags to include.
+- `exclude_tags` (list[str]) — HTML tags to exclude.
+- `only_main_content` (bool) — strip nav, footer, and boilerplate.
+- `timeout` (int) — timeout in milliseconds.
+- `wait_for` (int) — wait for page to render (milliseconds).
+- `mobile` (bool) — use mobile viewport.
+- `parsers` (list) — file parsing controls. Values: `"pdf"` or `{"type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": int}`.
+- `actions` (list) — pre-scrape browser actions. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`.
+- `location` (dict or Location) — `{"country": str, "languages": [str]}` for geo-aware scraping.
+- `skip_tls_verification` (bool) — skip TLS verification.
+- `remove_base64_images` (bool) — drop base64 images from markdown.
+- `fast_mode` (bool) — faster scrapes with reduced fidelity.
+- `block_ads` (bool) — block ads and cookie popups.
+- `proxy` (str) — proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`.
+- `max_age` (int) — use cached data up to this age (milliseconds).
+- `store_in_cache` (bool) — cache the result.
+- `lockdown` (bool) — serve only from cache, never make outbound requests.
+- `profile` (dict) — `{"name": str, "save_changes": bool}` for persistent browser profile.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job via code or natural language. At least one of `code` or `prompt` must be non-empty. `prompt` is keyword-only.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id from scrape response")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+print(result.output)
+
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+- `job_id` (str, required) — scrape job ID from `document.metadata.scrape_id`.
+- `code` (str) — code to run in the browser session.
+- `prompt` (str, keyword-only) — natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty.
+- `language` (str) — runtime language. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+- `timeout` (int) — execution timeout in seconds.
+
+Response fields: `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+Stop session: `client.stop_interaction(job_id)` ends the browser session. Returns `BrowserDeleteResponse` with `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`. Also: `scrape_url` → `scrape`, `crawl_url` → `crawl`, `map_url` → `map`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- Snake_case parameters are converted to camelCase for the API automatically.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/pyproject.toml`
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,208 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` crate SDK source and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- `search` — use when you start with a query and need discovery.
+- `scrape` — use when you already have a URL and want page content.
+- `interact` — use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let options = SearchOptions {
+    sources: Some(vec![SearchSource::Web]),
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        only_main_content: Some(true),
+        ..Default::default()
+    }),
+    ..Default::default()
+};
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", options)
+    .await?;
+
+if let Some(web) = results.data.web {
+    for item in web {
+        // item is SearchResultOrDocument::WebResult or ::Document
+    }
+}
+```
+
+Return value: `SearchResponse` contains `data: SearchData` with optional vecs `web`, `news`, `images`. Web entries are `SearchResultOrDocument::WebResult(SearchResultWeb)` or `SearchResultOrDocument::Document(Document)` when scrape options hydrated them.
+
+### Parameters
+
+- `query` (`impl AsRef<str>`, required) — search query. Use `site:example.com` to limit to a domain.
+- `options.sources` (`Vec<SearchSource>`) — which sources to search. Values: `Web`, `News`, `Images`.
+- `options.categories` (`Vec<SearchCategory>`) — filter by category. Values: `Github`, `Research`, `Pdf`.
+- `options.limit` (u32) — cap number of results.
+- `options.tbs` (String) — time-based filter, e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`.
+- `options.location` (String) — localized results.
+- `options.include_domains` (`Vec<String>`) — restrict to these domains.
+- `options.exclude_domains` (`Vec<String>`) — exclude these domains.
+- `options.ignore_invalid_urls` (bool) — drop URLs that cannot be scraped.
+- `options.timeout` (u32) — request timeout in milliseconds.
+- `options.scrape_options` (`ScrapeOptions`) — scrape each result. See Scrape parameters.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".to_string()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        ..Default::default()
+    })
+    .await?;
+```
+
+### Parameters
+
+- `url` (`impl AsRef<str>`, required) — URL to scrape.
+- `options.formats` (`Vec<Format>`) — output formats. Values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`. Also: `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`.
+- `options.headers` (`HashMap<String, String>`) — custom request headers.
+- `options.include_tags` (`Vec<String>`) — HTML tags to include.
+- `options.exclude_tags` (`Vec<String>`) — HTML tags to exclude.
+- `options.only_main_content` (bool) — strip nav, footer, and boilerplate.
+- `options.timeout` (u32) — timeout in milliseconds.
+- `options.wait_for` (u32) — wait for page to render (milliseconds).
+- `options.mobile` (bool) — use mobile viewport.
+- `options.parsers` (`Vec<ParserConfig>`) — file parsing. Values: `ParserConfig::Simple("pdf".to_string())`, `ParserConfig::Pdf { parser_type, mode, max_pages }`.
+- `options.actions` (`Vec<Action>`) — pre-scrape browser actions. Variants: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`.
+- `options.location` (`LocationConfig`) — `{ country, languages }` for geo-aware scraping.
+- `options.skip_tls_verification` (bool) — skip TLS verification.
+- `options.remove_base64_images` (bool) — drop base64 images from markdown.
+- `options.fast_mode` (bool) — faster scrapes with reduced fidelity.
+- `options.block_ads` (bool) — block ads and cookie popups.
+- `options.proxy` (`ProxyType`) — proxy control. Values: `Basic`, `Stealth`, `Enhanced`, `Auto`.
+- `options.max_age` (u32) — use cached data up to this age (milliseconds).
+- `options.min_age` (u32) — use cached data only if at least this old (milliseconds).
+- `options.store_in_cache` (bool) — cache the result.
+- `options.lockdown` (bool) — serve only from cache.
+- `options.profile` (`ProfileConfig`) — `{ name, save_changes }` for persistent browser profile.
+- `options.json_options` (`JsonOptions`) — configure JSON extraction: `{ schema, system_prompt, prompt }`.
+- `options.screenshot_options` (`ScreenshotOptions`) — configure screenshots: `{ full_page, quality, viewport }`.
+- `options.change_tracking_options` (`ChangeTrackingOptions`) — configure change tracking: `{ modes, schema, prompt, tag }`. Modes: `GitDiff`, `Json`.
+- `options.attribute_selectors` (`Vec<AttributeSelector>`) — attribute extraction: `{ selector, attribute }`.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job via code or natural language. At least one of `code` or `prompt` must be non-empty, otherwise the SDK returns `FirecrawlError::Misuse`.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, ScrapeExecuteOptions};
+
+let doc = client
+    .scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    })
+    .await?;
+
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_deref())
+    .expect("Missing scrapeId");
+
+let result = client
+    .interact(job_id, ScrapeExecuteOptions {
+        prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+        ..Default::default()
+    })
+    .await?;
+
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+- `job_id` (`impl AsRef<str>`, required) — scrape job ID.
+- `options.code` (`Option<String>`) — code to run in the browser session.
+- `options.prompt` (`Option<String>`) — natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty.
+- `options.language` (`ScrapeExecuteLanguage`) — runtime. Values: `Python`, `Node`, `Bash`. Default: `Node`.
+- `options.timeout` (u32) — execution timeout in seconds.
+
+Response fields: `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+Stop session: `client.stop_interaction(job_id)` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>`. Response: `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- `ScrapeOptions` has dedicated `json_options`, `screenshot_options`, `change_tracking_options`, and `attribute_selectors` fields for advanced format configuration.
+- `search_and_scrape(query, limit)` is a convenience helper that calls `search` with default `ScrapeOptions` and returns `Vec<Document>`.
+- All types are exported at the crate root: `use firecrawl::Client`, not `use firecrawl::v2::Client`.
+- All option structs derive `Default`, so use `..Default::default()` for partial initialization.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart file per SDK language (Node.js, Python, Rust, Java, Elixir) in `docs/agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with confirmed parameters, SDK method signatures, realistic examples, and language-specific notes
- Generated from SDK source code and the v2 OpenAPI spec — no invented parameters or behavior

**Note:** These files are intended for the `firecrawl-docs` repo at `agent-quickstart/`. They are placed in `firecrawl/docs/agent-quickstart/` here because the `firecrawl-docs` repo was not writable in this session. The files should be moved to `firecrawl-docs/agent-quickstart/` before merging.

## Test plan

- [ ] Verify each quickstart file renders cleanly as Mintlify MDX
- [ ] Spot-check parameter lists against current SDK source
- [ ] Move files to `firecrawl-docs/agent-quickstart/` for final placement

https://claude.ai/code/session_013SgV583Cj5rh2zWAK27aWG

---
_Generated by [Claude Code](https://claude.ai/code/session_013SgV583Cj5rh2zWAK27aWG)_