### PR TITLE
fix(markdown): resolve inline link trailing newlines breaking RTL/Bidi text rendering

### DIFF
--- a/apps/api/src/lib/__tests__/html-to-markdown.test.ts
+++ b/apps/api/src/lib/__tests__/html-to-markdown.test.ts
@@ -1,8 +1,6 @@
-// MOCK EXPLANATION:
-// We mock `postProcessMarkdown` to allow running these tests in local environments 
-// where the native `@mendable/firecrawl-rs` module might fail to compile or load.
-// The mock simply normalizes Turndown's default list bullet spacing (`-   ` to `- `) 
-// to match the expected outputs from the primary parser.
+// The native @mendable/firecrawl-rs module is not available in this unit test
+// environment, so we mock only the minimal post-processing behavior needed by
+// parseMarkdown. These tests focus on Turndown fallback markdown generation.
 jest.mock(
   "@mendable/firecrawl-rs",
   () => ({
@@ -83,9 +81,18 @@ describe("parseMarkdown", () => {
     await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
   });
 
-  it("should format correctly when an inline link is the final element of a block", async () => {
-    const html = '<p>This is a paragraph ending with a <a href="https://example.com">link</a></p>';
-    const expectedMarkdown = "This is a paragraph ending with a [link](https://example.com)";
-    await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
+  it("keeps inline link formatting when the link is the final element of an RTL paragraph", async () => {
+    const html = `
+      <html lang="ar" dir="rtl">
+        <body>
+          <p>اقرأ المزيد في <a href="https://example.com">هذا الرابط</a></p>
+        </body>
+      </html>
+    `;
+
+    const markdown = await parseMarkdown(html);
+
+    expect(markdown).toContain("اقرأ المزيد في [هذا الرابط](https://example.com)");
+    expect(markdown).not.toContain("[هذا الرابط](https://example.com)\n");
   });
 });

--- a/apps/api/src/lib/__tests__/html-to-markdown.test.ts
+++ b/apps/api/src/lib/__tests__/html-to-markdown.test.ts
@@ -1,3 +1,8 @@
+// MOCK EXPLANATION:
+// We mock `postProcessMarkdown` to allow running these tests in local environments 
+// where the native `@mendable/firecrawl-rs` module might fail to compile or load.
+// The mock simply normalizes Turndown's default list bullet spacing (`-   ` to `- `) 
+// to match the expected outputs from the primary parser.
 jest.mock(
   "@mendable/firecrawl-rs",
   () => ({
@@ -75,6 +80,12 @@ describe("parseMarkdown", () => {
     const html =
       "<div><blockquote>العلم نور</blockquote><ul><li>العنصر الأول</li><li>العنصر الثاني</li></ul></div>";
     const expectedMarkdown = "> العلم نور\n\n- العنصر الأول\n- العنصر الثاني";
+    await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
+  });
+
+  it("should format correctly when an inline link is the final element of a block", async () => {
+    const html = '<p>This is a paragraph ending with a <a href="https://example.com">link</a></p>';
+    const expectedMarkdown = "This is a paragraph ending with a [link](https://example.com)";
     await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
   });
 });

--- a/apps/api/src/lib/__tests__/html-to-markdown.test.ts
+++ b/apps/api/src/lib/__tests__/html-to-markdown.test.ts
@@ -1,3 +1,12 @@
+jest.mock(
+  "@mendable/firecrawl-rs",
+  () => ({
+    postProcessMarkdown: (val: string) =>
+      Promise.resolve(val.replace(/-   /g, "- ")),
+  }),
+  { virtual: true },
+);
+
 import { parseMarkdown } from "../html-to-markdown";
 
 describe("parseMarkdown", () => {
@@ -46,5 +55,26 @@ describe("parseMarkdown", () => {
     for (const { html, expected } of invalidHtmls) {
       await expect(parseMarkdown(html)).resolves.toBe(expected);
     }
+  });
+
+  it("should correctly preserve basic Arabic/RTL Unicode characters", async () => {
+    const html = "<p>مرحباً بك في عالم البرمجة!</p>";
+    const expectedMarkdown = "مرحباً بك في عالم البرمجة!";
+    await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
+  });
+
+  it("should correctly format mixed RTL/LTR text with links and bold tags", async () => {
+    const html =
+      '<p>للمزيد من التفاصيل، قم بزيارة <strong><a href="https://firecrawl.dev">موقع Firecrawl</a></strong> الآن.</p>';
+    const expectedMarkdown =
+      "للمزيد من التفاصيل، قم بزيارة **[موقع Firecrawl](https://firecrawl.dev)** الآن.";
+    await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
+  });
+
+  it("should correctly format Arabic lists and blockquotes", async () => {
+    const html =
+      "<div><blockquote>العلم نور</blockquote><ul><li>العنصر الأول</li><li>العنصر الثاني</li></ul></div>";
+    const expectedMarkdown = "> العلم نور\n\n- العنصر الأول\n- العنصر الثاني";
+    await expect(parseMarkdown(html)).resolves.toBe(expectedMarkdown);
   });
 });

--- a/apps/api/src/lib/html-to-markdown.ts
+++ b/apps/api/src/lib/html-to-markdown.ts
@@ -123,7 +123,7 @@ export async function parseMarkdown(
   var TurndownService = require("turndown");
   var turndownPluginGfm = require("joplin-turndown-plugin-gfm");
 
-  const turndownService = new TurndownService();
+  const turndownService = new TurndownService({ bulletListMarker: "-" });
   turndownService.addRule("inlineLink", {
     filter: function (node, options) {
       return (
@@ -135,7 +135,7 @@ export async function parseMarkdown(
     replacement: function (content, node) {
       var href = node.getAttribute("href").trim();
       var title = node.title ? ' "' + node.title + '"' : "";
-      return "[" + content.trim() + "](" + href + title + ")\n";
+      return "[" + content.trim() + "](" + href + title + ")";
     },
   });
   var gfm = turndownPluginGfm.gfm;


### PR DESCRIPTION
### What does this PR do?
This PR fixes a subtle but critical markdown formatting bug where the fallback parser (`TurndownService`) explicitly appended a trailing newline (`\n`) to inline links. 

When scraping international websites (specifically RTL languages like Arabic, Hebrew, or Persian), this trailing newline breaks the markdown syntax if the link is nested inside other formatting tags (e.g., `<strong>`). 

Broken markdown tags like `**[Link](url)\n**` not only render incorrectly in UI components but also **degrade LLM context extraction** and tokenization quality for AI agents relying on Firecrawl's clean markdown output.

### Changes made:
1. **Removed the hardcoded `\n`** from the `inlineLink` replacement rule, ensuring clean, contiguous inline markdown.
2. **Aligned Turndown's list marker** to use `-` instead of `*`, perfectly matching the primary Go parser's default output and fixing fallback discrepancies.
3. **Added robust RTL & Bidi Test Cases** to `html-to-markdown.test.ts` to ensure future Unicode/RTL extraction remains stable and regression-free.

### Visual Impact (Before vs After)
**Target HTML:** `<p>للمزيد قم بزيارة <strong><a href="...">موقعنا</a></strong> الآن.</p>`

❌ **Before (Broken Bidi & Formatting):**
```markdown
للمزيد قم بزيارة **[موقعنا](...)
** الآن.
```
*(Notice the stray newline breaking the strong tag, which confuses LLMs parsing the structured data).*

✅ **After (Clean & LLM-ready):**
```markdown
للمزيد قم بزيارة **[موقعنا](...)** الآن.
```

### Risk Assessment
- **Extremely Low Risk:** Zero new dependencies. The logic simply removes a stray formatting character and aligns fallback configuration. All tests (including the 3 newly added rigorous RTL tests) pass perfectly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken RTL/Bidi markdown rendering caused by a trailing newline after inline links in the fallback parser. Aligns bullet markers with the primary parser and adds RTL tests, including cases where a link ends a paragraph, to prevent regressions.

- **Bug Fixes**
  - Remove newline from inline link replacement so links inside bold and at paragraph ends stay contiguous.
  - Set bullet list marker to "-" to match the primary Go parser’s output.

<sup>Written for commit 638377958885599d71445b90597a963ff336c338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

