### PR TITLE
fix(api): preserve backlog status on nuq add

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -73,6 +73,12 @@ jobs:
       - run: pnpm config set store-dir ~/.pnpm-store
       - run: mkdir -p ~/.pnpm-store
 
+      - name: Install FoundationDB client library
+        run: |
+          curl -fsSL -o /tmp/fdb-clients.deb \
+            "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb"
+          sudo dpkg -i /tmp/fdb-clients.deb
+
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -231,13 +237,6 @@ jobs:
         run: |
           docker build -t firecrawl/nuq-postgres:latest ./apps/nuq-postgres
           docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres --name postgres firecrawl/nuq-postgres:latest
-
-      - name: Install FoundationDB client library
-        if: matrix.nuq == 'fdb'
-        run: |
-          curl -fsSL -o /tmp/fdb-clients.deb \
-            "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb"
-          sudo dpkg -i /tmp/fdb-clients.deb
 
       - name: Start FoundationDB
         if: matrix.nuq == 'fdb'

--- a/apps/api/src/__tests__/nuq-postgres.test.ts
+++ b/apps/api/src/__tests__/nuq-postgres.test.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "crypto";
+import { Pool } from "pg";
+import { config } from "../config";
+import { nuqShutdown, scrapeQueue } from "../services/worker/nuq";
+
+const describeIf = config.NUQ_DATABASE_URL ? describe : describe.skip;
+
+describeIf("NuQ Postgres queue", () => {
+  let cleanupPool: Pool;
+  const ids: string[] = [];
+
+  beforeAll(() => {
+    cleanupPool = new Pool({
+      connectionString: config.NUQ_DATABASE_URL,
+      application_name: "nuq-postgres-test",
+    });
+  });
+
+  afterEach(async () => {
+    if (ids.length === 0) return;
+    await cleanupPool.query(
+      "DELETE FROM nuq.queue_scrape_backlog WHERE id = ANY($1::uuid[])",
+      [ids],
+    );
+    await cleanupPool.query(
+      "DELETE FROM nuq.queue_scrape WHERE id = ANY($1::uuid[])",
+      [ids],
+    );
+    ids.length = 0;
+  });
+
+  afterAll(async () => {
+    await cleanupPool.end();
+    await nuqShutdown();
+  });
+
+  function scrapeData() {
+    return {
+      mode: "single_urls",
+      url: "https://example.com",
+      team_id: randomUUID(),
+    } as any;
+  }
+
+  test("single backlogged inserts report backlog status", async () => {
+    const addJobId = randomUUID();
+    const addJobIfNotExistsId = randomUUID();
+    ids.push(addJobId, addJobIfNotExistsId);
+
+    await expect(
+      scrapeQueue.addJob(addJobId, scrapeData(), {
+        backlogged: true,
+        backloggedTimesOutAt: new Date(Date.now() + 60_000),
+      }),
+    ).resolves.toMatchObject({
+      id: addJobId,
+      status: "backlog",
+    });
+
+    await expect(
+      scrapeQueue.addJobIfNotExists(addJobIfNotExistsId, scrapeData(), {
+        backlogged: true,
+        backloggedTimesOutAt: new Date(Date.now() + 60_000),
+      }),
+    ).resolves.toMatchObject({
+      id: addJobIfNotExistsId,
+      status: "backlog",
+    });
+
+    await expect(
+      scrapeQueue.addJobIfNotExists(addJobIfNotExistsId, scrapeData(), {
+        backlogged: true,
+        backloggedTimesOutAt: new Date(Date.now() + 60_000),
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -842,6 +842,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
               ],
             )
           ).rows[0],
+          options.backlogged,
         )!;
 
         setSpanAttributes(span, {
@@ -902,6 +903,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
               ],
             )
           ).rows[0],
+          options.backlogged,
         );
 
         setSpanAttributes(span, {


### PR DESCRIPTION
## Summary
- preserve `backlog` status when single NuQ/Postgres inserts target the backlog table
- add a NuQ/Postgres regression test gated on `NUQ_DATABASE_URL`
- install FoundationDB client headers before self-hosted dependency fetch so the allowed native binding can compile in CI

## Verification
- `pnpm exec vitest run src/__tests__/nuq-postgres.test.ts --reporter=default` (skips without `NUQ_DATABASE_URL`)
- Minikube real-operation harness against in-cluster NuQ Postgres and FoundationDB: enqueue, dequeue, locks, finish, fail, priority, backlog promotion, FDB gates, queue-cap rejection
- Forced FDB down by scaling operator to 0, deleting FDB process pods and cluster-file ConfigMap, then reran real NuQ/Postgres add -> take -> renew -> finish -> get completed successfully
