### PR TITLE
fix: remove console.log statements from e2e_extract test file (#1234)

### DIFF
--- a/apps/api/src/__tests__/e2e_extract/index.test.ts
+++ b/apps/api/src/__tests__/e2e_extract/index.test.ts
@@ -27,7 +27,6 @@ describe("E2E Tests for Extract API Routes", () => {
           },
         });
 
-      console.log(response.body);
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty("data");
       expect(response.body.data).toHaveProperty("authors");
@@ -69,7 +68,6 @@ describe("E2E Tests for Extract API Routes", () => {
       expect(response.body).toHaveProperty("data");
       expect(response.body.data).toHaveProperty("founders");
 
-      console.log(response.body.data?.founders);
       let gotItRight = 0;
       for (const founder of response.body.data?.founders) {
         if (founder.includes("Caleb")) gotItRight++;
@@ -106,7 +104,6 @@ describe("E2E Tests for Extract API Routes", () => {
         });
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty("data");
-      console.log(response.body.data);
 
       let gotItRight = 0;
       for (const hiring of response.body.data?.items) {
@@ -170,7 +167,6 @@ describe("E2E Tests for Extract API Routes", () => {
           },
         });
 
-      console.log(response.body);
       // expect(response.statusCode).toBe(200);
       // expect(response.body).toHaveProperty("data");
       // expect(response.body.data?.pciDssCompliance).toBe(true);
@@ -200,7 +196,6 @@ describe("E2E Tests for Extract API Routes", () => {
           allowExternalLinks: true,
         });
 
-      console.log(response.body);
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty("data");
       expect(response.body.data?.isGreenhouseATS).toBe(true);
@@ -231,7 +226,6 @@ describe("E2E Tests for Extract API Routes", () => {
           allowExternalLinks: true,
         });
 
-      console.log(response.body.data?.items);
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty("data");
       expect(response.body.data?.items.length).toBe(4);
@@ -275,7 +269,6 @@ describe("E2E Tests for Extract API Routes", () => {
           allowExternalLinks: true,
         });
 
-      console.log(response.body.data);
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty("data");
       expect(response.body.data?.name).toBe("Eric Ciarla");
@@ -297,7 +290,6 @@ describe("E2E Tests for Extract API Routes", () => {
           prompt: "What is the title and description of the page?",
         });
 
-      console.log(response.body.data);
       expect(response.statusCode).toBe(200);
       expect(response.body).toHaveProperty("data");
       expect(typeof response.body.data).toBe("object");


### PR DESCRIPTION
# PR Title: fix: remove console.log statements from e2e_extract test file

## Summary
This PR removes debug `console.log` statements from the `apps/api/src/__tests__/e2e_extract/index.test.ts` file. These debug statements were likely left over from development and should be removed for cleaner test output.

## Changes Made
- Removed 8 `console.log` statements from the e2e_extract test file
- Cleaned up test output by removing unnecessary debug statements
- Improved test code maintainability

## Testing
- Verified that all tests still pass after removing the console.log statements
- The test logic remains unchanged, only debug output was removed

## Screenshots
N/A (test code cleanup)

## Related Issues
Fixes: #1234 (good first issue - code cleanup)

## Type of Change
- [x] Code cleanup (non-breaking change, no functional impact)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
This is a simple cleanup PR that removes debug statements from test files. This improves the development experience by providing cleaner test output and makes the codebase more maintainable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed 8 debug console.log statements from apps/api/src/__tests__/e2e_extract/index.test.ts to clean up test output. No logic changes; tests still pass.

<sup>Written for commit ab1f1965264b8417ad53004e251dc54c69448dd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

