### PR TITLE
test(api): make map redirect snip deterministic

### DIFF
--- a/apps/api/src/__tests__/snips/mocks/map-redirect.json
+++ b/apps/api/src/__tests__/snips/mocks/map-redirect.json
@@ -1,0 +1,18 @@
+[
+  {
+    "time": 1782145899000,
+    "options": {
+      "url": "http://www.firecrawl.dev/sitemap.xml",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "http://www.firecrawl.dev/sitemap.xml",
+      "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
+      "status": 200,
+      "headers": [["content-type", "application/xml"]]
+    }
+  }
+]

--- a/apps/api/src/__tests__/snips/v2/map.test.ts
+++ b/apps/api/src/__tests__/snips/v2/map.test.ts
@@ -132,26 +132,30 @@ describe("Map tests", () => {
         {
           url: "http://firecrawl.com",
           limit: 5,
+          sitemap: "only",
+          useIndex: false,
+          useMock: "map-redirect",
+          ignoreCache: true,
         },
         identity,
       );
+
+      if (response.statusCode !== 200) {
+        console.warn(
+          "Map redirect test failed",
+          JSON.stringify(response.body, null, 2),
+        );
+      }
 
       expect(response.statusCode).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.links.length).toBeGreaterThan(0);
 
-      const nonFirecrawlLinks = response.body.links.filter(
-        link => !link.url.includes("firecrawl.dev"),
-      );
-      if (nonFirecrawlLinks.length > 0) {
-        console.log(
-          "Links not containing 'firecrawl.dev':",
-          JSON.stringify(nonFirecrawlLinks, null, 2),
-        );
-      }
-
       expect(
         response.body.links.every(link => link.url.includes("firecrawl.dev")),
+      ).toBe(true);
+      expect(
+        response.body.links.every(link => !link.url.includes("firecrawl.com")),
       ).toBe(true);
     },
     60000,


### PR DESCRIPTION
## Summary
- make the `handles redirects correctly` map snip deterministic by using `sitemap: "only"`, `useIndex: false`, and a local mock fixture for the redirected Firecrawl sitemap
- keep the redirect assertion focused on the intended contract: returned links are on `firecrawl.dev` and not the pre-redirect `firecrawl.com` host

## Root cause
The flaky failure in Server Test Suite run 27964298412 came from the redirect snip depending on live sitemap/search/index discovery after `http://firecrawl.com` redirects to `www.firecrawl.dev`. In the fetch/no-proxy/searxng/openai/fdb self-hosted lane, that external discovery can return zero links, so the test hit `expected 0 to be greater than 0` even though redirect resolution itself was not the failing behavior.

## Test plan
- `TEST_SUITE_SELF_HOSTED=true TEST_API_URL=http://localhost:3002 pnpm harness sh -c 'pnpx wait-on tcp:3002 -t 60000 && sleep 3 && pnpm exec vitest run src/__tests__/snips/v2/map.test.ts -t "handles redirects correctly" --reporter=dot'`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the map redirect test deterministic to remove flakiness when `firecrawl.com` redirects to `www.firecrawl.dev`. The test now uses a local mock sitemap and only asserts that resolved links are on `firecrawl.dev`.

- **Bug Fixes**
  - Force deterministic discovery with `sitemap: "only"`, `useIndex: false`, and `ignoreCache: true`.
  - Add `apps/api/src/__tests__/snips/mocks/map-redirect.json` to mock the redirected sitemap.
  - Update assertions to require `firecrawl.dev` links and exclude `firecrawl.com`; warn on non-200 responses.

<sup>Written for commit 5723423ce99a94914f945bc0b7ef6dd306ddfd02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

