### PR TITLE
fix(webhook): sign queued deliveries

### DIFF
--- a/apps/api/src/services/webhook/delivery.test.ts
+++ b/apps/api/src/services/webhook/delivery.test.ts
@@ -1,7 +1,22 @@
 import { WebhookEvent } from "./types";
-import { webhookEventMatchesFilter } from "./delivery";
+import { WebhookSender, webhookEventMatchesFilter } from "./delivery";
+import { buildWebhookDeliveryHeaders } from "./headers";
+import { webhookSchema } from "./schema";
+import { config } from "../../config";
+import { webhookQueue } from "./queue";
 
 describe("webhook delivery", () => {
+  const originalWebhookUseRabbitMq = config.WEBHOOK_USE_RABBITMQ;
+  const originalRabbitMqUrl = config.NUQ_RABBITMQ_URL;
+  const originalAllowLocalWebhooks = config.ALLOW_LOCAL_WEBHOOKS;
+
+  afterEach(() => {
+    config.WEBHOOK_USE_RABBITMQ = originalWebhookUseRabbitMq;
+    config.NUQ_RABBITMQ_URL = originalRabbitMqUrl;
+    config.ALLOW_LOCAL_WEBHOOKS = originalAllowLocalWebhooks;
+    jest.restoreAllMocks();
+  });
+
   describe("webhookEventMatchesFilter", () => {
     it("matches full monitor event names", () => {
       expect(
@@ -25,6 +40,135 @@ describe("webhook delivery", () => {
       expect(
         webhookEventMatchesFilter(["completed"], WebhookEvent.CRAWL_COMPLETED),
       ).toBe(true);
+    });
+  });
+
+  describe("buildWebhookDeliveryHeaders", () => {
+    const payload = {
+      success: true,
+      type: WebhookEvent.CRAWL_PAGE,
+      id: "crawl-123",
+      webhookId: "webhook-123",
+      data: [],
+    };
+
+    it("adds stable delivery metadata and a signature for direct delivery", () => {
+      const payloadString = JSON.stringify(payload);
+
+      expect(
+        buildWebhookDeliveryHeaders({
+          configHeaders: {
+            "X-Customer-Trace": "trace-1",
+            "x-firecrawl-event": "customer-event",
+          },
+          deliveryMode: "direct",
+          jobId: "crawl-123",
+          payload,
+          payloadString,
+          scrapeId: "scrape-123",
+          secret: "secret",
+        }),
+      ).toEqual({
+        "Content-Type": "application/json",
+        "X-Customer-Trace": "trace-1",
+        "X-Firecrawl-Webhook-Id": "webhook-123",
+        "X-Firecrawl-Event": WebhookEvent.CRAWL_PAGE,
+        "X-Firecrawl-Job-Id": "crawl-123",
+        "X-Firecrawl-Delivery-Mode": "direct",
+        "X-Firecrawl-Scrape-Id": "scrape-123",
+        "X-Firecrawl-Signature":
+          "sha256=29729c39fd5f57c6f4d50c86dd20256a5d77b7b39d19531c17805163fb830d40",
+      });
+    });
+
+    it("signs queued deliveries before publishing to RabbitMQ", () => {
+      const payloadString = JSON.stringify(payload);
+
+      const headers = buildWebhookDeliveryHeaders({
+        deliveryMode: "queued",
+        jobId: "crawl-123",
+        payload,
+        payloadString,
+        secret: "secret",
+      });
+
+      expect(headers["X-Firecrawl-Delivery-Mode"]).toBe("queued");
+      expect(headers["X-Firecrawl-Signature"]).toBe(
+        "sha256=29729c39fd5f57c6f4d50c86dd20256a5d77b7b39d19531c17805163fb830d40",
+      );
+    });
+  });
+
+  describe("webhookSchema", () => {
+    it("rejects attempts to override Firecrawl-managed delivery headers", () => {
+      const parsed = webhookSchema.safeParse({
+        url: "https://example.com/webhook",
+        headers: {
+          "x-firecrawl-webhook-id": "customer-value",
+        },
+      });
+
+      expect(parsed.success).toBe(false);
+    });
+  });
+
+  describe("WebhookSender", () => {
+    it("publishes queued deliveries with signed Firecrawl metadata headers", async () => {
+      config.WEBHOOK_USE_RABBITMQ = true;
+      config.NUQ_RABBITMQ_URL = "amqp://rabbitmq";
+      config.ALLOW_LOCAL_WEBHOOKS = true;
+      const publish = jest
+        .spyOn(webhookQueue, "publish")
+        .mockResolvedValue(undefined);
+
+      const sender = new WebhookSender(
+        {
+          url: "https://example.com/webhook",
+          headers: {
+            "X-Customer-Trace": "trace-1",
+            "x-firecrawl-job-id": "customer-job",
+          },
+          metadata: {},
+          events: [],
+        },
+        "secret",
+        { teamId: "team-123", jobId: "crawl-123", v0: false },
+      );
+
+      const result = await sender.send(WebhookEvent.CRAWL_PAGE, {
+        success: true,
+        data: [],
+        scrapeId: "scrape-123",
+        awaitWebhook: true,
+      });
+
+      expect(result).toEqual({
+        attempted: true,
+        delivered: false,
+        queued: true,
+      });
+      expect(publish).toHaveBeenCalledTimes(1);
+      const [message] = publish.mock.calls[0];
+      expect(message).toMatchObject({
+        webhook_url: "https://example.com/webhook",
+        team_id: "team-123",
+        job_id: "crawl-123",
+        scrape_id: "scrape-123",
+        event: WebhookEvent.CRAWL_PAGE,
+      });
+      expect(message.payload.webhookId).toEqual(expect.any(String));
+      expect(message.headers["X-Customer-Trace"]).toBe("trace-1");
+      expect(message.headers["x-firecrawl-job-id"]).toBeUndefined();
+      expect(message.headers["X-Firecrawl-Webhook-Id"]).toBe(
+        message.payload.webhookId,
+      );
+      expect(message.headers["X-Firecrawl-Event"]).toBe(
+        WebhookEvent.CRAWL_PAGE,
+      );
+      expect(message.headers["X-Firecrawl-Job-Id"]).toBe("crawl-123");
+      expect(message.headers["X-Firecrawl-Scrape-Id"]).toBe("scrape-123");
+      expect(message.headers["X-Firecrawl-Delivery-Mode"]).toBe("queued");
+      expect(message.headers["X-Firecrawl-Signature"]).toMatch(/^sha256=/);
     });
   });
 });

--- a/apps/api/src/services/webhook/delivery.ts
+++ b/apps/api/src/services/webhook/delivery.ts
@@ -1,6 +1,5 @@
 import undici from "undici";
 import { config } from "../../config";
-import { createHmac } from "crypto";
 import { logger as _logger, logger } from "../../lib/logger";
 import {
   getSecureDispatcherNoCookies,
@@ -17,6 +16,7 @@ import { db } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { webhookQueue } from "./queue";
 import { randomUUID } from "crypto";
+import { buildWebhookDeliveryHeaders } from "./headers";
 
 const WEBHOOK_INSERT_QUEUE_KEY = "webhook-insert-queue";
 const WEBHOOK_INSERT_BATCH_SIZE = 1000;
@@ -127,11 +127,21 @@ export class WebhookSender {
       return { delivered: false, skipped: true };
     }
 
+    const payloadString = JSON.stringify(payload);
+
     if (this.usesWebhookQueue()) {
       const queueMessage: WebhookQueueMessage = {
         webhook_url: this.config.url,
         payload,
-        headers: this.config.headers,
+        headers: buildWebhookDeliveryHeaders({
+          configHeaders: this.config.headers,
+          deliveryMode: "queued",
+          jobId: this.context.jobId,
+          payload,
+          payloadString,
+          scrapeId,
+          secret: this.secret,
+        }),
         team_id: this.context.teamId,
         job_id: this.context.jobId,
         scrape_id: scrapeId ?? null,
@@ -156,17 +166,15 @@ export class WebhookSender {
       return { delivered: false, queued: true };
     }
 
-    const payloadString = JSON.stringify(payload);
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      ...this.config.headers,
-    };
-
-    if (this.secret) {
-      const hmac = createHmac("sha256", this.secret);
-      hmac.update(payloadString);
-      headers["X-Firecrawl-Signature"] = `sha256=${hmac.digest("hex")}`;
-    }
+    const headers = buildWebhookDeliveryHeaders({
+      configHeaders: this.config.headers,
+      deliveryMode: "direct",
+      jobId: this.context.jobId,
+      payload,
+      payloadString,
+      scrapeId,
+      secret: this.secret,
+    });
 
     const abortController = new AbortController();
     const timeoutHandle = setTimeout(

--- a/apps/api/src/services/webhook/headers.ts
+++ b/apps/api/src/services/webhook/headers.ts
@@ -1,0 +1,57 @@
+import { createHmac } from "crypto";
+
+export const FIRECRAWL_MANAGED_WEBHOOK_HEADERS = [
+  "X-Firecrawl-Signature",
+  "X-Firecrawl-Webhook-Id",
+  "X-Firecrawl-Event",
+  "X-Firecrawl-Job-Id",
+  "X-Firecrawl-Scrape-Id",
+  "X-Firecrawl-Delivery-Mode",
+] as const;
+
+const FIRECRAWL_MANAGED_WEBHOOK_HEADERS_LOWER =
+  FIRECRAWL_MANAGED_WEBHOOK_HEADERS.map(header => header.toLowerCase());
+
+export function isFirecrawlManagedWebhookHeader(header: string): boolean {
+  return FIRECRAWL_MANAGED_WEBHOOK_HEADERS_LOWER.includes(header.toLowerCase());
+}
+
+export function buildWebhookDeliveryHeaders(params: {
+  configHeaders?: Record<string, string>;
+  deliveryMode: "direct" | "queued";
+  jobId: string;
+  payload: {
+    type: string;
+    webhookId: string;
+  };
+  payloadString: string;
+  scrapeId?: string;
+  secret?: string;
+}): Record<string, string> {
+  const customerHeaders = Object.fromEntries(
+    Object.entries(params.configHeaders ?? {}).filter(
+      ([header]) => !isFirecrawlManagedWebhookHeader(header),
+    ),
+  );
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...customerHeaders,
+    "X-Firecrawl-Webhook-Id": params.payload.webhookId,
+    "X-Firecrawl-Event": params.payload.type,
+    "X-Firecrawl-Job-Id": params.jobId,
+    "X-Firecrawl-Delivery-Mode": params.deliveryMode,
+  };
+
+  if (params.scrapeId) {
+    headers["X-Firecrawl-Scrape-Id"] = params.scrapeId;
+  }
+
+  if (params.secret) {
+    const hmac = createHmac("sha256", params.secret);
+    hmac.update(params.payloadString);
+    headers["X-Firecrawl-Signature"] = `sha256=${hmac.digest("hex")}`;
+  }
+
+  return headers;
+}

--- a/apps/api/src/services/webhook/schema.ts
+++ b/apps/api/src/services/webhook/schema.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
+import {
+  FIRECRAWL_MANAGED_WEBHOOK_HEADERS,
+  isFirecrawlManagedWebhookHeader,
+} from "./headers";
 
-const BLACKLISTED_WEBHOOK_HEADERS = ["x-firecrawl-signature"];
+const BLACKLISTED_WEBHOOK_HEADERS = [...FIRECRAWL_MANAGED_WEBHOOK_HEADERS];
 
 export function createWebhookSchema<T extends [string, ...string[]]>(
   events: T,
 ) {
-  const blacklistedLower = BLACKLISTED_WEBHOOK_HEADERS.map(h =>
-    h.toLowerCase(),
-  );
   return z.preprocess(
     x => (typeof x === "string" ? { url: x } : x),
     z
@@ -18,10 +19,7 @@ export function createWebhookSchema<T extends [string, ...string[]]>(
         events: z.array(z.enum(events)).prefault([...events]),
       })
       .refine(
-        obj =>
-          !Object.keys(obj.headers).some(key =>
-            blacklistedLower.includes(key.toLowerCase()),
-          ),
+        obj => !Object.keys(obj.headers).some(isFirecrawlManagedWebhookHeader),
         `The following headers are not allowed: ${BLACKLISTED_WEBHOOK_HEADERS.join(", ")}`,
       ),
   );


### PR DESCRIPTION
Queued webhook deliveries currently do not carry the same Firecrawl signature headers as direct deliveries. This makes verification behavior differ depending on whether RabbitMQ is enabled.

This PR adds a shared webhook header builder, signs direct and queued deliveries through the same path, and prevents user-provided webhook headers from overriding Firecrawl-owned signature headers.

Changes:
- add a shared helper for Firecrawl webhook delivery headers
- include signed headers in RabbitMQ webhook jobs
- reject/ignore Firecrawl-owned header overrides from user webhook config
- add tests for direct delivery, queued delivery, and header override behavior

Checks run locally:
- pnpm --filter @mendable/firecrawl-api test -- delivery.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queued webhook deliveries now include the same Firecrawl HMAC signature and metadata headers as direct deliveries. Verification is now consistent whether RabbitMQ is enabled or not.

- **Bug Fixes**
  - Added a shared `buildWebhookDeliveryHeaders` helper to sign payloads and set headers for both direct and queued paths.
  - Prevented user-configured headers from overriding Firecrawl-managed headers; schema now rejects these overrides.
  - Added tests for direct delivery, queued delivery, and header override behavior.

<sup>Written for commit 5baaeb97b3ec880deecc872f13d1ae738829b03c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

