### PR TITLE
fix(api): run YouTube postprocessor for Shorts URLs

### DIFF
--- a/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
@@ -27,6 +27,15 @@ describe("youtubePostprocessor.shouldRun", () => {
     ).toBe(true);
   });
 
+  it("runs for YouTube Shorts video URLs", () => {
+    expect(
+      youtubePostprocessor.shouldRun(
+        meta,
+        new URL("https://www.youtube.com/shorts/H4fUJQCIV5E"),
+      ),
+    ).toBe(true);
+  });
+
   it("does not run for non-video YouTube paths or already processed URLs", () => {
     expect(
       youtubePostprocessor.shouldRun(meta, new URL("https://www.youtube.com/")),
@@ -35,6 +44,12 @@ describe("youtubePostprocessor.shouldRun", () => {
       youtubePostprocessor.shouldRun(
         meta,
         new URL("https://www.youtube.com/live/"),
+      ),
+    ).toBe(false);
+    expect(
+      youtubePostprocessor.shouldRun(
+        meta,
+        new URL("https://www.youtube.com/shorts/"),
       ),
     ).toBe(false);
     expect(

--- a/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
@@ -57,7 +57,10 @@ function isYouTubeVideoPath(url: URL): boolean {
   }
 
   const pathParts = url.pathname.split("/").filter(Boolean);
-  return pathParts.length === 2 && pathParts[0] === "live";
+  return (
+    pathParts.length === 2 &&
+    (pathParts[0] === "live" || pathParts[0] === "shorts")
+  );
 }
 
 function buildMarkdown(


### PR DESCRIPTION
### Bug

`isYouTubeVideoPath` in `apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts` only recognizes two video URL shapes:

- `youtube.com/watch?v=<id>`
- `youtube.com/live/<id>`

YouTube Shorts are served at `youtube.com/shorts/<id>` and are regular videos with transcripts and metadata. Because that path is not matched, `youtubePostprocessor.shouldRun` returns `false` for Shorts, so the YouTube-specific transcript/metadata extraction is silently skipped and the URL falls back to generic HTML scraping.

### Fix

Treat `/shorts/<id>` the same way as the existing `/live/<id>` case in `isYouTubeVideoPath`. The guard still requires exactly two path segments, so `/shorts/` (no id) is correctly rejected, matching the existing `/live/` behavior.

### Verification

Extended the existing unit test (`youtube.test.ts`) with a Shorts happy-path case and a `/shorts/` (missing id) negative case.

```
$ pnpm exec vitest run src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts

 ✓ src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts (4 tests) 7ms
   ✓ runs for YouTube live video URLs
   ✓ keeps existing YouTube video URL support
   ✓ runs for YouTube Shorts video URLs
   ✓ does not run for non-video YouTube paths or already processed URLs

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Before the change, the new "runs for YouTube Shorts video URLs" case fails (`expected false to be true`); after it passes, and the pre-existing cases stay green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the YouTube postprocessor for Shorts URLs so transcripts and metadata are extracted instead of falling back to generic HTML scraping.

- **Bug Fixes**
  - Extended `isYouTubeVideoPath` to treat `/shorts/<id>` like `/live/<id>`; rejects `/shorts/` with no id.
  - Added unit tests for the Shorts happy path and missing-id case.

<sup>Written for commit af5f8b8d919d974f7ceaea3abef2d6218f4a5c4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

