### PR TITLE
fix(python-sdk): handle async v1 batch scrape response dict

### DIFF
--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -4015,13 +4015,10 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             headers
         )
 
-        if response.get('status_code') == 200:
-            try:
-                return V1BatchScrapeResponse(**response.json())
-            except:
-                raise Exception(f'Failed to parse Firecrawl response as JSON.')
-        else:
-            await self._handle_error(response, 'start batch scrape job')
+        if response.get('success'):
+            return V1BatchScrapeResponse(**response)
+
+        await self._handle_error(response, 'start batch scrape job')
 
     async def crawl_url(
         self,

--- a/apps/python-sdk/tests/test_v1_async_batch_scrape.py
+++ b/apps/python-sdk/tests/test_v1_async_batch_scrape.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from firecrawl.v1.client import AsyncV1FirecrawlApp
+
+
+def test_async_batch_scrape_urls_accepts_parsed_json_response(monkeypatch):
+    app = AsyncV1FirecrawlApp(api_key="fc-test", api_url="http://localhost:9")
+    calls = []
+
+    async def fake_post_request(url, data, headers):
+        calls.append((url, data, headers))
+        return {
+            "success": True,
+            "id": "batch-123",
+            "url": "http://localhost:9/v1/batch/scrape/batch-123",
+        }
+
+    async def fail_handle_error(response, action):
+        raise AssertionError(f"unexpected error path: {action} {response!r}")
+
+    monkeypatch.setattr(app, "_async_post_request", fake_post_request)
+    monkeypatch.setattr(app, "_handle_error", fail_handle_error)
+
+    result = asyncio.run(app.async_batch_scrape_urls(["https://example.com"]))
+
+    assert result.success is True
+    assert result.id == "batch-123"
+    assert result.url == "http://localhost:9/v1/batch/scrape/batch-123"
+    assert calls[0][1]["urls"] == ["https://example.com"]


### PR DESCRIPTION
## Summary
- Fix `AsyncV1FirecrawlApp.async_batch_scrape_urls` to handle the parsed JSON dict returned by `_async_post_request`.
- Return `V1BatchScrapeResponse(**response)` on successful API responses instead of checking a nonexistent `status_code` key and calling `.json()` on a dict.
- Add a focused regression test for the success path.

Fixes #3477.

## To verify
- `python -m pytest tests\test_v1_async_batch_scrape.py -q`
- `python -m pytest tests\test_v1_aliases.py tests\test_v1_async_batch_scrape.py -q`
- `python -m py_compile firecrawl\v1\client.py tests\test_v1_async_batch_scrape.py`
- `git diff --check`

## Notes
- `python -m pytest tests -q` currently has unrelated existing failures in `test_change_tracking.py` and `test_timeout_conversion.py`; they assert older top-level client/timeout behavior and do not exercise this async v1 batch path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `AsyncV1FirecrawlApp.async_batch_scrape_urls` by correctly handling the dict response and returning `V1BatchScrapeResponse` on success. Fixes #3477.

- **Bug Fixes**
  - Accept parsed dict from `_async_post_request`; on `success`, return `V1BatchScrapeResponse(**response)`, otherwise call `_handle_error`.
  - Remove invalid `status_code` check and `.json()` call; add a regression test for the success path.

<sup>Written for commit 18d5d94663c01c5d1b27cc2346364b38cebaf5e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

