### PR TITLE
fix(python-sdk): correct search() docstring param name   (page_options → scrape_options)

### DIFF
--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -402,7 +402,7 @@ class FirecrawlClient:
             tbs: Time-based search filter
             location: Location string for search
             timeout: Request timeout in milliseconds (default: 300000)
-            page_options: Options for scraping individual pages
+            scrape_options: Options for scraping each search result page
 
         Returns:
             SearchData containing the search results


### PR DESCRIPTION
The `Firecrawl.search()` docstring documents a `page_options` parameter, but the method has no such parameter — the real one is `scrape_options` (in the signature, passed to `SearchRequest`, validated in `v2/methods/search.py`). Copying the documented name raises 'TypeError`. The public docs already use `scrape_options`; this one-line change aligns the
docstring with the signature and the docs. No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Python SDK docstring for `Firecrawl.search()` by renaming `page_options` to `scrape_options` to match the method signature and public docs. Prevents `TypeError` when users copy the documented parameter.

<sup>Written for commit b1faef7f0f16c87f17f34b64f21c0722129b23fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

