### PR TITLE
[codex] restore safe API image build caching

### DIFF
--- a/.github/workflows/deploy-image-staging.yml
+++ b/.github/workflows/deploy-image-staging.yml
@@ -73,6 +73,31 @@ jobs:
           tags: ${{ needs.version.outputs.image }}:sha-${{ needs.version.outputs.short_sha }}-staging-${{ matrix.platform_suffix }}
           platforms: ${{ matrix.platform }}
           provenance: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=registry,ref=${{ needs.version.outputs.image }}:buildcache-staging-${{ matrix.platform_suffix }}
+          cache-to: type=registry,ref=${{ needs.version.outputs.image }}:buildcache-staging-${{ matrix.platform_suffix }},mode=max
+
+      - name: Verify pushed image contents
+        env:
+          IMAGE_TAG: ${{ needs.version.outputs.image }}:sha-${{ needs.version.outputs.short_sha }}-staging-${{ matrix.platform_suffix }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          docker pull "${IMAGE_TAG}"
+          actual_sha="$(docker run --rm --entrypoint node "${IMAGE_TAG}" -p 'process.env.FIRECRAWL_BUILD_SHA')"
+          if [ "${actual_sha}" != "${EXPECTED_SHA}" ]; then
+            echo "::error::Image build SHA mismatch: expected ${EXPECTED_SHA}, got ${actual_sha}"
+            exit 1
+          fi
+
+          docker run --rm --entrypoint node "${IMAGE_TAG}" -e '
+            const fs = require("fs");
+            for (const path of ["dist/src/harness.js", "dist/src/controllers/v0/crawl-status.js", "BUILD_SHA"]) {
+              if (!fs.statSync(path).size) {
+                throw new Error(`${path} missing or empty`);
+              }
+            }
+          '
 
   publish:
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -88,12 +113,15 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: 'Create and Push Staging Multi-Arch Manifest'
+        timeout-minutes: 10
         env:
           IMAGE: ${{ needs.version.outputs.image }}
           STAGING_IMAGE: ${{ needs.version.outputs.staging_image }}
           VERSION: ${{ needs.version.outputs.version }}
           SHORT_SHA: ${{ needs.version.outputs.short_sha }}
         run: |
+          set -euo pipefail
+
           amd64_image="${IMAGE}:sha-${SHORT_SHA}-staging-linux-amd64"
           arm64_image="${IMAGE}:sha-${SHORT_SHA}-staging-linux-arm64"
           manifest_tags=(
@@ -103,7 +131,9 @@ jobs:
           )
 
           for target in "${manifest_tags[@]}"; do
-            docker manifest rm "${target}" >/dev/null 2>&1 || true
-            docker manifest create "${target}" "${amd64_image}" "${arm64_image}"
-            docker manifest push "${target}"
+            echo "Publishing multi-arch manifest ${target}"
+            docker buildx imagetools create \
+              --tag "${target}" \
+              "${amd64_image}" \
+              "${arm64_image}"
           done

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -98,7 +98,31 @@ jobs:
           tags: ${{ needs.version.outputs.image }}:sha-${{ needs.version.outputs.short_sha }}-${{ matrix.platform_suffix }}
           platforms: ${{ matrix.platform }}
           provenance: false
-          no-cache: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=registry,ref=${{ needs.version.outputs.image }}:buildcache-${{ matrix.platform_suffix }}
+          cache-to: type=registry,ref=${{ needs.version.outputs.image }}:buildcache-${{ matrix.platform_suffix }},mode=max
+
+      - name: Verify pushed image contents
+        env:
+          IMAGE_TAG: ${{ needs.version.outputs.image }}:sha-${{ needs.version.outputs.short_sha }}-${{ matrix.platform_suffix }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          docker pull "${IMAGE_TAG}"
+          actual_sha="$(docker run --rm --entrypoint node "${IMAGE_TAG}" -p 'process.env.FIRECRAWL_BUILD_SHA')"
+          if [ "${actual_sha}" != "${EXPECTED_SHA}" ]; then
+            echo "::error::Image build SHA mismatch: expected ${EXPECTED_SHA}, got ${actual_sha}"
+            exit 1
+          fi
+
+          docker run --rm --entrypoint node "${IMAGE_TAG}" -e '
+            const fs = require("fs");
+            for (const path of ["dist/src/harness.js", "dist/src/controllers/v0/crawl-status.js", "BUILD_SHA"]) {
+              if (!fs.statSync(path).size) {
+                throw new Error(`${path} missing or empty`);
+              }
+            }
+          '
 
   publish:
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -141,6 +165,7 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: 'Create and Push Multi-Arch Manifest'
+        timeout-minutes: 10
         env:
           IMAGE: ${{ needs.version.outputs.image }}
           VERSION: ${{ needs.version.outputs.version }}
@@ -148,6 +173,8 @@ jobs:
           MAJOR_MINOR: ${{ needs.version.outputs.major_minor }}
           SHORT_SHA: ${{ needs.version.outputs.short_sha }}
         run: |
+          set -euo pipefail
+
           amd64_image="${IMAGE}:sha-${SHORT_SHA}-linux-amd64"
           arm64_image="${IMAGE}:sha-${SHORT_SHA}-linux-arm64"
           manifest_tags=(
@@ -159,7 +186,9 @@ jobs:
           )
 
           for target in "${manifest_tags[@]}"; do
-            docker manifest rm "${target}" >/dev/null 2>&1 || true
-            docker manifest create "${target}" "${amd64_image}" "${arm64_image}"
-            docker manifest push "${target}"
+            echo "Publishing multi-arch manifest ${target}"
+            docker buildx imagetools create \
+              --tag "${target}" \
+              "${amd64_image}" \
+              "${arm64_image}"
           done

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -44,9 +44,12 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path \
     && chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
-# Copy source files
+# Copy dependency inputs. The native workspace is included here because its
+# install script builds the Rust package; API TypeScript source is copied after
+# dependency install so source-only changes do not invalidate this layer.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
-COPY . .
+COPY patches ./patches
+COPY native ./native
 
 # Install dependencies
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
@@ -54,8 +57,14 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=cache,target=/app/native/target \
     pnpm install --frozen-lockfile
 
+COPY . .
+
 # Build the application from a clean output directory.
 RUN rm -rf dist && pnpm run build
+ARG GIT_SHA=unknown
+RUN test -s dist/src/harness.js && \
+    test -s dist/src/controllers/v0/crawl-status.js && \
+    printf '%s\n' "$GIT_SHA" > BUILD_SHA
 
 # Remove dev dependencies
 RUN pnpm prune --prod --ignore-scripts
@@ -80,13 +89,18 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 EXPOSE 8080
 WORKDIR /app
+ARG GIT_SHA=unknown
+ENV FIRECRAWL_BUILD_SHA=$GIT_SHA
 
 # Copy built application
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/native ./native
+COPY --from=build /app/BUILD_SHA ./BUILD_SHA
 
 # Copy Go shared library
 COPY --from=go-build /app/sharedLibs/go-html-to-md/libhtml-to-markdown.so ./sharedLibs/go-html-to-md/
+
+RUN node -e 'const fs = require("fs"); for (const p of ["dist/src/harness.js", "dist/src/controllers/v0/crawl-status.js", "BUILD_SHA"]) { if (!fs.statSync(p).size) throw new Error(`${p} missing or empty`); }'
 
 CMD ["node", "dist/src/harness.js", "--start-docker"]


### PR DESCRIPTION
## Summary

- restore remote BuildKit cache for API image builds using per-platform registry cache tags
- keep dependency install source-safe by copying only package manifests, patches, and the native workspace before `pnpm install`
- embed the source commit SHA in the image and verify pushed images contain the expected SHA plus non-empty compiled `dist` files

## Validation

- `docker build --build-arg GIT_SHA=local-cache-test-final2 -t firecrawl-api-cache-safe-final -f apps/api/Dockerfile apps/api`
- `docker run --rm --entrypoint node firecrawl-api-cache-safe-final -p 'process.env.FIRECRAWL_BUILD_SHA'`
- TypeScript-only source-change probe confirmed `pnpm install` remained cached while `COPY . .`, `pnpm run build`, and SHA/compiled-file checks reran
- `git diff --check`
- parsed `.github/workflows/deploy-image.yml` as YAML

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores safe Docker image build caching for the API and adds post-push checks to ensure images include the correct commit SHA and built assets. Applies to both production and staging multi-arch builds.

- **Refactors**
  - CI (prod + staging): Enable remote BuildKit cache per platform; pass `GIT_SHA`; verify `FIRECRAWL_BUILD_SHA` matches the commit and `dist` files/`BUILD_SHA` are non-empty; publish manifests via `docker buildx imagetools` with stricter error handling.
  - Dockerfile: Install deps from manifests, `patches`, and `native` only; use cache mounts; copy source after; write `BUILD_SHA`, set `FIRECRAWL_BUILD_SHA`, and assert required files in build and final stages.

<sup>Written for commit f70ab9a82c3c3e70850fdf5b77edcd10fe279115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

