### PR TITLE
docs: add ecosystem and extensions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ---
 
+## Ecosystem & Extensions
+
+We provide several standalone tools and resources to enhance your Firecrawl experience, especially when building AI agents and robust applications:
+
+- **[Firecrawl CLI](./firecrawl-cli)**: Command-line tools for using Firecrawl right from the terminal. Supports commands for search, scrape, crawl, map, interact, and agent jobs.
+- **[Firecrawl CLI Skills](./firecrawl-cli-skills)**: Agent skills that teach coding agents how to use the Firecrawl CLI for live web work during a session.
+- **[Firecrawl Skills](./firecrawl-skills)**: Core skills and examples for adding Firecrawl to product code, choosing the right endpoints, wiring SDKs, and securely setting up API keys.
+- **[Firecrawl Workflows](./firecrawl-workflows)**: Workflow skills for repeatable Firecrawl-powered deliverables, such as competitor analysis and website design clone briefs.
+
+---
+
 ## Integrations
 
 **Agents & AI Tools**


### PR DESCRIPTION
## Overview
This PR updates the `README.md` to introduce a new **"Ecosystem & Extensions"** section. As the Firecrawl ecosystem continues to grow, several highly useful standalone features have been developed (CLI, CLI Skills, Core Skills, and Workflows). 

While these were briefly referenced under integrations, this update surfaces them directly in the README so developers and agentic AI users can easily discover and utilize them locally.

## Changes Made
- Added a new `## Ecosystem & Extensions` section immediately preceding the `## Integrations` section.
- Added explicit documentation and repository links for:
  - `firecrawl-cli`
  - `firecrawl-cli-skills`
  - `firecrawl-skills`
  - `firecrawl-workflows`
- **No existing documentation, guides, or API endpoints were removed or altered.**

## Why is this necessary?
To provide better visibility for tooling and agent capabilities that live within or alongside the main Firecrawl repository, ensuring that contributors and users are aware of the full breadth of the product ecosystem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an “Ecosystem & Extensions” section to the README to highlight standalone Firecrawl tools for agents and apps. It lists and links `firecrawl-cli`, `firecrawl-cli-skills`, `firecrawl-skills`, and `firecrawl-workflows`, placed above Integrations.

<sup>Written for commit da7d27a338c784c6678d11c89d1803fb41b54bf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

