### PR TITLE
(fix/monitoring) Email Confirmation

### DIFF
--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -193,6 +193,12 @@ export async function monitorEmailUnsubscribeRaw(token: string) {
     .send({ token });
 }
 
+export async function monitorEmailConfirmRawViaQuery(token: string) {
+  return await request(TEST_API_URL)
+    .post(`/v2/monitor/email/confirm`)
+    .query({ token });
+}
+
 export async function parseRaw(
   body: {
     options?: Omit<ParseRequestInput, "file">;

--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -179,6 +179,20 @@ export async function monitorCheckRaw(
   return query ? req.query(query) : req;
 }
 
+export async function monitorEmailConfirmRaw(token: string) {
+  return await request(TEST_API_URL)
+    .post(`/v2/monitor/email/confirm`)
+    .set("Content-Type", "application/json")
+    .send({ token });
+}
+
+export async function monitorEmailUnsubscribeRaw(token: string) {
+  return await request(TEST_API_URL)
+    .post(`/v2/monitor/email/unsubscribe`)
+    .set("Content-Type", "application/json")
+    .send({ token });
+}
+
 export async function parseRaw(
   body: {
     options?: Omit<ParseRequestInput, "file">;

--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -10,6 +10,8 @@ import {
   monitorCheckRaw,
   monitorCreateRaw,
   monitorDeleteRaw,
+  monitorEmailConfirmRaw,
+  monitorEmailUnsubscribeRaw,
   monitorGetRaw,
   monitorListRaw,
   monitorPatchRaw,
@@ -307,6 +309,117 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
     },
     2 * scrapeTimeout,
   );
+
+  describe("email recipient opt-in", () => {
+    function externalRecipient(): string {
+      // Random throwaway address. Real Resend isn't called in the test API,
+      // but the address still needs to look valid for the API to accept it.
+      const id = Math.random().toString(36).slice(2, 10);
+      return `optin-${id}@external-test.example`;
+    }
+
+    it("starts external recipients as pending without sending notifications", async () => {
+      const recipient = externalRecipient();
+      const create = await monitorCreateRaw(
+        {
+          name: "opt-in monitor",
+          schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+          targets: [
+            {
+              type: "scrape",
+              urls: [createTestIdUrl()],
+              scrapeOptions: { formats: ["markdown"] },
+            },
+          ],
+          notification: {
+            email: { enabled: true, recipients: [recipient] },
+          },
+        },
+        identity,
+      );
+      expect(create.statusCode).toBe(200);
+      expect(create.body.data.emailRecipientSubscriptions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            email: recipient.toLowerCase(),
+            status: "pending",
+            source: "opt_in",
+          }),
+        ]),
+      );
+
+      const get = await monitorGetRaw(create.body.data.id, identity);
+      expect(get.body.data.emailRecipientSubscriptions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            email: recipient.toLowerCase(),
+            status: "pending",
+          }),
+        ]),
+      );
+
+      await monitorDeleteRaw(create.body.data.id, identity);
+    });
+
+    it("rejects malformed confirm/unsubscribe tokens with a 400 JSON error", async () => {
+      const badConfirm = await monitorEmailConfirmRaw("x");
+      expect(badConfirm.statusCode).toBe(400);
+      expect(badConfirm.body).toEqual({
+        success: false,
+        error: "invalid_token",
+      });
+
+      const badUnsub = await monitorEmailUnsubscribeRaw("x");
+      expect(badUnsub.statusCode).toBe(400);
+      expect(badUnsub.body).toEqual({
+        success: false,
+        error: "invalid_token",
+      });
+    });
+
+    it("returns 404 JSON for unknown but well-formed tokens", async () => {
+      const unknownToken = "a".repeat(43);
+
+      const confirm = await monitorEmailConfirmRaw(unknownToken);
+      expect(confirm.statusCode).toBe(404);
+      expect(confirm.body).toEqual({
+        success: false,
+        error: "not_found",
+      });
+
+      const unsub = await monitorEmailUnsubscribeRaw(unknownToken);
+      expect(unsub.statusCode).toBe(404);
+      expect(unsub.body).toEqual({
+        success: false,
+        error: "not_found",
+      });
+    });
+
+    it("does not require opt-in when recipients are unset (team-default path)", async () => {
+      // Falls back to team members in send path; create-time sync only runs
+      // against explicit recipients, so emailRecipientSubscriptions should
+      // be empty here.
+      const create = await monitorCreateRaw(
+        {
+          name: "team default monitor",
+          schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+          targets: [
+            {
+              type: "scrape",
+              urls: [createTestIdUrl()],
+              scrapeOptions: { formats: ["markdown"] },
+            },
+          ],
+          notification: { email: { enabled: true } },
+        },
+        identity,
+      );
+      expect(create.statusCode).toBe(200);
+      expect(create.body.data.emailRecipientSubscriptions).toEqual([]);
+
+      await monitorDeleteRaw(create.body.data.id, identity);
+    });
+  });
 
   it(
     "accepts mixed json + git-diff changeTracking modes",

--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -11,6 +11,7 @@ import {
   monitorCreateRaw,
   monitorDeleteRaw,
   monitorEmailConfirmRaw,
+  monitorEmailConfirmRawViaQuery,
   monitorEmailUnsubscribeRaw,
   monitorGetRaw,
   monitorListRaw,
@@ -370,6 +371,18 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
       const badUnsub = await monitorEmailUnsubscribeRaw("x");
       expect(badUnsub.statusCode).toBe(400);
       expect(badUnsub.body).toEqual({
+        success: false,
+        error: "invalid_token",
+      });
+    });
+
+    it("rejects tokens sent in the query string (body-only)", async () => {
+      // Tokens in URLs leak into access/proxy logs and APM URL tags, so
+      // the controller deliberately ignores query params.
+      const unknownToken = "a".repeat(43);
+      const response = await monitorEmailConfirmRawViaQuery(unknownToken);
+      expect(response.statusCode).toBe(400);
+      expect(response.body).toEqual({
         success: false,
         error: "invalid_token",
       });

--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -312,8 +312,6 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
 
   describe("email recipient opt-in", () => {
     function externalRecipient(): string {
-      // Random throwaway address. Real Resend isn't called in the test API,
-      // but the address still needs to look valid for the API to accept it.
       const id = Math.random().toString(36).slice(2, 10);
       return `optin-${id}@external-test.example`;
     }
@@ -396,9 +394,6 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
     });
 
     it("does not require opt-in when recipients are unset (team-default path)", async () => {
-      // Falls back to team members in send path; create-time sync only runs
-      // against explicit recipients, so emailRecipientSubscriptions should
-      // be empty here.
       const create = await monitorCreateRaw(
         {
           name: "team default monitor",

--- a/apps/api/src/controllers/v2/monitor.ts
+++ b/apps/api/src/controllers/v2/monitor.ts
@@ -593,16 +593,18 @@ type EmailActionResponse =
       error: "invalid_token" | "not_found" | "internal_error";
     };
 
-function parseTokenFromRequest(req: any): string | null {
+
+function parseTokenFromRequest(req: { body?: unknown }): string | null {
   const candidate =
-    (req.body && typeof req.body === "object" ? (req.body as any).token : null) ??
-    (req.query && typeof req.query === "object" ? (req.query as any).token : null);
+    req.body && typeof req.body === "object"
+      ? (req.body as { token?: unknown }).token
+      : null;
   const parsed = emailActionBodySchema.safeParse({ token: candidate });
   return parsed.success ? parsed.data.token : null;
 }
 
 export async function confirmMonitorEmailController(
-  req: { body?: unknown; query?: unknown },
+  req: { body?: unknown },
   res: Response,
 ) {
   const token = parseTokenFromRequest(req);
@@ -658,7 +660,7 @@ export async function confirmMonitorEmailController(
 }
 
 export async function unsubscribeMonitorEmailController(
-  req: { body?: unknown; query?: unknown },
+  req: { body?: unknown },
   res: Response,
 ) {
   const token = parseTokenFromRequest(req);

--- a/apps/api/src/controllers/v2/monitor.ts
+++ b/apps/api/src/controllers/v2/monitor.ts
@@ -41,6 +41,13 @@ import {
   type WebhookLogRow,
 } from "../../services/webhook/logs";
 import { WebhookEvent } from "../../services/webhook";
+import {
+  confirmRecipientByToken,
+  getMonitorNameById,
+  listMonitorEmailRecipients,
+  unsubscribeRecipientByToken,
+} from "../../services/monitoring/email_recipients";
+import { syncMonitorEmailRecipients } from "../../services/monitoring/email_recipients_sync";
 
 const logger = _logger.child({ module: "monitor-controller" });
 
@@ -67,7 +74,17 @@ function rejectZdr(
   return false;
 }
 
-function serializeMonitor(monitor: any) {
+function serializeMonitor(
+  monitor: any,
+  options?: {
+    emailRecipientSubscriptions?: Array<{
+      email: string;
+      status: "pending" | "confirmed" | "unsubscribed";
+      source: "team" | "opt_in" | "legacy";
+      confirmationEmailSent?: boolean;
+    }>;
+  },
+) {
   return {
     id: monitor.id,
     name: monitor.name,
@@ -82,6 +99,9 @@ function serializeMonitor(monitor: any) {
     targets: monitor.targets,
     webhook: monitor.webhook,
     notification: monitor.notification,
+    ...(options?.emailRecipientSubscriptions !== undefined
+      ? { emailRecipientSubscriptions: options.emailRecipientSubscriptions }
+      : {}),
     retentionDays: monitor.retention_days,
     estimatedCreditsPerMonth: monitor.estimated_credits_per_month,
     lastCheckSummary: monitor.last_check_summary,
@@ -90,6 +110,16 @@ function serializeMonitor(monitor: any) {
     createdAt: monitor.created_at,
     updatedAt: monitor.updated_at,
   };
+}
+
+async function loadEmailRecipientSubscriptions(monitorId: string) {
+  const rows = await listMonitorEmailRecipients(monitorId);
+  return rows.map(r => ({
+    email: r.email,
+    status: r.status,
+    source: r.source,
+    confirmationEmailSent: r.confirmation_sent_at !== null,
+  }));
 }
 
 function overlayWebhookLog<T extends { notificationStatus: any }>(
@@ -190,9 +220,22 @@ export async function createMonitorController(
     }),
   );
 
+  // Reconcile per-recipient opt-in records. Team members are auto-confirmed
+  // here; external recipients receive a one-time confirmation email and
+  // start in "pending" until they click the link.
+  const sync = await syncMonitorEmailRecipients({ monitor }).catch(error => {
+    logger.warn("Failed to sync monitor email recipients on create", {
+      error,
+      monitorId: monitor.id,
+    });
+    return { recipients: [] };
+  });
+
   res.status(200).json({
     success: true,
-    data: serializeMonitor(monitor),
+    data: serializeMonitor(monitor, {
+      emailRecipientSubscriptions: sync.recipients,
+    }),
   });
 }
 
@@ -209,7 +252,7 @@ export async function listMonitorsController(
 
   res.status(200).json({
     success: true,
-    data: monitors.map(serializeMonitor),
+    data: monitors.map(monitor => serializeMonitor(monitor)),
   });
 }
 
@@ -223,9 +266,21 @@ export async function getMonitorController(
     return res.status(404).json({ success: false, error: "Monitor not found" });
   }
 
+  const subscriptions = await loadEmailRecipientSubscriptions(monitorId).catch(
+    error => {
+      logger.warn("Failed to load email recipient subscriptions", {
+        error,
+        monitorId,
+      });
+      return [];
+    },
+  );
+
   res.status(200).json({
     success: true,
-    data: serializeMonitor(monitor),
+    data: serializeMonitor(monitor, {
+      emailRecipientSubscriptions: subscriptions,
+    }),
   });
 }
 
@@ -303,9 +358,29 @@ export async function updateMonitorController(
     }),
   );
 
+  // Re-sync per-recipient opt-in only if the notification config was touched
+  // — avoids hitting the recipients table on every unrelated update.
+  let subscriptions: Awaited<
+    ReturnType<typeof loadEmailRecipientSubscriptions>
+  > = [];
+  if (input.notification !== undefined) {
+    const sync = await syncMonitorEmailRecipients({ monitor }).catch(error => {
+      logger.warn("Failed to sync monitor email recipients on update", {
+        error,
+        monitorId: monitor.id,
+      });
+      return { recipients: [] };
+    });
+    subscriptions = sync.recipients;
+  } else {
+    subscriptions = await loadEmailRecipientSubscriptions(monitor.id);
+  }
+
   res.status(200).json({
     success: true,
-    data: serializeMonitor(monitor),
+    data: serializeMonitor(monitor, {
+      emailRecipientSubscriptions: subscriptions,
+    }),
   });
 }
 
@@ -499,4 +574,150 @@ export async function getMonitorCheckController(
       next,
     },
   });
+}
+
+// =========================================================================
+// Email opt-in / opt-out endpoints
+// =========================================================================
+//
+// These endpoints back the public confirm/unsubscribe pages served by
+// firecrawl-web. The web page POSTs the token from email links and renders
+// the JSON response with its own branding. The token IS the auth here —
+// recipients aren't necessarily Firecrawl users, so no API key is required.
+// POSTs (not GETs) are used so passive link scanners / preview tools that
+// hit the dashboard URL don't accidentally consume the token.
+
+const emailActionBodySchema = z.object({
+  // base64url of 32 random bytes = 43 chars. We accept up to 64 to leave
+  // room for future formats without breaking old links.
+  token: z.string().min(16).max(64),
+});
+
+type EmailActionResponse =
+  | {
+      success: true;
+      // What actually happened. The page renders different copy per state.
+      result: "confirmed" | "already_confirmed" | "unsubscribed" | "already_unsubscribed";
+      email: string;
+      monitorName: string | null;
+    }
+  | {
+      success: false;
+      error: "invalid_token" | "not_found" | "internal_error";
+    };
+
+function parseTokenFromRequest(req: any): string | null {
+  // Body for POST, query for backwards compat / curl testing.
+  const candidate =
+    (req.body && typeof req.body === "object" ? (req.body as any).token : null) ??
+    (req.query && typeof req.query === "object" ? (req.query as any).token : null);
+  const parsed = emailActionBodySchema.safeParse({ token: candidate });
+  return parsed.success ? parsed.data.token : null;
+}
+
+export async function confirmMonitorEmailController(
+  req: { body?: unknown; query?: unknown },
+  res: Response,
+) {
+  const token = parseTokenFromRequest(req);
+  if (!token) {
+    const body: EmailActionResponse = {
+      success: false,
+      error: "invalid_token",
+    };
+    return res.status(400).json(body);
+  }
+
+  try {
+    const row = await confirmRecipientByToken(token);
+    if (!row) {
+      const body: EmailActionResponse = {
+        success: false,
+        error: "not_found",
+      };
+      return res.status(404).json(body);
+    }
+
+    const monitorName = await getMonitorNameById(row.monitor_id);
+
+    let result: "confirmed" | "already_confirmed" | "already_unsubscribed";
+    if (row.status === "unsubscribed") {
+      result = "already_unsubscribed";
+    } else if (
+      row.confirmed_at !== null &&
+      // confirmRecipientByToken is a no-op when already confirmed: confirmed_at
+      // stays unchanged. We can't perfectly tell whether this call did the
+      // confirmation, but for the user-visible copy the distinction doesn't
+      // matter — "you're subscribed" is correct either way. We still expose
+      // already_confirmed so the page can show a subtle "no change" note.
+      new Date().getTime() - new Date(row.confirmed_at).getTime() > 5_000
+    ) {
+      result = "already_confirmed";
+    } else {
+      result = "confirmed";
+    }
+
+    const body: EmailActionResponse = {
+      success: true,
+      result,
+      email: row.email,
+      monitorName,
+    };
+    return res.status(200).json(body);
+  } catch (error) {
+    logger.error("Failed to confirm monitor email recipient", { error });
+    const body: EmailActionResponse = {
+      success: false,
+      error: "internal_error",
+    };
+    return res.status(500).json(body);
+  }
+}
+
+export async function unsubscribeMonitorEmailController(
+  req: { body?: unknown; query?: unknown },
+  res: Response,
+) {
+  const token = parseTokenFromRequest(req);
+  if (!token) {
+    const body: EmailActionResponse = {
+      success: false,
+      error: "invalid_token",
+    };
+    return res.status(400).json(body);
+  }
+
+  try {
+    const row = await unsubscribeRecipientByToken(token);
+    if (!row) {
+      const body: EmailActionResponse = {
+        success: false,
+        error: "not_found",
+      };
+      return res.status(404).json(body);
+    }
+
+    const monitorName = await getMonitorNameById(row.monitor_id);
+
+    const result: "unsubscribed" | "already_unsubscribed" =
+      row.unsubscribed_at !== null &&
+      new Date().getTime() - new Date(row.unsubscribed_at).getTime() > 5_000
+        ? "already_unsubscribed"
+        : "unsubscribed";
+
+    const body: EmailActionResponse = {
+      success: true,
+      result,
+      email: row.email,
+      monitorName,
+    };
+    return res.status(200).json(body);
+  } catch (error) {
+    logger.error("Failed to unsubscribe monitor email recipient", { error });
+    const body: EmailActionResponse = {
+      success: false,
+      error: "internal_error",
+    };
+    return res.status(500).json(body);
+  }
 }

--- a/apps/api/src/controllers/v2/monitor.ts
+++ b/apps/api/src/controllers/v2/monitor.ts
@@ -220,9 +220,6 @@ export async function createMonitorController(
     }),
   );
 
-  // Reconcile per-recipient opt-in records. Team members are auto-confirmed
-  // here; external recipients receive a one-time confirmation email and
-  // start in "pending" until they click the link.
   const sync = await syncMonitorEmailRecipients({ monitor }).catch(error => {
     logger.warn("Failed to sync monitor email recipients on create", {
       error,
@@ -358,8 +355,7 @@ export async function updateMonitorController(
     }),
   );
 
-  // Re-sync per-recipient opt-in only if the notification config was touched
-  // — avoids hitting the recipients table on every unrelated update.
+  // Only re-sync when notification config actually changed.
   let subscriptions: Awaited<
     ReturnType<typeof loadEmailRecipientSubscriptions>
   > = [];
@@ -576,27 +572,18 @@ export async function getMonitorCheckController(
   });
 }
 
-// =========================================================================
-// Email opt-in / opt-out endpoints
-// =========================================================================
-//
-// These endpoints back the public confirm/unsubscribe pages served by
-// firecrawl-web. The web page POSTs the token from email links and renders
-// the JSON response with its own branding. The token IS the auth here —
-// recipients aren't necessarily Firecrawl users, so no API key is required.
-// POSTs (not GETs) are used so passive link scanners / preview tools that
-// hit the dashboard URL don't accidentally consume the token.
+// Unauthenticated POST endpoints — the token is the credential. Backs the
+// firecrawl-web confirm/unsubscribe pages; POST-only so passive GET scanners
+// can't consume tokens against the dashboard URL.
 
 const emailActionBodySchema = z.object({
-  // base64url of 32 random bytes = 43 chars. We accept up to 64 to leave
-  // room for future formats without breaking old links.
+  // 32-byte base64url is 43 chars; range leaves room for future formats.
   token: z.string().min(16).max(64),
 });
 
 type EmailActionResponse =
   | {
       success: true;
-      // What actually happened. The page renders different copy per state.
       result: "confirmed" | "already_confirmed" | "unsubscribed" | "already_unsubscribed";
       email: string;
       monitorName: string | null;
@@ -607,7 +594,6 @@ type EmailActionResponse =
     };
 
 function parseTokenFromRequest(req: any): string | null {
-  // Body for POST, query for backwards compat / curl testing.
   const candidate =
     (req.body && typeof req.body === "object" ? (req.body as any).token : null) ??
     (req.query && typeof req.query === "object" ? (req.query as any).token : null);
@@ -640,16 +626,13 @@ export async function confirmMonitorEmailController(
 
     const monitorName = await getMonitorNameById(row.monitor_id);
 
+    // Heuristic: if confirmed_at is older than 5s, this call was a no-op
+    // (already confirmed). Used only to flavor the rendered page.
     let result: "confirmed" | "already_confirmed" | "already_unsubscribed";
     if (row.status === "unsubscribed") {
       result = "already_unsubscribed";
     } else if (
       row.confirmed_at !== null &&
-      // confirmRecipientByToken is a no-op when already confirmed: confirmed_at
-      // stays unchanged. We can't perfectly tell whether this call did the
-      // confirmation, but for the user-visible copy the distinction doesn't
-      // matter — "you're subscribed" is correct either way. We still expose
-      // already_confirmed so the page can show a subtle "no change" note.
       new Date().getTime() - new Date(row.confirmed_at).getTime() > 5_000
     ) {
       result = "already_confirmed";

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -68,6 +68,7 @@ import {
   scrapeStopInteractiveBrowserController,
 } from "../controllers/v2/scrape-browser";
 import {
+  confirmMonitorEmailController,
   createMonitorController,
   deleteMonitorController,
   getMonitorCheckController,
@@ -75,6 +76,7 @@ import {
   listMonitorChecksController,
   listMonitorsController,
   runMonitorController,
+  unsubscribeMonitorEmailController,
   updateMonitorController,
 } from "../controllers/v2/monitor";
 
@@ -482,6 +484,18 @@ v2Router.get(
   "/monitor",
   authMiddleware(RateLimiterMode.CrawlStatus),
   wrap(listMonitorsController),
+);
+
+// Public email opt-in/out endpoints. No auth — the token is the auth.
+// These back the public confirm/unsubscribe pages served by firecrawl-web;
+// the page POSTs the token from the email link and renders the response.
+// Registered before /monitor/:monitorId so "email" isn't captured as a
+// monitor UUID. POST-only on purpose: passive link scanners that issue GETs
+// against the dashboard URL never touch this endpoint.
+v2Router.post("/monitor/email/confirm", wrap(confirmMonitorEmailController));
+v2Router.post(
+  "/monitor/email/unsubscribe",
+  wrap(unsubscribeMonitorEmailController),
 );
 
 v2Router.get(

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -486,12 +486,8 @@ v2Router.get(
   wrap(listMonitorsController),
 );
 
-// Public email opt-in/out endpoints. No auth — the token is the auth.
-// These back the public confirm/unsubscribe pages served by firecrawl-web;
-// the page POSTs the token from the email link and renders the response.
-// Registered before /monitor/:monitorId so "email" isn't captured as a
-// monitor UUID. POST-only on purpose: passive link scanners that issue GETs
-// against the dashboard URL never touch this endpoint.
+// Public, unauthenticated — token in body is the credential. Registered
+// before /monitor/:monitorId so "email" isn't parsed as a monitor UUID.
 v2Router.post("/monitor/email/confirm", wrap(confirmMonitorEmailController));
 v2Router.post(
   "/monitor/email/unsubscribe",

--- a/apps/api/src/services/monitoring/email_recipients.test.ts
+++ b/apps/api/src/services/monitoring/email_recipients.test.ts
@@ -1,31 +1,58 @@
 type QueryResult = { data: unknown; error: unknown };
+type ChainOp = "select" | "insert" | "update" | "delete" | "unknown";
 
 const fromMock = jest.fn();
-const selectMock = jest.fn();
-const insertMock = jest.fn();
-const eqMonitorMock = jest.fn();
-const eqEmailMock = jest.fn();
-const maybeSingleSelectMock = jest.fn();
-const maybeSingleInsertMock = jest.fn();
-const insertSelectMock = jest.fn();
 
-function configureSupabaseMocks(opts: {
-  selectMaybeSingle: () => Promise<QueryResult>;
-  insertMaybeSingle?: () => Promise<QueryResult>;
-}) {
-  maybeSingleSelectMock.mockImplementation(opts.selectMaybeSingle);
-  maybeSingleInsertMock.mockImplementation(
-    opts.insertMaybeSingle ?? (() => Promise.resolve({ data: null, error: null })),
-  );
-  eqEmailMock.mockReturnValue({ maybeSingle: maybeSingleSelectMock });
-  eqMonitorMock.mockReturnValue({ eq: eqEmailMock });
-  insertSelectMock.mockReturnValue({ maybeSingle: maybeSingleInsertMock });
-  selectMock.mockReturnValue({ eq: eqMonitorMock });
-  insertMock.mockReturnValue({ select: insertSelectMock });
-  fromMock.mockReturnValue({
-    select: selectMock,
-    insert: insertMock,
-  });
+// Each test queues responses in the order the code under test will execute
+// queries. The fluent chain swallows any sequence of select/insert/update/
+// eq/neq calls and resolves at .maybeSingle() / .single() with the next
+// queued result. Tests stay explicit about query order without coupling to
+// the precise method chain shape.
+type QueuedResponse = (op: ChainOp) => Promise<QueryResult>;
+let queue: QueuedResponse[] = [];
+
+function queueResponses(responses: QueuedResponse[]): void {
+  queue = [...responses];
+}
+
+function makeChain(): any {
+  let op: ChainOp | null = null;
+  const setOp = (next: ChainOp) => {
+    if (op === null) op = next;
+  };
+  const resolve = (): Promise<QueryResult> => {
+    const next = queue.shift();
+    if (!next) {
+      throw new Error(
+        `No queued Supabase response for op=${op ?? "unknown"} (queue exhausted)`,
+      );
+    }
+    return next(op ?? "unknown");
+  };
+  const builder: any = {
+    select: () => {
+      setOp("select");
+      return builder;
+    },
+    insert: () => {
+      setOp("insert");
+      return builder;
+    },
+    update: () => {
+      setOp("update");
+      return builder;
+    },
+    delete: () => {
+      setOp("delete");
+      return builder;
+    },
+    eq: () => builder,
+    neq: () => builder,
+    in: () => builder,
+    maybeSingle: resolve,
+    single: resolve,
+  };
+  return builder;
 }
 
 jest.mock("../supabase", () => ({
@@ -37,28 +64,17 @@ jest.mock("../supabase", () => ({
   },
 }));
 
-import { ensureMonitorEmailRecipient } from "./email_recipients";
+import {
+  confirmRecipientByToken,
+  ensureMonitorEmailRecipient,
+  unsubscribeRecipientByToken,
+} from "./email_recipients";
 
 beforeEach(() => {
+  queue = [];
   fromMock.mockReset();
-  selectMock.mockReset();
-  insertMock.mockReset();
-  eqMonitorMock.mockReset();
-  eqEmailMock.mockReset();
-  maybeSingleSelectMock.mockReset();
-  maybeSingleInsertMock.mockReset();
-  insertSelectMock.mockReset();
+  fromMock.mockImplementation(() => makeChain());
 });
-
-const baseInput = {
-  monitorId: "monitor-1",
-  teamId: "team-1",
-  input: {
-    email: "alerts@example.com",
-    source: "opt_in" as const,
-    status: "pending" as const,
-  },
-};
 
 function recipientRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -79,85 +95,189 @@ function recipientRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+const baseEnsureInput = {
+  monitorId: "monitor-1",
+  teamId: "team-1",
+  input: {
+    email: "alerts@example.com",
+    source: "opt_in" as const,
+    status: "pending" as const,
+  },
+};
+
+const ok = (data: unknown): QueuedResponse => () =>
+  Promise.resolve({ data, error: null });
+const fail = (error: unknown): QueuedResponse => () =>
+  Promise.resolve({ data: null, error });
+
 describe("ensureMonitorEmailRecipient", () => {
   it("returns existing row when the recipient already exists (no insert)", async () => {
     const existing = recipientRow({ status: "confirmed", source: "team" });
-    configureSupabaseMocks({
-      selectMaybeSingle: () => Promise.resolve({ data: existing, error: null }),
-    });
+    queueResponses([ok(existing)]);
 
-    const result = await ensureMonitorEmailRecipient(baseInput);
+    const result = await ensureMonitorEmailRecipient(baseEnsureInput);
 
     expect(result).toEqual({ row: existing, created: false });
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(queue.length).toBe(0);
   });
 
   it("inserts and returns created=true when no row exists", async () => {
     const inserted = recipientRow();
-    configureSupabaseMocks({
-      selectMaybeSingle: () => Promise.resolve({ data: null, error: null }),
-      insertMaybeSingle: () => Promise.resolve({ data: inserted, error: null }),
-    });
+    queueResponses([ok(null), ok(inserted)]);
 
-    const result = await ensureMonitorEmailRecipient(baseInput);
+    const result = await ensureMonitorEmailRecipient(baseEnsureInput);
 
     expect(result).toEqual({ row: inserted, created: true });
-    expect(insertMock).toHaveBeenCalledTimes(1);
   });
 
   it("treats a concurrent-insert unique violation as not-created (no throw)", async () => {
-    // Concurrent sync wrote the row between our SELECT and INSERT.
     const winnerRow = recipientRow({ id: "rec-winner" });
-    let selectCalls = 0;
-    configureSupabaseMocks({
-      selectMaybeSingle: () => {
-        selectCalls += 1;
-        if (selectCalls === 1) return Promise.resolve({ data: null, error: null });
-        return Promise.resolve({ data: winnerRow, error: null });
-      },
-      insertMaybeSingle: () =>
-        Promise.resolve({
-          data: null,
-          error: { code: "23505", message: "duplicate key" },
-        }),
-    });
+    queueResponses([
+      ok(null),
+      fail({ code: "23505", message: "duplicate key" }),
+      ok(winnerRow),
+    ]);
 
-    const result = await ensureMonitorEmailRecipient(baseInput);
+    const result = await ensureMonitorEmailRecipient(baseEnsureInput);
 
     expect(result).toEqual({ row: winnerRow, created: false });
-    expect(selectCalls).toBe(2);
   });
 
   it("rethrows non-unique insert errors", async () => {
-    configureSupabaseMocks({
-      selectMaybeSingle: () => Promise.resolve({ data: null, error: null }),
-      insertMaybeSingle: () =>
-        Promise.resolve({
-          data: null,
-          error: { code: "42501", message: "permission denied" },
-        }),
-    });
+    queueResponses([
+      ok(null),
+      fail({ code: "42501", message: "permission denied" }),
+    ]);
 
-    await expect(ensureMonitorEmailRecipient(baseInput)).rejects.toThrow(
+    await expect(ensureMonitorEmailRecipient(baseEnsureInput)).rejects.toThrow(
       /permission denied/,
     );
   });
 
   it("rethrows unique violations when no winning row can be re-fetched", async () => {
-    // Defensive: if the unique violation is on `token` (not the recipient
-    // pair) the re-fetch returns nothing and we should surface the error
-    // instead of silently lying about creation.
-    configureSupabaseMocks({
-      selectMaybeSingle: () => Promise.resolve({ data: null, error: null }),
-      insertMaybeSingle: () =>
-        Promise.resolve({
-          data: null,
-          error: { code: "23505", message: "duplicate key" },
-        }),
-    });
+    queueResponses([
+      ok(null),
+      fail({ code: "23505", message: "duplicate key" }),
+      ok(null),
+    ]);
 
-    await expect(ensureMonitorEmailRecipient(baseInput)).rejects.toThrow(
+    await expect(ensureMonitorEmailRecipient(baseEnsureInput)).rejects.toThrow(
       /duplicate key/,
     );
+  });
+});
+
+describe("confirmRecipientByToken", () => {
+  it("transitions pending → confirmed when no race", async () => {
+    const pending = recipientRow({ status: "pending" });
+    const confirmed = recipientRow({
+      status: "confirmed",
+      confirmed_at: "now",
+    });
+    queueResponses([ok(pending), ok(confirmed)]);
+
+    const result = await confirmRecipientByToken("tok-1");
+
+    expect(result).toEqual(confirmed);
+  });
+
+  it("returns the row unchanged when status is already confirmed (no UPDATE)", async () => {
+    const confirmed = recipientRow({
+      status: "confirmed",
+      confirmed_at: "now",
+    });
+    queueResponses([ok(confirmed)]);
+
+    const result = await confirmRecipientByToken("tok-1");
+
+    expect(result).toEqual(confirmed);
+  });
+
+  it("returns the row unchanged when status is unsubscribed (no UPDATE)", async () => {
+    const unsubscribed = recipientRow({
+      status: "unsubscribed",
+      unsubscribed_at: "now",
+    });
+    queueResponses([ok(unsubscribed)]);
+
+    const result = await confirmRecipientByToken("tok-1");
+
+    expect(result).toEqual(unsubscribed);
+  });
+
+  it("does NOT overwrite a racing unsubscribe — refetches and returns it", async () => {
+    // SELECT sees pending, but between SELECT and our conditional UPDATE
+    // another caller unsubscribed the row. The UPDATE WHERE status='pending'
+    // affects 0 rows, and we re-fetch to discover the unsubscribed state.
+    const pending = recipientRow({ status: "pending" });
+    const unsubscribed = recipientRow({
+      status: "unsubscribed",
+      unsubscribed_at: "now",
+    });
+    queueResponses([ok(pending), ok(null), ok(unsubscribed)]);
+
+    const result = await confirmRecipientByToken("tok-1");
+
+    expect(result).toEqual(unsubscribed);
+    expect(result?.status).toBe("unsubscribed");
+  });
+});
+
+describe("unsubscribeRecipientByToken", () => {
+  it("transitions pending → unsubscribed when no race", async () => {
+    const pending = recipientRow({ status: "pending" });
+    const unsubscribed = recipientRow({
+      status: "unsubscribed",
+      unsubscribed_at: "now",
+    });
+    queueResponses([ok(pending), ok(unsubscribed)]);
+
+    const result = await unsubscribeRecipientByToken("tok-1");
+
+    expect(result).toEqual(unsubscribed);
+  });
+
+  it("transitions confirmed → unsubscribed when no race", async () => {
+    const confirmed = recipientRow({
+      status: "confirmed",
+      confirmed_at: "now",
+    });
+    const unsubscribed = recipientRow({
+      status: "unsubscribed",
+      unsubscribed_at: "now",
+    });
+    queueResponses([ok(confirmed), ok(unsubscribed)]);
+
+    const result = await unsubscribeRecipientByToken("tok-1");
+
+    expect(result).toEqual(unsubscribed);
+  });
+
+  it("returns the row unchanged when already unsubscribed (no UPDATE)", async () => {
+    const unsubscribed = recipientRow({
+      status: "unsubscribed",
+      unsubscribed_at: "now",
+    });
+    queueResponses([ok(unsubscribed)]);
+
+    const result = await unsubscribeRecipientByToken("tok-1");
+
+    expect(result).toEqual(unsubscribed);
+  });
+
+  it("handles a racing unsubscribe by re-fetching the terminal state", async () => {
+    // SELECT sees pending; concurrent caller unsubscribes; our conditional
+    // UPDATE WHERE status != 'unsubscribed' affects 0 rows. Re-fetch
+    // confirms the terminal state.
+    const pending = recipientRow({ status: "pending" });
+    const alreadyUnsub = recipientRow({
+      status: "unsubscribed",
+      unsubscribed_at: "now",
+    });
+    queueResponses([ok(pending), ok(null), ok(alreadyUnsub)]);
+
+    const result = await unsubscribeRecipientByToken("tok-1");
+
+    expect(result).toEqual(alreadyUnsub);
   });
 });

--- a/apps/api/src/services/monitoring/email_recipients.test.ts
+++ b/apps/api/src/services/monitoring/email_recipients.test.ts
@@ -1,0 +1,163 @@
+type QueryResult = { data: unknown; error: unknown };
+
+const fromMock = jest.fn();
+const selectMock = jest.fn();
+const insertMock = jest.fn();
+const eqMonitorMock = jest.fn();
+const eqEmailMock = jest.fn();
+const maybeSingleSelectMock = jest.fn();
+const maybeSingleInsertMock = jest.fn();
+const insertSelectMock = jest.fn();
+
+function configureSupabaseMocks(opts: {
+  selectMaybeSingle: () => Promise<QueryResult>;
+  insertMaybeSingle?: () => Promise<QueryResult>;
+}) {
+  maybeSingleSelectMock.mockImplementation(opts.selectMaybeSingle);
+  maybeSingleInsertMock.mockImplementation(
+    opts.insertMaybeSingle ?? (() => Promise.resolve({ data: null, error: null })),
+  );
+  eqEmailMock.mockReturnValue({ maybeSingle: maybeSingleSelectMock });
+  eqMonitorMock.mockReturnValue({ eq: eqEmailMock });
+  insertSelectMock.mockReturnValue({ maybeSingle: maybeSingleInsertMock });
+  selectMock.mockReturnValue({ eq: eqMonitorMock });
+  insertMock.mockReturnValue({ select: insertSelectMock });
+  fromMock.mockReturnValue({
+    select: selectMock,
+    insert: insertMock,
+  });
+}
+
+jest.mock("../supabase", () => ({
+  supabase_service: {
+    from: (...args: unknown[]) => fromMock(...args),
+  },
+  supabase_rr_service: {
+    from: (...args: unknown[]) => fromMock(...args),
+  },
+}));
+
+import { ensureMonitorEmailRecipient } from "./email_recipients";
+
+beforeEach(() => {
+  fromMock.mockReset();
+  selectMock.mockReset();
+  insertMock.mockReset();
+  eqMonitorMock.mockReset();
+  eqEmailMock.mockReset();
+  maybeSingleSelectMock.mockReset();
+  maybeSingleInsertMock.mockReset();
+  insertSelectMock.mockReset();
+});
+
+const baseInput = {
+  monitorId: "monitor-1",
+  teamId: "team-1",
+  input: {
+    email: "alerts@example.com",
+    source: "opt_in" as const,
+    status: "pending" as const,
+  },
+};
+
+function recipientRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "rec-1",
+    monitor_id: "monitor-1",
+    team_id: "team-1",
+    email: "alerts@example.com",
+    status: "pending",
+    token: "tok-1",
+    source: "opt_in",
+    confirmation_sent_at: null,
+    confirmed_at: null,
+    unsubscribed_at: null,
+    last_notified_at: null,
+    created_at: "now",
+    updated_at: "now",
+    ...overrides,
+  };
+}
+
+describe("ensureMonitorEmailRecipient", () => {
+  it("returns existing row when the recipient already exists (no insert)", async () => {
+    const existing = recipientRow({ status: "confirmed", source: "team" });
+    configureSupabaseMocks({
+      selectMaybeSingle: () => Promise.resolve({ data: existing, error: null }),
+    });
+
+    const result = await ensureMonitorEmailRecipient(baseInput);
+
+    expect(result).toEqual({ row: existing, created: false });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("inserts and returns created=true when no row exists", async () => {
+    const inserted = recipientRow();
+    configureSupabaseMocks({
+      selectMaybeSingle: () => Promise.resolve({ data: null, error: null }),
+      insertMaybeSingle: () => Promise.resolve({ data: inserted, error: null }),
+    });
+
+    const result = await ensureMonitorEmailRecipient(baseInput);
+
+    expect(result).toEqual({ row: inserted, created: true });
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a concurrent-insert unique violation as not-created (no throw)", async () => {
+    // Concurrent sync wrote the row between our SELECT and INSERT.
+    const winnerRow = recipientRow({ id: "rec-winner" });
+    let selectCalls = 0;
+    configureSupabaseMocks({
+      selectMaybeSingle: () => {
+        selectCalls += 1;
+        if (selectCalls === 1) return Promise.resolve({ data: null, error: null });
+        return Promise.resolve({ data: winnerRow, error: null });
+      },
+      insertMaybeSingle: () =>
+        Promise.resolve({
+          data: null,
+          error: { code: "23505", message: "duplicate key" },
+        }),
+    });
+
+    const result = await ensureMonitorEmailRecipient(baseInput);
+
+    expect(result).toEqual({ row: winnerRow, created: false });
+    expect(selectCalls).toBe(2);
+  });
+
+  it("rethrows non-unique insert errors", async () => {
+    configureSupabaseMocks({
+      selectMaybeSingle: () => Promise.resolve({ data: null, error: null }),
+      insertMaybeSingle: () =>
+        Promise.resolve({
+          data: null,
+          error: { code: "42501", message: "permission denied" },
+        }),
+    });
+
+    await expect(ensureMonitorEmailRecipient(baseInput)).rejects.toThrow(
+      /permission denied/,
+    );
+  });
+
+  it("rethrows unique violations when no winning row can be re-fetched", async () => {
+    // Defensive: if the unique violation is on `token` (not the recipient
+    // pair) the re-fetch returns nothing and we should surface the error
+    // instead of silently lying about creation.
+    configureSupabaseMocks({
+      selectMaybeSingle: () => Promise.resolve({ data: null, error: null }),
+      insertMaybeSingle: () =>
+        Promise.resolve({
+          data: null,
+          error: { code: "23505", message: "duplicate key" },
+        }),
+    });
+
+    await expect(ensureMonitorEmailRecipient(baseInput)).rejects.toThrow(
+      /duplicate key/,
+    );
+  });
+});

--- a/apps/api/src/services/monitoring/email_recipients.test.ts
+++ b/apps/api/src/services/monitoring/email_recipients.test.ts
@@ -1,33 +1,43 @@
 type QueryResult = { data: unknown; error: unknown };
 type ChainOp = "select" | "insert" | "update" | "delete" | "unknown";
+type ClientKind = "primary" | "rr";
 
-const fromMock = jest.fn();
+type CallRecord = { client: ClientKind; op: ChainOp };
+
+const fromPrimary = jest.fn();
+const fromRR = jest.fn();
+const calls: CallRecord[] = [];
 
 // Each test queues responses in the order the code under test will execute
 // queries. The fluent chain swallows any sequence of select/insert/update/
 // eq/neq calls and resolves at .maybeSingle() / .single() with the next
 // queued result. Tests stay explicit about query order without coupling to
 // the precise method chain shape.
-type QueuedResponse = (op: ChainOp) => Promise<QueryResult>;
+type QueuedResponse = (
+  client: ClientKind,
+  op: ChainOp,
+) => Promise<QueryResult>;
 let queue: QueuedResponse[] = [];
 
 function queueResponses(responses: QueuedResponse[]): void {
   queue = [...responses];
 }
 
-function makeChain(): any {
+function makeChain(client: ClientKind): any {
   let op: ChainOp | null = null;
   const setOp = (next: ChainOp) => {
     if (op === null) op = next;
   };
   const resolve = (): Promise<QueryResult> => {
+    const finalOp = op ?? "unknown";
+    calls.push({ client, op: finalOp });
     const next = queue.shift();
     if (!next) {
       throw new Error(
-        `No queued Supabase response for op=${op ?? "unknown"} (queue exhausted)`,
+        `No queued Supabase response for client=${client} op=${finalOp} (queue exhausted)`,
       );
     }
-    return next(op ?? "unknown");
+    return next(client, finalOp);
   };
   const builder: any = {
     select: () => {
@@ -57,10 +67,10 @@ function makeChain(): any {
 
 jest.mock("../supabase", () => ({
   supabase_service: {
-    from: (...args: unknown[]) => fromMock(...args),
+    from: (...args: unknown[]) => fromPrimary(...args),
   },
   supabase_rr_service: {
-    from: (...args: unknown[]) => fromMock(...args),
+    from: (...args: unknown[]) => fromRR(...args),
   },
 }));
 
@@ -72,8 +82,11 @@ import {
 
 beforeEach(() => {
   queue = [];
-  fromMock.mockReset();
-  fromMock.mockImplementation(() => makeChain());
+  calls.length = 0;
+  fromPrimary.mockReset();
+  fromRR.mockReset();
+  fromPrimary.mockImplementation(() => makeChain("primary"));
+  fromRR.mockImplementation(() => makeChain("rr"));
 });
 
 function recipientRow(overrides: Record<string, unknown> = {}) {
@@ -141,6 +154,13 @@ describe("ensureMonitorEmailRecipient", () => {
     const result = await ensureMonitorEmailRecipient(baseEnsureInput);
 
     expect(result).toEqual({ row: winnerRow, created: false });
+    // The race-recovery re-fetch MUST hit the primary; the read replica may
+    // not yet have the row the concurrent writer just committed.
+    expect(calls.map(c => ({ client: c.client, op: c.op }))).toEqual([
+      { client: "rr", op: "select" },
+      { client: "primary", op: "insert" },
+      { client: "primary", op: "select" },
+    ]);
   });
 
   it("rethrows non-unique insert errors", async () => {
@@ -220,6 +240,12 @@ describe("confirmRecipientByToken", () => {
 
     expect(result).toEqual(unsubscribed);
     expect(result?.status).toBe("unsubscribed");
+    // The post-UPDATE re-fetch MUST hit primary so we don't get a stale
+    // 'pending' from the read replica right after our conditional write.
+    expect(calls[calls.length - 1]).toEqual({
+      client: "primary",
+      op: "select",
+    });
   });
 });
 
@@ -279,5 +305,9 @@ describe("unsubscribeRecipientByToken", () => {
     const result = await unsubscribeRecipientByToken("tok-1");
 
     expect(result).toEqual(alreadyUnsub);
+    expect(calls[calls.length - 1]).toEqual({
+      client: "primary",
+      op: "select",
+    });
   });
 });

--- a/apps/api/src/services/monitoring/email_recipients.ts
+++ b/apps/api/src/services/monitoring/email_recipients.ts
@@ -1,0 +1,274 @@
+import { randomBytes } from "crypto";
+import { logger as _logger } from "../../lib/logger";
+import { supabase_rr_service, supabase_service } from "../supabase";
+
+const logger = _logger.child({ module: "monitor-email-recipients" });
+
+export type MonitorEmailRecipientStatus =
+  | "pending"
+  | "confirmed"
+  | "unsubscribed";
+
+export type MonitorEmailRecipientSource = "team" | "opt_in" | "legacy";
+
+export type MonitorEmailRecipientRow = {
+  id: string;
+  monitor_id: string;
+  team_id: string;
+  email: string;
+  status: MonitorEmailRecipientStatus;
+  token: string;
+  source: MonitorEmailRecipientSource;
+  confirmation_sent_at: string | null;
+  confirmed_at: string | null;
+  unsubscribed_at: string | null;
+  last_notified_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export function normalizeRecipientEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+// 32 bytes of entropy, base64url-encoded (43 chars, URL safe, no padding).
+// Plenty of bits to make tokens unguessable and unique without UUID overhead.
+export function generateRecipientToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function throwIfError(error: any, message: string): void {
+  if (error) {
+    throw new Error(`${message}: ${error.message ?? JSON.stringify(error)}`);
+  }
+}
+
+export async function listMonitorEmailRecipients(
+  monitorId: string,
+): Promise<MonitorEmailRecipientRow[]> {
+  const { data, error } = await supabase_rr_service
+    .from("monitor_email_recipients")
+    .select("*")
+    .eq("monitor_id", monitorId);
+
+  throwIfError(error, "Failed to list monitor email recipients");
+  return (data ?? []) as MonitorEmailRecipientRow[];
+}
+
+export async function getRecipientByToken(
+  token: string,
+): Promise<MonitorEmailRecipientRow | null> {
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+
+  const { data, error } = await supabase_rr_service
+    .from("monitor_email_recipients")
+    .select("*")
+    .eq("token", trimmed)
+    .maybeSingle();
+
+  throwIfError(error, "Failed to look up monitor email recipient by token");
+  return (data ?? null) as MonitorEmailRecipientRow | null;
+}
+
+/**
+ * Look up the monitor name for a given monitor id. Used by the email opt-in
+ * controllers so the public confirmation/unsubscribe pages can show the
+ * recipient which monitor they're acting on.
+ */
+export async function getMonitorNameById(
+  monitorId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase_rr_service
+    .from("monitors")
+    .select("name")
+    .eq("id", monitorId)
+    .maybeSingle();
+
+  if (error) {
+    logger.warn("Failed to load monitor name for opt-in response", {
+      error,
+      monitorId,
+    });
+    return null;
+  }
+  return (data?.name as string | undefined) ?? null;
+}
+
+/**
+ * Look up which of the given emails are members of the monitor's team. Members
+ * are auto-confirmed because they already have dashboard access to this
+ * monitor; requiring them to click an opt-in link would be pure friction.
+ */
+export async function getTeamMemberEmails(
+  teamId: string,
+  emails: string[],
+): Promise<Set<string>> {
+  if (emails.length === 0) return new Set();
+
+  const { data, error } = await supabase_rr_service
+    .from("user_teams")
+    .select("users(email)")
+    .eq("team_id", teamId);
+
+  if (error) {
+    logger.warn("Failed to load team member emails for recipient sync", {
+      error,
+      teamId,
+    });
+    return new Set();
+  }
+
+  const wanted = new Set(emails.map(normalizeRecipientEmail));
+  const matches = new Set<string>();
+  for (const row of data ?? []) {
+    const email = (row as any).users?.email;
+    if (typeof email === "string") {
+      const normalized = normalizeRecipientEmail(email);
+      if (wanted.has(normalized)) matches.add(normalized);
+    }
+  }
+  return matches;
+}
+
+export type RecipientUpsertInput = {
+  email: string;
+  source: MonitorEmailRecipientSource;
+  status: MonitorEmailRecipientStatus;
+};
+
+export type RecipientUpsertResult = {
+  row: MonitorEmailRecipientRow;
+  created: boolean;
+};
+
+/**
+ * Idempotently create a recipient row. If a row already exists for
+ * (monitor_id, email):
+ *   - returns the existing row unchanged (so an opt-out is honored even if
+ *     the monitor is edited and the email re-added)
+ *   - records `created = false`
+ *
+ * If the row is new, the caller should send a confirmation email when the
+ * status is `pending`.
+ */
+export async function ensureMonitorEmailRecipient(params: {
+  monitorId: string;
+  teamId: string;
+  input: RecipientUpsertInput;
+}): Promise<RecipientUpsertResult> {
+  const email = normalizeRecipientEmail(params.input.email);
+
+  const existing = await supabase_rr_service
+    .from("monitor_email_recipients")
+    .select("*")
+    .eq("monitor_id", params.monitorId)
+    .eq("email", email)
+    .maybeSingle();
+
+  throwIfError(existing.error, "Failed to look up monitor email recipient");
+  if (existing.data) {
+    return {
+      row: existing.data as MonitorEmailRecipientRow,
+      created: false,
+    };
+  }
+
+  const now = new Date().toISOString();
+  const token = generateRecipientToken();
+  const insert = {
+    monitor_id: params.monitorId,
+    team_id: params.teamId,
+    email,
+    status: params.input.status,
+    token,
+    source: params.input.source,
+    confirmation_sent_at: params.input.status === "pending" ? now : null,
+    confirmed_at: params.input.status === "confirmed" ? now : null,
+    created_at: now,
+    updated_at: now,
+  };
+
+  const { data, error } = await supabase_service
+    .from("monitor_email_recipients")
+    .insert(insert)
+    .select("*")
+    .single();
+
+  throwIfError(error, "Failed to insert monitor email recipient");
+  return { row: data as MonitorEmailRecipientRow, created: true };
+}
+
+export async function markRecipientConfirmationSent(
+  id: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const { error } = await supabase_service
+    .from("monitor_email_recipients")
+    .update({ confirmation_sent_at: now, updated_at: now })
+    .eq("id", id);
+
+  throwIfError(error, "Failed to mark recipient confirmation sent");
+}
+
+export async function confirmRecipientByToken(
+  token: string,
+): Promise<MonitorEmailRecipientRow | null> {
+  const row = await getRecipientByToken(token);
+  if (!row) return null;
+  if (row.status === "confirmed") return row;
+
+  // Once a recipient unsubscribes we treat that as permanent — re-confirming
+  // would let a malicious actor effectively re-subscribe someone after they
+  // opted out. They have to be re-added to a monitor manually, which sends a
+  // fresh confirmation email.
+  if (row.status === "unsubscribed") return row;
+
+  const now = new Date().toISOString();
+  const { data, error } = await supabase_service
+    .from("monitor_email_recipients")
+    .update({ status: "confirmed", confirmed_at: now, updated_at: now })
+    .eq("id", row.id)
+    .select("*")
+    .single();
+
+  throwIfError(error, "Failed to confirm monitor email recipient");
+  return data as MonitorEmailRecipientRow;
+}
+
+export async function unsubscribeRecipientByToken(
+  token: string,
+): Promise<MonitorEmailRecipientRow | null> {
+  const row = await getRecipientByToken(token);
+  if (!row) return null;
+  if (row.status === "unsubscribed") return row;
+
+  const now = new Date().toISOString();
+  const { data, error } = await supabase_service
+    .from("monitor_email_recipients")
+    .update({ status: "unsubscribed", unsubscribed_at: now, updated_at: now })
+    .eq("id", row.id)
+    .select("*")
+    .single();
+
+  throwIfError(error, "Failed to unsubscribe monitor email recipient");
+  return data as MonitorEmailRecipientRow;
+}
+
+export async function touchRecipientsNotified(
+  ids: string[],
+): Promise<void> {
+  if (ids.length === 0) return;
+  const now = new Date().toISOString();
+  const { error } = await supabase_service
+    .from("monitor_email_recipients")
+    .update({ last_notified_at: now, updated_at: now })
+    .in("id", ids);
+
+  if (error) {
+    logger.warn("Failed to update last_notified_at on recipients", {
+      error,
+      ids,
+    });
+  }
+}

--- a/apps/api/src/services/monitoring/email_recipients.ts
+++ b/apps/api/src/services/monitoring/email_recipients.ts
@@ -148,6 +148,20 @@ async function fetchRecipientByMonitorEmail(
   return (data ?? null) as MonitorEmailRecipientRow | null;
 }
 
+// Reads from the write client to avoid read-replica lag when we need the
+// authoritative current state right after a conditional UPDATE.
+async function fetchRecipientByIdPrimary(
+  id: string,
+): Promise<MonitorEmailRecipientRow | null> {
+  const { data, error } = await supabase_service
+    .from("monitor_email_recipients")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  throwIfError(error, "Failed to look up monitor email recipient by id");
+  return (data ?? null) as MonitorEmailRecipientRow | null;
+}
+
 // Idempotent: existing rows are returned unchanged so prior unsubscribe
 // decisions persist across monitor edits. The unique (monitor_id, email)
 // constraint is the source of truth — a TOCTOU between the SELECT and the
@@ -223,16 +237,23 @@ export async function confirmRecipientByToken(
   // Unsubscribe is permanent — never let a confirm link reverse it.
   if (row.status === "unsubscribed") return row;
 
+  // Conditional UPDATE: only transition pending → confirmed. If status flips
+  // (e.g. concurrent unsubscribe) between our SELECT and this UPDATE we
+  // affect 0 rows; re-fetch and return the actual current state so an
+  // in-flight confirm can't silently overwrite a terminal unsubscribe.
   const now = new Date().toISOString();
   const { data, error } = await supabase_service
     .from("monitor_email_recipients")
     .update({ status: "confirmed", confirmed_at: now, updated_at: now })
     .eq("id", row.id)
+    .eq("status", "pending")
     .select("*")
-    .single();
+    .maybeSingle();
 
   throwIfError(error, "Failed to confirm monitor email recipient");
-  return data as MonitorEmailRecipientRow;
+  if (data) return data as MonitorEmailRecipientRow;
+
+  return await fetchRecipientByIdPrimary(row.id);
 }
 
 export async function unsubscribeRecipientByToken(
@@ -242,16 +263,22 @@ export async function unsubscribeRecipientByToken(
   if (!row) return null;
   if (row.status === "unsubscribed") return row;
 
+  // Conditional UPDATE: only writes when the row isn't already unsubscribed,
+  // so two racing unsubscribes don't double-write timestamps. 0 rows here
+  // means a concurrent call beat us to the terminal state.
   const now = new Date().toISOString();
   const { data, error } = await supabase_service
     .from("monitor_email_recipients")
     .update({ status: "unsubscribed", unsubscribed_at: now, updated_at: now })
     .eq("id", row.id)
+    .neq("status", "unsubscribed")
     .select("*")
-    .single();
+    .maybeSingle();
 
   throwIfError(error, "Failed to unsubscribe monitor email recipient");
-  return data as MonitorEmailRecipientRow;
+  if (data) return data as MonitorEmailRecipientRow;
+
+  return await fetchRecipientByIdPrimary(row.id);
 }
 
 export async function touchRecipientsNotified(

--- a/apps/api/src/services/monitoring/email_recipients.ts
+++ b/apps/api/src/services/monitoring/email_recipients.ts
@@ -31,8 +31,7 @@ export function normalizeRecipientEmail(email: string): string {
   return email.trim().toLowerCase();
 }
 
-// 32 bytes of entropy, base64url-encoded (43 chars, URL safe, no padding).
-// Plenty of bits to make tokens unguessable and unique without UUID overhead.
+// 32 bytes → 43 chars base64url, no padding. 256 bits of entropy.
 export function generateRecipientToken(): string {
   return randomBytes(32).toString("base64url");
 }
@@ -71,11 +70,6 @@ export async function getRecipientByToken(
   return (data ?? null) as MonitorEmailRecipientRow | null;
 }
 
-/**
- * Look up the monitor name for a given monitor id. Used by the email opt-in
- * controllers so the public confirmation/unsubscribe pages can show the
- * recipient which monitor they're acting on.
- */
 export async function getMonitorNameById(
   monitorId: string,
 ): Promise<string | null> {
@@ -95,11 +89,7 @@ export async function getMonitorNameById(
   return (data?.name as string | undefined) ?? null;
 }
 
-/**
- * Look up which of the given emails are members of the monitor's team. Members
- * are auto-confirmed because they already have dashboard access to this
- * monitor; requiring them to click an opt-in link would be pure friction.
- */
+// Team members are auto-confirmed; they already have dashboard access.
 export async function getTeamMemberEmails(
   teamId: string,
   emails: string[],
@@ -142,16 +132,8 @@ export type RecipientUpsertResult = {
   created: boolean;
 };
 
-/**
- * Idempotently create a recipient row. If a row already exists for
- * (monitor_id, email):
- *   - returns the existing row unchanged (so an opt-out is honored even if
- *     the monitor is edited and the email re-added)
- *   - records `created = false`
- *
- * If the row is new, the caller should send a confirmation email when the
- * status is `pending`.
- */
+// Idempotent: existing rows are returned unchanged so prior unsubscribe
+// decisions persist across monitor edits.
 export async function ensureMonitorEmailRecipient(params: {
   monitorId: string;
   teamId: string;
@@ -218,10 +200,7 @@ export async function confirmRecipientByToken(
   if (!row) return null;
   if (row.status === "confirmed") return row;
 
-  // Once a recipient unsubscribes we treat that as permanent — re-confirming
-  // would let a malicious actor effectively re-subscribe someone after they
-  // opted out. They have to be re-added to a monitor manually, which sends a
-  // fresh confirmation email.
+  // Unsubscribe is permanent — never let a confirm link reverse it.
   if (row.status === "unsubscribed") return row;
 
   const now = new Date().toISOString();

--- a/apps/api/src/services/monitoring/email_recipients.ts
+++ b/apps/api/src/services/monitoring/email_recipients.ts
@@ -4,6 +4,8 @@ import { supabase_rr_service, supabase_service } from "../supabase";
 
 const logger = _logger.child({ module: "monitor-email-recipients" });
 
+const POSTGRES_UNIQUE_VIOLATION = "23505";
+
 export type MonitorEmailRecipientStatus =
   | "pending"
   | "confirmed"
@@ -132,8 +134,25 @@ export type RecipientUpsertResult = {
   created: boolean;
 };
 
+async function fetchRecipientByMonitorEmail(
+  monitorId: string,
+  email: string,
+): Promise<MonitorEmailRecipientRow | null> {
+  const { data, error } = await supabase_rr_service
+    .from("monitor_email_recipients")
+    .select("*")
+    .eq("monitor_id", monitorId)
+    .eq("email", email)
+    .maybeSingle();
+  throwIfError(error, "Failed to look up monitor email recipient");
+  return (data ?? null) as MonitorEmailRecipientRow | null;
+}
+
 // Idempotent: existing rows are returned unchanged so prior unsubscribe
-// decisions persist across monitor edits.
+// decisions persist across monitor edits. The unique (monitor_id, email)
+// constraint is the source of truth — a TOCTOU between the SELECT and the
+// INSERT below is caught via the unique-violation handler so concurrent
+// syncs of the same monitor return the same row instead of 500ing.
 export async function ensureMonitorEmailRecipient(params: {
   monitorId: string;
   teamId: string;
@@ -141,29 +160,18 @@ export async function ensureMonitorEmailRecipient(params: {
 }): Promise<RecipientUpsertResult> {
   const email = normalizeRecipientEmail(params.input.email);
 
-  const existing = await supabase_rr_service
-    .from("monitor_email_recipients")
-    .select("*")
-    .eq("monitor_id", params.monitorId)
-    .eq("email", email)
-    .maybeSingle();
-
-  throwIfError(existing.error, "Failed to look up monitor email recipient");
-  if (existing.data) {
-    return {
-      row: existing.data as MonitorEmailRecipientRow,
-      created: false,
-    };
+  const existing = await fetchRecipientByMonitorEmail(params.monitorId, email);
+  if (existing) {
+    return { row: existing, created: false };
   }
 
   const now = new Date().toISOString();
-  const token = generateRecipientToken();
   const insert = {
     monitor_id: params.monitorId,
     team_id: params.teamId,
     email,
     status: params.input.status,
-    token,
+    token: generateRecipientToken(),
     source: params.input.source,
     confirmation_sent_at: params.input.status === "pending" ? now : null,
     confirmed_at: params.input.status === "confirmed" ? now : null,
@@ -175,9 +183,21 @@ export async function ensureMonitorEmailRecipient(params: {
     .from("monitor_email_recipients")
     .insert(insert)
     .select("*")
-    .single();
+    .maybeSingle();
 
-  throwIfError(error, "Failed to insert monitor email recipient");
+  if (error) {
+    if ((error as { code?: string }).code === POSTGRES_UNIQUE_VIOLATION) {
+      const winner = await fetchRecipientByMonitorEmail(
+        params.monitorId,
+        email,
+      );
+      if (winner) {
+        return { row: winner, created: false };
+      }
+    }
+    throwIfError(error, "Failed to insert monitor email recipient");
+  }
+
   return { row: data as MonitorEmailRecipientRow, created: true };
 }
 

--- a/apps/api/src/services/monitoring/email_recipients.ts
+++ b/apps/api/src/services/monitoring/email_recipients.ts
@@ -148,8 +148,25 @@ async function fetchRecipientByMonitorEmail(
   return (data ?? null) as MonitorEmailRecipientRow | null;
 }
 
-// Reads from the write client to avoid read-replica lag when we need the
-// authoritative current state right after a conditional UPDATE.
+// Read replicas can lag behind a freshly-committed INSERT, which is exactly
+// the moment this re-fetch runs (the concurrent writer just won the unique
+// race). Reading from the primary guarantees we see their row.
+async function fetchRecipientByMonitorEmailPrimary(
+  monitorId: string,
+  email: string,
+): Promise<MonitorEmailRecipientRow | null> {
+  const { data, error } = await supabase_service
+    .from("monitor_email_recipients")
+    .select("*")
+    .eq("monitor_id", monitorId)
+    .eq("email", email)
+    .maybeSingle();
+  throwIfError(error, "Failed to look up monitor email recipient");
+  return (data ?? null) as MonitorEmailRecipientRow | null;
+}
+
+// Same rationale as ...Primary above: a conditional UPDATE just landed, so
+// the replica may not have caught up yet when we re-read.
 async function fetchRecipientByIdPrimary(
   id: string,
 ): Promise<MonitorEmailRecipientRow | null> {
@@ -201,7 +218,7 @@ export async function ensureMonitorEmailRecipient(params: {
 
   if (error) {
     if ((error as { code?: string }).code === POSTGRES_UNIQUE_VIOLATION) {
-      const winner = await fetchRecipientByMonitorEmail(
+      const winner = await fetchRecipientByMonitorEmailPrimary(
         params.monitorId,
         email,
       );

--- a/apps/api/src/services/monitoring/email_recipients_sync.test.ts
+++ b/apps/api/src/services/monitoring/email_recipients_sync.test.ts
@@ -1,0 +1,224 @@
+jest.mock("../supabase", () => ({
+  supabase_service: {},
+  supabase_rr_service: {},
+}));
+
+const mockEnsureRecipient = jest.fn();
+const mockListRecipients = jest.fn();
+const mockGetTeamMemberEmails = jest.fn();
+
+jest.mock("./email_recipients", () => {
+  const actual = jest.requireActual("./email_recipients");
+  return {
+    ...actual,
+    ensureMonitorEmailRecipient: (...args: unknown[]) =>
+      mockEnsureRecipient(...args),
+    listMonitorEmailRecipients: (...args: unknown[]) =>
+      mockListRecipients(...args),
+    getTeamMemberEmails: (...args: unknown[]) =>
+      mockGetTeamMemberEmails(...args),
+  };
+});
+
+const mockSendConfirmationEmail = jest.fn();
+jest.mock("../notification/monitoring_email", () => ({
+  sendMonitoringConfirmationEmail: (...args: unknown[]) =>
+    mockSendConfirmationEmail(...args),
+}));
+
+import { syncMonitorEmailRecipients } from "./email_recipients_sync";
+
+beforeEach(() => {
+  mockEnsureRecipient.mockReset();
+  mockListRecipients.mockReset();
+  mockGetTeamMemberEmails.mockReset();
+  mockSendConfirmationEmail.mockReset();
+  mockSendConfirmationEmail.mockResolvedValue({
+    attempted: true,
+    success: true,
+  });
+});
+
+function recipientRow(
+  email: string,
+  status: "pending" | "confirmed" | "unsubscribed",
+  source: "team" | "opt_in" | "legacy",
+) {
+  return {
+    id: `rec-${email}`,
+    monitor_id: "monitor-1",
+    team_id: "team-1",
+    email,
+    status,
+    token: `tok-${email}`,
+    source,
+    confirmation_sent_at: status === "pending" ? new Date().toISOString() : null,
+    confirmed_at: status === "confirmed" ? new Date().toISOString() : null,
+    unsubscribed_at:
+      status === "unsubscribed" ? new Date().toISOString() : null,
+    last_notified_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function monitor(recipients: string[]): any {
+  return {
+    id: "monitor-1",
+    team_id: "team-1",
+    name: "Test monitor",
+    notification: {
+      email: { enabled: true, recipients },
+    },
+  };
+}
+
+describe("syncMonitorEmailRecipients", () => {
+  it("returns nothing when there are no configured recipients", async () => {
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor([]),
+    });
+    expect(result.recipients).toEqual([]);
+    expect(mockEnsureRecipient).not.toHaveBeenCalled();
+  });
+
+  it("auto-confirms team members without sending confirmation email", async () => {
+    mockListRecipients.mockResolvedValue([]);
+    mockGetTeamMemberEmails.mockResolvedValue(new Set(["owner@team.com"]));
+    mockEnsureRecipient.mockImplementation(async ({ input }) => ({
+      row: recipientRow(input.email, "confirmed", "team"),
+      created: true,
+    }));
+
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor(["owner@team.com"]),
+    });
+
+    expect(mockEnsureRecipient).toHaveBeenCalledWith({
+      monitorId: "monitor-1",
+      teamId: "team-1",
+      input: { email: "owner@team.com", source: "team", status: "confirmed" },
+    });
+    expect(mockSendConfirmationEmail).not.toHaveBeenCalled();
+    expect(result.recipients[0]).toMatchObject({
+      email: "owner@team.com",
+      status: "confirmed",
+      source: "team",
+      created: true,
+    });
+  });
+
+  it("sends a confirmation email to brand new external recipients", async () => {
+    mockListRecipients.mockResolvedValue([]);
+    mockGetTeamMemberEmails.mockResolvedValue(new Set());
+    mockEnsureRecipient.mockImplementation(async ({ input }) => ({
+      row: recipientRow(input.email, "pending", "opt_in"),
+      created: true,
+    }));
+
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor(["random@elsewhere.com"]),
+    });
+
+    expect(mockEnsureRecipient).toHaveBeenCalledWith({
+      monitorId: "monitor-1",
+      teamId: "team-1",
+      input: {
+        email: "random@elsewhere.com",
+        source: "opt_in",
+        status: "pending",
+      },
+    });
+    expect(mockSendConfirmationEmail).toHaveBeenCalledTimes(1);
+    expect(result.recipients[0]).toMatchObject({
+      email: "random@elsewhere.com",
+      status: "pending",
+      source: "opt_in",
+      confirmationEmailSent: true,
+      created: true,
+    });
+  });
+
+  it("does not re-send a confirmation email for an existing pending recipient", async () => {
+    mockListRecipients.mockResolvedValue([
+      recipientRow("waiting@elsewhere.com", "pending", "opt_in"),
+    ]);
+    mockGetTeamMemberEmails.mockResolvedValue(new Set());
+
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor(["waiting@elsewhere.com"]),
+    });
+
+    expect(mockEnsureRecipient).not.toHaveBeenCalled();
+    expect(mockSendConfirmationEmail).not.toHaveBeenCalled();
+    expect(result.recipients[0]).toMatchObject({
+      email: "waiting@elsewhere.com",
+      status: "pending",
+      created: false,
+    });
+  });
+
+  it("preserves prior unsubscribe when the same email is re-added later", async () => {
+    mockListRecipients.mockResolvedValue([
+      recipientRow("ghost@elsewhere.com", "unsubscribed", "opt_in"),
+    ]);
+    mockGetTeamMemberEmails.mockResolvedValue(new Set());
+
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor(["ghost@elsewhere.com"]),
+    });
+
+    expect(mockEnsureRecipient).not.toHaveBeenCalled();
+    expect(mockSendConfirmationEmail).not.toHaveBeenCalled();
+    expect(result.recipients[0]).toMatchObject({
+      email: "ghost@elsewhere.com",
+      status: "unsubscribed",
+    });
+  });
+
+  it("normalizes emails (lowercases, trims, dedupes) before reconciling", async () => {
+    mockListRecipients.mockResolvedValue([]);
+    mockGetTeamMemberEmails.mockResolvedValue(new Set(["dup@example.com"]));
+    mockEnsureRecipient.mockImplementation(async ({ input }) => ({
+      row: recipientRow(input.email, "confirmed", "team"),
+      created: true,
+    }));
+
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor([
+        "Dup@Example.com",
+        "  dup@example.com  ",
+        "dup@EXAMPLE.com",
+      ]),
+    });
+
+    expect(mockEnsureRecipient).toHaveBeenCalledTimes(1);
+    expect(result.recipients).toHaveLength(1);
+    expect(result.recipients[0].email).toBe("dup@example.com");
+  });
+
+  it("handles a mix of team members and externals in one sync", async () => {
+    mockListRecipients.mockResolvedValue([]);
+    mockGetTeamMemberEmails.mockResolvedValue(new Set(["owner@team.com"]));
+    mockEnsureRecipient.mockImplementation(async ({ input }) => ({
+      row: recipientRow(
+        input.email,
+        input.status,
+        input.source,
+      ),
+      created: true,
+    }));
+
+    const result = await syncMonitorEmailRecipients({
+      monitor: monitor(["owner@team.com", "external@elsewhere.com"]),
+    });
+
+    expect(mockSendConfirmationEmail).toHaveBeenCalledTimes(1);
+    const emailedTo = mockSendConfirmationEmail.mock.calls[0][0].recipient.email;
+    expect(emailedTo).toBe("external@elsewhere.com");
+
+    const byEmail = new Map(result.recipients.map(r => [r.email, r]));
+    expect(byEmail.get("owner@team.com")?.status).toBe("confirmed");
+    expect(byEmail.get("external@elsewhere.com")?.status).toBe("pending");
+  });
+});

--- a/apps/api/src/services/monitoring/email_recipients_sync.ts
+++ b/apps/api/src/services/monitoring/email_recipients_sync.ts
@@ -1,0 +1,120 @@
+import { logger as _logger } from "../../lib/logger";
+import { sendMonitoringConfirmationEmail } from "../notification/monitoring_email";
+import {
+  ensureMonitorEmailRecipient,
+  getTeamMemberEmails,
+  listMonitorEmailRecipients,
+  normalizeRecipientEmail,
+  type MonitorEmailRecipientRow,
+} from "./email_recipients";
+import type { MonitorRow } from "./types";
+
+const logger = _logger.child({ module: "monitor-email-recipients-sync" });
+
+export type SyncedRecipient = {
+  email: string;
+  status: MonitorEmailRecipientRow["status"];
+  source: MonitorEmailRecipientRow["source"];
+  confirmationEmailSent: boolean;
+  /** True if this row was created during this sync (vs. already existed). */
+  created: boolean;
+};
+
+export type SyncResult = {
+  recipients: SyncedRecipient[];
+};
+
+/**
+ * Reconcile the canonical list of `notification.email.recipients` for a
+ * monitor against the per-recipient subscription table.
+ *
+ * Rules:
+ * - Team-member emails are auto-confirmed (they already have dashboard access
+ *   to this monitor; making them click an opt-in link would be pure friction).
+ * - All other newly added emails start in `pending` and receive a one-time
+ *   confirmation email. They will not receive monitor alerts until they click
+ *   the confirm link.
+ * - Existing rows are left alone — once a recipient confirms or unsubscribes
+ *   that decision persists even if the monitor is edited and the recipient
+ *   is re-added.
+ *
+ * Recipients that were previously configured but are no longer in the list
+ * are not deleted; we keep the row so that a quick "remove then re-add"
+ * doesn't accidentally re-send a confirmation email to someone who already
+ * confirmed (or worse, undo an unsubscribe).
+ */
+export async function syncMonitorEmailRecipients(params: {
+  monitor: MonitorRow;
+}): Promise<SyncResult> {
+  const configured = params.monitor.notification?.email?.recipients ?? [];
+  const normalized = Array.from(
+    new Set(
+      configured
+        .map(normalizeRecipientEmail)
+        .filter(email => email.length > 0),
+    ),
+  );
+
+  if (normalized.length === 0) {
+    return { recipients: [] };
+  }
+
+  const [existingRows, teamMatches] = await Promise.all([
+    listMonitorEmailRecipients(params.monitor.id),
+    getTeamMemberEmails(params.monitor.team_id, normalized),
+  ]);
+  const existingByEmail = new Map(existingRows.map(r => [r.email, r]));
+
+  const results: SyncedRecipient[] = [];
+
+  for (const email of normalized) {
+    const existing = existingByEmail.get(email);
+    if (existing) {
+      results.push({
+        email: existing.email,
+        status: existing.status,
+        source: existing.source,
+        confirmationEmailSent: existing.confirmation_sent_at !== null,
+        created: false,
+      });
+      continue;
+    }
+
+    const isTeamMember = teamMatches.has(email);
+    const { row, created } = await ensureMonitorEmailRecipient({
+      monitorId: params.monitor.id,
+      teamId: params.monitor.team_id,
+      input: {
+        email,
+        source: isTeamMember ? "team" : "opt_in",
+        status: isTeamMember ? "confirmed" : "pending",
+      },
+    });
+
+    let confirmationEmailSent = false;
+    if (created && !isTeamMember && row.status === "pending") {
+      const sendResult = await sendMonitoringConfirmationEmail({
+        recipient: row,
+        monitorName: params.monitor.name,
+      }).catch(error => {
+        logger.warn("Confirmation email send threw", {
+          error,
+          recipientId: row.id,
+          monitorId: params.monitor.id,
+        });
+        return { attempted: true, success: false } as const;
+      });
+      confirmationEmailSent = sendResult.attempted && sendResult.success;
+    }
+
+    results.push({
+      email: row.email,
+      status: row.status,
+      source: row.source,
+      confirmationEmailSent,
+      created,
+    });
+  }
+
+  return { recipients: results };
+}

--- a/apps/api/src/services/monitoring/email_recipients_sync.ts
+++ b/apps/api/src/services/monitoring/email_recipients_sync.ts
@@ -16,7 +16,6 @@ export type SyncedRecipient = {
   status: MonitorEmailRecipientRow["status"];
   source: MonitorEmailRecipientRow["source"];
   confirmationEmailSent: boolean;
-  /** True if this row was created during this sync (vs. already existed). */
   created: boolean;
 };
 
@@ -24,25 +23,9 @@ export type SyncResult = {
   recipients: SyncedRecipient[];
 };
 
-/**
- * Reconcile the canonical list of `notification.email.recipients` for a
- * monitor against the per-recipient subscription table.
- *
- * Rules:
- * - Team-member emails are auto-confirmed (they already have dashboard access
- *   to this monitor; making them click an opt-in link would be pure friction).
- * - All other newly added emails start in `pending` and receive a one-time
- *   confirmation email. They will not receive monitor alerts until they click
- *   the confirm link.
- * - Existing rows are left alone — once a recipient confirms or unsubscribes
- *   that decision persists even if the monitor is edited and the recipient
- *   is re-added.
- *
- * Recipients that were previously configured but are no longer in the list
- * are not deleted; we keep the row so that a quick "remove then re-add"
- * doesn't accidentally re-send a confirmation email to someone who already
- * confirmed (or worse, undo an unsubscribe).
- */
+// Team members → auto-confirmed. External addresses → pending + confirmation
+// email. Existing rows are preserved (so a quick remove-then-re-add doesn't
+// undo a prior unsubscribe or re-send a confirmation).
 export async function syncMonitorEmailRecipients(params: {
   monitor: MonitorRow;
 }): Promise<SyncResult> {

--- a/apps/api/src/services/notification/monitoring_email.test.ts
+++ b/apps/api/src/services/notification/monitoring_email.test.ts
@@ -1,21 +1,87 @@
 jest.mock("../supabase", () => ({
   supabase_service: {},
+  supabase_rr_service: {},
 }));
 
+const mockEnsureRecipient = jest.fn();
+const mockListRecipients = jest.fn();
+const mockTouchNotified = jest.fn();
+const mockMarkConfirmationSent = jest.fn();
+
+jest.mock("../monitoring/email_recipients", () => {
+  const actual = jest.requireActual("../monitoring/email_recipients");
+  return {
+    ...actual,
+    ensureMonitorEmailRecipient: (...args: unknown[]) =>
+      mockEnsureRecipient(...args),
+    listMonitorEmailRecipients: (...args: unknown[]) =>
+      mockListRecipients(...args),
+    touchRecipientsNotified: (...args: unknown[]) => mockTouchNotified(...args),
+    markRecipientConfirmationSent: (...args: unknown[]) =>
+      mockMarkConfirmationSent(...args),
+  };
+});
+
+const mockResendSend = jest.fn();
 jest.mock("resend", () => ({
   Resend: jest.fn().mockImplementation(() => ({
-    emails: { send: jest.fn() },
+    emails: { send: mockResendSend },
   })),
 }));
 
 import {
+  buildConfirmationHtml,
   buildHtml,
   buildMonitoringCheckDashboardUrl,
+  buildRecipientConfirmationUrl,
+  buildRecipientUnsubscribeUrl,
+  sendMonitoringConfirmationEmail,
   sendMonitoringEmailSummary,
   type MonitoringEmailPayload,
 } from "./monitoring_email";
 
-describe("monitoring email", () => {
+beforeEach(() => {
+  mockEnsureRecipient.mockReset();
+  mockListRecipients.mockReset();
+  mockTouchNotified.mockReset();
+  mockMarkConfirmationSent.mockReset();
+  mockResendSend.mockReset();
+  mockResendSend.mockResolvedValue({ data: { id: "msg-1" }, error: null });
+  mockTouchNotified.mockResolvedValue(undefined);
+  mockMarkConfirmationSent.mockResolvedValue(undefined);
+  process.env.RESEND_API_KEY = "test-key";
+});
+
+afterAll(() => {
+  delete process.env.RESEND_API_KEY;
+});
+
+function fakeRecipient(
+  email: string,
+  status: "pending" | "confirmed" | "unsubscribed",
+  source: "team" | "opt_in" | "legacy" = "opt_in",
+) {
+  // URL-safe token (no need to worry about URL encoding in assertions).
+  const sanitized = email.replace(/[^a-z0-9]/gi, "");
+  return {
+    id: `rec-${sanitized}`,
+    monitor_id: "monitor-1",
+    team_id: "team-1",
+    email,
+    status,
+    token: `tok-${sanitized}`,
+    source,
+    confirmation_sent_at: status === "pending" ? new Date().toISOString() : null,
+    confirmed_at: status === "confirmed" ? new Date().toISOString() : null,
+    unsubscribed_at:
+      status === "unsubscribed" ? new Date().toISOString() : null,
+    last_notified_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+describe("monitoring email URLs", () => {
   it("builds a dashboard link for a monitor check", () => {
     expect(
       buildMonitoringCheckDashboardUrl(
@@ -30,7 +96,22 @@ describe("monitoring email", () => {
     );
   });
 
-  it("includes the dashboard check link in the email html", () => {
+  it("builds opt-in and unsubscribe URLs against the dashboard base", () => {
+    // The opt-in pages live in firecrawl-web; the page POSTs to the API on
+    // mount. That keeps Firecrawl branding consistent and stops passive
+    // link scanners from accidentally consuming GETs against the API.
+    const confirm = buildRecipientConfirmationUrl("abc123");
+    expect(confirm).toContain("/monitoring/email/confirm");
+    expect(confirm).not.toContain("/v2/");
+    expect(confirm).toContain("token=abc123");
+
+    const unsub = buildRecipientUnsubscribeUrl("abc123");
+    expect(unsub).toContain("/monitoring/email/unsubscribe");
+    expect(unsub).not.toContain("/v2/");
+    expect(unsub).toContain("token=abc123");
+  });
+
+  it("includes the dashboard check link and unsubscribe footer in the email html", () => {
     const dashboardUrl = buildMonitoringCheckDashboardUrl(
       {
         monitorId: "monitor-1",
@@ -57,55 +138,146 @@ describe("monitoring email", () => {
         },
       ],
       creditsUsed: 1,
+      unsubscribeUrl:
+        "https://www.firecrawl.dev/monitoring/email/unsubscribe?token=tok123",
     };
 
-    expect(buildHtml(payload)).toContain(
+    const html = buildHtml(payload);
+    expect(html).toContain(
       `<a href="${dashboardUrl}">View this check in the dashboard</a>`,
     );
+    expect(html).toContain(
+      "https://www.firecrawl.dev/monitoring/email/unsubscribe?token=tok123",
+    );
+    expect(html).toContain("Unsubscribe from this monitor");
   });
 
-  describe("sendMonitoringEmailSummary — judgment gating", () => {
-    function buildArgs(opts: {
-      goal?: string | null;
-      emailEnabled?: boolean;
-      pages: Array<{
-        status: string;
-        meaningful?: boolean | null;
-      }>;
-    }) {
-      return {
-        monitor: {
-          id: "monitor-1",
-          team_id: "team-1",
-          name: "Test",
-          goal: opts.goal ?? null,
-          judge_enabled: Boolean(opts.goal),
-          notification: opts.emailEnabled
-            ? { email: { enabled: true, recipients: ["a@b.com"] } }
-            : null,
-        } as any,
-        check: {
-          id: "check-1",
-          changed_count: opts.pages.filter(p => p.status === "changed").length,
-          new_count: opts.pages.filter(p => p.status === "new").length,
-          removed_count: opts.pages.filter(p => p.status === "removed").length,
-          error_count: opts.pages.filter(p => p.status === "error").length,
-        } as any,
-        pages: opts.pages.map((p, i) => ({
-          url: `https://example.com/${i}`,
-          status: p.status,
-          judgment:
-            p.meaningful === null || p.meaningful === undefined
-              ? null
-              : {
-                  meaningful: p.meaningful,
-                  confidence: "high" as const,
-                  reason: "test",
-                  fields: [],
-                },
-        })),
-      };
-    }
+  it("omits the unsubscribe footer when no unsubscribe URL is provided", () => {
+    const html = buildHtml({
+      monitorId: "m1",
+      monitorName: "M",
+      checkId: "c1",
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      summary: { changed: 0, new: 1, removed: 0, error: 0, totalPages: 1 },
+      pages: [{ url: "https://example.com", status: "new" }],
+      creditsUsed: 1,
+    });
+    expect(html).not.toContain("Unsubscribe from this monitor");
+  });
+});
+
+describe("buildConfirmationHtml", () => {
+  it("renders a confirm CTA and a fallback unsubscribe link", () => {
+    const html = buildConfirmationHtml({
+      monitorName: "Marketing site",
+      recipientEmail: "alerts@example.com",
+      confirmUrl:
+        "https://www.firecrawl.dev/monitoring/email/confirm?token=tok1",
+      unsubscribeUrl:
+        "https://www.firecrawl.dev/monitoring/email/unsubscribe?token=tok1",
+    });
+    expect(html).toContain("Confirm subscription");
+    expect(html).toContain("Marketing site");
+    expect(html).toContain("alerts@example.com");
+    expect(html).toContain("token=tok1");
+  });
+
+  it("escapes HTML in recipient and monitor names", () => {
+    const html = buildConfirmationHtml({
+      monitorName: "<script>x</script>",
+      recipientEmail: "a@b.com",
+      confirmUrl: "https://example.com/c?token=t",
+      unsubscribeUrl: "https://example.com/u?token=t",
+    });
+    expect(html).not.toContain("<script>x</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("sendMonitoringConfirmationEmail", () => {
+  it("sends a Resend email and marks confirmation_sent_at", async () => {
+    const result = await sendMonitoringConfirmationEmail({
+      recipient: fakeRecipient("new@example.com", "pending"),
+      monitorName: "My monitor",
+    });
+    expect(result).toEqual({ attempted: true, success: true });
+    expect(mockResendSend).toHaveBeenCalledTimes(1);
+    expect(mockResendSend.mock.calls[0][0].to).toBe("new@example.com");
+    expect(mockResendSend.mock.calls[0][0].subject).toContain(
+      'Confirm subscription',
+    );
+    expect(mockMarkConfirmationSent).toHaveBeenCalledWith("rec-newexamplecom");
+  });
+
+  it("returns failure if Resend reports an error", async () => {
+    mockResendSend.mockResolvedValueOnce({ data: null, error: "boom" });
+    const result = await sendMonitoringConfirmationEmail({
+      recipient: fakeRecipient("new@example.com", "pending"),
+      monitorName: "My monitor",
+    });
+    expect(result.attempted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(mockMarkConfirmationSent).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendMonitoringEmailSummary", () => {
+  function buildArgs(opts: {
+    goal?: string | null;
+    emailEnabled?: boolean;
+    recipients?: string[];
+    pages: Array<{
+      status: string;
+      meaningful?: boolean | null;
+    }>;
+  }) {
+    return {
+      monitor: {
+        id: "monitor-1",
+        team_id: "team-1",
+        name: "Test",
+        goal: opts.goal ?? null,
+        judge_enabled: Boolean(opts.goal),
+        notification: opts.emailEnabled
+          ? {
+              email: {
+                enabled: true,
+                recipients: opts.recipients ?? ["a@b.com"],
+              },
+            }
+          : null,
+      } as any,
+      check: {
+        id: "check-1",
+        changed_count: opts.pages.filter(p => p.status === "changed").length,
+        new_count: opts.pages.filter(p => p.status === "new").length,
+        removed_count: opts.pages.filter(p => p.status === "removed").length,
+        error_count: opts.pages.filter(p => p.status === "error").length,
+      } as any,
+      pages: opts.pages.map((p, i) => ({
+        url: `https://example.com/${i}`,
+        status: p.status,
+        judgment:
+          p.meaningful === null || p.meaningful === undefined
+            ? null
+            : {
+                meaningful: p.meaningful,
+                confidence: "high" as const,
+                reason: "test",
+                fields: [],
+              },
+      })),
+    };
+  }
+
+  describe("judgment gating", () => {
+    beforeEach(() => {
+      // Default: one confirmed recipient so judgment gating tests assert the
+      // judgment logic rather than recipient filtering.
+      mockListRecipients.mockResolvedValue([
+        fakeRecipient("a@b.com", "confirmed"),
+      ]);
+    });
 
     it("suppresses email when goal set and all changed pages are noise", async () => {
       const result = await sendMonitoringEmailSummary(
@@ -180,6 +352,119 @@ describe("monitoring email", () => {
       (args.check as any).changed_count = 50;
       const result = await sendMonitoringEmailSummary(args);
       expect(result.attempted).toBe(true);
+    });
+  });
+
+  describe("opt-in gating", () => {
+    it("skips entirely when no recipients have confirmed", async () => {
+      mockListRecipients.mockResolvedValue([
+        fakeRecipient("a@b.com", "pending"),
+      ]);
+      const result = await sendMonitoringEmailSummary(
+        buildArgs({
+          emailEnabled: true,
+          recipients: ["a@b.com"],
+          pages: [{ status: "changed" }],
+        }),
+      );
+      expect(result.attempted).toBe(false);
+      expect(result.recipients).toEqual([]);
+      expect(result.pendingRecipients).toBe(1);
+      expect(mockResendSend).not.toHaveBeenCalled();
+    });
+
+    it("skips unsubscribed recipients but emails confirmed ones", async () => {
+      mockListRecipients.mockResolvedValue([
+        fakeRecipient("good@example.com", "confirmed"),
+        fakeRecipient("blocked@example.com", "unsubscribed"),
+      ]);
+      const result = await sendMonitoringEmailSummary(
+        buildArgs({
+          emailEnabled: true,
+          recipients: ["good@example.com", "blocked@example.com"],
+          pages: [{ status: "changed" }],
+        }),
+      );
+      expect(result.attempted).toBe(true);
+      expect(result.recipients).toEqual(["good@example.com"]);
+      expect(result.unsubscribedRecipients).toBe(1);
+      expect(mockResendSend).toHaveBeenCalledTimes(1);
+      expect(mockResendSend.mock.calls[0][0].to).toBe("good@example.com");
+    });
+
+    it("sends one email per recipient with a unique unsubscribe link", async () => {
+      mockListRecipients.mockResolvedValue([
+        fakeRecipient("a@example.com", "confirmed"),
+        fakeRecipient("b@example.com", "confirmed"),
+      ]);
+      const result = await sendMonitoringEmailSummary(
+        buildArgs({
+          emailEnabled: true,
+          recipients: ["a@example.com", "b@example.com"],
+          pages: [{ status: "changed" }],
+        }),
+      );
+      expect(result.attempted).toBe(true);
+      expect(mockResendSend).toHaveBeenCalledTimes(2);
+      const calls = mockResendSend.mock.calls.map(c => c[0]);
+      const aCall = calls.find(c => c.to === "a@example.com");
+      const bCall = calls.find(c => c.to === "b@example.com");
+      expect(aCall.html).toContain("token=tok-aexamplecom");
+      expect(bCall.html).toContain("token=tok-bexamplecom");
+      expect(aCall.html).not.toContain("token=tok-bexamplecom");
+      expect(mockTouchNotified).toHaveBeenCalledWith([
+        "rec-aexamplecom",
+        "rec-bexamplecom",
+      ]);
+    });
+
+    it("bootstraps legacy monitors when recipient rows are entirely missing", async () => {
+      // No DB backfill path: explicit recipients on old monitors have zero
+      // rows. First send lazily creates confirmed 'legacy' rows so delivery
+      // keeps working without manual re-save.
+      mockListRecipients.mockResolvedValue([]);
+      mockEnsureRecipient.mockResolvedValue({
+        created: true,
+        row: fakeRecipient("unknown@example.com", "confirmed", "legacy"),
+      });
+
+      const result = await sendMonitoringEmailSummary(
+        buildArgs({
+          emailEnabled: true,
+          recipients: ["unknown@example.com"],
+          pages: [{ status: "changed" }],
+        }),
+      );
+      expect(result.attempted).toBe(true);
+      expect(result.recipients).toEqual(["unknown@example.com"]);
+      expect(mockEnsureRecipient).toHaveBeenCalledWith({
+        monitorId: "monitor-1",
+        teamId: "team-1",
+        input: {
+          email: "unknown@example.com",
+          source: "legacy",
+          status: "confirmed",
+        },
+      });
+    });
+
+    it("treats missing recipients as pending when rows are partially present", async () => {
+      // If a monitor already has some rows, we keep strict gating for any
+      // missing addresses rather than auto-confirming.
+      mockListRecipients.mockResolvedValue([
+        fakeRecipient("known@example.com", "confirmed"),
+      ]);
+      const result = await sendMonitoringEmailSummary(
+        buildArgs({
+          emailEnabled: true,
+          recipients: ["known@example.com", "unknown@example.com"],
+          pages: [{ status: "changed" }],
+        }),
+      );
+      expect(result.attempted).toBe(true);
+      expect(result.recipients).toEqual(["known@example.com"]);
+      expect(result.pendingRecipients).toBe(1);
+      expect(mockEnsureRecipient).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/services/notification/monitoring_email.test.ts
+++ b/apps/api/src/services/notification/monitoring_email.test.ts
@@ -61,7 +61,6 @@ function fakeRecipient(
   status: "pending" | "confirmed" | "unsubscribed",
   source: "team" | "opt_in" | "legacy" = "opt_in",
 ) {
-  // URL-safe token (no need to worry about URL encoding in assertions).
   const sanitized = email.replace(/[^a-z0-9]/gi, "");
   return {
     id: `rec-${sanitized}`,
@@ -97,9 +96,6 @@ describe("monitoring email URLs", () => {
   });
 
   it("builds opt-in and unsubscribe URLs against the dashboard base", () => {
-    // The opt-in pages live in firecrawl-web; the page POSTs to the API on
-    // mount. That keeps Firecrawl branding consistent and stops passive
-    // link scanners from accidentally consuming GETs against the API.
     const confirm = buildRecipientConfirmationUrl("abc123");
     expect(confirm).toContain("/monitoring/email/confirm");
     expect(confirm).not.toContain("/v2/");
@@ -272,8 +268,6 @@ describe("sendMonitoringEmailSummary", () => {
 
   describe("judgment gating", () => {
     beforeEach(() => {
-      // Default: one confirmed recipient so judgment gating tests assert the
-      // judgment logic rather than recipient filtering.
       mockListRecipients.mockResolvedValue([
         fakeRecipient("a@b.com", "confirmed"),
       ]);
@@ -419,9 +413,6 @@ describe("sendMonitoringEmailSummary", () => {
     });
 
     it("bootstraps legacy monitors when recipient rows are entirely missing", async () => {
-      // No DB backfill path: explicit recipients on old monitors have zero
-      // rows. First send lazily creates confirmed 'legacy' rows so delivery
-      // keeps working without manual re-save.
       mockListRecipients.mockResolvedValue([]);
       mockEnsureRecipient.mockResolvedValue({
         created: true,
@@ -449,8 +440,6 @@ describe("sendMonitoringEmailSummary", () => {
     });
 
     it("treats missing recipients as pending when rows are partially present", async () => {
-      // If a monitor already has some rows, we keep strict gating for any
-      // missing addresses rather than auto-confirming.
       mockListRecipients.mockResolvedValue([
         fakeRecipient("known@example.com", "confirmed"),
       ]);

--- a/apps/api/src/services/notification/monitoring_email.ts
+++ b/apps/api/src/services/notification/monitoring_email.ts
@@ -4,8 +4,19 @@ import { config } from "../../config";
 import { logger as _logger } from "../../lib/logger";
 import { supabase_service } from "../supabase";
 import type { MonitorCheckRow, MonitorRow } from "../monitoring/types";
+import {
+  ensureMonitorEmailRecipient,
+  listMonitorEmailRecipients,
+  markRecipientConfirmationSent,
+  normalizeRecipientEmail,
+  touchRecipientsNotified,
+  type MonitorEmailRecipientRow,
+} from "../monitoring/email_recipients";
 
 const logger = _logger.child({ module: "monitoring-email" });
+
+const FROM_ADDRESS = "Firecrawl <notifications@notifications.firecrawl.dev>";
+const REPLY_TO_ADDRESS = "help@firecrawl.com";
 
 type MonitoringEmailPage = {
   url: string;
@@ -72,6 +83,11 @@ export type MonitoringEmailPayload = {
   };
   pages: MonitoringEmailPage[];
   creditsUsed: number | null;
+  /**
+   * Per-recipient unsubscribe link. When omitted (e.g. legacy callers or
+   * preview tooling), the email footer omits the unsubscribe row.
+   */
+  unsubscribeUrl?: string;
 };
 
 async function getTeamEmails(teamId: string): Promise<string[]> {
@@ -120,6 +136,35 @@ export function buildMonitoringCheckDashboardUrl(
   );
   url.searchParams.set("checkId", params.checkId);
   return url.toString();
+}
+
+function buildPublicWebUrl(path: string, token: string): string {
+  const base = config.FIRECRAWL_DASHBOARD_URL.trim();
+  const url = new URL(path, base);
+  url.searchParams.set("token", token);
+  return url.toString();
+}
+
+// Email opt-in links land on the firecrawl-web public pages, not the API.
+// The page POSTs the token to the API on mount and renders a branded result
+// using the design system — keeps Firecrawl branding consistent and avoids
+// passive link scanners (Outlook Safe Links, etc.) consuming GETs against
+// the API.
+export function buildRecipientConfirmationUrl(token: string): string {
+  return buildPublicWebUrl("/monitoring/email/confirm", token);
+}
+
+export function buildRecipientUnsubscribeUrl(token: string): string {
+  return buildPublicWebUrl("/monitoring/email/unsubscribe", token);
+}
+
+function buildUnsubscribeFooter(unsubscribeUrl: string): string {
+  const safe = escapeHtml(unsubscribeUrl);
+  return `<hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0 12px;" />
+<p style="color:#6b7280;font-size:12px;line-height:1.6;margin:0;">
+You're receiving this because you opted in to Firecrawl monitor alerts at this address.
+<a href="${safe}" style="color:#6b7280;text-decoration:underline;">Unsubscribe from this monitor</a>.
+</p>`;
 }
 
 export function buildHtml(payload: MonitoringEmailPayload): string {
@@ -179,7 +224,225 @@ ${pageItems ? `<p>Top pages:</p><ul>${pageItems}</ul>` : ""}
 <p><a href="${dashboardUrl}">View this check in the dashboard</a></p>
 <p>Check ID: <code>${escapeHtml(payload.checkId)}</code></p>
 <p>Credits used: ${payload.creditsUsed ?? "unknown"}</p>
+<br/>Thanks,<br/>Firecrawl Team<br/>
+${payload.unsubscribeUrl ? buildUnsubscribeFooter(payload.unsubscribeUrl) : ""}`;
+}
+
+export function buildConfirmationHtml(params: {
+  monitorName: string;
+  recipientEmail: string;
+  confirmUrl: string;
+  unsubscribeUrl: string;
+}): string {
+  const monitorName = escapeHtml(params.monitorName);
+  const recipientEmail = escapeHtml(params.recipientEmail);
+  const confirmUrl = escapeHtml(params.confirmUrl);
+  const unsubscribeUrl = escapeHtml(params.unsubscribeUrl);
+
+  return `Hey there,<br/>
+<p>A Firecrawl user added <strong>${recipientEmail}</strong> as a notification recipient for the monitor <strong>${monitorName}</strong>.</p>
+<p>If you'd like to receive change-detection emails for this monitor, please confirm:</p>
+<p style="margin:24px 0;">
+  <a href="${confirmUrl}"
+     style="display:inline-block;padding:10px 18px;background:#fa5d19;color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;">
+    Confirm subscription
+  </a>
+</p>
+<p style="color:#6b7280;font-size:13px;line-height:1.6;">
+  If that button doesn't work, copy and paste this link into your browser:<br/>
+  <a href="${confirmUrl}" style="color:#fa5d19;word-break:break-all;">${confirmUrl}</a>
+</p>
+<p style="color:#6b7280;font-size:13px;line-height:1.6;">
+  You will not receive any monitor notifications at this address until you click the link above. If you didn't expect this email you can safely ignore it, or
+  <a href="${unsubscribeUrl}" style="color:#6b7280;text-decoration:underline;">block all future emails from this monitor</a>.
+</p>
 <br/>Thanks,<br/>Firecrawl Team<br/>`;
+}
+
+function getResendClient(): Resend | null {
+  const key = config.RESEND_API_KEY?.trim();
+  if (!key) return null;
+  return new Resend(key);
+}
+
+/**
+ * Send the one-time confirmation email to a freshly added external recipient.
+ * Safe to call multiple times — we keep `confirmation_sent_at` up to date but
+ * the recipient row is idempotent.
+ */
+export async function sendMonitoringConfirmationEmail(params: {
+  recipient: MonitorEmailRecipientRow;
+  monitorName: string;
+}): Promise<{ attempted: boolean; success: boolean; error?: string }> {
+  const resend = getResendClient();
+  if (!resend) {
+    logger.warn(
+      "Skipping monitor opt-in email; RESEND_API_KEY is not set",
+      {
+        monitorId: params.recipient.monitor_id,
+        recipientId: params.recipient.id,
+      },
+    );
+    return { attempted: false, success: true };
+  }
+
+  const confirmUrl = buildRecipientConfirmationUrl(params.recipient.token);
+  const unsubscribeUrl = buildRecipientUnsubscribeUrl(params.recipient.token);
+  const html = buildConfirmationHtml({
+    monitorName: params.monitorName,
+    recipientEmail: params.recipient.email,
+    confirmUrl,
+    unsubscribeUrl,
+  });
+
+  try {
+    const { error } = await resend.emails.send({
+      from: FROM_ADDRESS,
+      to: params.recipient.email,
+      reply_to: REPLY_TO_ADDRESS,
+      subject: `Confirm subscription: Firecrawl monitor "${params.monitorName}"`,
+      html,
+    });
+
+    if (error) {
+      logger.warn("Failed to send monitor confirmation email", {
+        error,
+        recipientId: params.recipient.id,
+        monitorId: params.recipient.monitor_id,
+      });
+      return {
+        attempted: true,
+        success: false,
+        error: typeof error === "string" ? error : JSON.stringify(error),
+      };
+    }
+
+    await markRecipientConfirmationSent(params.recipient.id);
+    logger.info("Sent monitor confirmation email", {
+      recipientId: params.recipient.id,
+      monitorId: params.recipient.monitor_id,
+    });
+    return { attempted: true, success: true };
+  } catch (error) {
+    logger.warn("Exception sending monitor confirmation email", {
+      error,
+      recipientId: params.recipient.id,
+    });
+    return {
+      attempted: true,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+type ResolvedRecipients = {
+  confirmedRecipients: MonitorEmailRecipientRow[];
+  pending: number;
+  unsubscribed: number;
+  total: number;
+};
+
+async function resolveSendableRecipients(
+  monitor: MonitorRow,
+): Promise<ResolvedRecipients> {
+  const configEmail = monitor.notification?.email;
+  const explicitConfigured = Array.isArray(configEmail?.recipients)
+    ? (configEmail!.recipients as string[])
+        .map(normalizeRecipientEmail)
+        .filter(Boolean)
+    : [];
+
+  if (explicitConfigured.length > 0) {
+    let rows = await listMonitorEmailRecipients(monitor.id);
+
+    // No DB backfill path: lazily bootstrap legacy monitors the first time
+    // they attempt to send after this feature rolls out.
+    //
+    // Why only when rows.length === 0?
+    // - Existing monitors created pre-rollout have no recipient rows at all.
+    // - New/updated monitors run through sync on create/update and should
+    //   already have rows. If a monitor has partial rows, we keep strict
+    //   gating for any missing addresses (pending) instead of auto-confirming.
+    if (rows.length === 0) {
+      const legacyRows = await Promise.all(
+        explicitConfigured.map(async email => {
+          const { row } = await ensureMonitorEmailRecipient({
+            monitorId: monitor.id,
+            teamId: monitor.team_id,
+            input: {
+              email,
+              source: "legacy",
+              status: "confirmed",
+            },
+          });
+          return row;
+        }),
+      );
+      rows = legacyRows;
+      logger.info("Bootstrapped legacy monitor recipients without DB backfill", {
+        monitorId: monitor.id,
+        recipients: explicitConfigured,
+      });
+    }
+
+    const rowsByEmail = new Map(rows.map(r => [r.email, r]));
+
+    const confirmedRecipients: MonitorEmailRecipientRow[] = [];
+    let pending = 0;
+    let unsubscribed = 0;
+
+    for (const email of explicitConfigured) {
+      const row = rowsByEmail.get(email);
+      if (!row) {
+        // Row missing entirely — runner sees a recipient the controller
+        // never reconciled (e.g. data inserted directly into JSONB). Treat
+        // as pending so we never send to it without an opt-in record.
+        pending += 1;
+        continue;
+      }
+      if (row.status === "confirmed") {
+        confirmedRecipients.push(row);
+      } else if (row.status === "unsubscribed") {
+        unsubscribed += 1;
+      } else {
+        pending += 1;
+      }
+    }
+
+    return {
+      confirmedRecipients,
+      pending,
+      unsubscribed,
+      total: explicitConfigured.length,
+    };
+  }
+
+  // No explicit recipients configured -> fall back to team members. Team
+  // members are implicitly confirmed (they have dashboard access already).
+  // We still respect their global notification_preferences via getTeamEmails.
+  const teamEmails = await getTeamEmails(monitor.team_id);
+  const syntheticRows: MonitorEmailRecipientRow[] = await Promise.all(
+    teamEmails.map(async email => {
+      const { row } = await ensureMonitorEmailRecipient({
+        monitorId: monitor.id,
+        teamId: monitor.team_id,
+        input: {
+          email,
+          source: "team",
+          status: "confirmed",
+        },
+      });
+      return row;
+    }),
+  );
+
+  return {
+    confirmedRecipients: syntheticRows.filter(r => r.status === "confirmed"),
+    pending: 0,
+    unsubscribed: syntheticRows.filter(r => r.status === "unsubscribed").length,
+    total: teamEmails.length,
+  };
 }
 
 export async function sendMonitoringEmailSummary(params: {
@@ -190,6 +453,8 @@ export async function sendMonitoringEmailSummary(params: {
   attempted: boolean;
   success: boolean;
   recipients: string[];
+  pendingRecipients?: number;
+  unsubscribedRecipients?: number;
   error?: string;
 }> {
   const configEmail = params.monitor.notification?.email;
@@ -264,91 +529,149 @@ export async function sendMonitoringEmailSummary(params: {
     }
   }
 
-  const explicitRecipients = configEmail.recipients ?? [];
-  const teamRecipients =
-    explicitRecipients.length > 0
-      ? []
-      : await getTeamEmails(params.monitor.team_id);
-  const recipients = [...new Set([...explicitRecipients, ...teamRecipients])];
-  if (recipients.length === 0) {
-    logger.info("Skipping monitoring email summary; no recipients configured", {
-      monitorId: params.monitor.id,
-      checkId: params.check.id,
-    });
-    return { attempted: false, success: true, recipients };
+  const resolved = await resolveSendableRecipients(params.monitor);
+  if (resolved.confirmedRecipients.length === 0) {
+    logger.info(
+      "Skipping monitoring email summary; no confirmed recipients",
+      {
+        monitorId: params.monitor.id,
+        checkId: params.check.id,
+        configured: resolved.total,
+        pending: resolved.pending,
+        unsubscribed: resolved.unsubscribed,
+      },
+    );
+    return {
+      attempted: false,
+      success: true,
+      recipients: [],
+      pendingRecipients: resolved.pending,
+      unsubscribedRecipients: resolved.unsubscribed,
+    };
   }
 
-  const resendApiKey = config.RESEND_API_KEY?.trim();
-  if (!resendApiKey) {
+  const resend = getResendClient();
+  if (!resend) {
     logger.warn(
       "Skipping monitoring email summary; RESEND_API_KEY is not set",
       {
         monitorId: params.monitor.id,
         checkId: params.check.id,
-        recipients,
+        recipients: resolved.confirmedRecipients.map(r => r.email),
       },
     );
-    return { attempted: false, success: true, recipients };
+    return {
+      attempted: false,
+      success: true,
+      recipients: resolved.confirmedRecipients.map(r => r.email),
+      pendingRecipients: resolved.pending,
+      unsubscribedRecipients: resolved.unsubscribed,
+    };
   }
 
-  const payload: MonitoringEmailPayload = {
+  const dashboardUrl = buildMonitoringCheckDashboardUrl({
     monitorId: params.monitor.id,
-    monitorName: params.monitor.name,
     checkId: params.check.id,
-    dashboardUrl: buildMonitoringCheckDashboardUrl({
-      monitorId: params.monitor.id,
-      checkId: params.check.id,
-    }),
-    summary: {
-      changed: params.check.changed_count,
-      new: params.check.new_count,
-      removed: params.check.removed_count,
-      error: params.check.error_count,
-      totalPages: params.check.total_pages,
-    },
-    pages: params.pages,
-    creditsUsed: params.check.actual_credits,
-  };
+  });
 
-  const resend = new Resend(resendApiKey);
-  try {
-    const { error } = await resend.emails.send({
-      from: "Firecrawl <notifications@notifications.firecrawl.dev>",
-      to: recipients,
-      reply_to: "help@firecrawl.com",
-      subject: `Monitor changes detected: ${params.monitor.name}`,
-      html: buildHtml(payload),
-    });
-
-    if (error) {
-      logger.warn("Monitoring email summary send failed", {
+  // Send one email per recipient so each gets a unique unsubscribe link.
+  // This avoids exposing the entire recipient list (BCC privacy) and lets
+  // each recipient opt out independently without touching the others.
+  const sendResults = await Promise.all(
+    resolved.confirmedRecipients.map(async recipient => {
+      const payload: MonitoringEmailPayload = {
         monitorId: params.monitor.id,
+        monitorName: params.monitor.name,
         checkId: params.check.id,
-        recipients,
-        error,
-      });
-      return {
-        attempted: true,
-        success: false,
-        recipients,
-        error: typeof error === "string" ? error : JSON.stringify(error),
+        dashboardUrl,
+        summary: {
+          changed: params.check.changed_count,
+          new: params.check.new_count,
+          removed: params.check.removed_count,
+          error: params.check.error_count,
+          totalPages: params.check.total_pages,
+        },
+        pages: params.pages,
+        creditsUsed: params.check.actual_credits,
+        unsubscribeUrl: buildRecipientUnsubscribeUrl(recipient.token),
       };
-    }
 
-    logger.info("Monitoring email summary sent", {
+      try {
+        const { error } = await resend.emails.send({
+          from: FROM_ADDRESS,
+          to: recipient.email,
+          reply_to: REPLY_TO_ADDRESS,
+          subject: `Monitor changes detected: ${params.monitor.name}`,
+          html: buildHtml(payload),
+        });
+        if (error) {
+          return {
+            recipient,
+            success: false,
+            error:
+              typeof error === "string" ? error : JSON.stringify(error),
+          };
+        }
+        return { recipient, success: true };
+      } catch (error) {
+        return {
+          recipient,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+
+  const succeededIds = sendResults
+    .filter(r => r.success)
+    .map(r => r.recipient.id);
+  const failures = sendResults.filter(r => !r.success);
+  const allRecipientEmails = resolved.confirmedRecipients.map(r => r.email);
+
+  if (succeededIds.length > 0) {
+    await touchRecipientsNotified(succeededIds);
+  }
+
+  if (failures.length === allRecipientEmails.length) {
+    const errorSummary = failures
+      .map(f => `${f.recipient.email}: ${f.error}`)
+      .join("; ");
+    logger.warn("Monitor email summary failed for all recipients", {
       monitorId: params.monitor.id,
       checkId: params.check.id,
-      recipients,
+      failures: errorSummary,
     });
-
-    return { attempted: true, success: true, recipients };
-  } catch (error) {
-    logger.warn("Failed to send monitoring email summary", { error });
     return {
       attempted: true,
       success: false,
-      recipients,
-      error: error instanceof Error ? error.message : String(error),
+      recipients: allRecipientEmails,
+      pendingRecipients: resolved.pending,
+      unsubscribedRecipients: resolved.unsubscribed,
+      error: errorSummary,
     };
   }
+
+  if (failures.length > 0) {
+    logger.warn("Monitor email summary partially failed", {
+      monitorId: params.monitor.id,
+      checkId: params.check.id,
+      delivered: succeededIds.length,
+      failed: failures.length,
+    });
+  } else {
+    logger.info("Monitor email summary sent", {
+      monitorId: params.monitor.id,
+      checkId: params.check.id,
+      recipients: allRecipientEmails,
+    });
+  }
+
+  return {
+    attempted: true,
+    success: true,
+    recipients: allRecipientEmails,
+    pendingRecipients: resolved.pending,
+    unsubscribedRecipients: resolved.unsubscribed,
+  };
 }

--- a/apps/api/src/services/notification/monitoring_email.ts
+++ b/apps/api/src/services/notification/monitoring_email.ts
@@ -83,10 +83,7 @@ export type MonitoringEmailPayload = {
   };
   pages: MonitoringEmailPage[];
   creditsUsed: number | null;
-  /**
-   * Per-recipient unsubscribe link. When omitted (e.g. legacy callers or
-   * preview tooling), the email footer omits the unsubscribe row.
-   */
+  // When omitted, the footer drops the unsubscribe row.
   unsubscribeUrl?: string;
 };
 
@@ -145,11 +142,9 @@ function buildPublicWebUrl(path: string, token: string): string {
   return url.toString();
 }
 
-// Email opt-in links land on the firecrawl-web public pages, not the API.
-// The page POSTs the token to the API on mount and renders a branded result
-// using the design system — keeps Firecrawl branding consistent and avoids
-// passive link scanners (Outlook Safe Links, etc.) consuming GETs against
-// the API.
+// Email links land on the firecrawl-web pages, which POST the token to the
+// API. Keeps branding consistent and stops passive link scanners (Outlook
+// Safe Links, etc.) from accidentally consuming tokens with bare GETs.
 export function buildRecipientConfirmationUrl(token: string): string {
   return buildPublicWebUrl("/monitoring/email/confirm", token);
 }
@@ -265,11 +260,6 @@ function getResendClient(): Resend | null {
   return new Resend(key);
 }
 
-/**
- * Send the one-time confirmation email to a freshly added external recipient.
- * Safe to call multiple times — we keep `confirmation_sent_at` up to date but
- * the recipient row is idempotent.
- */
 export async function sendMonitoringConfirmationEmail(params: {
   recipient: MonitorEmailRecipientRow;
   monitorName: string;
@@ -356,14 +346,10 @@ async function resolveSendableRecipients(
   if (explicitConfigured.length > 0) {
     let rows = await listMonitorEmailRecipients(monitor.id);
 
-    // No DB backfill path: lazily bootstrap legacy monitors the first time
-    // they attempt to send after this feature rolls out.
-    //
-    // Why only when rows.length === 0?
-    // - Existing monitors created pre-rollout have no recipient rows at all.
-    // - New/updated monitors run through sync on create/update and should
-    //   already have rows. If a monitor has partial rows, we keep strict
-    //   gating for any missing addresses (pending) instead of auto-confirming.
+    // Legacy monitors (configured pre-opt-in) have zero rows; bootstrap them
+    // as confirmed so existing alerts keep flowing without a DB backfill.
+    // Partial-row monitors keep strict gating — missing addresses stay
+    // pending rather than getting auto-confirmed.
     if (rows.length === 0) {
       const legacyRows = await Promise.all(
         explicitConfigured.map(async email => {
@@ -395,9 +381,8 @@ async function resolveSendableRecipients(
     for (const email of explicitConfigured) {
       const row = rowsByEmail.get(email);
       if (!row) {
-        // Row missing entirely — runner sees a recipient the controller
-        // never reconciled (e.g. data inserted directly into JSONB). Treat
-        // as pending so we never send to it without an opt-in record.
+        // Recipient appears in JSONB but has no opt-in row — treat as
+        // pending so we never send without an explicit record.
         pending += 1;
         continue;
       }
@@ -418,9 +403,8 @@ async function resolveSendableRecipients(
     };
   }
 
-  // No explicit recipients configured -> fall back to team members. Team
-  // members are implicitly confirmed (they have dashboard access already).
-  // We still respect their global notification_preferences via getTeamEmails.
+  // Fallback: team members (auto-confirmed; getTeamEmails still applies
+  // their global notification_preferences).
   const teamEmails = await getTeamEmails(monitor.team_id);
   const syntheticRows: MonitorEmailRecipientRow[] = await Promise.all(
     teamEmails.map(async email => {
@@ -487,9 +471,8 @@ export async function sendMonitoringEmailSummary(params: {
     return { attempted: false, success: true, recipients: [] };
   }
 
-  // Caller may pass a paginated subset; only trust the judgment-based
-  // suppression when changedPages covers the full changed_count. A missed
-  // meaningful alert is worse than an extra noisy email.
+  // Trust judgment-based suppression only when the changed page list is
+  // complete (a missed meaningful alert is worse than a noisy one).
   if (params.monitor.judge_enabled && params.monitor.goal) {
     const changedPages = params.pages.filter(p => p.status === "changed");
     const nonChangedActivity = params.pages.some(
@@ -574,9 +557,7 @@ export async function sendMonitoringEmailSummary(params: {
     checkId: params.check.id,
   });
 
-  // Send one email per recipient so each gets a unique unsubscribe link.
-  // This avoids exposing the entire recipient list (BCC privacy) and lets
-  // each recipient opt out independently without touching the others.
+  // One email per recipient: unique unsubscribe links + no recipient leakage.
   const sendResults = await Promise.all(
     resolved.confirmedRecipients.map(async recipient => {
       const payload: MonitoringEmailPayload = {

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -660,6 +660,25 @@ export interface MonitorEmailNotification {
   includeDiffs?: boolean;
 }
 
+/**
+ * Per-recipient opt-in state for monitor email notifications.
+ *
+ * External recipients (not members of the team that owns the monitor) must
+ * confirm their subscription via a one-time email before they receive any
+ * monitor notifications. Team members are auto-confirmed.
+ *
+ * - `pending`      → confirmation email sent, no notifications yet
+ * - `confirmed`    → notifications enabled
+ * - `unsubscribed` → recipient opted out and cannot be re-added without a new
+ *                    confirmation flow
+ */
+export interface MonitorEmailRecipientSubscription {
+  email: string;
+  status: "pending" | "confirmed" | "unsubscribed";
+  source: "team" | "opt_in" | "legacy";
+  confirmationEmailSent?: boolean;
+}
+
 export interface MonitorNotification {
   email?: MonitorEmailNotification;
 }
@@ -731,6 +750,13 @@ export interface Monitor {
   targets: MonitorTarget[];
   webhook?: MonitorWebhookConfig | null;
   notification?: MonitorNotification | null;
+  /**
+   * Present on create/update/get responses. Reflects the opt-in state of every
+   * email recipient currently configured on the monitor. Absent when the API
+   * has not reconciled recipients (e.g. team-default delivery with no
+   * explicit recipients).
+   */
+  emailRecipientSubscriptions?: MonitorEmailRecipientSubscription[];
   retentionDays: number;
   estimatedCreditsPerMonth?: number | null;
   lastCheckSummary?: MonitorSummary | null;

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -874,6 +874,30 @@ class MonitorNotification(BaseModel):
     email: Optional[MonitorEmailNotification] = None
 
 
+class MonitorEmailRecipientSubscription(BaseModel):
+    """Per-recipient opt-in state for monitor email notifications.
+
+    External recipients (not members of the team that owns the monitor) must
+    confirm their subscription via a one-time email before they receive any
+    monitor notifications. Team members are auto-confirmed.
+
+    Statuses:
+      - ``pending``      - confirmation email sent, no notifications yet
+      - ``confirmed``    - notifications enabled
+      - ``unsubscribed`` - recipient opted out and cannot be re-added without
+                            a new confirmation flow
+    """
+
+    model_config = {"populate_by_name": True}
+
+    email: str
+    status: Literal["pending", "confirmed", "unsubscribed"]
+    source: Literal["team", "opt_in", "legacy"]
+    confirmation_email_sent: Optional[bool] = Field(
+        default=None, alias="confirmationEmailSent"
+    )
+
+
 class MonitorTarget(BaseModel):
     """A scrape or crawl target stored on a monitor."""
 
@@ -938,6 +962,12 @@ class Monitor(BaseModel):
     targets: List[Dict[str, Any]]
     webhook: Optional[Dict[str, Any]] = None
     notification: Optional[Dict[str, Any]] = None
+    # Present on create/update/get when the API has reconciled email
+    # recipients (i.e. notification.email.recipients is non-empty). Each
+    # entry reports a recipient's opt-in status.
+    email_recipient_subscriptions: Optional[List[MonitorEmailRecipientSubscription]] = (
+        Field(default=None, alias="emailRecipientSubscriptions")
+    )
     retention_days: int = Field(alias="retentionDays")
     estimated_credits_per_month: Optional[int] = Field(default=None, alias="estimatedCreditsPerMonth")
     last_check_summary: Optional[MonitorSummary] = Field(default=None, alias="lastCheckSummary")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds opt-in and unsubscribe for monitor email notifications. External recipients must confirm before they get alerts; team members are auto-confirmed.

- **New Features**
  - Added POST-only `/v2/monitor/email/confirm` and `/v2/monitor/email/unsubscribe` (token in body; unauthenticated). Query-string tokens are rejected; JSON errors use `invalid_token` (400) and `not_found` (404).
  - Reconcile recipients on create/update: normalize and dedupe emails, auto-confirm team members, set externals to `pending`, send confirmation emails for new externals, and return `emailRecipientSubscriptions` (includes `status`, `source`, and `confirmationEmailSent`). `GET /v2/monitor/:id` also returns current subscriptions.
  - Summary emails send one per confirmed recipient with a unique unsubscribe link and footer; skip delivery when no recipients are confirmed; update `last_notified_at` for delivered recipients.
  - Legacy monitors with no rows are auto-bootstrapped as `confirmed`; partial/missing rows are treated as `pending`.

- **Migration**
  - No manual steps. Existing monitors keep sending.
  - SDKs: added optional `emailRecipientSubscriptions` to `Monitor` in `apps/js-sdk/firecrawl` and `apps/python-sdk/firecrawl`.
  - If you set explicit external recipients, they start as `pending` until they confirm; team-default delivery (no recipients set) is unchanged.

<sup>Written for commit 91d92312e6fa647c0b4afe623fe02bda59f3a664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3645?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

