### PR TITLE
fix: rename json field in MonitorPageDiff/MonitorPageSnapshot to avoid Pydantic warning

### DIFF
--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1052,23 +1052,23 @@ class MonitorCheck(BaseModel):
 class MonitorPageDiff(BaseModel):
     """Diff payload returned alongside a monitor page.
 
-    Markdown-only monitors populate both `text` (unified diff) and `json`
-    (the parseDiff AST). JSON-extraction monitors populate `json` only,
-    where `json` is the per-field `{previous, current}` map. Mixed-mode
-    monitors (JSON + git-diff) populate both `json` (field diff) and
+    Markdown-only monitors populate both `text` (unified diff) and `json_data`
+    (the parseDiff AST). JSON-extraction monitors populate `json_data` only,
+    where `json_data` is the per-field `{previous, current}` map. Mixed-mode
+    monitors (JSON + git-diff) populate both `json_data` (field diff) and
     `text` (markdown sidecar).
     """
     model_config = {"populate_by_name": True, "extra": "allow"}
 
     text: Optional[str] = None
-    json: Optional[Any] = None  # markdown→parseDiff AST | json→field diff
+    json_data: Optional[Any] = Field(default=None, alias="json")
 
 
 class MonitorPageSnapshot(BaseModel):
     """Current JSON extraction at this run. JSON / mixed mode only."""
     model_config = {"populate_by_name": True, "extra": "allow"}
 
-    json: Optional[Dict[str, Any]] = None
+    json_data: Optional[Dict[str, Any]] = Field(default=None, alias="json")
 
 
 class MonitorCheckPage(BaseModel):


### PR DESCRIPTION
## What

The `MonitorPageDiff` and `MonitorPageSnapshot` models in `firecrawl-v2` define a field named `json`, which shadows Pydantic's built-in `.json()` method on `BaseModel`. This causes a `UserWarning` every time the SDK is imported.

## Why

Pydantic reserves certain attribute names on `BaseModel`. When a model field has the same name, Pydantic emits a warning at class-definition time (import time), making the SDK noisy for users.

The warning looks like:
```
/home/.../firecrawl/v2/types.py:988: UserWarning: Field name "json" in "MonitorPageDiff" shadows an attribute in parent "BaseModel"
```

## How

Renamed the Python attribute from `json` to `json_data` and added `Field(alias="json")` so the API wire format stays the same. Both models already have `populate_by_name: True` in their config, so `json_data` is the clean Python name while `json` continues to work for serialization/deserialization.

## Testing

- Verified no `UserWarning` is emitted on import
- Verified deserialization from `{"json": ...}` still works via the alias
- Verified `model_dump(by_alias=True)` produces `{"json": ...}` as expected

Fixes #3643

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `json` to `json_data` in `MonitorPageDiff` and `MonitorPageSnapshot` to avoid `pydantic` BaseModel `.json()` shadowing and remove import warnings. Wire format stays `json` via `Field(alias="json")`.

<sup>Written for commit 387fabd24609e873b8c671e8cde4a4f001968b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

