### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 versions

### DIFF
--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-java-sdk.yml
+++ b/.github/workflows/publish-java-sdk.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache Gradle packages
         if: ${{ env.VERSION_INCREMENTED == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/publish-rust-sdk.yml
+++ b/.github/workflows/publish-rust-sdk.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache cargo registry
         if: ${{ env.VERSION_INCREMENTED == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test-dotnet-sdk.yml
+++ b/.github/workflows/test-dotnet-sdk.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up .NET 8
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/test-go-html-to-md-service.yml
+++ b/.github/workflows/test-go-html-to-md-service.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test-go-sdk.yml
+++ b/.github/workflows/test-go-sdk.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test-java-sdk.yml
+++ b/.github/workflows/test-java-sdk.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 11
         uses: actions/setup-java@v4
@@ -32,7 +32,7 @@ jobs:
           java-version: "11"
 
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/test-js-sdk.yml
+++ b/.github/workflows/test-js-sdk.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/test-php-sdk.yml
+++ b/.github/workflows/test-php-sdk.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('apps/php-sdk/composer.json') }}

--- a/.github/workflows/test-ruby-sdk.yml
+++ b/.github/workflows/test-ruby-sdk.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -20,7 +20,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -364,7 +364,7 @@ jobs:
           cd logs
           zip -r logs.zip ./*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: Logs (kubernetes, ${{ matrix.ai }}, ${{ matrix.search }}, ${{ matrix.engine }}, ${{ matrix.proxy }})
@@ -530,7 +530,7 @@ jobs:
   #         echo "${{ secrets.LOG_ENCRYPTION_KEY }}" | gpg --batch --yes --passphrase-fd 0 -c logs.zip
   #         rm logs.zip
 
-  #     - uses: actions/upload-artifact@v4
+  #     - uses: actions/upload-artifact@v5
   #       if: always()
   #       with:
   #         name: Encrypted Logs


### PR DESCRIPTION
## Was

GitHub erzwingt ab **2026-06-16** Node.js 24 fuer Actions und entfernt Node.js 20 am **2026-09-16** vom Runner. Dieser PR aktualisiert alle betroffenen Actions auf ihre aktuellen Node-24-Major-Versionen:

| Action | Vorher | Nachher |
|--------|--------|---------|
| actions/checkout | v4 | v5 |
| actions/upload-artifact | v4 | v5 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |

13 Workflow-Dateien geaendert. Beseitigt die Deprecation-Warnung in CI.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade GitHub Actions across 13 workflows to Node 24–compatible versions, removing Node 20 deprecation warnings and ensuring CI keeps working after runner changes. No workflow logic changes.

- **Dependencies**
  - `actions/checkout`: v4 -> v5
  - `actions/upload-artifact`: v4 -> v5
  - `actions/setup-node`: v4 -> v6
  - `actions/cache`: v4 -> v5

<sup>Written for commit dd6c75f0070888f78faed51e5e87f417b25458ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

