### PR TITLE
feat(test-suite): add extraction quality regression suite

### DIFF
--- a/apps/test-suite/extraction-quality/README.md
+++ b/apps/test-suite/extraction-quality/README.md
@@ -1,0 +1,51 @@
+# Extraction Quality Benchmark
+
+This benchmark helps score web data extraction results before they are used for RAG ingestion, search indexes, or downstream agents.
+
+It is intentionally independent of Firecrawl internals. A test case gives the benchmark an `actual` extraction result and an `expected` contract. The scorer reports where the extraction failed instead of returning a single opaque pass or fail.
+
+## What It Scores
+
+- Required structured fields such as `company.name` or `jobs.0.title`
+- Fuzzy expected values for fields that may be worded slightly differently
+- Table or collection coverage, including minimum row counts and required columns
+- Markdown section evidence
+- Markdown preservation for headings, lists, links, and code blocks
+
+## Run
+
+```bash
+cd apps/test-suite
+pnpm test:extraction-quality
+node extraction-quality/run-benchmark.mjs
+```
+
+You can pass one or more case files to run a focused benchmark:
+
+```bash
+node extraction-quality/run-benchmark.mjs extraction-quality/fixtures/careers-page.json
+```
+
+## Case Shape
+
+```json
+{
+  "name": "SPA careers page extraction",
+  "url": "https://example.com/careers",
+  "actual": {
+    "company": { "name": "Example Robotics" },
+    "jobs": [{ "title": "Robotics Software Engineer" }],
+    "markdown": "# Careers\n\n- Robotics Software Engineer"
+  },
+  "expected": {
+    "minScore": 0.9,
+    "requiredFields": ["company.name", "jobs.0.title"],
+    "values": [{ "path": "jobs.0.title", "value": "Robotics Software Engineer" }],
+    "tables": [{ "path": "jobs", "minRows": 1, "requiredColumns": ["title"] }],
+    "sections": ["Careers"],
+    "markdown": { "headings": true, "lists": true }
+  }
+}
+```
+
+This gives contributors and maintainers a place to add small, reproducible extraction fixtures when a site shape regresses.

--- a/apps/test-suite/extraction-quality/README.md
+++ b/apps/test-suite/extraction-quality/README.md
@@ -17,7 +17,7 @@ It is intentionally independent of Firecrawl internals. A test case gives the be
 ```bash
 cd apps/test-suite
 pnpm test:extraction-quality
-node extraction-quality/run-benchmark.mjs
+pnpm benchmark:extraction-quality
 ```
 
 You can pass one or more case files to run a focused benchmark:
@@ -25,6 +25,41 @@ You can pass one or more case files to run a focused benchmark:
 ```bash
 node extraction-quality/run-benchmark.mjs extraction-quality/fixtures/careers-page.json
 ```
+
+To run the full manifest without using the package script:
+
+```bash
+node extraction-quality/run-benchmark.mjs \
+  --manifest extraction-quality/manifest.json \
+  --baseline extraction-quality/baselines/current.json \
+  --output-json extraction-quality/results/latest.json \
+  --output-markdown extraction-quality/results/latest.md
+```
+
+The manifest run writes a JSON artifact for CI and a Markdown report for humans. It fails when a case fails its `minScore`, when the suite breaks its gates, or when a case drops more than the allowed score delta from the baseline.
+
+## Regression Gates
+
+`manifest.json` defines suite-level gates:
+
+- `minAverageScore`: minimum average score across all cases
+- `maxFailedCases`: maximum number of failed fixtures allowed
+
+The CLI also accepts:
+
+- `--baseline`: previous benchmark summary to compare against
+- `--max-score-drop`: maximum allowed per-case score drop before flagging a regression
+- `--min-average-score`: override the manifest average score gate
+- `--max-failed-cases`: override the manifest failed case gate
+
+This catches subtle regressions where the suite still passes overall but a specific extraction surface gets worse.
+
+## Included Scenarios
+
+- Careers page extraction: structured roles plus markdown evidence
+- Pricing table extraction: plan rows, nested feature lists, and preserved links
+- API docs extraction: endpoint metadata, parameter tables, links, and code blocks
+- Noisy SPA careers extraction: script-heavy markdown with job data and mailto links
 
 ## Case Shape
 

--- a/apps/test-suite/extraction-quality/baselines/current.json
+++ b/apps/test-suite/extraction-quality/baselines/current.json
@@ -1,0 +1,31 @@
+{
+  "summary": {
+    "cases": 4,
+    "passed": 4,
+    "failed": 0,
+    "averageScore": 1,
+    "failedByMetric": {},
+    "results": [
+      {
+        "name": "SPA careers page extraction",
+        "score": 1,
+        "passed": true
+      },
+      {
+        "name": "SaaS pricing table extraction",
+        "score": 1,
+        "passed": true
+      },
+      {
+        "name": "API docs extraction",
+        "score": 1,
+        "passed": true
+      },
+      {
+        "name": "Noisy SPA careers extraction",
+        "score": 1,
+        "passed": true
+      }
+    ]
+  }
+}

--- a/apps/test-suite/extraction-quality/fixtures/careers-page.json
+++ b/apps/test-suite/extraction-quality/fixtures/careers-page.json
@@ -1,0 +1,51 @@
+{
+  "name": "SPA careers page extraction",
+  "url": "https://example.com/careers",
+  "actual": {
+    "company": {
+      "name": "Example Robotics"
+    },
+    "jobs": [
+      {
+        "title": "Robotics Software Engineer",
+        "team": "Autonomy",
+        "location": "San Francisco"
+      },
+      {
+        "title": "Search Infrastructure Engineer",
+        "team": "Data",
+        "location": "Remote"
+      }
+    ],
+    "markdown": "# Careers\n\n## Open roles\n\n- Robotics Software Engineer\n- Search Infrastructure Engineer\n\n```json\n{\"department\":\"Autonomy\"}\n```"
+  },
+  "expected": {
+    "minScore": 0.9,
+    "requiredFields": ["company.name", "jobs.0.title", "jobs.0.location", "jobs.1.title"],
+    "values": [
+      {
+        "path": "jobs.0.title",
+        "value": "Robotics Software Engineer",
+        "threshold": 0.8
+      },
+      {
+        "path": "jobs.1.team",
+        "value": "Data",
+        "threshold": 0.8
+      }
+    ],
+    "tables": [
+      {
+        "path": "jobs",
+        "minRows": 2,
+        "requiredColumns": ["title", "team", "location"]
+      }
+    ],
+    "sections": ["Careers", "Open roles"],
+    "markdown": {
+      "headings": true,
+      "lists": true,
+      "codeBlocks": true
+    }
+  }
+}

--- a/apps/test-suite/extraction-quality/fixtures/docs-api-page.json
+++ b/apps/test-suite/extraction-quality/fixtures/docs-api-page.json
@@ -1,0 +1,68 @@
+{
+  "name": "API docs extraction",
+  "url": "https://example.com/docs/api/scrape",
+  "actual": {
+    "product": {
+      "name": "Example API"
+    },
+    "endpoint": {
+      "method": "POST",
+      "path": "/v1/scrape",
+      "auth": "Bearer token"
+    },
+    "parameters": [
+      {
+        "name": "url",
+        "type": "string",
+        "required": true
+      },
+      {
+        "name": "formats",
+        "type": "array",
+        "required": false
+      },
+      {
+        "name": "timeout",
+        "type": "number",
+        "required": false
+      }
+    ],
+    "markdown": "# Scrape API\n\nSend a `POST /v1/scrape` request with a target URL.\n\n```bash\ncurl -X POST https://api.example.com/v1/scrape\n```\n\n## Parameters\n\n- `url` string required\n- `formats` array optional\n- `timeout` number optional\n\n[API reference](/docs/api)"
+  },
+  "expected": {
+    "minScore": 0.93,
+    "requiredFields": [
+      "product.name",
+      "endpoint.method",
+      "endpoint.path",
+      "parameters.0.name",
+      "parameters.0.required"
+    ],
+    "values": [
+      {
+        "path": "endpoint.path",
+        "value": "/v1/scrape",
+        "threshold": 0.75
+      },
+      {
+        "path": "parameters.1.name",
+        "value": "formats",
+        "threshold": 0.8
+      }
+    ],
+    "tables": [
+      {
+        "path": "parameters",
+        "minRows": 3,
+        "requiredColumns": ["name", "type", "required"]
+      }
+    ],
+    "sections": ["Scrape API", "Parameters"],
+    "markdown": {
+      "headings": true,
+      "lists": true,
+      "links": true,
+      "codeBlocks": true
+    }
+  }
+}

--- a/apps/test-suite/extraction-quality/fixtures/noisy-spa-careers.json
+++ b/apps/test-suite/extraction-quality/fixtures/noisy-spa-careers.json
@@ -1,0 +1,53 @@
+{
+  "name": "Noisy SPA careers extraction",
+  "url": "https://example.com/jobs",
+  "actual": {
+    "company": {
+      "name": "Example Agents"
+    },
+    "jobs": [
+      {
+        "title": "Founding AI Infrastructure Engineer",
+        "team": "Platform",
+        "location": "San Francisco or Remote",
+        "requirements": ["LLM serving", "observability", "distributed systems"]
+      },
+      {
+        "title": "Product Engineer",
+        "team": "Web",
+        "location": "New York",
+        "requirements": ["React", "TypeScript"]
+      }
+    ],
+    "markdown": "# Careers\n\n<script>window.__jobs = true</script>\n\n## Engineering\n\n- Founding AI Infrastructure Engineer\n- Product Engineer\n\nApply at [jobs@example.com](mailto:jobs@example.com)"
+  },
+  "expected": {
+    "minScore": 0.9,
+    "requiredFields": ["company.name", "jobs.0.title", "jobs.0.location", "jobs.0.requirements", "jobs.1.title"],
+    "values": [
+      {
+        "path": "jobs.0.title",
+        "value": "Founding AI Infrastructure Engineer",
+        "threshold": 0.8
+      },
+      {
+        "path": "jobs.0.requirements",
+        "value": "LLM serving observability distributed systems",
+        "threshold": 0.45
+      }
+    ],
+    "tables": [
+      {
+        "path": "jobs",
+        "minRows": 2,
+        "requiredColumns": ["title", "team", "location", "requirements"]
+      }
+    ],
+    "sections": ["Careers", "Engineering"],
+    "markdown": {
+      "headings": true,
+      "lists": true,
+      "links": true
+    }
+  }
+}

--- a/apps/test-suite/extraction-quality/fixtures/pricing-table.json
+++ b/apps/test-suite/extraction-quality/fixtures/pricing-table.json
@@ -1,0 +1,58 @@
+{
+  "name": "SaaS pricing table extraction",
+  "url": "https://example.com/pricing",
+  "actual": {
+    "company": {
+      "name": "Example Cloud"
+    },
+    "plans": [
+      {
+        "name": "Starter",
+        "price": "$29",
+        "billingPeriod": "month",
+        "features": ["10k pages", "basic support"]
+      },
+      {
+        "name": "Scale",
+        "price": "$199",
+        "billingPeriod": "month",
+        "features": ["500k pages", "priority queue", "webhooks"]
+      },
+      {
+        "name": "Enterprise",
+        "price": "Custom",
+        "billingPeriod": "annual",
+        "features": ["dedicated cluster", "SAML", "SLA"]
+      }
+    ],
+    "markdown": "# Pricing\n\n| Plan | Price | Includes |\n|---|---:|---|\n| Starter | $29/mo | 10k pages |\n| Scale | $199/mo | 500k pages, webhooks |\n| Enterprise | Custom | SAML, SLA |\n\n[Contact sales](/contact)"
+  },
+  "expected": {
+    "minScore": 0.92,
+    "requiredFields": ["company.name", "plans.0.name", "plans.0.price", "plans.1.features", "plans.2.price"],
+    "values": [
+      {
+        "path": "plans.1.name",
+        "value": "Scale",
+        "threshold": 0.8
+      },
+      {
+        "path": "plans.2.features",
+        "value": "dedicated cluster SAML SLA",
+        "threshold": 0.45
+      }
+    ],
+    "tables": [
+      {
+        "path": "plans",
+        "minRows": 3,
+        "requiredColumns": ["name", "price", "billingPeriod", "features"]
+      }
+    ],
+    "sections": ["Pricing", "Starter", "Enterprise"],
+    "markdown": {
+      "headings": true,
+      "links": true
+    }
+  }
+}

--- a/apps/test-suite/extraction-quality/manifest.json
+++ b/apps/test-suite/extraction-quality/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "firecrawl-extraction-regression-suite",
+  "gates": {
+    "minAverageScore": 0.9,
+    "maxFailedCases": 0
+  },
+  "suites": [
+    {
+      "name": "structured-extraction",
+      "cases": [
+        "fixtures/careers-page.json",
+        "fixtures/pricing-table.json",
+        "fixtures/docs-api-page.json",
+        "fixtures/noisy-spa-careers.json"
+      ]
+    }
+  ]
+}

--- a/apps/test-suite/extraction-quality/run-benchmark.mjs
+++ b/apps/test-suite/extraction-quality/run-benchmark.mjs
@@ -147,6 +147,10 @@ const args = parseArgs(process.argv.slice(2));
 const runConfig = await collectRunConfig(args);
 const results = [];
 
+if (runConfig.caseFiles.length === 0) {
+  throw new Error(`No benchmark cases found for suite "${runConfig.name}"`);
+}
+
 for (const file of runConfig.caseFiles) {
   const benchmarkCase = await readBenchmarkCase(file);
   results.push(evaluateExtraction(benchmarkCase));

--- a/apps/test-suite/extraction-quality/run-benchmark.mjs
+++ b/apps/test-suite/extraction-quality/run-benchmark.mjs
@@ -1,28 +1,186 @@
 #!/usr/bin/env node
 
-import { readdir } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { evaluateExtraction, readBenchmarkCase, summarize } from "./scorer.mjs";
+import {
+  applyGates,
+  compareToBaseline,
+  evaluateExtraction,
+  readBenchmarkCase,
+  summarize,
+} from "./scorer.mjs";
 
-async function collectCaseFiles(args) {
-  if (args.length > 0) return args;
+const DEFAULT_FIXTURE_DIR = path.join(import.meta.dirname, "fixtures");
 
-  const fixtureDir = path.join(import.meta.dirname, "fixtures");
-  const entries = await readdir(fixtureDir);
-  return entries.filter((entry) => entry.endsWith(".json")).map((entry) => path.join(fixtureDir, entry));
+function parseArgs(argv) {
+  const args = {
+    files: [],
+    manifest: null,
+    baseline: null,
+    outputJson: null,
+    outputMarkdown: null,
+    maxScoreDrop: 0.02,
+    minAverageScore: null,
+    maxFailedCases: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--manifest") args.manifest = argv[++index];
+    else if (arg === "--baseline") args.baseline = argv[++index];
+    else if (arg === "--output-json") args.outputJson = argv[++index];
+    else if (arg === "--output-markdown") args.outputMarkdown = argv[++index];
+    else if (arg === "--max-score-drop") args.maxScoreDrop = Number(argv[++index]);
+    else if (arg === "--min-average-score") args.minAverageScore = Number(argv[++index]);
+    else if (arg === "--max-failed-cases") args.maxFailedCases = Number(argv[++index]);
+    else if (arg.startsWith("--")) throw new Error(`Unknown argument: ${arg}`);
+    else args.files.push(arg);
+  }
+
+  return args;
 }
 
-const files = await collectCaseFiles(process.argv.slice(2));
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+async function collectDefaultCaseFiles() {
+  const entries = await readdir(DEFAULT_FIXTURE_DIR);
+  return entries.filter((entry) => entry.endsWith(".json")).map((entry) => path.join(DEFAULT_FIXTURE_DIR, entry));
+}
+
+async function collectManifestCaseFiles(manifestPath) {
+  const manifest = await readJson(manifestPath);
+  const manifestDir = path.dirname(manifestPath);
+  const suites = manifest.suites ?? [];
+  const caseFiles = [];
+
+  for (const suite of suites) {
+    for (const caseFile of suite.cases ?? []) {
+      caseFiles.push(path.resolve(manifestDir, caseFile));
+    }
+  }
+
+  return {
+    name: manifest.name ?? path.basename(manifestPath),
+    caseFiles,
+    gates: manifest.gates ?? {},
+  };
+}
+
+async function collectRunConfig(args) {
+  if (args.manifest) return collectManifestCaseFiles(args.manifest);
+  if (args.files.length > 0) {
+    return {
+      name: "custom",
+      caseFiles: args.files.map((file) => path.resolve(file)),
+      gates: {},
+    };
+  }
+  return {
+    name: "default",
+    caseFiles: await collectDefaultCaseFiles(),
+    gates: {},
+  };
+}
+
+function resultStatus(result) {
+  return result.passed ? "pass" : "fail";
+}
+
+function buildMarkdownReport(payload) {
+  const lines = [
+    "# Extraction Quality Benchmark",
+    "",
+    `Suite: ${payload.name}`,
+    "",
+    "| Case | Status | Score | Min score | Failures |",
+    "|---|---:|---:|---:|---|",
+  ];
+
+  for (const result of payload.summary.results) {
+    const failures = (result.failures ?? []).map((failure) => failure.message).join("<br>");
+    lines.push(
+      `| ${result.name} | ${resultStatus(result)} | ${result.score.toFixed(4)} | ${result.minScore.toFixed(4)} | ${failures || "none"} |`,
+    );
+  }
+
+  lines.push("", "## Summary", "");
+  lines.push(`- Cases: ${payload.summary.cases}`);
+  lines.push(`- Passed: ${payload.summary.passed}`);
+  lines.push(`- Failed: ${payload.summary.failed}`);
+  lines.push(`- Average score: ${payload.summary.averageScore.toFixed(4)}`);
+
+  const failedMetrics = Object.entries(payload.summary.failedByMetric ?? {});
+  if (failedMetrics.length > 0) {
+    lines.push("", "## Failure taxonomy", "");
+    for (const [metric, count] of failedMetrics) {
+      lines.push(`- ${metric}: ${count}`);
+    }
+  }
+
+  if (payload.regressions.length > 0) {
+    lines.push("", "## Baseline regressions", "");
+    for (const regression of payload.regressions) {
+      lines.push(
+        `- ${regression.name}: ${regression.previousScore.toFixed(4)} -> ${regression.currentScore.toFixed(4)}`,
+      );
+    }
+  }
+
+  if (payload.gateFailures.length > 0) {
+    lines.push("", "## Gate failures", "");
+    for (const failure of payload.gateFailures) {
+      lines.push(`- ${failure}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function writeArtifact(file, content) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, content);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const runConfig = await collectRunConfig(args);
 const results = [];
 
-for (const file of files) {
+for (const file of runConfig.caseFiles) {
   const benchmarkCase = await readBenchmarkCase(file);
   results.push(evaluateExtraction(benchmarkCase));
 }
 
 const summary = summarize(results);
-console.log(JSON.stringify(summary, null, 2));
+const baseline = args.baseline ? await readJson(args.baseline) : null;
+const baselineSummary = baseline?.summary ?? baseline;
+const regressions = compareToBaseline(summary, baselineSummary, args.maxScoreDrop);
+const gates = {
+  ...runConfig.gates,
+  ...(args.minAverageScore === null ? {} : { minAverageScore: args.minAverageScore }),
+  ...(args.maxFailedCases === null ? {} : { maxFailedCases: args.maxFailedCases }),
+};
+const gateFailures = applyGates(summary, gates, regressions);
+const payload = {
+  name: runConfig.name,
+  generatedAt: new Date().toISOString(),
+  caseFiles: runConfig.caseFiles,
+  gates,
+  regressions,
+  gateFailures,
+  summary,
+};
 
-if (summary.failed > 0) {
+if (args.outputJson) {
+  await writeArtifact(args.outputJson, `${JSON.stringify(payload, null, 2)}\n`);
+}
+if (args.outputMarkdown) {
+  await writeArtifact(args.outputMarkdown, buildMarkdownReport(payload));
+}
+
+console.log(JSON.stringify(payload, null, 2));
+
+if (summary.failed > 0 || gateFailures.length > 0) {
   process.exitCode = 1;
 }

--- a/apps/test-suite/extraction-quality/run-benchmark.mjs
+++ b/apps/test-suite/extraction-quality/run-benchmark.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { evaluateExtraction, readBenchmarkCase, summarize } from "./scorer.mjs";
+
+async function collectCaseFiles(args) {
+  if (args.length > 0) return args;
+
+  const fixtureDir = path.join(import.meta.dirname, "fixtures");
+  const entries = await readdir(fixtureDir);
+  return entries.filter((entry) => entry.endsWith(".json")).map((entry) => path.join(fixtureDir, entry));
+}
+
+const files = await collectCaseFiles(process.argv.slice(2));
+const results = [];
+
+for (const file of files) {
+  const benchmarkCase = await readBenchmarkCase(file);
+  results.push(evaluateExtraction(benchmarkCase));
+}
+
+const summary = summarize(results);
+console.log(JSON.stringify(summary, null, 2));
+
+if (summary.failed > 0) {
+  process.exitCode = 1;
+}

--- a/apps/test-suite/extraction-quality/scorer.mjs
+++ b/apps/test-suite/extraction-quality/scorer.mjs
@@ -220,19 +220,23 @@ export function evaluateExtraction(caseDefinition) {
 
   const failures = [];
   for (const field of metrics.requiredFields.missing) {
-    failures.push(`missing required field: ${field}`);
+    failures.push({ metric: "requiredFields", message: `missing required field: ${field}` });
   }
   for (const detail of metrics.expectedValues.details) {
-    if (!detail.passed) failures.push(`low similarity at ${detail.path}: ${detail.similarity.toFixed(2)}`);
+    if (!detail.passed) {
+      failures.push({ metric: "expectedValues", message: `low similarity at ${detail.path}: ${detail.similarity.toFixed(2)}` });
+    }
   }
   for (const detail of metrics.tableCoverage.details) {
-    if (detail.score < 1) failures.push(`table coverage gap at ${detail.path}: ${detail.score.toFixed(2)}`);
+    if (detail.score < 1) {
+      failures.push({ metric: "tableCoverage", message: `table coverage gap at ${detail.path}: ${detail.score.toFixed(2)}` });
+    }
   }
   for (const detail of metrics.sectionCoverage.details) {
-    if (!detail.found) failures.push(`missing section evidence: ${detail.section}`);
+    if (!detail.found) failures.push({ metric: "sectionCoverage", message: `missing section evidence: ${detail.section}` });
   }
   for (const detail of metrics.markdownPreservation.details) {
-    if (!detail.found) failures.push(`markdown did not preserve ${detail.name}`);
+    if (!detail.found) failures.push({ metric: "markdownPreservation", message: `markdown did not preserve ${detail.name}` });
   }
 
   return {
@@ -252,11 +256,63 @@ export async function readBenchmarkCase(path) {
 
 export function summarize(results) {
   const average = results.reduce((total, result) => total + result.score, 0) / Math.max(results.length, 1);
+  const failedByMetric = {};
+  for (const result of results) {
+    for (const failure of result.failures ?? []) {
+      failedByMetric[failure.metric] = (failedByMetric[failure.metric] ?? 0) + 1;
+    }
+  }
+
   return {
     cases: results.length,
     passed: results.filter((result) => result.passed).length,
     failed: results.filter((result) => !result.passed).length,
     averageScore: Math.round(average * 10000) / 10000,
+    failedByMetric,
     results,
   };
+}
+
+export function compareToBaseline(summary, baseline, maxScoreDrop = 0.02) {
+  if (!baseline) return [];
+
+  const baselineByName = new Map((baseline.results ?? []).map((result) => [result.name, result]));
+  const regressions = [];
+  for (const result of summary.results) {
+    const previous = baselineByName.get(result.name);
+    if (!previous) continue;
+
+    const scoreDrop = Number((previous.score - result.score).toFixed(4));
+    if (scoreDrop > maxScoreDrop) {
+      regressions.push({
+        name: result.name,
+        previousScore: previous.score,
+        currentScore: result.score,
+        scoreDrop,
+        maxScoreDrop,
+      });
+    }
+  }
+
+  return regressions;
+}
+
+export function applyGates(summary, gates = {}, regressions = []) {
+  const failures = [];
+  const minAverageScore = gates.minAverageScore ?? 0;
+  const maxFailedCases = gates.maxFailedCases ?? 0;
+
+  if (summary.averageScore < minAverageScore) {
+    failures.push(`average score ${summary.averageScore.toFixed(4)} is below ${minAverageScore.toFixed(4)}`);
+  }
+  if (summary.failed > maxFailedCases) {
+    failures.push(`failed cases ${summary.failed} is above ${maxFailedCases}`);
+  }
+  for (const regression of regressions) {
+    failures.push(
+      `${regression.name} score dropped ${regression.scoreDrop.toFixed(4)} from baseline, max allowed ${regression.maxScoreDrop.toFixed(4)}`,
+    );
+  }
+
+  return failures;
 }

--- a/apps/test-suite/extraction-quality/scorer.mjs
+++ b/apps/test-suite/extraction-quality/scorer.mjs
@@ -282,13 +282,13 @@ export function compareToBaseline(summary, baseline, maxScoreDrop = 0.02) {
     const previous = baselineByName.get(result.name);
     if (!previous) continue;
 
-    const scoreDrop = Number((previous.score - result.score).toFixed(4));
+    const scoreDrop = previous.score - result.score;
     if (scoreDrop > maxScoreDrop) {
       regressions.push({
         name: result.name,
         previousScore: previous.score,
         currentScore: result.score,
-        scoreDrop,
+        scoreDrop: Number(scoreDrop.toFixed(4)),
         maxScoreDrop,
       });
     }

--- a/apps/test-suite/extraction-quality/scorer.mjs
+++ b/apps/test-suite/extraction-quality/scorer.mjs
@@ -58,6 +58,12 @@ function ratio(numerator, denominator) {
   return Math.max(0, Math.min(1, numerator / denominator));
 }
 
+function numericCount(value) {
+  if (Array.isArray(value)) return value.length;
+  const count = Number(value ?? 0);
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}
+
 export function scoreRequiredFields(actual, requiredFields = []) {
   const missing = [];
   let present = 0;
@@ -111,7 +117,7 @@ export function scoreTableCoverage(actual, expectedTables = []) {
 
   for (const table of expectedTables) {
     const actualRows = getPath(actual, table.path);
-    const rowCount = Array.isArray(actualRows) ? actualRows.length : Number(actualRows ?? 0);
+    const rowCount = numericCount(actualRows);
     const requiredRows = table.minRows ?? table.rows ?? 1;
     const rowScore = ratio(rowCount, requiredRows);
 

--- a/apps/test-suite/extraction-quality/scorer.mjs
+++ b/apps/test-suite/extraction-quality/scorer.mjs
@@ -1,0 +1,256 @@
+import { readFile } from "node:fs/promises";
+
+const DEFAULT_WEIGHTS = {
+  requiredFields: 0.25,
+  expectedValues: 0.25,
+  tableCoverage: 0.2,
+  sectionCoverage: 0.15,
+  markdownPreservation: 0.15,
+};
+
+export function normalizeText(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function tokens(value) {
+  return new Set(normalizeText(value).split(/\s+/).filter(Boolean));
+}
+
+export function tokenSimilarity(left, right) {
+  const leftTokens = tokens(left);
+  const rightTokens = tokens(right);
+  if (leftTokens.size === 0 && rightTokens.size === 0) return 1;
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) intersection += 1;
+  }
+  const union = new Set([...leftTokens, ...rightTokens]).size;
+  return intersection / union;
+}
+
+export function getPath(value, path) {
+  return String(path)
+    .split(".")
+    .filter(Boolean)
+    .reduce((current, part) => {
+      if (current === null || current === undefined) return undefined;
+      if (Array.isArray(current) && /^\d+$/.test(part)) return current[Number(part)];
+      return current[part];
+    }, value);
+}
+
+function hasUsableValue(value) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+}
+
+function ratio(numerator, denominator) {
+  if (denominator === 0) return 1;
+  return Math.max(0, Math.min(1, numerator / denominator));
+}
+
+export function scoreRequiredFields(actual, requiredFields = []) {
+  const missing = [];
+  let present = 0;
+
+  for (const field of requiredFields) {
+    if (hasUsableValue(getPath(actual, field))) {
+      present += 1;
+    } else {
+      missing.push(field);
+    }
+  }
+
+  return {
+    score: ratio(present, requiredFields.length),
+    present,
+    total: requiredFields.length,
+    missing,
+  };
+}
+
+export function scoreExpectedValues(actual, expectedValues = []) {
+  const details = [];
+  let total = 0;
+
+  for (const expectation of expectedValues) {
+    const actualValue = getPath(actual, expectation.path);
+    const expectedValue = expectation.value;
+    const threshold = expectation.threshold ?? 0.72;
+    const similarity = tokenSimilarity(actualValue, expectedValue);
+    const passed = similarity >= threshold;
+    total += passed ? 1 : similarity;
+    details.push({
+      path: expectation.path,
+      expected: expectedValue,
+      actual: actualValue,
+      similarity,
+      threshold,
+      passed,
+    });
+  }
+
+  return {
+    score: ratio(total, expectedValues.length),
+    details,
+  };
+}
+
+export function scoreTableCoverage(actual, expectedTables = []) {
+  const details = [];
+  let total = 0;
+
+  for (const table of expectedTables) {
+    const actualRows = getPath(actual, table.path);
+    const rowCount = Array.isArray(actualRows) ? actualRows.length : Number(actualRows ?? 0);
+    const requiredRows = table.minRows ?? table.rows ?? 1;
+    const rowScore = ratio(rowCount, requiredRows);
+
+    const requiredColumns = table.requiredColumns ?? [];
+    let columnScore = 1;
+    const missingColumns = [];
+    if (requiredColumns.length > 0 && Array.isArray(actualRows) && actualRows.length > 0) {
+      const seenColumns = new Set(actualRows.flatMap((row) => Object.keys(row ?? {})));
+      for (const column of requiredColumns) {
+        if (!seenColumns.has(column)) missingColumns.push(column);
+      }
+      columnScore = ratio(requiredColumns.length - missingColumns.length, requiredColumns.length);
+    } else if (requiredColumns.length > 0) {
+      columnScore = 0;
+      missingColumns.push(...requiredColumns);
+    }
+
+    const score = rowScore * 0.7 + columnScore * 0.3;
+    total += score;
+    details.push({
+      path: table.path,
+      rowCount,
+      requiredRows,
+      requiredColumns,
+      missingColumns,
+      score,
+    });
+  }
+
+  return {
+    score: ratio(total, expectedTables.length),
+    details,
+  };
+}
+
+export function scoreSectionCoverage(markdown = "", expectedSections = []) {
+  const normalizedMarkdown = normalizeText(markdown);
+  const details = expectedSections.map((section) => {
+    const found = normalizedMarkdown.includes(normalizeText(section));
+    return { section, found };
+  });
+
+  return {
+    score: ratio(details.filter((detail) => detail.found).length, expectedSections.length),
+    details,
+  };
+}
+
+export function scoreMarkdownPreservation(markdown = "", expectations = {}) {
+  const checks = [
+    {
+      name: "codeBlocks",
+      expected: Boolean(expectations.codeBlocks),
+      found: /```|<code[\s>]/i.test(markdown),
+    },
+    {
+      name: "links",
+      expected: Boolean(expectations.links),
+      found: /\[[^\]]+\]\([^)]+\)|<a\s/i.test(markdown),
+    },
+    {
+      name: "headings",
+      expected: Boolean(expectations.headings),
+      found: /^#{1,6}\s+\S/m.test(markdown),
+    },
+    {
+      name: "lists",
+      expected: Boolean(expectations.lists),
+      found: /^(\s*[-*+]\s+|\s*\d+\.\s+)/m.test(markdown),
+    },
+  ].filter((check) => check.expected);
+
+  return {
+    score: ratio(checks.filter((check) => check.found).length, checks.length),
+    details: checks,
+  };
+}
+
+export function evaluateExtraction(caseDefinition) {
+  const {
+    name,
+    url,
+    actual = {},
+    expected = {},
+    markdown = actual.markdown ?? "",
+    weights = DEFAULT_WEIGHTS,
+  } = caseDefinition;
+
+  const metrics = {
+    requiredFields: scoreRequiredFields(actual, expected.requiredFields ?? []),
+    expectedValues: scoreExpectedValues(actual, expected.values ?? []),
+    tableCoverage: scoreTableCoverage(actual, expected.tables ?? []),
+    sectionCoverage: scoreSectionCoverage(markdown, expected.sections ?? []),
+    markdownPreservation: scoreMarkdownPreservation(markdown, expected.markdown ?? {}),
+  };
+
+  const score = Object.entries(weights).reduce((total, [metric, weight]) => {
+    return total + (metrics[metric]?.score ?? 0) * weight;
+  }, 0);
+
+  const failures = [];
+  for (const field of metrics.requiredFields.missing) {
+    failures.push(`missing required field: ${field}`);
+  }
+  for (const detail of metrics.expectedValues.details) {
+    if (!detail.passed) failures.push(`low similarity at ${detail.path}: ${detail.similarity.toFixed(2)}`);
+  }
+  for (const detail of metrics.tableCoverage.details) {
+    if (detail.score < 1) failures.push(`table coverage gap at ${detail.path}: ${detail.score.toFixed(2)}`);
+  }
+  for (const detail of metrics.sectionCoverage.details) {
+    if (!detail.found) failures.push(`missing section evidence: ${detail.section}`);
+  }
+  for (const detail of metrics.markdownPreservation.details) {
+    if (!detail.found) failures.push(`markdown did not preserve ${detail.name}`);
+  }
+
+  return {
+    name,
+    url,
+    score,
+    passed: score >= (expected.minScore ?? 0.85),
+    minScore: expected.minScore ?? 0.85,
+    metrics,
+    failures,
+  };
+}
+
+export async function readBenchmarkCase(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+export function summarize(results) {
+  const average = results.reduce((total, result) => total + result.score, 0) / Math.max(results.length, 1);
+  return {
+    cases: results.length,
+    passed: results.filter((result) => result.passed).length,
+    failed: results.filter((result) => !result.passed).length,
+    averageScore: Math.round(average * 10000) / 10000,
+    results,
+  };
+}

--- a/apps/test-suite/extraction-quality/scorer.test.mjs
+++ b/apps/test-suite/extraction-quality/scorer.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  evaluateExtraction,
+  getPath,
+  scoreExpectedValues,
+  scoreRequiredFields,
+  summarize,
+  tokenSimilarity,
+} from "./scorer.mjs";
+
+test("getPath reads nested objects and arrays", () => {
+  const actual = { jobs: [{ title: "Search Engineer" }], company: { name: "Firecrawl" } };
+
+  assert.equal(getPath(actual, "jobs.0.title"), "Search Engineer");
+  assert.equal(getPath(actual, "company.name"), "Firecrawl");
+  assert.equal(getPath(actual, "missing.path"), undefined);
+});
+
+test("field coverage catches missing structured fields", () => {
+  const score = scoreRequiredFields(
+    { company: { name: "Firecrawl" }, jobs: [{ title: "Research Engineer" }] },
+    ["company.name", "jobs.0.title", "jobs.0.location"],
+  );
+
+  assert.equal(score.present, 2);
+  assert.equal(score.total, 3);
+  assert.deepEqual(score.missing, ["jobs.0.location"]);
+  assert.equal(score.score, 2 / 3);
+});
+
+test("expected values use token similarity instead of exact string equality", () => {
+  const score = scoreExpectedValues(
+    { role: "Research Engineer for search and information retrieval" },
+    [{ path: "role", value: "Search/IR Research Engineer", threshold: 0.3 }],
+  );
+
+  assert.ok(tokenSimilarity("Search/IR Research Engineer", "Research Engineer for search") > 0.3);
+  assert.equal(score.details[0].passed, true);
+});
+
+test("evaluateExtraction combines schema, value, table, section, and markdown checks", () => {
+  const result = evaluateExtraction({
+    name: "careers extraction",
+    url: "https://example.com/careers",
+    actual: {
+      company: { name: "Firecrawl" },
+      jobs: [
+        { title: "Research Engineer", team: "Search", location: "San Francisco" },
+        { title: "Web Automation Engineer", team: "Browser", location: "Remote" },
+      ],
+      markdown: "# Careers\n\n- Research Engineer\n- Web Automation Engineer\n\n```ts\ncrawl(url)\n```",
+    },
+    expected: {
+      minScore: 0.9,
+      requiredFields: ["company.name", "jobs.0.title", "jobs.1.title"],
+      values: [{ path: "jobs.0.title", value: "Research Engineer", threshold: 0.8 }],
+      tables: [{ path: "jobs", minRows: 2, requiredColumns: ["title", "team", "location"] }],
+      sections: ["Careers", "Research Engineer"],
+      markdown: { headings: true, lists: true, codeBlocks: true },
+    },
+  });
+
+  assert.equal(result.passed, true);
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.metrics.tableCoverage.details[0].missingColumns.length, 0);
+});
+
+test("summarize reports aggregate pass and fail counts", () => {
+  const summary = summarize([
+    { score: 0.91, passed: true },
+    { score: 0.7, passed: false },
+  ]);
+
+  assert.equal(summary.cases, 2);
+  assert.equal(summary.passed, 1);
+  assert.equal(summary.failed, 1);
+  assert.equal(summary.averageScore, 0.805);
+});

--- a/apps/test-suite/extraction-quality/scorer.test.mjs
+++ b/apps/test-suite/extraction-quality/scorer.test.mjs
@@ -5,6 +5,7 @@ import {
   getPath,
   scoreExpectedValues,
   scoreRequiredFields,
+  scoreTableCoverage,
   summarize,
   tokenSimilarity,
 } from "./scorer.mjs";
@@ -64,6 +65,20 @@ test("evaluateExtraction combines schema, value, table, section, and markdown ch
   assert.equal(result.passed, true);
   assert.equal(result.failures.length, 0);
   assert.equal(result.metrics.tableCoverage.details[0].missingColumns.length, 0);
+});
+
+test("table coverage treats non-numeric row counts as zero", () => {
+  const score = scoreTableCoverage(
+    { jobs: { rows: "unknown" }, links: "not-a-number" },
+    [
+      { path: "jobs", minRows: 2, requiredColumns: ["title"] },
+      { path: "links", minRows: 1 },
+    ],
+  );
+
+  assert.equal(Number.isNaN(score.score), false);
+  assert.equal(score.details[0].rowCount, 0);
+  assert.equal(score.details[1].rowCount, 0);
 });
 
 test("summarize reports aggregate pass and fail counts", () => {

--- a/apps/test-suite/extraction-quality/scorer.test.mjs
+++ b/apps/test-suite/extraction-quality/scorer.test.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
+import { promisify } from "node:util";
 import {
   applyGates,
   compareToBaseline,
@@ -11,6 +16,8 @@ import {
   summarize,
   tokenSimilarity,
 } from "./scorer.mjs";
+
+const execFileAsync = promisify(execFile);
 
 test("getPath reads nested objects and arrays", () => {
   const actual = { jobs: [{ title: "Search Engineer" }], company: { name: "Firecrawl" } };
@@ -117,6 +124,23 @@ test("baseline comparison reports score drops over threshold", () => {
   ]);
 });
 
+test("baseline comparison uses raw score drops before display rounding", () => {
+  const current = summarize([{ name: "pricing", score: 0.90996, passed: true, failures: [] }]);
+  const baseline = summarize([{ name: "pricing", score: 0.93, passed: true, failures: [] }]);
+
+  const regressions = compareToBaseline(current, baseline, 0.02);
+
+  assert.deepEqual(regressions, [
+    {
+      name: "pricing",
+      previousScore: 0.93,
+      currentScore: 0.90996,
+      scoreDrop: 0.02,
+      maxScoreDrop: 0.02,
+    },
+  ]);
+});
+
 test("quality gates combine average score, failed cases, and baseline regressions", () => {
   const summary = {
     averageScore: 0.82,
@@ -142,4 +166,30 @@ test("quality gates combine average score, failed cases, and baseline regression
     "failed cases 2 is above 0",
     "docs score dropped 0.0400 from baseline, max allowed 0.0200",
   ]);
+});
+
+test("benchmark runner fails when a manifest resolves no cases", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "firecrawl-empty-benchmark-"));
+  const manifestPath = path.join(tempDir, "manifest.json");
+
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      name: "empty-suite",
+      suites: [{ name: "empty", cases: [] }],
+    }),
+  );
+
+  try {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        path.join(import.meta.dirname, "run-benchmark.mjs"),
+        "--manifest",
+        manifestPath,
+      ]),
+      /No benchmark cases found for suite "empty-suite"/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });

--- a/apps/test-suite/extraction-quality/scorer.test.mjs
+++ b/apps/test-suite/extraction-quality/scorer.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  applyGates,
+  compareToBaseline,
   evaluateExtraction,
   getPath,
   scoreExpectedValues,
@@ -83,12 +85,61 @@ test("table coverage treats non-numeric row counts as zero", () => {
 
 test("summarize reports aggregate pass and fail counts", () => {
   const summary = summarize([
-    { score: 0.91, passed: true },
-    { score: 0.7, passed: false },
+    { score: 0.91, passed: true, failures: [] },
+    {
+      score: 0.7,
+      passed: false,
+      failures: [{ metric: "requiredFields", message: "missing required field: jobs.0.title" }],
+    },
   ]);
 
   assert.equal(summary.cases, 2);
   assert.equal(summary.passed, 1);
   assert.equal(summary.failed, 1);
   assert.equal(summary.averageScore, 0.805);
+  assert.deepEqual(summary.failedByMetric, { requiredFields: 1 });
+});
+
+test("baseline comparison reports score drops over threshold", () => {
+  const current = summarize([{ name: "pricing", score: 0.86, passed: true, failures: [] }]);
+  const baseline = summarize([{ name: "pricing", score: 0.93, passed: true, failures: [] }]);
+
+  const regressions = compareToBaseline(current, baseline, 0.02);
+
+  assert.deepEqual(regressions, [
+    {
+      name: "pricing",
+      previousScore: 0.93,
+      currentScore: 0.86,
+      scoreDrop: 0.07,
+      maxScoreDrop: 0.02,
+    },
+  ]);
+});
+
+test("quality gates combine average score, failed cases, and baseline regressions", () => {
+  const summary = {
+    averageScore: 0.82,
+    failed: 2,
+  };
+  const failures = applyGates(
+    summary,
+    {
+      minAverageScore: 0.9,
+      maxFailedCases: 0,
+    },
+    [
+      {
+        name: "docs",
+        scoreDrop: 0.04,
+        maxScoreDrop: 0.02,
+      },
+    ],
+  );
+
+  assert.deepEqual(failures, [
+    "average score 0.8200 is below 0.9000",
+    "failed cases 2 is above 0",
+    "docs score dropped 0.0400 from baseline, max allowed 0.0200",
+  ]);
 });

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "test:extraction-quality": "node --test extraction-quality/*.test.mjs",
     "test:load": "artillery run --output ./load-test-results/test-run-report.json load-test.yml"
   },
   "author": "",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "benchmark:extraction-quality": "node extraction-quality/run-benchmark.mjs --manifest extraction-quality/manifest.json --baseline extraction-quality/baselines/current.json --output-json extraction-quality/results/latest.json --output-markdown extraction-quality/results/latest.md",
     "test:extraction-quality": "node --test extraction-quality/*.test.mjs",
     "test:load": "artillery run --output ./load-test-results/test-run-report.json load-test.yml"
   },


### PR DESCRIPTION
## Summary
- expand the extraction-quality benchmark into a manifest-driven regression suite
- add baseline score comparison with per-case drift detection
- add suite gates for average score and failed cases
- write JSON and Markdown artifacts for CI and review
- add fixtures for pricing tables, API docs, and noisy SPA careers pages
- keep the runner independent of Firecrawl internals and external services

This is meant to make extraction regressions easier to reproduce before they reach crawler or agent workflows. It gives maintainers a small offline suite that can catch missing fields, table coverage gaps, markdown preservation loss, and score drops against a checked-in baseline.

## Checks
- node --test extraction-quality/*.test.mjs
- node extraction-quality/run-benchmark.mjs --manifest extraction-quality/manifest.json --baseline extraction-quality/baselines/current.json --output-json /tmp/firecrawl-extraction-quality.json --output-markdown /tmp/firecrawl-extraction-quality.md
- node extraction-quality/run-benchmark.mjs --manifest extraction-quality/manifest.json --baseline extraction-quality/baselines/current.json --max-score-drop 0.02
- git diff --check

Note: this local machine has node but not npm or pnpm, so I validated the underlying Node commands directly instead of package-script wrappers.