### PR TITLE
fix(map): rank search results by relevance before applying limit

### DIFF
--- a/apps/api/src/lib/__tests__/map-rank.test.ts
+++ b/apps/api/src/lib/__tests__/map-rank.test.ts
@@ -1,0 +1,38 @@
+import { rankAndCapMapResults } from "../map-rank";
+import { MapDocument } from "../../controllers/v2/types";
+
+describe("rankAndCapMapResults", () => {
+  const results: MapDocument[] = [
+    { url: "https://example.com/contact" },
+    { url: "https://example.com/about" },
+    { url: "https://example.com/blog/post-about-firecrawl" },
+  ];
+
+  it("ranks by relevance before applying the limit (#3335)", () => {
+    // The only relevant page sits at index 2, beyond the limit. Ranking must
+    // run before the cutoff, otherwise it is sliced away before being scored.
+    const out = rankAndCapMapResults(results, "blog post", 2);
+
+    expect(out.length).toBe(2);
+    expect(out.map(r => r.url)).toContain(
+      "https://example.com/blog/post-about-firecrawl",
+    );
+    // Most relevant result ranks first.
+    expect(out[0].url).toBe("https://example.com/blog/post-about-firecrawl");
+  });
+
+  it("preserves order and only applies the cutoff when there is no search", () => {
+    const out = rankAndCapMapResults(results, undefined, 2);
+
+    expect(out.map(r => r.url)).toEqual([
+      "https://example.com/contact",
+      "https://example.com/about",
+    ]);
+  });
+
+  it("returns all results when the limit is not exceeded", () => {
+    const out = rankAndCapMapResults(results, undefined, 10);
+
+    expect(out.length).toBe(results.length);
+  });
+});

--- a/apps/api/src/lib/map-rank.ts
+++ b/apps/api/src/lib/map-rank.ts
@@ -1,0 +1,27 @@
+import { MapDocument, MAX_MAP_LIMIT } from "../controllers/v2/types";
+import { performCosineSimilarityV2 } from "./map-cosine";
+
+/**
+ * Rank map results by relevance to the search query and cap them to the limit.
+ *
+ * When a search query is provided the cosine ranking must run *before* the
+ * cutoff: otherwise the slice keeps the first N links in their original
+ * (arbitrary) order, so relevant pages further down never get scored and are
+ * dropped before ranking. With no search query the order is preserved. (#3335)
+ */
+export function rankAndCapMapResults(
+  mapResults: MapDocument[],
+  search: string | undefined,
+  limit: number,
+): MapDocument[] {
+  if (search) {
+    mapResults = performCosineSimilarityV2(mapResults, search.toLowerCase());
+  }
+
+  const minimumCutoff = Math.min(MAX_MAP_LIMIT, limit);
+  if (mapResults.length > minimumCutoff) {
+    mapResults = mapResults.slice(0, minimumCutoff);
+  }
+
+  return mapResults;
+}

--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -21,7 +21,7 @@ import {
   queryIndexAtDomainSplitLevelWithMeta,
   queryIndexAtSplitLevelWithMeta,
 } from "../services/index";
-import { performCosineSimilarityV2 } from "./map-cosine";
+import { rankAndCapMapResults } from "./map-rank";
 import { Logger } from "winston";
 
 // Max Links that "Smart /map" can return
@@ -299,15 +299,7 @@ export async function getMapResults({
       );
     }
 
-    const minimumCutoff = Math.min(MAX_MAP_LIMIT, limit);
-    if (mapResults.length > minimumCutoff) {
-      mapResults = mapResults.slice(0, minimumCutoff);
-    }
-
-    if (search) {
-      const searchQuery = search.toLowerCase();
-      mapResults = performCosineSimilarityV2(mapResults, searchQuery);
-    }
+    mapResults = rankAndCapMapResults(mapResults, search, limit);
   }
 
   mapResults = mapResults


### PR DESCRIPTION
## Problem
Fixes #3335.

On `/v2/map` (and `/v1/map`) requests that pass both `search` and `limit`, the limit is applied **before** the cosine relevance ranking. In `getMapResults` the results were sliced to the cutoff first and only then re-ranked:

```ts
const minimumCutoff = Math.min(MAX_MAP_LIMIT, limit);
if (mapResults.length > minimumCutoff) {
  mapResults = mapResults.slice(0, minimumCutoff); // cut first…
}
if (search) {
  mapResults = performCosineSimilarityV2(mapResults, search.toLowerCase()); // …rank after
}
```

Because the slice keeps the first N links in their original (arbitrary) order, any page that sits lower in the initial ordering never gets scored — it is discarded before ranking. As reported in #3335, relevant results are missing whenever they fall outside the first N links.

## Solution
Run the relevance ranking **before** the cutoff, so the most relevant links bubble up and survive the limit. The ordering rule is extracted into a small pure helper, `rankAndCapMapResults`, to keep it in one place and make it testable:

- `search` present → cosine-rank, then cap to `min(MAX_MAP_LIMIT, limit)`
- no `search` → order preserved, cap only

No change to the public response shape or to the no-search path.

## Testing
Added `apps/api/src/lib/__tests__/map-rank.test.ts`:
- a relevant link positioned beyond the limit survives and ranks first (the #3335 regression)
- with no search query, original order is preserved and only the cutoff applies
- all results are returned when the limit is not exceeded

```
PASS src/lib/__tests__/map-rank.test.ts
  rankAndCapMapResults
    ✓ ranks by relevance before applying the limit (#3335)
    ✓ preserves order and only applies the cutoff when there is no search
    ✓ returns all results when the limit is not exceeded
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ranks map search results by relevance before enforcing the limit so relevant pages aren’t dropped. Fixes #3335 with no API or no-search behavior changes.

- **Bug Fixes**
  - Introduced `rankAndCapMapResults` to rank by cosine similarity when `search` is present, then cap to `min(MAX_MAP_LIMIT, limit)`; without `search`, preserve order and only cap.
  - Updated `/v2/map` and `/v1/map` to use the new helper.
  - Added unit tests to cover rank-before-limit, no-search order preservation, and non-exceeding limit cases.

<sup>Written for commit 6b0979f41879b52e1e5b24f1c122c8c8d2cefc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

