### PR TITLE
bump sdk versions

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.25.0",
+  "version": "4.25.1",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.28.0"
+__version__ = "4.28.1"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped patch versions for the Firecrawl SDKs to release the latest changes and keep versions in sync. `@mendable/firecrawl-js` 4.25.0 → 4.25.1; `firecrawl` (Python) 4.28.0 → 4.28.1.

<sup>Written for commit 84ddbc1825f1932826dc65db103a3486305619d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3640?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

