### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,300 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` hex package) and the v2 OpenAPI spec. Function names and parameter keys are auto-generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+{:firecrawl, "~> 1.5"}
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# or pass api_key per call
+{:ok, res} = Firecrawl.search_and_scrape(
+  [query: "firecrawl webhooks"],
+  api_key: "fc-your-api-key"
+)
+```
+
+There is no client object. Authentication is handled via application config or per-request options.
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  sources: [:web],
+  limit: 5,
+  scrape_options: [
+    formats: ["markdown"],
+    only_main_content: true
+  ]
+)
+```
+
+### Parameters
+
+- `query`
+  - Type: string (required)
+  - The search query. Use `site:example.com` to limit results to a domain.
+
+- `sources`
+  - Type: list of atoms, strings, or maps
+  - Controls which sources are searched. Values: `:web`, `:news`, `:images`.
+
+- `categories`
+  - Type: list of atoms, strings, or maps
+  - Filters results by category. Values: `:github`, `:research`, `:pdf`.
+
+- `include_domains`
+  - Type: list of strings
+  - Only include results from these domains.
+
+- `exclude_domains`
+  - Type: list of strings
+  - Exclude results from these domains.
+
+- `limit`
+  - Type: integer
+  - Caps the number of results.
+
+- `tbs`
+  - Type: string
+  - Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+
+- `location`
+  - Type: string
+  - Localized results (e.g. `"San Francisco,California,United States"`). Note: this is a plain string, not a keyword list.
+
+- `country`
+  - Type: string
+  - ISO 3166-1 alpha-2 code for geo-targeting (e.g. `"US"`).
+
+- `ignore_invalid_urls`
+  - Type: boolean
+  - Drops URLs that cannot be scraped by other endpoints.
+
+- `timeout`
+  - Type: integer
+  - Request timeout in milliseconds.
+
+- `enterprise`
+  - Type: list of strings
+  - Enterprise ZDR options. Values: `"zdr"`, `"anon"`.
+
+- `scrape_options`
+  - Type: keyword list
+  - Scrapes each search result inline. See Scrape parameters for fields.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    %{type: "json", prompt: "Extract plan names and prices."}
+  ],
+  only_main_content: true
+)
+```
+
+### Parameters
+
+- `url`
+  - Type: string (required)
+  - The page to scrape.
+
+- `formats`
+  - Type: list of format strings or format maps
+  - Output formats to request.
+  - String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`
+  - Map formats: `%{type: "json", prompt: "..."}`, `%{type: "screenshot", fullPage: true}`, `%{type: "changeTracking", modes: ["git-diff"]}`
+
+- `headers`
+  - Type: map
+  - Custom request headers.
+
+- `include_tags`
+  - Type: list of strings
+  - Include only specific HTML tags.
+
+- `exclude_tags`
+  - Type: list of strings
+  - Exclude specific HTML tags.
+
+- `only_main_content`
+  - Type: boolean
+  - Strips nav, footer, and other boilerplate.
+
+- `timeout`
+  - Type: integer
+  - Timeout in milliseconds. Min 1000, default 60000, max 300000.
+
+- `wait_for`
+  - Type: integer
+  - Wait for the page to render (milliseconds).
+
+- `mobile`
+  - Type: boolean
+  - Uses a mobile viewport.
+
+- `parsers`
+  - Type: list of parser maps
+  - File parsing controls. Values: `%{type: "pdf", mode: "auto", maxPages: 5}`
+
+- `actions`
+  - Type: list of action maps
+  - Pre-scrape browser actions.
+  - Action types: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`
+
+- `location`
+  - Type: keyword list (e.g. `[country: "US", languages: ["en-US"]]`)
+  - Geo or language-aware scraping. Note: this is a keyword list, not a plain string (unlike `search`).
+
+- `skip_tls_verification`
+  - Type: boolean
+  - Skips TLS verification.
+
+- `remove_base64_images`
+  - Type: boolean
+  - Drops base64 images from markdown output.
+
+- `block_ads`
+  - Type: boolean
+  - Ad and cookie popup blocking.
+
+- `proxy`
+  - Type: atom
+  - Proxy control. Values: `:basic`, `:enhanced`, `:auto`.
+
+- `max_age`
+  - Type: integer
+  - Cached data up to this age (milliseconds).
+
+- `min_age`
+  - Type: integer
+  - Cached data only if at least this old (milliseconds).
+
+- `store_in_cache`
+  - Type: boolean
+  - Cache the result on Firecrawl's side.
+
+- `lockdown`
+  - Type: boolean
+  - Serve only previously cached results; never make outbound requests.
+
+- `profile`
+  - Type: keyword list with `name:` and optional `save_changes:`
+  - Persistent browser profile shared across scrapes and interactions.
+
+- `zero_data_retention`
+  - Type: boolean
+  - Enable zero data retention for this scrape.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code execution in the browser session tied to a scrape job. The Elixir SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, scrape_res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = get_in(scrape_res.body, ["data", "metadata", "scrapeId"])
+
+{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+
+# When done, tear down the session
+{:ok, _} = Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+- `job_id`
+  - Type: string (required, first argument)
+  - The scrape job ID.
+
+- `code`
+  - Type: string (required)
+  - Code to run in the browser session.
+
+- `language`
+  - Type: atom or string
+  - Runtime to use. Values: `:python`, `:node`, `:bash`.
+
+- `timeout`
+  - Type: integer
+  - Execution timeout in seconds.
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id)` ends the browser session.
+
+## Notes
+
+- The Elixir client is auto-generated from the OpenAPI spec. Function names match OpenAPI `operationId` values.
+- There are no deprecated aliases — each function has a single canonical name.
+- Each function has a bang (`!`) variant that raises on error (e.g. `search_and_scrape!`).
+- Parameters use `snake_case` (idiomatic Elixir); they are automatically converted to `camelCase` JSON keys.
+- Enum parameters use Elixir atoms (e.g. `proxy: :basic`, `language: :node`).
+- `location` type differs between search (plain string) and scrape (keyword list).
+- This SDK exposes **code-based interactions only** — there is no `prompt` parameter on `interact_with_scrape_browser_session`.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,316 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-java`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.8.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.8.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+
+SearchData results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    SearchOptions.builder()
+        .sources(List.of("web"))
+        .limit(5)
+        .scrapeOptions(
+            ScrapeOptions.builder()
+                .formats(List.of("markdown"))
+                .onlyMainContent(true)
+                .build()
+        )
+        .build()
+);
+
+List<Map<String, Object>> web = results.getWeb();
+```
+
+### Return value
+
+`SearchData` with `getWeb()`, `getNews()`, `getImages()` — each returns `List<Map<String, Object>>` (may be null). Do not treat `SearchData` as a directly iterable list.
+
+### Parameters
+
+- `query`
+  - Type: String
+  - The search query. Use `site:example.com` to limit results to a domain.
+
+- `options.sources`
+  - Type: `List<Object>`
+  - Controls which sources are searched. Values: `"web"`, `"news"`, `"images"`.
+
+- `options.categories`
+  - Type: `List<Object>`
+  - Filters results by category. Values: `"github"`, `"research"`, `"pdf"`.
+
+- `options.includeDomains`
+  - Type: `List<String>`
+  - Only include results from these domains.
+
+- `options.excludeDomains`
+  - Type: `List<String>`
+  - Exclude results from these domains.
+
+- `options.limit`
+  - Type: Integer
+  - Caps the number of results.
+
+- `options.tbs`
+  - Type: String
+  - Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+
+- `options.location`
+  - Type: String
+  - Localized results. Note: this is a plain `String`, not a `LocationConfig`.
+
+- `options.ignoreInvalidURLs`
+  - Type: Boolean
+  - Drops URLs that cannot be scraped by other endpoints.
+
+- `options.timeout`
+  - Type: Integer
+  - Request timeout in milliseconds.
+
+- `options.scrapeOptions`
+  - Type: `ScrapeOptions`
+  - Scrapes each search result inline. See Scrape parameters for fields.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)`
+
+### Example
+
+```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+
+Document doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of(
+            "markdown",
+            JsonFormat.builder().prompt("Extract plan names and prices.").build()
+        ))
+        .onlyMainContent(true)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+- `url`
+  - Type: String
+  - The page to scrape.
+
+- `options.formats`
+  - Type: `List<Object>`
+  - Output formats to request. Accepts strings and typed format objects.
+  - String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`
+  - Typed format objects:
+    - `JsonFormat.builder().prompt("...").schema(Map).build()`
+    - `QuestionFormat.builder().question("...").build()`
+    - `HighlightsFormat.builder().query("...").build()`
+
+- `options.headers`
+  - Type: `Map<String, String>`
+  - Custom request headers.
+
+- `options.includeTags`
+  - Type: `List<String>`
+  - Include only specific HTML tags.
+
+- `options.excludeTags`
+  - Type: `List<String>`
+  - Exclude specific HTML tags.
+
+- `options.onlyMainContent`
+  - Type: Boolean
+  - Strips nav, footer, and other boilerplate.
+
+- `options.timeout`
+  - Type: Integer
+  - Timeout in milliseconds.
+
+- `options.waitFor`
+  - Type: Integer
+  - Wait for the page to render (milliseconds).
+
+- `options.mobile`
+  - Type: Boolean
+  - Uses a mobile viewport.
+
+- `options.parsers`
+  - Type: `List<Object>`
+  - File parsing controls. Values: `"pdf"` or `Map.of("type", "pdf", "maxPages", 5)`.
+
+- `options.actions`
+  - Type: `List<Map<String, Object>>`
+  - Pre-scrape browser actions.
+  - Action types: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`
+
+- `options.location`
+  - Type: `LocationConfig`
+  - Geo or language-aware scraping. Built via `LocationConfig.builder().country("US").languages(List.of("en-US")).build()`.
+
+- `options.skipTlsVerification`
+  - Type: Boolean
+  - Skips TLS verification.
+
+- `options.removeBase64Images`
+  - Type: Boolean
+  - Drops base64 images from markdown output.
+
+- `options.blockAds`
+  - Type: Boolean
+  - Ad and cookie popup blocking.
+
+- `options.proxy`
+  - Type: String
+  - Proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL.
+
+- `options.maxAge`
+  - Type: Long
+  - Cached data up to this age (milliseconds).
+
+- `options.storeInCache`
+  - Type: Boolean
+  - Cache the result on Firecrawl's side.
+
+- `options.lockdown`
+  - Type: Boolean
+  - Serve only previously cached results; never make outbound requests.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code execution in the browser session tied to a scrape job. The Java SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+`client.interact(jobId, code)` or `client.interact(jobId, code, language, timeout)`
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape(
+    "https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build()
+);
+
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+
+System.out.println(result.getStdout());
+
+// When done, tear down the session
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+- `jobId`
+  - Type: String
+  - The scrape job ID.
+
+- `code`
+  - Type: String
+  - Code to run in the browser session.
+
+- `language`
+  - Type: String
+  - Runtime to use. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+
+- `timeout`
+  - Type: Integer
+  - Execution timeout in seconds (1–300). Null uses the API default (30 seconds).
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` ends the browser session.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`. Deprecated format: `QueryFormat` → use `QuestionFormat` or `HighlightsFormat`.
+- The Java SDK exposes **code-based interactions only** — there is no `prompt` parameter on `interact` (unlike Node.js, Python, and Rust SDKs).
+- All options classes use the builder pattern with `SomeOptions.builder()...build()`.
+- `formats` field is `List<Object>` to allow mixing plain strings with typed format objects.
+- `SearchOptions.location` is a plain `String`, while `ScrapeOptions.location` is a `LocationConfig` object.
+- All async methods return `CompletableFuture<T>` (e.g. `scrapeAsync`, `searchAsync`, `interactAsync`).
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,296 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl/apps/js-sdk/firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  sources: ["web"],
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true,
+  },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+### Return value
+
+`SearchData` with optional arrays — access `result.web`, `result.news`, `result.images`. Do **not** access `result.data`.
+
+### Parameters
+
+- `query`
+  - Type: string
+  - The search query. Use `site:example.com` to limit results to a domain.
+
+- `options.sources`
+  - Type: array of `"web"` | `"news"` | `"images"` (or typed source objects)
+  - Controls which sources are searched.
+
+- `options.categories`
+  - Type: array of `"github"` | `"research"` | `"pdf"` (or typed category objects)
+  - Filters results by category.
+
+- `options.limit`
+  - Type: number
+  - Caps the number of results.
+
+- `options.tbs`
+  - Type: string
+  - Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+
+- `options.location`
+  - Type: string
+  - Localized results (e.g. `"San Francisco,California,United States"`).
+
+- `options.includeDomains`
+  - Type: array of strings
+  - Only include results from these domains. Mutually exclusive with `excludeDomains`.
+
+- `options.excludeDomains`
+  - Type: array of strings
+  - Exclude results from these domains. Mutually exclusive with `includeDomains`.
+
+- `options.ignoreInvalidURLs`
+  - Type: boolean
+  - Drops URLs that cannot be scraped by other endpoints.
+
+- `options.timeout`
+  - Type: number
+  - Request timeout in milliseconds.
+
+- `options.scrapeOptions`
+  - Type: `ScrapeOptions`
+  - Scrapes each search result inline. See Scrape parameters for fields.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+- `url`
+  - Type: string
+  - The page to scrape.
+
+- `options.formats`
+  - Type: array of format strings or format objects
+  - Output formats to request.
+  - Plain string formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Object-only formats:
+    - `{ type: "json", prompt?: string, schema?: JSON schema or Zod schema }` — at least one of `prompt` or `schema` required
+    - `{ type: "question", question: string }`
+    - `{ type: "highlights", query: string }`
+    - `{ type: "screenshot", fullPage?, quality?, viewport? }`
+    - `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?, prompt?, tag? }` — `modes` required
+    - `{ type: "attributes", selectors: Array<{ selector, attribute }> }`
+  - The SDK rejects plain string `"json"` — use the object form.
+
+- `options.headers`
+  - Type: `Record<string, string>`
+  - Custom request headers.
+
+- `options.includeTags`
+  - Type: array of strings
+  - Include only specific HTML tags.
+
+- `options.excludeTags`
+  - Type: array of strings
+  - Exclude specific HTML tags.
+
+- `options.onlyMainContent`
+  - Type: boolean
+  - Strips nav, footer, and other boilerplate.
+
+- `options.timeout`
+  - Type: number
+  - Timeout in milliseconds.
+
+- `options.waitFor`
+  - Type: number
+  - Wait for the page to render (milliseconds).
+
+- `options.mobile`
+  - Type: boolean
+  - Uses a mobile viewport.
+
+- `options.parsers`
+  - Type: array of parser names or parser objects
+  - File parsing controls (e.g. PDF).
+  - Values: `"pdf"` or `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`
+
+- `options.actions`
+  - Type: array of action objects
+  - Pre-scrape browser actions.
+  - Action types: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`: `up`/`down`, optional `selector`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf` (`format`, `landscape`, `scale`)
+
+- `options.location`
+  - Type: `{ country: string, languages: string[] }`
+  - Geo or language-aware scraping.
+
+- `options.skipTlsVerification`
+  - Type: boolean
+  - Skips TLS verification.
+
+- `options.removeBase64Images`
+  - Type: boolean
+  - Drops base64 images from markdown output.
+
+- `options.fastMode`
+  - Type: boolean
+  - Faster scrapes with reduced fidelity.
+
+- `options.blockAds`
+  - Type: boolean
+  - Ad and cookie popup blocking.
+
+- `options.proxy`
+  - Type: string
+  - Proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL.
+
+- `options.maxAge`
+  - Type: number
+  - Cached data up to this age (milliseconds).
+
+- `options.minAge`
+  - Type: number
+  - Cached data only if at least this old (milliseconds).
+
+- `options.storeInCache`
+  - Type: boolean
+  - Cache the result on Firecrawl's side.
+
+- `options.profile`
+  - Type: `{ name: string, saveChanges?: boolean }`
+  - Persistent browser profile shared across scrapes and interactions.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrapeId`). At least one of `code` or `prompt` is required.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId from scrape response");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+
+console.log(result.output);
+
+// When done, tear down the session
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+- `jobId`
+  - Type: string
+  - The scrape job ID from `document.metadata.scrapeId`.
+
+- `args.code`
+  - Type: string
+  - Code to run in the browser session (e.g. Playwright `page` usage in the `node` runtime).
+
+- `args.prompt`
+  - Type: string
+  - Natural-language instruction for the browser agent.
+
+- `args.language`
+  - Type: string
+  - Runtime to use. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+
+- `args.timeout`
+  - Type: number
+  - Execution timeout in seconds.
+
+### Stop session
+
+`client.stopInteraction(jobId)` ends the browser session.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` / `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,295 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    sources=["web"],
+    limit=5,
+    scrape_options=ScrapeOptions(
+        formats=["markdown"],
+        only_main_content=True,
+    ),
+)
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+### Return value
+
+`SearchData` with optional lists — access `result.web`, `result.news`, `result.images`. Do **not** access `result.data` (raises `AttributeError` intentionally).
+
+### Parameters
+
+- `query`
+  - Type: str
+  - The search query. Use `site:example.com` to limit results to a domain.
+
+- `sources`
+  - Type: list of `"web"` | `"news"` | `"images"` (or `Source` objects)
+  - Controls which sources are searched.
+
+- `categories`
+  - Type: list of `"github"` | `"research"` | `"pdf"` (or `Category` objects)
+  - Filters results by category.
+
+- `include_domains`
+  - Type: list of str
+  - Only include results from these domains. Mutually exclusive with `exclude_domains`.
+
+- `exclude_domains`
+  - Type: list of str
+  - Exclude results from these domains. Mutually exclusive with `include_domains`.
+
+- `limit`
+  - Type: int
+  - Caps the number of results. Default: `5`.
+
+- `tbs`
+  - Type: str
+  - Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+
+- `location`
+  - Type: str
+  - Localized results (e.g. `"San Francisco,California,United States"`). Note: this is a plain string, not a `Location` object.
+
+- `ignore_invalid_urls`
+  - Type: bool
+  - Drops URLs that cannot be scraped by other endpoints.
+
+- `timeout`
+  - Type: int
+  - Request timeout in milliseconds. Default: `300000`.
+
+- `scrape_options`
+  - Type: `ScrapeOptions`
+  - Scrapes each search result inline. See Scrape parameters for fields.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+- `url`
+  - Type: str
+  - The page to scrape.
+
+- `formats`
+  - Type: list of format strings or format dicts
+  - Output formats to request.
+  - Plain string formats: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Object-only formats:
+    - `{"type": "json", "prompt": "...", "schema": {...}}` — at least one of `prompt` or `schema` required
+    - `{"type": "question", "question": "..."}`
+    - `{"type": "highlights", "query": "..."}`
+    - `{"type": "screenshot", "full_page": True, "quality": 80, "viewport": {"width": 1280, "height": 720}}`
+    - `{"type": "changeTracking", "modes": ["git-diff"], "schema": {...}, "prompt": "...", "tag": "..."}`
+    - `{"type": "attributes", "selectors": [{"selector": "a", "attribute": "href"}]}`
+
+- `headers`
+  - Type: dict of str to str
+  - Custom request headers.
+
+- `include_tags`
+  - Type: list of str
+  - Include only specific HTML tags.
+
+- `exclude_tags`
+  - Type: list of str
+  - Exclude specific HTML tags.
+
+- `only_main_content`
+  - Type: bool
+  - Strips nav, footer, and other boilerplate.
+
+- `timeout`
+  - Type: int
+  - Timeout in milliseconds.
+
+- `wait_for`
+  - Type: int
+  - Wait for the page to render (milliseconds).
+
+- `mobile`
+  - Type: bool
+  - Uses a mobile viewport.
+
+- `parsers`
+  - Type: list of parser names or parser dicts
+  - File parsing controls (e.g. PDF).
+  - Values: `"pdf"` or `{"type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": 5}`
+
+- `actions`
+  - Type: list of action dicts
+  - Pre-scrape browser actions.
+  - Action types: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`: `up`/`down`, optional `selector`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf` (`format`, `landscape`, `scale`)
+
+- `location`
+  - Type: `Location` object or dict with `country` and `languages`
+  - Geo or language-aware scraping. Note: this is a `Location` object, not a plain string (unlike `search`).
+
+- `skip_tls_verification`
+  - Type: bool
+  - Skips TLS verification.
+
+- `remove_base64_images`
+  - Type: bool
+  - Drops base64 images from markdown output.
+
+- `fast_mode`
+  - Type: bool
+  - Faster scrapes with reduced fidelity.
+
+- `block_ads`
+  - Type: bool
+  - Ad and cookie popup blocking.
+
+- `proxy`
+  - Type: str
+  - Proxy control. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`.
+
+- `max_age`
+  - Type: int
+  - Cached data up to this age (milliseconds).
+
+- `store_in_cache`
+  - Type: bool
+  - Cache the result on Firecrawl's side.
+
+- `lockdown`
+  - Type: bool
+  - Serve only previously cached results; never make outbound requests.
+
+- `profile`
+  - Type: dict with `name` and optional `save_changes`
+  - Persistent browser profile shared across scrapes and interactions.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrape_id`). At least one of `code` or `prompt` is required.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id from scrape response")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+
+print(result.output)
+
+# When done, tear down the session
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+- `job_id`
+  - Type: str
+  - The scrape job ID from `document.metadata.scrape_id`.
+
+- `code`
+  - Type: str (positional, optional if `prompt` is set)
+  - Code to run in the browser session.
+
+- `prompt`
+  - Type: str (keyword-only, optional if `code` is set)
+  - Natural-language instruction for the browser agent.
+
+- `language`
+  - Type: str
+  - Runtime to use. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+
+- `timeout`
+  - Type: int
+  - Execution timeout in seconds.
+
+### Stop session
+
+`client.stop_interaction(job_id)` ends the browser session.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`; `scrape_url` → `scrape`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- `FirecrawlApp` is an alias for `Firecrawl`.
+- Format strings accept both `camelCase` and `snake_case` (e.g. `"rawHtml"` or `"raw_html"`).
+- `location` parameter differs between `scrape` (a `Location` object) and `search` (a plain string).
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,348 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, SearchSource, ScrapeOptions, Format};
+
+let options = SearchOptions {
+    sources: Some(vec![SearchSource::Web]),
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        only_main_content: Some(true),
+        ..Default::default()
+    }),
+    ..Default::default()
+};
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", options)
+    .await?;
+
+if let Some(web) = results.data.web {
+    for item in web {
+        // item is SearchResultOrDocument::WebResult or ::Document
+        println!("{:?}", item);
+    }
+}
+```
+
+### Return type
+
+`SearchResponse` with `success: bool`, `data: SearchData`, `warning: Option<String>`. `SearchData` has `web`, `news`, `images` fields.
+
+### Parameters
+
+- `query`
+  - Type: `impl AsRef<str>`
+  - The search query. Use `site:example.com` to limit results to a domain.
+
+- `options.sources`
+  - Type: `Vec<SearchSource>`
+  - Controls which sources are searched. Values: `Web`, `News`, `Images`.
+
+- `options.categories`
+  - Type: `Vec<SearchCategory>`
+  - Filters results by category. Values: `Github`, `Research`, `Pdf`.
+
+- `options.include_domains`
+  - Type: `Vec<String>`
+  - Only include results from these domains.
+
+- `options.exclude_domains`
+  - Type: `Vec<String>`
+  - Exclude results from these domains.
+
+- `options.limit`
+  - Type: `u32`
+  - Caps the number of results.
+
+- `options.tbs`
+  - Type: `String`
+  - Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+
+- `options.location`
+  - Type: `String`
+  - Localized results (e.g. `"San Francisco,California,United States"`).
+
+- `options.ignore_invalid_urls`
+  - Type: `bool`
+  - Drops URLs that cannot be scraped by other endpoints.
+
+- `options.timeout`
+  - Type: `u32`
+  - Request timeout in milliseconds.
+
+- `options.scrape_options`
+  - Type: `ScrapeOptions`
+  - Scrapes each search result inline. See Scrape parameters for fields.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".to_string()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        ..Default::default()
+    })
+    .await?;
+
+println!("{:?}", doc.markdown);
+println!("{:?}", doc.json);
+```
+
+### Parameters
+
+- `url`
+  - Type: `impl AsRef<str>`
+  - The page to scrape.
+
+- `options.formats`
+  - Type: `Vec<Format>`
+  - Output formats to request.
+  - Enum values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`
+  - Object-only variants: `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`
+
+- `options.headers`
+  - Type: `HashMap<String, String>`
+  - Custom request headers.
+
+- `options.include_tags`
+  - Type: `Vec<String>`
+  - Include only specific HTML tags.
+
+- `options.exclude_tags`
+  - Type: `Vec<String>`
+  - Exclude specific HTML tags.
+
+- `options.only_main_content`
+  - Type: `bool`
+  - Strips nav, footer, and other boilerplate.
+
+- `options.timeout`
+  - Type: `u32`
+  - Timeout in milliseconds.
+
+- `options.wait_for`
+  - Type: `u32`
+  - Wait for the page to render (milliseconds).
+
+- `options.mobile`
+  - Type: `bool`
+  - Uses a mobile viewport.
+
+- `options.parsers`
+  - Type: `Vec<ParserConfig>`
+  - File parsing controls.
+  - Values: `ParserConfig::Simple("pdf".to_string())` or `ParserConfig::Pdf { parser_type, mode, max_pages }`
+
+- `options.actions`
+  - Type: `Vec<Action>`
+  - Pre-scrape browser actions.
+  - Action types: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Screenshot`, `Scrape`, `ExecuteJavascript`, `Pdf`
+
+- `options.location`
+  - Type: `LocationConfig` with `country` and `languages`
+  - Geo or language-aware scraping.
+
+- `options.skip_tls_verification`
+  - Type: `bool`
+  - Skips TLS verification.
+
+- `options.remove_base64_images`
+  - Type: `bool`
+  - Drops base64 images from markdown output.
+
+- `options.fast_mode`
+  - Type: `bool`
+  - Faster scrapes with reduced fidelity.
+
+- `options.block_ads`
+  - Type: `bool`
+  - Ad and cookie popup blocking.
+
+- `options.proxy`
+  - Type: `ProxyType`
+  - Proxy control. Values: `Basic`, `Stealth`, `Enhanced`, `Auto`.
+
+- `options.max_age`
+  - Type: `u32`
+  - Cached data up to this age (milliseconds).
+
+- `options.min_age`
+  - Type: `u32`
+  - Cached data only if at least this old (milliseconds).
+
+- `options.store_in_cache`
+  - Type: `bool`
+  - Cache the result on Firecrawl's side.
+
+- `options.lockdown`
+  - Type: `bool`
+  - Serve only previously cached results; never make outbound requests.
+
+- `options.profile`
+  - Type: `ProfileConfig` with `name` and optional `save_changes`
+  - Persistent browser profile shared across scrapes and interactions.
+
+- `options.json_options`
+  - Type: `JsonOptions` with `schema`, `system_prompt`, `prompt`
+  - JSON extraction configuration.
+
+- `options.screenshot_options`
+  - Type: `ScreenshotOptions` with `full_page`, `quality`, `viewport`
+  - Screenshot configuration.
+
+- `options.change_tracking_options`
+  - Type: `ChangeTrackingOptions` with `modes` (`GitDiff`/`Json`), `schema`, `prompt`, `tag`
+  - Change tracking configuration.
+
+- `options.attribute_selectors`
+  - Type: `Vec<AttributeSelector>` with `selector` and `attribute`
+  - Attribute extraction configuration.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. At least one of `code` or `prompt` is required (SDK returns `FirecrawlError::Misuse` otherwise).
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let doc = client
+    .scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    })
+    .await?;
+
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_ref())
+    .expect("Missing scrapeId from scrape response");
+
+let result = client
+    .interact(
+        job_id,
+        ScrapeExecuteOptions {
+            prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+println!("{:?}", result.output);
+
+// When done, tear down the session
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+- `job_id`
+  - Type: `impl AsRef<str>`
+  - The scrape job ID.
+
+- `options.code`
+  - Type: `Option<String>`
+  - Code to run in the browser session.
+
+- `options.prompt`
+  - Type: `Option<String>`
+  - Natural-language instruction for the browser agent.
+
+- `options.language`
+  - Type: `ScrapeExecuteLanguage`
+  - Runtime to use. Values: `Python`, `Node`, `Bash`. Default: `Node`.
+
+- `options.timeout`
+  - Type: `u32`
+  - Execution timeout in seconds.
+
+### Stop session
+
+`client.stop_interaction(job_id)` ends the browser session.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`.
+- All methods are `async` and require a Tokio runtime.
+- All options structs derive `Default` — use `..Default::default()` to fill remaining fields.
+- Rust uses `snake_case` field names; JSON serialization converts to `camelCase` automatically.
+- `search_and_scrape(query, limit)` is a convenience helper that calls `search` with default scrape options and returns `Vec<Document>`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one-file-per-language agent quickstart docs covering `search`, `scrape`, and `interact` endpoints for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file includes: install command, auth pattern, method signatures, realistic examples, every confirmed parameter with descriptions, deprecated aliases, and language-specific notes
- Generated from actual SDK source code and cross-referenced against the v2 OpenAPI spec

**Note:** These files are intended for `firecrawl-docs` under `agent-quickstart/`. They were placed in `docs/agent-quickstart/` here because the GitHub integration lacked write access to `firecrawl/firecrawl-docs`. To ship, move these files to `firecrawl-docs/agent-quickstart/`.

## Test plan

- [ ] Review each quickstart file for accuracy against current SDK source
- [ ] Verify parameter lists match the v2 OpenAPI spec
- [ ] Move files to `firecrawl-docs/agent-quickstart/` and add navigation entries to `docs.json`
- [ ] Confirm Mintlify renders each page cleanly

https://claude.ai/code/session_01Ticvh1BZW3CZFW79Xcp3rL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ticvh1BZW3CZFW79Xcp3rL)_