### PR TITLE
Add `gstack` to the integration enum

### DIFF
--- a/apps/api/src/utils/integration.ts
+++ b/apps/api/src/utils/integration.ts
@@ -17,6 +17,7 @@ enum IntegrationEnum {
   VIASOCKET = "viasocket",
   CLI = "cli",
   HERMES = "hermes",
+  GSTACK = "gstack",
 }
 
 export const integrationSchema = z


### PR DESCRIPTION
Adds `gstack` to `IntegrationEnum` in `apps/api/src/utils/integration.ts`.

**Why:** [gstack](https://github.com/garrytan/gstack) (Garry Tan's Claude Code skill suite, ~broad install base) now uses Firecrawl as its **native web search + clean URL→markdown fetch** — new `$B search` / `$B fetch` primitives and a `/web-search` skill, all routed through the v2 SDK. Those calls want to set `integration: "gstack"` for usage attribution, but the value is currently rejected by `integrationSchema` (not in the enum), which 400s the request.

This one-line addition registers `gstack` so the integration can attribute its traffic, consistent with the other partner integrations (dify, langchain, crewai, n8n, …).

No other changes — `integrationSchema` derives its allowed values from `Object.values(IntegrationEnum)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)