### PR TITLE
Add parse upload refs for hosted MCP

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -48,6 +48,8 @@ jobs:
       HOST: 0.0.0.0
       TEST_SUITE_SELF_HOSTED: true
       TEST_SUITE_WEBSITE: http://127.0.0.1:4321
+      TEST_API_KEY: test
+      TEST_TEAM_ID: bypass
       OPENAI_API_KEY: ${{ matrix.ai == 'openai' && secrets.OPENAI_API_KEY || '' }}
       GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
       SEARXNG_ENDPOINT: ${{ matrix.search == 'searxng' && 'http://localhost:3434' || '' }}
@@ -63,6 +65,14 @@ jobs:
       USE_GO_MARKDOWN_PARSER: true
       ALLOW_LOCAL_WEBHOOKS: true
       FIRECRAWL_LOG_TO_FILE: true
+      # Exercise the parse upload-ref path in self-hosted CI. The snips run
+      # against a separately started API server, so these must be server envs,
+      # not test-process mutations.
+      ENV: test
+      PARSE_UPLOAD_STORAGE_DRIVER: local
+      PARSE_UPLOAD_REF_SECRET: parse-upload-ref-ci-secret
+      PARSE_UPLOAD_REF_TEST_REQUIRED: true
+      IDMUX_URL: ${{ secrets.IDMUX_URL }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -70,7 +70,6 @@ jobs:
       # not test-process mutations.
       ENV: test
       PARSE_UPLOAD_STORAGE_DRIVER: local
-      PARSE_UPLOAD_REF_SECRET: parse-upload-ref-ci-secret
       PARSE_UPLOAD_REF_TEST_REQUIRED: true
       IDMUX_URL: ${{ secrets.IDMUX_URL }}
     steps:
@@ -232,6 +231,9 @@ jobs:
           pnpm preview --port 4321 --strictPort --host 127.0.0.1 > test-site.log 2>&1 &
           pnpx wait-on tcp:4321 -t 20s
         working-directory: apps/test-site
+
+      - name: Generate parse upload ref secret
+        run: echo "PARSE_UPLOAD_REF_SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
 
       - name: Start playwright
         if: matrix.engine == 'playwright'

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -18,6 +18,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { db } from "../../../db/connection";
 import * as schema from "../../../db/schema";
 import { config } from "../../../config";
+import { getRedisConnection } from "../../../services/queue-service";
 
 const DOCX_FIXTURE_BASE64 =
   "UEsDBBQAAAAIAKtlbVzXeYTq8QAAALgBAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbH2QzU7DMBCE730Ky9cqccoBIZSkB36OwKE8wMreJFb9J69b2rdn00KREOVozXwz62nXB+/EHjPZGDq5qhspMOhobBg7+b55ru6koALBgIsBO3lEkut+0W6OCUkwHKiTUynpXinSE3qgOiYMrAwxeyj8zKNKoLcworppmlulYygYSlXmDNkvhGgfcYCdK+LpwMr5loyOpHg4e+e6TkJKzmoorKt9ML+Kqq+SmsmThyabaMkGqa6VzOL1jh/0lSfK1qB4g1xewLNRfcRslIl65xmu/0/649o4DFbjhZ/TUo4aiXh77+qL4sGG71+06jR8/wlQSwMEFAAAAAgAq2VtXCAbhuqyAAAALgEAAAsAAABfcmVscy8ucmVsc43Puw6CMBQG4J2naM4uBQdjDIXFmLAafICmPZRGeklbL7y9HRzEODie23fyN93TzOSOIWpnGdRlBQStcFJbxeAynDZ7IDFxK/nsLDJYMELXFs0ZZ57yTZy0jyQjNjKYUvIHSqOY0PBYOo82T0YXDE+5DIp6Lq5cId1W1Y6GTwPagpAVS3rJIPSyBjIsHv/h3ThqgUcnbgZt+vHlayPLPChMDB4uSCrf7TKzQHNKuorZvgBQSwMEFAAAAAgAq2VtXCCNfXOwAAAA7AAAABEAAAB3b3JkL2RvY3VtZW50LnhtbDWOMQvCMBCFd3/FkV1THURKGwfFVQcF19icWmjuQi5a/fcmBZeP93jw3TXbjx/gjVF6plYtF5UCpI5dT49WXc6H+UaBJEvODkzYqi+K2ppZM9aOu5dHSpANJPXYqmdKodZauid6KwsOSHm7c/Q25RofeuToQuQORfIBP+hVVa21tz0pMwPI1hu7b4lTCSYjFiRzslEQ9sfdFS5hYOvgjJIaXbbCODFMGv33lPT/0/wAUEsBAhQDFAAAAAgAq2VtXNd5hOrxAAAAuAEAABMAAAAAAAAAAAAAAIABAAAAAFtDb250ZW50X1R5cGVzXS54bWxQSwECFAMUAAAACACrZW1cIBuG6rIAAAAuAQAACwAAAAAAAAAAAAAAgAEiAQAAX3JlbHMvLnJlbHNQSwECFAMUAAAACACrZW1cII19c7AAAADsAAAAEQAAAAAAAAAAAAAAgAH9AQAAd29yZC9kb2N1bWVudC54bWxQSwUGAAAAAAMAAwC5AAAA3AIAAAAA";
@@ -38,6 +39,11 @@ const originalParseUploadStorageDriver = config.PARSE_UPLOAD_STORAGE_DRIVER;
 const originalEnv = config.ENV;
 const parseUploadRefTestRequired =
   process.env.PARSE_UPLOAD_REF_TEST_REQUIRED === "true";
+const parseUploadUnparsedWindowMs = 24 * 60 * 60 * 1000;
+
+function getUnparsedUploadRefsKey(teamId: string) {
+  return `parse-upload-refs:${teamId}`;
+}
 
 function enableLocalUploadRefAdapter() {
   (config as any).ENV = "test";
@@ -73,6 +79,33 @@ async function mintUploadRef(
   }
 
   expect(init.statusCode).toBe(200);
+  expect(init.body.success).toBe(true);
+  expect(init.body.data.uploadRef).toEqual(expect.any(String));
+  return init.body.data as {
+    uploadRef: string;
+    uploadUrl: string;
+    method: string;
+    headers?: Record<string, string>;
+    fields?: Record<string, string>;
+    maxSizeBytes: number;
+  };
+}
+
+async function mintRequiredUploadRef(
+  owner: Identity,
+  filename = "upload-ref.html",
+  contentType = "text/html",
+) {
+  const init = await request(TEST_API_URL)
+    .post("/v2/parse/upload-url")
+    .set("Authorization", `Bearer ${owner.apiKey}`)
+    .set("Content-Type", "application/json")
+    .send({
+      filename,
+      contentType,
+    });
+
+  expect(init.statusCode, JSON.stringify(init.body)).toBe(200);
   expect(init.body.success).toBe(true);
   expect(init.body.data.uploadRef).toEqual(expect.any(String));
   return init.body.data as {
@@ -257,6 +290,83 @@ describe("/v2/parse", () => {
 
       expect(failure.statusCode).toBe(400);
       expect(failure.body.success).toBe(false);
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "limits each team to 10 unparsed upload refs from the last 24 hours",
+    async () => {
+      enableLocalUploadRefAdapter();
+
+      const capIdentity = await idmux({
+        name: `parse-upload-ref-cap-${Date.now()}`,
+        concurrency: 100,
+        credits: 1000000,
+      });
+      const key = getUnparsedUploadRefsKey(capIdentity.teamId);
+      await getRedisConnection().del(key);
+
+      const oldScore = Date.now() - parseUploadUnparsedWindowMs - 1000;
+      await getRedisConnection().zadd(
+        key,
+        ...Array.from({ length: 10 }).flatMap((_, i) => [oldScore, `old-${i}`]),
+      );
+
+      const first = await mintRequiredUploadRef(capIdentity, "cap-0.html");
+
+      const refs = [first];
+      for (let i = 1; i < 10; i++) {
+        const init = await mintRequiredUploadRef(capIdentity, `cap-${i}.html`);
+        refs.push(init);
+      }
+
+      const rejected = await request(TEST_API_URL)
+        .post("/v2/parse/upload-url")
+        .set("Authorization", `Bearer ${capIdentity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          filename: "cap-rejected.html",
+          contentType: "text/html",
+        });
+
+      expect(rejected.statusCode).toBe(429);
+      expect(rejected.body.success).toBe(false);
+      expect(rejected.body.code).toBe("PARSE_UPLOAD_UNPARSED_LIMIT_REACHED");
+
+      const upload = await uploadToMintedTarget(
+        refs[0],
+        htmlFixture,
+        "cap-0.html",
+      );
+      expect([200, 201, 204]).toContain(upload.status);
+
+      const parsed = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .set("Authorization", `Bearer ${capIdentity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          uploadRef: refs[0].uploadRef,
+          formats: ["markdown"],
+        });
+
+      expect(parsed.statusCode, JSON.stringify(parsed.body)).toBe(200);
+      expect(parsed.body.success).toBe(true);
+
+      const acceptedAfterParse = await waitForSingleRow(async () => {
+        const init = await request(TEST_API_URL)
+          .post("/v2/parse/upload-url")
+          .set("Authorization", `Bearer ${capIdentity.apiKey}`)
+          .set("Content-Type", "application/json")
+          .send({
+            filename: "cap-accepted-after-parse.html",
+            contentType: "text/html",
+          });
+
+        return init.statusCode === 200 ? init : null;
+      });
+
+      expect(acceptedAfterParse?.body.success).toBe(true);
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -36,6 +36,8 @@ let identity: Identity;
 let pdfFixture: Buffer | null = null;
 const originalParseUploadStorageDriver = config.PARSE_UPLOAD_STORAGE_DRIVER;
 const originalEnv = config.ENV;
+const parseUploadRefTestRequired =
+  process.env.PARSE_UPLOAD_REF_TEST_REQUIRED === "true";
 
 function enableLocalUploadRefAdapter() {
   (config as any).ENV = "test";
@@ -61,6 +63,9 @@ async function mintUploadRef(
     typeof init.body.code === "string" &&
     init.body.code.startsWith("PARSE_UPLOAD_")
   ) {
+    if (parseUploadRefTestRequired) {
+      expect(init.statusCode).toBe(200);
+    }
     console.warn(
       `Skipping uploadRef storage-dependent test because ${TEST_API_URL} is not configured for parse upload refs: ${init.body.code}`,
     );
@@ -224,10 +229,9 @@ describe("/v2/parse", () => {
         .send({
           uploadRef: init.uploadRef,
           formats: ["markdown"],
-          zeroDataRetention: true,
         });
 
-      expect(result.statusCode).toBe(200);
+      expect(result.statusCode, JSON.stringify(result.body)).toBe(200);
       expect(result.body.success).toBe(true);
       expect(result.body.data.markdown).toContain("Parse HTML Upload Test");
       expect(result.body.data.metadata.sourceURL).toBe("upload-ref.html");
@@ -259,6 +263,13 @@ describe("/v2/parse", () => {
   it(
     "rejects upload-ref signing without authentication",
     async () => {
+      if (!config.USE_DB_AUTHENTICATION) {
+        console.warn(
+          "Skipping uploadRef unauthenticated signing test because authentication is bypassed when USE_DB_AUTHENTICATION is disabled",
+        );
+        return;
+      }
+
       enableLocalUploadRefAdapter();
 
       const failure = await request(TEST_API_URL)
@@ -278,31 +289,36 @@ describe("/v2/parse", () => {
   it(
     "rejects upload refs owned by another team",
     async () => {
-      if (!config.IDMUX_URL) {
-        console.warn(
-          "Skipping uploadRef cross-team test because IDMUX_URL is not set",
-        );
-        return;
-      }
-
-      const otherIdentity = await idmux({
-        name: "parse-upload-ref-other-team",
-        concurrency: 100,
-        credits: 1000000,
-      });
-      expect(otherIdentity.teamId).not.toBe(identity.teamId);
-
       const init = await mintUploadRef(identity);
       if (!init) return;
+
+      const canUseRealSecondTeam =
+        !!config.IDMUX_URL && config.USE_DB_AUTHENTICATION === true;
+      const otherIdentity = canUseRealSecondTeam
+        ? await idmux({
+            name: "parse-upload-ref-other-team",
+            concurrency: 100,
+            credits: 1000000,
+          })
+        : identity;
+
+      if (canUseRealSecondTeam) {
+        expect(otherIdentity.teamId).not.toBe(identity.teamId);
+      }
+
+      const uploadRef = canUseRealSecondTeam
+        ? init.uploadRef
+        : withUploadRefPayload(init.uploadRef, payload => {
+            payload.teamId = "parse-upload-ref-other-team";
+          });
 
       const failure = await request(TEST_API_URL)
         .post("/v2/parse")
         .set("Authorization", `Bearer ${otherIdentity.apiKey}`)
         .set("Content-Type", "application/json")
         .send({
-          uploadRef: init.uploadRef,
+          uploadRef,
           formats: ["markdown"],
-          zeroDataRetention: true,
         });
 
       expect(failure.statusCode).toBe(403);
@@ -325,7 +341,6 @@ describe("/v2/parse", () => {
         .send({
           uploadRef: tamperUploadRefSignature(init.uploadRef),
           formats: ["markdown"],
-          zeroDataRetention: true,
         });
 
       expect(failure.statusCode).toBe(400);
@@ -342,9 +357,9 @@ describe("/v2/parse", () => {
       if (!init) return;
 
       const payload = decodeUploadRefPayload(init.uploadRef);
-      if (payload.driver !== "local") {
+      if (payload.driver !== "local" && !config.PARSE_UPLOAD_REF_SECRET) {
         console.warn(
-          "Skipping uploadRef expiry test because the configured server uses a non-local signing secret",
+          "Skipping uploadRef expiry test because the configured server signing secret is not available to this test process",
         );
         return;
       }
@@ -360,7 +375,6 @@ describe("/v2/parse", () => {
         .send({
           uploadRef: expiredUploadRef,
           formats: ["markdown"],
-          zeroDataRetention: true,
         });
 
       expect(failure.statusCode).toBe(400);

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -111,11 +111,12 @@ async function uploadToMintedTarget(
 }
 
 function getLocalUploadRefSecret() {
-  return (
-    config.PARSE_UPLOAD_REF_SECRET ??
-    config.BULL_AUTH_KEY ??
-    "development-parse-upload-ref-secret"
-  );
+  if (!config.PARSE_UPLOAD_REF_SECRET) {
+    throw new Error(
+      "PARSE_UPLOAD_REF_SECRET is required for uploadRef test signing",
+    );
+  }
+  return config.PARSE_UPLOAD_REF_SECRET;
 }
 
 function resignUploadRefPayload(payload: Record<string, unknown>) {

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -5,6 +5,7 @@ import {
   TEST_PRODUCTION,
   TEST_SUITE_WEBSITE,
 } from "../lib";
+import crypto from "node:crypto";
 import request, {
   idmux,
   Identity,
@@ -35,6 +36,71 @@ let identity: Identity;
 let pdfFixture: Buffer | null = null;
 const originalParseUploadStorageDriver = config.PARSE_UPLOAD_STORAGE_DRIVER;
 const originalEnv = config.ENV;
+
+function enableLocalUploadRefAdapter() {
+  (config as any).ENV = "test";
+  (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+}
+
+async function mintLocalUploadRef(
+  owner: Identity,
+  filename = "upload-ref.html",
+  contentType = "text/html",
+) {
+  enableLocalUploadRefAdapter();
+
+  const init = await request(TEST_API_URL)
+    .post("/v2/parse/upload-url")
+    .set("Authorization", `Bearer ${owner.apiKey}`)
+    .set("Content-Type", "application/json")
+    .send({
+      filename,
+      contentType,
+    });
+
+  expect(init.statusCode).toBe(200);
+  expect(init.body.success).toBe(true);
+  expect(init.body.data.uploadRef).toEqual(expect.any(String));
+  return init.body.data.uploadRef as string;
+}
+
+function getLocalUploadRefSecret() {
+  return (
+    config.PARSE_UPLOAD_REF_SECRET ??
+    config.BULL_AUTH_KEY ??
+    "development-parse-upload-ref-secret"
+  );
+}
+
+function resignUploadRefPayload(payload: Record<string, unknown>) {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  const signature = crypto
+    .createHmac("sha256", getLocalUploadRefSecret())
+    .update(encodedPayload)
+    .digest("base64url");
+
+  return `${encodedPayload}.${signature}`;
+}
+
+function withUploadRefPayload(
+  uploadRef: string,
+  mutate: (payload: Record<string, any>) => void,
+) {
+  const [encodedPayload] = uploadRef.split(".");
+  const payload = JSON.parse(
+    Buffer.from(encodedPayload, "base64url").toString("utf8"),
+  );
+  mutate(payload);
+  return resignUploadRefPayload(payload);
+}
+
+function tamperUploadRefSignature(uploadRef: string) {
+  const [encodedPayload, signature] = uploadRef.split(".");
+  const replacement = signature.endsWith("A") ? "B" : "A";
+  return `${encodedPayload}.${signature.slice(0, -1)}${replacement}`;
+}
 
 async function waitForSingleRow<T>(
   fetcher: () => Promise<T | null>,
@@ -97,8 +163,7 @@ describe("/v2/parse", () => {
   it(
     "parses an upload-ref HTML file into markdown",
     async () => {
-      (config as any).ENV = "test";
-      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+      enableLocalUploadRefAdapter();
 
       const init = await request(TEST_API_URL)
         .post("/v2/parse/upload-url")
@@ -142,8 +207,7 @@ describe("/v2/parse", () => {
   it(
     "rejects oversized declared upload-ref sizes before signing",
     async () => {
-      (config as any).ENV = "test";
-      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+      enableLocalUploadRefAdapter();
 
       const failure = await request(TEST_API_URL)
         .post("/v2/parse/upload-url")
@@ -164,8 +228,7 @@ describe("/v2/parse", () => {
   it(
     "rejects upload-ref signing without authentication",
     async () => {
-      (config as any).ENV = "test";
-      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+      enableLocalUploadRefAdapter();
 
       const failure = await request(TEST_API_URL)
         .post("/v2/parse/upload-url")
@@ -182,10 +245,90 @@ describe("/v2/parse", () => {
   );
 
   it(
+    "rejects upload refs owned by another team",
+    async () => {
+      if (!config.IDMUX_URL) {
+        console.warn(
+          "Skipping uploadRef cross-team test because IDMUX_URL is not set",
+        );
+        return;
+      }
+
+      const otherIdentity = await idmux({
+        name: "parse-upload-ref-other-team",
+        concurrency: 100,
+        credits: 1000000,
+      });
+      expect(otherIdentity.teamId).not.toBe(identity.teamId);
+
+      const uploadRef = await mintLocalUploadRef(identity);
+      const failure = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .set("Authorization", `Bearer ${otherIdentity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          uploadRef,
+          formats: ["markdown"],
+          zeroDataRetention: true,
+        });
+
+      expect(failure.statusCode).toBe(403);
+      expect(failure.body.success).toBe(false);
+      expect(failure.body.error).toMatch(/authenticated team/i);
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "rejects tampered upload refs",
+    async () => {
+      const uploadRef = await mintLocalUploadRef(identity);
+      const failure = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          uploadRef: tamperUploadRefSignature(uploadRef),
+          formats: ["markdown"],
+          zeroDataRetention: true,
+        });
+
+      expect(failure.statusCode).toBe(400);
+      expect(failure.body.success).toBe(false);
+      expect(failure.body.error).toMatch(/signature/i);
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "rejects expired upload refs",
+    async () => {
+      const uploadRef = await mintLocalUploadRef(identity);
+      const expiredUploadRef = withUploadRefPayload(uploadRef, payload => {
+        payload.expiresAt = Date.now() - 1000;
+      });
+
+      const failure = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          uploadRef: expiredUploadRef,
+          formats: ["markdown"],
+          zeroDataRetention: true,
+        });
+
+      expect(failure.statusCode).toBe(400);
+      expect(failure.body.success).toBe(false);
+      expect(failure.body.error).toMatch(/expired/i);
+    },
+    scrapeTimeout,
+  );
+
+  it(
     "mints upload refs for xhtml files accepted by parse",
     async () => {
-      (config as any).ENV = "test";
-      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+      enableLocalUploadRefAdapter();
 
       const init = await request(TEST_API_URL)
         .post("/v2/parse/upload-url")

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -40,6 +40,13 @@ const originalEnv = config.ENV;
 const parseUploadRefTestRequired =
   process.env.PARSE_UPLOAD_REF_TEST_REQUIRED === "true";
 const parseUploadUnparsedWindowMs = 24 * 60 * 60 * 1000;
+const keylessRequestsPerDay = Number(process.env.KEYLESS_REQUESTS_PER_DAY);
+const keylessCreditsPerDay = Number(process.env.KEYLESS_CREDITS_PER_DAY);
+const keylessEnabled =
+  Number.isFinite(keylessRequestsPerDay) &&
+  keylessRequestsPerDay > 0 &&
+  Number.isFinite(keylessCreditsPerDay) &&
+  keylessCreditsPerDay > 0;
 
 function getUnparsedUploadRefsKey(teamId: string) {
   return `parse-upload-refs:${teamId}`;
@@ -382,27 +389,54 @@ describe("/v2/parse", () => {
   );
 
   it(
-    "rejects upload-ref signing without authentication",
+    "handles upload-ref signing without authentication according to keyless config",
     async () => {
       if (!config.USE_DB_AUTHENTICATION) {
         console.warn(
-          "Skipping uploadRef unauthenticated signing test because authentication is bypassed when USE_DB_AUTHENTICATION is disabled",
+          "Skipping unauthenticated uploadRef signing test because authentication is bypassed when USE_DB_AUTHENTICATION is disabled",
         );
         return;
       }
 
       enableLocalUploadRefAdapter();
 
-      const failure = await request(TEST_API_URL)
+      const response = await request(TEST_API_URL)
         .post("/v2/parse/upload-url")
         .set("Content-Type", "application/json")
         .send({
-          filename: "upload-ref.html",
+          filename: "upload-ref-keyless.html",
           contentType: "text/html",
         });
 
-      expect(failure.statusCode).not.toBe(200);
-      expect(failure.body.success).toBe(false);
+      if (!keylessEnabled) {
+        expect(response.statusCode).not.toBe(200);
+        expect(response.body.success).toBe(false);
+        return;
+      }
+
+      expect(response.statusCode, JSON.stringify(response.body)).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.uploadRef).toEqual(expect.any(String));
+      expect(response.body.data.uploadUrl).toEqual(expect.any(String));
+
+      const upload = await uploadToMintedTarget(
+        response.body.data,
+        htmlFixture,
+        "upload-ref-keyless.html",
+      );
+      expect([200, 201, 204]).toContain(upload.status);
+
+      const parsed = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .set("Content-Type", "application/json")
+        .send({
+          uploadRef: response.body.data.uploadRef,
+          formats: ["markdown"],
+        });
+
+      expect(parsed.statusCode, JSON.stringify(parsed.body)).toBe(200);
+      expect(parsed.body.success).toBe(true);
+      expect(parsed.body.data.markdown).toContain("Parse HTML Upload Test");
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -5,7 +5,14 @@ import {
   TEST_PRODUCTION,
   TEST_SUITE_WEBSITE,
 } from "../lib";
-import { idmux, Identity, parse, parseWithFailure, scrapeTimeout } from "./lib";
+import request, {
+  idmux,
+  Identity,
+  parse,
+  parseWithFailure,
+  scrapeTimeout,
+  TEST_API_URL,
+} from "./lib";
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "../../../db/connection";
 import * as schema from "../../../db/schema";
@@ -26,6 +33,8 @@ const htmlFixture = `
 
 let identity: Identity;
 let pdfFixture: Buffer | null = null;
+const originalParseUploadStorageDriver = config.PARSE_UPLOAD_STORAGE_DRIVER;
+const originalEnv = config.ENV;
 
 async function waitForSingleRow<T>(
   fetcher: () => Promise<T | null>,
@@ -40,6 +49,12 @@ async function waitForSingleRow<T>(
   }
   return null;
 }
+
+afterEach(() => {
+  (config as any).PARSE_UPLOAD_STORAGE_DRIVER =
+    originalParseUploadStorageDriver;
+  (config as any).ENV = originalEnv;
+});
 
 beforeAll(async () => {
   identity = await idmux({
@@ -75,6 +90,115 @@ describe("/v2/parse", () => {
       expect(result.markdown).toContain("Parse HTML Upload Test");
       expect(result.metadata.creditsUsed).toBe(1);
       expect(result.metadata.sourceURL).toBe("upload.html");
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "parses an upload-ref HTML file into markdown",
+    async () => {
+      (config as any).ENV = "test";
+      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+
+      const init = await request(TEST_API_URL)
+        .post("/v2/parse/upload-url")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          filename: "upload-ref.html",
+          contentType: "text/html",
+        });
+
+      expect(init.statusCode).toBe(200);
+      expect(init.body.success).toBe(true);
+      expect(init.body.data.uploadRef).toEqual(expect.any(String));
+      expect(init.body.data.maxSizeBytes).toBe(50 * 1024 * 1024);
+
+      const upload = await fetch(init.body.data.uploadUrl, {
+        method: "PUT",
+        headers: init.body.data.headers,
+        body: htmlFixture,
+      });
+      expect(upload.status).toBe(200);
+
+      const result = await request(TEST_API_URL)
+        .post("/v2/parse")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          uploadRef: init.body.data.uploadRef,
+          formats: ["markdown"],
+          zeroDataRetention: true,
+        });
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.success).toBe(true);
+      expect(result.body.data.markdown).toContain("Parse HTML Upload Test");
+      expect(result.body.data.metadata.sourceURL).toBe("upload-ref.html");
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "rejects oversized declared upload-ref sizes before signing",
+    async () => {
+      (config as any).ENV = "test";
+      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+
+      const failure = await request(TEST_API_URL)
+        .post("/v2/parse/upload-url")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          filename: "too-large.pdf",
+          contentType: "application/pdf",
+          declaredSizeBytes: 50 * 1024 * 1024 + 1,
+        });
+
+      expect(failure.statusCode).toBe(400);
+      expect(failure.body.success).toBe(false);
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "rejects upload-ref signing without authentication",
+    async () => {
+      (config as any).ENV = "test";
+      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+
+      const failure = await request(TEST_API_URL)
+        .post("/v2/parse/upload-url")
+        .set("Content-Type", "application/json")
+        .send({
+          filename: "upload-ref.html",
+          contentType: "text/html",
+        });
+
+      expect(failure.statusCode).not.toBe(200);
+      expect(failure.body.success).toBe(false);
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "mints upload refs for xhtml files accepted by parse",
+    async () => {
+      (config as any).ENV = "test";
+      (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
+
+      const init = await request(TEST_API_URL)
+        .post("/v2/parse/upload-url")
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .set("Content-Type", "application/json")
+        .send({
+          filename: "upload-ref.xhtml",
+          contentType: "application/xhtml+xml",
+        });
+
+      expect(init.statusCode).toBe(200);
+      expect(init.body.success).toBe(true);
+      expect(init.body.data.uploadRef).toEqual(expect.any(String));
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -42,13 +42,11 @@ function enableLocalUploadRefAdapter() {
   (config as any).PARSE_UPLOAD_STORAGE_DRIVER = "local";
 }
 
-async function mintLocalUploadRef(
+async function mintUploadRef(
   owner: Identity,
   filename = "upload-ref.html",
   contentType = "text/html",
 ) {
-  enableLocalUploadRefAdapter();
-
   const init = await request(TEST_API_URL)
     .post("/v2/parse/upload-url")
     .set("Authorization", `Bearer ${owner.apiKey}`)
@@ -58,10 +56,53 @@ async function mintLocalUploadRef(
       contentType,
     });
 
+  if (
+    init.statusCode === 503 &&
+    typeof init.body.code === "string" &&
+    init.body.code.startsWith("PARSE_UPLOAD_")
+  ) {
+    console.warn(
+      `Skipping uploadRef storage-dependent test because ${TEST_API_URL} is not configured for parse upload refs: ${init.body.code}`,
+    );
+    return null;
+  }
+
   expect(init.statusCode).toBe(200);
   expect(init.body.success).toBe(true);
   expect(init.body.data.uploadRef).toEqual(expect.any(String));
-  return init.body.data.uploadRef as string;
+  return init.body.data as {
+    uploadRef: string;
+    uploadUrl: string;
+    method: string;
+    headers?: Record<string, string>;
+    fields?: Record<string, string>;
+    maxSizeBytes: number;
+  };
+}
+
+async function uploadToMintedTarget(
+  init: NonNullable<Awaited<ReturnType<typeof mintUploadRef>>>,
+  content: string,
+  filename = "upload-ref.html",
+  contentType = "text/html",
+) {
+  if (init.method === "POST" && init.fields) {
+    const form = new FormData();
+    for (const key of Object.keys(init.fields).sort()) {
+      form.append(key, init.fields[key]);
+    }
+    form.append("file", new Blob([content], { type: contentType }), filename);
+    return await fetch(init.uploadUrl, {
+      method: "POST",
+      body: form,
+    });
+  }
+
+  return await fetch(init.uploadUrl, {
+    method: init.method || "PUT",
+    headers: init.headers,
+    body: content,
+  });
 }
 
 function getLocalUploadRefSecret() {
@@ -100,6 +141,11 @@ function tamperUploadRefSignature(uploadRef: string) {
   const [encodedPayload, signature] = uploadRef.split(".");
   const replacement = signature.endsWith("A") ? "B" : "A";
   return `${encodedPayload}.${signature.slice(0, -1)}${replacement}`;
+}
+
+function decodeUploadRefPayload(uploadRef: string) {
+  const [encodedPayload] = uploadRef.split(".");
+  return JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
 }
 
 async function waitForSingleRow<T>(
@@ -163,35 +209,20 @@ describe("/v2/parse", () => {
   it(
     "parses an upload-ref HTML file into markdown",
     async () => {
-      enableLocalUploadRefAdapter();
+      const init = await mintUploadRef(identity);
+      if (!init) return;
 
-      const init = await request(TEST_API_URL)
-        .post("/v2/parse/upload-url")
-        .set("Authorization", `Bearer ${identity.apiKey}`)
-        .set("Content-Type", "application/json")
-        .send({
-          filename: "upload-ref.html",
-          contentType: "text/html",
-        });
+      expect(init.maxSizeBytes).toBe(50 * 1024 * 1024);
 
-      expect(init.statusCode).toBe(200);
-      expect(init.body.success).toBe(true);
-      expect(init.body.data.uploadRef).toEqual(expect.any(String));
-      expect(init.body.data.maxSizeBytes).toBe(50 * 1024 * 1024);
-
-      const upload = await fetch(init.body.data.uploadUrl, {
-        method: "PUT",
-        headers: init.body.data.headers,
-        body: htmlFixture,
-      });
-      expect(upload.status).toBe(200);
+      const upload = await uploadToMintedTarget(init, htmlFixture);
+      expect([200, 201, 204]).toContain(upload.status);
 
       const result = await request(TEST_API_URL)
         .post("/v2/parse")
         .set("Authorization", `Bearer ${identity.apiKey}`)
         .set("Content-Type", "application/json")
         .send({
-          uploadRef: init.body.data.uploadRef,
+          uploadRef: init.uploadRef,
           formats: ["markdown"],
           zeroDataRetention: true,
         });
@@ -261,13 +292,15 @@ describe("/v2/parse", () => {
       });
       expect(otherIdentity.teamId).not.toBe(identity.teamId);
 
-      const uploadRef = await mintLocalUploadRef(identity);
+      const init = await mintUploadRef(identity);
+      if (!init) return;
+
       const failure = await request(TEST_API_URL)
         .post("/v2/parse")
         .set("Authorization", `Bearer ${otherIdentity.apiKey}`)
         .set("Content-Type", "application/json")
         .send({
-          uploadRef,
+          uploadRef: init.uploadRef,
           formats: ["markdown"],
           zeroDataRetention: true,
         });
@@ -282,13 +315,15 @@ describe("/v2/parse", () => {
   it(
     "rejects tampered upload refs",
     async () => {
-      const uploadRef = await mintLocalUploadRef(identity);
+      const init = await mintUploadRef(identity);
+      if (!init) return;
+
       const failure = await request(TEST_API_URL)
         .post("/v2/parse")
         .set("Authorization", `Bearer ${identity.apiKey}`)
         .set("Content-Type", "application/json")
         .send({
-          uploadRef: tamperUploadRefSignature(uploadRef),
+          uploadRef: tamperUploadRefSignature(init.uploadRef),
           formats: ["markdown"],
           zeroDataRetention: true,
         });
@@ -303,8 +338,18 @@ describe("/v2/parse", () => {
   it(
     "rejects expired upload refs",
     async () => {
-      const uploadRef = await mintLocalUploadRef(identity);
-      const expiredUploadRef = withUploadRefPayload(uploadRef, payload => {
+      const init = await mintUploadRef(identity);
+      if (!init) return;
+
+      const payload = decodeUploadRefPayload(init.uploadRef);
+      if (payload.driver !== "local") {
+        console.warn(
+          "Skipping uploadRef expiry test because the configured server uses a non-local signing secret",
+        );
+        return;
+      }
+
+      const expiredUploadRef = withUploadRefPayload(init.uploadRef, payload => {
         payload.expiresAt = Date.now() - 1000;
       });
 
@@ -328,20 +373,14 @@ describe("/v2/parse", () => {
   it(
     "mints upload refs for xhtml files accepted by parse",
     async () => {
-      enableLocalUploadRefAdapter();
+      const init = await mintUploadRef(
+        identity,
+        "upload-ref.xhtml",
+        "application/xhtml+xml",
+      );
+      if (!init) return;
 
-      const init = await request(TEST_API_URL)
-        .post("/v2/parse/upload-url")
-        .set("Authorization", `Bearer ${identity.apiKey}`)
-        .set("Content-Type", "application/json")
-        .send({
-          filename: "upload-ref.xhtml",
-          contentType: "application/xhtml+xml",
-        });
-
-      expect(init.statusCode).toBe(200);
-      expect(init.body.success).toBe(true);
-      expect(init.body.data.uploadRef).toEqual(expect.any(String));
+      expect(init.uploadRef).toEqual(expect.any(String));
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -307,66 +307,76 @@ describe("/v2/parse", () => {
       const key = getUnparsedUploadRefsKey(capIdentity.teamId);
       await getRedisConnection().del(key);
 
-      const oldScore = Date.now() - parseUploadUnparsedWindowMs - 1000;
-      await getRedisConnection().zadd(
-        key,
-        ...Array.from({ length: 10 }).flatMap((_, i) => [oldScore, `old-${i}`]),
-      );
+      try {
+        const oldScore = Date.now() - parseUploadUnparsedWindowMs - 1000;
+        await getRedisConnection().zadd(
+          key,
+          ...Array.from({ length: 10 }).flatMap((_, i) => [
+            oldScore,
+            `old-${i}`,
+          ]),
+        );
 
-      const first = await mintRequiredUploadRef(capIdentity, "cap-0.html");
+        const first = await mintRequiredUploadRef(capIdentity, "cap-0.html");
 
-      const refs = [first];
-      for (let i = 1; i < 10; i++) {
-        const init = await mintRequiredUploadRef(capIdentity, `cap-${i}.html`);
-        refs.push(init);
-      }
+        const refs = [first];
+        for (let i = 1; i < 10; i++) {
+          const init = await mintRequiredUploadRef(
+            capIdentity,
+            `cap-${i}.html`,
+          );
+          refs.push(init);
+        }
 
-      const rejected = await request(TEST_API_URL)
-        .post("/v2/parse/upload-url")
-        .set("Authorization", `Bearer ${capIdentity.apiKey}`)
-        .set("Content-Type", "application/json")
-        .send({
-          filename: "cap-rejected.html",
-          contentType: "text/html",
-        });
-
-      expect(rejected.statusCode).toBe(429);
-      expect(rejected.body.success).toBe(false);
-      expect(rejected.body.code).toBe("PARSE_UPLOAD_UNPARSED_LIMIT_REACHED");
-
-      const upload = await uploadToMintedTarget(
-        refs[0],
-        htmlFixture,
-        "cap-0.html",
-      );
-      expect([200, 201, 204]).toContain(upload.status);
-
-      const parsed = await request(TEST_API_URL)
-        .post("/v2/parse")
-        .set("Authorization", `Bearer ${capIdentity.apiKey}`)
-        .set("Content-Type", "application/json")
-        .send({
-          uploadRef: refs[0].uploadRef,
-          formats: ["markdown"],
-        });
-
-      expect(parsed.statusCode, JSON.stringify(parsed.body)).toBe(200);
-      expect(parsed.body.success).toBe(true);
-
-      const acceptedAfterParse = await waitForSingleRow(async () => {
-        const init = await request(TEST_API_URL)
+        const rejected = await request(TEST_API_URL)
           .post("/v2/parse/upload-url")
           .set("Authorization", `Bearer ${capIdentity.apiKey}`)
           .set("Content-Type", "application/json")
           .send({
-            filename: "cap-accepted-after-parse.html",
+            filename: "cap-rejected.html",
             contentType: "text/html",
           });
 
-        return init.statusCode === 200 ? init : null;
-      });
+        expect(rejected.statusCode).toBe(429);
+        expect(rejected.body.success).toBe(false);
+        expect(rejected.body.code).toBe("PARSE_UPLOAD_UNPARSED_LIMIT_REACHED");
 
-      expect(acceptedAfterParse?.body.success).toBe(true);
+        const upload = await uploadToMintedTarget(
+          refs[0],
+          htmlFixture,
+          "cap-0.html",
+        );
+        expect([200, 201, 204]).toContain(upload.status);
+
+        const parsed = await request(TEST_API_URL)
+          .post("/v2/parse")
+          .set("Authorization", `Bearer ${capIdentity.apiKey}`)
+          .set("Content-Type", "application/json")
+          .send({
+            uploadRef: refs[0].uploadRef,
+            formats: ["markdown"],
+          });
+
+        expect(parsed.statusCode, JSON.stringify(parsed.body)).toBe(200);
+        expect(parsed.body.success).toBe(true);
+
+        const acceptedAfterParse = await waitForSingleRow(async () => {
+          const init = await request(TEST_API_URL)
+            .post("/v2/parse/upload-url")
+            .set("Authorization", `Bearer ${capIdentity.apiKey}`)
+            .set("Content-Type", "application/json")
+            .send({
+              filename: "cap-accepted-after-parse.html",
+              contentType: "text/html",
+            });
+
+          return init.statusCode === 200 ? init : null;
+        });
+
+        expect(acceptedAfterParse?.body.success).toBe(true);
+      } finally {
+        await getRedisConnection().del(key);
+      }
     },
     scrapeTimeout,
   );

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -141,7 +141,7 @@ const configSchema = z.object({
   GCS_MEDIA_BUCKET_NAME: z.string().optional(),
   GCS_PARSE_UPLOAD_BUCKET_NAME: z.string().optional(),
   PARSE_UPLOAD_STORAGE_DRIVER: z.enum(["local", "gcs"]).optional(),
-  PARSE_UPLOAD_REF_SECRET: z.string().optional(),
+  PARSE_UPLOAD_REF_SECRET: emptyStringAsUndefined(z.string().trim().min(1)),
   PARSE_UPLOAD_PUBLIC_BASE_URL: z.string().url().optional(),
 
   // ClickHouse (Search Analytics)

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -139,6 +139,10 @@ const configSchema = z.object({
   GCS_FIRE_ENGINE_BUCKET_NAME: z.string().optional(),
   GCS_INDEX_BUCKET_NAME: z.string().optional(),
   GCS_MEDIA_BUCKET_NAME: z.string().optional(),
+  GCS_PARSE_UPLOAD_BUCKET_NAME: z.string().optional(),
+  PARSE_UPLOAD_STORAGE_DRIVER: z.enum(["local", "gcs"]).optional(),
+  PARSE_UPLOAD_REF_SECRET: z.string().optional(),
+  PARSE_UPLOAD_PUBLIC_BASE_URL: z.string().url().optional(),
 
   // ClickHouse (Search Analytics)
   CLICKHOUSE_ANALYTICS_URL: z.string().optional(),

--- a/apps/api/src/controllers/v2/parse-upload.ts
+++ b/apps/api/src/controllers/v2/parse-upload.ts
@@ -7,11 +7,15 @@ import { z } from "zod";
 import { config } from "../../config";
 import { logger as _logger } from "../../lib/logger";
 import { withSpan, setSpanAttributes } from "../../lib/otel-tracer";
+import { getRedisConnection } from "../../services/queue-service";
 import { RequestWithAuth, UploadedParseFile } from "./types";
 import { detectUploadedFileKind } from "./parse";
 
 const PARSE_UPLOAD_MAX_BYTES = 50 * 1024 * 1024;
 const PARSE_UPLOAD_TTL_MS = 10 * 60 * 1000;
+const PARSE_UPLOAD_UNPARSED_LIMIT = 10;
+const PARSE_UPLOAD_UNPARSED_WINDOW_MS = 24 * 60 * 60 * 1000;
+const PARSE_UPLOAD_UNPARSED_TTL_SECONDS = 25 * 60 * 60;
 const uploadInitSchema = z.strictObject({
   filename: z.string().min(1).max(512),
   contentType: z.string().min(1).max(255).optional(),
@@ -179,6 +183,76 @@ function makeObjectPath(
   return `parse-uploads/${teamId}/${uploadId}/${sanitizeFilename(filename)}`;
 }
 
+function getUnparsedUploadsKey(teamId: string) {
+  return `parse-upload-refs:${teamId}`;
+}
+
+async function reserveUnparsedUploadRef(teamId: string, uploadId: string) {
+  const now = Date.now();
+  const cutoff = now - PARSE_UPLOAD_UNPARSED_WINDOW_MS;
+  const result = await getRedisConnection().eval(
+    `
+      redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
+      local count = redis.call("ZCARD", KEYS[1])
+      if count >= tonumber(ARGV[3]) then
+        redis.call("EXPIRE", KEYS[1], tonumber(ARGV[5]))
+        return count
+      end
+      redis.call("ZADD", KEYS[1], ARGV[2], ARGV[4])
+      redis.call("EXPIRE", KEYS[1], tonumber(ARGV[5]))
+      return -1
+    `,
+    1,
+    getUnparsedUploadsKey(teamId),
+    cutoff,
+    now,
+    PARSE_UPLOAD_UNPARSED_LIMIT,
+    uploadId,
+    PARSE_UPLOAD_UNPARSED_TTL_SECONDS,
+  );
+
+  if (Number(result) !== -1) {
+    throw new Error("PARSE_UPLOAD_UNPARSED_LIMIT_REACHED");
+  }
+}
+
+async function releaseUnparsedUploadRef(teamId: string, uploadId: string) {
+  const cutoff = Date.now() - PARSE_UPLOAD_UNPARSED_WINDOW_MS;
+  const key = getUnparsedUploadsKey(teamId);
+  await getRedisConnection()
+    .pipeline()
+    .zremrangebyscore(key, "-inf", cutoff)
+    .zrem(key, uploadId)
+    .expire(key, PARSE_UPLOAD_UNPARSED_TTL_SECONDS)
+    .exec();
+}
+
+async function reserveUnparsedUploadRefOrRespond(
+  res: Response,
+  teamId: string,
+  uploadId: string,
+) {
+  try {
+    await reserveUnparsedUploadRef(teamId, uploadId);
+    return false;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "PARSE_UPLOAD_UNPARSED_LIMIT_REACHED"
+    ) {
+      res.status(429).json({
+        success: false,
+        code: "PARSE_UPLOAD_UNPARSED_LIMIT_REACHED",
+        error:
+          "Too many unparsed uploads. Parse or wait for existing upload references before minting more.",
+      });
+      return true;
+    }
+
+    throw error;
+  }
+}
+
 export async function parseUploadUrlController(
   req: RequestWithAuth<{}, any, any>,
   res: Response,
@@ -269,6 +343,12 @@ export async function parseUploadUrlController(
         ],
       });
 
+      if (
+        await reserveUnparsedUploadRefOrRespond(res, req.auth.team_id, uploadId)
+      ) {
+        return;
+      }
+
       return res.status(200).json({
         success: true,
         data: {
@@ -281,6 +361,12 @@ export async function parseUploadUrlController(
           maxSizeBytes: PARSE_UPLOAD_MAX_BYTES,
         },
       });
+    }
+
+    if (
+      await reserveUnparsedUploadRefOrRespond(res, req.auth.team_id, uploadId)
+    ) {
+      return;
     }
 
     localUploads.set(uploadId, {
@@ -500,7 +586,10 @@ export async function parseUploadRefPayloadMiddleware(
       file: resolved.file,
     };
     res.once("finish", () => {
-      resolved.cleanup().catch(error => {
+      Promise.all([
+        resolved.cleanup(),
+        releaseUnparsedUploadRef(payload.teamId, payload.uploadId),
+      ]).catch(error => {
         _logger.warn("Failed to clean up parse upload", {
           error,
           uploadId: payload.uploadId,

--- a/apps/api/src/controllers/v2/parse-upload.ts
+++ b/apps/api/src/controllers/v2/parse-upload.ts
@@ -362,6 +362,22 @@ export async function parseLocalUploadController(req: Request, res: Response) {
   return res.status(200).json({ success: true });
 }
 
+export function parseLocalUploadStorageGuard(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (!isLocalUploadAdapterAllowed() || getParseUploadDriver() !== "local") {
+    return res.status(404).json({
+      success: false,
+      code: "NOT_FOUND",
+      error: "Local parse upload storage is disabled.",
+    });
+  }
+
+  next();
+}
+
 async function resolveUploadRef(payload: ParseUploadRefPayload): Promise<{
   file: UploadedParseFile;
   cleanup: () => Promise<void>;

--- a/apps/api/src/controllers/v2/parse-upload.ts
+++ b/apps/api/src/controllers/v2/parse-upload.ts
@@ -73,13 +73,7 @@ function isLocalUploadAdapterAllowed() {
 }
 
 function getEffectiveRefSecret(): string | null {
-  if (!isLocalUploadAdapterAllowed())
-    return config.PARSE_UPLOAD_REF_SECRET ?? null;
-  return (
-    config.PARSE_UPLOAD_REF_SECRET ??
-    config.BULL_AUTH_KEY ??
-    "development-parse-upload-ref-secret"
-  );
+  return config.PARSE_UPLOAD_REF_SECRET ?? null;
 }
 
 function base64UrlEncode(input: Buffer | string): string {

--- a/apps/api/src/controllers/v2/parse-upload.ts
+++ b/apps/api/src/controllers/v2/parse-upload.ts
@@ -1,0 +1,509 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import { Request, Response, NextFunction } from "express";
+import { Storage } from "@google-cloud/storage";
+import { v7 as uuidv7 } from "uuid";
+import { z } from "zod";
+import { config } from "../../config";
+import { logger as _logger } from "../../lib/logger";
+import { withSpan, setSpanAttributes } from "../../lib/otel-tracer";
+import { RequestWithAuth, UploadedParseFile } from "./types";
+import { detectUploadedFileKind } from "./parse";
+
+const PARSE_UPLOAD_MAX_BYTES = 50 * 1024 * 1024;
+const PARSE_UPLOAD_TTL_MS = 10 * 60 * 1000;
+const uploadInitSchema = z.strictObject({
+  filename: z.string().min(1).max(512),
+  contentType: z.string().min(1).max(255).optional(),
+  declaredSizeBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(PARSE_UPLOAD_MAX_BYTES)
+    .optional(),
+});
+
+type ParseUploadDriver = "local" | "gcs";
+
+type ParseUploadRefPayload = {
+  v: 1;
+  driver: ParseUploadDriver;
+  uploadId: string;
+  teamId: string;
+  objectPath: string;
+  filename: string;
+  contentType?: string;
+  expiresAt: number;
+  maxBytes: number;
+};
+
+type LocalUploadRecord = {
+  buffer?: Buffer;
+  filename: string;
+  contentType?: string;
+  teamId: string;
+  expiresAt: number;
+  maxBytes: number;
+};
+
+const localUploads = new Map<string, LocalUploadRecord>();
+
+function getParseUploadDriver(): ParseUploadDriver {
+  if (config.PARSE_UPLOAD_STORAGE_DRIVER === "gcs") return "gcs";
+  if (config.PARSE_UPLOAD_STORAGE_DRIVER === "local") return "local";
+  if (config.GCS_PARSE_UPLOAD_BUCKET_NAME) return "gcs";
+  return isLocalUploadAdapterAllowed() ? "local" : "gcs";
+}
+
+function getStorageClient() {
+  const credentials = config.GCS_CREDENTIALS
+    ? JSON.parse(atob(config.GCS_CREDENTIALS))
+    : undefined;
+  return new Storage({ credentials });
+}
+
+function isLocalUploadAdapterAllowed() {
+  const env = config.ENV?.toLowerCase();
+  return (
+    env === "development" ||
+    env === "test" ||
+    env === "local" ||
+    process.env.NODE_ENV === "test"
+  );
+}
+
+function getEffectiveRefSecret(): string | null {
+  if (!isLocalUploadAdapterAllowed())
+    return config.PARSE_UPLOAD_REF_SECRET ?? null;
+  return (
+    config.PARSE_UPLOAD_REF_SECRET ??
+    config.BULL_AUTH_KEY ??
+    "development-parse-upload-ref-secret"
+  );
+}
+
+function base64UrlEncode(input: Buffer | string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function base64UrlDecode(input: string): Buffer {
+  return Buffer.from(input, "base64url");
+}
+
+function signUploadRef(payload: ParseUploadRefPayload): string {
+  const secret = getEffectiveRefSecret();
+  if (!secret) {
+    throw new Error(
+      "PARSE_UPLOAD_REF_SECRET is required for parse upload refs.",
+    );
+  }
+
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest("base64url");
+
+  return `${encodedPayload}.${signature}`;
+}
+
+function verifyUploadRef(uploadRef: string): ParseUploadRefPayload {
+  const secret = getEffectiveRefSecret();
+  if (!secret) {
+    throw new Error(
+      "PARSE_UPLOAD_REF_SECRET is required for parse upload refs.",
+    );
+  }
+
+  const [encodedPayload, signature, extra] = uploadRef.split(".");
+  if (!encodedPayload || !signature || extra !== undefined) {
+    throw new Error("Invalid uploadRef format.");
+  }
+
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest("base64url");
+
+  const signatureBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expected);
+  if (
+    signatureBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(signatureBuffer, expectedBuffer)
+  ) {
+    throw new Error("Invalid uploadRef signature.");
+  }
+
+  const decoded = JSON.parse(base64UrlDecode(encodedPayload).toString("utf8"));
+  const parsed = z
+    .strictObject({
+      v: z.literal(1),
+      driver: z.enum(["local", "gcs"]),
+      uploadId: z.string().min(1),
+      teamId: z.string().min(1),
+      objectPath: z.string().min(1),
+      filename: z.string().min(1),
+      contentType: z.string().optional(),
+      expiresAt: z.number().int().positive(),
+      maxBytes: z.number().int().positive().max(PARSE_UPLOAD_MAX_BYTES),
+    })
+    .parse(decoded);
+
+  if (Date.now() > parsed.expiresAt) {
+    throw new Error("uploadRef has expired.");
+  }
+
+  return parsed;
+}
+
+function sanitizeFilename(filename: string): string {
+  const base = path.basename(filename).replace(/[^a-zA-Z0-9._-]/g, "_");
+  return base || "upload";
+}
+
+function isSupportedParseUpload(filename: string, contentType?: string) {
+  return detectUploadedFileKind(filename, contentType) !== null;
+}
+
+function cleanupExpiredLocalUploads(now = Date.now()) {
+  for (const [uploadId, record] of localUploads.entries()) {
+    if (now > record.expiresAt) localUploads.delete(uploadId);
+  }
+}
+
+function buildPublicBaseUrl(req: Request): string {
+  const configured = config.PARSE_UPLOAD_PUBLIC_BASE_URL;
+  if (configured) return configured.replace(/\/$/, "");
+  return `${req.protocol}://${req.get("host")}`;
+}
+
+function makeObjectPath(
+  teamId: string,
+  uploadId: string,
+  filename: string,
+): string {
+  return `parse-uploads/${teamId}/${uploadId}/${sanitizeFilename(filename)}`;
+}
+
+export async function parseUploadUrlController(
+  req: RequestWithAuth<{}, any, any>,
+  res: Response,
+) {
+  return withSpan("api.parse.upload_url", async span => {
+    const parsed = uploadInitSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        code: "BAD_REQUEST",
+        error:
+          parsed.error.issues[0]?.message ?? "Invalid upload init request.",
+      });
+    }
+
+    const { filename, contentType, declaredSizeBytes } = parsed.data;
+    if (!isSupportedParseUpload(filename, contentType)) {
+      return res.status(400).json({
+        success: false,
+        code: "UNSUPPORTED_FILE_TYPE",
+        error:
+          "Unsupported upload type. Supported file extensions include .html, .htm, .xhtml, .pdf, .docx, .doc, .odt, .rtf, .xlsx, .xls, or matching supported MIME types.",
+      });
+    }
+
+    cleanupExpiredLocalUploads();
+    const driver = getParseUploadDriver();
+    if (!getEffectiveRefSecret()) {
+      return res.status(503).json({
+        success: false,
+        code: "PARSE_UPLOAD_REF_SECRET_MISSING",
+        error: "Parse upload references are not configured.",
+      });
+    }
+
+    if (driver === "local" && !isLocalUploadAdapterAllowed()) {
+      return res.status(503).json({
+        success: false,
+        code: "PARSE_UPLOAD_STORAGE_DISABLED",
+        error:
+          "Local parse upload storage is disabled outside development/test.",
+      });
+    }
+
+    const uploadId = uuidv7();
+    const expiresAt = Date.now() + PARSE_UPLOAD_TTL_MS;
+    const objectPath = makeObjectPath(req.auth.team_id, uploadId, filename);
+    const refPayload: ParseUploadRefPayload = {
+      v: 1,
+      driver,
+      uploadId,
+      teamId: req.auth.team_id,
+      objectPath,
+      filename: sanitizeFilename(filename),
+      contentType,
+      expiresAt,
+      maxBytes: PARSE_UPLOAD_MAX_BYTES,
+    };
+    const uploadRef = signUploadRef(refPayload);
+
+    setSpanAttributes(span, {
+      "parse_upload.driver": driver,
+      "parse_upload.team_id": req.auth.team_id,
+      "parse_upload.declared_size": declaredSizeBytes,
+    });
+
+    if (driver === "gcs") {
+      if (!config.GCS_PARSE_UPLOAD_BUCKET_NAME) {
+        return res.status(503).json({
+          success: false,
+          code: "PARSE_UPLOAD_STORAGE_DISABLED",
+          error: "Parse upload storage is not configured.",
+        });
+      }
+
+      const bucket = getStorageClient().bucket(
+        config.GCS_PARSE_UPLOAD_BUCKET_NAME,
+      );
+      const file = bucket.file(objectPath);
+      const [policy] = await file.generateSignedPostPolicyV4({
+        expires: expiresAt,
+        fields: {
+          "Content-Type": contentType || "application/octet-stream",
+        },
+        conditions: [
+          ["content-length-range", 1, PARSE_UPLOAD_MAX_BYTES],
+          ["eq", "$Content-Type", contentType || "application/octet-stream"],
+        ],
+      });
+
+      return res.status(200).json({
+        success: true,
+        data: {
+          uploadUrl: policy.url,
+          uploadRef,
+          method: "POST",
+          headers: {},
+          fields: policy.fields,
+          expiresAt: new Date(expiresAt).toISOString(),
+          maxSizeBytes: PARSE_UPLOAD_MAX_BYTES,
+        },
+      });
+    }
+
+    localUploads.set(uploadId, {
+      filename: sanitizeFilename(filename),
+      contentType,
+      teamId: req.auth.team_id,
+      expiresAt,
+      maxBytes: PARSE_UPLOAD_MAX_BYTES,
+    });
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        uploadUrl: `${buildPublicBaseUrl(req)}/v2/parse/upload/${uploadId}?uploadRef=${encodeURIComponent(uploadRef)}`,
+        uploadRef,
+        method: "PUT",
+        headers: {
+          "Content-Type": contentType || "application/octet-stream",
+        },
+        expiresAt: new Date(expiresAt).toISOString(),
+        maxSizeBytes: PARSE_UPLOAD_MAX_BYTES,
+      },
+    });
+  });
+}
+
+export async function parseLocalUploadController(req: Request, res: Response) {
+  if (!isLocalUploadAdapterAllowed()) {
+    return res.status(404).json({
+      success: false,
+      code: "NOT_FOUND",
+      error: "Local parse upload storage is disabled.",
+    });
+  }
+  cleanupExpiredLocalUploads();
+
+  const uploadRef =
+    typeof req.query.uploadRef === "string" ? req.query.uploadRef : "";
+  let payload: ParseUploadRefPayload;
+  try {
+    payload = verifyUploadRef(uploadRef);
+  } catch (error) {
+    return res.status(400).json({
+      success: false,
+      code: "BAD_REQUEST",
+      error: error instanceof Error ? error.message : "Invalid uploadRef.",
+    });
+  }
+
+  if (payload.driver !== "local" || payload.uploadId !== req.params.uploadId) {
+    return res.status(400).json({
+      success: false,
+      code: "BAD_REQUEST",
+      error: "uploadRef does not match this upload URL.",
+    });
+  }
+
+  const record = localUploads.get(payload.uploadId);
+  if (!record || record.teamId !== payload.teamId) {
+    return res.status(404).json({
+      success: false,
+      code: "NOT_FOUND",
+      error: "Upload URL not found or expired.",
+    });
+  }
+
+  const body = Buffer.isBuffer(req.body)
+    ? req.body
+    : Buffer.from(req.body ?? "");
+  if (body.length > record.maxBytes) {
+    return res.status(400).json({
+      success: false,
+      code: "BAD_REQUEST",
+      error: "Uploaded file exceeds maximum size of 50MB.",
+    });
+  }
+
+  record.buffer = body;
+  return res.status(200).json({ success: true });
+}
+
+async function resolveUploadRef(payload: ParseUploadRefPayload): Promise<{
+  file: UploadedParseFile;
+  cleanup: () => Promise<void>;
+}> {
+  if (payload.driver === "local") {
+    cleanupExpiredLocalUploads();
+    const record = localUploads.get(payload.uploadId);
+    if (!record || record.teamId !== payload.teamId || !record.buffer) {
+      throw new Error(
+        "Uploaded file is not available. Upload the file before parsing.",
+      );
+    }
+    if (record.buffer.length > payload.maxBytes) {
+      throw new Error("Uploaded file exceeds maximum size of 50MB.");
+    }
+
+    const kind = detectUploadedFileKind(payload.filename, payload.contentType);
+    if (!kind) {
+      throw new Error("Unsupported upload type.");
+    }
+
+    return {
+      file: {
+        buffer: record.buffer,
+        filename: payload.filename,
+        contentType: payload.contentType,
+        kind,
+      },
+      cleanup: async () => {
+        localUploads.delete(payload.uploadId);
+      },
+    };
+  }
+
+  if (!config.GCS_PARSE_UPLOAD_BUCKET_NAME) {
+    throw new Error("Parse upload storage is not configured.");
+  }
+
+  const file = getStorageClient()
+    .bucket(config.GCS_PARSE_UPLOAD_BUCKET_NAME)
+    .file(payload.objectPath);
+  const [metadata] = await file.getMetadata();
+  const size = Number(metadata.size ?? 0);
+  if (!Number.isFinite(size) || size > payload.maxBytes) {
+    throw new Error("Uploaded file exceeds maximum size of 50MB.");
+  }
+
+  const [buffer] = await file.download();
+  if (buffer.length > payload.maxBytes) {
+    throw new Error("Uploaded file exceeds maximum size of 50MB.");
+  }
+
+  const kind = detectUploadedFileKind(payload.filename, payload.contentType);
+  if (!kind) {
+    throw new Error("Unsupported upload type.");
+  }
+
+  return {
+    file: {
+      buffer,
+      filename: payload.filename,
+      contentType: payload.contentType,
+      kind,
+    },
+    cleanup: async () => {
+      try {
+        await file.delete({ ignoreNotFound: true });
+      } catch (error) {
+        _logger.warn("Failed to clean up parse upload object", {
+          error,
+          uploadId: payload.uploadId,
+        });
+      }
+    },
+  };
+}
+
+export async function parseUploadRefPayloadMiddleware(
+  req: RequestWithAuth<{}, any, any>,
+  res: Response,
+  next: NextFunction,
+) {
+  const uploadRef = req.body?.uploadRef;
+  if (typeof uploadRef !== "string" || uploadRef.length === 0) {
+    res.status(400).json({
+      success: false,
+      code: "BAD_REQUEST",
+      error:
+        "Missing file upload. Send multipart/form-data with a 'file' field, or JSON with an 'uploadRef'.",
+    });
+    return;
+  }
+
+  let payload: ParseUploadRefPayload;
+  try {
+    payload = verifyUploadRef(uploadRef);
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      code: "BAD_REQUEST",
+      error: error instanceof Error ? error.message : "Invalid uploadRef.",
+    });
+    return;
+  }
+
+  if (payload.teamId !== req.auth.team_id) {
+    res.status(403).json({
+      success: false,
+      code: "FORBIDDEN",
+      error: "uploadRef does not belong to the authenticated team.",
+    });
+    return;
+  }
+
+  try {
+    const resolved = await resolveUploadRef(payload);
+    const { uploadRef: _uploadRef, ...options } = req.body;
+    req.body = {
+      ...options,
+      file: resolved.file,
+    };
+    res.once("finish", () => {
+      resolved.cleanup().catch(error => {
+        _logger.warn("Failed to clean up parse upload", {
+          error,
+          uploadId: payload.uploadId,
+        });
+      });
+    });
+    next();
+  } catch (error) {
+    res.status(400).json({
+      success: false,
+      code: "BAD_REQUEST",
+      error:
+        error instanceof Error ? error.message : "Failed to resolve uploadRef.",
+    });
+  }
+}

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -49,7 +49,7 @@ const DOCUMENT_EXTENSIONS = new Set([
   ".xls",
 ]);
 
-function detectUploadedFileKind(
+export function detectUploadedFileKind(
   filename: string,
   contentType?: string | null,
 ): UploadedParseFileKind | null {

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -16,6 +16,7 @@ import {
 } from "../controllers/v2/parse";
 import {
   parseLocalUploadController,
+  parseLocalUploadStorageGuard,
   parseUploadRefPayloadMiddleware,
   parseUploadUrlController,
 } from "../controllers/v2/parse-upload";
@@ -296,6 +297,7 @@ v2Router.post(
 
 v2Router.put(
   "/parse/upload/:uploadId",
+  parseLocalUploadStorageGuard,
   express.raw({ type: "*/*", limit: "50mb" }),
   wrap(parseLocalUploadController),
 );
@@ -304,8 +306,8 @@ v2Router.post(
   "/parse",
   authMiddleware(RateLimiterMode.Scrape, { allowKeyless: true }),
   countryCheck,
-  parsePayloadMiddleware,
   checkCreditsMiddleware(1),
+  parsePayloadMiddleware,
   wrap(parseController),
 );
 

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -14,6 +14,11 @@ import {
   parseController,
   parseMultipartPayloadMiddleware,
 } from "../controllers/v2/parse";
+import {
+  parseLocalUploadController,
+  parseUploadRefPayloadMiddleware,
+  parseUploadUrlController,
+} from "../controllers/v2/parse-upload";
 import { batchScrapeController } from "../controllers/v2/batch-scrape";
 import { crawlController } from "../controllers/v2/crawl";
 import { crawlParamsPreviewController } from "../controllers/v2/crawl-params-preview";
@@ -115,6 +120,29 @@ const parseUploadMiddleware: express.RequestHandler = (req, res, next) => {
   });
 };
 
+const parsePayloadMiddleware: express.RequestHandler = (req, res, next) => {
+  const contentType = req.headers["content-type"] || "";
+  if (
+    typeof contentType === "string" &&
+    contentType.includes("multipart/form-data")
+  ) {
+    return parseUploadMiddleware(req, res, err => {
+      if (err) return next(err);
+      return parseMultipartPayloadMiddleware(req, res, next);
+    });
+  }
+
+  if (req.body && typeof req.body === "object" && "uploadRef" in req.body) {
+    return parseUploadRefPayloadMiddleware(req as any, res, next);
+  }
+
+  return res.status(400).json({
+    success: false,
+    code: "BAD_REQUEST",
+    error:
+      "Missing file upload. Send multipart/form-data with a 'file' field, or JSON with an 'uploadRef'.",
+  });
+};
 // Add timing middleware to all v2 routes
 v2Router.use(requestTimingMiddleware("v2"));
 
@@ -260,11 +288,23 @@ v2Router.post(
 );
 
 v2Router.post(
+  "/parse/upload-url",
+  authMiddleware(RateLimiterMode.Scrape),
+  countryCheck,
+  wrap(parseUploadUrlController),
+);
+
+v2Router.put(
+  "/parse/upload/:uploadId",
+  express.raw({ type: "*/*", limit: "50mb" }),
+  wrap(parseLocalUploadController),
+);
+
+v2Router.post(
   "/parse",
   authMiddleware(RateLimiterMode.Scrape, { allowKeyless: true }),
   countryCheck,
-  parseUploadMiddleware,
-  parseMultipartPayloadMiddleware,
+  parsePayloadMiddleware,
   checkCreditsMiddleware(1),
   wrap(parseController),
 );

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -290,7 +290,7 @@ v2Router.post(
 
 v2Router.post(
   "/parse/upload-url",
-  authMiddleware(RateLimiterMode.Scrape),
+  authMiddleware(RateLimiterMode.Scrape, { allowKeyless: true }),
   countryCheck,
   wrap(parseUploadUrlController),
 );


### PR DESCRIPTION
## Summary

Adds hosted parse support for local files without giving the remote MCP server filesystem access and without exposing long-lived Firecrawl API keys to the model or shell.

The API side adds an authenticated upload-reference flow:

1. `POST /v2/parse/upload-url` mints a short-lived, team-scoped `uploadRef` and upload target.
2. The client uploads the file bytes directly to storage using the returned signed upload parameters.
3. `POST /v2/parse` accepts JSON with `uploadRef`, resolves the uploaded bytes server-side, and then reuses the existing parse pipeline.

The existing multipart `/v2/parse` behavior is preserved.

Key details:

- Upload refs are HMAC signed, expire after 10 minutes, and include team, object path, filename, content type, and max size.
- `/v2/parse/upload-url` is authenticated only. Keyless users cannot mint upload refs.
- The parse-by-ref request must be authenticated as the same team that minted the ref.
- Production storage uses GCS signed POST policies with `content-length-range` enforcement.
- A local in-memory adapter is available only for development/test/local environments.
- Uploaded GCS objects are best-effort deleted after parse resolution, with bucket lifecycle expected as the backstop.

## Rollout notes

Required production/staging config:

- `PARSE_UPLOAD_REF_SECRET`: signing secret for upload refs. Required outside local/dev/test.
- `GCS_PARSE_UPLOAD_BUCKET_NAME`: bucket used for temporary parse uploads.
- `PARSE_UPLOAD_STORAGE_DRIVER=gcs`: explicit production storage driver.
- `GCS_CREDENTIALS`: existing base64 service account JSON used by the API GCS client.

Infra requirements:

- The service account must be able to sign GCS POST policies and create/read/delete objects in the parse upload bucket.
- The parse upload bucket should have a lifecycle rule for abandoned uploads.
- The bucket should be dedicated to temporary parse uploads if possible, rather than mixed with served media.

Security/product behavior:

- This PR does not echo raw Firecrawl API keys into curl commands or tool responses.
- This PR does not add keyless upload-ref minting.
- Billing/credits remain on the final authenticated `/v2/parse` request.

## Verification

Local build/static checks:

- `pnpm --dir apps/api/native build`
- `pnpm --dir apps/api build`
- `git -C firecrawl diff --check`

Targeted test/import check:

- `TEST_SUITE_SELF_HOSTED=1 TEST_SUITE_WEBSITE=https://example.com TEST_API_URL=http://127.0.0.1:65535 TEST_API_KEY=test TEST_TEAM_ID=test pnpm --dir firecrawl/apps/api exec vitest run src/__tests__/snips/v2/parse.test.ts --testNamePattern '__upload_ref_import_only_no_match__'`

Added parse uploadRef security coverage:

- Cross-team consumption is rejected with 403 when idmux provides distinct test teams and the running server has parse upload storage configured.
- Tampered uploadRef signatures are rejected when uploadRef minting is configured.
- Expired local uploadRefs are rejected when the running server uses the local test adapter.
- Storage-dependent uploadRef snips skip when the self-hosted test server reports parse upload refs are not configured, instead of assuming test-process config mutations affect the server.

Real GCS validation, using a bucket in a personal GCP project:

- Created an isolated parse-upload bucket with a 1-day lifecycle deletion rule.
- Created a bucket-scoped service account for signing and object access.
- Verified V4 signed POST policy generation with `@google-cloud/storage`.
- Verified curl upload through the signed POST policy.
- Verified service-account read/download/delete of the uploaded object.
- Verified `content-length-range` rejects oversized uploads before object creation.
- Ran a controller-level smoke with temporary Redis: upload-url minting, signed POST upload, uploadRef resolution, and cleanup against the GCS bucket.

## Remaining review items

- UploadRef security tests execute in CI against a configured self-hosted server: happy path, tenant mismatch, tampered ref, expiry, oversized declaration, and xhtml minting passed on `ac81a2c`; later pushes tighten signing-secret handling and add cheaper request gates.
- Current non-code red at `692d8df` is Vercel deploy authorization. Superagent Security Scan, audit, and NuQ FoundationDB core pass; server matrix checks are still running.
- Production bucket name, IAM, lifecycle policy, and secret wiring need infra-owner review before rollout.
- Docs/skill wording should be updated after the API and MCP PRs land so hosted users understand the two-step upload flow.

