### PR TITLE
feat(api): emit api_surface_first_used PostHog milestone

### DIFF
--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -186,13 +186,16 @@ export async function logRequest(request: LoggedRequest) {
 
   // Emit a one-time PostHog milestone the first time this team uses each
   // surface (playground / sdk / mcp / cli / api / ...). Fire-and-forget.
-  trackFirstSurfaceUse({
-    teamId: request.team_id,
-    origin: request.origin,
-    kind: request.kind,
-    apiVersion: request.api_version,
-    apiKeyId: request.api_key_id,
-  });
+  // Skip zero-data-retention requests — don't send their metadata to PostHog.
+  if (!request.zeroDataRetention) {
+    trackFirstSurfaceUse({
+      teamId: request.team_id,
+      origin: request.origin,
+      kind: request.kind,
+      apiVersion: request.api_version,
+      apiKeyId: request.api_key_id,
+    });
+  }
 
   // Sanitize user-provided fields (most likely sources of null bytes)
   const sanitizedOrigin = sanitizeString(request.origin);

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -191,6 +191,7 @@ export async function logRequest(request: LoggedRequest) {
     origin: request.origin,
     kind: request.kind,
     apiVersion: request.api_version,
+    apiKeyId: request.api_key_id,
   });
 
   // Sanitize user-provided fields (most likely sources of null bytes)

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -20,6 +20,7 @@ import type { Document, ScrapeOptions } from "../../controllers/v2/types";
 import type { CostTracking } from "../../lib/cost-tracking";
 import type { Logger } from "winston";
 import { saveExtractResult } from "../../lib/extract/extract-redis";
+import { trackFirstSurfaceUse } from "../posthog";
 configDotenv();
 
 const previewTeamId = "3adefd26-77ec-5968-8dcf-c94b5630d1de";
@@ -181,6 +182,15 @@ export async function logRequest(request: LoggedRequest) {
     requestId: request.id,
     teamId: request.team_id,
     zeroDataRetention: request.zeroDataRetention,
+  });
+
+  // Emit a one-time PostHog milestone the first time this team uses each
+  // surface (playground / sdk / mcp / cli / api / ...). Fire-and-forget.
+  trackFirstSurfaceUse({
+    teamId: request.team_id,
+    origin: request.origin,
+    kind: request.kind,
+    apiVersion: request.api_version,
   });
 
   // Sanitize user-provided fields (most likely sources of null bytes)

--- a/apps/api/src/services/posthog.ts
+++ b/apps/api/src/services/posthog.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { redisEvictConnection } from "./redis";
 import { dbRr } from "../db/connection";
 import * as schema from "../db/schema";
@@ -90,7 +90,9 @@ async function resolveDistinctId(
       .select({ email: schema.users.email })
       .from(schema.api_keys)
       .leftJoin(schema.users, eq(schema.users.id, schema.api_keys.owner_id))
-      .where(eq(schema.api_keys.id, apiKeyId))
+      // Scope to the team so a stale/mismatched apiKeyId can't attribute this
+      // team's milestone to another team's owner email — falls back to teamId.
+      .where(and(eq(schema.api_keys.id, apiKeyId), eq(schema.api_keys.team_id, teamId)))
       .limit(1);
     return rows[0]?.email || teamId;
   } catch {
@@ -122,6 +124,11 @@ export function trackFirstSurfaceUse(args: {
   apiKeyId?: number | null;
 }): void {
   const { teamId, origin, kind, apiVersion, apiKeyId } = args;
+
+  // No PostHog key → capture is a no-op. Bail BEFORE the Redis SETNX so we don't
+  // burn the dedup marker without emitting (which would lose the milestone for
+  // good once PostHog is enabled).
+  if (!POSTHOG_API_KEY) return;
 
   // Skip anonymous / preview traffic — not a real team milestone.
   if (!teamId || teamId === "preview" || teamId.startsWith("preview_")) return;

--- a/apps/api/src/services/posthog.ts
+++ b/apps/api/src/services/posthog.ts
@@ -1,4 +1,7 @@
+import { eq } from "drizzle-orm";
 import { redisEvictConnection } from "./redis";
+import { dbRr } from "../db/connection";
+import * as schema from "../db/schema";
 import { logger as _logger } from "../lib/logger";
 
 /**
@@ -70,6 +73,32 @@ export function originToSurface(origin?: string | null): RequestSurface {
 }
 
 /**
+ * Resolve the PostHog distinct_id for a request. firecrawl-web identifies
+ * persons by email (`posthog.identify(user.email)`), so to attribute backend
+ * events to the same person we key on the API key owner's email. Falls back to
+ * the team_id (team-level) when the owner/email can't be resolved.
+ *
+ * Only called on the rare gated-first event, so the extra read is cheap.
+ */
+async function resolveDistinctId(
+  teamId: string,
+  apiKeyId?: number | null,
+): Promise<string> {
+  if (!apiKeyId) return teamId;
+  try {
+    const rows = await dbRr
+      .select({ email: schema.users.email })
+      .from(schema.api_keys)
+      .leftJoin(schema.users, eq(schema.users.id, schema.api_keys.owner_id))
+      .where(eq(schema.api_keys.id, apiKeyId))
+      .limit(1);
+    return rows[0]?.email || teamId;
+  } catch {
+    return teamId;
+  }
+}
+
+/**
  * Emit a one-time `api_surface_first_used` event the first time a team makes a
  * request from a given surface (playground / sdk / mcp / cli / api / ...).
  *
@@ -90,8 +119,9 @@ export function trackFirstSurfaceUse(args: {
   origin?: string | null;
   kind: string;
   apiVersion: string;
+  apiKeyId?: number | null;
 }): void {
-  const { teamId, origin, kind, apiVersion } = args;
+  const { teamId, origin, kind, apiVersion, apiKeyId } = args;
 
   // Skip anonymous / preview traffic — not a real team milestone.
   if (!teamId || teamId === "preview" || teamId.startsWith("preview_")) return;
@@ -104,7 +134,11 @@ export function trackFirstSurfaceUse(args: {
       const isFirst = await redisEvictConnection.set(key, "1", "NX");
       if (isFirst !== "OK") return;
 
-      capturePostHog("api_surface_first_used", teamId, {
+      // Key to the person (api-key owner email) so the event attributes to the
+      // same PostHog person the dashboard identifies, e.g. for experiments.
+      const distinctId = await resolveDistinctId(teamId, apiKeyId);
+
+      capturePostHog("api_surface_first_used", distinctId, {
         surface,
         raw_origin: origin ?? null,
         kind,

--- a/apps/api/src/services/posthog.ts
+++ b/apps/api/src/services/posthog.ts
@@ -1,0 +1,124 @@
+import { redisEvictConnection } from "./redis";
+import { logger as _logger } from "../lib/logger";
+
+/**
+ * Lightweight, dependency-free PostHog capture for the API.
+ *
+ * The API has no PostHog SDK wired up, so we POST directly to the capture
+ * endpoint. Everything here is best-effort and fire-and-forget: a missing key
+ * or a network error must never affect request handling.
+ *
+ * Configure via env:
+ *   POSTHOG_API_KEY  — project API key (if unset, capture is a no-op)
+ *   POSTHOG_HOST     — ingestion host (defaults to https://us.i.posthog.com)
+ */
+const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY;
+const POSTHOG_HOST = process.env.POSTHOG_HOST || "https://us.i.posthog.com";
+
+export function capturePostHog(
+  event: string,
+  distinctId: string,
+  properties: Record<string, unknown> = {},
+): void {
+  if (!POSTHOG_API_KEY) return;
+
+  // Fire-and-forget — do not await in the request path, never throw.
+  void (async () => {
+    try {
+      await fetch(`${POSTHOG_HOST.replace(/\/$/, "")}/capture/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          api_key: POSTHOG_API_KEY,
+          event,
+          distinct_id: distinctId,
+          properties,
+        }),
+      });
+    } catch (error) {
+      _logger.debug("PostHog capture failed", { module: "posthog", event, error });
+    }
+  })();
+}
+
+/** Normalized request surface, derived from the free-form `origin` field. */
+export type RequestSurface =
+  | "playground"
+  | "sdk"
+  | "mcp"
+  | "cli"
+  | "api"
+  | "monitor"
+  | "other";
+
+/**
+ * Map the free-form `origin` request field to a coarse surface category.
+ *
+ * `origin` is client-set (defaults to "api"); these are the values observed in
+ * practice. NOTE: confirm the exact strings sent by firecrawl-mcp and
+ * firecrawl-cli — adjust the prefixes below if they differ.
+ */
+export function originToSurface(origin?: string | null): RequestSurface {
+  const o = (origin ?? "").toLowerCase();
+  if (o === "website" || o.includes("playground")) return "playground";
+  if (o.startsWith("mcp")) return "mcp";
+  if (o.startsWith("cli") || o.includes("firecrawl-cli")) return "cli";
+  if (o.includes("sdk")) return "sdk"; // e.g. "api-sdk"
+  if (o.startsWith("monitor")) return "monitor";
+  if (o === "api") return "api";
+  return "other";
+}
+
+/**
+ * Emit a one-time `api_surface_first_used` event the first time a team makes a
+ * request from a given surface (playground / sdk / mcp / cli / api / ...).
+ *
+ * Dedup is a Redis SET NX (no DB change): the key is written once per
+ * (team, surface), so the event fires at most once per pair. Volume is bounded
+ * by #teams × #surfaces, independent of total request volume.
+ *
+ * Durability caveat: the marker lives on the evict Redis connection, so an
+ * eviction / flush can let the event re-fire for a team. That is acceptable for
+ * a milestone (PostHog `first_time_for_user` / min-timestamp analysis dedupes
+ * downstream). If exactly-once is ever required, back this with a Postgres
+ * table keyed on (team_id, surface) instead.
+ *
+ * Fire-and-forget: never awaited in the request path, never throws.
+ */
+export function trackFirstSurfaceUse(args: {
+  teamId: string;
+  origin?: string | null;
+  kind: string;
+  apiVersion: string;
+}): void {
+  const { teamId, origin, kind, apiVersion } = args;
+
+  // Skip anonymous / preview traffic — not a real team milestone.
+  if (!teamId || teamId === "preview" || teamId.startsWith("preview_")) return;
+
+  void (async () => {
+    try {
+      const surface = originToSurface(origin);
+      const key = `firecrawl:surface_first:${teamId}:${surface}`;
+      // SET key 1 NX → "OK" only the very first time; null otherwise. Atomic.
+      const isFirst = await redisEvictConnection.set(key, "1", "NX");
+      if (isFirst !== "OK") return;
+
+      capturePostHog("api_surface_first_used", teamId, {
+        surface,
+        raw_origin: origin ?? null,
+        kind,
+        api_version: apiVersion,
+        team_id: teamId,
+        // Associate with the PostHog `team` group for team-level analysis.
+        $groups: { team: teamId },
+      });
+    } catch (error) {
+      _logger.debug("trackFirstSurfaceUse failed", {
+        module: "posthog",
+        teamId,
+        error,
+      });
+    }
+  })();
+}


### PR DESCRIPTION
## What

Emits a one-time PostHog event — `api_surface_first_used` — the **first time a team makes a request from each surface** (playground / sdk / mcp / cli / api / monitor), derived from the existing free-form `origin` field that's already on every request and logged in `logRequest`. Useful for measuring per-surface adoption without a per-request event.

## How

- **`apps/api/src/services/posthog.ts`** (new):
  - `capturePostHog()` — dependency-free POST to `${POSTHOG_HOST}/capture/`, gated on `POSTHOG_API_KEY` (no-op if unset), fire-and-forget, never throws. (`POSTHOG_API_KEY`/`POSTHOG_HOST` already exist in `.env.example`.)
  - `originToSurface(origin)` — normalizes the free-form origin → `playground | sdk | mcp | cli | api | monitor | other`.
  - `trackFirstSurfaceUse()` — **Redis `SET NX`** keyed on `(team_id, surface)` → fires the event only on the genuine first. No DB change; volume bounded by `#teams × #surfaces`.
  - Person attribution: resolves the api-key owner's email (`api_keys.owner_id → users.email`, scoped to the team) for `distinct_id`; falls back to `team_id`.
- **`logRequest`** calls it fire-and-forget; skips preview/anonymous teams **and zero-data-retention requests**.

## UX / safety

- Fully off the request path: fire-and-forget on a persistent server; the owner-email lookup runs only on the gated-first event (read replica).
- `POSTHOG_API_KEY` is checked **before** the `SETNX`, so the dedup marker isn't burned without an event being emitted.
- Durability caveat (inline): the marker is on the evict Redis, so an eviction can rarely re-fire a milestone — acceptable for analytics; dedupe downstream via `first_time_for_user` / min-timestamp, or back with a Postgres `(team_id, surface)` table if exactly-once is needed.
- **MCP/CLI origins**: confirm the exact `origin` strings sent by `firecrawl-mcp` / `firecrawl-cli` and adjust the prefix map if needed.

## Test plan

- `POSTHOG_API_KEY` unset → no-op, request path unaffected, no marker written.
- Set → first request per `(team, surface)` emits one `api_surface_first_used`; subsequent same-surface requests don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)