### PR TITLE
fix(api): correct billing credit calculations

### DIFF
--- a/apps/api/src/services/monitoring/billing.test.ts
+++ b/apps/api/src/services/monitoring/billing.test.ts
@@ -1,5 +1,6 @@
 import {
   calculateMonitorCheckActualCredits,
+  calculateMonitorCheckActualCreditsPaginated,
   getMonitorTargetPerPageCredits,
 } from "./billing";
 import type { MonitorTarget } from "./types";
@@ -118,6 +119,28 @@ describe("monitor billing helpers", () => {
           ],
         }),
       ).toEqual({ actualCredits: 1, unknownTargetIds: ["missing"] });
+    });
+
+    it("aggregates all pages across pagination chunks", async () => {
+      const pages = [
+        { target_id: "json", status: "same" },
+        { target_id: "json", status: "changed" },
+        { target_id: "base", status: "new" },
+        { target_id: "json", status: "removed" },
+        { target_id: "missing", status: "same" },
+        { target_id: "missing", status: "changed" },
+      ];
+
+      await expect(
+        calculateMonitorCheckActualCreditsPaginated({
+          targets: [scrapeTarget("json", ["json"]), scrapeTarget("base")],
+          pageSize: 2,
+          loadPages: async ({ limit, skip }) => pages.slice(skip, skip + limit),
+        }),
+      ).resolves.toEqual({
+        actualCredits: 11,
+        unknownTargetIds: ["missing"],
+      });
     });
   });
 });

--- a/apps/api/src/services/monitoring/billing.test.ts
+++ b/apps/api/src/services/monitoring/billing.test.ts
@@ -1,0 +1,123 @@
+import {
+  calculateMonitorCheckActualCredits,
+  getMonitorTargetPerPageCredits,
+} from "./billing";
+import type { MonitorTarget } from "./types";
+
+function scrapeTarget(
+  id: string,
+  formats?: Array<string | Record<string, unknown>>,
+): MonitorTarget {
+  return {
+    id,
+    type: "scrape",
+    urls: ["https://example.com"],
+    scrapeOptions: formats ? { formats } : {},
+  };
+}
+
+describe("monitor billing helpers", () => {
+  describe("getMonitorTargetPerPageCredits", () => {
+    it("charges one credit for a base monitor scrape", () => {
+      expect(getMonitorTargetPerPageCredits(scrapeTarget("base"))).toBe(1);
+    });
+
+    it("charges five credits for json monitor scrapes", () => {
+      expect(
+        getMonitorTargetPerPageCredits(scrapeTarget("json", ["json"])),
+      ).toBe(5);
+      expect(
+        getMonitorTargetPerPageCredits(
+          scrapeTarget("change-tracking-json", [
+            { type: "changeTracking", modes: ["json"] },
+          ]),
+        ),
+      ).toBe(5);
+    });
+
+    it("charges seven credits for deterministic json monitor scrapes", () => {
+      expect(
+        getMonitorTargetPerPageCredits(
+          scrapeTarget("deterministic", [{ type: "deterministicJson" }]),
+        ),
+      ).toBe(7);
+    });
+  });
+
+  describe("calculateMonitorCheckActualCredits", () => {
+    it("uses recorded credits when a page has creditsUsed metadata", () => {
+      expect(
+        calculateMonitorCheckActualCredits({
+          targets: [scrapeTarget("base")],
+          pages: [
+            {
+              target_id: "base",
+              status: "same",
+              metadata: { creditsUsed: 9 },
+            },
+          ],
+        }),
+      ).toEqual({ actualCredits: 9, unknownTargetIds: [] });
+    });
+
+    it("falls back to target pricing when recorded credits are missing", () => {
+      expect(
+        calculateMonitorCheckActualCredits({
+          targets: [
+            scrapeTarget("base"),
+            scrapeTarget("json", ["json"]),
+            scrapeTarget("deterministic", [{ type: "deterministicJson" }]),
+          ],
+          pages: [
+            { target_id: "base", status: "same" },
+            { target_id: "json", status: "changed" },
+            { target_id: "deterministic", status: "new" },
+          ],
+        }),
+      ).toEqual({ actualCredits: 13, unknownTargetIds: [] });
+    });
+
+    it("does not bill removed pages because no current scrape ran", () => {
+      expect(
+        calculateMonitorCheckActualCredits({
+          targets: [scrapeTarget("json", ["json"])],
+          pages: [
+            {
+              target_id: "json",
+              status: "removed",
+              metadata: { creditsUsed: 5 },
+            },
+          ],
+        }),
+      ).toEqual({ actualCredits: 0, unknownTargetIds: [] });
+    });
+
+    it("bills error pages only when recorded credits are explicit", () => {
+      expect(
+        calculateMonitorCheckActualCredits({
+          targets: [scrapeTarget("json", ["json"])],
+          pages: [
+            { target_id: "json", status: "error" },
+            {
+              target_id: "json",
+              status: "error",
+              metadata: { creditsUsed: 1 },
+            },
+          ],
+        }),
+      ).toEqual({ actualCredits: 1, unknownTargetIds: [] });
+    });
+
+    it("does not bill unknown targets without recorded credits", () => {
+      expect(
+        calculateMonitorCheckActualCredits({
+          targets: [scrapeTarget("known")],
+          pages: [
+            { target_id: "missing", status: "same" },
+            { target_id: "known", status: "same" },
+          ],
+        }),
+      ).toEqual({ actualCredits: 1, unknownTargetIds: ["missing"] });
+    });
+  });
+});

--- a/apps/api/src/services/monitoring/billing.ts
+++ b/apps/api/src/services/monitoring/billing.ts
@@ -1,0 +1,81 @@
+import { includesFormat } from "../../lib/format-utils";
+import type { MonitorTarget } from "./types";
+
+type MonitorCreditPage = {
+  target_id: string;
+  status: string;
+  metadata?: unknown | null;
+};
+
+export function getMonitorTargetPerPageCredits(target: MonitorTarget): number {
+  const formats = Array.isArray(target.scrapeOptions?.formats)
+    ? (target.scrapeOptions!.formats as any[])
+    : [];
+  if (includesFormat(formats, "deterministicJson")) return 7;
+  const hasJson =
+    includesFormat(formats, "json") ||
+    formats.some(
+      format =>
+        format?.type === "changeTracking" &&
+        Array.isArray(format?.modes) &&
+        format.modes.includes("json"),
+    );
+  return hasJson ? 5 : 1;
+}
+
+function getRecordedCreditsUsed(metadata: unknown): number | null {
+  if (!metadata || typeof metadata !== "object") return null;
+
+  const creditsUsed = (metadata as { creditsUsed?: unknown }).creditsUsed;
+  if (
+    typeof creditsUsed !== "number" ||
+    !Number.isFinite(creditsUsed) ||
+    creditsUsed < 0
+  ) {
+    return null;
+  }
+
+  return Math.ceil(creditsUsed);
+}
+
+export function calculateMonitorCheckActualCredits(params: {
+  targets: MonitorTarget[];
+  pages: MonitorCreditPage[];
+}): { actualCredits: number; unknownTargetIds: string[] } {
+  const targetsById = new Map(
+    params.targets.map(target => [target.id, target] as const),
+  );
+  const unknownTargetIds = new Set<string>();
+  let actualCredits = 0;
+
+  for (const page of params.pages) {
+    if (page.status === "removed") {
+      // Removed pages are synthetic reconciliation rows copied from prior
+      // monitor_pages state. They do not represent a current scrape.
+      continue;
+    }
+
+    const recordedCredits = getRecordedCreditsUsed(page.metadata);
+    if (recordedCredits !== null) {
+      actualCredits += recordedCredits;
+      continue;
+    }
+
+    if (page.status === "error") {
+      continue;
+    }
+
+    const target = targetsById.get(page.target_id);
+    if (!target) {
+      unknownTargetIds.add(page.target_id);
+      continue;
+    }
+
+    actualCredits += getMonitorTargetPerPageCredits(target);
+  }
+
+  return {
+    actualCredits,
+    unknownTargetIds: Array.from(unknownTargetIds),
+  };
+}

--- a/apps/api/src/services/monitoring/billing.ts
+++ b/apps/api/src/services/monitoring/billing.ts
@@ -79,3 +79,38 @@ export function calculateMonitorCheckActualCredits(params: {
     unknownTargetIds: Array.from(unknownTargetIds),
   };
 }
+
+export async function calculateMonitorCheckActualCreditsPaginated(params: {
+  targets: MonitorTarget[];
+  pageSize: number;
+  loadPages: (params: {
+    limit: number;
+    skip: number;
+  }) => Promise<MonitorCreditPage[]>;
+}): Promise<{ actualCredits: number; unknownTargetIds: string[] }> {
+  const unknownTargetIds = new Set<string>();
+  let actualCredits = 0;
+  let skip = 0;
+
+  while (true) {
+    const pages = await params.loadPages({
+      limit: params.pageSize,
+      skip,
+    });
+    const chunk = calculateMonitorCheckActualCredits({
+      targets: params.targets,
+      pages,
+    });
+
+    actualCredits += chunk.actualCredits;
+    chunk.unknownTargetIds.forEach(targetId => unknownTargetIds.add(targetId));
+
+    if (pages.length < params.pageSize) break;
+    skip += params.pageSize;
+  }
+
+  return {
+    actualCredits,
+    unknownTargetIds: Array.from(unknownTargetIds),
+  };
+}

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -9,6 +9,7 @@ import { ScrapeJobData } from "../../types";
 import { getJobFromGCS } from "../../lib/gcs-jobs";
 import { includesFormat } from "../../lib/format-utils";
 import { computeAndPersistPageDiff } from "./diff-orchestrator";
+import { calculateMonitorCheckActualCredits } from "./billing";
 import { normalizeMonitorFormats } from "./diff";
 import { autumnService } from "../autumn/autumn.service";
 import { getBillingQueue } from "../queue-service";
@@ -1338,7 +1339,28 @@ export async function reconcileRunningMonitorChecks(
         countMonitorCheckPages({ checkId: check.id, status: "error" }),
       ]);
       const totalPages = same + changed + newCount + removed + errorCount;
-      const actualCredits = totalPages;
+      const creditPages = await listMonitorCheckPages({
+        teamId: monitor.team_id,
+        monitorId: monitor.id,
+        checkId: check.id,
+        limit: MONITOR_CHECK_PAGE_SCAN_LIMIT,
+        skip: 0,
+      });
+      // TODO(monitoring-billing): judge credits are currently billed per-page
+      // in results.ts, while estimates reserve by doubling scrape credits.
+      // Keep that behavior unchanged here and reconcile it separately.
+      const { actualCredits, unknownTargetIds } =
+        calculateMonitorCheckActualCredits({
+          targets: monitor.targets,
+          pages: creditPages,
+        });
+      if (unknownTargetIds.length > 0) {
+        logger.warn("Monitor check pages referenced unknown targets", {
+          monitorId: monitor.id,
+          checkId: check.id,
+          targetIds: unknownTargetIds,
+        });
+      }
 
       let finalized = await updateMonitorCheck(check.id, {
         status: errorCount > 0 ? "partial" : "completed",

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -9,7 +9,7 @@ import { ScrapeJobData } from "../../types";
 import { getJobFromGCS } from "../../lib/gcs-jobs";
 import { includesFormat } from "../../lib/format-utils";
 import { computeAndPersistPageDiff } from "./diff-orchestrator";
-import { calculateMonitorCheckActualCredits } from "./billing";
+import { calculateMonitorCheckActualCreditsPaginated } from "./billing";
 import { normalizeMonitorFormats } from "./diff";
 import { autumnService } from "../autumn/autumn.service";
 import { getBillingQueue } from "../queue-service";
@@ -1339,20 +1339,21 @@ export async function reconcileRunningMonitorChecks(
         countMonitorCheckPages({ checkId: check.id, status: "error" }),
       ]);
       const totalPages = same + changed + newCount + removed + errorCount;
-      const creditPages = await listMonitorCheckPages({
-        teamId: monitor.team_id,
-        monitorId: monitor.id,
-        checkId: check.id,
-        limit: MONITOR_CHECK_PAGE_SCAN_LIMIT,
-        skip: 0,
-      });
       // TODO(monitoring-billing): judge credits are currently billed per-page
       // in results.ts, while estimates reserve by doubling scrape credits.
       // Keep that behavior unchanged here and reconcile it separately.
       const { actualCredits, unknownTargetIds } =
-        calculateMonitorCheckActualCredits({
+        await calculateMonitorCheckActualCreditsPaginated({
           targets: monitor.targets,
-          pages: creditPages,
+          pageSize: MONITOR_CHECK_PAGE_SCAN_LIMIT,
+          loadPages: ({ limit, skip }) =>
+            listMonitorCheckPages({
+              teamId: monitor.team_id,
+              monitorId: monitor.id,
+              checkId: check.id,
+              limit,
+              skip,
+            }),
         });
       if (unknownTargetIds.length > 0) {
         logger.warn("Monitor check pages referenced unknown targets", {

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -3,8 +3,8 @@ import { v7 as uuidv7 } from "uuid";
 import { and, asc, count, desc, eq, isNull, ne } from "drizzle-orm";
 import { db, dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
-import { includesFormat } from "../../lib/format-utils";
 import { monitoringClaimDueMonitors } from "../../db/rpc";
+import { getMonitorTargetPerPageCredits } from "./billing";
 import {
   getNextMonitorRunAt,
   estimateRunsPerMonth,
@@ -32,28 +32,8 @@ function ensureTargetIds(targets: Array<Record<string, any>>): MonitorTarget[] {
   })) as MonitorTarget[];
 }
 
-// Per-page credit cost for a target's extraction mode. Mirrors
-// estimateActualCredits in runner.ts so the reserved/estimated credits match
-// what a check actually bills: deterministic JSON = 7, other JSON (plain or
-// changeTracking-json) = 5, otherwise the base scrape = 1.
-function perPageCredits(target: MonitorTarget): number {
-  const formats = Array.isArray(target.scrapeOptions?.formats)
-    ? (target.scrapeOptions!.formats as any[])
-    : [];
-  if (includesFormat(formats, "deterministicJson")) return 7;
-  const hasJson =
-    includesFormat(formats, "json") ||
-    formats.some(
-      format =>
-        format?.type === "changeTracking" &&
-        Array.isArray(format?.modes) &&
-        format.modes.includes("json"),
-    );
-  return hasJson ? 5 : 1;
-}
-
 function estimateTargetCredits(target: MonitorTarget): number {
-  const perPage = perPageCredits(target);
+  const perPage = getMonitorTargetPerPageCredits(target);
   if (target.type === "scrape") {
     return target.urls.length * perPage;
   }


### PR DESCRIPTION
# Problem

Monitor checks reserve credits using target-aware pricing, but the async monitor
reconciler finalized billing using only the number of page rows:

`actualCredits = same + changed + new + removed + error`

Currently every successful page costs exactly 1 credit. It under-bills monitor
targets that use advanced scrape formats that flow through monitor
scrapeOptions, such as JSON/changeTracking JSON and deterministicJson.

## Example

- 10 monitored pages with `scrapeOptions.formats = [{ type: "json" }]`
- estimated/reserved credits = 10 * 5 = 50
- previous async finalization billed = 10

The same issue affects deterministicJson monitors:

- estimated/reserved credits = 10 * 7 = 70
- previous async finalization billed = 10

It also over-counted synthetic removed rows and failed rows as billable pages
even when no current scrape produced billable work.

The bug came from drift between the old sync monitor helper path, which had
target-aware credit logic, and the active async reconciliation path, which
finalized with page count.

## Fix

Add shared monitor billing helpers that:

- use metadata.creditsUsed when present and valid
- fall back to monitor target pricing when metadata is missing
- charge JSON/changeTracking JSON as 5 credits/page
- charge deterministicJson as 7 credits/page
- charge base monitor pages as 1 credit/page
- charge removed pages as 0 because they are synthetic reconciliation rows
  copied from prior monitor state, not current scrapes
- charge error pages as 0 unless explicit creditsUsed metadata exists
- charge unknown target ids as 0 and return them so the runner can log a warning

Update monitor estimate code to use the same shared per-target pricing helper,
preventing future drift between estimate and actual billing.

Update monitor reconciliation to list check pages and calculate actualCredits
from those rows instead of totalPages. Summary counts remain unchanged.

## Tests

`src/services/monitoring/billing.test.ts`

- base monitor scrape = 1 credit
- JSON format = 5 credits
- changeTracking JSON mode = 5 credits
- deterministicJson = 7 credits
- recorded metadata.creditsUsed overrides fallback pricing
- removed pages do not bill
- error pages only bill with explicit creditsUsed
- unknown target ids are not billed and are surfaced for logging

## Follow-up

Judge billing remains intentionally unchanged in this PR. Current code bills
judge credits per page in results.ts, while estimates reserve judge-enabled
monitors by doubling scrape credits. This PR adds a TODO at finalization and
leaves that separate billing-policy mismatch for a focused follow-up for
firecrawl team members.

## EDIT

This bug was introduced at this commit bc3c57adbb26 where the new monitoring/runner.ts was setup. Old synchronous helpers were never deleted.

  - runSingleScrape(...)
  - runScrapeTarget(...)
  - runCrawlTarget(...)
  
  Replaced by:

  - enqueueMonitorScrapeTarget(...)
  - enqueueMonitorCrawlTarget(...)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes monitor billing by applying target-aware per-page pricing during reconciliation, aligning actual charges with estimates and preventing charges for synthetic removed/error pages. Computes credits by scanning check pages in chunks to handle large checks.

- Bug Fixes
  - Use recorded `metadata.creditsUsed` when present; otherwise per-target pricing: base=1, JSON/changeTracking JSON=5, `deterministicJson`=7.
  - Removed pages bill 0; error pages bill 0 unless `creditsUsed` is recorded. Credits are computed from listed check pages (scanned in chunks); unknown target ids are logged and billed 0.

- Refactors
  - Added shared billing helpers used by both estimates and finalization; updated estimate path in `store` to use the same helper.
  - Replaced runner’s page-count billing with the new paginated credit calculation.

<sup>Written for commit 8a646477ff8771e5d7d820ca1d04cac739fdb612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

