### PR TITLE
feat: make /interact /browser alias

### DIFF
--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -547,7 +547,7 @@ v2Router.get(
 );
 
 v2Router.post(
-  "/browser",
+  ["/browser", "/interact"],
   authMiddleware(RateLimiterMode.Browser),
   countryCheck,
   checkCreditsMiddleware(2),
@@ -555,19 +555,19 @@ v2Router.post(
 );
 
 v2Router.get(
-  "/browser",
+  ["/browser", "/interact"],
   authMiddleware(RateLimiterMode.BrowserExecute),
   wrap(browserListController),
 );
 
 v2Router.post(
-  "/browser/:sessionId/execute",
+  ["/browser/:sessionId/execute", "/interact/:sessionId/execute"],
   authMiddleware(RateLimiterMode.BrowserExecute),
   wrap(browserExecuteController),
 );
 
 v2Router.delete(
-  "/browser/:sessionId",
+  ["/browser/:sessionId", "/interact/:sessionId"],
   authMiddleware(RateLimiterMode.BrowserExecute),
   wrap(browserDeleteController),
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `/interact` as a full alias for `/browser` across create, list, execute, and delete endpoints. Behavior, rate limits, and credit checks remain the same.

- **New Features**
  - POST `/interact` (create session)
  - GET `/interact` (list sessions)
  - POST `/interact/:sessionId/execute`
  - DELETE `/interact/:sessionId`

- **Migration**
  - No changes required; `/browser` still works.
  - `/interact` is identical, including rate limits and 2-credit charge on create.

<sup>Written for commit 4e3cd4bd06c8f4294422d7d24e792c4867dca89d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

