### PR TITLE
fix(python-sdk): rename MonitorPage `json` field to avoid BaseModel shadowing

### DIFF
--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1024,17 +1024,17 @@ class MonitorPageDiff(BaseModel):
     monitors (JSON + git-diff) populate both `json` (field diff) and
     `text` (markdown sidecar).
     """
-    model_config = {"populate_by_name": True, "extra": "allow"}
+    model_config = {"populate_by_name": True, "extra": "allow", "protected_namespaces": ()}
 
     text: Optional[str] = None
-    json: Optional[Any] = None  # markdown→parseDiff AST | json→field diff
+    json_: Optional[Any] = Field(default=None, alias="json")  # markdown→parseDiff AST | json→field diff
 
 
 class MonitorPageSnapshot(BaseModel):
     """Current JSON extraction at this run. JSON / mixed mode only."""
-    model_config = {"populate_by_name": True, "extra": "allow"}
+    model_config = {"populate_by_name": True, "extra": "allow", "protected_namespaces": ()}
 
-    json: Optional[Dict[str, Any]] = None
+    json_: Optional[Dict[str, Any]] = Field(default=None, alias="json")
 
 
 class MonitorCheckPage(BaseModel):


### PR DESCRIPTION
## Summary

- `MonitorPageDiff` and `MonitorPageSnapshot` define a field named `json`, which shadows `pydantic.BaseModel.json()`. Importing the SDK emits a `UserWarning`.
- Renamed the field to `json_` with `Field(alias="json")` so the wire format is preserved (`populate_by_name=True` is already set).
- Added `"protected_namespaces": ()` to `model_config` to silence Pydantic's reserved-name warning for the alias.

Fixes #3643

## Test plan

- [ ] `from firecrawl.v2.types import MonitorPageDiff, MonitorPageSnapshot` — no `UserWarning` printed.
- [ ] `MonitorPageDiff(**{"json": {"a": 1}}).json_ == {"a": 1}` — incoming wire alias still populates.
- [ ] `MonitorPageDiff(json_={"a": 1}).model_dump(by_alias=True) == {"text": None, "json": {"a": 1}}` — outgoing serialization still uses `json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes import-time warnings in the Python SDK by renaming MonitorPage `json` fields that shadow `pydantic.BaseModel.json()`. Preserves the wire format so requests and responses still use `json`.

- **Bug Fixes**
  - Renamed `json` to `json_` in `MonitorPageDiff` and `MonitorPageSnapshot` with `Field(alias="json")`.
  - Added `model_config["protected_namespaces"] = ()` to silence `pydantic` reserved-name warnings.

<sup>Written for commit 68a597b370182a19eb8bc5c980e76503c0eaa141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3647?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

