### PR TITLE
feat(api): add NuQ FDB metrics

### DIFF
--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -9,7 +9,7 @@ import {
   getNuqFdbDatabase,
   getFdb,
 } from "../../services/worker/nuq-fdb/client";
-import { encodeJson } from "../../services/worker/nuq-fdb/keyspace";
+import { encodeI64, encodeJson } from "../../services/worker/nuq-fdb/keyspace";
 
 // These tests exercise the FDB queue core directly against a real FoundationDB
 // cluster (no API server needed). They are skipped when FDB is not configured.
@@ -139,9 +139,33 @@ describeIf("NuQ FDB core", () => {
     expect(jobs.filter(j => j.status === "backlog").length).toBe(3);
     expect(await queue.getTeamActiveCount(owner)).toBe(2);
     expect(await queue.getTeamPendingCount(owner)).toBe(3);
+    expect(await queue.getWorkerLoadCount()).toBe(2);
+
+    const queuedMetrics = await queue.getMetrics();
+    expect(queuedMetrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_teamgate_job_count{status="queued"} 2`,
+    );
+    expect(queuedMetrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_teamgate_job_count{status="active"} 0`,
+    );
+    expect(queuedMetrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_teamgate_job_count{status="backlog"} 3`,
+    );
 
     const taken = await takeAll(queue, 5);
     expect(taken.length).toBe(2);
+    expect(await queue.getWorkerLoadCount()).toBe(2);
+
+    const activeMetrics = await queue.getMetrics();
+    expect(activeMetrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_teamgate_job_count{status="queued"} 0`,
+    );
+    expect(activeMetrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_teamgate_job_count{status="active"} 2`,
+    );
+    expect(activeMetrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_teamgate_job_count{status="backlog"} 3`,
+    );
 
     // finishing one job promotes exactly one backlogged job
     await queue.jobFinish(taken[0].id, taken[0].lock!, null);
@@ -158,6 +182,20 @@ describeIf("NuQ FDB core", () => {
     for (const j of rest) await queue.jobFinish(j.id, j.lock!, null);
     expect(await queue.getTeamActiveCount(owner)).toBe(0);
     expect(await queue.getTeamPendingCount(owner)).toBe(0);
+  });
+
+  test("metrics count pending teams even without active index entries", async () => {
+    const { queue } = await makeCtx("pending-metrics");
+    const owner = freshOwner();
+
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(queue.ks.teamPendingCount(owner), encodeI64(4));
+    });
+
+    const metrics = await queue.getMetrics();
+    expect(metrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_pending_metrics_job_count{status="backlog"} 4`,
+    );
   });
 
   test("promotion respects priority order", async () => {

--- a/apps/api/src/controllers/v0/admin/metrics.ts
+++ b/apps/api/src/controllers/v0/admin/metrics.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { getRedisConnection } from "../../../services/queue-service";
+import { nuqFdbGetMetrics } from "../../../services/worker/nuq-fdb";
 import { nuqGetLocalMetrics } from "../../../services/worker/nuq";
 import { scrapeQueue } from "../../../services/worker/nuq-router";
 import { teamConcurrencySemaphore } from "../../../services/worker/team-semaphore";
@@ -50,4 +51,8 @@ ${semaphoreMetrics}`);
 
 export async function nuqMetricsController(_: Request, res: Response) {
   res.contentType("text/plain").send(await scrapeQueue.getMetrics());
+}
+
+export async function nuqFdbMetricsController(_: Request, res: Response) {
+  res.contentType("text/plain").send(await nuqFdbGetMetrics());
 }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -10,6 +10,7 @@ import { indexQueuePrometheus } from "../controllers/v0/admin/index-queue-promet
 import { triggerPrecrawl } from "../controllers/v0/admin/precrawl";
 import {
   metricsController,
+  nuqFdbMetricsController,
   nuqMetricsController,
 } from "../controllers/v0/admin/metrics";
 import { realtimeSearchController } from "../controllers/v2/f-search";
@@ -64,6 +65,11 @@ adminRouter.get(
 adminRouter.get(
   `/admin/${config.BULL_AUTH_KEY}/nuq-metrics`,
   wrap(nuqMetricsController),
+);
+
+adminRouter.get(
+  `/admin/${config.BULL_AUTH_KEY}/nuq-fdb-metrics`,
+  wrap(nuqFdbMetricsController),
 );
 
 adminRouter.post(

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -37,6 +37,19 @@ export const crawlGroupFdb = new NuQFdbJobGroup(
 
 export const externalSlotsFdb = new NuqFdbExternalSlots(scrapeQueueFdb.ks);
 
+export async function nuqFdbGetMetrics(): Promise<string> {
+  const [queueMetrics, workerLoad] = await Promise.all([
+    scrapeQueueFdb.getMetrics(),
+    scrapeQueueFdb.getWorkerLoadCount(),
+  ]);
+
+  return `${queueMetrics}
+# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+# TYPE firecrawl_nuq_fdb_pending_jobs gauge
+firecrawl_nuq_fdb_pending_jobs ${workerLoad}
+`;
+}
+
 let sweeper: NuqFdbSweeper | null = null;
 
 export function getNuqFdbSweeper(): NuqFdbSweeper {

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -168,6 +168,9 @@ export class NuqFdbKeyspace {
   teamLimit(tid: string): Buffer {
     return this.pack(["t", tid, "limit"]);
   }
+  teamRange() {
+    return this.packRange(["t"]);
+  }
   teamActive(tid: string): Buffer {
     return this.pack(["t", tid, "active"]);
   }
@@ -271,6 +274,9 @@ export class NuqFdbKeyspace {
   // === Time-ordered indexes (sweeper-owned)
   lease(bucket: number, expMs: number, id: string): Buffer {
     return this.pack(["lease", bucket, expMs, id]);
+  }
+  leaseRange() {
+    return this.packRange(["lease"]);
   }
   leaseScanRange(bucket: number, untilMs: number) {
     return {

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -1256,7 +1256,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const counts = new Map<string, number>();
       for (const [key, value] of rows) {
         const parts = ks.unpack(key as Buffer);
-        const teamId = parts[2];
+        const teamId = parts[3];
         if (typeof teamId !== "string") continue;
         const count = Math.max(0, decodeI64(value as Buffer));
         if (count > 0) counts.set(teamId, count);
@@ -1274,6 +1274,80 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         decodeI64(await tn.snapshot().get(this.ks.teamPendingCount(owner))),
       ),
     );
+  }
+
+  public async getWorkerLoadCount(): Promise<number> {
+    const ks = this.ks;
+    return await this.db.doTn(async tn => {
+      const [readyRows, activeRows] = await Promise.all([
+        tn
+          .snapshot()
+          .getRangeAll(
+            ks.readyShardCountRange().begin,
+            ks.readyShardCountRange().end,
+          ),
+        tn.snapshot().getRangeAll(ks.leaseRange().begin, ks.leaseRange().end),
+      ]);
+      const queued = readyRows.reduce(
+        (sum, [, value]) => sum + Math.max(0, decodeI64(value as Buffer)),
+        0,
+      );
+      return queued + activeRows.length;
+    });
+  }
+
+  private async getMetricCounts(): Promise<Record<NuQJobStatusCompat, number>> {
+    const ks = this.ks;
+    return await this.db.doTn(async tn => {
+      const [readyRows, activeRows, teamRows] = await Promise.all([
+        tn
+          .snapshot()
+          .getRangeAll(
+            ks.readyShardCountRange().begin,
+            ks.readyShardCountRange().end,
+          ),
+        tn.snapshot().getRangeAll(ks.leaseRange().begin, ks.leaseRange().end),
+        tn.snapshot().getRangeAll(ks.teamRange().begin, ks.teamRange().end),
+      ]);
+
+      const queued = readyRows.reduce(
+        (sum, [, value]) => sum + Math.max(0, decodeI64(value as Buffer)),
+        0,
+      );
+
+      let backlog = 0;
+      for (const [key, value] of teamRows) {
+        const parts = ks.unpack(key as Buffer);
+        if (parts[4] !== "pend") continue;
+        backlog += Math.max(0, decodeI64(value as Buffer));
+      }
+
+      return {
+        queued,
+        active: activeRows.length,
+        completed: 0,
+        failed: 0,
+        backlog,
+      };
+    });
+  }
+
+  public async getMetrics(): Promise<string> {
+    const metricName = `nuq_fdb_queue_${this.queueName.replace(/[^a-zA-Z0-9_]/g, "_")}_job_count`;
+    const statusCounts = await this.getMetricCounts();
+    return `# HELP ${metricName} Number of FDB jobs in each status\n# TYPE ${metricName} gauge\n${(
+      [
+        "queued",
+        "active",
+        "completed",
+        "failed",
+        "backlog",
+      ] satisfies NuQJobStatusCompat[]
+    )
+      .map(
+        status => `${metricName}{status="${status}"} ${statusCounts[status]}`,
+      )
+      .join("\n")}\n`;
   }
 }
 


### PR DESCRIPTION
## Summary\n- add FDB queue status gauges alongside existing NuQ queue metrics\n- expose a worker-load gauge for FDB autoscaling\n- add focused FDB core assertions for metric counts\n\n## Tests\n- pnpm build\n- pnpm test src/__tests__/nuq-fdb/core.test.ts (skips runtime cases without FDB_CLUSTER_FILE)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FDB queue metrics to NuQ and exposes them at a new admin endpoint for Prometheus scraping. Provides per-status job gauges and a worker-load gauge to support autoscaling.

- **New Features**
  - Added `nuq_fdb_queue_<queue>_job_count` gauge with statuses: queued, active, backlog, completed, failed.
  - Added `firecrawl_nuq_fdb_pending_jobs` gauge (ready-shard queued + active leases) for autoscaling.
  - Added `/admin/<BULL_AUTH_KEY>/nuq-fdb-metrics` endpoint that serves the FDB metrics.

<sup>Written for commit fec2d084ac71a74cad2374f76c4ea2cef5bbdb66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

