### PR TITLE
[codex] make parse keyless

### DIFF
--- a/apps/api/src/__tests__/snips/v2/keyless.test.ts
+++ b/apps/api/src/__tests__/snips/v2/keyless.test.ts
@@ -22,8 +22,8 @@ const KEYLESS_ENABLED =
   Number.isFinite(KEYLESS_CREDITS_PER_DAY) &&
   KEYLESS_CREDITS_PER_DAY > 0;
 
-// Keyless free tier: scrape, search, and interact work without an API key from
-// the official MCP server (origin "mcp*"), CLI (integration "cli"), or SDKs
+// Keyless free tier: scrape, parse, search, and interact work without an API key
+// from the official MCP server (origin "mcp*"), CLI (integration "cli"), or SDKs
 // (origin "<lang>-sdk@..."). Gated per-IP/day by a request cap AND a credit cap.
 // These tests are the only ones that exercise keyless mode, so they exclusively
 // own the `keyless_*` rate-limit keyspace — we flush it before each test (and run
@@ -104,6 +104,35 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
     expect(response.body.error).toContain("not available without an API key");
   });
 
+  it(
+    "allows keyless parse upload and charges the keyless credit cap (200)",
+    async () => {
+      const response = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .field(
+          "options",
+          JSON.stringify({ formats: ["markdown"], origin: "mcp" }),
+        )
+        .attach(
+          "file",
+          Buffer.from("<h1>Keyless Parse Upload</h1><p>Hello.</p>"),
+          { filename: "keyless.html", contentType: "text/html" },
+        );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.markdown).toContain("Keyless Parse Upload");
+      expect(response.body.data.metadata.creditsUsed).toBe(1);
+
+      const ip = await currentKeylessIp();
+      const creditsUsed = Number(
+        await redisRateLimitClient.get(`keyless_credits:${ip}`),
+      );
+      expect(creditsUsed).toBeGreaterThanOrEqual(1);
+    },
+    scrapeTimeout,
+  );
+
   it("enforces the daily request cap with the request signup message (429)", async () => {
     // Each request consumes a slot during auth, then fails fast in the controller
     // (no url) — so we exhaust the cap without real scrapes, and 0 credits.
@@ -142,6 +171,33 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
       .post("/v2/scrape")
       .set("Content-Type", "application/json")
       .send({ origin: "mcp" });
+
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.body.error).toContain("unauthenticated credits");
+  });
+
+  it("enforces the daily credit cap on parse (429)", async () => {
+    // Materialize the loopback IP, then seed its credit counter to the cap.
+    await request(TEST_API_URL)
+      .post("/v2/scrape")
+      .set("Content-Type", "application/json")
+      .send({ origin: "mcp" });
+    const ip = await currentKeylessIp();
+    await redisRateLimitClient.set(
+      `keyless_credits:${ip}`,
+      String(KEYLESS_CREDITS_PER_DAY),
+    );
+
+    const blocked = await request(TEST_API_URL)
+      .post("/v2/parse")
+      .field(
+        "options",
+        JSON.stringify({ formats: ["markdown"], origin: "mcp" }),
+      )
+      .attach("file", Buffer.from("<h1>Blocked</h1>"), {
+        filename: "blocked.html",
+        contentType: "text/html",
+      });
 
     expect(blocked.statusCode).toBe(429);
     expect(blocked.body.error).toContain("unauthenticated credits");

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -26,6 +26,7 @@ import { getErrorContactMessage } from "../../lib/deployment";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
 import type { BillingMetadata } from "../../services/billing/types";
 import { getScrapeZDR } from "../../lib/zdr-helpers";
+import { chargeKeylessCredits } from "../../lib/keyless";
 import path from "node:path";
 
 const AGENT_INTEROP_CONCURRENCY_BOOST = 3;
@@ -661,6 +662,11 @@ export async function parseController(
         concurrencyLimited,
         concurrencyQueueDurationMs: lockTime || undefined,
       });
+
+      chargeKeylessCredits(
+        req.auth.team_id,
+        doc?.metadata?.creditsUsed ?? 0,
+      ).catch(() => {});
 
       return res.status(200).json({
         success: true,

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -264,7 +264,7 @@ v2Router.post(
 
 v2Router.post(
   "/parse",
-  authMiddleware(RateLimiterMode.Scrape),
+  authMiddleware(RateLimiterMode.Scrape, { allowKeyless: true }),
   countryCheck,
   parseUploadMiddleware,
   parseMultipartPayloadMiddleware,


### PR DESCRIPTION
## Summary

- Enable keyless auth for `POST /v2/parse` through the existing `allowKeyless` middleware path.
- Charge successful parse uploads against the keyless per-IP credit bucket using returned `metadata.creditsUsed`.
- Add keyless snips for parse happy path and parse credit-cap rejection.

## Why

`/parse` shared the scrape rate limiter mode but was not opted into the keyless allowlist, so unauthenticated callers were blocked before reaching the upload parser. Once allowed, parse also needed explicit keyless credit accounting because it runs synchronously and does not pass through the scrape worker billing hook.

## Validation

Not run per instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables keyless access to `POST /v2/parse` and bills successful uploads against per‑IP keyless credits to enforce daily caps. Adds tests for the happy path and credit-cap rejection.

- **New Features**
  - Opts `/v2/parse` into keyless via `authMiddleware(RateLimiterMode.Scrape, { allowKeyless: true })`.
  - Charges keyless credits using `chargeKeylessCredits` with `metadata.creditsUsed`.
  - Adds snips covering 200 success and 429 when the keyless credit cap is reached.

<sup>Written for commit 62e458c16ac721c098c26321061b257f6f902864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

