### PR TITLE
fix: rename json field to json_data to avoid Pydantic BaseModel shadowing (fixes #3643)

### DIFF
--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1104,23 +1104,23 @@ class MonitorCheck(BaseModel):
 class MonitorPageDiff(BaseModel):
     """Diff payload returned alongside a monitor page.
 
-    Markdown-only monitors populate both `text` (unified diff) and `json`
-    (the parseDiff AST). JSON-extraction monitors populate `json` only,
-    where `json` is the per-field `{previous, current}` map. Mixed-mode
-    monitors (JSON + git-diff) populate both `json` (field diff) and
+    Markdown-only monitors populate both `text` (unified diff) and `json_data`
+    (the parseDiff AST). JSON-extraction monitors populate `json_data` only,
+    where `json_data` is the per-field `{previous, current}` map. Mixed-mode
+    monitors (JSON + git-diff) populate both `json_data` (field diff) and
     `text` (markdown sidecar).
     """
     model_config = {"populate_by_name": True, "extra": "allow"}
 
     text: Optional[str] = None
-    json: Optional[Any] = None  # markdown→parseDiff AST | json→field diff
+    json_data: Optional[Any] = Field(default=None, alias="json")  # markdown→parseDiff AST | json→field diff
 
 
 class MonitorPageSnapshot(BaseModel):
     """Current JSON extraction at this run. JSON / mixed mode only."""
     model_config = {"populate_by_name": True, "extra": "allow"}
 
-    json: Optional[Dict[str, Any]] = None
+    json_data: Optional[Dict[str, Any]] = Field(default=None, alias="json")
 
 
 class MonitorCheckPage(BaseModel):


### PR DESCRIPTION
## Description

Fixes #3643

 and  in  use  as a field name, which shadows Pydantic 's built-in  method. This triggers a  on every import:



## Fix

Renamed the Python attribute from  to  with  to:
- Eliminate the Pydantic shadowing warning
- Maintain full API serialization compatibility (the wire format still uses )
- Keep backward compatibility via  (both  and  work for construction)

## Changes

- :
  -  → 
  -  → 

## Verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the `json` fields to `json_data` in `MonitorPageDiff` and `MonitorPageSnapshot` to avoid shadowing Pydantic `BaseModel.json()` and eliminate the import warning. Wire format stays `json`. Fixes #3643.

- **Bug Fixes**
  - Use `Field(alias="json")` to keep API serialization.
  - Accept both `json` and `json_data` on init via `populate_by_name=True`.

<sup>Written for commit 633156cafb31eaadb9fe6026773fff6fa3c1313d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

