### PR TITLE
fix(api): shrink index DB pool to stay under pgbouncer max_client_conn

### DIFF
--- a/apps/api/src/db/connection.ts
+++ b/apps/api/src/db/connection.ts
@@ -5,9 +5,17 @@ import { logger } from "../lib/logger";
 
 type DB = NodePgDatabase;
 
+interface PoolSizing {
+  /** Max client connections this pool opens to the pooler. Default 20. */
+  max?: number;
+  /** Idle connections held open permanently. Default 0. */
+  min?: number;
+}
+
 function makeDb(
   connectionString: string | undefined,
   applicationName: string,
+  sizing: PoolSizing = {},
 ): DB | null {
   if (!connectionString) {
     return null;
@@ -16,8 +24,14 @@ function makeDb(
   const pool = new Pool({
     connectionString,
     application_name: applicationName,
-    max: 20,
-    min: 2,
+    // Each process opens up to `max` client connections per pool against the
+    // (transaction) pooler. Supabase pins pgbouncer's max_client_conn at 12000,
+    // so the fleet-wide budget is `pods * sum(max across pools)`. Keep these
+    // small — the transaction pooler multiplexes server connections, so a large
+    // per-process client pool buys little throughput but eats the global cap.
+    // `min: 0` lets idle pods release connections instead of holding them.
+    max: sizing.max ?? 20,
+    min: sizing.min ?? 0,
     keepAlive: true,
   });
   pool.on("error", err =>
@@ -62,7 +76,14 @@ const replicaDb = useDbAuthentication
       "firecrawl-api-rr",
     )
   : null;
-const indexDb = makeDb(config.INDEX_DATABASE_URL, "firecrawl-index");
+// The index pool was the sole consumer behind the 2026-06-11 pgbouncer
+// `08P01: no more connections allowed (max_client_conn)` incident. It runs
+// against the transaction pooler, so cap it well below the generic 20 to keep
+// the fleet-wide client-connection count under Supabase's 12000 ceiling.
+const indexDb = makeDb(config.INDEX_DATABASE_URL, "firecrawl-index", {
+  max: 6,
+  min: 0,
+});
 
 if (useDbAuthentication && !mainDb) {
   logger.error(


### PR DESCRIPTION
## What

Tunes the Postgres pool sizing in `apps/api/src/db/connection.ts` so the `firecrawl-index` pool stops exhausting Supabase's pgbouncer client-connection limit.

- `makeDb` now accepts per-pool `max`/`min` sizing.
- Default `min` drops **2 → 0** so idle pods release connections instead of permanently holding 2 per pool, per process, across the whole fleet.
- The index pool gets its own smaller budget: **`max: 6, min: 0`** (was sharing the generic `max: 20, min: 2`).

## Why

The 2026-06-11 **"Elevated Index failures"** HIGH-escalation incident ([#976830263](https://uptime.betterstack.com/team/t116723/incidents/976830263)) was a 3-minute spike of 470 `index-scrape-fails`. Pulling the GCP logs for the window, **448 of 452** failures were:

```
08P01 FATAL: no more connections allowed (max_client_conn)
  at execRows (src/db/rpc.js)
  at scrapeURLWithIndex (engines/index/index.js:223)   // index_get_recent_4(...)
```

That's **pgbouncer** rejecting connections (not Postgres `max_connections` — that would be `53300`). The remaining 4 were `ETIMEDOUT` to the same pooler endpoint (`:6543`). 41 teams were affected, so it was pool exhaustion under a traffic burst, not one caller.

Supabase **hardcodes pgbouncer `max_client_conn` to 12000**, so we can't raise the ceiling — the only lever is opening fewer client connections per process. With the old `max: 20` across pools, the fleet-wide budget (`pods × Σ max`) sat dangerously close to 12000 at steady state, and a normal burst tipped it over. The index pool runs against the **transaction** pooler, which multiplexes server connections, so a large per-process client pool buys little throughput while eating the global cap.

## Notes

- No E2E test added — this is connection-pool sizing, not request-path behavior; the win condition is fewer client connections to pgbouncer under load, observable in prod metrics rather than in `snips`.
- Pre-existing `knip` warnings in `src/services/posthog.ts` (unused exports from the recent PostHog merge) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink the index Postgres client pool and release idle connections to avoid exhausting pgbouncer `max_client_conn` during bursts. This caps per-process clients and mitigates recent index failures.

- **Bug Fixes**
  - `makeDb` now supports per-pool `max`/`min` sizing.
  - Default `min` lowered from 2 to 0 so idle pods release connections.
  - Index pool set to `max: 6, min: 0` (was `20/2`).

<sup>Written for commit c02f342895c2b4f612a393aa910118aee6dec83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

