### PR TITLE
fix(deterministic-json): clarify usage of askLlm for structured data

### DIFF
--- a/apps/api/src/lib/deterministicJson/llm/prompts.ts
+++ b/apps/api/src/lib/deterministicJson/llm/prompts.ts
@@ -50,7 +50,8 @@ Selectors:
 - Only standard CSS selectors work. To match by visible text, select structurally then filter in JS, e.g. \`[...doc.querySelectorAll('tr')].find(r => r.textContent.includes('Total'))\`.
 
 askLlm:
-- Use it for what selectors cannot do - summarize, classify, translate, disambiguate by meaning. It transforms the text you pass it (no outside lookups like currency conversion; returns null when the text lacks the answer), so pass the DOM text it needs - for a summary, the article body, not a bare title or label. If a field has a fixed value set, include it in the prompt.
+- If the data is already structured (a JSON body, a <script type="application/ld+json">, an inline state blob), JSON.parse it and read the field directly. Never ask askLlm to parse JSON you could parse deterministically.
+- Use it for what selectors and parsing cannot do - summarize, classify, translate, disambiguate by meaning. It transforms the text you pass it (no outside lookups like currency conversion; returns null when the text lacks the answer), so pass the DOM text it needs - for a summary, the article body, not a bare title or label. If a field has a fixed value set, include it in the prompt.
 - When you call askLlm once per item over a list, issue the calls concurrently with Promise.all rather than awaiting one at a time.
 
 Return only the function source, beginning with \`async function extract\`.`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified `askLlm` guidance in deterministic JSON prompts: prefer deterministic parsing for already structured data and reserve `askLlm` for semantic tasks. Added examples (JSON bodies, <script type="application/ld+json">, inline state) and explicit instruction to use JSON.parse instead of `askLlm` for parsing.

<sup>Written for commit 56b2f0ef712293b12077fe8bac175dd57a1ae5d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

