### PR TITLE
feat(self-host): support mobile viewport emulation on the playwright engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -355,7 +355,7 @@ const engineOptions: {
       video: false,
       atsv: false,
       location: false,
-      mobile: false,
+      mobile: true,
       skipTlsVerification: true,
       useFastMode: false,
       stealthProxy: false,

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -19,6 +19,7 @@ export async function scrapeURLWithPlaywright(
       timeout: meta.abort.scrapeTimeout(),
       headers: meta.options.headers,
       skip_tls_verification: meta.options.skipTlsVerification,
+      mobile: meta.options.mobile,
     },
     method: "POST",
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -178,6 +178,7 @@ interface UrlModel {
   headers?: { [key: string]: string };
   check_selector?: string;
   skip_tls_verification?: boolean;
+  mobile?: boolean;
 }
 
 let browser: Browser;
@@ -197,9 +198,19 @@ const initializeBrowser = async () => {
   });
 };
 
-const createContext = async (skipTlsVerification: boolean = false, userAgentOverride?: string): Promise<{ context: BrowserContext; securityState: ContextSecurityState }> => {
-  const userAgent = userAgentOverride || new UserAgent().toString();
-  const viewport = { width: 1280, height: 800 };
+// Default mobile UA used when the caller asks for a mobile render but didn't
+// pass a mobile UA of its own — a desktop UA alongside isMobile makes the page
+// serve its desktop layout, defeating the point of mobile emulation.
+const MOBILE_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const isMobileUserAgent = (ua?: string): boolean =>
+  !!ua && /Mobi|iPhone|iPod|Android/i.test(ua);
+
+const createContext = async (skipTlsVerification: boolean = false, userAgentOverride?: string, mobile: boolean = false): Promise<{ context: BrowserContext; securityState: ContextSecurityState }> => {
+  const userAgent = mobile
+    ? (isMobileUserAgent(userAgentOverride) ? userAgentOverride! : MOBILE_USER_AGENT)
+    : (userAgentOverride || new UserAgent().toString());
+  const viewport = mobile ? { width: 390, height: 844 } : { width: 1280, height: 800 };
   const securityState: ContextSecurityState = {
     blockedNavigationRequestUrl: null,
   };
@@ -209,6 +220,7 @@ const createContext = async (skipTlsVerification: boolean = false, userAgentOver
     viewport,
     ignoreHTTPSErrors: skipTlsVerification,
     serviceWorkers: 'block',
+    ...(mobile ? { isMobile: true, hasTouch: true, deviceScaleFactor: 3 } : {}),
   };
 
   if (PROXY_SERVER && PROXY_USERNAME && PROXY_PASSWORD) {
@@ -354,7 +366,7 @@ app.get('/health', async (req: Request, res: Response) => {
 });
 
 app.post('/scrape', async (req: Request, res: Response) => {
-  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false }: UrlModel = req.body;
+  const { url, wait_after_load = 0, timeout = 15000, headers, check_selector, skip_tls_verification = false, mobile = false }: UrlModel = req.body;
 
   console.log(`================= Scrape Request =================`);
   console.log(`URL: ${url}`);
@@ -363,6 +375,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   console.log(`Headers: ${headers ? JSON.stringify(headers) : 'None'}`);
   console.log(`Check Selector: ${check_selector ? check_selector : 'None'}`);
   console.log(`Skip TLS Verification: ${skip_tls_verification}`);
+  console.log(`Mobile: ${mobile}`);
   console.log(`==================================================`);
 
   if (!url) {
@@ -408,7 +421,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
       ? Object.entries(headers).find(([k]) => k.toLowerCase() === 'user-agent')?.[1]
       : undefined;
 
-    const contextBundle = await createContext(skip_tls_verification, userAgentOverride);
+    const contextBundle = await createContext(skip_tls_verification, userAgentOverride, mobile);
     requestContext = contextBundle.context;
     securityState = contextBundle.securityState;
     page = await requestContext.newPage();


### PR DESCRIPTION
## Problem

On self-hosted deployments (the `playwright` engine, no fire-engine), any scrape with `mobile: true` fails instantly with `SCRAPE_ALL_ENGINES_FAILED` (`Engines tried: []`) before any browser launches. The `mobile` feature is only declared on the `fire-engine;*` engines in the feature matrix, so `buildFallbackList` selects no engine for a mobile request on self-hosted installs.

Closes #3744

## Changes

- **`engines/index.ts`** — declare `mobile: true` on the `playwright` engine so it's selected when the mobile flag is set.
- **`engines/playwright/index.ts`** — forward `mobile` from the engine adapter to the playwright-service.
- **`playwright-service/api.ts`** — apply mobile emulation in `createContext`: mobile viewport (390×844), `isMobile` / `hasTouch` / `deviceScaleFactor: 3`, and a mobile UA when the caller didn't pass one (a desktop UA alongside `isMobile` would still serve the desktop layout).

## Verification

Built the playwright-service + api images and confirmed `mobile: true` now returns a real mobile render (the page serves its mobile layout, not the desktop one) instead of `SCRAPE_ALL_ENGINES_FAILED`. Desktop scrapes are unchanged.

## Notes

Playwright supports mobile emulation natively, so no new dependency is required. This only adds a mobile path for the self-hosted `playwright` engine; fire-engine behavior is untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables mobile viewport emulation on self-hosted `playwright` and fixes `mobile: true` scrapes failing with “Engines tried: []”. Mobile requests now run on `playwright` and render a real mobile layout.

- **New Features**
  - Advertise `mobile: true` for the `playwright` engine so it’s selected for mobile scrapes.
  - Forward the `mobile` flag from the engine adapter to the `playwright-service`.
  - Apply Playwright mobile emulation in `createContext`: 390×844 viewport, `isMobile`, `hasTouch`, `deviceScaleFactor: 3`, and a default mobile UA when none is provided.

<sup>Written for commit 85f4baf21d9029aa287f75fe6fa3cc83286eaae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

