### PR TITLE
fix(playwright-service): seed Cookie into the context jar so it survives redirects

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -715,6 +715,28 @@ describe("Scrape tests", () => {
         scrapeTimeout * 2 + 1 * indexCooldown,
       );
 
+      // Gated to the playwright engine (where cookies are seeded into the jar);
+      // a Cookie passed as an extra request header is dropped on redirect hops.
+      concurrentIf(HAS_PLAYWRIGHT && !HAS_FIRE_ENGINE)(
+        "forwards cookies across redirects",
+        async () => {
+          // httpbin's /cookies echoes the cookies it received. The cookie only
+          // survives the 302 hop if it was seeded into the browser cookie jar.
+          const response = await scrape(
+            {
+              url: "https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fcookies&status_code=302",
+              headers: { Cookie: "fc_cookie_redirect_test=1" },
+              formats: ["rawHtml"],
+              waitFor: 1000,
+            },
+            identity,
+          );
+
+          expect(response.rawHtml).toContain("fc_cookie_redirect_test");
+        },
+        scrapeTimeout,
+      );
+
       it.concurrent(
         "respects mobile",
         async () => {

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -414,10 +414,61 @@ app.post('/scrape', async (req: Request, res: Response) => {
     page = await requestContext.newPage();
 
     if (headers) {
-      // Remove the user-agent key before calling setExtraHTTPHeaders since
-      // we already forwarded it to the context-level userAgent option.
+      // A Cookie header passed through setExtraHTTPHeaders is sent on the first
+      // request but DROPPED on any redirect hop (the browser regenerates the
+      // redirected request from its cookie jar, which is empty). Authenticated
+      // sites that 302 (e.g. to /signin when the session looks absent) then
+      // land on the login page. Seed the cookie jar instead so Chromium re-sends
+      // it on every request, including redirects — matching what a raw HTTP
+      // client does.
+      const cookieHeader = Object.entries(headers).find(([k]) => k.toLowerCase() === 'cookie')?.[1];
+      if (cookieHeader) {
+        // Scope cookies to the registrable domain (e.g. ".example.com"), not
+        // host-only. Authenticated pages often 302 across sibling subdomains
+        // (example.com -> app.example.com); a host-only cookie set for the
+        // original host would not be sent to the redirect target, leaving the
+        // request unauthenticated. The Cookie header carries no domain info, so
+        // we apply the eTLD+1 — broad enough to follow the redirect, and these
+        // are first-party cookies being returned to their own origin anyway.
+        let cookieDomain: string | undefined;
+        try {
+          const host = new URL(url).hostname;
+          const labels = host.split('.');
+          cookieDomain = labels.length > 2 ? labels.slice(-2).join('.') : host;
+        } catch {
+          cookieDomain = undefined;
+        }
+        type SeedCookie = { name: string; value: string; url?: string; domain?: string; path?: string };
+        const cookies = cookieHeader
+          .split(';')
+          .map(pair => pair.trim())
+          .filter(Boolean)
+          .map((pair): SeedCookie | null => {
+            const eq = pair.indexOf('=');
+            if (eq === -1) return null;
+            const name = pair.slice(0, eq).trim();
+            const value = pair.slice(eq + 1).trim();
+            return cookieDomain
+              ? { name, value, domain: `.${cookieDomain}`, path: '/' }
+              : { name, value, url };
+          })
+          .filter((c): c is SeedCookie => c !== null);
+        if (cookies.length > 0) {
+          try {
+            await requestContext.addCookies(cookies);
+          } catch (error) {
+            console.warn('Failed to seed cookies from Cookie header:', error);
+          }
+        }
+      }
+
+      // Remove user-agent (already applied at the context level) and cookie
+      // (now seeded into the jar) before forwarding the rest verbatim.
       const filteredHeaders = Object.fromEntries(
-        Object.entries(headers).filter(([k]) => k.toLowerCase() !== 'user-agent')
+        Object.entries(headers).filter(([k]) => {
+          const lower = k.toLowerCase();
+          return lower !== 'user-agent' && lower !== 'cookie';
+        })
       );
       if (Object.keys(filteredHeaders).length > 0) {
         await page.setExtraHTTPHeaders(filteredHeaders);


### PR DESCRIPTION
Fixes #3725.

### Problem
The browser engine applies the `Cookie` request header via `page.setExtraHTTPHeaders()`. Chromium sends it on the first request but drops it on redirect hops (redirected requests are regenerated from the empty cookie jar), so authenticated pages that 302 before rendering — including across sibling subdomains — end up unauthenticated and the scrape returns the login page.

### Fix
In `apps/playwright-service-ts/api.ts`, parse the `Cookie` header and seed it into the browser context via `context.addCookies()`, scoped to the registrable domain (so it survives cross-subdomain redirects), and exclude `Cookie` from `setExtraHTTPHeaders`. Other headers are unchanged.

### Verification
Scraping a 302 redirect with a cookie against the self-hosted stack:
```bash
curl -s -X POST localhost:3002/v2/scrape -d '{"url":"https://httpbingo.org/redirect-to?url=https%3A%2F%2Fhttpbingo.org%2Fcookies&status_code=302","formats":["markdown"],"headers":{"Cookie":"probe=value"},"waitFor":1000}'
```
- **before:** destination echoes `{}` (cookie dropped on redirect)
- **after:** destination echoes `{"probe":"value"}` (cookie survives)

Direct (no-redirect) scrapes are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds the incoming `Cookie` header into the Playwright context so cookies persist across 302 redirects and sibling subdomains, fixing redirected authenticated scrapes.

- **Bug Fixes**
  - Parse `Cookie` and seed via `context.addCookies()`, scoped to the registrable domain; exclude `Cookie` and `user-agent` from `page.setExtraHTTPHeaders()` and forward other headers unchanged.
  - Added a Playwright-only test that verifies cookies survive 302 and cross-subdomain redirects; non-redirect flows are unchanged.

<sup>Written for commit 92b0bef424556bfc290c3dfb733a5ecc969ff768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

