### PR TITLE
fix(api): reject self-hosted scrape interact clearly

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/scrape-browser.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/scrape-browser.test.ts
@@ -1,0 +1,103 @@
+import type { Response } from "express";
+import { config } from "../../../config";
+import { supabaseGetScrapeById } from "../../../lib/supabase-jobs";
+import { scrapeInteractController } from "../scrape-browser";
+import type { RequestWithAuth } from "../types";
+
+jest.mock("uuid", () => ({
+  v7: jest.fn(() => "session-123"),
+}));
+
+jest.mock("../../../lib/supabase-jobs", () => ({
+  supabaseGetScrapeById: jest.fn(),
+}));
+
+jest.mock("../../../lib/browser-sessions", () => ({
+  insertBrowserSession: jest.fn(),
+  getBrowserSession: jest.fn(),
+  updateBrowserSessionActivity: jest.fn(() => Promise.resolve()),
+  updateBrowserSessionCreditsUsed: jest.fn(() => Promise.resolve()),
+  updateBrowserSessionScrapeId: jest.fn(() => Promise.resolve()),
+  claimBrowserSessionDestroyed: jest.fn(),
+  invalidateActiveBrowserSessionCount: jest.fn(() => Promise.resolve()),
+  getBrowserSessionFromScrape: jest.fn(),
+  markBrowserSessionUsedPrompt: jest.fn(() => Promise.resolve()),
+  didBrowserSessionUsePrompt: jest.fn(),
+  clearBrowserSessionPromptFlag: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../../../lib/concurrency-limit", () => ({
+  getConcurrencyLimitActiveJobsCount: jest.fn(),
+  pushConcurrencyLimitActiveJob: jest.fn(() => Promise.resolve()),
+  removeConcurrencyLimitActiveJob: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../../../lib/scrape-interact/browser-service-client", () => ({
+  browserServiceRequest: jest.fn(),
+  BrowserServiceError: class BrowserServiceError extends Error {
+    status = 500;
+  },
+}));
+
+jest.mock("../../../lib/scrape-interact/browser-agent", () => ({
+  executePromptViaBrowserAgent: jest.fn(),
+  executeCodeViaBrowserSession: jest.fn(),
+}));
+
+jest.mock("../../../lib/browser-session-activity", () => ({
+  enqueueBrowserSessionActivity: jest.fn(),
+}));
+
+jest.mock("../../../services/billing/credit_billing", () => ({
+  billTeam: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../../../services/logging/log_job", () => ({
+  logRequest: jest.fn(),
+}));
+
+jest.mock("../../../services/autumn/autumn.service", () => ({
+  autumnService: {
+    checkCredits: jest.fn(),
+  },
+}));
+
+describe("scrapeInteractController", () => {
+  const previousUseDbAuthentication = config.USE_DB_AUTHENTICATION;
+
+  const buildRes = () =>
+    ({
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    config.USE_DB_AUTHENTICATION = previousUseDbAuthentication;
+  });
+
+  it("rejects self-hosted scrape interact before querying Supabase", async () => {
+    config.USE_DB_AUTHENTICATION = false;
+
+    const req = {
+      params: { jobId: "scrape-123" },
+      body: { prompt: "click the first result" },
+      auth: { team_id: "team-123" },
+      acuc: {},
+    } as RequestWithAuth<{ jobId: string }, any, any>;
+    const res = buildRes();
+
+    await scrapeInteractController(req, res);
+
+    expect(supabaseGetScrapeById).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(501);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error:
+        "Scrape interact requires stored scrape context and is not available when database authentication is disabled.",
+    });
+  });
+});

--- a/apps/api/src/controllers/v2/__tests__/scrape-browser.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/scrape-browser.test.ts
@@ -1,64 +1,65 @@
 import type { Response } from "express";
+import { vi } from "vitest";
 import { config } from "../../../config";
 import { supabaseGetScrapeById } from "../../../lib/supabase-jobs";
 import { scrapeInteractController } from "../scrape-browser";
 import type { RequestWithAuth } from "../types";
 
-jest.mock("uuid", () => ({
-  v7: jest.fn(() => "session-123"),
+vi.mock("uuid", () => ({
+  v7: vi.fn(() => "session-123"),
 }));
 
-jest.mock("../../../lib/supabase-jobs", () => ({
-  supabaseGetScrapeById: jest.fn(),
+vi.mock("../../../lib/supabase-jobs", () => ({
+  supabaseGetScrapeById: vi.fn(),
 }));
 
-jest.mock("../../../lib/browser-sessions", () => ({
-  insertBrowserSession: jest.fn(),
-  getBrowserSession: jest.fn(),
-  updateBrowserSessionActivity: jest.fn(() => Promise.resolve()),
-  updateBrowserSessionCreditsUsed: jest.fn(() => Promise.resolve()),
-  updateBrowserSessionScrapeId: jest.fn(() => Promise.resolve()),
-  claimBrowserSessionDestroyed: jest.fn(),
-  invalidateActiveBrowserSessionCount: jest.fn(() => Promise.resolve()),
-  getBrowserSessionFromScrape: jest.fn(),
-  markBrowserSessionUsedPrompt: jest.fn(() => Promise.resolve()),
-  didBrowserSessionUsePrompt: jest.fn(),
-  clearBrowserSessionPromptFlag: jest.fn(() => Promise.resolve()),
+vi.mock("../../../lib/browser-sessions", () => ({
+  insertBrowserSession: vi.fn(),
+  getBrowserSession: vi.fn(),
+  updateBrowserSessionActivity: vi.fn(() => Promise.resolve()),
+  updateBrowserSessionCreditsUsed: vi.fn(() => Promise.resolve()),
+  updateBrowserSessionScrapeId: vi.fn(() => Promise.resolve()),
+  claimBrowserSessionDestroyed: vi.fn(),
+  invalidateActiveBrowserSessionCount: vi.fn(() => Promise.resolve()),
+  getBrowserSessionFromScrape: vi.fn(),
+  markBrowserSessionUsedPrompt: vi.fn(() => Promise.resolve()),
+  didBrowserSessionUsePrompt: vi.fn(),
+  clearBrowserSessionPromptFlag: vi.fn(() => Promise.resolve()),
 }));
 
-jest.mock("../../../lib/concurrency-limit", () => ({
-  getConcurrencyLimitActiveJobsCount: jest.fn(),
-  pushConcurrencyLimitActiveJob: jest.fn(() => Promise.resolve()),
-  removeConcurrencyLimitActiveJob: jest.fn(() => Promise.resolve()),
+vi.mock("../../../lib/concurrency-limit", () => ({
+  getConcurrencyLimitActiveJobsCount: vi.fn(),
+  pushConcurrencyLimitActiveJob: vi.fn(() => Promise.resolve()),
+  removeConcurrencyLimitActiveJob: vi.fn(() => Promise.resolve()),
 }));
 
-jest.mock("../../../lib/scrape-interact/browser-service-client", () => ({
-  browserServiceRequest: jest.fn(),
+vi.mock("../../../lib/scrape-interact/browser-service-client", () => ({
+  browserServiceRequest: vi.fn(),
   BrowserServiceError: class BrowserServiceError extends Error {
     status = 500;
   },
 }));
 
-jest.mock("../../../lib/scrape-interact/browser-agent", () => ({
-  executePromptViaBrowserAgent: jest.fn(),
-  executeCodeViaBrowserSession: jest.fn(),
+vi.mock("../../../lib/scrape-interact/browser-agent", () => ({
+  executePromptViaBrowserAgent: vi.fn(),
+  executeCodeViaBrowserSession: vi.fn(),
 }));
 
-jest.mock("../../../lib/browser-session-activity", () => ({
-  enqueueBrowserSessionActivity: jest.fn(),
+vi.mock("../../../lib/browser-session-activity", () => ({
+  enqueueBrowserSessionActivity: vi.fn(),
 }));
 
-jest.mock("../../../services/billing/credit_billing", () => ({
-  billTeam: jest.fn(() => Promise.resolve()),
+vi.mock("../../../services/billing/credit_billing", () => ({
+  billTeam: vi.fn(() => Promise.resolve()),
 }));
 
-jest.mock("../../../services/logging/log_job", () => ({
-  logRequest: jest.fn(),
+vi.mock("../../../services/logging/log_job", () => ({
+  logRequest: vi.fn(),
 }));
 
-jest.mock("../../../services/autumn/autumn.service", () => ({
+vi.mock("../../../services/autumn/autumn.service", () => ({
   autumnService: {
-    checkCredits: jest.fn(),
+    checkCredits: vi.fn(),
   },
 }));
 
@@ -67,12 +68,12 @@ describe("scrapeInteractController", () => {
 
   const buildRes = () =>
     ({
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
     }) as unknown as Response;
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -144,6 +144,14 @@ export async function scrapeInteractController(
 
   // --- Validate scrape ownership ---
 
+  if (config.USE_DB_AUTHENTICATION !== true) {
+    return res.status(501).json({
+      success: false,
+      error:
+        "Scrape interact requires stored scrape context and is not available when database authentication is disabled.",
+    });
+  }
+
   const scrape = (await supabaseGetScrapeById(
     scrapeId,
   )) as ScrapeContextRow | null;


### PR DESCRIPTION
## Summary
- return a clear 501 when `/v2/scrape/:jobId/interact` is used with database authentication disabled
- avoid falling through to the Supabase scrape lookup in self-hosted deployments
- add a controller regression test for the self-hosted path

Fixes #3570.

## To verify
- `pnpm exec jest src/controllers/v2/__tests__/scrape-browser.test.ts --runInBand`
- `git diff --check`

I also ran `pnpm exec tsc --noEmit --pretty false`; it still fails before this change on the local native package setup because `@mendable/firecrawl-rs` types are not generated when dependencies are installed with scripts disabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a 501 from `/v2/scrape/:jobId/interact` when database authentication is disabled, clearly signaling that interact is unsupported in self-hosted mode and skipping any Supabase lookup. Adds a `vitest` regression test to assert the early return and that no Supabase query is made.

<sup>Written for commit f6f184a13a2f0d0af228e0b30294a363a9e23244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

