### PR TITLE
fix(api): handle transient DB errors in nuq-prefetch-worker

### DIFF
--- a/apps/api/src/services/worker/nuq-prefetch-worker.ts
+++ b/apps/api/src/services/worker/nuq-prefetch-worker.ts
@@ -47,7 +47,11 @@ import { logger } from "../../lib/logger";
     await Promise.all([
       (async () => {
         while (true) {
-          await crawlFinishedQueue.prefetchJobs();
+          try {
+            await crawlFinishedQueue.prefetchJobs();
+          } catch (error) {
+            logger.warn("crawlFinishedQueue prefetch error, retrying", { error });
+          }
           await new Promise(resolve => setTimeout(resolve, 250));
         }
       })(),
@@ -56,13 +60,17 @@ import { logger } from "../../lib/logger";
           if (config.NUQ_PREFETCH_WORKER_HEARTBEAT_URL) {
             fetch(config.NUQ_PREFETCH_WORKER_HEARTBEAT_URL).catch(() => {});
           }
-          await scrapeQueue.prefetchJobs();
+          try {
+            await scrapeQueue.prefetchJobs();
+          } catch (error) {
+            logger.warn("scrapeQueue prefetch error, retrying", { error });
+          }
           await new Promise(resolve => setTimeout(resolve, 250));
         }
       })(),
     ]);
   } catch (error) {
-    logger.error("Error in prefetch worker", { error });
+    logger.error("Fatal error in prefetch worker", { error });
     process.exit(1);
   }
 


### PR DESCRIPTION
## Problem

When running self-hosted Firecrawl with an external PostgreSQL instance, `nuq-prefetch-worker` crashes immediately on startup if Postgres is not fully ready yet. The `prefetchJobs()` call throws a `57P03` error (the database system is starting up), which propagates out of the `while (true)` loop to the outer `catch`, causing `process.exit(1)`. This kills the entire worker harness.

This affects every cold start where Postgres takes more than a few seconds to initialize.

## Fix

Wrap each `prefetchJobs()` call in its own try/catch so transient errors are logged and retried after the 250ms delay, rather than crashing the process. The outer catch remains for truly fatal errors that escape the loops.

## Testing

Reproduced locally with Docker Compose. `firecrawl-api` would crash-loop on every fresh start until Postgres finished initializing. With this fix it retries gracefully and comes up healthy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `nuq-prefetch-worker` from crashing on startup when Postgres is still initializing by treating transient DB errors (like 57P03) as retriable. The worker now logs and retries every 250ms instead of exiting, improving cold-start stability with external DBs.

- **Bug Fixes**
  - Wrap `crawlFinishedQueue.prefetchJobs()` and `scrapeQueue.prefetchJobs()` in try/catch; log warn and continue.
  - Keep the 250ms retry delay; heartbeat behavior unchanged.
  - Retain outer catch for fatal errors; update message to “Fatal error in prefetch worker.”

<sup>Written for commit cad6685435530d802adef8d240723f08296ca3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

