### PR TITLE
fix(api): handle logging insert conflicts

### DIFF
--- a/apps/api/src/services/logging/log_job.test.ts
+++ b/apps/api/src/services/logging/log_job.test.ts
@@ -46,7 +46,12 @@ jest.mock("../../lib/extract/extract-redis", () => ({
   saveExtractResult: jest.fn(),
 }));
 
-import { logSearch, type LoggedSearch } from "./log_job";
+import {
+  logScrape,
+  logSearch,
+  type LoggedScrape,
+  type LoggedSearch,
+} from "./log_job";
 
 function makeSearch(overrides: Partial<LoggedSearch> = {}): LoggedSearch {
   return {
@@ -63,6 +68,22 @@ function makeSearch(overrides: Partial<LoggedSearch> = {}): LoggedSearch {
     is_successful: true,
     num_results: 0,
     results: null,
+    zeroDataRetention: false,
+    ...overrides,
+  };
+}
+
+function makeScrape(overrides: Partial<LoggedScrape> = {}): LoggedScrape {
+  return {
+    id: "scrape-id",
+    request_id: "request-id",
+    url: "https://example.com",
+    is_successful: true,
+    time_taken: 100,
+    team_id: "team-id",
+    options: {} as any,
+    credits_cost: 1,
+    skipNuq: false,
     zeroDataRetention: false,
     ...overrides,
   };
@@ -114,5 +135,49 @@ describe("logSearch", () => {
     };
     expect(context.extra.data).not.toContain("\\u0000");
     expect(context.extra.data).toContain("badquery");
+  });
+});
+
+describe("logScrape", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    insert.mockResolvedValue({ error: null });
+  });
+
+  it("treats duplicate scrape log inserts as already logged", async () => {
+    insert.mockResolvedValueOnce({
+      error: {
+        code: "23505",
+        message:
+          'duplicate key value violates unique constraint "scrapes_p202605_pkey"',
+        details: "Key (id)=(scrape-id) already exists.",
+      },
+    });
+
+    await logScrape(makeScrape(), true);
+
+    expect(from).toHaveBeenCalledWith("scrapes");
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("retries scrape log inserts when the request log is still being written", async () => {
+    insert
+      .mockResolvedValueOnce({
+        error: {
+          code: "23503",
+          message:
+            'insert or update on table "scrapes_p202605" violates foreign key constraint "scrapes_request_id_fkey"',
+          details:
+            'Key (request_id)=(request-id) is not present in table "requests".',
+        },
+      })
+      .mockResolvedValueOnce({ error: null });
+
+    await logScrape(makeScrape(), false);
+
+    expect(from).toHaveBeenCalledWith("scrapes");
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(captureException).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -33,6 +33,41 @@ function sanitizeString(value: string | null | undefined): string | null {
   return value.replace(nullByteRegex, "");
 }
 
+type SupabaseErrorLike = {
+  code?: unknown;
+  details?: unknown;
+  message?: unknown;
+};
+
+function getSupabaseErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as SupabaseErrorLike).code ?? "");
+  }
+
+  return "";
+}
+
+function getSupabaseErrorText(error: unknown): string {
+  if (!error || typeof error !== "object") return "";
+
+  const { details, message } = error as SupabaseErrorLike;
+  return `${String(message ?? "")} ${String(details ?? "")}`;
+}
+
+function isDuplicateInsertError(error: unknown): boolean {
+  return (
+    getSupabaseErrorCode(error) === "23505" &&
+    getSupabaseErrorText(error).includes("already exists")
+  );
+}
+
+function isMissingRequestForeignKeyError(error: unknown): boolean {
+  return (
+    getSupabaseErrorCode(error) === "23503" &&
+    getSupabaseErrorText(error).includes('not present in table "requests"')
+  );
+}
+
 async function robustInsert(
   table: string,
   data: any,
@@ -50,11 +85,23 @@ async function robustInsert(
   if (force) {
     let i = 0,
       done = false;
+    let skippedDuplicate = false;
     let lastError: any = null;
     while (i++ <= 10) {
       try {
         const { error } = await supabase_service.from(table).insert(data);
         if (error) {
+          if (isDuplicateInsertError(error)) {
+            logger.info("Skipping duplicate database insertion", {
+              error,
+              table,
+              attempt: i,
+            });
+            skippedDuplicate = true;
+            done = true;
+            break;
+          }
+
           lastError = error;
           logger.error(
             "Error inserting into database due to Supabase error, trying again",
@@ -66,6 +113,17 @@ async function robustInsert(
           break;
         }
       } catch (error) {
+        if (isDuplicateInsertError(error)) {
+          logger.info("Skipping duplicate database insertion", {
+            error,
+            table,
+            attempt: i,
+          });
+          skippedDuplicate = true;
+          done = true;
+          break;
+        }
+
         lastError = error;
         logger.error(
           "Error inserting into database due to unknown error, trying again",
@@ -76,7 +134,12 @@ async function robustInsert(
     }
 
     if (done) {
-      logger.info("Inserted into database successfully", { table });
+      logger.info(
+        skippedDuplicate
+          ? "Database insertion already exists"
+          : "Inserted into database successfully",
+        { table },
+      );
     } else {
       logger.error("Failed to insert into database after 10 attempts", {
         table,
@@ -103,6 +166,23 @@ async function robustInsert(
     try {
       const { error } = await supabase_service.from(table).insert(data);
       if (error) {
+        if (isDuplicateInsertError(error)) {
+          logger.info("Skipping duplicate database insertion", {
+            error,
+            table,
+          });
+          return;
+        }
+
+        if (isMissingRequestForeignKeyError(error)) {
+          logger.warn("Retrying database insertion after request log race", {
+            error,
+            table,
+          });
+          await robustInsert(table, data, true, logger);
+          return;
+        }
+
         logger.error("Error inserting into database due to Supabase error", {
           error,
           table,
@@ -124,10 +204,28 @@ async function robustInsert(
         logger.info("Inserted into database successfully", { table });
       }
     } catch (error) {
+      if (isDuplicateInsertError(error)) {
+        logger.info("Skipping duplicate database insertion", {
+          error,
+          table,
+        });
+        return;
+      }
+
+      if (isMissingRequestForeignKeyError(error)) {
+        logger.warn("Retrying database insertion after request log race", {
+          error,
+          table,
+        });
+        await robustInsert(table, data, true, logger);
+        return;
+      }
+
       logger.error("Error inserting into database due to unknown error", {
         error,
         table,
       });
+
       // Report to Sentry
       Sentry.captureException(error, {
         tags: {


### PR DESCRIPTION
## Summary

Handles expected logging insert constraint conflicts without reporting them as application errors. Duplicate primary-key inserts are treated as already logged, and scrape log inserts retry when they temporarily race the parent request log row.

This keeps real insert failures reportable while reducing noisy Sentry events from idempotent scrape logging and request-log ordering races.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle expected DB insert conflicts in logging to reduce noisy Sentry alerts while keeping real failures reportable. Duplicate inserts are treated as already logged, and `scrapes` inserts retry when the parent `requests` row hasn’t been written yet.

- **Bug Fixes**
  - Detect Supabase duplicate key errors (23505) and skip re-insert.
  - Detect missing `requests` FK (23503) and retry via `robustInsert`.
  - Preserve Sentry reporting for other failures.
  - Add tests for `logScrape` duplicate and FK-race cases.

<sup>Written for commit 11af59ba9e008bea1c10edb4f7020e84bc8a5c11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3656?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

