### PR TITLE
update deterministic json billing

### DIFF
--- a/apps/api/src/lib/scrape-billing.test.ts
+++ b/apps/api/src/lib/scrape-billing.test.ts
@@ -24,4 +24,66 @@ describe("calculateCreditsToBeBilled", () => {
 
     expect(credits).toBe(30);
   });
+
+  it("bills deterministic JSON at 10 credits when the script was generated", async () => {
+    const credits = await calculateCreditsToBeBilled(
+      {
+        formats: [{ type: "deterministicJson", schema: {} }],
+      } as any,
+      {
+        teamId: "team-id",
+      },
+      {
+        metadata: {
+          statusCode: 200,
+          proxyUsed: "basic",
+        },
+      } as any,
+      {
+        totalCost: 0.01,
+        calls: [
+          {
+            type: "other",
+            model: "vertex/gemini",
+            cost: 0.01,
+            metadata: { module: "deterministic-json", role: "codegen" },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    expect(credits).toBe(10);
+  });
+
+  it("bills deterministic JSON at 3 credits when a cached script was reused", async () => {
+    const credits = await calculateCreditsToBeBilled(
+      {
+        formats: [{ type: "deterministicJson", schema: {} }],
+      } as any,
+      {
+        teamId: "team-id",
+      },
+      {
+        metadata: {
+          statusCode: 200,
+          proxyUsed: "basic",
+        },
+      } as any,
+      {
+        totalCost: 0.001,
+        calls: [
+          {
+            type: "other",
+            model: "groq/llama",
+            cost: 0.001,
+            metadata: { module: "deterministic-json", role: "askLlm" },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    expect(credits).toBe(3);
+  });
 });

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -73,7 +73,14 @@ export async function calculateCreditsToBeBilled(
   }
 
   if (hasFormatOfType(options.formats, "deterministicJson")) {
-    creditsToBeBilled = 7;
+    // 10 when this run generated the extractor script, 3 when it reused a
+    // cached one. The codegen call is tagged in deterministicJson/llm/client.ts.
+    const generatedScript = costTrackingJSON.calls?.some(
+      call =>
+        call.metadata?.module === "deterministic-json" &&
+        call.metadata?.role === "codegen",
+    );
+    creditsToBeBilled = generatedScript ? 10 : 3;
   }
 
   if (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update billing for deterministic JSON: charge 10 credits when a new extractor script is generated, and 3 credits when a cached script is reused. Detection uses cost-tracking metadata to tell codegen from reuse.

- **New Features**
  - Billing now checks `costTrackingJSON.calls` for `{ module: "deterministic-json", role: "codegen" }` to select 10 vs 3 credits (was a flat 7).
  - Added tests covering both codegen and cached-script paths.

<sup>Written for commit 02b5ece83e6980a7eae496c95b05bc9185a1a54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

