### PR TITLE
feat(interact): return cdpUrl in the scrape interact response

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-browser.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-browser.test.ts
@@ -107,6 +107,8 @@ describe("Scrape browser interact replay", () => {
         expect(executeResponse.statusCode).toBe(200);
         expect(executeResponse.body.success).toBe(true);
         expect(executeResponse.body.stdout).toContain(marker);
+        expect(typeof executeResponse.body.cdpUrl).toBe("string");
+        expect(executeResponse.body.cdpUrl.length).toBeGreaterThan(0);
       } finally {
         if (scrapeId) {
           await scrapeStopInteractiveBrowserRaw(scrapeId, identity);

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -99,6 +99,7 @@ type BrowserExecuteRequest = z.infer<typeof browserExecuteRequestSchema>;
 
 interface BrowserExecuteResponse {
   success: boolean;
+  cdpUrl?: string;
   liveViewUrl?: string;
   interactiveLiveViewUrl?: string;
   output?: string;
@@ -361,6 +362,7 @@ export async function scrapeInteractController(
 
   return res.status(200).json({
     success: !hasError,
+    cdpUrl: session.cdp_url,
     liveViewUrl: session.cdp_path,
     interactiveLiveViewUrl: session.cdp_interactive_path,
     ...(agentOutput ? { output: agentOutput } : {}),

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.27.0",
+  "version": "4.28.0",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/scrape-browser.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/scrape-browser.unit.test.ts
@@ -33,6 +33,7 @@ describe("JS SDK v2 scrape-browser methods", () => {
       data: {
         success: true,
         output: "Clicked the button",
+        cdpUrl: "wss://browser.example.com/cdp",
         liveViewUrl: "https://live.example.com/view",
         interactiveLiveViewUrl: "https://live.example.com/interactive",
         stdout: "",
@@ -52,6 +53,7 @@ describe("JS SDK v2 scrape-browser methods", () => {
     );
     expect(response.success).toBe(true);
     expect(response.output).toBe("Clicked the button");
+    expect(response.cdpUrl).toBe("wss://browser.example.com/cdp");
     expect(response.liveViewUrl).toBe("https://live.example.com/view");
     expect(response.interactiveLiveViewUrl).toBe(
       "https://live.example.com/interactive",

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -1115,6 +1115,7 @@ export interface BrowserCreateResponse {
 
 export interface BrowserExecuteResponse {
   success: boolean;
+  cdpUrl?: string;
   liveViewUrl?: string;
   interactiveLiveViewUrl?: string;
   output?: string;

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.29.0"
+__version__ = "4.30.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_aio_scrape_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_aio_scrape_request_preparation.py
@@ -127,6 +127,7 @@ class TestAsyncScrapeRequestPreparation:
                 {
                     "success": True,
                     "output": "Clicked the button",
+                    "cdpUrl": "wss://browser.example.com/cdp",
                     "liveViewUrl": "https://live.example.com/view",
                     "interactiveLiveViewUrl": "https://live.example.com/interactive",
                     "stdout": "",
@@ -148,6 +149,7 @@ class TestAsyncScrapeRequestPreparation:
         }
         assert response.success is True
         assert response.output == "Clicked the button"
+        assert response.cdp_url == "wss://browser.example.com/cdp"
         assert response.live_view_url == "https://live.example.com/view"
         assert response.interactive_live_view_url == "https://live.example.com/interactive"
 

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_scrape_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_scrape_request_preparation.py
@@ -179,6 +179,7 @@ class TestScrapeRequestPreparation:
                 {
                     "success": True,
                     "output": "Clicked the button",
+                    "cdpUrl": "wss://browser.example.com/cdp",
                     "liveViewUrl": "https://live.example.com/view",
                     "interactiveLiveViewUrl": "https://live.example.com/interactive",
                     "stdout": "",
@@ -200,6 +201,7 @@ class TestScrapeRequestPreparation:
         }
         assert response.success is True
         assert response.output == "Clicked the button"
+        assert response.cdp_url == "wss://browser.example.com/cdp"
         assert response.live_view_url == "https://live.example.com/view"
         assert response.interactive_live_view_url == "https://live.example.com/interactive"
 

--- a/apps/python-sdk/firecrawl/v2/methods/aio/scrape.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/scrape.py
@@ -77,6 +77,8 @@ async def interact(
     normalized = dict(body)
     if "exitCode" in normalized and "exit_code" not in normalized:
         normalized["exit_code"] = normalized["exitCode"]
+    if "cdpUrl" in normalized and "cdp_url" not in normalized:
+        normalized["cdp_url"] = normalized["cdpUrl"]
     if "liveViewUrl" in normalized and "live_view_url" not in normalized:
         normalized["live_view_url"] = normalized["liveViewUrl"]
     if "interactiveLiveViewUrl" in normalized and "interactive_live_view_url" not in normalized:

--- a/apps/python-sdk/firecrawl/v2/methods/scrape.py
+++ b/apps/python-sdk/firecrawl/v2/methods/scrape.py
@@ -128,6 +128,8 @@ def interact(
     normalized = dict(payload)
     if "exitCode" in normalized and "exit_code" not in normalized:
         normalized["exit_code"] = normalized["exitCode"]
+    if "cdpUrl" in normalized and "cdp_url" not in normalized:
+        normalized["cdp_url"] = normalized["cdpUrl"]
     if "liveViewUrl" in normalized and "live_view_url" not in normalized:
         normalized["live_view_url"] = normalized["liveViewUrl"]
     if "interactiveLiveViewUrl" in normalized and "interactive_live_view_url" not in normalized:

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1158,6 +1158,7 @@ class BrowserExecuteResponse(BaseModel):
     """Response from executing code in a browser session."""
 
     success: bool
+    cdp_url: Optional[str] = None
     live_view_url: Optional[str] = None
     interactive_live_view_url: Optional[str] = None
     output: Optional[str] = None


### PR DESCRIPTION
## What

The `POST /v2/scrape/:jobId/interact` response surfaced the iframe view URLs (`liveViewUrl` / `interactiveLiveViewUrl`) but **not** the raw CDP WebSocket URL — even though it was already available on the session (`session.cdp_url`). This adds `cdpUrl` to the interact response so callers can connect to the live browser directly with Playwright/Puppeteer/any CDP client.

This matches what `POST /v2/browser` and the browser list endpoint already expose.

## Changes

- **API**: add `cdpUrl: session.cdp_url` to the interact response (`scrape-browser.ts`) + the `BrowserExecuteResponse` interface.
- **JS SDK**: add `cdpUrl?` to `BrowserExecuteResponse`; bump to `4.28.0`.
- **Python SDK**: add `cdp_url` to `BrowserExecuteResponse` + camelCase→snake_case normalization (sync + async); bump to `4.30.0`.
- **Tests**: assert `cdpUrl` flows through in the API snips happy-path and in the JS/Python SDK unit tests.

Docs PR: separate (firecrawl/docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the raw CDP WebSocket URL in `POST /v2/scrape/:jobId/interact` as `cdpUrl` so clients can connect to the live browser directly. This aligns the interact response with `/v2/browser` and the browser list.

- **New Features**
  - API: add `cdpUrl` from `session.cdp_url` to interact response.
  - JS SDK: add optional `cdpUrl` to `BrowserExecuteResponse`.
  - Python SDK: add `cdp_url` to `BrowserExecuteResponse` with camelCase→snake_case normalization (sync + async).
  - Tests: assert `cdpUrl` is returned in API and SDK unit tests.

- **Dependencies**
  - Bump `@mendable/firecrawl-js` to `4.28.0`.
  - Bump `firecrawl` (Python) to `4.30.0`.

<sup>Written for commit d6fdb532fb8f06c8a52fc1b05f58a169e908e82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

