### PR TITLE
fix: backlog timeout calculation

### DIFF
--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -27,6 +27,16 @@ import { abTestJob } from "./ab-test";
 import { NuQJob, scrapeQueue } from "./worker/nuq";
 import { serializeTraceContext } from "../lib/otel-tracer";
 import { isSelfHosted } from "../lib/deployment";
+import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
+
+// Queue-wait deadline for a backlogged job (how long its owner still cares about the result)
+function backlogTimeoutMs(data: ScrapeJobData): number {
+  if (data.crawl_id) return MAX_BACKLOG_TIMEOUT_MS;
+  if (data.monitoring) return MONITOR_CHECK_STALE_TIMEOUT_MS;
+  if (data.mode === "single_urls")
+    return data.scrapeOptions.timeout ?? 60 * 1000;
+  return 60 * 1000;
+}
 
 /**
  * Checks if a job is a crawl or batch scrape based on its options
@@ -61,10 +71,7 @@ async function _addScrapeJobToConcurrencyQueue(
       groupId: webScraperOptions.crawl_id ?? undefined,
       backlogged: true,
       backloggedTimesOutAt: new Date(
-        Date.now() +
-          (webScraperOptions.crawl_id
-            ? MAX_BACKLOG_TIMEOUT_MS
-            : (webScraperOptions.scrapeOptions?.timeout ?? 60 * 1000)),
+        Date.now() + backlogTimeoutMs(webScraperOptions),
       ),
     },
   );
@@ -77,9 +84,7 @@ async function _addScrapeJobToConcurrencyQueue(
       priority,
       listenable,
     },
-    webScraperOptions.crawl_id
-      ? MAX_BACKLOG_TIMEOUT_MS
-      : (webScraperOptions.scrapeOptions?.timeout ?? 60 * 1000),
+    backlogTimeoutMs(webScraperOptions),
   );
 }
 
@@ -101,12 +106,7 @@ async function _addScrapeJobsToConcurrencyQueue(
         ownerId: job.data.team_id ?? undefined,
         groupId: job.data.crawl_id ?? undefined,
         backlogged: true,
-        backloggedTimesOutAt: new Date(
-          Date.now() +
-            (job.data.crawl_id
-              ? MAX_BACKLOG_TIMEOUT_MS
-              : (job.data.scrapeOptions?.timeout ?? 60 * 1000)),
-        ),
+        backloggedTimesOutAt: new Date(Date.now() + backlogTimeoutMs(job.data)),
       },
     })),
   );
@@ -131,9 +131,7 @@ async function _addScrapeJobsToConcurrencyQueue(
         priority: job.priority,
         listenable: job.listenable ?? false,
       },
-      timeout: job.data.crawl_id
-        ? MAX_BACKLOG_TIMEOUT_MS
-        : (job.data.scrapeOptions?.timeout ?? 60 * 1000),
+      timeout: backlogTimeoutMs(job.data),
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes backlog timeout calculation for queued scrape jobs so deadlines match the job type. Prevents premature expiry for monitoring and avoids overly long waits for single-URL jobs.

- **Bug Fixes**
  - Centralized timeout logic in `backlogTimeoutMs(...)`.
  - Crawls use `MAX_BACKLOG_TIMEOUT_MS`; monitoring uses `MONITOR_CHECK_STALE_TIMEOUT_MS`; `single_urls` use `scrapeOptions.timeout` (fallback 60s); others default to 60s.
  - Applied consistently to `backloggedTimesOutAt` and queue `timeout` in both single and batch enqueue paths.

<sup>Written for commit 0e829429cb40f8bc5fb8bd76c6392c7d0a1005e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

