### PR TITLE
feat: extract post content as markdown

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/x-twitter/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/x-twitter/index.ts
@@ -442,7 +442,7 @@ function buildPostMarkdown(post: XTwitterPostData): string {
     lines.push(metrics.join(" | "));
   }
 
-  lines.push("", "## Post", "", formatBlockquote(post.text));
+  lines.push("", "## Post", "", post.text.trim());
 
   const thread = (post.thread ?? []).filter(item => item.text?.trim());
   if (thread.length > 0) {
@@ -561,7 +561,7 @@ async function fetchPost(
         "Current public X/Twitter post data with metrics, thread, and top comments.",
     }),
     abortSignal: meta.abort.asSignal(),
-    prompt: `Fetch the public X/Twitter post${handlePart} with post id ${xUrl.postId} at ${xUrl.normalizedUrl}. Return the post text, author, URL, created date, likes, and retweets. If this post is part of a thread, return the unrolled thread in chronological order under thread. Return the top 5 public comments or replies to the post under comments. Use the current public X data available to x_search.`,
+    prompt: `Fetch the public X/Twitter post${handlePart} with post id ${xUrl.postId} at ${xUrl.normalizedUrl}. Return the post body in text as GitHub-flavored Markdown, preserving its original structure like headings and lists. Also return author, URL, created date, likes, and retweets. If this post is part of a thread, return the unrolled thread in chronological order under thread. Return the top 5 public comments or replies to the post under comments. Use the current public X data available to x_search.`,
   });
 
   return output as XTwitterPostData;

--- a/apps/api/src/scraper/scrapeURL/engines/x-twitter/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/x-twitter/index.ts
@@ -442,7 +442,7 @@ function buildPostMarkdown(post: XTwitterPostData): string {
     lines.push(metrics.join(" | "));
   }
 
-  lines.push("", "## Post", "", post.text.trim());
+  lines.push("", "## Post", "", escapeMarkdownBlock(post.text.trim()));
 
   const thread = (post.thread ?? []).filter(item => item.text?.trim());
   if (thread.length > 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extract X/Twitter post bodies as GitHub-flavored Markdown to preserve original formatting. Removes automatic blockquote wrapping and escapes markdown so posts render correctly in our markdown output.

- **New Features**
  - Updated `fetchPost` prompt to return the post body as GitHub-flavored Markdown plus author, URL, created date, likes, retweets, thread, and comments.
  - `buildPostMarkdown` now escapes Markdown and inserts `post.text.trim()` under "## Post" (removed blockquote wrapping).

<sup>Written for commit ea8c88cac00bfc05b40293f9508ef1b456276339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

