### PR TITLE
feat: unfreeze node

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22.22-slim AS base
-# Pinned cause 22.23 is breaking gcs upload "ERR_STREAM_PREMATURE_CLOSE" https://www.googleapis.com/oauth2/v4/token
+FROM node:22-slim AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unfroze Node.js in the API Dockerfile by switching the base image from `node:22.22-slim` to `node:22-slim`. This restores minor/patch updates to pick up upstream fixes and security patches.

<sup>Written for commit 4e599c0dfe9c291ad6599639bf767474999c5709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

