### PR TITLE
fix: fix double polling interval conversion in crawl --wait

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -151,7 +151,7 @@ export async function waitForCrawlCompletion(http: HttpClient, jobId: string, po
       throw new JobTimeoutError(jobId, timeout, 'crawl');
     }
     
-    await new Promise((r) => setTimeout(r, Math.max(1000, pollInterval * 1000)));
+    await new Promise((r) => setTimeout(r, Math.max(1000, pollInterval)));
   }
 }
 


### PR DESCRIPTION
Fixes #3373. The pollInterval was being multiplied by 1000 twice, causing extremely long hangs. Changed to multiply only once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long hangs in `crawl --wait` by removing a double milliseconds conversion of `pollInterval` in `waitForCrawlCompletion`. Polling now respects the intended interval with a 1s minimum.

<sup>Written for commit 3a3ae5b0cf3c350ad78bdce4fe03d4f4db071c0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

