### PR TITLE
fix monitor check credit accounting

### DIFF
--- a/apps/api/src/services/monitoring/results.ts
+++ b/apps/api/src/services/monitoring/results.ts
@@ -2,7 +2,6 @@ import { NuQJob } from "../worker/nuq";
 import { ScrapeJobData } from "../../types";
 import { logger as _logger } from "../../lib/logger";
 import { createWebhookSender, WebhookEvent } from "../webhook";
-import { billTeam } from "../billing/credit_billing";
 import { computeAndPersistPageDiff } from "./diff-orchestrator";
 import { derivePageIsMeaningful } from "./page-events";
 import {
@@ -12,8 +11,6 @@ import {
   insertMonitorCheckPages,
   upsertMonitorPage,
 } from "./store";
-
-const JUDGE_CREDIT_COST = 1;
 
 const logger = _logger.child({ module: "monitoring-results" });
 
@@ -212,25 +209,6 @@ export async function recordMonitorScrapeSuccess(
     diffGcsKey,
     judgmentMeaningful: judgment?.meaningful,
   });
-
-  if (judgment) {
-    try {
-      await billTeam(
-        job.data.team_id,
-        undefined,
-        JUDGE_CREDIT_COST,
-        job.data.apiKeyId ?? null,
-        { endpoint: "monitor", jobId: monitoring.checkId },
-        logger,
-      );
-    } catch (error) {
-      logger.warn("Failed to bill judge credit", {
-        error,
-        monitorId: monitoring.monitorId,
-        checkId: monitoring.checkId,
-      });
-    }
-  }
 
   await sendMonitorPageWebhook({
     teamId: job.data.team_id,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -31,6 +31,7 @@ import {
   getMonitorCheck,
   getMonitorForUpdate,
   getMonitorPage,
+  calculateMonitorCheckActualCredits,
   countMonitorCheckPages,
   hashMonitorUrl,
   insertMonitorCheckPages,
@@ -1331,7 +1332,9 @@ export async function reconcileRunningMonitorChecks(
         countMonitorCheckPages({ checkId: check.id, status: "error" }),
       ]);
       const totalPages = same + changed + newCount + removed + errorCount;
-      const actualCredits = totalPages;
+      const actualCredits = await calculateMonitorCheckActualCredits({
+        checkId: check.id,
+      });
 
       let finalized = await updateMonitorCheck(check.id, {
         status: errorCount > 0 ? "partial" : "completed",

--- a/apps/api/src/services/monitoring/store.test.ts
+++ b/apps/api/src/services/monitoring/store.test.ts
@@ -1,0 +1,38 @@
+jest.mock("uuid", () => ({
+  v7: () => "test-uuid-v7",
+}));
+
+import {
+  calculateMonitorCheckActualCreditsFromPages,
+  estimateMonitorCreditsPerRun,
+} from "./store";
+import type { MonitorTarget } from "./types";
+
+describe("monitoring store credit helpers", () => {
+  it("estimates goal-enabled scrape monitors from scrape option costs", () => {
+    const targets: MonitorTarget[] = [
+      {
+        id: "target-1",
+        type: "scrape",
+        urls: ["https://example.com/a", "https://example.com/b"],
+        scrapeOptions: {
+          formats: [{ type: "changeTracking", modes: ["json"] }],
+          proxy: "stealth",
+        },
+      },
+    ];
+
+    expect(estimateMonitorCreditsPerRun(targets, false)).toBe(18);
+    expect(estimateMonitorCreditsPerRun(targets, true)).toBe(20);
+  });
+
+  it("calculates actual credits from page scrape usage plus judged pages", () => {
+    expect(
+      calculateMonitorCheckActualCreditsFromPages([
+        { metadata: { creditsUsed: 5 }, judgment: { meaningful: true } },
+        { metadata: { creditsUsed: 1 }, judgment: null },
+        { metadata: {}, judgment: { meaningful: false } },
+      ]),
+    ).toBe(9);
+  });
+});

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -28,7 +28,83 @@ function ensureTargetIds(targets: Array<Record<string, any>>): MonitorTarget[] {
   })) as MonitorTarget[];
 }
 
+function formatType(format: unknown): string | null {
+  if (typeof format === "string") return format;
+  if (
+    format &&
+    typeof format === "object" &&
+    "type" in format &&
+    typeof format.type === "string"
+  ) {
+    return format.type;
+  }
+  return null;
+}
+
+function hasFormatOfType(formats: unknown, type: string): boolean {
+  return (
+    Array.isArray(formats) &&
+    formats.some(format => formatType(format) === type)
+  );
+}
+
+function requestsJsonChangeTracking(formats: unknown): boolean {
+  if (!Array.isArray(formats)) return false;
+  return formats.some(format => {
+    if (
+      !format ||
+      typeof format !== "object" ||
+      !("type" in format) ||
+      format.type !== "changeTracking"
+    ) {
+      return false;
+    }
+    const modes = "modes" in format ? format.modes : undefined;
+    return Array.isArray(modes) && modes.includes("json");
+  });
+}
+
+function estimateScrapeOptionsCredits(
+  options: MonitorTarget["scrapeOptions"],
+): number {
+  const formats = options?.formats;
+  let credits = 1;
+
+  if (hasFormatOfType(formats, "json") || requestsJsonChangeTracking(formats)) {
+    credits = 5;
+  }
+
+  if (
+    hasFormatOfType(formats, "question") ||
+    hasFormatOfType(formats, "query")
+  ) {
+    credits += 4;
+  }
+  if (hasFormatOfType(formats, "highlights")) credits += 4;
+  if (hasFormatOfType(formats, "audio")) credits += 4;
+  if (hasFormatOfType(formats, "video")) credits += 4;
+
+  if (options?.proxy === "stealth" || options?.proxy === "enhanced") {
+    credits += 4;
+  }
+
+  return credits;
+}
+
 function estimateTargetCredits(target: MonitorTarget): number {
+  const creditsPerPage = estimateScrapeOptionsCredits(target.scrapeOptions);
+  if (target.type === "scrape") {
+    return target.urls.length * creditsPerPage;
+  }
+
+  const limit =
+    typeof target.crawlOptions?.limit === "number"
+      ? target.crawlOptions.limit
+      : 10000;
+  return Math.max(1, limit) * creditsPerPage;
+}
+
+function estimateTargetPageCount(target: MonitorTarget): number {
   if (target.type === "scrape") {
     return target.urls.length;
   }
@@ -44,11 +120,14 @@ export function estimateMonitorCreditsPerRun(
   targets: MonitorTarget[],
   judgeEnabled: boolean = false,
 ): number {
-  const scrapeCredits = targets.reduce(
+  const baseCredits = targets.reduce(
     (sum, target) => sum + estimateTargetCredits(target),
     0,
   );
-  return judgeEnabled ? scrapeCredits * 2 : scrapeCredits;
+  const judgeCredits = judgeEnabled
+    ? targets.reduce((sum, target) => sum + estimateTargetPageCount(target), 0)
+    : 0;
+  return baseCredits + judgeCredits;
 }
 
 function toMonitorSummary(check: MonitorCheckRow): MonitorSummary {
@@ -559,6 +638,47 @@ export async function countMonitorCheckPages(params: {
 
     const batch = data ?? [];
     total += batch.length;
+    if (batch.length < pageSize) break;
+    offset += pageSize;
+  }
+
+  return total;
+}
+
+export function calculateMonitorCheckActualCreditsFromPages(
+  pages: Array<{ metadata?: unknown; judgment?: unknown }>,
+): number {
+  return pages.reduce((total, page) => {
+    const metadata = page.metadata as { creditsUsed?: unknown } | null;
+    const baseCredits =
+      typeof metadata?.creditsUsed === "number" &&
+      Number.isFinite(metadata.creditsUsed)
+        ? metadata.creditsUsed
+        : 1;
+    const judgeCredits = page.judgment != null ? 1 : 0;
+    return total + baseCredits + judgeCredits;
+  }, 0);
+}
+
+export async function calculateMonitorCheckActualCredits(params: {
+  checkId: string;
+}): Promise<number> {
+  const pageSize = 1000;
+  let total = 0;
+  let offset = 0;
+
+  while (true) {
+    const { data, error } = await supabase_rr_service
+      .from("monitor_check_pages")
+      .select("metadata, judgment")
+      .eq("check_id", params.checkId)
+      .range(offset, offset + pageSize - 1);
+
+    throwIfError(error, "Failed to calculate monitor check credits");
+
+    const batch = data ?? [];
+    total += calculateMonitorCheckActualCreditsFromPages(batch);
+
     if (batch.length < pageSize) break;
     offset += pageSize;
   }


### PR DESCRIPTION
## Summary

Fixes monitor check credit accounting so the existing `actualCredits` field reflects total credits used for the check, including scrape option costs and goal judge calls.

## Root Cause

Monitor checks already estimated goal-enabled runs as more expensive, and changed pages already persisted `judgment` when the judge ran. However, reconciliation finalized `actualCredits` as `totalPages`, so it ignored:

- higher per-page scrape costs from options such as JSON/changeTracking and explicit stealth/enhanced proxy
- the 1-credit judge cost for changed pages that were judged

Judge credits were also being billed separately in the page-result path, which made `actualCredits` diverge from user-visible billing semantics.

## Changes

- Compute monitor check `actualCredits` from recorded page `metadata.creditsUsed` plus 1 credit for each page with a persisted `judgment`.
- Remove separate immediate judge billing from `recordMonitorScrapeSuccess`; monitor billing is centralized in check reconciliation.
- Improve create/check estimates for scrape options that can change base per-page costs, while keeping judge estimate as +1 possible credit per page.
- Add focused tests for monitor credit estimation and actual credit calculation.

## Validation

- `pnpm --filter firecrawl-scraper-js test -- src/services/monitoring/store.test.ts src/services/monitoring/runner.test.ts src/services/monitoring/meaningful-monitoring.test.ts`
- `pnpm --filter firecrawl-scraper-js build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes monitor check credit accounting so `actualCredits` matches real usage, including scrape option costs and judged pages. Centralizes billing in reconciliation to align with user-visible billing.

- **Bug Fixes**
  - Compute `actualCredits` from per-page `metadata.creditsUsed` plus 1 credit for pages with a persisted `judgment`.
  - Remove immediate judge billing; bill only during check reconciliation.
  - Improve credit estimates for scrape options (e.g., JSON/changeTracking, stealth/enhanced proxy); judge remains +1 per page.
  - Add tests for estimation and actual credit calculation.

<sup>Written for commit b691090f34d8c6b76214d66bd88b259dde0bd542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3651?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

