### PR TITLE
jitter scheduler claim to avoid thundering herd

### DIFF
--- a/apps/api/src/services/monitoring/jitter.ts
+++ b/apps/api/src/services/monitoring/jitter.ts
@@ -1,0 +1,13 @@
+import { createHash } from "crypto";
+
+const MAX_JITTER_MS = 5 * 60 * 1000;
+
+export function monitorJitterOffsetMs(
+  monitorId: string,
+  intervalMs: number,
+): number {
+  const jitterMaxMs = Math.min(Math.floor(intervalMs / 2), MAX_JITTER_MS);
+  if (jitterMaxMs <= 0) return 0;
+  const hash = createHash("sha256").update(monitorId).digest();
+  return hash.readUInt32BE(0) % jitterMaxMs;
+}

--- a/apps/api/src/services/monitoring/scheduler.ts
+++ b/apps/api/src/services/monitoring/scheduler.ts
@@ -5,6 +5,7 @@ import {
   advanceMonitorAfterSkippedCheck,
   claimDueMonitors,
   createMonitorCheck,
+  deferMonitorClaim,
   dispatchScheduledMonitorCheck,
   getMonitorCheck,
   updateMonitorCheck,
@@ -12,6 +13,8 @@ import {
 } from "./store";
 import { autumnService } from "../autumn/autumn.service";
 import { isMonitorCheckStale, MONITOR_CHECK_STALE_ERROR } from "./stale";
+import { validateMonitorCron } from "./cron";
+import { monitorJitterOffsetMs } from "./jitter";
 import type { MonitorRow } from "./types";
 
 const logger = _logger.child({ module: "monitoring-scheduler" });
@@ -40,6 +43,8 @@ export async function enqueueDueMonitorChecks(
 
   let enqueued = 0;
   for (let monitor of monitors) {
+    if (await deferForJitter(monitor)) continue;
+
     let check: Awaited<ReturnType<typeof createMonitorCheck>> | null = null;
     let dispatched = false;
     try {
@@ -133,6 +138,25 @@ export async function enqueueDueMonitorChecks(
   }
 
   return enqueued;
+}
+
+async function deferForJitter(monitor: MonitorRow): Promise<boolean> {
+  if (!monitor.next_run_at) return false;
+  const { intervalMs } = validateMonitorCron(
+    monitor.schedule_cron,
+    monitor.schedule_timezone,
+  );
+  const dueAt =
+    new Date(monitor.next_run_at).getTime() +
+    monitorJitterOffsetMs(monitor.id, intervalMs);
+  if (Date.now() >= dueAt) return false;
+  await deferMonitorClaim(monitor.id, new Date(dueAt)).catch(error =>
+    logger.warn("Failed to defer monitor claim for jitter", {
+      error,
+      monitorId: monitor.id,
+    }),
+  );
+  return true;
 }
 
 async function clearFinishedOrStaleCurrentCheck(

--- a/apps/api/src/services/monitoring/scheduler.ts
+++ b/apps/api/src/services/monitoring/scheduler.ts
@@ -43,11 +43,11 @@ export async function enqueueDueMonitorChecks(
 
   let enqueued = 0;
   for (let monitor of monitors) {
-    if (await deferForJitter(monitor)) continue;
-
     let check: Awaited<ReturnType<typeof createMonitorCheck>> | null = null;
     let dispatched = false;
     try {
+      if (await deferForJitter(monitor)) continue;
+
       if (monitor.current_check_id) {
         const cleared = await clearFinishedOrStaleCurrentCheck(monitor);
         if (cleared) {

--- a/apps/api/src/services/monitoring/scheduler.ts
+++ b/apps/api/src/services/monitoring/scheduler.ts
@@ -150,12 +150,15 @@ async function deferForJitter(monitor: MonitorRow): Promise<boolean> {
     new Date(monitor.next_run_at).getTime() +
     monitorJitterOffsetMs(monitor.id, intervalMs);
   if (Date.now() >= dueAt) return false;
-  await deferMonitorClaim(monitor.id, new Date(dueAt)).catch(error =>
+  try {
+    await deferMonitorClaim(monitor.id, new Date(dueAt));
+  } catch (error) {
     logger.warn("Failed to defer monitor claim for jitter", {
       error,
       monitorId: monitor.id,
-    }),
-  );
+    });
+    return false;
+  }
   return true;
 }
 

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -698,3 +698,19 @@ export async function claimDueMonitors(params: {
   throwIfError(error, "Failed to claim due monitors");
   return (data ?? []) as MonitorRow[];
 }
+
+export async function deferMonitorClaim(
+  monitorId: string,
+  until: Date,
+): Promise<void> {
+  const { error } = await supabase_service
+    .from("monitors")
+    .update({
+      locked_until: until.toISOString(),
+      locked_at: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", monitorId);
+
+  throwIfError(error, "Failed to defer monitor claim");
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add deterministic jitter to monitor scheduling to stagger check runs and avoid thundering herd spikes. The scheduler now defers claims until a per-monitor offset and updates `locked_until` to reschedule safely.

- **New Features**
  - Added `monitorJitterOffsetMs(monitorId, intervalMs)` with a stable offset up to min(interval/2, 5m) using a SHA-256 hash.
  - Scheduler defers due monitors until `next_run_at + jitter` via `deferMonitorClaim(id, dueAt)`; on write failure, falls through to enqueue; interval derived via `validateMonitorCron`. Errors are logged per monitor.
  - Store exposes `deferMonitorClaim` to set `locked_until`, clear `locked_at`, and bump `updated_at`.

<sup>Written for commit 0d8fed2c6859dc543f84c7ec9e8d4124d3988c8f. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3619?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

