### PR TITLE
fix(monitoring): monitoring updates

### DIFF
--- a/apps/api/src/services/monitoring/judgeChange.ts
+++ b/apps/api/src/services/monitoring/judgeChange.ts
@@ -122,7 +122,7 @@ function sanitizeMeaningfulChanges(
 }
 
 const JUDGE_MODEL_NAME = "gemini-3-flash-preview";
-const JUDGE_ATTEMPT_TIMEOUT_MS = 8_000;
+const JUDGE_ATTEMPT_TIMEOUT_MS = 30_000;
 const JUDGE_MAX_ATTEMPTS = 3;
 const JUDGE_BACKOFF_MS = [300, 800];
 const judgeModel = google(JUDGE_MODEL_NAME);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase monitoring judge attempt timeout from 8s to 30s to reduce flaky timeouts and stabilize change detection.
This allows slower responses from `gemini-3-flash-preview` while keeping retries and backoff unchanged.

<sup>Written for commit 673667033c64635c6f1d5610e0316a33bb2cc74c. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3633?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

