### PR TITLE
chore(api): fix knip complaints

### DIFF
--- a/apps/api/knip.config.ts
+++ b/apps/api/knip.config.ts
@@ -15,8 +15,6 @@ const config: KnipConfig = {
   ignore: [
     "native/**",
     "src/scraper/scrapeURL/engines/fire-engine/branding-script/**",
-    // Superseded by the integration proxy added in #3520; kept for now.
-    "src/controllers/v0/admin/rotate-api-key.ts",
   ],
   ignoreDependencies: ["undici-types", "stripe"],
 };

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -130,7 +130,6 @@
     "marked": "^14.1.2",
     "multer": "^2.1.1",
     "ollama-ai-provider": "^1.2.0",
-    "openai": "^5.20.2",
     "parse-diff": "^0.11.1",
     "pdf-parse": "^1.1.1",
     "pg": "^8.16.3",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -205,9 +205,6 @@ importers:
       ollama-ai-provider:
         specifier: ^1.2.0
         version: 1.2.0(zod@4.1.12)
-      openai:
-        specifier: ^5.20.2
-        version: 5.20.2(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
       parse-diff:
         specifier: ^0.11.1
         version: 0.11.1
@@ -10695,6 +10692,7 @@ snapshots:
     optionalDependencies:
       ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 4.1.12
+    optional: true
 
   ox@0.11.3(typescript@5.9.2)(zod@3.25.76):
     dependencies:

--- a/apps/api/src/__tests__/snips/lib.ts
+++ b/apps/api/src/__tests__/snips/lib.ts
@@ -9,7 +9,6 @@ import { TeamFlags } from "../../controllers/v1/types";
 // =========================================
 
 export const TEST_API_URL = config.TEST_API_URL;
-export const TEST_URL = TEST_API_URL; // backwards compat temp
 
 const stripTrailingSlash = (url: string) => {
   if (url.length < 1) throw new Error("Invalid URL supplied");


### PR DESCRIPTION
## Summary

- Remove stale `TEST_URL` backwards-compat alias from snips `lib.ts` — it was never imported from this file
- Remove `rotate-api-key.ts` from knip `ignore` list — file no longer exists
- Remove unused `openai` direct dependency — the package is only needed as an optional peer dep of `langsmith` (which pnpm resolves automatically); no code imports from it directly

All three changes bring `knip` (v5 and v6) to a clean exit.

## Test plan

- [x] `pnpm run knip` exits 0 (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `knip` findings by removing the stale `TEST_URL` alias from tests, dropping a deleted file from the `knip` ignore list, and removing the unused `openai` direct dependency (only an optional peer of `langsmith`). `knip` v5/v6 now exit cleanly.

<sup>Written for commit 93c1ef192b40b1dfac6350cc14b693b73324bc6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

