### PR TITLE
fix(api): emit crawl cancelled webhook without page failures

### DIFF
--- a/apps/api/src/services/webhook/types.ts
+++ b/apps/api/src/services/webhook/types.ts
@@ -7,6 +7,7 @@ export enum WebhookEvent {
   CRAWL_STARTED = "crawl.started",
   CRAWL_PAGE = "crawl.page",
   CRAWL_COMPLETED = "crawl.completed",
+  CRAWL_CANCELLED = "crawl.cancelled",
   BATCH_SCRAPE_STARTED = "batch_scrape.started",
   BATCH_SCRAPE_PAGE = "batch_scrape.page",
   BATCH_SCRAPE_COMPLETED = "batch_scrape.completed",
@@ -21,6 +22,7 @@ export type WebhookEventDataMap = {
   [WebhookEvent.CRAWL_STARTED]: CrawlStartedData;
   [WebhookEvent.CRAWL_PAGE]: CrawlPageData;
   [WebhookEvent.CRAWL_COMPLETED]: CrawlCompletedData;
+  [WebhookEvent.CRAWL_CANCELLED]: CrawlCancelledData;
   [WebhookEvent.BATCH_SCRAPE_STARTED]: BatchScrapeStartedData;
   [WebhookEvent.BATCH_SCRAPE_PAGE]: BatchScrapePageData;
   [WebhookEvent.BATCH_SCRAPE_COMPLETED]: BatchScrapeCompletedData;
@@ -84,6 +86,12 @@ interface CrawlPageData extends BaseWebhookData {
 interface CrawlCompletedData extends BaseWebhookData {
   success: true;
   data: Document[] | WebhookDocumentLink[]; // empty array or links (v0 compatible)
+}
+
+interface CrawlCancelledData extends BaseWebhookData {
+  success: false;
+  error: string;
+  data: [];
 }
 
 // batch scrape

--- a/apps/api/src/services/worker/crawl-logic.ts
+++ b/apps/api/src/services/worker/crawl-logic.ts
@@ -114,10 +114,18 @@ export async function finishCrawlSuper(job: NuQJob<any>) {
           source: doc?.metadata?.sourceURL ?? doc?.url ?? "",
         }));
         if (sc.crawlerOptions !== null) {
-          sender.send(WebhookEvent.CRAWL_COMPLETED, {
-            success: true,
-            data: documents,
-          });
+          if (sc.cancelled) {
+            sender.send(WebhookEvent.CRAWL_CANCELLED, {
+              success: false,
+              error: "Crawl was cancelled",
+              data: [],
+            });
+          } else {
+            sender.send(WebhookEvent.CRAWL_COMPLETED, {
+              success: true,
+              data: documents,
+            });
+          }
         } else {
           sender.send(WebhookEvent.BATCH_SCRAPE_COMPLETED, {
             success: true,
@@ -190,10 +198,18 @@ export async function finishCrawlSuper(job: NuQJob<any>) {
       });
       if (sender) {
         if (sc.crawlerOptions !== null) {
-          sender.send(WebhookEvent.CRAWL_COMPLETED, {
-            success: true,
-            data: [],
-          });
+          if (sc.cancelled) {
+            sender.send(WebhookEvent.CRAWL_CANCELLED, {
+              success: false,
+              error: "Crawl was cancelled",
+              data: [],
+            });
+          } else {
+            sender.send(WebhookEvent.CRAWL_COMPLETED, {
+              success: true,
+              data: [],
+            });
+          }
         } else {
           sender.send(WebhookEvent.BATCH_SCRAPE_COMPLETED, {
             success: true,

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -754,7 +754,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
         sourceURL: job.data.url,
       } as any;
 
-      if (sender) {
+      if (sender && !isCancelled) {
         if (job.data.crawlerOptions !== null) {
           sender.send(WebhookEvent.CRAWL_PAGE, {
             success: false,


### PR DESCRIPTION
## Summary
- add a terminal `crawl.cancelled` webhook event for cancelled crawl jobs
- avoid emitting per-page `crawl.page` failure webhooks when scrape jobs fail because the parent crawl was cancelled
- keep non-cancellation page failures and batch scrape behavior unchanged

Fixes #3614

## Validation
- `git diff --check`
- `npx prettier --check apps/api/src/services/worker/scrape-worker.ts apps/api/src/services/worker/crawl-logic.ts apps/api/src/services/webhook/types.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a terminal `crawl.cancelled` webhook for cancelled crawl jobs and stopped emitting per-page `crawl.page` failure webhooks when the parent crawl is cancelled. Non-cancellation failures and batch scrape events are unchanged; `crawl.completed` still fires for successful or non-cancelled crawls.

<sup>Written for commit 95ac69ba3f3943031c82cb3c7caad4e0b8007b67. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3623?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

