### PR TITLE
fix(playwright-service): seed Cookie headers into the context cookie jar so they survive redirects

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -434,28 +434,52 @@ app.post('/scrape', async (req: Request, res: Response) => {
       // Seed Cookie header values into the context's cookie jar instead of
       // setExtraHTTPHeaders: Chromium re-generates redirected requests from
       // the jar, so extra-header cookies are silently dropped on any redirect
-      // hop (#3725). The leading-dot domain (minus a "www." prefix) keeps the
-      // cookies valid across sibling subdomains of the scraped host.
+      // hop (#3725).
       const cookieHeader = Object.entries(headers).find(
         ([k]) => k.toLowerCase() === 'cookie'
       )?.[1];
+
+      // Only drop the raw Cookie header from setExtraHTTPHeaders once it has
+      // actually been seeded into the jar; if seeding fails we keep the header
+      // so the cookie is at least sent on the initial (pre-redirect) request.
+      let cookieSeededIntoJar = false;
       if (cookieHeader) {
-        const cookieDomain = '.' + new URL(url).hostname.replace(/^www\./, '');
-        await requestContext.addCookies(
-          parseCookieHeader(cookieHeader).map(cookie => ({
-            ...cookie,
-            domain: cookieDomain,
-            path: '/',
-          }))
-        );
+        try {
+          const baseDomain = new URL(url).hostname.replace(/^www\./, '');
+          const cookies = parseCookieHeader(cookieHeader).map(cookie => {
+            // __Host- cookies must be host-only (no Domain attribute), Secure,
+            // and Path=/ per RFC 6265bis. Binding to the origin makes Chromium
+            // store them host-only with path '/'; a synthesized Domain would be
+            // rejected via CDP.
+            if (cookie.name.startsWith('__Host-')) {
+              return { ...cookie, url: new URL(url).origin, secure: true };
+            }
+            // The leading-dot domain (minus a "www." prefix) keeps cookies
+            // valid across sibling subdomains of the scraped host on redirects.
+            const scoped = { ...cookie, domain: '.' + baseDomain, path: '/' };
+            // __Secure- cookies are allowed a Domain but must carry Secure.
+            return cookie.name.startsWith('__Secure-')
+              ? { ...scoped, secure: true }
+              : scoped;
+          });
+          await requestContext.addCookies(cookies);
+          cookieSeededIntoJar = true;
+        } catch (error) {
+          console.warn(
+            `Failed to seed cookies into jar, falling back to Cookie header: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
       }
 
-      // Remove user-agent (forwarded to the context-level userAgent option)
-      // and cookie (seeded into the jar above) before setExtraHTTPHeaders.
+      // Remove user-agent (forwarded to the context-level userAgent option),
+      // and the cookie only if it was seeded into the jar above.
       const filteredHeaders = Object.fromEntries(
-        Object.entries(headers).filter(
-          ([k]) => k.toLowerCase() !== 'user-agent' && k.toLowerCase() !== 'cookie'
-        )
+        Object.entries(headers).filter(([k]) => {
+          const key = k.toLowerCase();
+          if (key === 'user-agent') return false;
+          if (key === 'cookie') return !cookieSeededIntoJar;
+          return true;
+        })
       );
       if (Object.keys(filteredHeaders).length > 0) {
         await page.setExtraHTTPHeaders(filteredHeaders);

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -275,6 +275,23 @@ const isValidUrl = (urlString: string): boolean => {
   }
 };
 
+const parseCookieHeader = (cookieHeader: string): { name: string; value: string }[] =>
+  cookieHeader
+    .split(';')
+    .map(pair => pair.trim())
+    .filter(Boolean)
+    .map(pair => {
+      const separatorIndex = pair.indexOf('=');
+      if (separatorIndex === -1) {
+        return { name: pair, value: '' };
+      }
+      return {
+        name: pair.slice(0, separatorIndex).trim(),
+        value: pair.slice(separatorIndex + 1).trim(),
+      };
+    })
+    .filter(cookie => cookie.name.length > 0);
+
 const scrapePage = async (
   page: Page,
   url: string,
@@ -414,10 +431,31 @@ app.post('/scrape', async (req: Request, res: Response) => {
     page = await requestContext.newPage();
 
     if (headers) {
-      // Remove the user-agent key before calling setExtraHTTPHeaders since
-      // we already forwarded it to the context-level userAgent option.
+      // Seed Cookie header values into the context's cookie jar instead of
+      // setExtraHTTPHeaders: Chromium re-generates redirected requests from
+      // the jar, so extra-header cookies are silently dropped on any redirect
+      // hop (#3725). The leading-dot domain (minus a "www." prefix) keeps the
+      // cookies valid across sibling subdomains of the scraped host.
+      const cookieHeader = Object.entries(headers).find(
+        ([k]) => k.toLowerCase() === 'cookie'
+      )?.[1];
+      if (cookieHeader) {
+        const cookieDomain = '.' + new URL(url).hostname.replace(/^www\./, '');
+        await requestContext.addCookies(
+          parseCookieHeader(cookieHeader).map(cookie => ({
+            ...cookie,
+            domain: cookieDomain,
+            path: '/',
+          }))
+        );
+      }
+
+      // Remove user-agent (forwarded to the context-level userAgent option)
+      // and cookie (seeded into the jar above) before setExtraHTTPHeaders.
       const filteredHeaders = Object.fromEntries(
-        Object.entries(headers).filter(([k]) => k.toLowerCase() !== 'user-agent')
+        Object.entries(headers).filter(
+          ([k]) => k.toLowerCase() !== 'user-agent' && k.toLowerCase() !== 'cookie'
+        )
       );
       if (Object.keys(filteredHeaders).length > 0) {
         await page.setExtraHTTPHeaders(filteredHeaders);


### PR DESCRIPTION
## Summary

Fixes #3725.

When a scrape request includes a `Cookie` in `headers`, the self-hosted playwright service applied it via `page.setExtraHTTPHeaders()`. Chromium attaches extra headers to the initial request only — redirected requests are regenerated from the context cookie jar, which is empty, so the `Cookie` header is silently dropped on any redirect hop. Authenticated pages that 302 before rendering (login redirects, sibling-subdomain hops, consent flows) come back as the login/consent page even though the scrape "succeeds".

## Changes

- Parse the incoming `Cookie` header and seed each cookie into the browser context via `context.addCookies()` before navigation, so Chromium re-sends them on every hop including redirects.
- Cookies are scoped to a leading-dot domain derived from the target hostname (minus any `www.` prefix), so they remain valid across sibling subdomains of the scraped host.
- Stop forwarding the raw `Cookie` key through `setExtraHTTPHeaders()` to avoid sending conflicting values (User-Agent handling is unchanged).

## Verification

Self-hosted via docker compose, scraping `https://httpbin.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fcookies` with `"headers": {"Cookie": "patchtest=hello123; second=works"}`:

- **Before:** `{"cookies": {}}` — cookies lost on the redirect hop
- **After:** `{"cookies": {"patchtest": "hello123", "second": "works"}}`

Also regression-tested a non-redirecting cookie scrape (Google consent cookie on chromewebstore.google.com) — unchanged behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `Cookie` headers persist across redirects in the self-hosted `playwright` service by seeding them into the browser context cookie jar, with proper handling for `__Host-`/`__Secure-` cookies. Fixes #3725 so authenticated/consent flows no longer drop you on login pages after a 302.

- **Bug Fixes**
  - Parse the `Cookie` header and add cookies to the context jar before navigation so Chromium sends them on every redirect.
  - Scope cookies to a leading-dot domain from the target host (without `www.`) to keep them valid across sibling subdomains.
  - Handle `__Host-` as host-only with `secure` and path `/`, and `__Secure-` as `secure` (Domain allowed).
  - Remove the raw `Cookie` header from extra headers only if seeding succeeds; otherwise keep it for the initial request. `User-Agent` handling is unchanged.

<sup>Written for commit 0233fe9e6d6a5eaa13725b419ee82e3ef884c0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

