### PR TITLE
Validate finite JS SDK numeric options

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-data-property.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-data-property.test.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { search } from "../../../v2/methods/search";
 
 const fakeHttp = {

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/v1-aliases.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/v1-aliases.test.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { FirecrawlClient } from "../../../v2/client";
 
 const ALIAS_MAP: Record<string, string> = {

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/validation.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "@jest/globals";
-import { ensureValidFormats, ensureValidScrapeOptions } from "../../../v2/utils/validation";
+import {
+  ensureValidFormats,
+  ensureValidParseOptions,
+  ensureValidScrapeOptions,
+} from "../../../v2/utils/validation";
 import type { FormatOption } from "../../../v2/types";
 import { z } from "zod";
 
@@ -46,11 +50,50 @@ describe("v2 utils: validation", () => {
     expect(() => ensureValidFormats(formats)).toThrow(/non-negative number/i);
   });
 
+  test("ensureValidFormats: screenshot quality must be finite", () => {
+    expect(() =>
+      ensureValidFormats([{ type: "screenshot", quality: Number.NaN } as any]),
+    ).toThrow(/non-negative number/i);
+    expect(() =>
+      ensureValidFormats([
+        { type: "screenshot", quality: Number.POSITIVE_INFINITY } as any,
+      ]),
+    ).toThrow(/non-negative number/i);
+  });
+
   test("ensureValidScrapeOptions: validates timeout and waitFor bounds", () => {
-    expect(() => ensureValidScrapeOptions({ timeout: 0 })).toThrow(/timeout must be positive/i);
-    expect(() => ensureValidScrapeOptions({ waitFor: -1 })).toThrow(/waitFor must be non-negative/i);
+    expect(() => ensureValidScrapeOptions({ timeout: 0 })).toThrow(
+      /timeout must be positive/i,
+    );
+    expect(() => ensureValidScrapeOptions({ waitFor: -1 })).toThrow(
+      /waitFor must be non-negative/i,
+    );
     // valid
     expect(() => ensureValidScrapeOptions({ timeout: 1000, waitFor: 0 })).not.toThrow();
+  });
+
+  test("ensureValidScrapeOptions: rejects non-finite numeric options", () => {
+    expect(() => ensureValidScrapeOptions({ timeout: Number.NaN })).toThrow(
+      /timeout must be positive/i,
+    );
+    expect(() => ensureValidScrapeOptions({ timeout: Number.POSITIVE_INFINITY })).toThrow(
+      /timeout must be positive/i,
+    );
+    expect(() => ensureValidScrapeOptions({ waitFor: Number.NaN })).toThrow(
+      /waitFor must be non-negative/i,
+    );
+    expect(() => ensureValidScrapeOptions({ waitFor: Number.POSITIVE_INFINITY })).toThrow(
+      /waitFor must be non-negative/i,
+    );
+  });
+
+  test("ensureValidParseOptions: rejects non-finite timeout", () => {
+    expect(() => ensureValidParseOptions({ timeout: Number.NaN })).toThrow(
+      /timeout must be positive/i,
+    );
+    expect(() => ensureValidParseOptions({ timeout: Number.POSITIVE_INFINITY })).toThrow(
+      /timeout must be positive/i,
+    );
   });
 
   test("ensureValidFormats: accepts screenshot viewport width/height", () => {

--- a/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/validation.ts
@@ -10,7 +10,15 @@ import {
   type ScrapeOptions,
   type ScreenshotFormat,
 } from "../types";
-import { isZodSchema, zodSchemaToJsonSchema, looksLikeZodShape } from "../../utils/zodSchemaToJson";
+import {
+  isZodSchema,
+  zodSchemaToJsonSchema,
+  looksLikeZodShape,
+} from "../../utils/zodSchemaToJson";
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
 
 export function ensureValidFormats(formats?: FormatOption[]): void {
   if (!formats) return;
@@ -79,7 +87,7 @@ export function ensureValidFormats(formats?: FormatOption[]): void {
     if ((fmt as ScreenshotFormat).type === "screenshot") {
       // no-op; already camelCase; validate numeric fields if present
       const s = fmt as ScreenshotFormat;
-      if (s.quality != null && (typeof s.quality !== "number" || s.quality < 0)) {
+      if (s.quality != null && (!isFiniteNumber(s.quality) || s.quality < 0)) {
         throw new Error("screenshot.quality must be a non-negative number");
       }
     }
@@ -88,10 +96,16 @@ export function ensureValidFormats(formats?: FormatOption[]): void {
 
 export function ensureValidScrapeOptions(options?: ScrapeOptions): void {
   if (!options) return;
-  if (options.timeout != null && options.timeout <= 0) {
+  if (
+    options.timeout != null &&
+    (!isFiniteNumber(options.timeout) || options.timeout <= 0)
+  ) {
     throw new Error("timeout must be positive");
   }
-  if (options.waitFor != null && options.waitFor < 0) {
+  if (
+    options.waitFor != null &&
+    (!isFiniteNumber(options.waitFor) || options.waitFor < 0)
+  ) {
     throw new Error("waitFor must be non-negative");
   }
   ensureValidFormats(options.formats);
@@ -180,7 +194,10 @@ export function ensureValidParseFormats(formats?: ParseFormatOption[]): void {
 
 export function ensureValidParseOptions(options?: ParseOptions): void {
   if (!options) return;
-  if (options.timeout != null && options.timeout <= 0) {
+  if (
+    options.timeout != null &&
+    (!isFiniteNumber(options.timeout) || options.timeout <= 0)
+  ) {
     throw new Error("timeout must be positive");
   }
 


### PR DESCRIPTION
## What changed

- Reject non-finite JS SDK numeric options before requests are sent.
- Cover NaN and Infinity for scrape timeout, scrape waitFor, parse timeout, and screenshot quality.
- Import the Jest helper explicitly in two ESM unit tests so the v2 unit suite runs cleanly.

## Why

Plain JavaScript callers can pass NaN or Infinity even though the TypeScript types say these options are numbers. The previous comparisons rejected negative values but allowed non-finite numbers through to the SDK payload or timeout handling.

## Validation

- corepack pnpm exec jest --verbose src/__tests__/unit/v2/validation.test.ts
- $env:NODE_OPTIONS='--experimental-vm-modules'; corepack pnpm exec jest --verbose src/__tests__/unit/v2
- corepack pnpm run build

Build passes with the existing tsup warning in src/v1/index.ts about JSON import assertions.
