### PR TITLE
fix(python-sdk): silence monitor json field warnings

### DIFF
--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -39,6 +39,14 @@ warnings.filterwarnings(
     "ignore",
     message='Field name "json" in "Document" shadows an attribute in parent "BaseModel"',
 )
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "json" in "MonitorPageDiff" shadows an attribute in parent "BaseModel"',
+)
+warnings.filterwarnings(
+    "ignore",
+    message='Field name "json" in "MonitorPageSnapshot" shadows an attribute in parent "BaseModel"',
+)
 
 T = TypeVar("T")
 

--- a/apps/python-sdk/tests/test_v2_monitor_types.py
+++ b/apps/python-sdk/tests/test_v2_monitor_types.py
@@ -1,0 +1,14 @@
+import importlib
+import warnings
+
+import firecrawl.v2.types as v2_types
+
+
+def test_monitor_json_fields_do_not_warn_on_import():
+    with warnings.catch_warnings(record=True) as seen:
+        warnings.simplefilter("always")
+        importlib.reload(v2_types)
+
+    messages = [str(warning.message) for warning in seen]
+    assert not any("MonitorPageDiff" in message for message in messages)
+    assert not any("MonitorPageSnapshot" in message for message in messages)


### PR DESCRIPTION
## Summary
- Suppress the two missing Pydantic shadow-field warnings for monitor JSON payload models.
- Keep the existing public `json` fields and serialization behavior unchanged, matching the current handling for `Document` and `ScrapeFormats`.
- Add a regression test that reloads the v2 types module and checks the monitor warnings stay quiet.

Fixes #3643.

## To verify
- `python -m pytest tests\test_v2_monitor_types.py -q`
- `python -m pytest tests\test_v1_aliases.py tests\test_v2_monitor_types.py -q`
- `python -m py_compile firecrawl\v2\types.py tests\test_v2_monitor_types.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences `pydantic` shadow-field warnings for `MonitorPageDiff` and `MonitorPageSnapshot` `json` fields without changing public serialization, fixing #3643. Adds a regression test that reloads `firecrawl.v2.types` and confirms no warnings.

<sup>Written for commit 6a8d9dd3ce39c7d68ea5ca2400ab765f3d3f799f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

