### PR TITLE
fix(python-sdk): preserve ScreenshotFormat options via ScrapeFormats; docs typo fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ SUPABASE_SERVICE_TOKEN=
 # Other Optionals
 TEST_API_KEY= # use if you've set up authentication and want to test with a real API key
 OPENAI_API_KEY= # add for LLM dependent features (image alt generation, etc.)
-BULL_AUTH_KEY= @
+BULL_AUTH_KEY=
 PLAYWRIGHT_MICROSERVICE_URL=  # set if you'd like to run a playwright fallback
 LLAMAPARSE_API_KEY= #Set if you have a llamaparse key you'd like to use to parse pdfs
 SLACK_WEBHOOK_URL= # set if you'd like to send slack server health status messages

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -455,7 +455,7 @@ class ChangeTrackingFormat(Format):
     tag: Optional[str] = None
 
 
-class ScreenshotFormat(BaseModel):
+class ScreenshotFormat(Format):
     """Configuration for screenshot format."""
 
     type: Literal["screenshot"] = "screenshot"

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -643,6 +643,16 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                                     converted_formats.append(_validate_highlights_format(fmt.model_dump(exclude_none=True)))
                                 elif fmt.type == 'query':
                                     converted_formats.append(_validate_query_format(fmt.model_dump(exclude_none=True)))
+                                elif fmt.type == 'screenshot':
+                                    normalized = {'type': 'screenshot'}
+                                    if getattr(fmt, 'full_page', None) is not None:
+                                        normalized['fullPage'] = fmt.full_page
+                                    if getattr(fmt, 'quality', None) is not None:
+                                        normalized['quality'] = fmt.quality
+                                    vp = getattr(fmt, 'viewport', None)
+                                    if vp is not None:
+                                        normalized['viewport'] = vp.model_dump(exclude_none=True) if hasattr(vp, 'model_dump') else vp
+                                    converted_formats.append(normalized)
                                 elif fmt.type in ('changeTracking', 'change_tracking'):
                                     data = fmt.model_dump(exclude_none=True)
                                     data['type'] = _convert_format_string(data.get('type', fmt.type))

--- a/apps/python-sdk/tests/test_screenshot_format_options.py
+++ b/apps/python-sdk/tests/test_screenshot_format_options.py
@@ -1,0 +1,47 @@
+"""Tests that ScreenshotFormat options survive prepare_scrape_options regardless
+of whether formats are passed as a ScrapeFormats object or a plain list.
+
+Regression test for a bug where a ScreenshotFormat nested inside
+ScrapeFormats(formats=[...]) was collapsed to the bare string "screenshot",
+dropping full_page/quality/viewport, while the same format passed as a plain
+list was serialized correctly.
+"""
+
+from firecrawl.v2.types import ScrapeOptions, ScrapeFormats, ScreenshotFormat
+from firecrawl.v2.utils.validation import prepare_scrape_options
+
+
+def _screenshot_entry(prepared):
+    fmts = prepared["formats"]
+    matches = [f for f in fmts if isinstance(f, dict) and f.get("type") == "screenshot"]
+    assert len(matches) == 1, f"expected one screenshot dict, got {fmts!r}"
+    return matches[0]
+
+
+def test_screenshot_options_preserved_via_list():
+    opts = ScrapeOptions(formats=[ScreenshotFormat(full_page=True, quality=80)])
+    entry = _screenshot_entry(prepare_scrape_options(opts))
+    assert entry["fullPage"] is True
+    assert entry["quality"] == 80
+
+
+def test_screenshot_options_preserved_via_scrape_formats():
+    opts = ScrapeOptions(
+        formats=ScrapeFormats(formats=[ScreenshotFormat(full_page=True, quality=80)])
+    )
+    entry = _screenshot_entry(prepare_scrape_options(opts))
+    # Previously this lost fullPage/quality because the object was reduced to "screenshot".
+    assert entry["fullPage"] is True
+    assert entry["quality"] == 80
+
+
+def test_screenshot_via_list_and_scrape_formats_match():
+    list_entry = _screenshot_entry(
+        prepare_scrape_options(ScrapeOptions(formats=[ScreenshotFormat(full_page=True, quality=80)]))
+    )
+    obj_entry = _screenshot_entry(
+        prepare_scrape_options(
+            ScrapeOptions(formats=ScrapeFormats(formats=[ScreenshotFormat(full_page=True, quality=80)]))
+        )
+    )
+    assert list_entry == obj_entry


### PR DESCRIPTION
Two small, independent fixes.

## 1. `docs(contributing)`: remove stray `@` in `BULL_AUTH_KEY` env template
The local-setup `.env` template in `CONTRIBUTING.md` had `BULL_AUTH_KEY= @`. The trailing ` @` is copy-pasted verbatim by anyone following the guide and ends up as part of the key value. Dropped it.

## 2. `fix(python-sdk)`: ScreenshotFormat unusable inside ScrapeFormats
A `ScreenshotFormat` placed inside `ScrapeFormats(formats=[...])` was broken in two ways:

1. **Construction raised.** `ScreenshotFormat` subclassed `BaseModel` instead of `Format` — unlike every sibling (`JsonFormat`, `QuestionFormat`, `HighlightsFormat`, `QueryFormat`, `ChangeTrackingFormat`, `AttributesFormat`). `ScrapeFormats.validate_formats` does `isinstance(item, Format)`, so a `ScreenshotFormat` instance fell through to `raise ValueError("Invalid format format: ...")`.
2. **Options silently dropped.** Even once accepted, `prepare_scrape_options`' `ScrapeFormats` object branch had no `screenshot` case, so it was collapsed to the bare string `"screenshot"`, losing `full_page` / `quality` / `viewport`. The plain-`list` branch already handled this correctly — so the same format behaved differently depending on its container.

### Fix
- `ScreenshotFormat` now extends `Format` (consistent with all other format types).
- Added the `screenshot` case to the `ScrapeFormats` object branch in `prepare_scrape_options`, mirroring the existing list-branch logic.

### Tests
Added `apps/python-sdk/tests/test_screenshot_format_options.py` asserting screenshot options survive via both the plain-list and `ScrapeFormats` paths, and that the two produce identical output. All three pass; no regressions in the synchronous v2 unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python SDK so `ScreenshotFormat` works inside `ScrapeFormats` without dropping options, and removes a stray `@` from the `BULL_AUTH_KEY` example in CONTRIBUTING.

- **Bug Fixes**
  - Make `ScreenshotFormat` extend `Format` and handle `screenshot` in `prepare_scrape_options` to preserve `full_page`, `quality`, and `viewport`.
  - Clean up `.env` template: change `BULL_AUTH_KEY= @` to `BULL_AUTH_KEY=` in `CONTRIBUTING.md`.

<sup>Written for commit da72014e5d6059d02a0e1136eb252b65b01babdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

