### PR TITLE
test(api): properly gate branding extraction snips for fire-engine

### DIFF
--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -334,9 +334,11 @@ export async function queueBillingOperation(
       logger.info(
         "🔄 Billing queue reached batch size, triggering immediate processing",
       );
-      await processBillingBatch();
+      // Run in background instead of blocking the current request
+      processBillingBatch().catch(error => {
+        logger.error("Error in immediate billing batch processing", { error });
+      });
     }
-    // TODO is there a better way to do this?
 
     // Update cached credits used immediately to provide accurate feedback to users
     // This is optimistic - actual billing happens in batch


### PR DESCRIPTION
## Description
This PR refactors `batch_billing.ts` to execute `processBillingBatch()` asynchronously.

### Why?
Previously, when the queue length reached `BATCH_SIZE`, the API route would synchronously `await` the batch processor. This created a blocking bottleneck on the main event loop, causing severe latency spikes for the API request triggering the batch. 

Because `processBillingBatch()` uses a Redis lock (`acquireLock()`), running it as a fire-and-forget background promise is completely thread-safe and drastically reduces API response times under load.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run billing batch processing in the background instead of awaiting it on the request path to prevent blocking and latency spikes under load. When the queue hits batch size, we fire-and-forget `processBillingBatch()` with error logging; the Redis lock via `acquireLock()` keeps it safe.

<sup>Written for commit fe64ea59f40844b0de1e4be19d3d849a1727f123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

