### PR TITLE
fix(api): finish NuQ jobs before concurrency drain

### DIFF
--- a/apps/api/src/lib/concurrency-limit.test.ts
+++ b/apps/api/src/lib/concurrency-limit.test.ts
@@ -1,0 +1,143 @@
+const mockRedis = {
+  del: jest.fn(),
+  get: jest.fn(),
+  sadd: jest.fn(),
+  set: jest.fn(),
+  zadd: jest.fn(),
+  zcount: jest.fn(),
+  zpopmin: jest.fn(),
+  zrange: jest.fn(),
+  zrangebyscore: jest.fn(),
+  zrem: jest.fn(),
+  zremrangebyscore: jest.fn(),
+};
+
+const mockGetACUCTeam = jest.fn();
+const mockGetCrawl = jest.fn();
+const mockAbTestJob = jest.fn();
+const mockPromoteJobFromBacklogOrAdd = jest.fn();
+const mockLogger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+};
+
+jest.mock("../services/queue-service", () => ({
+  getRedisConnection: () => mockRedis,
+}));
+
+jest.mock("../controllers/auth", () => ({
+  getACUCTeam: (...args: any[]) => mockGetACUCTeam(...args),
+}));
+
+jest.mock("./crawl-redis", () => ({
+  getCrawl: (...args: any[]) => mockGetCrawl(...args),
+}));
+
+jest.mock("../services/ab-test", () => ({
+  abTestJob: (...args: any[]) => mockAbTestJob(...args),
+}));
+
+jest.mock("../services/worker/nuq", () => ({
+  scrapeQueue: {
+    promoteJobFromBacklogOrAdd: (...args: any[]) =>
+      mockPromoteJobFromBacklogOrAdd(...args),
+  },
+}));
+
+jest.mock("./logger", () => ({
+  logger: mockLogger,
+}));
+
+import { concurrentJobDone } from "./concurrency-limit";
+
+async function flushAsyncDrain() {
+  for (let i = 0; i < 5; i++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+}
+
+function makeJob(id: string, data: Record<string, any> = {}) {
+  return {
+    id,
+    data: {
+      mode: "single_urls",
+      team_id: "team-1",
+      ...data,
+    },
+    priority: 10,
+  } as any;
+}
+
+describe("concurrentJobDone", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRedis.del.mockResolvedValue(1);
+    mockRedis.get.mockResolvedValue(null);
+    mockRedis.sadd.mockResolvedValue(1);
+    mockRedis.set.mockResolvedValue("OK");
+    mockRedis.zadd.mockResolvedValue(1);
+    mockRedis.zcount.mockResolvedValue(0);
+    mockRedis.zpopmin.mockResolvedValue([]);
+    mockRedis.zrange.mockResolvedValue([]);
+    mockRedis.zrangebyscore.mockResolvedValue([]);
+    mockRedis.zrem.mockResolvedValue(1);
+    mockRedis.zremrangebyscore.mockResolvedValue(0);
+
+    mockGetACUCTeam.mockResolvedValue({ concurrency: 2 });
+    mockGetCrawl.mockResolvedValue(null);
+    mockPromoteJobFromBacklogOrAdd.mockResolvedValue({ id: "next-job" });
+  });
+
+  it("does not wait for queued job promotion before returning", async () => {
+    const nextJob = makeJob("next-job");
+    mockRedis.zpopmin.mockResolvedValueOnce([
+      nextJob.id,
+      String(Date.now() + 60_000),
+    ]);
+    mockRedis.get.mockResolvedValueOnce(JSON.stringify(nextJob));
+
+    await concurrentJobDone(makeJob("finished-job"));
+
+    expect(mockRedis.zrem).toHaveBeenCalledWith(
+      "concurrency-limiter:team-1",
+      "finished-job",
+    );
+    expect(mockPromoteJobFromBacklogOrAdd).not.toHaveBeenCalled();
+
+    await flushAsyncDrain();
+
+    expect(mockPromoteJobFromBacklogOrAdd).toHaveBeenCalledWith(
+      "next-job",
+      nextJob.data,
+      {
+        priority: nextJob.priority,
+        listenable: undefined,
+        ownerId: "team-1",
+        groupId: undefined,
+      },
+    );
+  });
+
+  it("does not fail job completion when concurrency cleanup fails", async () => {
+    const error = new Error("redis unavailable");
+    mockRedis.zrem.mockRejectedValueOnce(error);
+
+    await expect(concurrentJobDone(makeJob("finished-job"))).resolves.toBe(
+      undefined,
+    );
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to clean up completed concurrency job",
+      expect.objectContaining({
+        error,
+        jobId: "finished-job",
+        teamId: "team-1",
+      }),
+    );
+
+    await flushAsyncDrain();
+  });
+});

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -313,111 +313,140 @@ export async function getNextConcurrentJob(teamId: string): Promise<{
  * @param job The BullMQ job that is done.
  */
 export async function concurrentJobDone(job: NuQJob<any>) {
-  if (job.id && job.data && job.data.team_id) {
-    await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
-    await getRedisConnection().zrem(
-      constructQueueKey(job.data.team_id),
-      job.id,
-    );
-    await getRedisConnection().del(constructJobKey(job.id));
-    await cleanOldConcurrencyLimitEntries(job.data.team_id);
-    await cleanOldConcurrencyLimitedJobs(job.data.team_id);
+  if (!job.id || !job.data || !job.data.team_id) return;
 
-    if (job.data.crawl_id) {
-      await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
-      await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
-    }
+  try {
+    await cleanupCompletedConcurrencyJob(job);
+  } catch (error) {
+    logger.error("Failed to clean up completed concurrency job", {
+      error,
+      teamId: job.data.team_id,
+      jobId: job.id,
+      zeroDataRetention: job.data?.zeroDataRetention,
+    });
+  }
 
-    const maxTeamConcurrency =
-      (
-        await getACUCTeam(
-          job.data.team_id,
-          false,
-          true,
-          job.data.is_extract ? RateLimiterMode.Extract : RateLimiterMode.Crawl,
-        )
-      )?.concurrency ?? 2;
+  scheduleConcurrencyQueueDrain(job);
+}
 
-    let staleSkipped = 0;
-    while (staleSkipped < 100) {
-      const currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(job.data.team_id)
-      ).length;
+async function cleanupCompletedConcurrencyJob(job: NuQJob<any>) {
+  await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
+  await getRedisConnection().zrem(constructQueueKey(job.data.team_id), job.id);
+  await getRedisConnection().del(constructJobKey(job.id));
+  await cleanOldConcurrencyLimitEntries(job.data.team_id);
+  await cleanOldConcurrencyLimitedJobs(job.data.team_id);
 
-      if (currentActiveConcurrency >= maxTeamConcurrency) break;
+  if (job.data.crawl_id) {
+    await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
+    await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
+  }
+}
 
-      const nextJob = await getNextConcurrentJob(job.data.team_id);
-      if (nextJob === null) break;
+function scheduleConcurrencyQueueDrain(job: NuQJob<any>) {
+  const drain = setImmediate(() => {
+    drainConcurrencyQueue(job).catch(error => {
+      logger.error("Failed to drain concurrency queue after job completion", {
+        error,
+        teamId: job.data.team_id,
+        jobId: job.id,
+        zeroDataRetention: job.data?.zeroDataRetention,
+      });
+    });
+  });
 
-      await pushConcurrencyLimitActiveJob(
+  drain.unref?.();
+}
+
+async function drainConcurrencyQueue(job: NuQJob<any>) {
+  const maxTeamConcurrency =
+    (
+      await getACUCTeam(
         job.data.team_id,
+        false,
+        true,
+        job.data.is_extract ? RateLimiterMode.Extract : RateLimiterMode.Crawl,
+      )
+    )?.concurrency ?? 2;
+
+  let staleSkipped = 0;
+  while (staleSkipped < 100) {
+    const currentActiveConcurrency = (
+      await getConcurrencyLimitActiveJobs(job.data.team_id)
+    ).length;
+
+    if (currentActiveConcurrency >= maxTeamConcurrency) break;
+
+    const nextJob = await getNextConcurrentJob(job.data.team_id);
+    if (nextJob === null) break;
+
+    await pushConcurrencyLimitActiveJob(
+      job.data.team_id,
+      nextJob.job.id,
+      60 * 1000,
+    );
+
+    if (nextJob.job.data.crawl_id) {
+      await pushCrawlConcurrencyLimitActiveJob(
+        nextJob.job.data.crawl_id,
         nextJob.job.id,
         60 * 1000,
       );
 
-      if (nextJob.job.data.crawl_id) {
-        await pushCrawlConcurrencyLimitActiveJob(
-          nextJob.job.data.crawl_id,
-          nextJob.job.id,
-          60 * 1000,
+      const sc = await getCrawl(nextJob.job.data.crawl_id);
+      if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
+        await new Promise(resolve =>
+          setTimeout(resolve, sc.crawlerOptions.delay * 1000),
         );
-
-        const sc = await getCrawl(nextJob.job.data.crawl_id);
-        if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
-          await new Promise(resolve =>
-            setTimeout(resolve, sc.crawlerOptions.delay * 1000),
-          );
-        }
       }
+    }
 
-      abTestJob(nextJob.job.data);
+    abTestJob(nextJob.job.data);
 
-      const promotedSuccessfully =
-        (await scrapeQueue.promoteJobFromBacklogOrAdd(
-          nextJob.job.id,
-          nextJob.job.data,
-          {
-            priority: nextJob.job.priority,
-            listenable: nextJob.job.listenable,
-            ownerId: nextJob.job.data.team_id ?? undefined,
-            groupId: nextJob.job.data.crawl_id ?? undefined,
-          },
-        )) !== null;
+    const promotedSuccessfully =
+      (await scrapeQueue.promoteJobFromBacklogOrAdd(
+        nextJob.job.id,
+        nextJob.job.data,
+        {
+          priority: nextJob.job.priority,
+          listenable: nextJob.job.listenable,
+          ownerId: nextJob.job.data.team_id ?? undefined,
+          groupId: nextJob.job.data.crawl_id ?? undefined,
+        },
+      )) !== null;
 
-      if (promotedSuccessfully) {
-        logger.debug("Successfully promoted concurrent queued job", {
+    if (promotedSuccessfully) {
+      logger.debug("Successfully promoted concurrent queued job", {
+        teamId: job.data.team_id,
+        jobId: nextJob.job.id,
+        zeroDataRetention: nextJob.job.data?.zeroDataRetention,
+      });
+      break;
+    } else {
+      logger.warn(
+        "Was unable to promote concurrent queued job as it already exists in the database",
+        {
           teamId: job.data.team_id,
           jobId: nextJob.job.id,
           zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-        });
-        break;
-      } else {
-        logger.warn(
-          "Was unable to promote concurrent queued job as it already exists in the database",
-          {
-            teamId: job.data.team_id,
-            jobId: nextJob.job.id,
-            zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-          },
-        );
-        await removeConcurrencyLimitActiveJob(job.data.team_id, nextJob.job.id);
-        if (nextJob.job.data.crawl_id) {
-          await removeCrawlConcurrencyLimitActiveJob(
-            nextJob.job.data.crawl_id,
-            nextJob.job.id,
-          );
-        }
-        staleSkipped++;
-      }
-    }
-
-    if (staleSkipped >= 100) {
-      logger.warn(
-        "Skipped 100 stale entries in concurrency queue without a successful promotion",
-        {
-          teamId: job.data.team_id,
         },
       );
+      await removeConcurrencyLimitActiveJob(job.data.team_id, nextJob.job.id);
+      if (nextJob.job.data.crawl_id) {
+        await removeCrawlConcurrencyLimitActiveJob(
+          nextJob.job.data.crawl_id,
+          nextJob.job.id,
+        );
+      }
+      staleSkipped++;
     }
+  }
+
+  if (staleSkipped >= 100) {
+    logger.warn(
+      "Skipped 100 stale entries in concurrency queue without a successful promotion",
+      {
+        teamId: job.data.team_id,
+      },
+    );
   }
 }

--- a/apps/api/src/services/worker/nuq-worker.ts
+++ b/apps/api/src/services/worker/nuq-worker.ts
@@ -11,6 +11,7 @@ import Express from "express";
 import { _ } from "ajv";
 import { initializeBlocklist } from "../../scraper/WebScraper/utils/blocklist";
 import { initializeEngineForcing } from "../../scraper/WebScraper/utils/engine-forcing";
+import { concurrentJobDone } from "../../lib/concurrency-limit";
 
 (async () => {
   setSentryServiceTag("nuq-worker");
@@ -103,34 +104,38 @@ import { initializeEngineForcing } from "../../scraper/WebScraper/utils/engine-f
 
     clearInterval(lockRenewInterval);
 
-    if (processResult.ok) {
-      endJobTimer({ status: "success" });
-      if (
-        !(await scrapeQueue.jobFinish(
-          job.id,
-          job.lock!,
-          processResult.data,
-          logger,
-        ))
-      ) {
-        logger.warn("Could not update job status");
+    try {
+      if (processResult.ok) {
+        endJobTimer({ status: "success" });
+        if (
+          !(await scrapeQueue.jobFinish(
+            job.id,
+            job.lock!,
+            processResult.data,
+            logger,
+          ))
+        ) {
+          logger.warn("Could not update job status");
+        }
+      } else {
+        endJobTimer({ status: "failed" });
+        if (
+          !(await scrapeQueue.jobFail(
+            job.id,
+            job.lock!,
+            processResult.error instanceof Error
+              ? processResult.error.message
+              : typeof processResult.error === "string"
+                ? processResult.error
+                : JSON.stringify(processResult.error),
+            logger,
+          ))
+        ) {
+          logger.warn("Could not update job status");
+        }
       }
-    } else {
-      endJobTimer({ status: "failed" });
-      if (
-        !(await scrapeQueue.jobFail(
-          job.id,
-          job.lock!,
-          processResult.error instanceof Error
-            ? processResult.error.message
-            : typeof processResult.error === "string"
-              ? processResult.error
-              : JSON.stringify(processResult.error),
-          logger,
-        ))
-      ) {
-        logger.warn("Could not update job status");
-      }
+    } finally {
+      await concurrentJobDone(job);
     }
   }
 

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -6,10 +6,7 @@ import http from "http";
 import https from "https";
 
 import { logger as _logger } from "../../lib/logger";
-import {
-  concurrentJobDone,
-  pushConcurrencyLimitActiveJob,
-} from "../../lib/concurrency-limit";
+import { pushConcurrencyLimitActiveJob } from "../../lib/concurrency-limit";
 import { addJobPriority, deleteJobPriority } from "../../lib/job-priority";
 import { cacheableLookup } from "../../scraper/scrapeURL/lib/cacheableLookup";
 import { v7 as uuidv7 } from "uuid";
@@ -1265,80 +1262,72 @@ export const processJobInternal = async (job: NuQJob<ScrapeJobData>) => {
 
 async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
   try {
+    let extendLockInterval: NodeJS.Timeout | null = null;
+    if (
+      job.data?.mode !== "kickoff" &&
+      job.data?.team_id &&
+      !job.data.skipNuq
+    ) {
+      extendLockInterval = setInterval(async () => {
+        await pushConcurrencyLimitActiveJob(
+          job.data.team_id,
+          job.id,
+          60 * 1000,
+        ); // 60s lock renew, just like in the queue
+      }, jobLockExtendInterval);
+    }
+
+    await addJobPriority(job.data.team_id, job.id);
     try {
-      let extendLockInterval: NodeJS.Timeout | null = null;
-      if (
-        job.data?.mode !== "kickoff" &&
-        job.data?.team_id &&
-        !job.data.skipNuq
-      ) {
-        extendLockInterval = setInterval(async () => {
-          await pushConcurrencyLimitActiveJob(
-            job.data.team_id,
-            job.id,
-            60 * 1000,
-          ); // 60s lock renew, just like in the queue
-        }, jobLockExtendInterval);
-      }
-
-      await addJobPriority(job.data.team_id, job.id);
-      try {
-        if (job.data.mode === "kickoff") {
-          const result = await processKickoffJob(
-            job as NuQJob<ScrapeJobKickoff>,
-          );
-          if (result.success) {
-            return null;
-          } else {
-            throw (result as any).error;
-          }
-        } else if (job.data.mode === "kickoff_sitemap") {
-          const result = await processKickoffSitemapJob(
-            job as NuQJob<ScrapeJobKickoffSitemap>,
-          );
-          if (result.success) {
-            return null;
-          } else {
-            throw (result as any).error;
-          }
+      if (job.data.mode === "kickoff") {
+        const result = await processKickoffJob(job as NuQJob<ScrapeJobKickoff>);
+        if (result.success) {
+          return null;
         } else {
-          const result = await processJob(job as NuQJob<ScrapeJobSingleUrls>);
-          if (result.success) {
-            try {
-              if (job.data.team_id) {
-                await redisEvictConnection.set(
-                  "most-recent-success:" + job.data.team_id,
-                  new Date().toISOString(),
-                  "EX",
-                  60 * 60 * 24,
-                );
-              }
-            } catch (e) {
-              logger.warn("Failed to set most recent success", { error: e });
-            }
-
-            try {
-              if (config.GCS_BUCKET_NAME && !job.data.skipNuq) {
-                logger.debug("Job succeeded -- putting null in Redis");
-                return null;
-              } else {
-                logger.debug("Job succeeded -- putting result in Redis");
-                return result.document;
-              }
-            } catch (e) {}
-          } else {
-            throw (result as any).error;
-          }
+          throw (result as any).error;
         }
-      } finally {
-        await deleteJobPriority(job.data.team_id, job.id);
-        if (extendLockInterval) {
-          clearInterval(extendLockInterval);
+      } else if (job.data.mode === "kickoff_sitemap") {
+        const result = await processKickoffSitemapJob(
+          job as NuQJob<ScrapeJobKickoffSitemap>,
+        );
+        if (result.success) {
+          return null;
+        } else {
+          throw (result as any).error;
+        }
+      } else {
+        const result = await processJob(job as NuQJob<ScrapeJobSingleUrls>);
+        if (result.success) {
+          try {
+            if (job.data.team_id) {
+              await redisEvictConnection.set(
+                "most-recent-success:" + job.data.team_id,
+                new Date().toISOString(),
+                "EX",
+                60 * 60 * 24,
+              );
+            }
+          } catch (e) {
+            logger.warn("Failed to set most recent success", { error: e });
+          }
+
+          try {
+            if (config.GCS_BUCKET_NAME && !job.data.skipNuq) {
+              logger.debug("Job succeeded -- putting null in Redis");
+              return null;
+            } else {
+              logger.debug("Job succeeded -- putting result in Redis");
+              return result.document;
+            }
+          } catch (e) {}
+        } else {
+          throw (result as any).error;
         }
       }
     } finally {
-      if (!job.data.skipNuq) {
-        await concurrentJobDone(job);
+      await deleteJobPriority(job.data.team_id, job.id);
+      if (extendLockInterval) {
+        clearInterval(extendLockInterval);
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Finish NuQ scrape jobs before running concurrency queue drain work so successful jobs are marked completed before any delayed promotion of the next queued crawl. This keeps slow crawl-delay handling and best-effort queue draining from extending the replay window for already-completed jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finish NuQ job completion before draining the concurrency queue. Job status updates happen first, and queue draining runs asynchronously to avoid extending the replay window for completed jobs.

- **Bug Fixes**
  - Moved cleanup into `concurrentJobDone` and scheduled queue drain via `setImmediate` so it doesn’t block job completion.
  - Call `concurrentJobDone` from `nuq-worker` after `jobFinish`/`jobFail`; removed call from `scrape-worker` to prevent duplicates.
  - Drain errors are logged and do not affect job completion.
  - Added tests to verify non-blocking drain and resilience when Redis operations fail.

<sup>Written for commit c08acd125f89f98af91f902bce135c6a5d7cf468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3658?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

