### PR TITLE
fix(infra): pin remaining docker image tags to sha256 digests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
     # NOTE: If you want to use Valkey (open source) instead of Redis (source available),
     # uncomment the Valkey statement and comment out the Redis statement.
     # Using Valkey with Firecrawl is untested and not guaranteed to work. Use with caution.
-    image: redis:alpine
+    image: redis:alpine@sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1
     # image: valkey/valkey:alpine
 
     networks:
@@ -136,7 +136,7 @@ services:
         compress: "true"
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
     networks:
       - backend
     command: rabbitmq-server
@@ -175,7 +175,7 @@ services:
   # NUQ_BACKEND=fdb; the api container reads the shared cluster file from the
   # fdb-cluster-file volume. Replaces nuq-postgres once stable.
   foundationdb:
-    image: foundationdb/foundationdb:7.3.63
+    image: foundationdb/foundationdb:7.3.63@sha256:df1a2310c6dbe0d56def526b73606cc8fd414ecc42c50fba2588f13292f82d48
     environment:
       FDB_NETWORKING_MODE: container
       FDB_COORDINATOR_PORT: 4500
@@ -193,7 +193,7 @@ services:
 
   # one-shot: creates the database on first boot (no-op afterwards)
   foundationdb-init:
-    image: foundationdb/foundationdb:7.3.63
+    image: foundationdb/foundationdb:7.3.63@sha256:df1a2310c6dbe0d56def526b73606cc8fd414ecc42c50fba2588f13292f82d48
     depends_on:
       - foundationdb
     entrypoint:


### PR DESCRIPTION
## Description
This PR addresses issue #3804 by pinning the remaining floating Docker image tags in the primary `docker-compose.yaml` file to their explicit `sha256` digests.

### Changes Made
- Pinned `redis:alpine`
- Pinned `rabbitmq:3-management`
- Pinned `foundationdb/foundationdb:7.3.63`

*Note: The secondary compose files mentioned in the issue (`docker-compose.hardened.yml`, `dev/docker-compose.yml`, etc.) do not currently exist in the open-source tree.*

### Why?
Floating tags (like `:alpine` or `:3-management`) are susceptible to upstream overwrites, which poses a supply-chain security risk. By pinning these to immutable `sha256` digests, we ensure 100% reproducible builds and satisfy SOC2 compliance evidence requirements.

Fixes #3804


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned the remaining floating Docker image tags in the primary `docker-compose.yaml` to immutable SHA-256 digests for reproducible deployments and reduced supply-chain risk.

Pins `redis:alpine`, `rabbitmq:3-management`, and `foundationdb/foundationdb:7.3.63` (including `foundationdb-init`) to their digests.

<sup>Written for commit dedba9eb61a95877be07f30c8387b706d69b64ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

