### PR TITLE
fix(monitoring): increase judge timeout 

### DIFF
--- a/apps/api/src/services/monitoring/judgeChange.ts
+++ b/apps/api/src/services/monitoring/judgeChange.ts
@@ -92,7 +92,7 @@ function truncate(s: string, cap: number): string {
 }
 
 const JUDGE_MODEL_NAME = "gemini-2.5-flash-lite";
-const JUDGE_ATTEMPT_TIMEOUT_MS = 8_000;
+const JUDGE_ATTEMPT_TIMEOUT_MS = 30_000;
 const JUDGE_MAX_ATTEMPTS = 3;
 const JUDGE_BACKOFF_MS = [300, 800];
 const judgeModel = google(JUDGE_MODEL_NAME);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase judge attempt timeout in monitoring from 8,000 ms to 30,000 ms to avoid premature failures when calling `gemini-2.5-flash-lite`.
This reduces false timeouts and stabilizes judging, with retries and backoff unchanged.

<sup>Written for commit b4abfdeaab5a8a75578ccc36d229dc590e092e0b. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3632?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

