### PR TITLE
fix(api/gcs-jobs): fall back to legacy filename when reading jobs

### DIFF
--- a/apps/api/src/lib/gcs-jobs.ts
+++ b/apps/api/src/lib/gcs-jobs.ts
@@ -377,6 +377,35 @@ export async function saveLlmsTxtToGCS(
   });
 }
 
+async function downloadJobFromGCS(
+  bucketName: string,
+  filename: string,
+  jobId: string,
+): Promise<Document[] | null> {
+  const blob = storage.bucket(bucketName).file(filename);
+
+  try {
+    const [content] = await blob.download();
+    return JSON.parse(content.toString());
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      error.code === 404 &&
+      error.message.includes("No such object:")
+    ) {
+      return null;
+    }
+
+    logger.error(`Error getting job from GCS`, {
+      error,
+      jobId,
+      scrapeId: jobId,
+      filename,
+    });
+    throw error;
+  }
+}
+
 export async function getJobFromGCS(jobId: string): Promise<Document[] | null> {
   return await withSpan("firecrawl-gcs-get-job", async span => {
     setSpanAttributes(span, {
@@ -389,31 +418,28 @@ export async function getJobFromGCS(jobId: string): Promise<Document[] | null> {
       return null;
     }
 
-    const bucket = storage.bucket(config.GCS_BUCKET_NAME);
-    const blob = bucket.file(idToFilename(jobId));
+    const primaryFilename = idToFilename(jobId);
+    let result = await downloadJobFromGCS(
+      config.GCS_BUCKET_NAME,
+      primaryFilename,
+      jobId,
+    );
 
-    try {
-      const [content] = await blob.download();
-      const result = JSON.parse(content.toString());
-      setSpanAttributes(span, { "gcs.job_found": true });
-      return result;
-    } catch (error) {
-      if (
-        error instanceof ApiError &&
-        error.code === 404 &&
-        error.message.includes("No such object:")
-      ) {
-        setSpanAttributes(span, { "gcs.job_found": false });
-        return null;
-      }
-
-      logger.error(`Error getting job from GCS`, {
-        error,
+    // Fall back to the legacy `<id>.json` filename. Agent results are written
+    // by an external service that may still use the pre-cutover filename
+    // pattern, so the object can live under the legacy key even when
+    // idToFilename resolves to the new sha256-prefixed name.
+    const legacyFilename = `${jobId}.json`;
+    if (result === null && legacyFilename !== primaryFilename) {
+      result = await downloadJobFromGCS(
+        config.GCS_BUCKET_NAME,
+        legacyFilename,
         jobId,
-        scrapeId: jobId,
-      });
-      throw error;
+      );
     }
+
+    setSpanAttributes(span, { "gcs.job_found": result !== null });
+    return result;
   });
 }
 


### PR DESCRIPTION
Agent results are written to GCS by an external service that may still use the pre-cutover `<id>.json` filename, while `getJobFromGCS` now resolves v7 UUIDs created on/after 2026-05-26 to the new `sha256(id)-id.json` name (#3605). That mismatch made completed agent jobs return `data: null` with credits charged.

This retries the legacy `<id>.json` filename on a 404, so reads succeed regardless of which name the object was written under. No behavior change for jobs whose primary and legacy filenames are identical (non-v7 or pre-cutover IDs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GCS job reads by falling back to the legacy `<id>.json` key when the new `sha256(id)-id.json` object isn’t found. Prevents completed agent jobs from returning `data: null` and charging credits.

- **Bug Fixes**
  - Added `downloadJobFromGCS` helper that returns null on 404 and logs other errors.
  - `getJobFromGCS` retries `<id>.json` when the primary filename misses (only if different).
  - Sets `gcs.job_found` span based on result; no change for pre-cutover or non‑v7 IDs.

<sup>Written for commit 43409348443d845b9109db9807d0b7a21552b079. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3622?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

