### PR TITLE
fix: batch scrape successful status check

### DIFF
--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -17,7 +17,7 @@ def _parse_batch_scrape_documents(data_list: Optional[List[Any]]) -> List[Docume
 
 
 def _parse_batch_scrape_status_response(body: Dict[str, Any]) -> Dict[str, Any]:
-    if not body.get("success"):
+    if not body.get("success") and response.status_code >= 400:
         raise Exception(body.get("error", "Unknown error occurred"))
 
     return {
@@ -63,7 +63,7 @@ async def start_batch_scrape(client: AsyncHttpClient, urls: List[str], **kwargs)
     if response.status_code >= 400:
         handle_response_error(response, "start batch scrape")
     body = response.json()
-    if not body.get("success"):
+    if not body.get("success") and response.status_code >= 400:
         raise Exception(body.get("error", "Unknown error occurred"))
     return BatchScrapeResponse(id=body.get("id"), url=body.get("url"), invalid_urls=body.get("invalidURLs"))
 
@@ -235,6 +235,6 @@ async def get_batch_scrape_errors(client: AsyncHttpClient, job_id: str) -> Dict[
     if response.status_code >= 400:
         handle_response_error(response, "get batch scrape errors")
     body = response.json()
-    if not body.get("success"):
+    if not body.get("success") and response.status_code >= 400:
         raise Exception(body.get("error", "Unknown error occurred"))
     return body


### PR DESCRIPTION
Fixes #3477. Ensure exception is raised only when API response indicates failure, not incorrectly on successful paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false exceptions during batch scrape by raising only when the HTTP status is 400+ and the API marks the request as unsuccessful. Prevents errors being thrown on successful status checks and job initiation.

- **Bug Fixes**
  - Gate exception handling on both `success == false` and 4xx/5xx status for status, start, and error-fetch endpoints.
  - Aligns error handling with the API contract to avoid false negatives during batch scrape jobs.

<sup>Written for commit 68f758cc963032b3824e0ecbd007db343fdaa262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

