### PR TITLE
chore(sdk): bump python

### DIFF
--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.28.0"
+__version__ = "4.28.1"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.28.1"
+__version__ = "4.28.2"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump the `firecrawl` Python SDK version from 4.28.1 to 4.28.2 by updating `__version__` in `apps/python-sdk/firecrawl/__init__.py`. Patch release only; no functional changes.

<sup>Written for commit ba7a570b9544d818cd4eb0e6e3201cc56f36513f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3641?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

