### PR TITLE
docs(js-sdk): annotate timeout units in ScrapeOptions, MapOptions, ScrapeExecuteRequest

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -188,7 +188,7 @@ export interface ScrapeOptions {
   includeTags?: string[];
   excludeTags?: string[];
   onlyMainContent?: boolean;
-  timeout?: number;
+  timeout?: number; // ms
   waitFor?: number;
   mobile?: boolean;
   parsers?: Array<
@@ -697,7 +697,7 @@ export interface MapOptions {
   includeSubdomains?: boolean;
   ignoreQueryParameters?: boolean;
   limit?: number;
-  timeout?: number;
+  timeout?: number; // ms
   integration?: string;
   origin?: string;
   location?: LocationConfig;
@@ -1132,7 +1132,7 @@ export interface ScrapeExecuteRequest {
   code?: string;
   prompt?: string;
   language?: "python" | "node" | "bash";
-  timeout?: number;
+  timeout?: number; // seconds, max 300
   origin?: string;
 }
 


### PR DESCRIPTION
## Problem

Three `timeout` fields in the v2 TypeScript SDK lack unit documentation:

- `ScrapeOptions.timeout` — milliseconds
- `MapOptions.timeout` — milliseconds
- `ScrapeExecuteRequest.timeout` (used by `interact()`) — **seconds**, max 300

Without comments it is easy to pass the wrong unit. The confusion was reported in #3407, where users set `interact({ timeout: 300 })` expecting 5 minutes but got a 5.3 s Axios timeout, or passed `timeout: 450000` and hit a 400 from the API because 450 000 > 300 s.

The underlying SDK logic was already fixed in #3440 (interact now multiplies by 1000 before passing to Axios). This PR makes the distinction visible at the type level.

## What this changes

Added inline `// ms` and `// seconds, max 300` comments to the three fields in `types.ts`. No behaviour change.

## Testing

No runtime change — this is a documentation-only fix. Existing tests are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified timeout units in the v2 JS SDK types to prevent mixups. Added inline comments only: `ScrapeOptions.timeout` and `MapOptions.timeout` are milliseconds; `ScrapeExecuteRequest.timeout` is seconds (max 300).

<sup>Written for commit ab4892df24e28260625531fde2d0eb76bbf4cb4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

