### PR TITLE
fix(python-sdk): suppress Pydantic shadow warnings for MonitorPageDiff/Snapshot

### DIFF
--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -39,6 +39,14 @@ warnings.filterwarnings(
     "ignore",
     message='Field name "json" in "Document" shadows an attribute in parent "BaseModel"',
 )
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "json" in "MonitorPageDiff" shadows an attribute in parent "BaseModel"',
+)
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "json" in "MonitorPageSnapshot" shadows an attribute in parent "BaseModel"',
+)
 
 T = TypeVar("T")
 


### PR DESCRIPTION
## Summary

Fixes #3643 — `MonitorPageSnapshot` and `MonitorPageDiff` trigger `UserWarning` about shadowing Pydantic's `BaseModel.json()` method.

## Problem

The `json` field in `MonitorPageDiff` (line 1116) and `MonitorPageSnapshot` (line 1123) shadows Pydantic's built-in `json` attribute, causing a `UserWarning` on import.

## Fix

Add `warnings.filterwarnings("ignore", ...)` entries for these two classes, matching the existing pattern already used for `ScrapeFormats` and `Document` (lines 34-41 of `types.py`).

## Changes

- `apps/python-sdk/firecrawl/v2/types.py`: +8 lines (two warning filter entries)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses `pydantic` UserWarning caused by `json` field shadowing in `MonitorPageDiff` and `MonitorPageSnapshot`. Fixes #3643 by adding ignore filters in `apps/python-sdk/firecrawl/v2/types.py` to silence import-time warnings.

- **Bug Fixes**
  - Added two `warnings.filterwarnings("ignore", ...)` entries for these models.
  - Mirrors existing filters for `ScrapeFormats` and `Document`; no behavior change.

<sup>Written for commit db1a7cd685ee304bb70661723c5c29799b92209c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

