### PR TITLE
refactor: update Firecrawl import paths and package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ search_result = app.search("firecrawl", limit=5)
 
 **Node.js**
 ```javascript
-import Firecrawl from '@mendable/firecrawl-js';
+import Firecrawl from 'firecrawl';
 
 const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
 
@@ -161,7 +161,7 @@ result = app.scrape('firecrawl.dev')
 
 **Node.js**
 ```javascript
-import Firecrawl from '@mendable/firecrawl-js';
+import Firecrawl from 'firecrawl';
 
 const app = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 
@@ -219,7 +219,7 @@ app.interact(scrape_id, prompt="Click the first result")
 
 **Node.js**
 ```javascript
-import Firecrawl from '@mendable/firecrawl-js';
+import Firecrawl from 'firecrawl';
 
 const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
 
@@ -544,10 +544,10 @@ print(results)
 
 Install the SDK:
 ```bash
-npm install @mendable/firecrawl-js
+npm install firecrawl
 ```
 ```javascript
-import Firecrawl from '@mendable/firecrawl-js';
+import Firecrawl from 'firecrawl';
 
 const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ search_result = app.search("firecrawl", limit=5)
 
 **Node.js**
 ```javascript
-import Firecrawl from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 
 const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
 
@@ -161,7 +161,7 @@ result = app.scrape('firecrawl.dev')
 
 **Node.js**
 ```javascript
-import Firecrawl from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 
 const app = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 
@@ -219,7 +219,7 @@ app.interact(scrape_id, prompt="Click the first result")
 
 **Node.js**
 ```javascript
-import Firecrawl from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 
 const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
 
@@ -547,7 +547,7 @@ Install the SDK:
 npm install firecrawl
 ```
 ```javascript
-import Firecrawl from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 
 const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
 

--- a/apps/js-sdk/example.js
+++ b/apps/js-sdk/example.js
@@ -33,10 +33,10 @@ run().catch((e) => {
 
 // old stuff:
 
-import FirecrawlApp from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 import { z } from 'zod';
 
-const app = new FirecrawlApp({apiKey: "fc-YOUR_API_KEY"});
+const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
 
 const main = async () => {
 

--- a/apps/js-sdk/example.ts
+++ b/apps/js-sdk/example.ts
@@ -1,7 +1,7 @@
 // Placeholder v2 example (TypeScript)
 // Minimal usage of new FirecrawlClient. Replace with your API key before running.
 
-// import Firecrawl from '@mendable/firecrawl-js';
+// import Firecrawl from 'firecrawl';
 import Firecrawl from './firecrawl/src/index';
 
 const run = async () => {

--- a/apps/js-sdk/example.ts
+++ b/apps/js-sdk/example.ts
@@ -1,7 +1,7 @@
 // Placeholder v2 example (TypeScript)
 // Minimal usage of new FirecrawlClient. Replace with your API key before running.
 
-// import Firecrawl from 'firecrawl';
+// import { Firecrawl } from 'firecrawl';
 import Firecrawl from './firecrawl/src/index';
 
 const run = async () => {
@@ -36,9 +36,9 @@ run().catch((e) => {
 
 // old stuff:
 
-import FirecrawlApp, { CrawlStatusResponse, ErrorResponse } from 'firecrawl';
+import { Firecrawl, CrawlStatusResponse, ErrorResponse } from 'firecrawl';
 
-const app = new FirecrawlApp({apiKey: "fc-YOUR_API_KEY"});
+const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
 
 const main = async () => {
 

--- a/apps/js-sdk/example_v1.js
+++ b/apps/js-sdk/example_v1.js
@@ -1,4 +1,4 @@
-import FirecrawlApp from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 
 // Placeholder v1 example (JavaScript)
 // Mirrors the older SDK usage. Replace with your API key before running.

--- a/apps/js-sdk/example_v1.ts
+++ b/apps/js-sdk/example_v1.ts
@@ -1,7 +1,7 @@
 // Placeholder v1 example (TypeScript)
 // Mirrors the older SDK usage. Replace with your API key before running.
 
-// import FirecrawlApp from 'firecrawl';
+// import { Firecrawl } from 'firecrawl';
 import Firecrawl from './firecrawl/src/index'
 
 async function main() {

--- a/apps/js-sdk/firecrawl/README.md
+++ b/apps/js-sdk/firecrawl/README.md
@@ -7,7 +7,7 @@ The Firecrawl Node SDK is a library that lets you easily search, scrape, and int
 To install the Firecrawl Node SDK, you can use npm:
 
 ```bash
-npm install @mendable/firecrawl-js
+npm install firecrawl
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ npm install @mendable/firecrawl-js
 Here's an example of how to use the SDK with error handling:
 
 ```js
-import Firecrawl from '@mendable/firecrawl-js';
+import { Firecrawl } from 'firecrawl';
 
 const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
 
@@ -114,7 +114,7 @@ const status = await app.getCrawlStatus(id);
 Use `extract` with a prompt and schema. Zod schemas are supported directly.
 
 ```js
-import Firecrawl from '@mendable/firecrawl-js';
+import { Firecrawl } from 'firecrawl';
 import { z } from 'zod';
 
 const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
@@ -236,7 +236,7 @@ await watch.start();
 The feature‑frozen v1 is still available under `app.v1` with the original method names.
 
 ```js
-import Firecrawl from '@mendable/firecrawl-js';
+import { Firecrawl } from 'firecrawl';
 
 const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
 

--- a/apps/js-sdk/package.json
+++ b/apps/js-sdk/package.json
@@ -11,7 +11,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@mendable/firecrawl-js": "^4.3.4",
     "axios": "^1.15.2",
     "firecrawl": "^4.3.4",
     "uuid": "^10.0.0",

--- a/apps/js-sdk/pnpm-lock.yaml
+++ b/apps/js-sdk/pnpm-lock.yaml
@@ -12,9 +12,6 @@ importers:
 
   .:
     dependencies:
-      '@mendable/firecrawl-js':
-        specifier: ^4.3.4
-        version: 4.11.1
       axios:
         specifier: ^1.15.2
         version: 1.16.0
@@ -212,10 +209,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
-  '@mendable/firecrawl-js@4.11.1':
-    resolution: {integrity: sha512-GBfnP0fFw25185ZCyPNhfgmBdpWxRy2Q3cXhBWSUixmkVLCaFHnhX/vekYcrQBeWjfJbZC2dSukHtIPZGNivoA==}
-    engines: {node: '>=22.0.0'}
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -509,15 +502,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@mendable/firecrawl-js@4.11.1':
-    dependencies:
-      axios: 1.16.0
-      typescript-event-target: 1.1.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - debug
 
   '@tsconfig/node10@1.0.11': {}
 

--- a/examples/attributes-extraction-js-sdk.js
+++ b/examples/attributes-extraction-js-sdk.js
@@ -2,7 +2,7 @@
  * Example: Using Firecrawl JS SDK v2 to extract attributes from HTML elements
  */
 
-import FirecrawlApp from '@mendable/firecrawl-js';
+import FirecrawlApp from 'firecrawl';
 
 const app = new FirecrawlApp({ apiKey: process.env.FIRECRAWL_API_KEY });
 

--- a/examples/attributes-extraction-js-sdk.js
+++ b/examples/attributes-extraction-js-sdk.js
@@ -2,9 +2,9 @@
  * Example: Using Firecrawl JS SDK v2 to extract attributes from HTML elements
  */
 
-import FirecrawlApp from 'firecrawl';
+import { Firecrawl } from 'firecrawl';
 
-const app = new FirecrawlApp({ apiKey: process.env.FIRECRAWL_API_KEY });
+const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
 async function main() {
   console.log('🎯 Extracting attributes from Hacker News...');

--- a/examples/scrape_and_analyze_airbnb_data_e2b/package-lock.json
+++ b/examples/scrape_and_analyze_airbnb_data_e2b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.20.7",
         "@e2b/code-interpreter": "^0.0.2",
-        "@mendable/firecrawl-js": "^4.3.5",
         "buffer": "^6.0.3",
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "firecrawl": "^4.3.5"
       },
       "devDependencies": {
         "@types/node": "^20.12.12",
@@ -500,21 +500,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@mendable/firecrawl-js": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-4.3.5.tgz",
-      "integrity": "sha512-6Vd0bEVD0hOS4SXlmrBnOkm86WWqEITHSTXwdnjm6SkTz6ZF6o85gGHUvOYoky4w7AoLctAv8yqrm6aZsy4lfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.12.2",
-        "typescript-event-target": "^1.1.1",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.12.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
@@ -560,14 +545,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -800,16 +785,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/firecrawl": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/firecrawl/-/firecrawl-4.25.0.tgz",
+      "integrity": "sha512-vw5C+GHIIM+kopSD/WiiSkd/68vLetFVr12z4lsGIeLFjn7dRZFTOJeqY/M6F2vmqDay1ivmXCLAlvmGRTKL+A==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.15.2",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -820,9 +821,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -1170,9 +1171,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/examples/scrape_and_analyze_airbnb_data_e2b/package.json
+++ b/examples/scrape_and_analyze_airbnb_data_e2b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.7",
     "@e2b/code-interpreter": "^0.0.2",
-    "@mendable/firecrawl-js": "^4.3.5",
+    "firecrawl": "^4.3.5",
     "buffer": "^6.0.3",
     "dotenv": "^16.4.5"
   }

--- a/examples/scrape_and_analyze_airbnb_data_e2b/scraping.ts
+++ b/examples/scrape_and_analyze_airbnb_data_e2b/scraping.ts
@@ -1,6 +1,6 @@
 //@ts-ignore
 import * as fs from 'fs'
-import FirecrawlApp from 'firecrawl'
+import { Firecrawl } from 'firecrawl'
 import 'dotenv/config'
 import { config } from 'dotenv'
 import { z } from 'zod'
@@ -9,8 +9,8 @@ config()
 
 export async function scrapeAirbnb() {
   try {
-    // Initialize the FirecrawlApp with your API key
-    const app = new FirecrawlApp({ apiKey: process.env.FIRECRAWL_API_KEY })
+    // Initialize the Firecrawl with your API key
+    const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY })
 
     // Define the URL to crawl
     const listingsUrl =

--- a/examples/scrape_and_analyze_airbnb_data_e2b/scraping.ts
+++ b/examples/scrape_and_analyze_airbnb_data_e2b/scraping.ts
@@ -1,6 +1,6 @@
 //@ts-ignore
 import * as fs from 'fs'
-import FirecrawlApp from '@mendable/firecrawl-js'
+import FirecrawlApp from 'firecrawl'
 import 'dotenv/config'
 import { config } from 'dotenv'
 import { z } from 'zod'


### PR DESCRIPTION
Changed import statements in various files to use the new 'firecrawl' package instead of '@mendable/firecrawl-js'. Updated package.json files to reflect the new dependency. This ensures consistency across the codebase and aligns with the latest SDK version.