### PR TITLE
fix(api): fail open when rate-limit Redis is unreachable (#3728)

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -7,6 +7,10 @@ import { withAuth } from "../lib/withAuth";
 import { getAgentSponsorStatus } from "../services/agent-sponsor";
 import { getRateLimiter, getAutumnRateLimiter } from "../services/rate-limiter";
 import {
+  buildRateLimitMessage,
+  isRateLimiterRes,
+} from "../lib/rate-limit-error";
+import {
   KEYLESS_FREE_TIER_LIMIT_MESSAGE,
   consumeKeylessRequest,
   isKeylessConfigured,
@@ -810,27 +814,39 @@ async function supaAuthenticateUser(
   try {
     await rateLimiter.consume(team_endpoint_token);
   } catch (rateLimiterRes) {
-    logger.error(`Rate limit exceeded: ${rateLimiterRes}`, {
-      teamId,
-      mode,
-      rateLimiterRes,
-    });
+    // `consume()` rejects with a `RateLimiterRes` on a genuine rate-limit hit,
+    // but with a plain `Error` when the rate-limit Redis store is unreachable
+    // (no insuranceLimiter is configured). Only the former is a real 429 —
+    // treating a store/infra error as a 429 returns a bogus response with
+    // `undefined` fields on every authenticated request while Redis is down
+    // (issue #3728). Fail open on infra errors instead.
+    if (!isRateLimiterRes(rateLimiterRes)) {
+      logger.error("Rate limiter backing store error — failing open", {
+        teamId,
+        mode,
+        error: rateLimiterRes,
+      });
+    } else {
+      logger.error(`Rate limit exceeded: ${rateLimiterRes}`, {
+        teamId,
+        mode,
+        rateLimiterRes,
+      });
+      const { message } = buildRateLimitMessage(rateLimiterRes);
 
-    const secs = Math.round(rateLimiterRes.msBeforeNext / 1000) || 1;
-    const retryDate = new Date(Date.now() + rateLimiterRes.msBeforeNext);
+      // We can only send a rate limit email every 7 days, send notification already has the date in between checking
+      // const startDate = new Date();
+      // const endDate = new Date();
+      // endDate.setDate(endDate.getDate() + 7);
 
-    // We can only send a rate limit email every 7 days, send notification already has the date in between checking
-    // const startDate = new Date();
-    // const endDate = new Date();
-    // endDate.setDate(endDate.getDate() + 7);
+      // await sendNotification(team_id, NotificationType.RATE_LIMIT_REACHED, startDate.toISOString(), endDate.toISOString());
 
-    // await sendNotification(team_id, NotificationType.RATE_LIMIT_REACHED, startDate.toISOString(), endDate.toISOString());
-
-    return {
-      success: false,
-      error: `Rate limit exceeded. Consumed (req/min): ${rateLimiterRes.consumedPoints}, Remaining (req/min): ${rateLimiterRes.remainingPoints}. Upgrade your plan at https://firecrawl.dev/pricing for increased rate limits or please retry after ${secs}s, resets at ${retryDate}`,
-      status: 429,
-    };
+      return {
+        success: false,
+        error: message,
+        status: 429,
+      };
+    }
   }
 
   if (

--- a/apps/api/src/lib/rate-limit-error.test.ts
+++ b/apps/api/src/lib/rate-limit-error.test.ts
@@ -1,0 +1,52 @@
+import { RateLimiterRes } from "rate-limiter-flexible";
+import { isRateLimiterRes, buildRateLimitMessage } from "./rate-limit-error";
+
+/**
+ * Regression tests for issue #3728.
+ *
+ * The auth controller's rate-limit `catch` block used to assume every
+ * rejection from `rateLimiter.consume()` was a `RateLimiterRes` and read
+ * `.msBeforeNext` / `.consumedPoints` / `.remainingPoints` off it. When the
+ * rate-limit Redis store is unreachable — and with no `insuranceLimiter`
+ * configured (see `services/rate-limiter.ts`) — `consume()` rejects with a
+ * plain `Error` instead. That produced a bogus HTTP 429 with `undefined`
+ * fields on *every* authenticated request while the store was down.
+ *
+ * The fix discriminates the rejection: genuine `RateLimiterRes` -> 429 with
+ * populated fields (unchanged); store/infra `Error` -> fail open.
+ */
+describe("rate-limit-error discrimination (#3728)", () => {
+  it("treats a genuine RateLimiterRes as a real rate-limit hit", () => {
+    // RateLimiterRes(remainingPoints, msBeforeNext, consumedPoints, isFirstInDuration)
+    const res = new RateLimiterRes(0, 30000, 100, false);
+
+    expect(isRateLimiterRes(res)).toBe(true);
+
+    const { secs, message } = buildRateLimitMessage(res);
+    expect(secs).toBe(30);
+    // Populated, not "undefined", fields in the user-facing message.
+    expect(message).toContain("Consumed (req/min): 100");
+    expect(message).toContain("Remaining (req/min): 0");
+    expect(message).not.toContain("undefined");
+  });
+
+  it("does NOT treat a backing-store Error as a rate-limit hit (fail open)", () => {
+    // What `consume()` rejects with when rate-limit Redis is unreachable and
+    // no insuranceLimiter is configured.
+    const storeError = new Error("Connection is closed.");
+
+    // The fail-open assertion: an infra error must not be classified as a
+    // genuine rate-limit rejection, so the caller will NOT return a 429.
+    expect(isRateLimiterRes(storeError)).toBe(false);
+  });
+
+  it("does NOT treat undefined/null rejections as a rate-limit hit", () => {
+    expect(isRateLimiterRes(undefined)).toBe(false);
+    expect(isRateLimiterRes(null)).toBe(false);
+  });
+
+  it("does NOT treat an object with non-numeric msBeforeNext as a hit", () => {
+    expect(isRateLimiterRes({ msBeforeNext: undefined })).toBe(false);
+    expect(isRateLimiterRes({ msBeforeNext: "soon" })).toBe(false);
+  });
+});

--- a/apps/api/src/lib/rate-limit-error.ts
+++ b/apps/api/src/lib/rate-limit-error.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers for discriminating rate-limiter rejections.
+ *
+ * `rateLimiter.consume()` from `rate-limiter-flexible` rejects in two very
+ * different situations:
+ *
+ *   1. A genuine rate-limit hit — the rejection is a `RateLimiterRes` carrying
+ *      numeric `msBeforeNext` / `consumedPoints` / `remainingPoints` fields.
+ *   2. The backing store (rate-limit Redis) is unreachable — and because no
+ *      `insuranceLimiter` is configured, the rejection is a plain `Error`.
+ *
+ * Treating case (2) as case (1) produces a bogus HTTP 429 with `undefined`
+ * fields on every authenticated request while the store is down (see issue
+ * #3728). These helpers let callers fail-open on infrastructure errors instead.
+ */
+
+interface RateLimiterResLike {
+  msBeforeNext: number;
+  consumedPoints: number;
+  remainingPoints: number;
+}
+
+/**
+ * Type guard: was this rejection a genuine rate-limit hit (a `RateLimiterRes`),
+ * as opposed to a backing-store / infrastructure error (a plain `Error`)?
+ *
+ * Uses a structural check on `msBeforeNext` rather than `instanceof` so it stays
+ * correct across module-interop / dual-package edge cases where the constructor
+ * identity may differ.
+ */
+export function isRateLimiterRes(err: unknown): err is RateLimiterResLike {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    typeof (err as { msBeforeNext?: unknown }).msBeforeNext === "number"
+  );
+}
+
+/**
+ * Build the user-facing HTTP 429 "rate limit exceeded" message for a genuine
+ * rate-limit hit. Kept here so the catch block in the auth controller only
+ * formats this message once it has confirmed the rejection is a real
+ * `RateLimiterRes`.
+ */
+export function buildRateLimitMessage(res: RateLimiterResLike): {
+  secs: number;
+  message: string;
+} {
+  const secs = Math.round(res.msBeforeNext / 1000) || 1;
+  const retryDate = new Date(Date.now() + res.msBeforeNext);
+  return {
+    secs,
+    message: `Rate limit exceeded. Consumed (req/min): ${res.consumedPoints}, Remaining (req/min): ${res.remainingPoints}. Upgrade your plan at https://firecrawl.dev/pricing for increased rate limits or please retry after ${secs}s, resets at ${retryDate}`,
+  };
+}


### PR DESCRIPTION
## Problem

Fixes #3728.

`apps/api/src/controllers/auth.ts` is the sole production caller of `rateLimiter.consume()`. Its `catch` block assumed **every** rejection was a `RateLimiterRes` and unconditionally read `.msBeforeNext` / `.consumedPoints` / `.remainingPoints`:

```ts
const secs = Math.round(rateLimiterRes.msBeforeNext / 1000) || 1;
const retryDate = new Date(Date.now() + rateLimiterRes.msBeforeNext);
return {
  success: false,
  error: `Rate limit exceeded. Consumed (req/min): ${rateLimiterRes.consumedPoints}, ...`,
  status: 429,
};
```

But `rate-limiter-flexible` only rejects with a `RateLimiterRes` on a **genuine** limit hit. When the rate-limit Redis store is unreachable — and `apps/api/src/services/rate-limiter.ts` configures `RateLimiterRedis` with **no `insuranceLimiter`** — `consume()` rejects with a plain `Error` instead.

The old code then returned **HTTP 429** with `Consumed (req/min): undefined`, `Remaining (req/min): undefined`, and `resets at Invalid Date` on **every authenticated request** while the rate-limit Redis was down (i.e. the limiter fails *closed*).

## Fix (file)

`apps/api/src/controllers/auth.ts` — discriminate the rejection in the `catch` block:

- **Genuine `RateLimiterRes`** → return the existing 429 with populated fields (unchanged behavior, identical message).
- **Store / infra `Error`** → log it and **fail open** (fall through to the normal success path) instead of emitting a mislabeled 429.

The discrimination + message-building logic lives in a small, side-effect-free helper `apps/api/src/lib/rate-limit-error.ts` (`isRateLimiterRes` + `buildRateLimitMessage`) so it is unit-testable without booting the DB/Redis module graph. The guard is a structural check on `msBeforeNext` (resilient to module-interop `instanceof` edge cases), exactly the discriminator the issue author suggested.

## Test (RED-first)

`apps/api/src/lib/rate-limit-error.test.ts`:

1. **RED** (proven against the original catch logic before the fix): a plain backing-store `Error` produced a `status: 429` whose message contained `Consumed (req/min): undefined`, `Remaining (req/min): undefined`, and `Invalid Date`.
2. **GREEN** after the fix:
   - A genuine `RateLimiterRes` is still classified as a real hit and yields a populated message (no `undefined`).
   - A backing-store `Error` is **not** classified as a rate-limit hit → caller fails open (no 429).
   - `undefined` / `null` / non-numeric-`msBeforeNext` rejections are also treated as fail-open.

Hermetic — no live Redis/DB required, CI-safe.

## Verification

```
$ npx tsc --noEmit -p tsconfig.json     # 0 errors across apps/api
$ npx jest src/lib/rate-limit-error.test.ts
PASS src/lib/rate-limit-error.test.ts
  rate-limit-error discrimination (#3728)
    ✓ treats a genuine RateLimiterRes as a real rate-limit hit
    ✓ does NOT treat a backing-store Error as a rate-limit hit (fail open)
    ✓ does NOT treat undefined/null rejections as a rate-limit hit
    ✓ does NOT treat an object with non-numeric msBeforeNext as a hit
Tests: 4 passed, 4 total
```

`prettier` + `knip` (the repo pre-commit gate) both pass. Diff: 3 files, +137 / -20, no new dependencies.

---

> AGPL-3.0: this contribution is offered under the same license as the project.

> 🤖 AI-assistance: drafted with Claude (Opus 4.8), reviewed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail open in the auth rate limiter when the Redis backend is unreachable to prevent false 429s with undefined fields. Genuine limit hits still return 429 with a clear, populated message. Fixes #3728.

- **Bug Fixes**
  - In `apps/api/src/controllers/auth.ts`, differentiate `rateLimiter.consume()` rejections between real `RateLimiterRes` and infra `Error` from `rate-limiter-flexible` (no `insuranceLimiter`).
  - Infra errors: log and allow the request (no 429). Real hits: return 429 using `buildRateLimitMessage`.
  - Added `apps/api/src/lib/rate-limit-error.ts` (`isRateLimiterRes`, `buildRateLimitMessage`) and tests (`rate-limit-error.test.ts`).

<sup>Written for commit 844fb4c4004d633c6d7e03d4a9b43aedbf1bbdb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

