### PR TITLE
docs: fix example license links

### DIFF
--- a/examples/gpt-4.1-web-crawler/README.md
+++ b/examples/gpt-4.1-web-crawler/README.md
@@ -75,7 +75,7 @@ The crawler will then:
 
 ## License
 
-[MIT License](LICENSE)
+[MIT License](../../LICENSE)
 
 ## Contributing
 

--- a/examples/o4-mini-web-crawler/README.md
+++ b/examples/o4-mini-web-crawler/README.md
@@ -58,4 +58,4 @@ The crawler will search for pages likely to contain this information, analyze th
 
 ## License
 
-[MIT](LICENSE)
+[MIT](../../LICENSE)


### PR DESCRIPTION
## Summary
- fixes two example README license links that currently point to missing local `LICENSE` files
- points both nested example READMEs back to the repository-level `../../LICENSE`

## Test plan
- focused local markdown link check for both edited READMEs
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken license links in two example READMEs by pointing them to the repository-level ../../LICENSE. Prevents dead links and keeps license attribution correct.

<sup>Written for commit 1fd3a306c467c1dba0fe042f39e7de1961a4ac16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

