### PR TITLE
fix(api): build FoundationDB native binding

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -172,6 +172,7 @@
       "bigint-buffer",
       "bufferutil",
       "esbuild",
+      "foundationdb",
       "four-flap-bigint-buffer",
       "keccak",
       "koffi",

--- a/apps/api/pnpm-workspace.yaml
+++ b/apps/api/pnpm-workspace.yaml
@@ -5,3 +5,20 @@ minimumReleaseAge: 720 # 12 hours
 minimumReleaseAgeExclude:
   - fast-xml-parser
   - follow-redirects
+onlyBuiltDependencies:
+  - "@mendable/firecrawl-rs"
+  - "@sentry-internal/node-cpu-profiler"
+  - "@sentry/cli"
+  - bigint-buffer
+  - bufferutil
+  - esbuild
+  - foundationdb
+  - four-flap-bigint-buffer
+  - keccak
+  - koffi
+  - libpq
+  - msgpackr-extract
+  - oxc-resolver
+  - protobufjs
+  - utf-8-validate
+  - wordpos


### PR DESCRIPTION
## Summary
- allow the FoundationDB npm package build script in pnpm settings
- mirror the build-script allowlist into pnpm-workspace.yaml for current pnpm behavior

## Verification
- pnpm exec vitest run src/__tests__/nuq-fdb/router.test.ts src/__tests__/nuq-fdb/core.test.ts src/__tests__/nuq-fdb/stress.test.ts --reporter=default
- built local API image with FoundationDB native binding on linux/arm64


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables building the `foundationdb` native binding for the API by allowlisting its build script in `pnpm`. Fixes build failures and ensures linux/arm64 images include the native binary.

- **Bug Fixes**
  - Added `foundationdb` to the `pnpm` build allowlist in apps/api/package.json.
  - Mirrored the allowlist in apps/api/pnpm-workspace.yaml so the native binding builds in the workspace and CI.

<sup>Written for commit 3097342487bba4a1941e2748bdc01ef67b49c3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

