### PR TITLE
fix: detect bracketed private IPv6 hosts

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.test.ts
@@ -1,0 +1,11 @@
+import { isIPPrivate } from "./safeFetch";
+
+describe("isIPPrivate", () => {
+  it("treats bracketed IPv6 localhost hostnames as private", () => {
+    expect(isIPPrivate("[::1]")).toBe(true);
+  });
+
+  it("treats bracketed IPv4-mapped localhost hostnames as private", () => {
+    expect(isIPPrivate("[::ffff:7f00:1]")).toBe(true);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -13,6 +13,10 @@ export class InsecureConnectionError extends Error {
 }
 
 export function isIPPrivate(address: string): boolean {
+  if (address.startsWith("[") && address.endsWith("]")) {
+    address = address.slice(1, -1);
+  }
+
   if (!IPAddr.isValid(address)) return false;
 
   const addr = IPAddr.parse(address);


### PR DESCRIPTION
Normalizes bracketed IPv6 hostnames before private IP detection so localhost and IPv4-mapped localhost are blocked as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes private IP detection for bracketed IPv6 hostnames in the scraper. Addresses are normalized so [::1] and IPv4-mapped localhost are blocked as expected.

- **Bug Fixes**
  - Strip square brackets before IP validation in isIPPrivate.
  - Add unit tests for [::1] and [::ffff:7f00:1].

<sup>Written for commit 2a48db3928b2f15032779c747fc97b66b1ee91fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

