### PR TITLE
fix(monitoring): remove monitor scrape waitfor

### DIFF
--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -62,9 +62,6 @@ const logger = _logger.child({ module: "monitoring-runner" });
 const poll = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 export { isMonitorCheckStale, MONITOR_CHECK_STALE_TIMEOUT_MS };
 
-const MONITOR_DEFAULT_WAIT_FOR_MS = 5000;
-const MONITOR_MAX_WAIT_FOR_MS = 60000;
-const MONITOR_MAX_TIMEOUT_MS = MONITOR_MAX_WAIT_FOR_MS * 2;
 const MONITOR_NOTIFY_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
 const TERMINAL_CHECK_STATUSES = new Set([
   "completed",
@@ -139,18 +136,9 @@ function withMonitorScrapeDefaults(
   const formats = Array.isArray(options.formats)
     ? normalizeMonitorFormats(options.formats)
     : options.formats;
-  const waitFor =
-    typeof options.waitFor === "number"
-      ? options.waitFor
-      : MONITOR_DEFAULT_WAIT_FOR_MS;
-  const timeout =
-    typeof options.timeout === "number"
-      ? Math.min(Math.max(options.timeout, waitFor * 2), MONITOR_MAX_TIMEOUT_MS)
-      : Math.min(waitFor * 2, MONITOR_MAX_TIMEOUT_MS);
-
   return {
     maxAge: 0,
-    ...withMarkdownFormat({ ...options, formats, waitFor, timeout }),
+    ...withMarkdownFormat({ ...options, formats }),
   };
 }
 
@@ -383,7 +371,7 @@ async function runCrawlTarget(params: {
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
-    scrapeOptions: withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
+    scrapeOptions: withMarkdownFormat(params.target.scrapeOptions ?? {}),
     origin: "monitor",
   }) as CrawlRequest;
 
@@ -767,7 +755,7 @@ async function enqueueMonitorCrawlTarget(params: {
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
-    scrapeOptions: withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
+    scrapeOptions: withMarkdownFormat(params.target.scrapeOptions ?? {}),
     origin: "monitor",
   }) as CrawlRequest;
 
@@ -940,14 +928,19 @@ export async function processMonitorCheckJob(
       error: error instanceof Error ? error.message : String(error),
     });
 
-    if ((await claimMonitorNotification(check.id).catch(error => {
-      logger.warn("Failed to claim monitor notification; continuing without dedupe", {
-        error,
-        monitorId: monitor.id,
-        checkId: check.id,
-      });
-      return true;
-    }))) {
+    if (
+      await claimMonitorNotification(check.id).catch(error => {
+        logger.warn(
+          "Failed to claim monitor notification; continuing without dedupe",
+          {
+            error,
+            monitorId: monitor.id,
+            checkId: check.id,
+          },
+        );
+        return true;
+      })
+    ) {
       const notificationStatus = await sendNotifications({
         monitor,
         check,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -371,7 +371,7 @@ async function runCrawlTarget(params: {
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
-    scrapeOptions: withMarkdownFormat(params.target.scrapeOptions ?? {}),
+    scrapeOptions: withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
     origin: "monitor",
   }) as CrawlRequest;
 
@@ -755,7 +755,7 @@ async function enqueueMonitorCrawlTarget(params: {
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
-    scrapeOptions: withMarkdownFormat(params.target.scrapeOptions ?? {}),
+    scrapeOptions: withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
     origin: "monitor",
   }) as CrawlRequest;
 

--- a/apps/go-sdk/models.go
+++ b/apps/go-sdk/models.go
@@ -227,14 +227,23 @@ type MonitorPageSnapshot struct {
 	JSON map[string]interface{} `json:"json,omitempty"`
 }
 
+// MonitorMeaningfulChange is a single goal-relevant change selected by the
+// monitor judge.
+type MonitorMeaningfulChange struct {
+	Type   string  `json:"type"`
+	Before *string `json:"before"`
+	After  *string `json:"after"`
+	Reason string  `json:"reason"`
+}
+
 // MonitorPageJudgment is the judge's verdict on whether a page change is
 // meaningful. Populated on monitor check pages when the monitor has a
 // goal set and judging is enabled.
 type MonitorPageJudgment struct {
-	Meaningful bool     `json:"meaningful"`
-	Confidence string   `json:"confidence"`
-	Reason     string   `json:"reason"`
-	Fields     []string `json:"fields"`
+	Meaningful        bool                      `json:"meaningful"`
+	Confidence        string                    `json:"confidence"`
+	Reason            string                    `json:"reason"`
+	MeaningfulChanges []MonitorMeaningfulChange `json:"meaningfulChanges"`
 }
 
 // MonitorCheckPage is a single page result in a monitor check.

--- a/apps/go-sdk/monitor_models_test.go
+++ b/apps/go-sdk/monitor_models_test.go
@@ -1,0 +1,38 @@
+package firecrawl
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMonitorPageJudgmentParsesMeaningfulChanges(t *testing.T) {
+	payload := []byte(`{
+		"meaningful": true,
+		"confidence": "high",
+		"reason": "The tracked price changed.",
+		"meaningfulChanges": [
+			{
+				"type": "changed",
+				"before": "$10",
+				"after": "$12",
+				"reason": "Price increased."
+			}
+		]
+	}`)
+
+	var judgment MonitorPageJudgment
+	if err := json.Unmarshal(payload, &judgment); err != nil {
+		t.Fatalf("Unmarshal MonitorPageJudgment: %v", err)
+	}
+
+	if !judgment.Meaningful || judgment.Confidence != "high" {
+		t.Fatalf("judgment = %+v", judgment)
+	}
+	if len(judgment.MeaningfulChanges) != 1 {
+		t.Fatalf("meaningfulChanges length = %d, want 1", len(judgment.MeaningfulChanges))
+	}
+	change := judgment.MeaningfulChanges[0]
+	if change.Type != "changed" || change.Before == nil || *change.Before != "$10" || change.After == nil || *change.After != "$12" {
+		t.Fatalf("meaningful change = %+v", change)
+	}
+}

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/test_monitor_types.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/test_monitor_types.py
@@ -1,0 +1,22 @@
+from firecrawl.v2.types import MonitorPageJudgment
+
+
+def test_monitor_page_judgment_parses_meaningful_changes():
+    judgment = MonitorPageJudgment.model_validate(
+        {
+            "meaningful": True,
+            "confidence": "high",
+            "reason": "The tracked price changed.",
+            "meaningfulChanges": [
+                {
+                    "type": "changed",
+                    "before": "$10",
+                    "after": "$12",
+                    "reason": "Price increased.",
+                }
+            ],
+        }
+    )
+
+    assert judgment.meaningful is True
+    assert judgment.meaningful_changes[0].type == "changed"

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -960,7 +960,6 @@ class MonitorPageJudgment(BaseModel):
     meaningful: bool
     confidence: Literal["high", "medium", "low"]
     reason: str
-    fields: List[str]
     meaningful_changes: List[MonitorMeaningfulChange] = Field(default_factory=list, alias="meaningfulChanges")
 
 

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -947,11 +947,21 @@ class Monitor(BaseModel):
     updated_at: str = Field(alias="updatedAt")
 
 
+class MonitorMeaningfulChange(BaseModel):
+    type: Literal["added", "removed", "changed"]
+    before: Optional[str] = None
+    after: Optional[str] = None
+    reason: str
+
+
 class MonitorPageJudgment(BaseModel):
+    model_config = {"populate_by_name": True}
+
     meaningful: bool
     confidence: Literal["high", "medium", "low"]
     reason: str
     fields: List[str]
+    meaningful_changes: List[MonitorMeaningfulChange] = Field(default_factory=list, alias="meaningfulChanges")
 
 
 class MonitorCheck(BaseModel):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed monitor-specific scrape waitFor/timeout defaults in favor of standard `withMarkdownFormat`, reducing delays and flaky timeouts. Also added meaningful change details to monitor judgments in the Go and Python SDKs.

- **Bug Fixes**
  - Use `withMarkdownFormat` for monitor crawl targets; drop monitor-only `waitFor`/timeout defaults; keep `maxAge: 0`.
  - Minor cleanup in notification claim error handling (no behavior change).

- **New Features**
  - Introduce `MonitorMeaningfulChange` and surface meaningful changes in judgments: Go (`MeaningfulChanges`), Python (`meaningful_changes`, alias `"meaningfulChanges"`, `populate_by_name`).
  - Add unit tests in both SDKs to verify parsing.

<sup>Written for commit a2c342f0fbeb8a99f42901233a5f42593c046768. Summary will update on new commits. <a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3638?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

