### PR TITLE
feat(api): add prometheus integration value

### DIFF
--- a/apps/api/src/utils/integration.ts
+++ b/apps/api/src/utils/integration.ts
@@ -18,6 +18,7 @@ enum IntegrationEnum {
   CLI = "cli",
   HERMES = "hermes",
   GSTACK = "gstack",
+  PROMETHEUS = "prometheus",
 }
 
 export const integrationSchema = z


### PR DESCRIPTION
Adds `prometheus` as a recognized `integration` value.

## What
- Added `PROMETHEUS = "prometheus"` to `IntegrationEnum` in `apps/api/src/utils/integration.ts`, the single source of truth that `integrationSchema` validates against. All v1/v2 endpoints import this schema, so they now accept `"prometheus"`.

## SDK
No JS SDK change needed — the SDK types `integration` as a plain `string` and passes any value through to the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for `prometheus` as an accepted `integration` value in the API. All v1/v2 endpoints using the shared `integrationSchema` now accept it; no JS SDK changes needed.

<sup>Written for commit 595da7945bcc2d926ec705beb31ea616ca980f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

