### PR TITLE
fix(api): isolate FDB router wait test from Redis

### DIFF
--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "crypto";
+import { vi } from "vitest";
 import { config } from "../../config";
+import { redisEvictConnection } from "../../services/redis";
 import {
   fdbQueueEnabled,
   isFdbTeam,
@@ -112,10 +114,17 @@ describeIf("NuQ router (forced FDB mode)", () => {
 
   test("optional FDB waitForJob uses caller timeout, not the quick optional-op timeout", async () => {
     const forcedBackend = config.NUQ_BACKEND;
+    const redisGet = vi.spyOn(redisEvictConnection, "get");
+    const redisSet = vi.spyOn(redisEvictConnection, "set");
     config.NUQ_BACKEND = "pg";
     try {
       const teamId = randomUUID();
       const jobId = randomUUID();
+      redisGet.mockImplementation(async key =>
+        key === `nuq:job_backend:${jobId}` ? "fdb" : null,
+      );
+      redisSet.mockResolvedValue("OK" as any);
+
       const { jobs, backloggedCount } = await fdbEnqueueScrapeJobs(
         [
           {
@@ -146,6 +155,8 @@ describeIf("NuQ router (forced FDB mode)", () => {
       await expect(wait).resolves.toBeDefined();
     } finally {
       config.NUQ_BACKEND = forcedBackend;
+      redisGet.mockRestore();
+      redisSet.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary
- keep the optional FDB waitForJob regression test in router optional mode
- stub the Redis backend marker calls inside that test so it does not require a live Redis connection
- preserve the actual assertion that routed FDB waitForJob survives longer than the quick optional-op timeout

## Root cause
The test flipped NUQ_BACKEND to pg to exercise optional FDB routing, then depended on Redis-backed job backend markers. When Redis was unavailable, ioredis rejected with MaxRetriesPerRequestError before the FDB timeout behavior was tested.

## Validation
- git diff --check
- Attempted: NUQ_FDB_TESTS=1 pnpm harness vitest run src/__tests__/nuq-fdb/router.test.ts
- Blocked locally: pnpm install fails while building foundationdb@2.0.1 because the installed system FoundationDB C header is older than the requested API version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the optional-mode FDB router waitForJob test from Redis by stubbing backend marker reads/writes. This removes the live Redis requirement, prevents `ioredis` MaxRetriesPerRequestError when Redis is down, and keeps the assertion that FDB waitForJob uses the caller timeout (longer than the quick optional-op timeout).

<sup>Written for commit d7d0f08d7c69e9fa8fc9f9bf5090e34dc0584a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

