### PR TITLE
feat(api): add media discovery format

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -423,12 +423,25 @@ const queryFormatWithOptions = z.strictObject({
 
 type QueryFormatWithOptions = z.output<typeof queryFormatWithOptions>;
 
+const mediaFormatWithOptions = z.strictObject({
+  type: z.literal("media"),
+  types: z
+    .enum(["video", "audio"])
+    .array()
+    .optional()
+    .prefault(["video", "audio"]),
+  limit: z.int().positive().finite().max(100).optional().prefault(25),
+});
+
+type MediaFormatWithOptions = z.output<typeof mediaFormatWithOptions>;
+
 export type FormatObject =
   | { type: "markdown" }
   | { type: "html" }
   | { type: "rawHtml" }
   | { type: "links" }
   | { type: "images" }
+  | MediaFormatWithOptions
   | { type: "summary" }
   | JsonFormatWithOptions
   | ChangeTrackingFormatWithOptions
@@ -603,6 +616,7 @@ const baseScrapeOptions = z.strictObject({
           z.strictObject({ type: z.literal("rawHtml") }),
           z.strictObject({ type: z.literal("links") }),
           z.strictObject({ type: z.literal("images") }),
+          mediaFormatWithOptions,
           z.strictObject({ type: z.literal("summary") }),
           jsonFormatWithOptions,
           changeTrackingFormatWithOptions,
@@ -1211,6 +1225,32 @@ export type PIIBlock = {
   counts: Partial<Record<RedactPIIEntity, number>>;
 };
 
+type MediaItem = {
+  type: "video" | "audio";
+  present: true;
+  presence: "html" | "embed" | "metadata" | "jsonLd" | "text";
+  sourceURL: string;
+  url?: string;
+  title?: string;
+  thumbnail?: string;
+  description?: string;
+  provider?: string;
+  mimeType?: string;
+  duration?: string;
+  count?: number;
+};
+
+type MediaBlock = {
+  summary: {
+    total: number;
+    audio: number;
+    video: number;
+    hasAudio: boolean;
+    hasVideo: boolean;
+  };
+  items: MediaItem[];
+};
+
 export type Document = {
   title?: string;
   description?: string;
@@ -1220,6 +1260,7 @@ export type Document = {
   rawHtml?: string;
   links?: string[];
   images?: string[];
+  media?: MediaBlock;
   screenshot?: string;
   audio?: string;
   video?: string;
@@ -1930,6 +1971,7 @@ export const searchRequestSchema = z
                 z.strictObject({ type: z.literal("rawHtml") }),
                 z.strictObject({ type: z.literal("links") }),
                 z.strictObject({ type: z.literal("images") }),
+                mediaFormatWithOptions,
                 z.strictObject({ type: z.literal("summary") }),
                 jsonFormatWithOptions,
                 questionFormatWithOptions,

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/extractMedia.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/extractMedia.test.ts
@@ -1,0 +1,168 @@
+import { extractMedia } from "../extractMedia";
+
+describe("extractMedia", () => {
+  const baseUrl = "https://example.com/products/phone";
+
+  it("extracts native video and audio sources with titles and thumbnails", async () => {
+    const media = await extractMedia(
+      `
+        <html>
+          <head><title>Product page</title></head>
+          <body>
+            <figure>
+              <video poster="/thumbs/demo.jpg" title="Product demo">
+                <source src="/media/demo.mp4" type="video/mp4">
+              </video>
+              <figcaption>Phone demo video</figcaption>
+            </figure>
+            <audio aria-label="Launch podcast">
+              <source src="https://cdn.example.com/podcast.mp3" type="audio/mpeg">
+            </audio>
+          </body>
+        </html>
+      `,
+      baseUrl,
+    );
+
+    expect(media.summary).toEqual({
+      total: 2,
+      audio: 1,
+      video: 1,
+      hasAudio: true,
+      hasVideo: true,
+    });
+    expect(media.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "video",
+          presence: "html",
+          present: true,
+          sourceURL: baseUrl,
+          url: "https://example.com/media/demo.mp4",
+          title: "Product demo",
+          thumbnail: "https://example.com/thumbs/demo.jpg",
+          mimeType: "video/mp4",
+        }),
+        expect.objectContaining({
+          type: "audio",
+          presence: "html",
+          present: true,
+          sourceURL: baseUrl,
+          url: "https://cdn.example.com/podcast.mp3",
+          title: "Launch podcast",
+          mimeType: "audio/mpeg",
+        }),
+      ]),
+    );
+  });
+
+  it("extracts metadata and JSON-LD media", async () => {
+    const media = await extractMedia(
+      `
+        <html>
+          <head>
+            <meta property="og:title" content="Metadata title">
+            <meta property="og:image" content="/og.jpg">
+            <meta property="og:video:secure_url" content="https://videos.example.com/demo.webm">
+            <meta property="og:video:type" content="video/webm">
+            <script type="application/ld+json">
+              {
+                "@context": "https://schema.org",
+                "@type": "AudioObject",
+                "name": "Narrated review",
+                "contentUrl": "/audio/review.m4a",
+                "encodingFormat": "audio/mp4",
+                "duration": "PT3M"
+              }
+            </script>
+          </head>
+        </html>
+      `,
+      baseUrl,
+    );
+
+    expect(media.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "video",
+          presence: "metadata",
+          url: "https://videos.example.com/demo.webm",
+          title: "Metadata title",
+          thumbnail: "https://example.com/og.jpg",
+          mimeType: "video/webm",
+        }),
+        expect.objectContaining({
+          type: "audio",
+          presence: "jsonLd",
+          url: "https://example.com/audio/review.m4a",
+          title: "Narrated review",
+          mimeType: "audio/mp4",
+          duration: "PT3M",
+        }),
+      ]),
+    );
+  });
+
+  it("extracts embed links and filters requested media types", async () => {
+    const media = await extractMedia(
+      `
+        <html>
+          <head><title>Media embeds</title></head>
+          <body>
+            <iframe src="https://www.youtube.com/embed/abc123" title="Video embed"></iframe>
+            <a href="https://soundcloud.com/example/episode">Listen</a>
+          </body>
+        </html>
+      `,
+      baseUrl,
+      { types: ["video"] },
+    );
+
+    expect(media.summary).toEqual({
+      total: 1,
+      audio: 0,
+      video: 1,
+      hasAudio: false,
+      hasVideo: true,
+    });
+    expect(media.items).toHaveLength(1);
+    expect(media.items[0]).toEqual(
+      expect.objectContaining({
+        type: "video",
+        presence: "embed",
+        url: "https://www.youtube.com/embed/abc123",
+        provider: "youtube",
+        title: "Video embed",
+      }),
+    );
+  });
+
+  it("records text-only presence counts when URLs are absent", async () => {
+    const media = await extractMedia(
+      `
+        <html>
+          <head>
+            <title>Apple - iPhone 17 256GB - Black (Verizon)</title>
+            <meta property="og:image" content="/product.jpg">
+          </head>
+          <body>
+            <button>2 Videos</button>
+          </body>
+        </html>
+      `,
+      baseUrl,
+    );
+
+    expect(media.summary.video).toBe(2);
+    expect(media.summary.total).toBe(2);
+    expect(media.items).toEqual([
+      expect.objectContaining({
+        type: "video",
+        presence: "text",
+        count: 2,
+        title: "Apple - iPhone 17 256GB - Black (Verizon)",
+        thumbnail: "https://example.com/product.jpg",
+      }),
+    ]);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/lib/extractMedia.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractMedia.ts
@@ -1,0 +1,562 @@
+import { AnyNode, Cheerio, CheerioAPI, load } from "cheerio";
+
+type MediaType = "audio" | "video";
+type MediaPresence = "html" | "embed" | "metadata" | "jsonLd" | "text";
+
+type MediaItem = {
+  type: MediaType;
+  present: true;
+  presence: MediaPresence;
+  sourceURL: string;
+  url?: string;
+  title?: string;
+  thumbnail?: string;
+  description?: string;
+  provider?: string;
+  mimeType?: string;
+  duration?: string;
+  count?: number;
+};
+
+type MediaBlock = {
+  summary: {
+    total: number;
+    audio: number;
+    video: number;
+    hasAudio: boolean;
+    hasVideo: boolean;
+  };
+  items: MediaItem[];
+};
+
+type ExtractMediaOptions = {
+  types?: MediaType[];
+  limit?: number;
+};
+
+const DEFAULT_MEDIA_TYPES: MediaType[] = ["video", "audio"];
+const DEFAULT_LIMIT = 25;
+
+function normalizeWhitespace(
+  value: string | undefined | null,
+): string | undefined {
+  const normalized = value?.replace(/\s+/g, " ").trim();
+  return normalized || undefined;
+}
+
+function resolveUrl(
+  value: string | undefined | null,
+  baseUrl: string,
+  baseHref = "",
+): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  const lowered = raw.toLowerCase();
+  if (
+    lowered.startsWith("javascript:") ||
+    lowered.startsWith("mailto:") ||
+    lowered.startsWith("tel:") ||
+    lowered.startsWith("blob:") ||
+    lowered.startsWith("data:") ||
+    lowered.startsWith("#")
+  ) {
+    return undefined;
+  }
+
+  let resolutionBase = baseUrl;
+  if (baseHref) {
+    try {
+      resolutionBase = new URL(baseHref, baseUrl).href;
+    } catch {
+      resolutionBase = baseUrl;
+    }
+  }
+
+  try {
+    return new URL(raw, resolutionBase).href;
+  } catch {
+    return undefined;
+  }
+}
+
+function getMetaContent(
+  $: CheerioAPI,
+  selectors: string[],
+): string | undefined {
+  for (const selector of selectors) {
+    const content = normalizeWhitespace($(selector).first().attr("content"));
+    if (content) return content;
+  }
+  return undefined;
+}
+
+function getPageTitle($: CheerioAPI): string | undefined {
+  return (
+    getMetaContent($, [
+      'meta[property="og:title"]',
+      'meta[name="twitter:title"]',
+      'meta[name="title"]',
+    ]) ?? normalizeWhitespace($("title").first().text())
+  );
+}
+
+function getFallbackThumbnail(
+  $: CheerioAPI,
+  baseUrl: string,
+  baseHref: string,
+): string | undefined {
+  return resolveUrl(
+    getMetaContent($, [
+      'meta[property="og:image"]',
+      'meta[property="og:image:url"]',
+      'meta[property="og:image:secure_url"]',
+      'meta[name="twitter:image"]',
+      'meta[name="twitter:image:src"]',
+      'meta[itemprop="image"]',
+    ]),
+    baseUrl,
+    baseHref,
+  );
+}
+
+function providerFromUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+
+  try {
+    const host = new URL(value).hostname.toLowerCase().replace(/^www\./, "");
+    if (host === "youtu.be" || host.endsWith("youtube.com")) return "youtube";
+    if (host.endsWith("vimeo.com")) return "vimeo";
+    if (host.endsWith("wistia.com") || host.endsWith("wistia.net")) {
+      return "wistia";
+    }
+    if (host.endsWith("brightcove.net") || host.endsWith("brightcove.com")) {
+      return "brightcove";
+    }
+    if (host.endsWith("vidyard.com")) return "vidyard";
+    if (host.endsWith("dailymotion.com")) return "dailymotion";
+    if (host.endsWith("tiktok.com")) return "tiktok";
+    if (host.endsWith("soundcloud.com")) return "soundcloud";
+    if (host.endsWith("spotify.com")) return "spotify";
+    if (host.endsWith("podcasts.apple.com")) return "apple-podcasts";
+    return host;
+  } catch {
+    return undefined;
+  }
+}
+
+function inferMediaType(
+  value: string | undefined,
+  mimeType?: string,
+): MediaType | undefined {
+  const mime = mimeType?.toLowerCase();
+  if (mime?.startsWith("video/")) return "video";
+  if (mime?.startsWith("audio/")) return "audio";
+
+  const lowered = value?.toLowerCase() ?? "";
+  if (
+    /\.(mp4|m4v|webm|mov|avi|mkv|m3u8)([?#].*)?$/.test(lowered) ||
+    lowered.includes("youtube.com/watch") ||
+    lowered.includes("youtube.com/embed") ||
+    lowered.includes("youtu.be/") ||
+    lowered.includes("vimeo.com/") ||
+    lowered.includes("wistia.") ||
+    lowered.includes("brightcove") ||
+    lowered.includes("vidyard") ||
+    lowered.includes("dailymotion.com") ||
+    lowered.includes("tiktok.com/embed")
+  ) {
+    return "video";
+  }
+
+  if (
+    /\.(mp3|m4a|wav|ogg|oga|aac|flac)([?#].*)?$/.test(lowered) ||
+    lowered.includes("soundcloud.com/") ||
+    lowered.includes("spotify.com/embed") ||
+    lowered.includes("podcasts.apple.com/")
+  ) {
+    return "audio";
+  }
+
+  return undefined;
+}
+
+function getElementTitle(
+  $: CheerioAPI,
+  element: Cheerio<AnyNode>,
+  fallbackTitle: string | undefined,
+): string | undefined {
+  return (
+    normalizeWhitespace(element.attr("title")) ??
+    normalizeWhitespace(element.attr("aria-label")) ??
+    normalizeWhitespace(element.attr("data-title")) ??
+    normalizeWhitespace(
+      element.closest("figure").find("figcaption").first().text(),
+    ) ??
+    fallbackTitle
+  );
+}
+
+function firstString(value: unknown): string | undefined {
+  if (typeof value === "string") return normalizeWhitespace(value);
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = firstString(item);
+      if (found) return found;
+    }
+  }
+  if (value && typeof value === "object") {
+    const objectValue = value as Record<string, unknown>;
+    return (
+      firstString(objectValue.url) ??
+      firstString(objectValue.contentUrl) ??
+      firstString(objectValue.embedUrl) ??
+      firstString(objectValue["@id"])
+    );
+  }
+  return undefined;
+}
+
+function schemaTypes(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(schemaTypes);
+  return [];
+}
+
+function visitJsonLd(
+  value: unknown,
+  visitor: (node: Record<string, unknown>) => void,
+) {
+  if (Array.isArray(value)) {
+    value.forEach(item => visitJsonLd(item, visitor));
+    return;
+  }
+
+  if (!value || typeof value !== "object") return;
+
+  const node = value as Record<string, unknown>;
+  visitor(node);
+
+  for (const nested of Object.values(node)) {
+    if (nested && typeof nested === "object") {
+      visitJsonLd(nested, visitor);
+    }
+  }
+}
+
+function parseJsonLd(scriptText: string): unknown | undefined {
+  const trimmed = scriptText.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function buildSummary(items: MediaItem[]): MediaBlock["summary"] {
+  const summary = {
+    total: 0,
+    audio: 0,
+    video: 0,
+    hasAudio: false,
+    hasVideo: false,
+  };
+
+  for (const item of items) {
+    const count = Math.max(1, item.count ?? 1);
+    summary.total += count;
+    summary[item.type] += count;
+  }
+
+  summary.hasAudio = summary.audio > 0;
+  summary.hasVideo = summary.video > 0;
+  return summary;
+}
+
+export async function extractMedia(
+  html: string,
+  baseUrl: string,
+  options: ExtractMediaOptions = {},
+): Promise<MediaBlock> {
+  const $ = load(html);
+  const baseHref = $("base[href]").first().attr("href") || "";
+  const requestedTypes = new Set(options.types ?? DEFAULT_MEDIA_TYPES);
+  const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_LIMIT, 100));
+  const pageTitle = getPageTitle($);
+  const fallbackThumbnail = getFallbackThumbnail($, baseUrl, baseHref);
+  const itemsByKey = new Map<string, MediaItem>();
+
+  function addMedia(item: Omit<MediaItem, "present" | "sourceURL">) {
+    if (!requestedTypes.has(item.type)) return;
+
+    const normalized: MediaItem = {
+      ...item,
+      present: true,
+      sourceURL: baseUrl,
+      title: normalizeWhitespace(item.title),
+      thumbnail: resolveUrl(item.thumbnail, baseUrl, baseHref),
+      url: resolveUrl(item.url, baseUrl, baseHref),
+      description: normalizeWhitespace(item.description),
+      provider: item.provider ?? providerFromUrl(item.url),
+      mimeType: normalizeWhitespace(item.mimeType),
+      duration: normalizeWhitespace(item.duration),
+      count: item.count && item.count > 1 ? item.count : undefined,
+    };
+
+    if (
+      !normalized.url &&
+      !normalized.title &&
+      !normalized.thumbnail &&
+      !normalized.count
+    ) {
+      return;
+    }
+
+    const key = [
+      normalized.type,
+      normalized.url ?? "",
+      normalized.presence,
+      normalized.title ?? "",
+      normalized.thumbnail ?? "",
+    ].join("|");
+    const existing = itemsByKey.get(key);
+    if (existing) {
+      itemsByKey.set(key, {
+        ...existing,
+        ...Object.fromEntries(
+          Object.entries(normalized).filter(([, value]) => value !== undefined),
+        ),
+        count: Math.max(existing.count ?? 1, normalized.count ?? 1),
+      });
+      return;
+    }
+
+    itemsByKey.set(key, normalized);
+  }
+
+  $("video").each((_, element) => {
+    const video = $(element);
+    const title = getElementTitle($, video, pageTitle);
+    const thumbnail =
+      resolveUrl(video.attr("poster"), baseUrl, baseHref) ?? fallbackThumbnail;
+    const directSrc = video.attr("src");
+    const sources = directSrc
+      ? [{ url: directSrc, mimeType: video.attr("type") }]
+      : video
+          .find("source[src]")
+          .map((__, source) => ({
+            url: $(source).attr("src"),
+            mimeType: $(source).attr("type"),
+          }))
+          .get();
+
+    if (sources.length === 0) {
+      addMedia({
+        type: "video",
+        presence: "html",
+        title,
+        thumbnail,
+      });
+      return;
+    }
+
+    for (const source of sources) {
+      addMedia({
+        type: "video",
+        presence: "html",
+        url: source.url,
+        title,
+        thumbnail,
+        mimeType: source.mimeType,
+      });
+    }
+  });
+
+  $("audio").each((_, element) => {
+    const audio = $(element);
+    const title = getElementTitle($, audio, pageTitle);
+    const directSrc = audio.attr("src");
+    const sources = directSrc
+      ? [{ url: directSrc, mimeType: audio.attr("type") }]
+      : audio
+          .find("source[src]")
+          .map((__, source) => ({
+            url: $(source).attr("src"),
+            mimeType: $(source).attr("type"),
+          }))
+          .get();
+
+    if (sources.length === 0) {
+      addMedia({
+        type: "audio",
+        presence: "html",
+        title,
+      });
+      return;
+    }
+
+    for (const source of sources) {
+      addMedia({
+        type: "audio",
+        presence: "html",
+        url: source.url,
+        title,
+        mimeType: source.mimeType,
+      });
+    }
+  });
+
+  $("iframe[src], embed[src], object[data]").each((_, element) => {
+    const embedded = $(element);
+    const url = embedded.attr("src") ?? embedded.attr("data");
+    const type = inferMediaType(url, embedded.attr("type"));
+    if (!type) return;
+
+    addMedia({
+      type,
+      presence: "embed",
+      url,
+      title: getElementTitle($, embedded, pageTitle),
+      thumbnail: fallbackThumbnail,
+      mimeType: embedded.attr("type"),
+      provider: providerFromUrl(url),
+    });
+  });
+
+  $("a[href]").each((_, element) => {
+    const link = $(element);
+    const url = link.attr("href");
+    const type = inferMediaType(url, link.attr("type"));
+    if (!type) return;
+
+    addMedia({
+      type,
+      presence: "embed",
+      url,
+      title:
+        normalizeWhitespace(link.attr("title")) ??
+        normalizeWhitespace(link.text()) ??
+        pageTitle,
+      thumbnail: fallbackThumbnail,
+      mimeType: link.attr("type"),
+      provider: providerFromUrl(url),
+    });
+  });
+
+  const metadataVideoUrls = [
+    'meta[property="og:video"]',
+    'meta[property="og:video:url"]',
+    'meta[property="og:video:secure_url"]',
+    'meta[name="twitter:player"]',
+    'meta[name="twitter:player:stream"]',
+  ];
+  for (const selector of metadataVideoUrls) {
+    const url = getMetaContent($, [selector]);
+    if (!url) continue;
+    addMedia({
+      type: "video",
+      presence: "metadata",
+      url,
+      title: pageTitle,
+      thumbnail: fallbackThumbnail,
+      mimeType: getMetaContent($, ['meta[property="og:video:type"]']),
+      provider: providerFromUrl(url),
+    });
+  }
+
+  const metadataAudioUrls = [
+    'meta[property="og:audio"]',
+    'meta[property="og:audio:url"]',
+    'meta[property="og:audio:secure_url"]',
+  ];
+  for (const selector of metadataAudioUrls) {
+    const url = getMetaContent($, [selector]);
+    if (!url) continue;
+    addMedia({
+      type: "audio",
+      presence: "metadata",
+      url,
+      title: pageTitle,
+      thumbnail: fallbackThumbnail,
+      mimeType: getMetaContent($, ['meta[property="og:audio:type"]']),
+      provider: providerFromUrl(url),
+    });
+  }
+
+  $('script[type="application/ld+json"]').each((_, element) => {
+    const parsed = parseJsonLd($(element).text());
+    if (!parsed) return;
+
+    visitJsonLd(parsed, node => {
+      const types = schemaTypes(node["@type"]).map(type => type.toLowerCase());
+      const isVideo = types.includes("videoobject");
+      const isAudio = types.includes("audioobject");
+      if (!isVideo && !isAudio) return;
+
+      const url =
+        firstString(node.contentUrl) ??
+        firstString(node.embedUrl) ??
+        firstString(node.url);
+      const thumbnail =
+        firstString(node.thumbnailUrl) ?? firstString(node.thumbnail);
+      const mimeType =
+        firstString(node.encodingFormat) ?? firstString(node.mimeType);
+      const duration = firstString(node.duration);
+
+      addMedia({
+        type: isVideo ? "video" : "audio",
+        presence: "jsonLd",
+        url,
+        title:
+          firstString(node.name) ??
+          firstString(node.headline) ??
+          firstString(node.title) ??
+          pageTitle,
+        thumbnail: thumbnail ?? fallbackThumbnail,
+        description: firstString(node.description),
+        mimeType,
+        duration,
+        provider: providerFromUrl(url),
+      });
+    });
+  });
+
+  const currentItems = () => Array.from(itemsByKey.values());
+  const bodyText = normalizeWhitespace($("body").text()) ?? "";
+
+  if (!currentItems().some(item => item.type === "video")) {
+    const match = bodyText.match(/\b(\d{1,3})\s+videos?\b/i);
+    if (match) {
+      addMedia({
+        type: "video",
+        presence: "text",
+        title: pageTitle,
+        thumbnail: fallbackThumbnail,
+        count: Number(match[1]),
+      });
+    }
+  }
+
+  if (!currentItems().some(item => item.type === "audio")) {
+    const match = bodyText.match(
+      /\b(\d{1,3})\s+(?:audio|podcasts?|tracks?)\b/i,
+    );
+    if (match) {
+      addMedia({
+        type: "audio",
+        presence: "text",
+        title: pageTitle,
+        thumbnail: fallbackThumbnail,
+        count: Number(match[1]),
+      });
+    }
+  }
+
+  const items = currentItems().slice(0, limit);
+  return {
+    summary: buildSummary(items),
+    items,
+  };
+}

--- a/apps/api/src/scraper/scrapeURL/transformers/__tests__/media.test.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/__tests__/media.test.ts
@@ -1,0 +1,94 @@
+jest.mock("../../../../services/index", () => ({
+  useIndex: false,
+  useSearchIndex: false,
+}));
+
+jest.mock("../../../../services/indexing/indexer-queue", () => ({
+  indexerQueue: { sendToWorker: jest.fn() },
+}));
+
+jest.mock("../llmExtract", () => ({
+  performLLMExtract: (_meta: unknown, document: unknown) => document,
+  performSummary: (_meta: unknown, document: unknown) => document,
+  performCleanContent: (_meta: unknown, document: unknown) => document,
+}));
+
+jest.mock("../query", () => ({
+  performQuery: (_meta: unknown, document: unknown) => document,
+}));
+
+jest.mock("../agent", () => ({
+  performAgent: (_meta: unknown, document: unknown) => document,
+}));
+
+jest.mock("../performAttributes", () => ({
+  performAttributes: (_meta: unknown, document: unknown) => document,
+}));
+
+jest.mock("../diff", () => ({
+  deriveDiff: (_meta: unknown, document: unknown) => document,
+}));
+
+jest.mock("../audio", () => ({
+  fetchAudio: (_meta: unknown, document: unknown) => document,
+}));
+
+jest.mock("../video", () => ({
+  fetchVideo: (_meta: unknown, document: unknown) => document,
+}));
+
+import { coerceFieldsToFormats } from "../index";
+
+describe("coerceFieldsToFormats media", () => {
+  const media = {
+    summary: {
+      total: 1,
+      audio: 0,
+      video: 1,
+      hasAudio: false,
+      hasVideo: true,
+    },
+    items: [
+      {
+        type: "video",
+        present: true,
+        presence: "metadata",
+        sourceURL: "https://example.com",
+        url: "https://cdn.example.com/video.mp4",
+      },
+    ],
+  };
+
+  function meta(formats: any[]) {
+    return {
+      options: { formats },
+      internalOptions: {},
+      logger: {
+        warn: jest.fn(),
+        debug: jest.fn(),
+      },
+    } as any;
+  }
+
+  it("keeps media only when the media format is requested", () => {
+    const document = { metadata: {}, media: structuredClone(media) } as any;
+
+    const result = coerceFieldsToFormats(
+      meta([{ type: "media", types: ["video"], limit: 10 }]),
+      document,
+    );
+
+    expect(result.media).toEqual(media);
+  });
+
+  it("removes media when the media format is not requested", () => {
+    const document = { metadata: {}, media: structuredClone(media) } as any;
+
+    const result = coerceFieldsToFormats(
+      meta([{ type: "markdown" }]),
+      document,
+    );
+
+    expect(result.media).toBeUndefined();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -4,6 +4,7 @@ import { Document } from "../../../controllers/v2/types";
 import { htmlTransform } from "../lib/removeUnwantedElements";
 import { extractLinks } from "../lib/extractLinks";
 import { extractImages } from "../lib/extractImages";
+import { extractMedia } from "../lib/extractMedia";
 import { extractMetadata } from "../lib/extractMetadata";
 import {
   performLLMExtract,
@@ -271,6 +272,36 @@ async function deriveImagesFromHTML(
   return document;
 }
 
+async function deriveMediaFromHTML(
+  meta: Meta,
+  document: Document,
+): Promise<Document> {
+  const mediaFormat = hasFormatOfType(meta.options.formats, "media");
+  if (!mediaFormat) {
+    return document;
+  }
+
+  if (document.html === undefined) {
+    throw new Error(
+      "html is undefined -- this transformer is being called out of order",
+    );
+  }
+
+  document.media = await extractMedia(
+    document.html,
+    document.metadata.url ??
+      document.metadata.sourceURL ??
+      meta.rewrittenUrl ??
+      meta.url,
+    {
+      types: mediaFormat.types,
+      limit: mediaFormat.limit,
+    },
+  );
+
+  return document;
+}
+
 async function deriveBrandingFromActions(
   meta: Meta,
   document: Document,
@@ -311,12 +342,16 @@ async function deriveBrandingFromActions(
   return document;
 }
 
-function coerceFieldsToFormats(meta: Meta, document: Document): Document {
+export function coerceFieldsToFormats(
+  meta: Meta,
+  document: Document,
+): Document {
   const hasMarkdown = hasFormatOfType(meta.options.formats, "markdown");
   const hasRawHtml = hasFormatOfType(meta.options.formats, "rawHtml");
   const hasHtml = hasFormatOfType(meta.options.formats, "html");
   const hasLinks = hasFormatOfType(meta.options.formats, "links");
   const hasImages = hasFormatOfType(meta.options.formats, "images");
+  const hasMedia = hasFormatOfType(meta.options.formats, "media");
   const hasChangeTracking = hasFormatOfType(
     meta.options.formats,
     "changeTracking",
@@ -389,6 +424,19 @@ function coerceFieldsToFormats(meta: Meta, document: Document): Document {
     meta.logger.warn(
       "Request had format: images, but there was no images field in the result.",
       { hasImages, hasImagesField: document.images !== undefined },
+    );
+  }
+
+  if (!hasMedia && document.media !== undefined) {
+    meta.logger.warn(
+      "Removed media from Document because it wasn't in formats -- this is wasteful and indicates a bug.",
+      { hasMedia, hasMediaField: document.media !== undefined },
+    );
+    delete document.media;
+  } else if (hasMedia && document.media === undefined) {
+    meta.logger.warn(
+      "Request had format: media, but there was no media field in the result.",
+      { hasMedia, hasMediaField: document.media !== undefined },
     );
   }
 
@@ -571,6 +619,7 @@ const transformerStack: Transformer[] = [
   performRedactPII,
   deriveLinksFromHTML,
   deriveImagesFromHTML,
+  deriveMediaFromHTML,
   deriveBrandingFromActions,
   deriveMetadataFromRawHTML,
   ...(useIndex ? [sendDocumentToIndex] : []),

--- a/apps/js-sdk/firecrawl/README.md
+++ b/apps/js-sdk/firecrawl/README.md
@@ -58,6 +58,19 @@ const doc = await app.scrape('https://www.youtube.com/watch?v=dQw4w9WgXcQ', {
 console.log(doc.video);
 ```
 
+### Media discovery
+
+Use the `media` format to discover audio and video references on a page without downloading the media file. The returned `media` field includes presence, source URL, title, thumbnail, provider, and counts when available.
+
+```js
+const doc = await app.scrape('https://example.com/product', {
+  formats: [{ type: 'media', types: ['video', 'audio'], limit: 10 }],
+});
+
+console.log(doc.media?.summary);
+console.log(doc.media?.items);
+```
+
 ### Parsing uploaded files
 
 Use `parse` to upload a file (`html`, `pdf`, `docx`, etc.) as multipart form data and process it through the same parsing pipeline.

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/validation.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/validation.test.ts
@@ -14,6 +14,22 @@ describe("v2 utils: validation", () => {
     expect(() => ensureValidFormats(formats)).not.toThrow();
   });
 
+  test("ensureValidFormats: accepts media discovery format", () => {
+    const formats: FormatOption[] = [
+      { type: "media", types: ["video", "audio"], limit: 10 },
+    ];
+    expect(() => ensureValidFormats(formats)).not.toThrow();
+  });
+
+  test("ensureValidFormats: validates media discovery options", () => {
+    expect(() =>
+      ensureValidFormats([{ type: "media", types: ["image"] } as any]),
+    ).toThrow(/media format types/i);
+    expect(() =>
+      ensureValidFormats([{ type: "media", limit: 0 } as any]),
+    ).toThrow(/media format limit/i);
+  });
+
   test("ensureValidFormats: json format requires prompt or schema", () => {
     // Valid cases - should not throw
     const valid1: FormatOption[] = [{ type: "json", prompt: "p" } as any];
@@ -107,4 +123,3 @@ describe("v2 utils: validation", () => {
     expect(() => ensureValidFormats(formats)).toThrow(/\.shape property/i);
   });
 });
-

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -7,6 +7,7 @@ export type FormatString =
   | "rawHtml"
   | "links"
   | "images"
+  | "media"
   | "screenshot"
   | "summary"
   | "changeTracking"
@@ -69,6 +70,14 @@ export interface HighlightsFormat {
   query: string;
 }
 
+export type MediaType = "video" | "audio";
+
+export interface MediaFormat {
+  type: "media";
+  types?: MediaType[];
+  limit?: number;
+}
+
 /** @deprecated Use QuestionFormat or HighlightsFormat instead. */
 export interface QueryFormat {
   type: "query";
@@ -85,6 +94,7 @@ export type FormatOption =
   | AttributesFormat
   | QuestionFormat
   | HighlightsFormat
+  | MediaFormat
   | QueryFormat;
 
 export type ParseFormatString = Exclude<
@@ -535,6 +545,29 @@ export interface Document {
   metadata?: DocumentMetadata;
   links?: string[];
   images?: string[];
+  media?: {
+    summary: {
+      total: number;
+      audio: number;
+      video: number;
+      hasAudio: boolean;
+      hasVideo: boolean;
+    };
+    items: Array<{
+      type: MediaType;
+      present: true;
+      presence: "html" | "embed" | "metadata" | "jsonLd" | "text";
+      sourceURL: string;
+      url?: string;
+      title?: string;
+      thumbnail?: string;
+      description?: string;
+      provider?: string;
+      mimeType?: string;
+      duration?: string;
+      count?: number;
+    }>;
+  };
   screenshot?: string;
   audio?: string;
   video?: string;

--- a/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
@@ -7,6 +7,7 @@ import {
   type QuestionFormat,
   type HighlightsFormat,
   type QueryFormat,
+  type MediaFormat,
   type ScrapeOptions,
   type ScreenshotFormat,
 } from "../types";
@@ -76,6 +77,23 @@ export function ensureValidFormats(formats?: FormatOption[]): void {
       }
       continue;
     }
+    if ((fmt as MediaFormat).type === "media") {
+      const m = fmt as MediaFormat;
+      if (
+        m.types != null &&
+        (!Array.isArray(m.types) ||
+          m.types.some(type => type !== "video" && type !== "audio"))
+      ) {
+        throw new Error("media format types must be 'video' or 'audio'");
+      }
+      if (
+        m.limit != null &&
+        (!Number.isInteger(m.limit) || m.limit <= 0 || m.limit > 100)
+      ) {
+        throw new Error("media format limit must be an integer between 1 and 100");
+      }
+      continue;
+    }
     if ((fmt as ScreenshotFormat).type === "screenshot") {
       // no-op; already camelCase; validate numeric fields if present
       const s = fmt as ScreenshotFormat;
@@ -102,20 +120,21 @@ export function ensureValidParseFormats(formats?: ParseFormatOption[]): void {
 
   for (const fmt of formats) {
     if (typeof fmt === "string") {
-      if (fmt === "json") {
+      const fmtString: string = fmt;
+      if (fmtString === "json") {
         throw new Error("json format must be an object with { type: 'json', prompt, schema }");
       }
-      if (fmt === "screenshot") {
+      if (fmtString === "screenshot") {
         throw new Error("parse does not support screenshot format");
       }
-      if (fmt === "changeTracking") {
+      if (fmtString === "changeTracking") {
         throw new Error("parse does not support changeTracking format");
       }
-      if (fmt === "branding") {
+      if (fmtString === "branding") {
         throw new Error("parse does not support branding format");
       }
-      if (fmt === "audio" || fmt === "video") {
-        throw new Error(`parse does not support ${fmt} format`);
+      if (fmtString === "audio" || fmtString === "video") {
+        throw new Error(`parse does not support ${fmtString} format`);
       }
       continue;
     }
@@ -211,4 +230,3 @@ export function ensureValidParseOptions(options?: ParseOptions): void {
 
   ensureValidParseFormats(options.formats);
 }
-

--- a/apps/python-sdk/README.md
+++ b/apps/python-sdk/README.md
@@ -58,6 +58,20 @@ doc = firecrawl.scrape('https://www.youtube.com/watch?v=dQw4w9WgXcQ', formats=['
 print(doc.video)
 ```
 
+### Media discovery
+
+Use the `media` format to discover audio and video references on a page without downloading the media file. The returned `media` field includes presence, source URL, title, thumbnail, provider, and counts when available.
+
+```python
+doc = firecrawl.scrape(
+  'https://example.com/product',
+  formats=[{'type': 'media', 'types': ['video', 'audio'], 'limit': 10}]
+)
+
+print(doc.media.summary)
+print(doc.media.items)
+```
+
 ### Parsing uploaded files
 
 Use `parse` to upload local bytes/files (`html`, `pdf`, `docx`, etc.) as multipart form data and return the parsed document.

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_metadata_extras.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_metadata_extras.py
@@ -88,6 +88,36 @@ class TestDocumentMetadataExtras:
         md = doc.metadata_dict
         assert md["x-list"] == [1, "a", 3]
 
+    def test_media_response_is_typed(self):
+        raw = {
+            "media": {
+                "summary": {
+                    "total": 1,
+                    "audio": 0,
+                    "video": 1,
+                    "hasAudio": False,
+                    "hasVideo": True,
+                },
+                "items": [
+                    {
+                        "type": "video",
+                        "present": True,
+                        "presence": "metadata",
+                        "sourceURL": "https://example.com/product",
+                        "url": "https://cdn.example.com/video.mp4",
+                        "mimeType": "video/mp4",
+                    }
+                ],
+            }
+        }
+
+        doc = Document(**normalize_document_input(raw))
+
+        assert doc.media is not None
+        assert doc.media.summary.has_video is True
+        assert doc.media.items[0].source_url == "https://example.com/product"
+        assert doc.media.items[0].mime_type == "video/mp4"
+
     def test_metadata_typed_extras_property(self):
         md = DocumentMetadata(title="T", **{"x-foo": "bar"})
         # extras accessor should expose unknown keys

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -2,6 +2,7 @@ import pytest
 from firecrawl.v2.types import (
     HighlightsFormat,
     JsonFormat,
+    MediaFormat,
     QueryFormat,
     QuestionFormat,
     ScrapeOptions,
@@ -115,6 +116,28 @@ class TestPrepareScrapeOptions:
         assert result["formats"] == ["markdown", "video"]
         assert result["timeout"] == 30000
         assert result["waitFor"] == 2000
+
+    def test_prepare_media_format(self):
+        """Test media discovery format preparation."""
+        options = ScrapeOptions(
+            formats=[{"type": "media", "types": ["video", "audio"], "limit": 10}]
+        )
+        result = prepare_scrape_options(options)
+
+        assert result["formats"] == [
+            {"type": "media", "types": ["video", "audio"], "limit": 10}
+        ]
+
+    def test_prepare_media_format_model(self):
+        """Test typed media discovery format preparation."""
+        options = ScrapeOptions(
+            formats=[MediaFormat(types=["video"], limit=5)]
+        )
+        result = prepare_scrape_options(options)
+
+        assert result["formats"] == [
+            {"type": "media", "types": ["video"], "limit": 5}
+        ]
 
     def test_prepare_snake_case_conversion(self):
         """Test snake_case to camelCase conversion."""

--- a/apps/python-sdk/firecrawl/types.py
+++ b/apps/python-sdk/firecrawl/types.py
@@ -12,6 +12,9 @@ from .v2.types import (
     # Document types
     Document,
     DocumentMetadata,
+    MediaBlock,
+    MediaItem,
+    MediaSummary,
     
     # Scrape types
     ScrapeFormats,
@@ -46,6 +49,7 @@ from .v2.types import (
     SourceOption,
     Format,
     JsonFormat,
+    MediaFormat,
     QuestionFormat,
     HighlightsFormat,
     QueryFormat,
@@ -95,6 +99,9 @@ __all__ = [
     # Document types
     'Document',
     'DocumentMetadata',
+    'MediaBlock',
+    'MediaItem',
+    'MediaSummary',
     
     # Scrape types
     'ScrapeFormats',
@@ -130,6 +137,7 @@ __all__ = [
     'SourceOption',
     'Format',
     'JsonFormat',
+    'MediaFormat',
     'QuestionFormat',
     'HighlightsFormat',
     'QueryFormat',
@@ -170,4 +178,4 @@ __all__ = [
     # Configuration types
     'ClientConfig',
     'AgentOptions',
-]  
+]

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -322,6 +322,46 @@ class PIIBlock(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class MediaSummary(BaseModel):
+    """Summary counts for discovered page media."""
+
+    total: int = 0
+    audio: int = 0
+    video: int = 0
+    has_audio: bool = Field(default=False, alias="hasAudio")
+    has_video: bool = Field(default=False, alias="hasVideo")
+
+    model_config = {"populate_by_name": True}
+
+
+class MediaItem(BaseModel):
+    """A discovered audio or video reference on a page."""
+
+    type: Literal["video", "audio"]
+    present: bool = True
+    presence: Literal["html", "embed", "metadata", "jsonLd", "text"]
+    source_url: str = Field(alias="sourceURL")
+    url: Optional[str] = None
+    title: Optional[str] = None
+    thumbnail: Optional[str] = None
+    description: Optional[str] = None
+    provider: Optional[str] = None
+    mime_type: Optional[str] = Field(default=None, alias="mimeType")
+    duration: Optional[str] = None
+    count: Optional[int] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class MediaBlock(BaseModel):
+    """Discovered page media."""
+
+    summary: MediaSummary
+    items: List[MediaItem] = []
+
+    model_config = {"populate_by_name": True}
+
+
 class Document(BaseModel):
     """A scraped document."""
 
@@ -333,6 +373,7 @@ class Document(BaseModel):
     metadata: Optional[DocumentMetadata] = None
     links: Optional[List[str]] = None
     images: Optional[List[str]] = None
+    media: Optional[MediaBlock] = None
     screenshot: Optional[str] = None
     audio: Optional[str] = None
     video: Optional[str] = None
@@ -460,6 +501,7 @@ FormatString = Literal[
     "rawHtml",
     "links",
     "images",
+    "media",
     "screenshot",
     "summary",
     "changeTracking",
@@ -544,6 +586,14 @@ class HighlightsFormat(Format):
     query: str
 
 
+class MediaFormat(Format):
+    """Configuration for media discovery."""
+
+    type: Literal["media"] = "media"
+    types: Optional[List[Literal["video", "audio"]]] = None
+    limit: Optional[int] = None
+
+
 class QueryFormat(Format):
     """Deprecated query format. Use QuestionFormat or HighlightsFormat instead."""
 
@@ -561,6 +611,7 @@ FormatOption = Union[
     AttributesFormat,
     QuestionFormat,
     HighlightsFormat,
+    MediaFormat,
     QueryFormat,
     Format,
 ]
@@ -577,6 +628,7 @@ class ScrapeFormats(BaseModel):
     summary: bool = False
     links: bool = False
     images: bool = False
+    media: bool = False
     screenshot: bool = False
     change_tracking: bool = False
     json: bool = False

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -641,6 +641,8 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                                     converted_formats.append(_validate_question_format(fmt.model_dump(exclude_none=True)))
                                 elif fmt.type == 'highlights':
                                     converted_formats.append(_validate_highlights_format(fmt.model_dump(exclude_none=True)))
+                                elif fmt.type == 'media':
+                                    converted_formats.append(fmt.model_dump(exclude_none=True))
                                 elif fmt.type == 'query':
                                     converted_formats.append(_validate_query_format(fmt.model_dump(exclude_none=True)))
                                 elif fmt.type in ('changeTracking', 'change_tracking'):
@@ -663,6 +665,8 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                         converted_formats.append("summary")
                     if original_formats.links:
                         converted_formats.append("links")
+                    if original_formats.media:
+                        converted_formats.append("media")
                     if original_formats.screenshot:
                         converted_formats.append("screenshot")
                     if original_formats.change_tracking:
@@ -728,6 +732,8 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                                 data = fmt.model_dump(exclude_none=True)
                                 data['type'] = _convert_format_string(data.get('type', fmt.type))
                                 converted_formats.append(data)
+                            elif fmt.type == 'media':
+                                converted_formats.append(fmt.model_dump(exclude_none=True))
                             else:
                                 converted_formats.append(_convert_format_string(fmt.type))
                         else:
@@ -803,5 +809,5 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
             else:
                 # For fields that don't need conversion, use as-is
                 scrape_data[key] = value
-    
-    return scrape_data  
+
+    return scrape_data


### PR DESCRIPTION
## Summary

Adds an additive `media` scrape format for discovering page audio and video references without downloading media files. The API now returns a `media` block with summary counts and item-level details like presence, source URL, title, thumbnail, provider, MIME type, and duration where available, with matching JS and Python SDK types, validation, docs, and focused tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new media discovery format to find audio and video on a page without downloading files. Returns a `media` block with summary counts and item details, with full API, JS, and Python SDK support.

- New Features
  - API: new `media` format with options `types` (['video', 'audio'], default both) and `limit` (1–100, default 25).
  - Extraction: detects media from native tags, embeds/links, Open Graph, and JSON-LD; resolves URLs, infers provider, supports text-only counts, de-duplicates, and enforces limit.
  - Response: `media.summary` (total, audio, video, hasAudio, hasVideo) and `media.items` (type, presence, sourceURL, url, title, thumbnail, provider, mimeType, duration, count).
  - Pipeline: only computed when `media` is requested; pruned with warnings if not requested.
  - SDKs: `firecrawl` JS and Python SDKs updated with types, validation, and docs; usage examples added.
  - Tests: unit tests for extraction, transformer coercion, and SDK validations.

<sup>Written for commit c4261f092cbca402309165461013345c13e129ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

