### PR TITLE
fix(search): accept scrapeOptions.zeroDataRetention in /v2/search

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -116,6 +116,20 @@ export async function searchController(
       });
     }
 
+    // Extract scrape-side ZDR flag; strip it before forwarding scrapeOptions
+    // since ScrapeOptions does not carry this field downstream
+    const scrapeZDR: boolean =
+      !!(req.body.scrapeOptions as any)?.zeroDataRetention;
+
+    let forwardedScrapeOptions = req.body.scrapeOptions;
+    if (scrapeZDR && forwardedScrapeOptions) {
+      const { zeroDataRetention: _zdr, ...rest } =
+        forwardedScrapeOptions as typeof forwardedScrapeOptions & {
+          zeroDataRetention?: boolean;
+        };
+      forwardedScrapeOptions = rest as typeof forwardedScrapeOptions;
+    }
+
     const result = await executeSearch(
       {
         query: req.body.query,
@@ -130,7 +144,7 @@ export async function searchController(
         includeDomains: req.body.includeDomains,
         excludeDomains: req.body.excludeDomains,
         enterprise: req.body.enterprise,
-        scrapeOptions: req.body.scrapeOptions,
+        scrapeOptions: forwardedScrapeOptions,
         timeout: req.body.timeout,
       },
       {
@@ -142,7 +156,7 @@ export async function searchController(
         jobId,
         apiVersion: "v2",
         bypassBilling: !shouldBill,
-        zeroDataRetention: isZDROrAnon,
+        zeroDataRetention: (isZDROrAnon ?? false) || scrapeZDR,
         billing,
         agentIndexOnly: (req as any).agentIndexOnly ?? false,
       },

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1836,6 +1836,7 @@ export const searchRequestSchema = z
           .refine(x => {
             return x.filter(f => f.type === "screenshot").length <= 1;
           }, "You may only specify one screenshot format"),
+        zeroDataRetention: z.boolean().optional(),
       })
       .optional(),
     __agentInterop: z


### PR DESCRIPTION
## Problem

The `/v2/search` docs describe combining enterprise ZDR (for the search portion) with `scrapeOptions.zeroDataRetention` (for the scraping portion). However, any request including `scrapeOptions.zeroDataRetention` was rejected with `400 Invalid request body` because the field was missing from the search `scrapeOptions` schema.

Closes #3441

## What this changes

- **`types.ts`** — adds `zeroDataRetention: z.boolean().optional()` to the `scrapeOptions` extension inside `searchRequestSchema`, mirroring the field already present in `scrapeRequestSchema` and `parseRequestSchema`.

- **`search.ts`** (controller) — extracts `scrapeOptions.zeroDataRetention` before forwarding to `executeSearch`, strips it from the `scrapeOptions` payload (so it stays out of the internal scrape-job options), and ORs it with the enterprise ZDR flag when setting the scrape context's `zeroDataRetention`. Either path now enables ZDR for the scrape portion of a search request.

## Testing

Manual validation that `searchRequestSchema.parse` now accepts `scrapeOptions.zeroDataRetention: true` without rejection, and that the field previously rejected with a strict-object error is now accepted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `scrapeOptions.zeroDataRetention` in `/v2/search` and applies it to the scraping phase. Fixes the 400 error and aligns behavior with the docs so either enterprise ZDR or the per-scrape flag enables ZDR for scraping.

- **Bug Fixes**
  - Added `zeroDataRetention?: boolean` to `searchRequestSchema.scrapeOptions`.
  - Controller extracts and strips `scrapeOptions.zeroDataRetention` before forwarding and ORs it with enterprise ZDR when setting the scrape context.

<sup>Written for commit 25c3c791b23185ba9c6631de46eaa066d0ba2ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3644?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

