### PR TITLE
docs: fix example documentation typos

### DIFF
--- a/examples/blog-articles/amazon-price-tracking/notebook.md
+++ b/examples/blog-articles/amazon-price-tracking/notebook.md
@@ -468,7 +468,7 @@ The relationship between `Product` and `PriceHistory` is bidirectional, allowing
 
 These models provide the structure for storing and querying our price tracking data in a PostgreSQL database using SQLAlchemy's ORM capabilities.
 
-Now, we define a `Database` class with a singe `add_product` method:
+Now, we define a `Database` class with a single `add_product` method:
 
 ```python
 class Database:

--- a/examples/contradiction_testing/web-data-contradiction-testing-using-llms.mdx
+++ b/examples/contradiction_testing/web-data-contradiction-testing-using-llms.mdx
@@ -16,7 +16,7 @@ To use Claude Opus and Firecrawl, you will need to get your API keys. You can ge
 
 ## Load website with Firecrawl
 
-To be able to get all the data from our website page put it into an easy to read format for the LLM, we will use [FireCrawl](https://firecrawl.dev). It handles by-passing JS-blocked websites, extracting the main content, and outputting in a LLM-readable format for increased accuracy.
+To be able to get all the data from our website page put it into an easy to read format for the LLM, we will use [FireCrawl](https://firecrawl.dev). It handles bypassing JS-blocked websites, extracting the main content, and outputting in a LLM-readable format for increased accuracy.
 
 Here is how we will scrape a website url using Firecrawl-py
 

--- a/examples/web_data_extraction/web-data-extraction-using-llms.mdx
+++ b/examples/web_data_extraction/web-data-extraction-using-llms.mdx
@@ -16,7 +16,7 @@ To use Groq and Firecrawl, you will need to get your API keys. You can get your 
 
 ## Load website with Firecrawl
 
-To be able to get all the data from a website page and make sure it is in the cleanest format, we will use [FireCrawl](https://firecrawl.dev). It handles by-passing JS-blocked websites, extracting the main content, and outputting in a LLM-readable format for increased accuracy.
+To be able to get all the data from a website page and make sure it is in the cleanest format, we will use [FireCrawl](https://firecrawl.dev). It handles bypassing JS-blocked websites, extracting the main content, and outputting in a LLM-readable format for increased accuracy.
 
 Here is how we will scrape a website url using Firecrawl. We will also set a `pageOptions` for only extracting the main content (`onlyMainContent: True`) of the website page - excluding the navs, footers, etc.
 


### PR DESCRIPTION
Summary:
- Fixes clear spelling or wording mistakes in documentation.
- Keeps the change text-only with no behavior impact.

Testing:
- `git diff --check`
- `uvx codespell` on the changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed minor typos in example docs (Amazon price tracking notebook and web data extraction guides): “singe” → “single” and “by-passing” → “bypassing”. Improves clarity only; no behavior or code changes.

<sup>Written for commit cba3d397b3b9f6099a045a8d10eeb3710ffbc2e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

