### PR TITLE
fix(api): preserve implicit table headers

### DIFF
--- a/apps/api/sharedLibs/go-html-to-md/go.mod
+++ b/apps/api/sharedLibs/go-html-to-md/go.mod
@@ -4,13 +4,15 @@ go 1.23.0
 
 toolchain go1.24.0
 
-require github.com/firecrawl/html-to-markdown v0.0.0-20260312013131-1af9901a5d61
+require (
+	github.com/PuerkitoBio/goquery v1.10.3
+	github.com/firecrawl/html-to-markdown v0.0.0-20260312013131-1af9901a5d61
+	golang.org/x/net v0.41.0
+)
 
 require (
-	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
-	golang.org/x/net v0.41.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/apps/api/sharedLibs/go-html-to-md/html-to-markdown.go
+++ b/apps/api/sharedLibs/go-html-to-md/html-to-markdown.go
@@ -5,15 +5,19 @@ package main
 */
 import "C"
 import (
+	"strings"
 	"unsafe"
 
+	"github.com/PuerkitoBio/goquery"
 	md "github.com/firecrawl/html-to-markdown"
 	"github.com/firecrawl/html-to-markdown/plugin"
+	"golang.org/x/net/html"
 )
 
 //export ConvertHTMLToMarkdown
 func ConvertHTMLToMarkdown(html *C.char) *C.char {
 	converter := md.NewConverter("", true, nil)
+	converter.Before(promoteImplicitTableHeaders)
 	converter.Use(plugin.GitHubFlavored())
 	converter.Use(plugin.RobustCodeBlock())
 
@@ -31,4 +35,85 @@ func FreeCString(s *C.char) {
 
 func main() {
 	// This function is required for the main package
+}
+
+func promoteImplicitTableHeaders(doc *goquery.Selection) {
+	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
+		if tableHasOwnHeader(table) {
+			return
+		}
+
+		rows := ownTableRows(table)
+		if rows.Length() < 2 {
+			return
+		}
+
+		firstRow := rows.First()
+		firstCells := firstRow.ChildrenFiltered("td")
+		if firstCells.Length() < 2 || firstCells.Length() != maxOwnRowCellCount(rows) {
+			return
+		}
+
+		if !plainNonEmptyCells(firstCells) || firstRow.Find("a, code, pre, img, input, button, select, textarea, table").Length() > 0 {
+			return
+		}
+
+		firstCells.Each(func(_ int, cell *goquery.Selection) {
+			for _, node := range cell.Nodes {
+				node.Data = "th"
+			}
+		})
+	})
+}
+
+func tableHasOwnHeader(table *goquery.Selection) bool {
+	return table.Find("thead, th").FilterFunction(func(_ int, item *goquery.Selection) bool {
+		return belongsToTable(item, table)
+	}).Length() > 0
+}
+
+func ownTableRows(table *goquery.Selection) *goquery.Selection {
+	return table.Find("tr").FilterFunction(func(_ int, row *goquery.Selection) bool {
+		return belongsToTable(row, table)
+	})
+}
+
+func belongsToTable(item *goquery.Selection, table *goquery.Selection) bool {
+	if len(item.Nodes) == 0 || len(table.Nodes) == 0 {
+		return false
+	}
+
+	for parent := item.Nodes[0].Parent; parent != nil; parent = parent.Parent {
+		if parent.Type == html.ElementNode && parent.Data == "table" {
+			return parent == table.Nodes[0]
+		}
+	}
+
+	return false
+}
+
+func maxOwnRowCellCount(rows *goquery.Selection) int {
+	maxCount := 0
+	rows.Each(func(_ int, row *goquery.Selection) {
+		count := row.ChildrenFiltered("td, th").Length()
+		if count > maxCount {
+			maxCount = count
+		}
+	})
+
+	return maxCount
+}
+
+func plainNonEmptyCells(cells *goquery.Selection) bool {
+	allNonEmpty := true
+	cells.EachWithBreak(func(_ int, cell *goquery.Selection) bool {
+		if strings.TrimSpace(cell.Text()) == "" {
+			allNonEmpty = false
+			return false
+		}
+
+		return true
+	})
+
+	return allNonEmpty
 }

--- a/apps/go-html-to-md-service/converter.go
+++ b/apps/go-html-to-md-service/converter.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
 	md "github.com/firecrawl/html-to-markdown"
 	"github.com/firecrawl/html-to-markdown/plugin"
+	"golang.org/x/net/html"
 )
 
 // Converter handles HTML to Markdown conversion
@@ -13,6 +17,7 @@ type Converter struct {
 // NewConverter creates a new Converter instance with pre-configured rules
 func NewConverter() *Converter {
 	converter := md.NewConverter("", true, nil)
+	converter.Before(promoteImplicitTableHeaders)
 	converter.Use(plugin.GitHubFlavored())
 	converter.Use(plugin.RobustCodeBlock())
 
@@ -26,3 +31,83 @@ func (c *Converter) ConvertHTMLToMarkdown(html string) (string, error) {
 	return c.converter.ConvertString(html)
 }
 
+func promoteImplicitTableHeaders(doc *goquery.Selection) {
+	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
+		if tableHasOwnHeader(table) {
+			return
+		}
+
+		rows := ownTableRows(table)
+		if rows.Length() < 2 {
+			return
+		}
+
+		firstRow := rows.First()
+		firstCells := firstRow.ChildrenFiltered("td")
+		if firstCells.Length() < 2 || firstCells.Length() != maxOwnRowCellCount(rows) {
+			return
+		}
+
+		if !plainNonEmptyCells(firstCells) || firstRow.Find("a, code, pre, img, input, button, select, textarea, table").Length() > 0 {
+			return
+		}
+
+		firstCells.Each(func(_ int, cell *goquery.Selection) {
+			for _, node := range cell.Nodes {
+				node.Data = "th"
+			}
+		})
+	})
+}
+
+func tableHasOwnHeader(table *goquery.Selection) bool {
+	return table.Find("thead, th").FilterFunction(func(_ int, item *goquery.Selection) bool {
+		return belongsToTable(item, table)
+	}).Length() > 0
+}
+
+func ownTableRows(table *goquery.Selection) *goquery.Selection {
+	return table.Find("tr").FilterFunction(func(_ int, row *goquery.Selection) bool {
+		return belongsToTable(row, table)
+	})
+}
+
+func belongsToTable(item *goquery.Selection, table *goquery.Selection) bool {
+	if len(item.Nodes) == 0 || len(table.Nodes) == 0 {
+		return false
+	}
+
+	for parent := item.Nodes[0].Parent; parent != nil; parent = parent.Parent {
+		if parent.Type == html.ElementNode && parent.Data == "table" {
+			return parent == table.Nodes[0]
+		}
+	}
+
+	return false
+}
+
+func maxOwnRowCellCount(rows *goquery.Selection) int {
+	maxCount := 0
+	rows.Each(func(_ int, row *goquery.Selection) {
+		count := row.ChildrenFiltered("td, th").Length()
+		if count > maxCount {
+			maxCount = count
+		}
+	})
+
+	return maxCount
+}
+
+func plainNonEmptyCells(cells *goquery.Selection) bool {
+	allNonEmpty := true
+	cells.EachWithBreak(func(_ int, cell *goquery.Selection) bool {
+		if strings.TrimSpace(cell.Text()) == "" {
+			allNonEmpty = false
+			return false
+		}
+
+		return true
+	})
+
+	return allNonEmpty
+}

--- a/apps/go-html-to-md-service/go.mod
+++ b/apps/go-html-to-md-service/go.mod
@@ -3,18 +3,18 @@ module github.com/firecrawl/go-html-to-md-service
 go 1.23.0
 
 require (
+	github.com/PuerkitoBio/goquery v1.10.3
 	github.com/firecrawl/html-to-markdown v0.0.0-20260312013131-1af9901a5d61
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/zerolog v1.33.0
+	golang.org/x/net v0.41.0
 )
 
 require (
-	github.com/PuerkitoBio/goquery v1.10.3 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/apps/go-html-to-md-service/handler_test.go
+++ b/apps/go-html-to-md-service/handler_test.go
@@ -256,6 +256,50 @@ func TestConverter_ComplexHTML(t *testing.T) {
 	}
 }
 
+func TestConverter_TableWithImplicitHeaderRow(t *testing.T) {
+	converter := NewConverter()
+
+	testHTML := `<table>
+		<tbody>
+			<tr>
+				<td>First Name</td>
+				<td>Last Name (Surname)</td>
+				<td>Zip Code</td>
+				<td>CCN Visa / Master Card / AMEX</td>
+				<td>Expiration Date</td>
+			</tr>
+			<tr>
+				<td>Thomas</td>
+				<td>Robinson</td>
+				<td>6878</td>
+				<td>5019717010103740</td>
+				<td>5/22/2024</td>
+			</tr>
+			<tr>
+				<td>Brian</td>
+				<td>King</td>
+				<td>94920</td>
+				<td>6331101999990010</td>
+				<td>5/23/2024</td>
+			</tr>
+		</tbody>
+	</table>`
+
+	markdown, err := converter.ConvertHTMLToMarkdown(testHTML)
+	if err != nil {
+		t.Fatalf("conversion failed: %v", err)
+	}
+
+	expectedMarkdown := `| First Name | Last Name (Surname) | Zip Code | CCN Visa / Master Card / AMEX | Expiration Date |
+| --- | --- | --- | --- | --- |
+| Thomas | Robinson | 6878 | 5019717010103740 | 5/22/2024 |
+| Brian | King | 94920 | 6331101999990010 | 5/23/2024 |`
+
+	if markdown != expectedMarkdown {
+		t.Fatalf("unexpected markdown:\n%s", markdown)
+	}
+}
+
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return bytes.Contains([]byte(s), []byte(substr))
@@ -340,4 +384,3 @@ func TestConvertHTML_NonZDR_LogsRequestID(t *testing.T) {
 		t.Errorf("expected completion log for non-ZDR conversion, got: %q", logs)
 	}
 }
-


### PR DESCRIPTION
## Summary

Preserves implicit headers in HTML tables whose first rectangular row is encoded with `td` cells by promoting that row before the Go markdown converter runs. This prevents the converter from emitting a blank synthetic Markdown header that hides column labels from downstream consumers, including redaction flows that rely on table context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves implicit HTML table headers by promoting the first plain `td` row to `th` before Markdown conversion. This prevents blank synthetic headers and keeps column labels available to downstream redaction flows.

- **Bug Fixes**
  - Added `promoteImplicitTableHeaders` preprocessor via `converter.Before(...)` in both `apps/api/sharedLibs/go-html-to-md` and `apps/go-html-to-md-service`.
  - Detects tables without headers where the first own row has only plain, non-empty `td` cells, at least two cells, and matches the max column count; converts those cells to `th`.
  - Added test to assert header row is preserved in Markdown.

- **Dependencies**
  - Added direct deps: `github.com/PuerkitoBio/goquery` and `golang.org/x/net` in both `go.mod` files.

<sup>Written for commit c3ba5eb3d6cd39fea539bff2a97587dd71393a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

