### PR TITLE
feat: pin node to 22.22, latest version broke gcs upload

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM node:22-slim AS base
+FROM node:22.22-slim AS base
+# Pinned cause 22.23 is breaking gcs upload "ERR_STREAM_PREMATURE_CLOSE" https://www.googleapis.com/oauth2/v4/token
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin `apps/api` Docker base image to `node:22.22-slim` to prevent GCS upload failures seen with 22.23 (`ERR_STREAM_PREMATURE_CLOSE` during token exchange). Restores stable uploads while we investigate the upstream issue.

<sup>Written for commit 4331a26732b32232784d3c53f1040e5e4a516a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

