### PR TITLE
fix(billing): update monitoring estimates + final calculation

### DIFF
--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -451,12 +451,13 @@ describe("trackCredits", () => {
 describe("finalizeCreditsLock", () => {
   it("calls balances.finalize with confirm", async () => {
     const svc = makeService();
-    await svc.finalizeCreditsLock({
+    const result = await svc.finalizeCreditsLock({
       lockId: "lock-123",
       action: "confirm",
       properties: { source: "test" },
     });
 
+    expect(result).toBe(true);
     expect(mockFinalize).toHaveBeenCalledWith({
       lockId: "lock-123",
       action: "confirm",
@@ -468,8 +469,24 @@ describe("finalizeCreditsLock", () => {
   it("is a no-op when autumnClient is null", async () => {
     autumnClientRef = null;
     const svc = makeService();
-    await svc.finalizeCreditsLock({ lockId: "lock-123", action: "release" });
+    const result = await svc.finalizeCreditsLock({
+      lockId: "lock-123",
+      action: "release",
+    });
+    expect(result).toBe(false);
     expect(mockFinalize).not.toHaveBeenCalled();
+  });
+
+  it("returns false when finalize fails", async () => {
+    mockFinalize.mockRejectedValueOnce(new Error("finalize failed"));
+    const svc = makeService();
+
+    const result = await svc.finalizeCreditsLock({
+      lockId: "lock-123",
+      action: "confirm",
+    });
+
+    expect(result).toBe(false);
   });
 });
 

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -452,8 +452,8 @@ export class AutumnService {
     action,
     overrideValue,
     properties,
-  }: FinalizeCreditsLockParams): Promise<void> {
-    if (!autumnClient) return;
+  }: FinalizeCreditsLockParams): Promise<boolean> {
+    if (!autumnClient) return false;
 
     try {
       await autumnClient.balances.finalize({
@@ -467,6 +467,7 @@ export class AutumnService {
         action,
         overrideValue,
       });
+      return true;
     } catch (error) {
       logger.error(
         "Autumn finalizeCreditsLock failed — billing API may be unavailable",
@@ -477,6 +478,7 @@ export class AutumnService {
           error,
         },
       );
+      return false;
     }
   }
 

--- a/apps/api/src/services/monitoring/results.ts
+++ b/apps/api/src/services/monitoring/results.ts
@@ -2,7 +2,6 @@ import { NuQJob } from "../worker/nuq";
 import { ScrapeJobData } from "../../types";
 import { logger as _logger } from "../../lib/logger";
 import { createWebhookSender, WebhookEvent } from "../webhook";
-import { billTeam } from "../billing/credit_billing";
 import { computeAndPersistPageDiff } from "./diff-orchestrator";
 import { derivePageIsMeaningful } from "./page-events";
 import {
@@ -12,8 +11,6 @@ import {
   insertMonitorCheckPages,
   upsertMonitorPage,
 } from "./store";
-
-const JUDGE_CREDIT_COST = 1;
 
 const logger = _logger.child({ module: "monitoring-results" });
 
@@ -212,25 +209,6 @@ export async function recordMonitorScrapeSuccess(
     diffGcsKey,
     judgmentMeaningful: judgment?.meaningful,
   });
-
-  if (judgment) {
-    try {
-      await billTeam(
-        job.data.team_id,
-        undefined,
-        JUDGE_CREDIT_COST,
-        job.data.apiKeyId ?? null,
-        { endpoint: "monitor", jobId: monitoring.checkId },
-        logger,
-      );
-    } catch (error) {
-      logger.warn("Failed to bill judge credit", {
-        error,
-        monitorId: monitoring.monitorId,
-        checkId: monitoring.checkId,
-      });
-    }
-  }
 
   await sendMonitorPageWebhook({
     teamId: job.data.team_id,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -31,6 +31,7 @@ import {
   getMonitorCheck,
   getMonitorForUpdate,
   getMonitorPage,
+  calculateMonitorCheckActualCredits,
   countMonitorCheckPages,
   hashMonitorUrl,
   insertMonitorCheckPages,
@@ -612,8 +613,9 @@ async function billMonitorCheck(params: {
   actualCredits: number;
   lockId: string | null;
 }): Promise<void> {
+  let finalizedInAutumn = false;
   if (params.lockId) {
-    await autumnService.finalizeCreditsLock({
+    finalizedInAutumn = await autumnService.finalizeCreditsLock({
       lockId: params.lockId,
       action: "confirm",
       overrideValue: params.actualCredits,
@@ -638,7 +640,7 @@ async function billMonitorCheck(params: {
       timestamp: new Date().toISOString(),
       originating_job_id: params.check.id,
       api_key_id: null,
-      autumnTrackInRequest: Boolean(params.lockId),
+      autumnTrackInRequest: finalizedInAutumn,
     },
     {
       jobId: uuidv7(),
@@ -1331,7 +1333,9 @@ export async function reconcileRunningMonitorChecks(
         countMonitorCheckPages({ checkId: check.id, status: "error" }),
       ]);
       const totalPages = same + changed + newCount + removed + errorCount;
-      const actualCredits = totalPages;
+      const actualCredits = await calculateMonitorCheckActualCredits({
+        checkId: check.id,
+      });
 
       let finalized = await updateMonitorCheck(check.id, {
         status: errorCount > 0 ? "partial" : "completed",

--- a/apps/api/src/services/monitoring/store.test.ts
+++ b/apps/api/src/services/monitoring/store.test.ts
@@ -1,0 +1,55 @@
+jest.mock("uuid", () => ({
+  v7: () => "test-uuid-v7",
+}));
+
+import {
+  calculateMonitorCheckActualCreditsFromPages,
+  estimateMonitorCreditsPerRun,
+} from "./store";
+import type { MonitorTarget } from "./types";
+
+describe("monitoring store credit helpers", () => {
+  it("estimates goal-enabled scrape monitors from scrape option costs", () => {
+    const targets: MonitorTarget[] = [
+      {
+        id: "target-1",
+        type: "scrape",
+        urls: ["https://example.com/a", "https://example.com/b"],
+        scrapeOptions: {
+          formats: [{ type: "changeTracking", modes: ["json"] }],
+          proxy: "stealth",
+        },
+      },
+    ];
+
+    expect(estimateMonitorCreditsPerRun(targets, false)).toBe(18);
+    expect(estimateMonitorCreditsPerRun(targets, true)).toBe(20);
+  });
+
+  it("adds predictable lockdown costs and judge credits separately", () => {
+    const targets: MonitorTarget[] = [
+      {
+        id: "target-1",
+        type: "scrape",
+        urls: ["https://example.com/a"],
+        scrapeOptions: {
+          lockdown: true,
+        },
+      },
+    ];
+
+    expect(estimateMonitorCreditsPerRun(targets, false)).toBe(5);
+    expect(estimateMonitorCreditsPerRun(targets, true)).toBe(6);
+  });
+
+  it("calculates actual credits from page scrape usage plus judged pages", () => {
+    expect(
+      calculateMonitorCheckActualCreditsFromPages([
+        { metadata: { creditsUsed: 5 }, judgment: { meaningful: true } },
+        { metadata: { creditsUsed: 1 }, judgment: null },
+        { metadata: {}, judgment: { meaningful: false } },
+        { status: "removed", metadata: {}, judgment: null },
+      ]),
+    ).toBe(9);
+  });
+});

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -28,7 +28,84 @@ function ensureTargetIds(targets: Array<Record<string, any>>): MonitorTarget[] {
   })) as MonitorTarget[];
 }
 
-function estimateTargetCredits(target: MonitorTarget): number {
+function formatType(format: unknown): string | null {
+  if (typeof format === "string") return format;
+  if (
+    format &&
+    typeof format === "object" &&
+    "type" in format &&
+    typeof format.type === "string"
+  ) {
+    return format.type;
+  }
+  return null;
+}
+
+function hasFormatOfType(formats: unknown, type: string): boolean {
+  return (
+    Array.isArray(formats) &&
+    formats.some(format => formatType(format) === type)
+  );
+}
+
+function requestsJsonChangeTracking(formats: unknown): boolean {
+  if (!Array.isArray(formats)) return false;
+  return formats.some(format => {
+    if (
+      !format ||
+      typeof format !== "object" ||
+      !("type" in format) ||
+      format.type !== "changeTracking"
+    ) {
+      return false;
+    }
+    const modes = "modes" in format ? format.modes : undefined;
+    return Array.isArray(modes) && modes.includes("json");
+  });
+}
+
+function estimateBaseCreditsPerPage(
+  options: MonitorTarget["scrapeOptions"],
+): number {
+  const formats = options?.formats;
+  let credits = 1;
+
+  if (hasFormatOfType(formats, "json") || requestsJsonChangeTracking(formats)) {
+    credits = 5;
+  }
+
+  if (
+    hasFormatOfType(formats, "question") ||
+    hasFormatOfType(formats, "query")
+  ) {
+    credits += 4;
+  }
+  if (hasFormatOfType(formats, "highlights")) credits += 4;
+  if (hasFormatOfType(formats, "audio")) credits += 4;
+  if (hasFormatOfType(formats, "video")) credits += 4;
+
+  if (options?.proxy === "stealth" || options?.proxy === "enhanced") {
+    credits += 4;
+  }
+  if (options?.lockdown) credits += 4;
+
+  return credits;
+}
+
+function estimateTargetBaseCredits(target: MonitorTarget): number {
+  const creditsPerPage = estimateBaseCreditsPerPage(target.scrapeOptions);
+  if (target.type === "scrape") {
+    return target.urls.length * creditsPerPage;
+  }
+
+  const limit =
+    typeof target.crawlOptions?.limit === "number"
+      ? target.crawlOptions.limit
+      : 10000;
+  return Math.max(1, limit) * creditsPerPage;
+}
+
+function estimateTargetPageCount(target: MonitorTarget): number {
   if (target.type === "scrape") {
     return target.urls.length;
   }
@@ -44,11 +121,14 @@ export function estimateMonitorCreditsPerRun(
   targets: MonitorTarget[],
   judgeEnabled: boolean = false,
 ): number {
-  const scrapeCredits = targets.reduce(
-    (sum, target) => sum + estimateTargetCredits(target),
+  const baseCredits = targets.reduce(
+    (sum, target) => sum + estimateTargetBaseCredits(target),
     0,
   );
-  return judgeEnabled ? scrapeCredits * 2 : scrapeCredits;
+  const judgeCredits = judgeEnabled
+    ? targets.reduce((sum, target) => sum + estimateTargetPageCount(target), 0)
+    : 0;
+  return baseCredits + judgeCredits;
 }
 
 function toMonitorSummary(check: MonitorCheckRow): MonitorSummary {
@@ -559,6 +639,49 @@ export async function countMonitorCheckPages(params: {
 
     const batch = data ?? [];
     total += batch.length;
+    if (batch.length < pageSize) break;
+    offset += pageSize;
+  }
+
+  return total;
+}
+
+export function calculateMonitorCheckActualCreditsFromPages(
+  pages: Array<{ metadata?: unknown; judgment?: unknown; status?: string }>,
+): number {
+  return pages.reduce((total, page) => {
+    const metadata = page.metadata as { creditsUsed?: unknown } | null;
+    const recordedCredits = metadata?.creditsUsed;
+    const baseCredits =
+      typeof recordedCredits === "number" && Number.isFinite(recordedCredits)
+        ? recordedCredits
+        : page.status === "removed"
+          ? 0
+          : 1;
+    const judgeCredits = page.judgment != null ? 1 : 0;
+    return total + baseCredits + judgeCredits;
+  }, 0);
+}
+
+export async function calculateMonitorCheckActualCredits(params: {
+  checkId: string;
+}): Promise<number> {
+  const pageSize = 1000;
+  let total = 0;
+  let offset = 0;
+
+  while (true) {
+    const { data, error } = await supabase_rr_service
+      .from("monitor_check_pages")
+      .select("metadata, judgment, status")
+      .eq("check_id", params.checkId)
+      .range(offset, offset + pageSize - 1);
+
+    throwIfError(error, "Failed to calculate monitor check credits");
+
+    const batch = data ?? [];
+    total += calculateMonitorCheckActualCreditsFromPages(batch);
+
     if (batch.length < pageSize) break;
     offset += pageSize;
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes monitor credit accounting by using per-run estimates and actuals from page usage. Removes per-judgment billing and only flags Autumn tracking when finalize succeeds.

- **Bug Fixes**
  - Calculate actual credits from pages (metadata.creditsUsed; removed=0; +1 per judged page) and use this in reconcile/billing.
  - Finalize Autumn credits lock with overrideValue and return a boolean; set autumnTrackInRequest only on success.
  - Remove per-judgment billing in results to prevent double charges.

- **New Features**
  - Add `estimateMonitorCreditsPerRun`: base per-page from formats (json/changeTracking/query/question/highlights/audio/video), proxy, and lockdown; judge credits counted separately (1/page).
  - Add `calculateMonitorCheckActualCredits` (+ `calculateMonitorCheckActualCreditsFromPages`) and unit tests for estimators and Autumn finalize behavior.

<sup>Written for commit 4b1b408b4b66300233c15534ad4f07b3e9f7b6f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3653?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

