### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/docs-staging/agent-quickstart/elixir.mdx
+++ b/docs-staging/agent-quickstart/elixir.mdx
@@ -1,0 +1,206 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` Hex package v1.5.0) and the v2 OpenAPI spec. Function names, parameters, and types match the SDK public API.
+
+## Install
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:firecrawl, "~> 1.5"}
+  ]
+end
+```
+
+## Authenticate
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+```
+
+You can also pass `api_key:` as an option to any function call to override the configured key.
+
+## When To Use What
+
+- **`search_and_scrape`** — start with a query and need discovery. Returns grouped results by source.
+- **`scrape_and_extract_from_url`** — already have a URL and want page content in one or more formats.
+- **`interact_with_scrape_browser_session`** — page needs clicks, forms, or post-scrape browser actions. Requires a job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain to a site with `site:` in the query.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ []) → {:ok, Req.Response.t()} | {:error, Exception.t()}
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  limit: 5,
+  scrape_options: [
+    formats: ["markdown"],
+    only_main_content: true
+  ]
+)
+
+web_results = response.body["data"]["web"] || []
+for hit <- web_results do
+  IO.puts("#{hit["url"]}: #{String.slice(hit["markdown"] || "", 0..199)}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | Search query. Use `site:example.com` to scope. Required. |
+| `sources` | `list` | Sources: `["web"]`, `["news"]`, `["images"]`. Default: `["web"]`. |
+| `categories` | `list` | Categories to filter results. |
+| `include_domains` | `list[string]` | Whitelist specific domains. |
+| `exclude_domains` | `list[string]` | Blacklist specific domains. |
+| `limit` | `integer` | Maximum number of results. |
+| `tbs` | `string` | Time-based search filter (e.g. `qdr:d`). |
+| `location` | `string` | Geographic location string. |
+| `country` | `string` | ISO country code (e.g. `"US"`). |
+| `ignore_invalid_urls` | `boolean` | Skip invalid URLs in results. |
+| `timeout` | `integer` | Request timeout in milliseconds. |
+| `scrape_options` | `keyword` | Apply scrape options to each result. See Scrape parameters. |
+| `enterprise` | `list[string]` | Enterprise ZDR options: `["zdr"]` or `["anon"]`. |
+
+**Bang variant:** `Firecrawl.search_and_scrape!/2` raises on error instead of returning `{:error, ...}`.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL in one or more output formats.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ []) → {:ok, Req.Response.t()} | {:error, Exception.t()}
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    "links",
+    %{"type" => "json", "prompt" => "Extract plan names and prices."}
+  ],
+  only_main_content: true,
+  wait_for: 1000
+)
+
+IO.puts(response.body["data"]["markdown"])
+IO.inspect(response.body["data"]["json"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | Target URL to scrape. Required. |
+| `formats` | `list` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Maps for complex types: `%{"type" => "json", "prompt" => ...}`, `%{"type" => "question", "question" => ...}`, `%{"type" => "highlights", "query" => ...}`. |
+| `headers` | `map` | Custom HTTP headers. |
+| `include_tags` | `list[string]` | HTML tags to include. |
+| `exclude_tags` | `list[string]` | HTML tags to exclude. |
+| `only_main_content` | `boolean` | Strip nav, footer, boilerplate. |
+| `timeout` | `integer` | Timeout in milliseconds (min 1000, default 60000, max 300000). |
+| `wait_for` | `integer` | Wait before scraping, in milliseconds. |
+| `mobile` | `boolean` | Use mobile viewport. |
+| `parsers` | `list` | Parser configs (e.g. PDF mode control). |
+| `actions` | `list[map]` | Browser actions: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `keyword` | Location settings: `country`, `languages`. |
+| `skip_tls_verification` | `boolean` | Skip TLS verification. |
+| `remove_base64_images` | `boolean` | Remove base64 images from output. |
+| `block_ads` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy type. |
+| `max_age` | `integer` | Use cached result if younger than this (milliseconds). |
+| `min_age` | `integer` | Use cached result only if at least this old (milliseconds). |
+| `store_in_cache` | `boolean` | Cache the result. |
+| `lockdown` | `boolean` | Serve only cached results, never make outbound requests. |
+| `profile` | `keyword` | `[name: "my-profile", save_changes: true]` for persistent browser state. |
+| `zero_data_retention` | `boolean` | Enable zero data retention. |
+
+**Bang variant:** `Firecrawl.scrape_and_extract_from_url!/2` raises on error.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for code execution or browser automation. Requires a job ID from a prior scrape.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ []) → {:ok, Req.Response.t()} | {:error, Exception.t()}
+```
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "console.log(await page.title());",
+  language: :node
+)
+IO.puts(result.body["stdout"])
+
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `string` | Scrape job ID from `metadata["scrapeId"]`. First argument, not in keyword list. |
+| `code` | `string` | Code to execute in the browser session. Required. |
+| `language` | `:python \| :node \| :bash` | Runtime for code execution. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+| `origin` | `string` | Origin tag for telemetry. |
+
+**Stop session:** `Firecrawl.stop_interactive_scrape_browser_session(job_id)` ends the browser session.
+
+**Bang variant:** `Firecrawl.interact_with_scrape_browser_session!/3` raises on error.
+
+## Notes
+
+- **Function names** are OpenAPI-shaped (e.g. `scrape_and_extract_from_url`, not `scrape`). Use the exact names from source.
+- **Naming:** Parameters use snake_case in Elixir. The SDK converts to camelCase for the API.
+- **Atoms for enums:** Use atoms like `:basic`, `:node`, `:python` for enum values.
+- **Bang variants:** Every function has a `!` variant that raises instead of returning `{:error, ...}`.
+- **Options list:** The second (or third for interact) argument is always a keyword list for HTTP-level options like `api_key:`, `base_url:`.
+- **Responses** are raw `Req.Response` structs. Access data via `response.body["data"]`.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-staging/agent-quickstart/java.mdx
+++ b/docs-staging/agent-quickstart/java.mdx
@@ -1,0 +1,224 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-java` v1.8.0) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+**Maven:**
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.8.0</version>
+</dependency>
+```
+
+**Gradle:**
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.8.0'
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+// Or from environment variable / system property:
+// FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+Builder options: `apiUrl(String)` (default `"https://api.firecrawl.dev"`), `timeoutMs(long)` (default 300000), `maxRetries(int)` (default 3), `backoffFactor(double)` (default 0.5).
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns grouped results by source.
+- **`scrape`** — already have a URL and want page content in one or more formats.
+- **`interact`** — page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain to a site with `site:` in the query.
+
+### Preferred SDK method
+
+```java
+client.search(query) → SearchData
+client.search(query, options) → SearchData
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    SearchOptions.builder()
+        .limit(5)
+        .scrapeOptions(ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .onlyMainContent(true)
+            .build())
+        .build()
+);
+
+for (var hit : results.getWeb()) {
+    System.out.println(hit.get("url"));
+}
+```
+
+### Parameters
+
+All `SearchOptions` fields are optional (builder pattern):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `String` | Search query. Use `site:example.com` to scope. |
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"`, or `{type: "web"}` maps. |
+| `categories` | `List<Object>` | Categories: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Whitelist specific domains. |
+| `excludeDomains` | `List<String>` | Blacklist specific domains. |
+| `limit` | `Integer` | Maximum number of results. |
+| `tbs` | `String` | Time-based search filter (e.g. `qdr:d`). |
+| `location` | `String` | Geographic location string. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs in results. |
+| `timeout` | `Integer` | Request timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | Apply scrape options to each result. See Scrape parameters. |
+| `integration` | `String` | Integration identifier. |
+
+**Return value:** `SearchData` with `.getWeb()`, `.getNews()`, `.getImages()` lists.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL in one or more output formats.
+
+### Preferred SDK method
+
+```java
+client.scrape(url) → Document
+client.scrape(url, options) → Document
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import java.util.List;
+import java.util.Map;
+
+Document doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of(
+            "markdown",
+            "links",
+            Map.of("type", "json", "prompt", "Extract plan names and prices.")
+        ))
+        .onlyMainContent(true)
+        .waitFor(1000)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+All `ScrapeOptions` fields are optional (builder pattern):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `String` | Target URL to scrape. |
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`, `"video"`. Object forms: `Map.of("type", "json", "prompt", ...)`, `Map.of("type", "question", "question", ...)`, `Map.of("type", "highlights", "query", ...)`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent` | `Boolean` | Strip nav, footer, boilerplate. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `waitFor` | `Integer` | Wait before scraping, in milliseconds. |
+| `mobile` | `Boolean` | Use mobile viewport. |
+| `parsers` | `List<Object>` | Parser configs (e.g. `Map.of("type", "pdf", "maxPages", 10)`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `LocationConfig` | `LocationConfig.builder().country("US").languages(List.of("en-US")).build()`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. |
+| `removeBase64Images` | `Boolean` | Remove base64 images from output. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. |
+| `proxy` | `String` | `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom URL. |
+| `maxAge` | `Long` | Use cached result if younger than this (milliseconds). |
+| `storeInCache` | `Boolean` | Cache the result. |
+| `lockdown` | `Boolean` | Serve only cached results, never make outbound requests. |
+| `integration` | `String` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or code execution. Requires `scrapeId` from a prior scrape's metadata.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code) → BrowserExecuteResponse
+client.interact(jobId, code, language, timeout) → BrowserExecuteResponse
+client.interact(jobId, code, language, timeout, origin) → BrowserExecuteResponse
+```
+
+### Example
+
+```java
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(jobId, "console.log(await page.title());");
+System.out.println(result.getStdout());
+
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `String` | Scrape job ID from `document.getMetadata().get("scrapeId")`. |
+| `code` | `String` | Code to execute in the browser session. |
+| `language` | `String` | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: 30. |
+| `origin` | `String` | Origin tag for request attribution. |
+
+**Stop session:** `client.stopInteractiveBrowser(jobId)` ends the browser session and returns billing info.
+
+**Note:** The Java SDK `interact` method requires `code` as a required parameter. For prompt-based interaction, use the HTTP API directly.
+
+## Notes
+
+- **Deprecated aliases:** `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- **Naming:** All parameters use camelCase (Java convention).
+- **Async variants:** Every method has an `Async` suffix variant returning `CompletableFuture<T>` (e.g. `scrapeAsync`, `searchAsync`, `interactAsync`).
+- **Builder pattern:** All options use `ClassName.builder().field(...).build()`.
+- **Requires:** Java 11+, OkHttp, Jackson.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/pom.xml`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-staging/agent-quickstart/node.mdx
+++ b/docs-staging/agent-quickstart/node.mdx
@@ -1,0 +1,193 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`@mendable/firecrawl-js`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+You can also pass just a string: `new Firecrawl("fc-...")`. The client reads `FIRECRAWL_API_KEY` and `FIRECRAWL_API_URL` from environment variables as fallbacks.
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns grouped results by source.
+- **`scrape`** — already have a URL and want page content in one or more formats.
+- **`interact`** — page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain to a site with `site:` in the query.
+
+### Preferred SDK method
+
+```ts
+client.search(query, options?) → Promise<SearchData>
+```
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true,
+  },
+});
+
+for (const hit of results.web ?? []) {
+  console.log(hit.url, hit.markdown?.slice(0, 200));
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | Search query. Use `site:example.com` to scope. |
+| `options.sources` | `("web" \| "news" \| "images")[]` | Which result sources to include. |
+| `options.categories` | `("github" \| "research" \| "pdf")[]` | Filter results by category. |
+| `options.includeDomains` | `string[]` | Whitelist specific domains. |
+| `options.excludeDomains` | `string[]` | Blacklist specific domains. Mutually exclusive with `includeDomains`. |
+| `options.limit` | `number` | Maximum number of results. |
+| `options.tbs` | `string` | Time-based search filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `options.location` | `string` | Geographic location string for localized results. |
+| `options.ignoreInvalidURLs` | `boolean` | Skip invalid URLs in results. |
+| `options.timeout` | `number` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Apply scrape options to each search result. See Scrape parameters. |
+| `options.integration` | `string` | Integration identifier. |
+
+**Return value:** `SearchData` with optional arrays `.web`, `.news`, `.images`. Results are **not** in `.data`.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL in one or more output formats.
+
+### Preferred SDK method
+
+```ts
+client.scrape(url, options?) → Promise<Document>
+```
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    "links",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+  waitFor: 1000,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | Target URL to scrape. |
+| `options.formats` | `FormatOption[]` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors: [{ selector, attribute }] }`. |
+| `options.headers` | `Record<string, string>` | Custom HTTP headers. |
+| `options.includeTags` | `string[]` | HTML tags to include. |
+| `options.excludeTags` | `string[]` | HTML tags to exclude. |
+| `options.onlyMainContent` | `boolean` | Strip nav, footer, boilerplate. |
+| `options.timeout` | `number` | Timeout in milliseconds. |
+| `options.waitFor` | `number` | Wait before scraping, in milliseconds. |
+| `options.mobile` | `boolean` | Use mobile viewport. |
+| `options.parsers` | `(string \| { type: "pdf", mode?: "fast" \| "auto" \| "ocr", maxPages?: number })[]` | Parser configs (e.g. PDF). |
+| `options.actions` | `ActionOption[]` | Browser actions: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `options.location` | `{ country?: string, languages?: string[] }` | Geo and language settings. |
+| `options.skipTlsVerification` | `boolean` | Skip TLS verification. |
+| `options.removeBase64Images` | `boolean` | Remove base64 images from output. |
+| `options.fastMode` | `boolean` | Faster scrapes with reduced fidelity. |
+| `options.blockAds` | `boolean` | Block ads and cookie popups. |
+| `options.proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto" \| string` | Proxy type or custom URL. |
+| `options.maxAge` | `number` | Use cached result if younger than this (milliseconds). |
+| `options.minAge` | `number` | Use cached result only if at least this old (milliseconds). |
+| `options.storeInCache` | `boolean` | Cache the result. |
+| `options.lockdown` | `boolean` | Serve only cached results, never make outbound requests. |
+| `options.profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile. |
+| `options.integration` | `string` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or natural-language instructions that go beyond pre-scrape `actions`. Requires `metadata.scrapeId` from a prior scrape.
+
+### Preferred SDK method
+
+```ts
+client.interact(jobId, args) → Promise<ScrapeExecuteResponse>
+```
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.scrapeId;
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+console.log(result.output);
+
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `string` | Scrape job ID from `document.metadata.scrapeId`. |
+| `args.code` | `string` | Code to execute in the browser session (e.g. Playwright `page` usage). Either `code` or `prompt` required. |
+| `args.prompt` | `string` | Natural-language instruction for the browser agent. Either `code` or `prompt` required. |
+| `args.language` | `"python" \| "node" \| "bash"` | Runtime for code execution. Default: `"node"`. |
+| `args.timeout` | `number` | Execution timeout in seconds. |
+
+**Stop session:** `client.stopInteraction(jobId)` ends the browser session and returns billing info.
+
+## Notes
+
+- **Deprecated aliases:** `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- **Naming:** All parameters use camelCase.
+- **Package:** The npm package is `firecrawl` (exports `Firecrawl` and `FirecrawlClient`).
+- **Engine:** Requires Node.js >= 22.
+- **Zod schemas** passed to `json` or `changeTracking` formats are converted to JSON Schema by the SDK.
+- **Search results** are grouped by source (`.web`, `.news`, `.images`), not in a flat `.data` property.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json`
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-staging/agent-quickstart/python.mdx
+++ b/docs-staging/agent-quickstart/python.mdx
@@ -1,0 +1,187 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+The client reads `FIRECRAWL_API_KEY` from the environment if `api_key` is not provided. Optional kwargs: `api_url` (default `"https://api.firecrawl.dev"`), `timeout`, `max_retries` (default 3), `backoff_factor` (default 0.5).
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns grouped results by source.
+- **`scrape`** — already have a URL and want page content in one or more formats.
+- **`interact`** — page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain to a site with `site:` in the query.
+
+### Preferred SDK method
+
+```python
+client.search(query, **options) → SearchData
+```
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    limit=5,
+    scrape_options={
+        "formats": ["markdown"],
+        "only_main_content": True,
+    },
+)
+
+for hit in results.web or []:
+    print(hit.url, (hit.markdown or "")[:200])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | Search query. Use `site:example.com` to scope. |
+| `sources` | `list[str]` | Which result sources: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str]` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Whitelist specific domains. |
+| `exclude_domains` | `list[str]` | Blacklist specific domains. Mutually exclusive with `include_domains`. |
+| `limit` | `int` | Maximum number of results. |
+| `tbs` | `str` | Time-based search filter (e.g. `qdr:d` for past day). |
+| `location` | `str` | Geographic location string for localized results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs in results. |
+| `timeout` | `int` | Request timeout in milliseconds. |
+| `scrape_options` | `ScrapeOptions` | Apply scrape options to each result. See Scrape parameters. |
+| `integration` | `str` | Integration identifier. |
+
+**Return value:** `SearchData` with optional lists `.web`, `.news`, `.images`.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL in one or more output formats.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **options) → Document
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        "links",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+    wait_for=1000,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` | Target URL to scrape. |
+| `formats` | `list` | Output formats. Plain strings: `"markdown"`, `"html"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"change_tracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "change_tracking", "modes": [...], "schema": ..., "prompt": ..., "tag": ...}`, `{"type": "attributes", "selectors": [{"selector": ..., "attribute": ...}]}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. |
+| `include_tags` | `list[str]` | HTML tags to include. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Strip nav, footer, boilerplate. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait before scraping, in milliseconds. |
+| `mobile` | `bool` | Use mobile viewport. |
+| `parsers` | `list` | Parser configs (e.g. `[{"type": "pdf", "mode": "auto", "max_pages": 5}]`). |
+| `actions` | `list[dict]` | Browser actions: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `execute_javascript`, `pdf`. |
+| `location` | `dict` | `{"country": "US", "languages": ["en-US"]}`. |
+| `skip_tls_verification` | `bool` | Skip TLS verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from output. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom URL. |
+| `max_age` | `int` | Use cached result if younger than this (milliseconds). |
+| `store_in_cache` | `bool` | Cache the result. |
+| `lockdown` | `bool` | Serve only cached results, never make outbound requests. |
+| `profile` | `dict` | `{"name": "my-profile", "save_changes": True}` for persistent browser state. |
+| `integration` | `str` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or natural-language instructions that go beyond pre-scrape `actions`. Requires `scrape_id` from a prior scrape's metadata.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None) → BrowserExecuteResponse
+```
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id
+
+result = client.interact(
+    job_id,
+    prompt="Click the pricing tab and summarize the plans.",
+)
+print(result.output)
+
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `str` | Scrape job ID from `document.metadata.scrape_id`. |
+| `code` | `str` | Code to execute in the browser session. Either `code` or `prompt` required. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. Either `code` or `prompt` required. |
+| `language` | `"python" \| "node" \| "bash"` | Runtime for code execution. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+**Stop session:** `client.stop_interaction(job_id)` ends the browser session and returns billing info.
+
+## Notes
+
+- **Deprecated aliases:** `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`. V1 aliases: `scrape_url` → `scrape`, `crawl_url` → `crawl`, `map_url` → `map`.
+- **Naming:** All parameters use snake_case. The SDK accepts both snake_case and camelCase for format strings (e.g. `"raw_html"` or `"rawHtml"`).
+- **Async client:** `AsyncFirecrawl` provides the same API with `async`/`await`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs-staging/agent-quickstart/rust.mdx
+++ b/docs-staging/agent-quickstart/rust.mdx
@@ -1,0 +1,233 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate v2.7.0) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+
+// For self-hosted:
+// let client = Client::new_selfhosted("https://your-instance.com", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns grouped results by source.
+- **`scrape`** — already have a URL and want page content in one or more formats.
+- **`interact`** — page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain to a site with `site:` in the query.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options) → Result<SearchResponse, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let response = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    SearchOptions {
+        limit: Some(5),
+        scrape_options: Some(ScrapeOptions {
+            formats: Some(vec![Format::Markdown]),
+            only_main_content: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    },
+).await?;
+
+if let Some(web_results) = response.data.web {
+    for hit in web_results {
+        println!("{:?}", hit);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option<T>`:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `impl AsRef<str>` | Search query. Use `site:example.com` to scope. |
+| `limit` | `u32` | Maximum number of results. |
+| `sources` | `Vec<SearchSource>` | Sources: `Web`, `News`, `Images`. |
+| `categories` | `Vec<SearchCategory>` | Categories: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Vec<String>` | Whitelist specific domains. |
+| `exclude_domains` | `Vec<String>` | Blacklist specific domains. |
+| `tbs` | `String` | Time-based search filter (e.g. `qdr:d`). |
+| `location` | `String` | Geographic location string. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs in results. |
+| `timeout` | `u32` | Request timeout in milliseconds. |
+| `scrape_options` | `ScrapeOptions` | Apply scrape options to each result. See Scrape parameters. |
+| `integration` | `String` | Integration identifier. |
+
+**Return value:** `SearchResponse` with `data: SearchData` containing optional `web`, `news`, `images` vecs.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL in one or more output formats.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options) → Result<Document, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Links, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".into()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        wait_for: Some(1000),
+        ..Default::default()
+    },
+).await?;
+
+println!("{:?}", doc.markdown);
+println!("{:?}", doc.json);
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option<T>`:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `impl AsRef<str>` | Target URL to scrape. |
+| `formats` | `Vec<Format>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `headers` | `HashMap<String, String>` | Custom HTTP headers. |
+| `include_tags` | `Vec<String>` | HTML tags to include. |
+| `exclude_tags` | `Vec<String>` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Strip nav, footer, boilerplate. |
+| `timeout` | `u32` | Timeout in milliseconds. |
+| `wait_for` | `u32` | Wait before scraping, in milliseconds. |
+| `mobile` | `bool` | Use mobile viewport. |
+| `parsers` | `Vec<ParserConfig>` | Parser configs (e.g. PDF with mode and max_pages). |
+| `actions` | `Vec<Action>` | Browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `LocationConfig` | `country` and `languages` for geo routing. |
+| `skip_tls_verification` | `bool` | Skip TLS verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from output. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `ProxyType` | `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `u32` | Use cached result if younger than this (milliseconds). |
+| `min_age` | `u32` | Use cached result only if at least this old (milliseconds). |
+| `store_in_cache` | `bool` | Cache the result. |
+| `lockdown` | `bool` | Serve only cached results, never make outbound requests. |
+| `profile` | `ProfileConfig` | `name` and `save_changes` for persistent browser state. |
+| `integration` | `String` | Integration identifier. |
+| `json_options` | `JsonOptions` | `schema`, `system_prompt`, `prompt` for JSON extraction. |
+| `screenshot_options` | `ScreenshotOptions` | `full_page`, `quality`, `viewport`. |
+| `change_tracking_options` | `ChangeTrackingOptions` | `modes`, `schema`, `prompt`, `tag`. |
+| `attribute_selectors` | `Vec<AttributeSelector>` | `selector` and `attribute` pairs. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or natural-language instructions. Requires `scrape_id` from a prior scrape's metadata.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options) → Result<ScrapeExecuteResponse, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref().and_then(|m| m.scrape_id.as_ref()).unwrap();
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    prompt: Some("Click the pricing tab and summarize the plans.".into()),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.output);
+
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+All fields on `ScrapeExecuteOptions` are `Option<T>`:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `impl AsRef<str>` | Scrape job ID from `document.metadata.scrape_id`. |
+| `code` | `String` | Code to execute in the browser session. Either `code` or `prompt` required. |
+| `prompt` | `String` | Natural-language instruction for the browser agent. Either `code` or `prompt` required. |
+| `language` | `ScrapeExecuteLanguage` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `u32` | Execution timeout in seconds. |
+| `origin` | `String` | Origin tag for request attribution. |
+
+**Stop session:** `client.stop_interaction(job_id).await?` ends the browser session and returns billing info.
+
+## Notes
+
+- **Deprecated aliases:** `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- **Naming:** All struct fields use snake_case. JSON serialization uses camelCase via `#[serde(rename_all = "camelCase")]`.
+- **Convenience method:** `client.search_and_scrape(query, limit)` combines search + scrape in one call.
+- **Schema extraction:** `client.scrape_with_schema(url, schema, prompt)` is a shortcut for JSON extraction with a schema.
+- All methods are `async` and return `Result<T, FirecrawlError>`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file covers `search`, `scrape`, and `interact` endpoints with every confirmed parameter from SDK source and OpenAPI spec
- Files are staged under `docs-staging/agent-quickstart/` and are intended for `firecrawl-docs/agent-quickstart/`

**Note:** Write access to `firecrawl/firecrawl-docs` was unavailable during this session, so the files are staged here. To deploy, move the 5 MDX files from `docs-staging/agent-quickstart/` to the `agent-quickstart/` directory in `firecrawl-docs`, and add an "Agent Quickstarts" navigation group to `docs.json` under the "Build with AI" tab.

### What each quickstart covers

- Install command and package name
- Auth/client initialization pattern
- When to use search vs scrape vs interact
- Preferred SDK method for each endpoint
- Realistic working example for each endpoint
- Full parameter table with types and descriptions (confirmed from SDK source)
- Language-specific naming differences and deprecated aliases
- Source of truth file references

### Sources used

- JS SDK: `apps/js-sdk/firecrawl/src/v2/` (types.ts, client.ts)
- Python SDK: `apps/python-sdk/firecrawl/v2/` (types.py, client.py)
- Rust SDK: `apps/rust-sdk/src/` (client.rs, search.rs, scrape.rs, types.rs)
- Java SDK: `apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
- Elixir SDK: `apps/elixir-sdk/lib/firecrawl.ex`
- OpenAPI: `firecrawl-docs/api-reference/v2-openapi.json`

## Test plan

- [ ] Move files from `docs-staging/agent-quickstart/` to `firecrawl-docs/agent-quickstart/`
- [ ] Add navigation entries to `firecrawl-docs/docs.json`
- [ ] Verify each MDX file renders cleanly in Mintlify
- [ ] Spot-check parameter tables against current SDK source
- [ ] Remove `docs-staging/` directory after migration

https://claude.ai/code/session_016ip4Pzp3PkrmHAV5H7FVZv

---
_Generated by [Claude Code](https://claude.ai/code/session_016ip4Pzp3PkrmHAV5H7FVZv)_