### PR TITLE
fix(python-sdk): suppress monitor json shadow warnings

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/test_monitor_types.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/test_monitor_types.py
@@ -1,4 +1,23 @@
-from firecrawl.v2.types import MonitorPageJudgment
+import importlib
+import warnings
+
+import firecrawl.v2.types as types
+from firecrawl.v2.types import MonitorPageJudgment, MonitorPageDiff, MonitorPageSnapshot
+
+
+def test_monitor_page_types_import_without_json_shadow_warnings():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.reload(types)
+
+    assert not [warning for warning in caught if "MonitorPageDiff" in str(warning.message)]
+    assert not [warning for warning in caught if "MonitorPageSnapshot" in str(warning.message)]
+
+    diff = MonitorPageDiff.model_validate({"text": "diff", "json": [{"type": "changed"}]})
+    snapshot = MonitorPageSnapshot.model_validate({"json": {"price": "$12"}})
+
+    assert diff.json == [{"type": "changed"}]
+    assert snapshot.json == {"price": "$12"}
 
 
 def test_monitor_page_judgment_parses_meaningful_changes():

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -39,6 +39,14 @@ warnings.filterwarnings(
     "ignore",
     message='Field name "json" in "Document" shadows an attribute in parent "BaseModel"',
 )
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "json" in "MonitorPageDiff" shadows an attribute in parent "BaseModel"',
+)
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "json" in "MonitorPageSnapshot" shadows an attribute in parent "BaseModel"',
+)
 
 T = TypeVar("T")
 


### PR DESCRIPTION
## Summary
- suppress Pydantic `json` field shadow warnings for `MonitorPageDiff` and `MonitorPageSnapshot`
- add a regression test that reloads the v2 types module with warnings enabled
- verify monitor payloads still parse the `json` API field correctly

Fixes #3643

## Test plan
- `cd apps/python-sdk && uv run --with pytest --with pydantic --with requests --with httpx --with python-dotenv --with websockets --with nest-asyncio --with aiohttp pytest firecrawl/__tests__/unit/v2/test_monitor_types.py -q`
- `cd apps/python-sdk && uv run --with ruff ruff check firecrawl/v2/types.py firecrawl/__tests__/unit/v2/test_monitor_types.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress `pydantic` warnings for the `json` field in `MonitorPageDiff` and `MonitorPageSnapshot` to remove noisy import logs while keeping API payload parsing unchanged. Adds a regression test that reloads `firecrawl.v2.types` with warnings enabled and verifies no warnings and correct `json` field validation.

<sup>Written for commit 5a46044d61d8f164e9abe052ebe5886c2b15c05e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

