### PR TITLE
fix(api): keep auth chunk in self-host bypass

### DIFF
--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -1,45 +1,46 @@
+import { vi } from "vitest";
 import { authenticateUser } from "../auth";
 import { config } from "../../config";
 import { RateLimiterMode } from "../../types";
 
-jest.mock("../../services/queue-service", () => ({
-  getRedisConnection: jest.fn(() => ({
-    sadd: jest.fn(),
+vi.mock("../../services/queue-service", () => ({
+  getRedisConnection: vi.fn(() => ({
+    sadd: vi.fn(),
   })),
 }));
 
-jest.mock("uuid", () => ({
-  validate: jest.fn(() => true),
+vi.mock("uuid", () => ({
+  validate: vi.fn(() => true),
 }));
 
-jest.mock("../../services/redis", () => ({
-  getValue: jest.fn(),
-  setValue: jest.fn(),
-  deleteKey: jest.fn(),
+vi.mock("../../services/redis", () => ({
+  getValue: vi.fn(),
+  setValue: vi.fn(),
+  deleteKey: vi.fn(),
 }));
 
-jest.mock("../../services/redlock", () => ({
+vi.mock("../../services/redlock", () => ({
   redlock: {
-    using: jest.fn(),
+    using: vi.fn(),
   },
 }));
 
-jest.mock("../../db/connection", () => ({
+vi.mock("../../db/connection", () => ({
   db: {},
   dbRr: {},
 }));
 
-jest.mock("../../db/rpc", () => ({
-  authCreditUsageChunk: jest.fn(),
-  authCreditUsageChunkFromTeam: jest.fn(),
+vi.mock("../../db/rpc", () => ({
+  authCreditUsageChunk: vi.fn(),
+  authCreditUsageChunkFromTeam: vi.fn(),
 }));
 
-jest.mock("../../services/rate-limiter", () => ({
-  getRateLimiter: jest.fn(),
+vi.mock("../../services/rate-limiter", () => ({
+  getRateLimiter: vi.fn(),
 }));
 
-jest.mock("../../services/agent-sponsor", () => ({
-  getAgentSponsorStatus: jest.fn(),
+vi.mock("../../services/agent-sponsor", () => ({
+  getAgentSponsorStatus: vi.fn(),
 }));
 
 describe("authenticateUser", () => {

--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -1,0 +1,73 @@
+import { authenticateUser } from "../auth";
+import { config } from "../../config";
+import { RateLimiterMode } from "../../types";
+
+jest.mock("../../services/queue-service", () => ({
+  getRedisConnection: jest.fn(() => ({
+    sadd: jest.fn(),
+  })),
+}));
+
+jest.mock("uuid", () => ({
+  validate: jest.fn(() => true),
+}));
+
+jest.mock("../../services/redis", () => ({
+  getValue: jest.fn(),
+  setValue: jest.fn(),
+  deleteKey: jest.fn(),
+}));
+
+jest.mock("../../services/redlock", () => ({
+  redlock: {
+    using: jest.fn(),
+  },
+}));
+
+jest.mock("../../db/connection", () => ({
+  db: {},
+  dbRr: {},
+}));
+
+jest.mock("../../db/rpc", () => ({
+  authCreditUsageChunk: jest.fn(),
+  authCreditUsageChunkFromTeam: jest.fn(),
+}));
+
+jest.mock("../../services/rate-limiter", () => ({
+  getRateLimiter: jest.fn(),
+}));
+
+jest.mock("../../services/agent-sponsor", () => ({
+  getAgentSponsorStatus: jest.fn(),
+}));
+
+describe("authenticateUser", () => {
+  const originalUseDbAuth = config.USE_DB_AUTHENTICATION;
+
+  afterEach(() => {
+    config.USE_DB_AUTHENTICATION = originalUseDbAuth;
+  });
+
+  it("keeps a mock ACUC chunk in no-auth mode", async () => {
+    config.USE_DB_AUTHENTICATION = false;
+
+    const auth = await authenticateUser(
+      { headers: {}, socket: {} },
+      {},
+      RateLimiterMode.ExtractAgentPreview,
+    );
+
+    expect(auth.success).toBe(true);
+    if (!auth.success) throw new Error("expected bypass auth to succeed");
+    expect(auth.team_id).toBe("bypass");
+    expect(auth.chunk).toEqual(
+      expect.objectContaining({
+        api_key: "bypass",
+        api_key_id: 0,
+        team_id: "bypass",
+        is_extract: true,
+      }),
+    );
+  });
+});

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -633,10 +633,16 @@ export async function authenticateUser(
   mode?: RateLimiterMode,
   options?: { allowKeyless?: boolean },
 ): Promise<AuthResponse> {
+  const bypassChunk = mockACUC();
+  bypassChunk.is_extract =
+    mode === RateLimiterMode.Extract ||
+    mode === RateLimiterMode.ExtractStatus ||
+    mode === RateLimiterMode.ExtractAgentPreview;
+
   return withAuth(supaAuthenticateUser, {
     success: true,
-    chunk: null,
-    team_id: "bypass",
+    chunk: bypassChunk,
+    team_id: bypassChunk.team_id,
     org_id: null,
   })(req, res, mode, options);
 }


### PR DESCRIPTION
Fixes #3553.

## What changed

Self-hosted `USE_DB_AUTHENTICATION=false` already has a mock ACUC path in `getACUC()`, but `authenticateUser()` was still returning `chunk: null` through the auth bypass wrapper. `authMiddleware` then turned that into `req.acuc = undefined`, and `/v2/agent` later crashed when building the passthrough payload from `req.acuc!.api_key`.

This keeps a normal mock ACUC chunk in the bypass auth response and marks it as extract-mode when the current rate limiter mode is an extract/agent mode.

## Verification

```bash
pnpm install --frozen-lockfile --ignore-scripts
pnpm exec jest src/controllers/__tests__/auth.test.ts --runInBand
git diff --check
```

`pnpm exec tsc --noEmit --pretty false` does not complete in this local checkout because `@mendable/firecrawl-rs` types are not generated when install scripts are ignored. The target Jest test covers the changed no-auth branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent auth crash in self-hosted mode by keeping a mock ACUC chunk in the bypass path and marking extract mode when needed. Prevents `/v2/agent` from crashing when building the passthrough payload.

- **Bug Fixes**
  - Return a mock ACUC in `authenticateUser` for `USE_DB_AUTHENTICATION=false` instead of `chunk: null`.
  - Set `is_extract` when mode is `Extract`, `ExtractStatus`, or `ExtractAgentPreview`.
  - Add a `vitest` test to verify the bypass auth returns the mock chunk and sets `is_extract` in extract modes.

<sup>Written for commit 2fbf986a931bac1cb5df25b7510a3171005d5567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

