### PR TITLE
fix(api): add OpenAI fallback for scrape query answers

### DIFF
--- a/apps/api/src/scraper/scrapeURL/transformers/query.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/query.ts
@@ -138,6 +138,10 @@ ${escapePromptTags(markdown)}
       model: getModel("gemini-2.5-flash-lite", "google"),
     },
     {
+      name: "gpt-4o-mini",
+      model: getModel("gpt-4o-mini", "openai"),
+    },
+    {
       name: "gemini-2.5-flash-lite",
       model: getModel("gemini-2.5-flash-lite", "vertex"),
     },


### PR DESCRIPTION
## Summary
- Add `gpt-4o-mini` as a freeform scrape query fallback between Google Gemini and Vertex Gemini.
- Keeps Gemini primary while allowing OpenAI-backed Server Test Suite runs to still produce `data.answer` when Gemini is overloaded and Vertex credentials are unavailable.

## Root cause
Recent Server Test Suite logs for `apps/api/src/__tests__/snips/v2/scrape-query.test.ts` show `performQuery` failing on `gemini-2.5-flash-lite` with a temporary high-demand model error. The only fallback was Vertex Gemini, which then failed in the OpenAI CI matrix because `/home/runner/_work/firecrawl/firecrawl/apps/api/gke-key.json` was missing. `performFreeformQuery` returned `null`, `coerceFieldsToFormats` logged `Request had format question/query, but there was no answer field in the result`, and the snips assertions saw `response.answer === undefined`.

## Testing
- `pnpm --dir native build` passed.
- `npm_config_ignore_scripts=true pnpm harness pnpm vitest run src/__tests__/snips/v2/scrape-query.test.ts` built successfully but direct `vitest` does not match the harness readiness path and failed local env validation / API connection.
- `TEST_SUITE_SELF_HOSTED=true TEST_SUITE_WEBSITE=http://127.0.0.1:4321 npm_config_ignore_scripts=true pnpm harness pnpm test:snips -- src/__tests__/snips/v2/scrape-query.test.ts` reached service startup but could not complete locally because Redis is not running at `127.0.0.1:6379`; CI provides Redis for this suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAI fallback for freeform scrape queries to reduce test flakes and ensure `data.answer` is returned when Google Gemini is throttled and Vertex credentials are unavailable.

- **Bug Fixes**
  - Fallback order is now: Google Gemini → gpt-4o-mini → Vertex Gemini.
  - Prevents `answer` from being undefined in the scrape-query test when Gemini is at capacity or Vertex is not configured.

<sup>Written for commit ff4817da69d1021543883a06d8ea64cd06682979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

