### PR TITLE
fix(api): enforce scrape job permissions centrally

### DIFF
--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -8,7 +8,6 @@ import { RateLimiterMode, ScrapeJobSingleUrls } from "../../types";
 import { logSearch, logRequest } from "../../services/logging/log_job";
 import { PageOptions, SearchOptions } from "../../lib/entities";
 import { search } from "../../search";
-import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { v7 as uuidv7 } from "uuid";
 import { logger } from "../../lib/logger";
 import { redisEvictConnection } from "../../../src/services/redis";
@@ -99,13 +98,6 @@ async function searchHelper(
     return { success: true, data: res, returnCode: 200 };
   }
 
-  res = res.filter(
-    r =>
-      !isUrlBlocked(r.url, flags, {
-        team_id,
-        origin: req.body?.origin ?? null,
-      }),
-  );
   if (res.length > num_results) {
     res = res.slice(0, num_results);
   }
@@ -129,7 +121,10 @@ async function searchHelper(
         mode: "single_urls" as const,
         team_id: team_id,
         scrapeOptions,
-        internalOptions,
+        internalOptions: {
+          ...internalOptions,
+          teamFlags: flags,
+        },
         startTime: Date.now(),
         zeroDataRetention: false, // not supported on v0
         apiKeyId: api_key_id,

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -157,6 +157,7 @@ export async function batchScrapeController(
             ? true
             : false,
           zeroDataRetention,
+          teamFlags: req.acuc?.flags ?? null,
           agentIndexOnly: (req as any).agentIndexOnly ?? false,
         }, // NOTE: smart wait disabled for batch scrapes to ensure contentful scrape, speed does not matter
         team_id: req.auth.team_id,

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -132,6 +132,7 @@ export async function crawlController(
       teamId: req.auth.team_id,
       saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
       zeroDataRetention,
+      teamFlags: req.acuc?.flags ?? null,
       agentIndexOnly: (req as any).agentIndexOnly ?? false,
     }, // NOTE: smart wait disabled for crawls to ensure contentful scrape, speed does not matter
     team_id: req.auth.team_id,

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -249,6 +249,14 @@ export async function scrapeController(
         });
       }
 
+      if (e.code === "CRAWL_DENIAL") {
+        return res.status(403).json({
+          success: false,
+          code: e.code,
+          error: e.message,
+        });
+      }
+
       if (e.code === "SCRAPE_ACTIONS_NOT_SUPPORTED") {
         return res.status(400).json({
           success: false,

--- a/apps/api/src/controllers/v1/x402-search.ts
+++ b/apps/api/src/controllers/v1/x402-search.ts
@@ -13,8 +13,6 @@ import { v7 as uuidv7 } from "uuid";
 import { addScrapeJob, waitForJob } from "../../services/queue-jobs";
 import { logSearch, logRequest } from "../../services/logging/log_job";
 import { search } from "../../search";
-import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
-import { UNSUPPORTED_SITE_MESSAGE } from "../../lib/strings";
 import { logger as _logger } from "../../lib/logger";
 import type { Logger } from "winston";
 import { CostTracking } from "../../lib/cost-tracking";
@@ -22,7 +20,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { fromV1ScrapeOptions } from "../v2/types";
-import { ScrapeJobTimeoutError } from "../../lib/error";
+import { ScrapeJobTimeoutError, TransportableError } from "../../lib/error";
 import { scrapeQueue } from "../../services/worker/nuq-router";
 import {
   applyZdrScope,
@@ -58,14 +56,6 @@ async function scrapeX402SearchResult(
   applyZdrScope(zeroDataRetention);
 
   try {
-    if (
-      isUrlBlocked(searchResult.url, flags, {
-        team_id: options.teamId,
-        origin: options.origin,
-      })
-    ) {
-      throw new Error("Could not scrape url: " + UNSUPPORTED_SITE_MESSAGE);
-    }
     logger.info("Adding scrape job [x402]", {
       scrapeId: jobId,
       url: searchResult.url,
@@ -95,6 +85,7 @@ async function scrapeX402SearchResult(
           teamId: options.teamId,
           bypassBilling: true,
           zeroDataRetention,
+          teamFlags: flags,
         },
         origin: options.origin,
         is_scrape: true,
@@ -151,16 +142,17 @@ async function scrapeX402SearchResult(
       costTracking,
     };
   } catch (error) {
+    const statusCode =
+      error instanceof TransportableError && error.code === "CRAWL_DENIAL"
+        ? 403
+        : 500;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
     logger.error(`Error in scrapeSearchResult [x402]: ${error}`, {
       scrapeId: jobId,
       url: searchResult.url,
       teamId: options.teamId,
     });
-
-    let statusCode = 0;
-    if (error?.message?.includes("Could not scrape url")) {
-      statusCode = 403;
-    }
 
     const document: Document = {
       title: searchResult.title,
@@ -168,7 +160,7 @@ async function scrapeX402SearchResult(
       url: searchResult.url,
       metadata: {
         statusCode,
-        error: error.message,
+        error: errorMessage,
         proxyUsed: "basic",
       },
     };
@@ -250,16 +242,6 @@ export async function x402SearchController(
       country: req.body.country,
       location: req.body.location,
     });
-
-    if (req.body.ignoreInvalidURLs) {
-      searchResults = searchResults.filter(
-        result =>
-          !isUrlBlocked(result.url, req.acuc?.flags ?? null, {
-            team_id: req.auth.team_id,
-            origin: req.body.origin ?? null,
-          }),
-      );
-    }
 
     logger.info("Searching [x402] completed", {
       num_results: searchResults.length,

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -172,6 +172,7 @@ export async function batchScrapeController(
             : false,
           zeroDataRetention,
           bypassBilling: !(req.body.__agentInterop?.shouldBill ?? true),
+          teamFlags: req.acuc?.flags ?? null,
           agentIndexOnly: (req as any).agentIndexOnly ?? false,
         }, // NOTE: smart wait disabled for batch scrapes to ensure contentful scrape, speed does not matter
         team_id: req.auth.team_id,

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -191,6 +191,7 @@ export async function crawlController(
       teamId: req.auth.team_id,
       saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
       zeroDataRetention,
+      teamFlags: req.acuc?.flags ?? null,
       agentIndexOnly: (req as any).agentIndexOnly ?? false,
     },
     team_id: req.auth.team_id,

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -592,6 +592,17 @@ export async function parseController(
             });
           }
 
+          if (e.code === "CRAWL_DENIAL") {
+            setSpanAttributes(span, {
+              "parse.status_code": 403,
+            });
+            return res.status(403).json({
+              success: false,
+              code: e.code,
+              error: e.message,
+            });
+          }
+
           if (e.code === "SCRAPE_ACTIONS_NOT_SUPPORTED") {
             setSpanAttributes(span, {
               "parse.status_code": 400,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -383,6 +383,17 @@ export async function scrapeController(
             });
           }
 
+          if (e.code === "CRAWL_DENIAL") {
+            setSpanAttributes(span, {
+              "scrape.status_code": 403,
+            });
+            return res.status(403).json({
+              success: false,
+              code: e.code,
+              error: e.message,
+            });
+          }
+
           if (e.code === "SCRAPE_ACTIONS_NOT_SUPPORTED") {
             setSpanAttributes(span, {
               "scrape.status_code": 400,

--- a/apps/api/src/controllers/v2/x402-search.ts
+++ b/apps/api/src/controllers/v2/x402-search.ts
@@ -13,7 +13,6 @@ import { v7 as uuidv7 } from "uuid";
 import { addScrapeJob, waitForJob } from "../../services/queue-jobs";
 import { logSearch, logRequest } from "../../services/logging/log_job";
 import { search } from "../../search/v2";
-import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { logger as _logger } from "../../lib/logger";
 import type { Logger } from "winston";
 import { getJobPriority } from "../../lib/job-priority";
@@ -22,7 +21,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { SearchV2Response } from "../../lib/entities";
-import { ScrapeJobTimeoutError } from "../../lib/error";
+import { ScrapeJobTimeoutError, TransportableError } from "../../lib/error";
 import { scrapeQueue } from "../../services/worker/nuq-router";
 import { z } from "zod";
 import {
@@ -94,6 +93,7 @@ async function startX420ScrapeJob(
         teamId: options.teamId,
         bypassBilling: true,
         zeroDataRetention,
+        teamFlags: flags,
       },
       origin: options.origin,
       // Do not touch this flag
@@ -174,6 +174,12 @@ async function scrapeX420SearchResult(
       costTracking,
     };
   } catch (error) {
+    const statusCode =
+      error instanceof TransportableError && error.code === "CRAWL_DENIAL"
+        ? 403
+        : 500;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
     logger.error(`Error in scrapeSearchResult [x402]: ${error}`, {
       url: searchResult.url,
       teamId: options.teamId,
@@ -184,8 +190,8 @@ async function scrapeX420SearchResult(
       description: searchResult.description,
       url: searchResult.url,
       metadata: {
-        statusCode: 500,
-        error: error.message,
+        statusCode,
+        error: errorMessage,
         proxyUsed: "basic",
       },
     };
@@ -400,73 +406,52 @@ export async function x402SearchController(
         scrapeInput: ScrapeJobInput;
       }> = [];
 
-      const blockContext = {
-        team_id: req.auth.team_id,
-        origin: req.body.origin ?? null,
-      };
-
-      // Add web results (skip blocked URLs)
+      // Add web results. Scrape permissions are enforced by the scrape worker.
       if (searchResponse.web) {
         searchResponse.web.forEach(item => {
-          if (!isUrlBlocked(item.url, req.acuc?.flags ?? null, blockContext)) {
-            itemsToScrape.push({
-              item,
-              type: "web",
-              scrapeInput: {
-                url: item.url,
-                title: item.title,
-                description: item.description,
-              },
-            });
-          } else {
-            logger.info(`Skipping blocked URL [x402]: ${item.url}`);
-          }
+          itemsToScrape.push({
+            item,
+            type: "web",
+            scrapeInput: {
+              url: item.url,
+              title: item.title,
+              description: item.description,
+            },
+          });
         });
       }
 
-      // Add news results (only those with URLs and not blocked)
+      // Add news results (only those with URLs).
       if (searchResponse.news) {
         searchResponse.news
           .filter(item => item.url)
           .forEach(item => {
-            if (
-              !isUrlBlocked(item.url!, req.acuc?.flags ?? null, blockContext)
-            ) {
-              itemsToScrape.push({
-                item,
-                type: "news",
-                scrapeInput: {
-                  url: item.url!,
-                  title: item.title || "",
-                  description: item.snippet || "",
-                },
-              });
-            } else {
-              logger.info(`Skipping blocked URL [x402]: ${item.url}`);
-            }
+            itemsToScrape.push({
+              item,
+              type: "news",
+              scrapeInput: {
+                url: item.url!,
+                title: item.title || "",
+                description: item.snippet || "",
+              },
+            });
           });
       }
 
-      // Add image results (only those with URLs and not blocked)
+      // Add image results (only those with URLs).
       if (searchResponse.images) {
         searchResponse.images
           .filter(item => item.url)
           .forEach(item => {
-            if (
-              !isUrlBlocked(item.url!, req.acuc?.flags ?? null, blockContext)
-            ) {
-              itemsToScrape.push({
-                item,
-                type: "image",
-                scrapeInput: {
-                  url: item.url!,
-                  title: item.title || "",
-                  description: "",
-                },
-              });
-            } else {
-              logger.info(`Skipping blocked URL [x402]: ${item.url}`);
-            }
+            itemsToScrape.push({
+              item,
+              type: "image",
+              scrapeInput: {
+                url: item.url!,
+                title: item.title || "",
+                description: "",
+              },
+            });
           });
       }
 

--- a/apps/api/src/lib/scrape-job-permissions.test.ts
+++ b/apps/api/src/lib/scrape-job-permissions.test.ts
@@ -1,0 +1,95 @@
+import type { ScrapeJobSingleUrls } from "../types";
+import { checkScrapeJobPermissions } from "./scrape-job-permissions";
+import { UNSUPPORTED_SITE_MESSAGE } from "./strings";
+
+const baseJobData: ScrapeJobSingleUrls = {
+  mode: "single_urls",
+  url: "https://example.com",
+  team_id: "team-1",
+  scrapeOptions: {} as any,
+  internalOptions: { teamId: "team-1" },
+  origin: "api",
+  zeroDataRetention: false,
+  apiKeyId: null,
+};
+
+describe("checkScrapeJobPermissions", () => {
+  const isBlocked = vi.fn((url: string) => {
+    const hostname = new URL(url).hostname;
+    return hostname === "linkedin.com" || hostname.endsWith(".linkedin.com");
+  });
+
+  beforeEach(() => {
+    isBlocked.mockClear();
+  });
+
+  it("rejects blocked scrape job URLs", () => {
+    const result = checkScrapeJobPermissions(
+      {
+        ...baseJobData,
+        url: "https://www.linkedin.com/in/example",
+      },
+      null,
+      isBlocked,
+    );
+
+    expect(result.error).toBe(UNSUPPORTED_SITE_MESSAGE);
+    expect(isBlocked).toHaveBeenCalledWith(
+      "https://www.linkedin.com/in/example",
+      null,
+      {
+        team_id: "team-1",
+        origin: "api",
+      },
+    );
+  });
+
+  it("allows unblocked scrape job URLs", () => {
+    const result = checkScrapeJobPermissions(baseJobData, null, isBlocked);
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it("mirrors scrape permissions for nested scrape options", () => {
+    const result = checkScrapeJobPermissions(
+      {
+        ...baseJobData,
+        scrapeOptions: {
+          location: { country: "us-whitelist" },
+        } as any,
+      },
+      null,
+      isBlocked,
+    );
+
+    expect(result.error).toContain("Static IP addresses are not enabled");
+  });
+
+  it("allows nested scrape options when the team has permission", () => {
+    const result = checkScrapeJobPermissions(
+      {
+        ...baseJobData,
+        scrapeOptions: {
+          location: { country: "us-whitelist" },
+        } as any,
+      },
+      { ipWhitelist: true },
+      isBlocked,
+    );
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it("mirrors crawl permission checks for crawler options", () => {
+    const result = checkScrapeJobPermissions(
+      {
+        ...baseJobData,
+        crawlerOptions: { ignoreRobotsTxt: true },
+      },
+      null,
+      isBlocked,
+    );
+
+    expect(result.error).toContain("ignoreRobotsTxt parameter");
+  });
+});

--- a/apps/api/src/lib/scrape-job-permissions.ts
+++ b/apps/api/src/lib/scrape-job-permissions.ts
@@ -1,0 +1,32 @@
+import type { ScrapeJobSingleUrls } from "../types";
+import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";
+import { checkPermissions } from "./permissions";
+import { UNSUPPORTED_SITE_MESSAGE } from "./strings";
+
+type BlockContext = {
+  team_id?: string | null;
+  origin?: string | null;
+};
+
+type BlocklistCheck = (
+  url: string,
+  flags: any,
+  context?: BlockContext,
+) => boolean;
+
+export function checkScrapeJobPermissions(
+  jobData: ScrapeJobSingleUrls,
+  flags: any,
+  isBlocked: BlocklistCheck = isUrlBlocked,
+): { error?: string } {
+  if (
+    isBlocked(jobData.url, flags, {
+      team_id: jobData.team_id,
+      origin: jobData.origin,
+    })
+  ) {
+    return { error: UNSUPPORTED_SITE_MESSAGE };
+  }
+
+  return checkPermissions(jobData, flags);
+}

--- a/apps/api/src/search/scrape.test.ts
+++ b/apps/api/src/search/scrape.test.ts
@@ -2,9 +2,10 @@ vi.mock("uuid", () => ({
   v7: vi.fn(() => "job-1"),
 }));
 
-import { scrapeSearchResults } from "./scrape";
+import { getItemsToScrape, scrapeSearchResults } from "./scrape";
 import { getJobPriority } from "../lib/job-priority";
 import { processJobInternal } from "../services/worker/scrape-worker";
+import { CrawlDenialError } from "../lib/error";
 
 vi.mock("../lib/job-priority", () => ({
   getJobPriority: vi.fn().mockResolvedValue(10),
@@ -18,6 +19,14 @@ vi.mock("../services/worker/scrape-worker", () => ({
 }));
 
 describe("scrapeSearchResults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(processJobInternal).mockResolvedValue({
+      markdown: "body",
+      metadata: { creditsUsed: 1, statusCode: 200, proxyUsed: "basic" },
+    } as any);
+  });
+
   it("preserves billing metadata on spawned scrape jobs", async () => {
     await scrapeSearchResults(
       [
@@ -50,6 +59,60 @@ describe("scrapeSearchResults", () => {
           billing: { endpoint: "agent" },
         }),
       }),
+    );
+  });
+
+  it("maps worker scrape denials to per-result 403 metadata", async () => {
+    vi.mocked(processJobInternal).mockRejectedValueOnce(
+      new CrawlDenialError("blocked"),
+    );
+
+    const results = await scrapeSearchResults(
+      [
+        {
+          url: "https://www.linkedin.com/in/example",
+          title: "Blocked",
+          description: "Desc",
+        },
+      ],
+      {
+        teamId: "team-1",
+        origin: "api",
+        timeout: 60_000,
+        scrapeOptions: {} as any,
+        apiKeyId: 123,
+      },
+      { debug: vi.fn(), info: vi.fn(), error: vi.fn() } as any,
+      null as any,
+    );
+
+    expect(results[0].document.metadata).toMatchObject({
+      statusCode: 403,
+      error: "blocked",
+      proxyUsed: "basic",
+    });
+  });
+});
+
+describe("getItemsToScrape", () => {
+  it("passes URL-bearing search results through to the scrape layer", () => {
+    const items = getItemsToScrape(
+      {
+        web: [
+          {
+            url: "https://www.linkedin.com/in/example",
+            title: "Blocked",
+            description: "Desc",
+          },
+        ],
+      } as any,
+      null as any,
+      { team_id: "team-1", origin: "api" },
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0].scrapeInput.url).toBe(
+      "https://www.linkedin.com/in/example",
     );
   });
 });

--- a/apps/api/src/search/scrape.ts
+++ b/apps/api/src/search/scrape.ts
@@ -3,13 +3,13 @@ import type { Logger } from "winston";
 import { Document, ScrapeOptions, TeamFlags } from "../controllers/v2/types";
 import { CostTracking } from "../lib/cost-tracking";
 import { getJobPriority } from "../lib/job-priority";
-import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";
 import { NuQJob } from "../services/worker/nuq";
 import { processJobInternal } from "../services/worker/scrape-worker";
 import { ScrapeJobData } from "../types";
 import { SearchV2Response } from "../lib/entities";
 import type { BillingMetadata } from "../services/billing/types";
 import { getScrapeZDR } from "../lib/zdr-helpers";
+import { TransportableError } from "../lib/error";
 
 export interface DocumentWithCostTracking {
   document: Document;
@@ -117,6 +117,12 @@ async function scrapeSearchResultDirect(
       costTracking: new CostTracking().toJSON(),
     };
   } catch (error) {
+    const statusCode =
+      error instanceof TransportableError && error.code === "CRAWL_DENIAL"
+        ? 403
+        : 500;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
     logger.error(`Error in scrapeSearchResultDirect: ${error}`, {
       url: searchResult.url,
       teamId: options.teamId,
@@ -128,8 +134,8 @@ async function scrapeSearchResultDirect(
       description: searchResult.description,
       url: searchResult.url,
       metadata: {
-        statusCode: 500,
-        error: error.message,
+        statusCode,
+        error: errorMessage,
         proxyUsed: "basic",
       },
     };
@@ -143,30 +149,28 @@ async function scrapeSearchResultDirect(
 
 export function getItemsToScrape(
   searchResponse: SearchV2Response,
-  flags: TeamFlags,
-  context?: { team_id?: string | null; origin?: string | null },
+  _flags: TeamFlags,
+  _context?: { team_id?: string | null; origin?: string | null },
 ): ScrapeItem[] {
   const items: ScrapeItem[] = [];
 
   if (searchResponse.web) {
     for (const item of searchResponse.web) {
-      if (!isUrlBlocked(item.url, flags, context)) {
-        items.push({
-          item,
-          type: "web",
-          scrapeInput: {
-            url: item.url,
-            title: item.title,
-            description: item.description,
-          },
-        });
-      }
+      items.push({
+        item,
+        type: "web",
+        scrapeInput: {
+          url: item.url,
+          title: item.title,
+          description: item.description,
+        },
+      });
     }
   }
 
   if (searchResponse.news) {
     for (const item of searchResponse.news) {
-      if (item.url && !isUrlBlocked(item.url, flags, context)) {
+      if (item.url) {
         items.push({
           item,
           type: "news",
@@ -182,7 +186,7 @@ export function getItemsToScrape(
 
   if (searchResponse.images) {
     for (const item of searchResponse.images) {
-      if (item.url && !isUrlBlocked(item.url, flags, context)) {
+      if (item.url) {
         items.push({
           item,
           type: "image",

--- a/apps/api/src/services/queue-jobs.test.ts
+++ b/apps/api/src/services/queue-jobs.test.ts
@@ -1,0 +1,164 @@
+vi.mock("../lib/concurrency-limit", () => ({
+  cleanOldConcurrencyLimitEntries: vi.fn(async () => {}),
+  getConcurrencyLimitActiveJobs: vi.fn(async () => []),
+  getConcurrencyQueueJobsCount: vi.fn(async () => 0),
+  getCrawlConcurrencyLimitActiveJobs: vi.fn(async () => []),
+  getTeamQueueLimit: vi.fn(() => 10),
+  MAX_BACKLOG_TIMEOUT_MS: 24 * 60 * 60 * 1000,
+  pushConcurrencyLimitActiveJob: vi.fn(async () => {}),
+  pushConcurrencyLimitedJob: vi.fn(async () => {}),
+  pushConcurrencyLimitedJobs: vi.fn(async () => {}),
+  pushCrawlConcurrencyLimitActiveJob: vi.fn(async () => {}),
+  QueueFullError: class QueueFullError extends Error {},
+}));
+
+vi.mock("../lib/logger", () => {
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  return { logger };
+});
+
+vi.mock("./notification/email_notification", () => ({
+  sendNotificationWithCustomDays: vi.fn(),
+}));
+
+vi.mock("./notification/notification-check", () => ({
+  shouldSendConcurrencyLimitNotification: vi.fn(async () => false),
+}));
+
+vi.mock("../controllers/auth", () => ({
+  getACUCTeam: vi.fn(async () => ({ flags: null, concurrency: 2 })),
+}));
+
+vi.mock("../lib/gcs-jobs", () => ({
+  getJobFromGCS: vi.fn(),
+  removeJobFromGCS: vi.fn(),
+}));
+
+vi.mock("./ab-test", () => ({
+  abTestJob: vi.fn(),
+}));
+
+vi.mock("./worker/nuq", () => ({
+  scrapeQueue: {
+    addJob: vi.fn(async (id, data) => ({
+      id,
+      data,
+      status: "waiting",
+      createdAt: new Date(),
+      priority: 0,
+    })),
+    addJobs: vi.fn(async () => []),
+  },
+}));
+
+vi.mock("./worker/nuq-router", () => ({
+  fdbEnqueueScrapeJobs: vi.fn(),
+  resolveJobBackend: vi.fn(async () => "pg"),
+  scrapeQueue: {
+    removeJob: vi.fn(),
+    removeJobs: vi.fn(),
+    waitForJob: vi.fn(),
+  },
+}));
+
+vi.mock("./worker/nuq-fdb", () => ({
+  nuqFdbHealthCheck: vi.fn(async () => false),
+  scrapeQueueFdb: {
+    getTeamPendingCount: vi.fn(),
+  },
+  withFdbTimeout: vi.fn(value => value),
+}));
+
+vi.mock("../lib/otel-tracer", () => ({
+  serializeTraceContext: vi.fn(() => ({ traceparent: "traceparent" })),
+}));
+
+vi.mock("../lib/deployment", () => ({
+  isSelfHosted: vi.fn(() => true),
+}));
+
+vi.mock("./monitoring/stale", () => ({
+  MONITOR_CHECK_STALE_TIMEOUT_MS: 60 * 1000,
+}));
+
+vi.mock("../lib/crawl-redis", () => ({
+  getCrawl: vi.fn(async () => null),
+}));
+
+vi.mock("../lib/scrape-job-permissions", () => ({
+  checkScrapeJobPermissions: vi.fn(() => ({})),
+}));
+
+import { CrawlDenialError } from "../lib/error";
+import { checkScrapeJobPermissions } from "../lib/scrape-job-permissions";
+import { getACUCTeam } from "../controllers/auth";
+import type { ScrapeJobSingleUrls } from "../types";
+import { addScrapeJob } from "./queue-jobs";
+import { scrapeQueue } from "./worker/nuq";
+import { resolveJobBackend } from "./worker/nuq-router";
+
+const baseJobData: ScrapeJobSingleUrls = {
+  mode: "single_urls",
+  url: "https://www.linkedin.com/in/example",
+  team_id: "team-1",
+  scrapeOptions: {} as any,
+  internalOptions: {
+    teamId: "team-1",
+    teamFlags: null,
+  },
+  origin: "api",
+  zeroDataRetention: false,
+  apiKeyId: null,
+};
+
+describe("addScrapeJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkScrapeJobPermissions).mockReturnValue({});
+  });
+
+  it("rejects denied single-url scrape jobs before enqueueing", async () => {
+    vi.mocked(checkScrapeJobPermissions).mockReturnValueOnce({
+      error: "blocked",
+    });
+
+    await expect(addScrapeJob(baseJobData, "job-1")).rejects.toThrow(
+      CrawlDenialError,
+    );
+
+    expect(checkScrapeJobPermissions).toHaveBeenCalledWith(
+      baseJobData,
+      null,
+    );
+    expect(getACUCTeam).not.toHaveBeenCalled();
+    expect(resolveJobBackend).not.toHaveBeenCalled();
+    expect(scrapeQueue.addJob).not.toHaveBeenCalled();
+  });
+
+  it("leaves crawl-tracked jobs to the worker-side cleanup path", async () => {
+    vi.mocked(checkScrapeJobPermissions).mockReturnValue({
+      error: "blocked",
+    });
+
+    await addScrapeJob({ ...baseJobData, crawl_id: "crawl-1" }, "job-2");
+
+    expect(checkScrapeJobPermissions).not.toHaveBeenCalled();
+    expect(resolveJobBackend).toHaveBeenCalled();
+    expect(scrapeQueue.addJob).toHaveBeenCalledWith(
+      "job-2",
+      expect.objectContaining({
+        crawl_id: "crawl-1",
+        traceContext: { traceparent: "traceparent" },
+      }),
+      expect.objectContaining({
+        groupId: "crawl-1",
+        ownerId: "team-1",
+      }),
+    );
+  });
+});

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -21,8 +21,13 @@ import { getJobFromGCS, removeJobFromGCS } from "../lib/gcs-jobs";
 import { Document } from "../controllers/v1/types";
 import { getCrawl } from "../lib/crawl-redis";
 import { Logger } from "winston";
-import { ScrapeJobTimeoutError, TransportableError } from "../lib/error";
+import {
+  CrawlDenialError,
+  ScrapeJobTimeoutError,
+  TransportableError,
+} from "../lib/error";
 import { deserializeTransportableError } from "../lib/error-serde";
+import { checkScrapeJobPermissions } from "../lib/scrape-job-permissions";
 import { abTestJob } from "./ab-test";
 import { NuQJob, scrapeQueue } from "./worker/nuq";
 import {
@@ -60,6 +65,26 @@ function isCrawlOrBatchScrape(options: {
   // If crawlerOptions exists, it's a crawl
   // If crawl_id exists but no crawlerOptions, it's a batch scrape
   return !!options.crawlerOptions || !!options.crawl_id;
+}
+
+async function assertScrapeJobAllowed(webScraperOptions: ScrapeJobData) {
+  // Crawl-tracked jobs need worker-side denial so crawl completion cleanup runs.
+  if (
+    webScraperOptions.mode !== "single_urls" ||
+    webScraperOptions.crawl_id
+  ) {
+    return;
+  }
+
+  const flags =
+    webScraperOptions.internalOptions &&
+    "teamFlags" in webScraperOptions.internalOptions
+      ? webScraperOptions.internalOptions.teamFlags
+      : ((await getACUCTeam(webScraperOptions.team_id))?.flags ?? null);
+  const permissions = checkScrapeJobPermissions(webScraperOptions, flags);
+  if (permissions.error) {
+    throw new CrawlDenialError(permissions.error);
+  }
 }
 
 async function _addScrapeJobToConcurrencyQueue(
@@ -156,6 +181,8 @@ export async function _addScrapeJobToBullMQ(
   priority: number = 0,
   listenable: boolean = false,
 ): Promise<NuQJob<ScrapeJobData>> {
+  await assertScrapeJobAllowed(webScraperOptions);
+
   // direct adds bypass the gates; on the FDB backend that's a slotless enqueue
   if ((await resolveJobBackend(webScraperOptions)) === "fdb") {
     if (webScraperOptions.mode === "single_urls") {
@@ -504,6 +531,8 @@ export async function addScrapeJob(
   directToBullMQ: boolean = false,
   listenable: boolean = false,
 ): Promise<NuQJob<ScrapeJobData> | null> {
+  await assertScrapeJobAllowed(webScraperOptions);
+
   // Capture trace context to propagate to worker
   const traceContext = serializeTraceContext();
   const optionsWithTrace: ScrapeJobData = {

--- a/apps/api/src/services/worker/scrape-worker.test.ts
+++ b/apps/api/src/services/worker/scrape-worker.test.ts
@@ -1,0 +1,122 @@
+import type { NuQJob } from "./nuq";
+import type { ScrapeJobData } from "../../types";
+import { CrawlDenialError } from "../../lib/error";
+import { processJobInternal } from "./scrape-worker";
+import { addCrawlJobDone, getCrawl, normalizeURL } from "../../lib/crawl-redis";
+import { redisEvictConnection } from "../redis";
+import { startWebScraperPipeline } from "../../main/runWebScraper";
+
+vi.mock("../../lib/scrape-job-permissions", () => ({
+  checkScrapeJobPermissions: vi.fn(() => ({ error: "blocked" })),
+}));
+
+vi.mock("../../main/runWebScraper", () => ({
+  startWebScraperPipeline: vi.fn(),
+}));
+
+vi.mock("../../lib/crawl-redis", () => ({
+  addCrawlJobDone: vi.fn(async () => {}),
+  getCrawl: vi.fn(async () => ({
+    cancelled: false,
+    scrapeOptions: {},
+    crawlerOptions: {},
+  })),
+  normalizeURL: vi.fn((url: string) => url),
+}));
+
+vi.mock("../redis", () => ({
+  redisEvictConnection: {
+    srem: vi.fn(async () => 1),
+  },
+}));
+
+vi.mock("../../lib/concurrency-limit", () => ({
+  concurrentJobDone: vi.fn(async () => {}),
+  pushConcurrencyLimitActiveJob: vi.fn(async () => {}),
+}));
+
+vi.mock("../../lib/job-priority", () => ({
+  addJobPriority: vi.fn(async () => {}),
+  deleteJobPriority: vi.fn(async () => {}),
+  getJobPriority: vi.fn(async () => 10),
+}));
+
+vi.mock("../../controllers/auth", () => ({
+  getACUCTeam: vi.fn(async () => ({ flags: null })),
+}));
+
+vi.mock("../webhook/index", () => ({
+  createWebhookSender: vi.fn(async () => null),
+  WebhookEvent: {
+    CRAWL_PAGE: "crawl.page",
+    BATCH_SCRAPE_PAGE: "batch_scrape.page",
+  },
+}));
+
+vi.mock("../logging/log_job", () => ({
+  logScrape: vi.fn(async () => {}),
+}));
+
+vi.mock("../../lib/tracking", () => ({
+  trackScrape: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../monitoring/results", () => ({
+  recordMonitorScrapeFailure: vi.fn(async () => {}),
+  recordMonitorScrapeSuccess: vi.fn(async () => {}),
+}));
+
+describe("processJobInternal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks crawl child jobs done when scrape preflight denies them", async () => {
+    const job = {
+      id: "scrape-1",
+      status: "active",
+      createdAt: new Date(),
+      priority: 10,
+      data: {
+        mode: "single_urls",
+        url: "https://www.linkedin.com/in/example",
+        team_id: "team-1",
+        crawlerOptions: {},
+        scrapeOptions: {} as any,
+        internalOptions: {
+          teamId: "team-1",
+          teamFlags: null,
+          bypassBilling: true,
+        },
+        origin: "api",
+        crawl_id: "crawl-1",
+        zeroDataRetention: false,
+        apiKeyId: null,
+        skipNuq: true,
+      },
+    } as NuQJob<ScrapeJobData>;
+
+    await expect(processJobInternal(job)).rejects.toThrow(CrawlDenialError);
+
+    expect(startWebScraperPipeline).not.toHaveBeenCalled();
+    expect(addCrawlJobDone).toHaveBeenCalledWith(
+      "crawl-1",
+      "scrape-1",
+      false,
+      expect.anything(),
+    );
+    expect(getCrawl).toHaveBeenCalledWith("crawl-1");
+    expect(normalizeURL).toHaveBeenCalledWith(
+      "https://www.linkedin.com/in/example",
+      expect.anything(),
+    );
+    expect(redisEvictConnection.srem).toHaveBeenCalledWith(
+      "crawl:crawl-1:visited_unique",
+      "https://www.linkedin.com/in/example",
+    );
+    expect(redisEvictConnection.srem).toHaveBeenCalledWith(
+      "crawl:crawl-1:jobs_qualified",
+      "scrape-1",
+    );
+  });
+});

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -56,6 +56,7 @@ import { chargeKeylessCredits } from "../../lib/keyless";
 import { normalizeUrlOnlyHostname } from "../../lib/canonical-url";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { UNSUPPORTED_SITE_MESSAGE } from "../../lib/strings";
+import { checkScrapeJobPermissions } from "../../lib/scrape-job-permissions";
 import { generateURLSplits, queryIndexAtSplitLevel } from "../index";
 import { WebCrawler } from "../../scraper/WebScraper/crawler";
 import { calculateCreditsToBeBilled } from "../../lib/scrape-billing";
@@ -252,6 +253,15 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
       if (sc && sc.cancelled) {
         throw new JobCancelledError();
       }
+    }
+
+    const flags =
+      job.data.internalOptions?.teamFlags ??
+      (await getACUCTeam(job.data.team_id))?.flags ??
+      null;
+    const permissions = checkScrapeJobPermissions(job.data, flags);
+    if (permissions.error) {
+      throw new CrawlDenialError(permissions.error);
     }
 
     let pipeline: ScrapeUrlResponse | null = null;


### PR DESCRIPTION
## Summary

Move blocked-site and scrape permission enforcement to the internal single-URL scrape job boundary, so direct processJobInternal callers and queued scrape jobs cannot bypass the checks. Search + scrape, v0/v1/v2 x402 search, crawls, and batch scrapes now hand URL-bearing results to the scrape layer and rely on the shared scrape preflight for denial; direct API scrape/parse calls map that denial back to 403.

`addScrapeJob` now also rejects denied non-crawl single-URL scrape jobs before enqueueing, so entry points like search-driven scrape do not need to create a background job just to learn the request is forbidden. Crawl-tracked jobs still defer denial to the worker preflight, preserving crawl completion cleanup for child jobs.