### PR TITLE
Add agent quickstart docs for all 5 SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,209 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`:firecrawl` v1.5.0) and the v2 OpenAPI spec.
+
+## Install
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:firecrawl, "~> 1.5"}
+  ]
+end
+```
+
+## Authenticate
+
+Set the API key globally in your config:
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: "fc-..."
+```
+
+Or pass it per-request as an option:
+
+```elixir
+Firecrawl.search_and_scrape([query: "test"], api_key: "fc-...")
+```
+
+All functions also accept `base_url:` for self-hosted instances (default: `"https://api.firecrawl.dev/v2"`).
+
+## When To Use What
+
+- **`search_and_scrape`** — start with a query and need discovery.
+- **`scrape_and_extract_from_url`** — you already have a URL and want page content.
+- **`interact_with_scrape_browser_session`** — the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a text query, optionally scraping each result.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ []) → {:ok, %Req.Response{}} | {:error, term()}
+Firecrawl.search_and_scrape!(params, opts \\ []) → %Req.Response{}
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl webhook retries",
+  limit: 5
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+All parameters are passed as a keyword list in the first argument.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | `:string` | **yes** | The search query. |
+| `limit` | `:integer` | no | Max results to return. |
+| `country` | `:string` | no | ISO country code for geo-targeting (e.g. `"US"`). |
+| `location` | `:string` | no | Location for results (e.g. `"San Francisco,California,United States"`). |
+| `categories` | `{:list, :any}` | no | Categories to filter by. |
+| `sources` | `{:list, :any}` | no | Sources to search. Default: `["web"]`. |
+| `include_domains` | `{:list, :string}` | no | Domains to include. |
+| `exclude_domains` | `{:list, :string}` | no | Domains to exclude. |
+| `ignore_invalid_urls` | `:boolean` | no | Drop invalid URLs from results. |
+| `tbs` | `:string` | no | Time-based filter (e.g. `"qdr:d"`, `"sbd:1,qdr:w"`). |
+| `timeout` | `:integer` | no | Timeout in milliseconds. |
+| `scrape_options` | `:keyword_list` | no | Scrape settings for each result. See Scrape parameters. |
+| `enterprise` | `{:list, :string}` | no | Enterprise ZDR options: `["zdr"]` or `["anon"]`. |
+
+**JSON key mapping:** Elixir `snake_case` keys are converted to `camelCase` for the API (e.g. `include_domains` → `"includeDomains"`).
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL. Supports markdown, HTML, JSON extraction, and more.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ []) → {:ok, %Req.Response{}} | {:error, term()}
+Firecrawl.scrape_and_extract_from_url!(params, opts \\ []) → %Req.Response{}
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: ["markdown"],
+  only_main_content: true
+)
+
+IO.inspect(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list in the first argument.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | `:string` | **yes** | The URL to scrape. |
+| `formats` | `{:list, :any}` | no | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`, or format objects. |
+| `actions` | `{:list, :any}` | no | Pre-scrape browser actions. |
+| `block_ads` | `:boolean` | no | Block ads and cookie popups. |
+| `exclude_tags` | `{:list, :string}` | no | HTML tags to exclude. |
+| `headers` | `:any` | no | Custom HTTP headers. |
+| `include_tags` | `{:list, :string}` | no | HTML tags to include exclusively. |
+| `location` | `:keyword_list` | no | Geo settings: `[country: "US", languages: ["en-US"]]`. |
+| `max_age` | `:integer` | no | Use cached result if younger than this (ms). |
+| `min_age` | `:integer` | no | Cache-only mode. Set to `1` for any cached data. |
+| `mobile` | `:boolean` | no | Emulate a mobile device. |
+| `only_main_content` | `:boolean` | no | Strip boilerplate. |
+| `parsers` | `{:list, :any}` | no | File parsing controls. |
+| `profile` | `:keyword_list` | no | Persistent browser profile. |
+| `proxy` | `:basic \| :enhanced \| :auto` | no | Proxy type. |
+| `remove_base64_images` | `:boolean` | no | Strip base64 images from markdown. |
+| `skip_tls_verification` | `:boolean` | no | Skip TLS cert verification. |
+| `store_in_cache` | `:boolean` | no | Store result in cache. |
+| `lockdown` | `:boolean` | no | Cache-only, never makes outbound requests. |
+| `timeout` | `:integer` | no | Timeout in ms. Min 1 000, max 300 000. Default: 60 000. |
+| `wait_for` | `:integer` | no | Extra delay in ms before fetching content. |
+| `zero_data_retention` | `:boolean` | no | Enable zero data retention. |
+
+## Interact
+
+### Why use it
+
+Run code against the browser session tied to a prior scrape.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])
+  → {:ok, %Req.Response{}} | {:error, term()}
+Firecrawl.interact_with_scrape_browser_session!(job_id, params \\ [], opts \\ [])
+  → %Req.Response{}
+```
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: ~s|console.log(await page.title());|,
+  language: :node,
+  timeout: 30
+)
+
+IO.inspect(result.body)
+
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+The first argument is the `job_id` (string). Remaining parameters are a keyword list.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `job_id` | `String.t()` (1st arg) | **yes** | Scrape job ID. |
+| `code` | `:string` | **yes** | Code to execute in the browser sandbox. |
+| `language` | `:python \| :node \| :bash` | no | Execution runtime. Default: `:node`. |
+| `origin` | `:string` | no | Origin label for telemetry. |
+| `timeout` | `:integer` | no | Execution timeout in seconds. |
+
+### Stop session
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])
+```
+
+## Notes
+
+- The Elixir SDK is OpenAPI-shaped. Function names mirror the OpenAPI operation IDs rather than short aliases.
+- All non-bang functions return `{:ok, response}` or `{:error, exception}`. Bang variants (`!`) return the response directly or raise.
+- Proxy enum in Elixir uses atoms: `:basic`, `:enhanced`, `:auto`. Note: `"stealth"` from other SDKs is not in the Elixir validation — use `:enhanced` instead.
+- The `opts` keyword list (second argument) passes through to the `Req` HTTP client and can include `api_key:` and `base_url:` overrides.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,219 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`com.firecrawl:firecrawl-java` v1.8.0) and the v2 OpenAPI spec.
+
+## Install
+
+```groovy
+// Gradle (Kotlin DSL)
+implementation("com.firecrawl:firecrawl-java:1.8.0")
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.8.0</version>
+</dependency>
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-...")
+    .build();
+```
+
+Or read from the `FIRECRAWL_API_KEY` environment variable:
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+Builder also accepts `apiUrl`, `timeoutMs` (default 300 000), `maxRetries` (default 3), and `backoffFactor` (default 0.5).
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns lightweight results; add `scrapeOptions` to hydrate them.
+- **`scrape`** — you already have a URL and want page content in one or more formats.
+- **`interact`** — the page needs clicks, forms, or post-scrape browser actions. Requires a job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a text query, optionally scraping each result.
+
+### Preferred SDK method
+
+```java
+client.search(query) → SearchData
+client.search(query, options) → SearchData
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("firecrawl webhook retries",
+    SearchOptions.builder()
+        .limit(5)
+        .build());
+
+for (var page : results.getWeb()) {
+    System.out.println(page.get("title") + " " + page.get("url"));
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are nullable and default to `null`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` (required, 1st arg) | Search query. |
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"`. |
+| `categories` | `List<Object>` | Filter: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict to these domains. |
+| `excludeDomains` | `List<String>` | Exclude these domains. |
+| `limit` | `Integer` | Max results per source type. API default: 10. |
+| `tbs` | `String` | Time-based filter (e.g. `"qdr:d"`). |
+| `location` | `String` | Location for geo-targeted results. |
+| `ignoreInvalidURLs` | `Boolean` | Drop invalid URLs from results. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result. See Scrape parameters. |
+
+### Return value
+
+`SearchData` has `.getWeb()`, `.getNews()`, `.getImages()` — each returns a `List<Map<String, Object>>`.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL. Supports markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```java
+client.scrape(url) → Document
+client.scrape(url, options) → Document
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", Map.of("type", "json", "prompt", "Extract plan names and prices.")))
+        .onlyMainContent(true)
+        .build());
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are nullable and default to `null`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` (required, 1st arg) | The URL to scrape. |
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Objects: `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | HTML tags to include exclusively. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent` | `Boolean` | Strip boilerplate. API default: `true`. |
+| `timeout` | `Integer` | Timeout in ms. API default: 60 000. |
+| `waitFor` | `Integer` | Extra delay in ms before fetching content. |
+| `mobile` | `Boolean` | Emulate a mobile device. |
+| `parsers` | `List<Object>` | File parsing controls (e.g. PDF). |
+| `actions` | `List<Map<String, Object>>` | Pre-scrape browser actions. |
+| `location` | `LocationConfig` | Geo and language settings: `.country(String)`, `.languages(List<String>)`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS cert verification. |
+| `removeBase64Images` | `Boolean` | Strip base64 images from markdown. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Use cached result if younger than this (ms). |
+| `storeInCache` | `Boolean` | Store result in cache. |
+| `lockdown` | `Boolean` | Cache-only, never makes outbound requests. |
+
+## Interact
+
+### Why use it
+
+Run code against the browser session tied to a prior scrape. Use the job ID from the scrape response metadata.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code) → BrowserExecuteResponse
+client.interact(jobId, code, language, timeout) → BrowserExecuteResponse
+client.interact(jobId, code, language, timeout, origin) → BrowserExecuteResponse
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(jobId,
+    "console.log(await page.title());",
+    "node",
+    30);
+
+System.out.println(result.getStdout());
+
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` (required) | Scrape job ID from metadata. |
+| `code` | `String` (required) | Code to execute in the browser session. |
+| `language` | `String` | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds. Min 1, max 300. API default: 30. |
+| `origin` | `String` | Origin tag for request attribution. |
+
+### Stop session
+
+```java
+client.stopInteractiveBrowser(jobId) → BrowserDeleteResponse
+```
+
+## Notes
+
+- All methods have `*Async` variants returning `CompletableFuture`.
+- Uses camelCase parameter names matching the JSON API.
+- Deprecated aliases (migration only):
+  - `scrapeExecute` → `interact`
+  - `deleteScrapeBrowser` → `stopInteractiveBrowser`
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,192 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`@mendable/firecrawl-js` v4.25.1) and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+You can also pass the API key as a plain string: `new Firecrawl("fc-...")`. The client reads `FIRECRAWL_API_URL` for self-hosted instances.
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns lightweight results; add `scrapeOptions` to hydrate them.
+- **`scrape`** — you already have a URL and want page content in one or more formats.
+- **`interact`** — the page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a text query, optionally scraping each result. Constrain to a site with `site:example.com` in the query string.
+
+### Preferred SDK method
+
+```ts
+client.search(query, options?) → Promise<SearchData>
+```
+
+### Example
+
+```ts
+const results = await client.search("firecrawl webhook retries", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const page of results.web ?? []) {
+  console.log(page.title, page.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` (required, 1st arg) | Search query. Use `site:` to scope to a domain. |
+| `sources` | `("web" \| "news" \| "images")[]` | Which result sources to include. Default: `["web"]`. |
+| `categories` | `("github" \| "research" \| "pdf")[]` | Filter results by category. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude these domains from results. Cannot combine with `includeDomains`. |
+| `limit` | `number` | Max results per source type. API default: 10. |
+| `tbs` | `string` | Time-based filter. `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year), or custom range. |
+| `location` | `string` | Location for geo-targeted results (e.g. `"San Francisco,California,United States"`). |
+| `ignoreInvalidURLs` | `boolean` | Drop URLs invalid for other Firecrawl endpoints. |
+| `timeout` | `number` | Timeout in milliseconds. SDK adds a 5 000 ms buffer for the HTTP call. |
+| `scrapeOptions` | `ScrapeOptions` | Apply scrape settings to each search result. See Scrape parameters. |
+
+### Return value
+
+`SearchData` has three optional arrays: `web`, `news`, `images`. Do **not** access `.data` — it throws an error directing you to the correct fields.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL. Supports markdown, HTML, JSON extraction, screenshots, audio/video, and more.
+
+### Preferred SDK method
+
+```ts
+client.scrape(url, options?) → Promise<Document>
+```
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: ["markdown", { type: "json", prompt: "Extract plan names and prices." }],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` (required, 1st arg) | The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Objects: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers (cookies, user-agent, etc.). |
+| `includeTags` | `string[]` | HTML tags to include exclusively. |
+| `excludeTags` | `string[]` | HTML tags to exclude. |
+| `onlyMainContent` | `boolean` | Strip nav, footer, and boilerplate. API default: `true`. |
+| `timeout` | `number` | Timeout in ms. Min 1 000, max 300 000. API default: 60 000. |
+| `waitFor` | `number` | Extra delay in ms before fetching content. |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `parsers` | `ParserConfig[]` | File parsing controls. E.g. `[{ type: "pdf", mode: "auto", maxPages: 10 }]`. |
+| `actions` | `ActionOption[]` | Pre-scrape browser actions: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `screenshot`, `pdf`. |
+| `location` | `{ country?, languages? }` | Geo and language settings. Country is ISO 3166-1 alpha-2. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Strip base64 images from markdown output. API default: `true`. |
+| `fastMode` | `boolean` | Faster scrape with reduced fidelity. |
+| `blockAds` | `boolean` | Block ads and cookie popups. API default: `true`. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. API default: `"auto"`. |
+| `maxAge` | `number` | Use cached result if younger than this (ms). API default: 172 800 000 (2 days). |
+| `minAge` | `number` | Cache-only mode. Set to `1` to accept any cached data. Returns 404 on miss. |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. API default: `true`. |
+| `lockdown` | `boolean` | Cache-only, never makes outbound requests. |
+| `profile` | `{ name, saveChanges? }` | Persistent browser profile across scrape/interact sessions. |
+
+## Interact
+
+### Why use it
+
+Run code or natural-language prompts against the browser session tied to a prior scrape. Use the `scrapeId` from `document.metadata.scrapeId`.
+
+### Preferred SDK method
+
+```ts
+client.interact(jobId, args) → Promise<ScrapeExecuteResponse>
+```
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+
+const result = await client.interact(jobId, {
+  code: "console.log(await page.title());",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.stdout);
+
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` (required, 1st arg) | Scrape job ID from `document.metadata.scrapeId`. |
+| `code` | `string` | Code to execute. One of `code` or `prompt` is required. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. One of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Execution runtime. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds. Min 1, max 300. API default: 30. |
+
+### Stop session
+
+```ts
+client.stopInteraction(jobId) → Promise<ScrapeBrowserDeleteResponse>
+```
+
+## Notes
+
+- The default export `Firecrawl` is the v2 client. The legacy v1 surface is at `client.v1`.
+- Zod schemas in `formats` are auto-converted to JSON Schema by the SDK.
+- Package requires Node.js >= 22.
+- Deprecated aliases (migration only):
+  - `scrapeUrl` → `scrape`
+  - `scrapeExecute` → `interact`
+  - `stopInteractiveBrowser` / `deleteScrapeBrowser` → `stopInteraction`
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,191 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py`) and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-...")
+```
+
+If `api_key` is omitted, the client reads `FIRECRAWL_API_KEY` from the environment. Pass `api_url` for self-hosted instances.
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns lightweight results; add `scrape_options` to hydrate them.
+- **`scrape`** — you already have a URL and want page content in one or more formats.
+- **`interact`** — the page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a text query, optionally scraping each result. Constrain to a site with `site:example.com` in the query string.
+
+### Preferred SDK method
+
+```python
+client.search(query, **kwargs) → SearchData
+```
+
+### Example
+
+```python
+results = client.search(
+    "firecrawl webhook retries",
+    limit=5,
+    scrape_options=ScrapeOptions(formats=["markdown"]),
+)
+
+for page in results.web or []:
+    print(page.title, page.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` (required, positional) | Search query. Use `site:` to scope to a domain. |
+| `sources` | `list[str \| Source]` | Which sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list[str \| Category]` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Restrict to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude these domains. Cannot combine with `include_domains`. |
+| `limit` | `int` | Max results per source type. Model default: 5. |
+| `tbs` | `str` | Time-based filter. `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year), or custom range. |
+| `location` | `str` | Location for geo-targeted results. |
+| `ignore_invalid_urls` | `bool` | Drop URLs invalid for other Firecrawl endpoints. |
+| `timeout` | `int` | Timeout in milliseconds. Model default: 300 000. |
+| `scrape_options` | `ScrapeOptions` | Apply scrape settings to each result. See Scrape parameters. |
+
+### Return value
+
+`SearchData` has three optional lists: `.web`, `.news`, `.images`. Do **not** access `.data` — it raises `AttributeError` directing you to the correct fields.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL. Supports markdown, HTML, JSON extraction, screenshots, audio/video, and more.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **kwargs) → Document
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=["markdown", {"type": "json", "prompt": "Extract plan names and prices."}],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` (required, positional) | The URL to scrape. |
+| `formats` | `list[FormatOption]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"change_tracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Objects: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, etc. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. |
+| `include_tags` | `list[str]` | HTML tags to include exclusively. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Strip nav, footer, and boilerplate. API default: `True`. |
+| `timeout` | `int` | Timeout in ms. Min 1 000, max 300 000. API default: 60 000. |
+| `wait_for` | `int` | Extra delay in ms before fetching content. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list` | File parsing controls. E.g. `[{"type": "pdf", "mode": "auto", "maxPages": 10}]`. |
+| `actions` | `list` | Pre-scrape browser actions: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `screenshot`, `pdf`. |
+| `location` | `Location` | Geo and language settings. `Location(country="US", languages=["en-US"])`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Strip base64 images from markdown output. API default: `True`. |
+| `fast_mode` | `bool` | Faster scrape with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. API default: `True`. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. API default: `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this (ms). API default: 172 800 000 (2 days). |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. API default: `True`. |
+| `lockdown` | `bool` | Cache-only, never makes outbound requests. |
+| `profile` | `dict` | Persistent browser profile. `{"name": "my-session", "saveChanges": True}`. |
+
+**Note:** `ScrapeOptions` (used in `scrape_options` for search) also supports `min_age` which is not surfaced as a top-level `scrape()` keyword.
+
+## Interact
+
+### Why use it
+
+Run code or natural-language prompts against the browser session tied to a prior scrape. Use the `scrape_id` from `document.metadata["scrapeId"]`.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None) → BrowserExecuteResponse
+```
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("scrapeId")
+
+result = client.interact(
+    job_id,
+    code='console.log(await page.title());',
+    language="node",
+    timeout=30,
+)
+
+print(result.stdout)
+
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` (required, positional) | Scrape job ID from `document.metadata["scrapeId"]`. |
+| `code` | `str` | Code to execute. One of `code` or `prompt` is required. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. One of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Execution runtime. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds. Min 1, max 300. API default: 30. |
+
+### Stop session
+
+```python
+client.stop_interaction(job_id) → BrowserDeleteResponse
+```
+
+## Notes
+
+- `Firecrawl` and `FirecrawlApp` are aliases; prefer `Firecrawl`.
+- `AsyncFirecrawl` (alias `AsyncFirecrawlApp`) provides the same API with `async`/`await`.
+- Format strings accept both camelCase (`"rawHtml"`) and snake_case (`"raw_html"`) aliases.
+- Deprecated aliases (migration only):
+  - `scrape_url` → `scrape`
+  - `scrape_execute` → `interact`
+  - `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,234 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate v2.7.0) and the v2 OpenAPI spec.
+
+## Install
+
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2.7"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-...")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-..."))?;
+```
+
+## When To Use What
+
+- **`search`** — start with a query and need discovery. Returns lightweight results; add `scrape_options` to hydrate them.
+- **`scrape`** — you already have a URL and want page content in one or more formats.
+- **`interact`** — the page needs clicks, forms, or post-scrape browser actions. Requires a job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a text query, optionally scraping each result.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await → Result<SearchResponse, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+let client = Client::new("fc-...")?;
+
+let results = client.search("firecrawl webhook retries", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+for item in results.data.web.unwrap_or_default() {
+    println!("{:?}", item);
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option` and default to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` (required, 1st arg) | Search query. |
+| `limit` | `Option<u32>` | Max results to return. API default: 10. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Filter: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict to these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude these domains. |
+| `tbs` | `Option<String>` | Time-based filter (e.g. `"qdr:d"`). |
+| `location` | `Option<String>` | Location for geo-targeted results. |
+| `ignore_invalid_urls` | `Option<bool>` | Drop invalid URLs from results. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape each result. See Scrape parameters. |
+
+### Convenience
+
+```rust
+client.search_and_scrape(query, limit).await → Result<Vec<Document>, FirecrawlError>
+```
+
+Returns only hydrated `Document` results with default scrape options.
+
+## Scrape
+
+### Why use it
+
+Fetch structured content from a known URL. Supports markdown, HTML, JSON extraction, screenshots, and more.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await → Result<Document, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-...")?;
+
+let doc = client.scrape("https://example.com/pricing", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Json]),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option` and default to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` (required, 1st arg) | The URL to scrape. |
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include exclusively. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `only_main_content` | `Option<bool>` | Strip boilerplate. API default: `true`. |
+| `timeout` | `Option<u32>` | Timeout in ms. API default: 60 000. |
+| `wait_for` | `Option<u32>` | Extra delay in ms before fetching content. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | File parsing controls (e.g. PDF). |
+| `actions` | `Option<Vec<Action>>` | Pre-scrape browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Screenshot`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Geo and language settings: `country`, `languages`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS cert verification. |
+| `remove_base64_images` | `Option<bool>` | Strip base64 images from markdown. |
+| `fast_mode` | `Option<bool>` | Faster scrape with reduced fidelity. |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Use cached result if younger than this (seconds). |
+| `min_age` | `Option<u32>` | Cache-only mode. |
+| `store_in_cache` | `Option<bool>` | Store result in cache. |
+| `lockdown` | `Option<bool>` | Cache-only, never makes outbound requests. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile: `name`, `save_changes`. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction: `schema`, `system_prompt`, `prompt`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `full_page`, `quality`, `viewport`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking: `modes`, `schema`, `prompt`, `tag`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `selector`, `attribute`. |
+
+### Convenience
+
+```rust
+client.scrape_with_schema(url, schema, prompt).await → Result<Value, FirecrawlError>
+```
+
+Extracts JSON using a schema and optional prompt.
+
+## Interact
+
+### Why use it
+
+Run code or natural-language prompts against the browser session tied to a prior scrape. Requires at least one of `code` or `prompt`.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await → Result<ScrapeExecuteResponse, FirecrawlError>
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, ScrapeExecuteLanguage, Format};
+
+let client = Client::new("fc-...")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.get("scrapeId"))
+    .and_then(|v| v.as_str())
+    .expect("Missing scrapeId");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some("console.log(await page.title());".into()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+
+println!("{}", result.stdout.unwrap_or_default());
+
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` (required, 1st arg) | Scrape job ID. |
+| `code` | `Option<String>` | Code to execute. One of `code` or `prompt` required. |
+| `prompt` | `Option<String>` | Natural-language instruction. One of `code` or `prompt` required. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. API default: 30. |
+
+### Stop session
+
+```rust
+client.stop_interaction(job_id).await → Result<ScrapeBrowserDeleteResponse, FirecrawlError>
+```
+
+## Notes
+
+- All async methods require a Tokio runtime.
+- `ScrapeOptions` uses `snake_case` field names in Rust but serializes to `camelCase` for the API.
+- Deprecated aliases (migration only):
+  - `scrape_execute` → `interact`
+  - `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each quickstart covers `search`, `scrape`, and `interact` endpoints with confirmed parameters from SDK source code and the v2 OpenAPI spec
- Files are in `docs/agent-quickstart/` — intended for `firecrawl-docs/agent-quickstart/` but the GitHub integration lacked write access to `firecrawl-docs`

## What's in each quickstart

- Install command and auth pattern
- "When To Use What" decision guide (search vs scrape vs interact)
- Per-endpoint sections: why use it, preferred SDK method, working example, full parameter table
- Language-specific notes, deprecated aliases, and source-of-truth file paths

## Sources used

- JS/TS SDK (`@mendable/firecrawl-js` v4.25.1)
- Python SDK (`firecrawl-py`)
- Rust SDK (`firecrawl` crate v2.7.0)
- Java SDK (`com.firecrawl:firecrawl-java` v1.8.0)
- Elixir SDK (`:firecrawl` v1.5.0)
- OpenAPI spec (`api-reference/v2-openapi.json`)

## Note

These files should ultimately live in `firecrawl-docs/agent-quickstart/`. The GitHub integration for this session did not have write permissions to `firecrawl/firecrawl-docs`, so they are placed in `firecrawl/firecrawl/docs/agent-quickstart/` as a staging location.

## Test plan

- [ ] Verify each quickstart renders cleanly as a Mintlify docs page
- [ ] Cross-check parameter tables against SDK source
- [ ] Move files to `firecrawl-docs/agent-quickstart/` when write access is available

https://claude.ai/code/session_01YSrrWtPBoGeXVAYbdHmuor

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSrrWtPBoGeXVAYbdHmuor)_