### PR TITLE
fix(python-sdk): handle async v1 batch scrape JSON

### DIFF
--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -4015,13 +4015,10 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             headers
         )
 
-        if response.get('status_code') == 200:
-            try:
-                return V1BatchScrapeResponse(**response.json())
-            except:
-                raise Exception(f'Failed to parse Firecrawl response as JSON.')
-        else:
-            await self._handle_error(response, 'start batch scrape job')
+        try:
+            return V1BatchScrapeResponse(**response)
+        except Exception as exc:
+            raise Exception('Failed to parse Firecrawl response as JSON.') from exc
 
     async def crawl_url(
         self,

--- a/apps/python-sdk/tests/test_v1_async_batch_scrape.py
+++ b/apps/python-sdk/tests/test_v1_async_batch_scrape.py
@@ -1,0 +1,34 @@
+import pytest
+
+from firecrawl.v1.client import AsyncV1FirecrawlApp
+
+
+@pytest.mark.asyncio
+async def test_async_batch_scrape_urls_accepts_parsed_json_response(monkeypatch):
+    client = AsyncV1FirecrawlApp(api_key="fc-test", api_url="http://localhost:9")
+    captured = {}
+
+    async def fake_post_request(url, data, headers):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        return {
+            "success": True,
+            "id": "batch-123",
+            "url": "http://localhost:9/v1/batch/scrape/batch-123",
+        }
+
+    async def fail_handle_error(*_args, **_kwargs):
+        raise AssertionError("_handle_error should not run for parsed success JSON")
+
+    monkeypatch.setattr(client, "_async_post_request", fake_post_request)
+    monkeypatch.setattr(client, "_handle_error", fail_handle_error)
+
+    result = await client.async_batch_scrape_urls(["https://example.com"])
+
+    assert result.success is True
+    assert result.id == "batch-123"
+    assert result.url == "http://localhost:9/v1/batch/scrape/batch-123"
+    assert captured["url"] == "http://localhost:9/v1/batch/scrape"
+    assert captured["data"]["urls"] == ["https://example.com"]
+    assert captured["data"]["origin"].startswith("python-sdk@")


### PR DESCRIPTION
## Summary

- fix `AsyncV1FirecrawlApp.async_batch_scrape_urls` to consume the parsed JSON dict returned by `_async_post_request`
- avoid treating that dict as a raw response object with `status_code` / `.json()`
- add a unit test for the async v1 batch scrape success path

Fixes #3477.

## To verify

```bash
cd apps/python-sdk
python -m pytest tests/test_v1_async_batch_scrape.py -q
python -m py_compile firecrawl/v1/client.py tests/test_v1_async_batch_scrape.py
python -m ruff check tests/test_v1_async_batch_scrape.py
git diff --check
```

I also tried `python -m ruff check firecrawl/v1/client.py tests/test_v1_async_batch_scrape.py`, but the existing `firecrawl/v1/client.py` has unrelated pre-existing lint failures such as duplicate class definitions and bare `except` blocks outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `AsyncV1FirecrawlApp.async_batch_scrape_urls` to consume parsed JSON from `_async_post_request`, construct `V1BatchScrapeResponse` directly, and raise a clear JSON-parse error on invalid payloads.
Add a unit test for the success path that ensures `_handle_error` is not called on valid responses.

<sup>Written for commit dc4f3103948e2ae3b554461c535f5d0ffa04573c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

