### PR TITLE
docs: add agent quickstart pages for 5 SDK languages

### DIFF
--- a/agent-quickstart-for-docs/README.md
+++ b/agent-quickstart-for-docs/README.md
@@ -1,0 +1,28 @@
+# Agent Quickstart Files
+
+These files are intended for **firecrawl-docs** repository at `agent-quickstart/`.
+
+## Files
+
+- `node.mdx` → `firecrawl-docs/agent-quickstart/node.mdx`
+- `python.mdx` → `firecrawl-docs/agent-quickstart/python.mdx`
+- `rust.mdx` → `firecrawl-docs/agent-quickstart/rust.mdx`
+- `java.mdx` → `firecrawl-docs/agent-quickstart/java.mdx`
+- `elixir.mdx` → `firecrawl-docs/agent-quickstart/elixir.mdx`
+
+## docs.json Navigation Update
+
+Add the following group to the "Build with AI" tab in `docs.json`, after "Agentic Debugging":
+
+```json
+{
+  "group": "Agent Quickstarts",
+  "pages": [
+    "agent-quickstart/node",
+    "agent-quickstart/python",
+    "agent-quickstart/rust",
+    "agent-quickstart/java",
+    "agent-quickstart/elixir"
+  ]
+}
+```

--- a/agent-quickstart-for-docs/elixir.mdx
+++ b/agent-quickstart-for-docs/elixir.mdx
@@ -1,0 +1,194 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` hex package source and the v2 OpenAPI spec. Function names and parameters match the SDK public API. The Elixir SDK is auto-generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+{:firecrawl, "~> 1.6"}
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# Or pass api_key per call:
+{:ok, res} = Firecrawl.search_and_scrape(
+  [query: "firecrawl webhooks"],
+  api_key: "fc-your-api-key"
+)
+```
+
+All functions accept a trailing `opts \\ []` keyword list with framework-level options:
+- `:api_key` — override the configured API key for a single request.
+- `:base_url` — override the default base URL (useful for self-hosted instances).
+
+## When To Use What
+
+- **search** — use when you start with a query and need discovery. Returns categorized results (web, news, images).
+- **scrape** — use when you already have a URL and want page content in one or more formats.
+- **interact** — use when the page needs clicks, forms, or post-scrape browser actions. Requires a scrape job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])` → `{:ok, Req.Response.t()} | {:error, term()}`
+
+Bang variant: `Firecrawl.search_and_scrape!(params \\ [], opts \\ [])` → `Req.Response.t()`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries"
+)
+
+web_results = res.body["data"]["web"] || []
+for item <- web_results do
+  IO.puts("#{item["url"]} #{item["title"]}")
+end
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | Search query. Use `site:example.com` to limit to a domain. Required. |
+| `sources` | `{:list, :any}` | Which sources to query: `:web`, `:news`, `:images`. Default: `[:web]`. |
+| `categories` | `{:list, :any}` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `{:list, :string}` | Restrict results to these domains. |
+| `exclude_domains` | `{:list, :string}` | Exclude these domains from results. |
+| `limit` | `:integer` | Maximum number of results. |
+| `tbs` | `:string` | Time-based search filter (e.g. `qdr:d` for past day). |
+| `location` | `:string` | Location string for localized results. |
+| `country` | `:string` | ISO country code for geo-targeting (e.g. `US`). |
+| `ignore_invalid_urls` | `:boolean` | Drop URLs that cannot be scraped by other endpoints. |
+| `timeout` | `:integer` | Request timeout in milliseconds. |
+| `scrape_options` | `:keyword_list` | Scrape each search result with these options (same fields as scrape). |
+| `enterprise` | `{:list, :string}` | Enterprise ZDR options: `["zdr"]` or `["anon"]`. |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])` → `{:ok, Req.Response.t()} | {:error, term()}`
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params \\ [], opts \\ [])` → `Req.Response.t()`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: ["markdown"],
+  only_main_content: true
+)
+
+IO.puts(res.body["data"]["markdown"])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | The URL to scrape. Required. |
+| `formats` | `{:list, :any}` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Maps: `%{type: "json", schema: ..., prompt: ...}`, `%{type: "question", question: ...}`, `%{type: "highlights", query: ...}`. |
+| `headers` | `:any` | Custom HTTP headers (cookies, user-agent, etc.). |
+| `include_tags` | `{:list, :string}` | Only include content from these HTML tags. |
+| `exclude_tags` | `{:list, :string}` | Exclude content from these HTML tags. |
+| `only_main_content` | `:boolean` | Strip nav, footer, and boilerplate. |
+| `timeout` | `:integer` | Timeout in milliseconds. Min: 1000, Default: 60000, Max: 300000. |
+| `wait_for` | `:integer` | Wait for the page to render (milliseconds). |
+| `mobile` | `:boolean` | Emulate a mobile viewport. |
+| `parsers` | `{:list, :any}` | Document parser controls (e.g. PDF parsing). |
+| `actions` | `{:list, :any}` | Browser actions before scraping. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `:keyword_list` | Location settings: `[country: "US", languages: ["en-US"]]`. |
+| `skip_tls_verification` | `:boolean` | Skip TLS certificate verification. |
+| `remove_base64_images` | `:boolean` | Drop base64 images from markdown output. |
+| `block_ads` | `:boolean` | Block ads and cookie popups. |
+| `proxy` | `:atom` | Proxy tier: `:basic`, `:enhanced`, `:auto`. |
+| `max_age` | `:integer` | Use cached data up to this age (milliseconds). Default: 2 days. |
+| `min_age` | `:integer` | Cache-only mode. Set to 1 to accept any cached data. |
+| `store_in_cache` | `:boolean` | Cache the result on Firecrawl's side. |
+| `lockdown` | `:boolean` | Only serve cached results; never make outbound requests. |
+| `redact_pii` | `:boolean` | Redact personally identifiable information. |
+| `profile` | `:keyword_list` | Persistent browser profile: `[name: "my-session", save_changes: true]`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows: clicking through pages, filling forms, or running code in the browser. Requires a scrape job ID from a prior scrape response.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])` → `{:ok, Req.Response.t()} | {:error, term()}`
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params \\ [], opts \\ [])` → `Req.Response.t()`
+
+### Example
+
+```elixir
+{:ok, scrape_res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = get_in(scrape_res.body, ["data", "metadata", "scrapeId"])
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "console.log(await page.title());",
+  language: :node
+)
+
+IO.puts(result.body["stdout"])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | Scrape job ID from the scrape response metadata. |
+| `code` | `:string` | Code to execute in the browser sandbox. Required. |
+| `language` | `:atom` | Runtime: `:python`, `:node`, `:bash`. |
+| `timeout` | `:integer` | Execution timeout in seconds. |
+| `origin` | `:string` | Origin label for telemetry. |
+
+### Stop a session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])` → `{:ok, Req.Response.t()} | {:error, term()}`
+
+## Notes
+
+- The Elixir SDK is **auto-generated** from the OpenAPI spec via `mix run generate.exs`. Function names reflect OpenAPI operation IDs.
+- All Elixir-side parameter names use `snake_case`. They are mapped to `camelCase` JSON keys automatically.
+- Parameters are validated at runtime using `NimbleOptions` schemas before the HTTP call.
+- The SDK does not set default values for API parameters — defaults are applied server-side.
+- Return values are raw `Req.Response.t()` structs. Access response data via `res.body`.
+- Non-bang variants return `{:ok, response}` or `{:error, exception}`. Bang variants raise on error.
+- Nested objects (like `location`, `profile`, `scrape_options`) are passed as keyword lists.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart-for-docs/java.mdx
+++ b/agent-quickstart-for-docs/java.mdx
@@ -1,0 +1,244 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl-java` SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.9.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.9.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+// Or from environment variable / system property directly:
+// FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- **search** — use when you start with a query and need discovery. Returns categorized results (web, news, images).
+- **scrape** — use when you already have a URL and want page content in one or more formats.
+- **interact** — use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+- `client.search(query)` → `SearchData`
+- `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries");
+
+if (results.getWeb() != null) {
+    for (var item : results.getWeb()) {
+        System.out.println(item.get("url") + " " + item.get("title"));
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | Search query. Use `site:example.com` to limit to a domain. |
+| `options.sources` | `List<Object>` | Which sources to query: `"web"`, `"news"`, `"images"`. |
+| `options.categories` | `List<Object>` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `options.includeDomains` | `List<String>` | Restrict results to these domains. |
+| `options.excludeDomains` | `List<String>` | Exclude these domains from results. |
+| `options.limit` | `Integer` | Maximum number of results. |
+| `options.tbs` | `String` | Time-based search filter (e.g. `qdr:d` for past day). |
+| `options.location` | `String` | Location string for localized results. |
+| `options.ignoreInvalidURLs` | `Boolean` | Drop URLs that cannot be scraped by other endpoints. |
+| `options.timeout` | `Integer` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each search result with these options (same fields as scrape). |
+
+### Return value
+
+`SearchData` with accessor methods:
+- `getWeb()` → `List<Map<String, Object>>` (may be null)
+- `getNews()` → `List<Map<String, Object>>` (may be null)
+- `getImages()` → `List<Map<String, Object>>` (may be null)
+
+Do **not** treat `SearchData` as a directly iterable list.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+
+### Preferred SDK method
+
+- `client.scrape(url)` → `Document`
+- `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+Document doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown"))
+        .onlyMainContent(true)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | The URL to scrape. |
+| `options.formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Objects: `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `options.headers` | `Map<String, String>` | Custom HTTP headers. |
+| `options.includeTags` | `List<String>` | Only include content from these HTML tags. |
+| `options.excludeTags` | `List<String>` | Exclude content from these HTML tags. |
+| `options.onlyMainContent` | `Boolean` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `Integer` | Timeout in milliseconds. |
+| `options.waitFor` | `Integer` | Wait for the page to render (milliseconds). |
+| `options.mobile` | `Boolean` | Emulate a mobile viewport. |
+| `options.parsers` | `List<Object>` | Document parser controls (e.g. `"pdf"` or map with `type`, `maxPages`). |
+| `options.actions` | `List<Map<String, Object>>` | Browser actions before scraping. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `options.location` | `LocationConfig` | `LocationConfig` with `country` and `languages` for geo-aware scraping. |
+| `options.skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `options.removeBase64Images` | `Boolean` | Drop base64 images from markdown output. |
+| `options.blockAds` | `Boolean` | Block ads and cookie popups. |
+| `options.proxy` | `String` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom URL. |
+| `options.maxAge` | `Long` | Use cached data up to this age (milliseconds). |
+| `options.storeInCache` | `Boolean` | Cache the result on Firecrawl's side. |
+| `options.lockdown` | `Boolean` | Only serve cached results; never make outbound requests. |
+| `options.redactPII` | `Boolean` | Redact personally identifiable information. |
+| `options.profile` | `Map` | Persistent browser profile with `name` and `saveChanges`. |
+
+### Format configuration objects
+
+- `JsonFormat.builder().prompt("...").schema(Map.of(...)).build()` — LLM extraction to structured JSON.
+- `QuestionFormat.builder().question("...").build()` — ask a question about the page.
+- `HighlightsFormat.builder().query("...").build()` — find relevant source text.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows: clicking through pages, filling forms, or running code in the browser. Requires a `scrapeId` from a prior scrape response.
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` → `BrowserExecuteResponse`
+- `client.interact(jobId, code, language, timeout)` → `BrowserExecuteResponse`
+- `client.interact(jobId, code, language, timeout, origin)` → `BrowserExecuteResponse`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.BrowserExecuteResponse;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+Document doc = client.scrape("https://example.com", ScrapeOptions.builder()
+    .formats(List.of("markdown"))
+    .build());
+
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+
+System.out.println(result.getStdout());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | Scrape job ID from `document.getMetadata().get("scrapeId")`. |
+| `code` | `String` | Code to run in the browser session. |
+| `language` | `String` | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). |
+| `origin` | `String` | Origin tag for request attribution. |
+
+### Stop a session
+
+`client.stopInteractiveBrowser(jobId)` → `BrowserDeleteResponse`
+
+### Async variants
+
+All methods have async counterparts returning `CompletableFuture`:
+- `scrapeAsync(url, options)`
+- `searchAsync(query, options)`
+- `interactAsync(jobId, code, language, timeout, origin)`
+- `stopInteractiveBrowserAsync(jobId)`
+
+## Notes
+
+- **Deprecated aliases**: `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- Java uses `camelCase` parameter names matching the API directly.
+- The SDK uses a builder pattern for `ScrapeOptions` and `SearchOptions`.
+- `SearchData` results are `List<Map<String, Object>>` — access fields by key.
+- The Java SDK does not currently expose a `prompt` parameter on `interact` — use `code` for browser interaction.
+- Requires Java 11+.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart-for-docs/node.mdx
+++ b/agent-quickstart-for-docs/node.mdx
@@ -1,0 +1,182 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` npm package source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+## When To Use What
+
+- **search** — use when you start with a query and need discovery. Returns categorized results (web, news, images).
+- **scrape** — use when you already have a URL and want page content in one or more formats.
+- **interact** — use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries");
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Search query. Use `site:example.com` to limit to a domain. |
+| `options.sources` | `("web" \| "news" \| "images")[]` | Which search sources to query. |
+| `options.categories` | `("github" \| "research" \| "pdf")[]` | Filter results by category. |
+| `options.includeDomains` | `string[]` | Restrict results to these domains. |
+| `options.excludeDomains` | `string[]` | Exclude these domains from results. |
+| `options.limit` | `number` | Maximum number of results. |
+| `options.tbs` | `string` | Time-based search filter (e.g. `qdr:d` for past day, `qdr:w` for past week). |
+| `options.location` | `string` | Location string for localized results. |
+| `options.ignoreInvalidURLs` | `boolean` | Drop URLs that cannot be scraped by other endpoints. |
+| `options.timeout` | `number` | Request timeout in milliseconds. |
+| `options.scrapeOptions` | `ScrapeOptions` | Scrape each search result with these options (same fields as scrape). |
+
+### Return value
+
+`SearchData` with optional arrays:
+- `web` — web index hits
+- `news` — news hits
+- `images` — image hits
+
+Do **not** access `result.data`. Results are in `result.web`, `result.news`, `result.images`.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: ["markdown"],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | The URL to scrape. |
+| `options.formats` | `FormatOption[]` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Objects: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`. |
+| `options.headers` | `Record<string, string>` | Custom HTTP headers for the request. |
+| `options.includeTags` | `string[]` | Only include content from these HTML tags. |
+| `options.excludeTags` | `string[]` | Exclude content from these HTML tags. |
+| `options.onlyMainContent` | `boolean` | Strip nav, footer, and other boilerplate. |
+| `options.timeout` | `number` | Timeout in milliseconds. |
+| `options.waitFor` | `number` | Wait for the page to render (milliseconds). |
+| `options.mobile` | `boolean` | Emulate a mobile viewport. |
+| `options.parsers` | `("pdf" \| { type: "pdf", mode?, maxPages? })[]` | Document parser controls (e.g. PDF parsing with `mode`: `"fast"`, `"auto"`, or `"ocr"`). |
+| `options.actions` | `ActionOption[]` | Browser actions before scraping. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `options.location` | `{ country?, languages? }` | Geo and language-aware scraping. |
+| `options.skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `options.removeBase64Images` | `boolean` | Drop base64 images from markdown output. |
+| `options.fastMode` | `boolean` | Faster scrapes with reduced fidelity. |
+| `options.blockAds` | `boolean` | Block ads and cookie popups. |
+| `options.proxy` | `string` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL. |
+| `options.maxAge` | `number` | Use cached data up to this age (milliseconds). |
+| `options.minAge` | `number` | Use cached data only if at least this old (milliseconds). |
+| `options.storeInCache` | `boolean` | Cache the result on Firecrawl's side. |
+| `options.lockdown` | `boolean` | Only serve cached results; never make outbound requests. |
+| `options.redactPII` | `boolean \| { mode?, entities?, replaceStyle? }` | Redact personally identifiable information. |
+| `options.profile` | `{ name, saveChanges? }` | Persistent browser profile shared across scrapes and interactions. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows: clicking through pages, filling forms, or running code in the browser. Requires a `scrapeId` from a prior scrape response (`doc.metadata.scrapeId`).
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+
+console.log(result.output);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | Scrape job ID from `document.metadata.scrapeId`. |
+| `args.code` | `string` | Code to run in the browser session (e.g. Playwright `page` usage). |
+| `args.prompt` | `string` | Natural-language instruction for the browser agent. |
+| `args.language` | `"python" \| "node" \| "bash"` | Runtime for code execution. Defaults to `"node"` when omitted. |
+| `args.timeout` | `number` | Execution timeout in seconds. |
+
+At least one of `code` or `prompt` must be provided.
+
+### Stop a session
+
+`client.stopInteraction(jobId)` → `Promise<ScrapeBrowserDeleteResponse>`
+
+## Notes
+
+- **Deprecated aliases**: `scrapeUrl` → `scrape`, `scrapeExecute` → `interact`, `stopInteractiveBrowser` / `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client. V1 is available under `client.v1`.
+- Zod schemas passed in `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+- The SDK rejects `"json"` as a plain string in `formats` — use `{ type: "json", prompt?, schema? }` instead.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart-for-docs/python.mdx
+++ b/agent-quickstart-for-docs/python.mdx
@@ -1,0 +1,179 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl-py` package source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+An async variant is available as `AsyncFirecrawl` with the same API.
+
+## When To Use What
+
+- **search** — use when you start with a query and need discovery. Returns categorized results (web, news, images).
+- **scrape** — use when you already have a URL and want page content in one or more formats.
+- **interact** — use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search("site:docs.firecrawl.dev webhook retries")
+
+for item in results.web or []:
+    print(item.url, item.title)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | Search query. Use `site:example.com` to limit to a domain. |
+| `sources` | `list[str]` | Which sources to query: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str]` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. |
+| `exclude_domains` | `list[str]` | Exclude these domains. Mutually exclusive with `include_domains`. |
+| `limit` | `int` | Maximum number of results. Default: `5`. |
+| `tbs` | `str` | Time-based search filter (e.g. `qdr:d` for past day). |
+| `location` | `str` | Location string for localized results. |
+| `ignore_invalid_urls` | `bool` | Drop URLs that cannot be scraped by other endpoints. |
+| `timeout` | `int` | Request timeout in milliseconds. Default: `300000`. |
+| `scrape_options` | `ScrapeOptions` | Scrape each search result with these options (same fields as scrape). |
+
+### Return value
+
+`SearchData` with optional lists:
+- `web` — web hits
+- `news` — news hits
+- `images` — image hits
+
+Do **not** access `result.data`. Results are in `result.web`, `result.news`, `result.images`.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=["markdown"],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | The URL to scrape. |
+| `formats` | `list` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Dicts: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": [...], "schema": ..., "prompt": ..., "tag": ...}`, `{"type": "attributes", "selectors": [...]}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. |
+| `include_tags` | `list[str]` | Only include content from these HTML tags. |
+| `exclude_tags` | `list[str]` | Exclude content from these HTML tags. |
+| `only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait for the page to render (milliseconds). |
+| `mobile` | `bool` | Emulate a mobile viewport. |
+| `parsers` | `list` | Document parser controls (e.g. `"pdf"` or `{"type": "pdf", "mode": "auto", "max_pages": 5}`). |
+| `actions` | `list[dict]` | Browser actions before scraping. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `Location` | `Location(country="US", languages=["en-US"])` for geo-aware scraping. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Drop base64 images from markdown output. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Use cached data up to this age (milliseconds). |
+| `store_in_cache` | `bool` | Cache the result on Firecrawl's side. |
+| `lockdown` | `bool` | Only serve cached results; never make outbound requests. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "my-session", "saveChanges": True}`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows: clicking through pages, filling forms, or running code in the browser. Requires a `scrape_id` from a prior scrape response (`doc.metadata.get("scrapeId")`).
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)` → `BrowserExecuteResponse`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("scrapeId") if doc.metadata else None
+if not job_id:
+    raise ValueError("Missing scrapeId")
+
+result = client.interact(
+    job_id,
+    prompt="Click the pricing tab and summarize the plans.",
+)
+
+print(result.output)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | Scrape job ID from `document.metadata["scrapeId"]`. |
+| `code` | `str` | Code to run in the browser session (e.g. Playwright `page` usage). |
+| `prompt` | `str` | Natural-language instruction for the browser agent. |
+| `language` | `str` | Runtime for code execution: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+At least one of `code` or `prompt` must be provided.
+
+### Stop a session
+
+`client.stop_interaction(job_id)` → `BrowserDeleteResponse`
+
+## Notes
+
+- **Deprecated aliases**: `scrape_url` → `scrape`, `scrape_execute` → `interact`, `delete_scrape_browser` / `stop_interactive_browser` → `stop_interaction`.
+- **Class aliases**: `FirecrawlApp` → `Firecrawl`, `AsyncFirecrawlApp` → `AsyncFirecrawl`.
+- Python uses `snake_case` parameter names. The SDK handles conversion to `camelCase` for the API.
+- Additional fields available via `ScrapeOptions` object (for `scrape_options` in search): `min_age`, `redact_pii`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart-for-docs/rust.mdx
+++ b/agent-quickstart-for-docs/rust.mdx
@@ -1,0 +1,228 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` crate source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- **search** — use when you start with a query and need discovery. Returns categorized results (web, news, images).
+- **scrape** — use when you already have a URL and want page content in one or more formats.
+- **interact** — use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query string.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+let client = Client::new("fc-your-api-key")?;
+
+let response = client
+    .search("site:docs.firecrawl.dev webhook retries", None)
+    .await?;
+
+if let Some(web_results) = &response.data.web {
+    for item in web_results {
+        println!("{:?}", item);
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | Search query. Use `site:example.com` to limit to a domain. |
+| `options.sources` | `Vec<SearchSource>` | Which sources to query: `Web`, `News`, `Images`. |
+| `options.categories` | `Vec<SearchCategory>` | Filter by category: `Github`, `Research`, `Pdf`. |
+| `options.include_domains` | `Vec<String>` | Restrict results to these domains. |
+| `options.exclude_domains` | `Vec<String>` | Exclude these domains from results. |
+| `options.limit` | `u32` | Maximum number of results. Default: 5, Max: 20. |
+| `options.tbs` | `String` | Time-based search filter (e.g. `qdr:d` for past day). |
+| `options.location` | `String` | Location string for localized results. |
+| `options.ignore_invalid_urls` | `bool` | Drop URLs that cannot be scraped by other endpoints. |
+| `options.timeout` | `u32` | Request timeout in milliseconds. |
+| `options.scrape_options` | `ScrapeOptions` | Scrape each search result with these options (same fields as scrape). |
+
+### Return value
+
+`SearchResponse` contains:
+- `success: bool`
+- `data: SearchData` with optional vecs: `web`, `news`, `images`
+- `warning: Option<String>`
+
+Web results are `SearchResultOrDocument` — either `WebResult(SearchResultWeb)` or `Document(Document)` when `scrape_options` hydrate the result.
+
+### Convenience method
+
+`client.search_and_scrape(query, limit)` → `Result<Vec<Document>, FirecrawlError>` — searches and returns only fully scraped documents.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats (markdown, HTML, JSON extraction, screenshots, etc.).
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client
+    .scrape(
+        "https://example.com/pricing",
+        ScrapeOptions {
+            formats: Some(vec![Format::Markdown]),
+            only_main_content: Some(true),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | The URL to scrape. |
+| `options.formats` | `Vec<Format>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `options.headers` | `HashMap<String, String>` | Custom HTTP headers. |
+| `options.include_tags` | `Vec<String>` | Only include content from these HTML tags. |
+| `options.exclude_tags` | `Vec<String>` | Exclude content from these HTML tags. |
+| `options.only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `u32` | Timeout in milliseconds. |
+| `options.wait_for` | `u32` | Wait for the page to render (milliseconds). |
+| `options.mobile` | `bool` | Emulate a mobile viewport. |
+| `options.parsers` | `Vec<ParserConfig>` | Document parser controls (e.g. PDF with mode and max_pages). |
+| `options.actions` | `Vec<Action>` | Browser actions before scraping. Variants: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `options.location` | `LocationConfig` | `LocationConfig { country, languages }` for geo-aware scraping. |
+| `options.skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `options.remove_base64_images` | `bool` | Drop base64 images from markdown output. |
+| `options.fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `options.block_ads` | `bool` | Block ads and cookie popups. |
+| `options.proxy` | `ProxyType` | Proxy tier: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `options.max_age` | `u32` | Use cached data up to this age (seconds). |
+| `options.min_age` | `u32` | Use cached data only if at least this old (seconds). |
+| `options.store_in_cache` | `bool` | Cache the result on Firecrawl's side. |
+| `options.lockdown` | `bool` | Only serve cached results; never make outbound requests. |
+| `options.redact_pii` | `bool` | Redact personally identifiable information. |
+| `options.profile` | `ProfileConfig` | Persistent browser profile: `ProfileConfig { name, save_changes }`. |
+| `options.json_options` | `JsonOptions` | JSON extraction: `JsonOptions { schema, system_prompt, prompt }`. |
+| `options.screenshot_options` | `ScreenshotOptions` | Screenshot config: `ScreenshotOptions { full_page, quality, viewport }`. |
+| `options.change_tracking_options` | `ChangeTrackingOptions` | Change tracking: `ChangeTrackingOptions { modes, schema, prompt, tag }`. |
+| `options.attribute_selectors` | `Vec<AttributeSelector>` | Attribute extraction: `AttributeSelector { selector, attribute }`. |
+
+### Convenience method
+
+`client.scrape_with_schema(url, schema, prompt)` → `Result<Value, FirecrawlError>` — scrapes with JSON format and returns `document.json`.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use it for multi-step flows: clicking through pages, filling forms, or running code in the browser. Requires a scrape ID from a prior scrape response.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client
+    .scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    })
+    .await?;
+
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_ref())
+    .expect("Missing scrapeId");
+
+let result = client
+    .interact(
+        job_id,
+        ScrapeExecuteOptions {
+            prompt: Some("Click the pricing tab and summarize the plans.".into()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+println!("{}", result.output.unwrap_or_default());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | Scrape job ID from document metadata. |
+| `options.code` | `Option<String>` | Code to run in the browser session. |
+| `options.prompt` | `Option<String>` | Natural-language instruction for the browser agent. |
+| `options.language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Defaults to `Node`. |
+| `options.timeout` | `Option<u32>` | Execution timeout in seconds. |
+
+At least one of `code` or `prompt` must be non-empty.
+
+### Stop a session
+
+`client.stop_interaction(job_id)` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>`
+
+## Notes
+
+- **Deprecated aliases**: `scrape_execute` → `interact`, `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`.
+- All struct fields use Rust `snake_case`. The SDK handles serde renaming to `camelCase` for the API.
+- `ScrapeOptions` uses `Default::default()` for convenient partial construction.
+- Format-specific options (`json_options`, `screenshot_options`, `change_tracking_options`, `attribute_selectors`) are separate fields on `ScrapeOptions` rather than embedded in the `Format` enum.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language (Node.js, Python, Rust, Java, Elixir)
- Each quickstart covers `search`, `scrape`, and `interact` with confirmed parameters, types, and realistic examples
- All content generated from SDK source code and the v2 OpenAPI spec — no invented methods or parameters

## Note: Target repository

**These files are intended for `firecrawl-docs` at `agent-quickstart/`**, not `firecrawl`. They are staged here because the CI environment lacked write access to `firecrawl-docs`. To complete the migration:

1. Copy `agent-quickstart-for-docs/*.mdx` → `firecrawl-docs/agent-quickstart/`
2. Add the "Agent Quickstarts" navigation group to `docs.json` (see `agent-quickstart-for-docs/README.md`)
3. Remove the `agent-quickstart-for-docs/` directory from this repo

## Files

| File | Language | Covers |
|---|---|---|
| `node.mdx` | Node.js / TypeScript | search, scrape, interact |
| `python.mdx` | Python | search, scrape, interact |
| `rust.mdx` | Rust | search, scrape, interact |
| `java.mdx` | Java | search, scrape, interact |
| `elixir.mdx` | Elixir | search, scrape, interact |

## Test plan

- [ ] Copy files to `firecrawl-docs/agent-quickstart/` and verify Mintlify renders them correctly
- [ ] Verify `docs.json` navigation update renders the "Agent Quickstarts" group in the "Build with AI" tab
- [ ] Spot-check parameter tables against SDK source for each language

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpd7n9WLoo7ptxoodgJh1Z)_