### PR TITLE
feat(monitoring): support am pm monitor schedules

### DIFF
--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1315,6 +1315,38 @@ describe("V2 Types Validation", () => {
       });
     });
 
+    it("should accept daily am/pm schedule text", () => {
+      const cases = [
+        ["daily at 9am", "0 9 * * *"],
+        ["daily at 9:30am", "30 9 * * *"],
+        ["daily at 5pm", "0 17 * * *"],
+        ["daily at 5:30 pm", "30 17 * * *"],
+        ["daily at 12am", "0 0 * * *"],
+        ["daily at 12pm", "0 12 * * *"],
+      ] as const;
+
+      for (const [text, cron] of cases) {
+        const result = updateMonitorSchema.parse({
+          schedule: { text },
+        });
+
+        expect(result.schedule).toEqual({
+          cron,
+          timezone: "UTC",
+        });
+      }
+    });
+
+    it("should reject invalid daily am/pm hours", () => {
+      expect(() =>
+        updateMonitorSchema.parse({
+          schedule: {
+            text: "daily at 13pm",
+          },
+        }),
+      ).toThrow("Daily schedule hour with am/pm must be between 1 and 12");
+    });
+
     it("should reject ambiguous schedule definitions", () => {
       expect(() =>
         updateMonitorSchema.parse({

--- a/apps/api/src/services/monitoring/cron.ts
+++ b/apps/api/src/services/monitoring/cron.ts
@@ -69,11 +69,24 @@ export function parseMonitorScheduleText(input: string): string {
   }
 
   const dailyMatch = text.match(
-    /^(?:daily|every day)(?: at (\d{1,2})(?::(\d{2}))?)?$/,
+    /^(?:daily|every day)(?: at (\d{1,2})(?::(\d{2}))?\s*(am|pm)?)?$/,
   );
   if (dailyMatch) {
-    const hour = dailyMatch[1] === undefined ? 0 : Number(dailyMatch[1]);
+    let hour = dailyMatch[1] === undefined ? 0 : Number(dailyMatch[1]);
     const minute = dailyMatch[2] === undefined ? 0 : Number(dailyMatch[2]);
+    const meridiem = dailyMatch[3];
+    if (meridiem !== undefined) {
+      if (!Number.isInteger(hour) || hour < 1 || hour > 12) {
+        throw new Error(
+          "Daily schedule hour with am/pm must be between 1 and 12",
+        );
+      }
+      if (meridiem === "am") {
+        hour = hour === 12 ? 0 : hour;
+      } else {
+        hour = hour === 12 ? 12 : hour + 12;
+      }
+    }
     if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
       throw new Error("Daily schedule hour must be between 0 and 23");
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add AM/PM support for daily monitor schedules so inputs like "daily at 5pm" convert to the correct cron. Enforces valid 12-hour ranges and keeps timezone as UTC.

- **New Features**
  - Accepts "daily at {h[:mm]} am/pm" (e.g., "9am", "9:30am", "5pm", "5:30 pm").
  - Converts to 24-hour cron (e.g., "9am" → "0 9 * * *", "12am" → "0 0 * * *", "12pm" → "0 12 * * *").
  - Rejects invalid 12-hour values (e.g., "13pm") with a clear error.
  - Adds tests for accepted and rejected cases; parsed schedules default to timezone "UTC".

<sup>Written for commit 9fab26def4ced0e4ccb72c8cd6daeabbfb297e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3642?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

