### PR TITLE
fix(go-sdk): embed JSON scrape options in formats

### DIFF
--- a/apps/go-sdk/options.go
+++ b/apps/go-sdk/options.go
@@ -100,18 +100,68 @@ func (o ScrapeOptions) MarshalJSON() ([]byte, error) {
 	type scrapeOptions ScrapeOptions
 	payload := struct {
 		scrapeOptions
-		Formats interface{} `json:"formats,omitempty"`
+		Formats     interface{}  `json:"formats,omitempty"`
+		JsonOptions *JsonOptions `json:"jsonOptions,omitempty"`
 	}{
 		scrapeOptions: scrapeOptions(o),
-	}
-
-	if len(o.FormatOptions) > 0 {
-		payload.Formats = o.FormatOptions
-	} else if len(o.Formats) > 0 {
-		payload.Formats = o.Formats
+		Formats:       o.formatsPayload(),
 	}
 
 	return json.Marshal(payload)
+}
+
+func (o ScrapeOptions) formatsPayload() interface{} {
+	if len(o.FormatOptions) > 0 {
+		if o.JsonOptions == nil {
+			return o.FormatOptions
+		}
+		formats := make([]interface{}, 0, len(o.FormatOptions)+1)
+		formats = append(formats, o.FormatOptions...)
+		formats = append(formats, newJSONFormat(o.JsonOptions))
+		return formats
+	}
+
+	if len(o.Formats) == 0 {
+		if o.JsonOptions == nil {
+			return nil
+		}
+		return []interface{}{newJSONFormat(o.JsonOptions)}
+	}
+
+	if o.JsonOptions == nil {
+		return o.Formats
+	}
+
+	formats := make([]interface{}, 0, len(o.Formats)+1)
+	replacedJSON := false
+	for _, format := range o.Formats {
+		if format == "json" {
+			formats = append(formats, newJSONFormat(o.JsonOptions))
+			replacedJSON = true
+			continue
+		}
+		formats = append(formats, format)
+	}
+	if !replacedJSON {
+		formats = append(formats, newJSONFormat(o.JsonOptions))
+	}
+	return formats
+}
+
+type jsonFormat struct {
+	Type   string                 `json:"type"`
+	Prompt string                 `json:"prompt,omitempty"`
+	Schema map[string]interface{} `json:"schema,omitempty"`
+}
+
+func newJSONFormat(options *JsonOptions) jsonFormat {
+	format := jsonFormat{Type: "json"}
+	if options == nil {
+		return format
+	}
+	format.Prompt = options.Prompt
+	format.Schema = options.Schema
+	return format
 }
 
 // CrawlOptions configures a crawl request.

--- a/apps/go-sdk/options_test.go
+++ b/apps/go-sdk/options_test.go
@@ -64,6 +64,50 @@ func TestScrapeOptionsPreservesStringFormats(t *testing.T) {
 	}
 }
 
+func TestScrapeOptionsEmbedsJsonOptionsInFormats(t *testing.T) {
+	payload, err := json.Marshal(ScrapeOptions{
+		Formats: []string{"markdown", "json"},
+		JsonOptions: &JsonOptions{
+			Prompt: "Extract greeting",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"hello": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal ScrapeOptions: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	if _, ok := body["jsonOptions"]; ok {
+		t.Fatalf("payload contains top-level jsonOptions: %s", payload)
+	}
+
+	formats, ok := body["formats"].([]interface{})
+	if !ok || len(formats) != 2 {
+		t.Fatalf("formats = %#v, want markdown plus json object", body["formats"])
+	}
+	if formats[0] != "markdown" {
+		t.Fatalf("formats[0] = %#v, want markdown", formats[0])
+	}
+	jsonFormat, ok := formats[1].(map[string]interface{})
+	if !ok {
+		t.Fatalf("formats[1] = %#v, want json object", formats[1])
+	}
+	if jsonFormat["type"] != "json" || jsonFormat["prompt"] != "Extract greeting" {
+		t.Fatalf("json format = %#v", jsonFormat)
+	}
+	if _, ok := jsonFormat["schema"].(map[string]interface{}); !ok {
+		t.Fatalf("json format missing schema: %#v", jsonFormat)
+	}
+}
+
 func TestScrapeOptionsSerializesRedactPII(t *testing.T) {
 	payload, err := json.Marshal(ScrapeOptions{
 		RedactPII: Bool(true),

--- a/apps/go-sdk/scrape_test.go
+++ b/apps/go-sdk/scrape_test.go
@@ -1,0 +1,74 @@
+package firecrawl
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/firecrawl/firecrawl/apps/go-sdk/option"
+)
+
+func TestScrapeSendsJsonOptionsAsFormatObject(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/scrape" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true,"data":{"json":{"hello":"world"}}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(
+		option.WithAPIKey("fc-test"),
+		option.WithAPIURL(server.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	doc, err := client.Scrape(context.Background(), "https://example.com", &ScrapeOptions{
+		Formats: []string{"json"},
+		JsonOptions: &JsonOptions{
+			Prompt: "Extract greeting",
+			Schema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"hello": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Scrape: %v", err)
+	}
+	if doc.JSON == nil {
+		t.Fatalf("doc.JSON is nil")
+	}
+
+	if _, ok := gotBody["jsonOptions"]; ok {
+		t.Fatalf("request body contains top-level jsonOptions: %#v", gotBody)
+	}
+	formats, ok := gotBody["formats"].([]interface{})
+	if !ok || len(formats) != 1 {
+		t.Fatalf("formats = %#v, want one json object", gotBody["formats"])
+	}
+	jsonFormat, ok := formats[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("formats[0] = %#v, want json object", formats[0])
+	}
+	if jsonFormat["type"] != "json" || jsonFormat["prompt"] != "Extract greeting" {
+		t.Fatalf("json format = %#v", jsonFormat)
+	}
+	if _, ok := jsonFormat["schema"].(map[string]interface{}); !ok {
+		t.Fatalf("json format missing schema: %#v", jsonFormat)
+	}
+}


### PR DESCRIPTION
Fixes #3394

## Summary
- embed Go SDK `JsonOptions` into the `formats` array as a JSON format object
- suppress top-level `jsonOptions` in scrape request bodies
- add serialization and request-body regression coverage

## Tests
- `go test ./... -run 'TestScrapeOptionsEmbedsJsonOptionsInFormats|TestScrapeSendsJsonOptionsAsFormatObject|TestScrapeOptionsPreservesStringFormats' -count=1 -v`
- `go test ./... -count=1`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embeds Go SDK `JsonOptions` into the `formats` array as a JSON format object and stops sending top-level `jsonOptions`. Fixes inconsistent payloads for scrape requests and addresses #3394.

- **Bug Fixes**
  - Marshal `JsonOptions` into `formats` as `{ type: "json", prompt, schema }`, replacing `"json"` when present or appending if missing.
  - Remove top-level `jsonOptions` from scrape request bodies.
  - Add serialization and request-body regression tests for `/v2/scrape`.

<sup>Written for commit fa64912cd070c19a35313f4f7ed24bc24bfb0c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

