### PR TITLE
fix(api): make default scrape timeout configurable

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -24,6 +24,10 @@ NUM_WORKERS_PER_QUEUE=8
 # Recommended: 8-16 for most setups, 32+ for high-performance servers
 CRAWL_CONCURRENT_REQUESTS=10
 
+# Default per-page scrape timeout in milliseconds. Individual API requests can
+# still override this with their timeout field.
+# SCRAPE_TIMEOUT_MS=30000
+
 # Maximum number of simultaneous crawl jobs
 # Controls how many crawl operations can run at the same time
 MAX_CONCURRENT_JOBS=5

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -26,6 +26,7 @@ import {
   updateMonitorSchema,
 } from "../../../services/monitoring/types";
 import { getNextMonitorRunAt } from "../../../services/monitoring/cron";
+import { DEFAULT_PROXY_SCRAPE_TIMEOUT_MS } from "../../../lib/scrape-timeout";
 
 describe("V2 Types Validation", () => {
   describe("scrapeRequestSchema", () => {
@@ -38,6 +39,7 @@ describe("V2 Types Validation", () => {
       expect(result.url).toBe("https://example.com");
       expect(result.origin).toBe("api");
       expect(result.formats).toEqual([{ type: "markdown" }]);
+      expect(result.timeout).toBe(DEFAULT_PROXY_SCRAPE_TIMEOUT_MS);
     });
 
     it("should accept valid scrape request with format objects", () => {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -118,6 +118,7 @@ const configSchema = z.object({
   SCRAPEURL_AB_RATE: z.coerce.number().optional(),
   SCRAPEURL_AB_EXTEND_MAXAGE: z.stringbool().optional(),
   SCRAPEURL_ENGINE_WATERFALL_DELAY_MS: z.coerce.number().default(0),
+  SCRAPE_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
 
   // Scrape Retry Limits
   SCRAPE_MAX_ATTEMPTS: z.coerce.number().int().positive().default(6),

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -17,6 +17,11 @@ import { integrationSchema } from "../../utils/integration";
 import { includesFormat } from "../../lib/format-utils";
 import { webhookSchema } from "../../services/webhook/schema";
 import { BrandingProfile } from "../../types/branding";
+import {
+  DEFAULT_JSON_SCRAPE_TIMEOUT_MS,
+  DEFAULT_PROXY_SCRAPE_TIMEOUT_MS,
+  DEFAULT_SCRAPE_TIMEOUT_MS,
+} from "../../lib/scrape-timeout";
 
 type Format =
   | "markdown"
@@ -551,14 +556,16 @@ const extractTransformRequired = <T extends ScrapeOptions>(obj: T): T => {
 
 const extractTransform = (obj: ScrapeOptions) => {
   // Handle timeout
+  obj = { ...obj, timeout: obj.timeout ?? DEFAULT_SCRAPE_TIMEOUT_MS };
+
   if (
     (includesFormat(obj.formats, "extract") ||
       obj.extract ||
       includesFormat(obj.formats, "json") ||
       obj.jsonOptions) &&
-    obj.timeout === 30000
+    obj.timeout === DEFAULT_SCRAPE_TIMEOUT_MS
   ) {
-    obj = { ...obj, timeout: 60000 };
+    obj = { ...obj, timeout: DEFAULT_JSON_SCRAPE_TIMEOUT_MS };
   }
 
   if (
@@ -568,8 +575,11 @@ const extractTransform = (obj: ScrapeOptions) => {
     obj = { ...obj, waitFor: 5000 };
   }
 
-  if (includesFormat(obj.formats, "changeTracking") && obj.timeout === 30000) {
-    obj = { ...obj, timeout: 60000 };
+  if (
+    includesFormat(obj.formats, "changeTracking") &&
+    obj.timeout === DEFAULT_SCRAPE_TIMEOUT_MS
+  ) {
+    obj = { ...obj, timeout: DEFAULT_JSON_SCRAPE_TIMEOUT_MS };
   }
 
   if ((obj as ScrapeOptions).agent) {
@@ -580,9 +590,9 @@ const extractTransform = (obj: ScrapeOptions) => {
     (obj.proxy === "stealth" ||
       obj.proxy === "enhanced" ||
       obj.proxy === "auto") &&
-    obj.timeout === 30000
+    obj.timeout === DEFAULT_SCRAPE_TIMEOUT_MS
   ) {
-    obj = { ...obj, timeout: 120000 };
+    obj = { ...obj, timeout: DEFAULT_PROXY_SCRAPE_TIMEOUT_MS };
   }
 
   if (includesFormat(obj.formats, "json")) {
@@ -626,11 +636,12 @@ const fire1Refine = (obj: ScrapeOptionsBase): boolean => {
 };
 
 const waitForRefine = (obj?: ScrapeOptionsBase): boolean => {
-  if (obj && obj.waitFor !== undefined && obj.timeout !== undefined) {
-    if (typeof obj.timeout !== "number" || obj.timeout <= 0) {
+  if (obj && obj.waitFor !== undefined) {
+    const timeout = obj.timeout ?? DEFAULT_SCRAPE_TIMEOUT_MS;
+    if (typeof timeout !== "number" || timeout <= 0) {
       return false;
     }
-    return obj.waitFor <= obj.timeout / 2;
+    return obj.waitFor <= timeout / 2;
   }
   return true;
 };
@@ -785,7 +796,7 @@ const scrapeRequestSchemaBase = baseScrapeOptions
     jsonOptions: extractOptionsWithAgent.optional(),
     origin: z.string().optional().prefault("api"),
     integration: integrationSchema.optional().transform(val => val || null),
-    timeout: z.int().positive().min(1000).prefault(30000),
+    timeout: z.int().positive().min(1000).prefault(DEFAULT_SCRAPE_TIMEOUT_MS),
     zeroDataRetention: z.boolean().optional(),
   })
   .strict();

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -26,6 +26,11 @@ import {
   createWebhookSchema,
 } from "../../services/webhook/schema";
 import { BrandingProfile } from "../../types/branding";
+import {
+  DEFAULT_JSON_SCRAPE_TIMEOUT_MS,
+  DEFAULT_PROXY_SCRAPE_TIMEOUT_MS,
+  DEFAULT_SCRAPE_TIMEOUT_MS,
+} from "../../lib/scrape-timeout";
 
 // Base URL schema with common validation logic
 export const URL = z.preprocess(
@@ -707,11 +712,12 @@ const baseScrapeOptions = z.strictObject({
 type ScrapeOptionsBase = z.infer<typeof baseScrapeOptions>;
 
 const waitForRefine = (obj?: ScrapeOptionsBase): boolean => {
-  if (obj && obj.waitFor && obj.timeout) {
-    if (typeof obj.timeout !== "number" || obj.timeout <= 0) {
+  if (obj && obj.waitFor !== undefined) {
+    const timeout = obj.timeout ?? DEFAULT_SCRAPE_TIMEOUT_MS;
+    if (typeof timeout !== "number" || timeout <= 0) {
       return false;
     }
-    return obj.waitFor <= obj.timeout / 2;
+    return obj.waitFor <= timeout / 2;
   }
   return true;
 };
@@ -727,12 +733,12 @@ const extractTransformImpl = <T extends ScrapeOptionsBase | undefined>(
 ): T extends undefined ? undefined : T => {
   if (!obj) return obj as T extends undefined ? undefined : T;
   // Handle timeout
-  let result = { ...obj };
+  let result = { ...obj, timeout: obj.timeout ?? DEFAULT_SCRAPE_TIMEOUT_MS };
   if (
     obj.formats.find(x => typeof x === "object" && x.type === "json") &&
-    obj.timeout === 30000
+    result.timeout === DEFAULT_SCRAPE_TIMEOUT_MS
   ) {
-    result = { ...result, timeout: 60000 };
+    result = { ...result, timeout: DEFAULT_JSON_SCRAPE_TIMEOUT_MS };
   }
 
   const changeTracking = obj.formats?.find(
@@ -743,17 +749,17 @@ const extractTransformImpl = <T extends ScrapeOptionsBase | undefined>(
     result = { ...result, waitFor: 5000 };
   }
 
-  if (changeTracking && obj.timeout === 30000) {
-    result = { ...result, timeout: 60000 };
+  if (changeTracking && result.timeout === DEFAULT_SCRAPE_TIMEOUT_MS) {
+    result = { ...result, timeout: DEFAULT_JSON_SCRAPE_TIMEOUT_MS };
   }
 
   if (
     (obj.proxy === "stealth" ||
       obj.proxy === "enhanced" ||
       obj.proxy === "auto") &&
-    obj.timeout === 30000
+    result.timeout === DEFAULT_SCRAPE_TIMEOUT_MS
   ) {
-    result = { ...result, timeout: 120000 };
+    result = { ...result, timeout: DEFAULT_PROXY_SCRAPE_TIMEOUT_MS };
   }
 
   if (obj.lockdown && obj.maxAge === undefined) {

--- a/apps/api/src/lib/default-values.ts
+++ b/apps/api/src/lib/default-values.ts
@@ -1,6 +1,8 @@
+import { DEFAULT_LEGACY_SCRAPE_TIMEOUT_MS } from "./scrape-timeout";
+
 export const defaultOrigin = "api";
 
-export const defaultTimeout = 60000; // 60 seconds
+export const defaultTimeout = DEFAULT_LEGACY_SCRAPE_TIMEOUT_MS;
 
 export const defaultPageOptions = {
   onlyMainContent: false,

--- a/apps/api/src/lib/scrape-timeout.test.ts
+++ b/apps/api/src/lib/scrape-timeout.test.ts
@@ -1,0 +1,23 @@
+describe("scrape timeout configuration", () => {
+  const originalScrapeTimeout = process.env.SCRAPE_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalScrapeTimeout === undefined) {
+      delete process.env.SCRAPE_TIMEOUT_MS;
+    } else {
+      process.env.SCRAPE_TIMEOUT_MS = originalScrapeTimeout;
+    }
+    jest.resetModules();
+  });
+
+  it("uses SCRAPE_TIMEOUT_MS when configured", async () => {
+    jest.resetModules();
+    process.env.SCRAPE_TIMEOUT_MS = "45000";
+
+    const { DEFAULT_LEGACY_SCRAPE_TIMEOUT_MS, DEFAULT_SCRAPE_TIMEOUT_MS } =
+      require("./scrape-timeout") as typeof import("./scrape-timeout.js");
+
+    expect(DEFAULT_SCRAPE_TIMEOUT_MS).toBe(45_000);
+    expect(DEFAULT_LEGACY_SCRAPE_TIMEOUT_MS).toBe(45_000);
+  });
+});

--- a/apps/api/src/lib/scrape-timeout.ts
+++ b/apps/api/src/lib/scrape-timeout.ts
@@ -1,0 +1,14 @@
+import { config } from "../config";
+
+export const DEFAULT_SCRAPE_TIMEOUT_MS = config.SCRAPE_TIMEOUT_MS ?? 30_000;
+export const DEFAULT_LEGACY_SCRAPE_TIMEOUT_MS =
+  config.SCRAPE_TIMEOUT_MS ?? 60_000;
+
+export const DEFAULT_JSON_SCRAPE_TIMEOUT_MS = Math.max(
+  DEFAULT_SCRAPE_TIMEOUT_MS,
+  60_000,
+);
+export const DEFAULT_PROXY_SCRAPE_TIMEOUT_MS = Math.max(
+  DEFAULT_SCRAPE_TIMEOUT_MS,
+  120_000,
+);


### PR DESCRIPTION
## Summary

Fixes #3751 by making the default scrape timeout configurable through `SCRAPE_TIMEOUT_MS`.

- adds `SCRAPE_TIMEOUT_MS` config/env support
- centralizes scrape timeout defaults
- applies the configured default before JSON/change-tracking/proxy timeout upgrades
- covers the config helper and v2 validation behavior

## Tests

- `npm run test -- --runInBand src/lib/scrape-timeout.test.ts`
- `npm run test -- --runInBand src/__tests__/snips/v2/types-validation.test.ts`
- `npx prettier --check src/lib/scrape-timeout.ts src/lib/scrape-timeout.test.ts src/controllers/v1/types.ts src/controllers/v2/types.ts src/config.ts src/lib/default-values.ts src/__tests__/snips/v2/types-validation.test.ts .env.example`
- `git diff --check`

Note: `npm run build` currently fails in this checkout because `@mendable/firecrawl-rs` workspace declarations are unavailable locally; the errors are outside the touched files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the default scrape timeout configurable via `SCRAPE_TIMEOUT_MS` and centralizes timeout logic used by v1/v2. Fixes #3751 while keeping longer timeouts for JSON and proxy scrapes.

- **Bug Fixes**
  - Added `SCRAPE_TIMEOUT_MS` to `config` and `.env.example`.
  - Introduced `lib/scrape-timeout` with base, JSON (≥60s), and proxy (≥120s) defaults; legacy default now derives from the base.
  - v1/v2 schemas now set a default `timeout` when missing, and only upgrade it for JSON/change-tracking/proxy when equal to the base default; `waitFor` validation uses the effective timeout.
  - Updated tests for v2 validation and new config behavior.

<sup>Written for commit ce40afbb2065c4f3091d0773f3a4966548ce55e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

