### PR TITLE
feat: patch node-fetch, gcs bug

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -216,6 +216,9 @@
       "shell-quote@<1.8.4": "1.8.4",
       "esbuild@>=0.17.0 <0.28.1": "0.28.1",
       "@opentelemetry/core@>=2.0.0 <2.8.0": "2.8.0"
+    },
+    "patchedDependencies": {
+      "node-fetch@2.7.0": "patches/node-fetch@2.7.0.patch"
     }
   },
   "lint-staged": {

--- a/apps/api/patches/node-fetch@2.7.0.patch
+++ b/apps/api/patches/node-fetch@2.7.0.patch
@@ -1,0 +1,31 @@
+diff --git a/lib/index.js b/lib/index.js
+index 567ff5da58e83683bec0ea9e86221041ddf9435f..7ca5fc0c441fe25201ce1757d255c945724e7364 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1738,13 +1738,19 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+ 
+ 		if (headers['transfer-encoding'] === 'chunked' && !headers['content-length']) {
+ 			response.once('close', function (hadError) {
+-				// tests for socket presence, as in some situations the
+-				// the 'socket' event is not triggered for the request
+-				// (happens in deno), avoids `TypeError`
+-				// if a data listener is still present we didn't end cleanly
+-				const hasDataListener = socket && socket.listenerCount('data') > 0;
+-
+-				if (hasDataListener && !hadError) {
++				// PATCH (firecrawl): use Node's HTTP-parser-backed completion flag
++				// instead of the socket data-listener heuristic. The listener count is
++				// teardown-order dependent and false-positives on COMPLETE chunked
++				// responses on Node >=22.23.0, breaking gtoken/gaxios OAuth token
++				// fetches to googleapis.com/oauth2/v4/token. Genuine truncation still
++				// leaves response.complete === false, so real errors still surface.
++				// Refs:
++				//   node-fetch bug:   https://github.com/node-fetch/node-fetch/issues/1767
++				//   related variant:  https://github.com/node-fetch/node-fetch/issues/1576
++				//   upstream PR (diff bug): https://github.com/node-fetch/node-fetch/pull/1687
++				//   Node trigger:     https://nodejs.org/en/blog/release/v22.23.0 (CVE-2026-48931; llhttp 9.4.2)
++				//   completion flag:  https://nodejs.org/api/http.html#messagecomplete
++				if (response.complete === false && !hadError) {
+ 					const err = new Error('Premature close');
+ 					err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+ 					errorCallback(err);

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -40,6 +40,11 @@ overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   '@opentelemetry/core@>=2.0.0 <2.8.0': 2.8.0
 
+patchedDependencies:
+  node-fetch@2.7.0:
+    hash: cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b
+    path: patches/node-fetch@2.7.0.patch
+
 importers:
 
   .:
@@ -6471,7 +6476,7 @@ snapshots:
   '@sentry/cli@2.58.2(encoding@0.1.13)':
     dependencies:
       https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
       progress: 2.0.3
       proxy-from-env: 1.1.0
       which: 2.0.2
@@ -7027,7 +7032,7 @@ snapshots:
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
       jayson: 4.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
       rpc-websockets: 9.1.3
       superstruct: 2.0.2
     transitivePeerDependencies:
@@ -8170,7 +8175,7 @@ snapshots:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
       uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
@@ -8861,7 +8866,7 @@ snapshots:
 
   node-ensure@0.0.0: {}
 
-  node-fetch@2.7.0(encoding@0.1.13):
+  node-fetch@2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
     optionalDependencies:
@@ -9572,7 +9577,7 @@ snapshots:
     dependencies:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 11.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
https://github.com/nodejs/node/issues/63989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patched `node-fetch@2.7.0` to fix false "Premature close" errors on Node 22.23+, restoring reliable GCS auth/token requests and downstream API calls.

- **Bug Fixes**
  - Use `response.complete` for chunked-response completion in `node-fetch` to avoid false `ERR_STREAM_PREMATURE_CLOSE` that broke Google Cloud Storage flows.

- **Dependencies**
  - Added `patchedDependencies` for `node-fetch@2.7.0` in `apps/api/package.json` and updated `pnpm-lock.yaml` to apply the patch.

<sup>Written for commit 74f52414c4ac2ee59a9b7e5197c248d008538da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

