### PR TITLE
fix(pdf): fall back to OCR when auto mode returns garbled text (#3784)

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/textQuality.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/textQuality.test.ts
@@ -1,0 +1,97 @@
+import {
+  garbledTextRatio,
+  isLikelyGarbled,
+  GARBLED_TEXT_THRESHOLD,
+} from "../textQuality";
+
+describe("garbledTextRatio", () => {
+  it("returns 0 for a clean ASCII paragraph", () => {
+    const text =
+      "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs.";
+    expect(garbledTextRatio(text)).toBe(0);
+    expect(isLikelyGarbled(text)).toBe(false);
+  });
+
+  it("returns 0 for a clean Chinese paragraph (real Hanzi)", () => {
+    const text = "你好世界，这是一段正常的中文文本，用于测试质量检测。";
+    expect(garbledTextRatio(text)).toBe(0);
+    expect(isLikelyGarbled(text)).toBe(false);
+  });
+
+  it("returns ~1 for a string full of replacement characters", () => {
+    const text = "�".repeat(50);
+    expect(garbledTextRatio(text)).toBe(1);
+    expect(isLikelyGarbled(text)).toBe(true);
+  });
+
+  it("flags a string full of Private Use Area codepoints", () => {
+    // U+E000..U+E031
+    let text = "";
+    for (let cp = 0xe000; cp < 0xe032; cp++) {
+      text += String.fromCodePoint(cp);
+    }
+    expect(garbledTextRatio(text)).toBe(1);
+    expect(isLikelyGarbled(text)).toBe(true);
+  });
+
+  it("flags Plane 15/16 PUA codepoints", () => {
+    const text =
+      String.fromCodePoint(0xf0000).repeat(10) +
+      String.fromCodePoint(0x100000).repeat(10);
+    expect(garbledTextRatio(text)).toBe(1);
+    expect(isLikelyGarbled(text)).toBe(true);
+  });
+
+  it("flags C0/C1 control characters but not tab/newline/CR", () => {
+    const controls = "\x00\x01\x02\x7f\x80\x9f".repeat(10);
+    expect(garbledTextRatio(controls)).toBe(1);
+
+    // Whitespace controls are excluded entirely (denominator skips them).
+    expect(garbledTextRatio("\t\n\r")).toBe(0);
+  });
+
+  it("stays below threshold for mostly clean text with a few symbols", () => {
+    const text =
+      "Energy E = mc² and the area is πr². Temperature was 20°C. " +
+      "Mostly normal prose with the occasional symbol sprinkled in.";
+    const ratio = garbledTextRatio(text);
+    expect(ratio).toBeLessThan(GARBLED_TEXT_THRESHOLD);
+    expect(isLikelyGarbled(text)).toBe(false);
+  });
+
+  it("excludes whitespace from the denominator", () => {
+    // 5 replacement chars surrounded by lots of spaces. The spaces must not
+    // dilute the ratio.
+    const text = "     " + "�".repeat(5) + "     ";
+    expect(garbledTextRatio(text)).toBe(1);
+  });
+
+  it("returns 0 for empty or whitespace only input", () => {
+    expect(garbledTextRatio("")).toBe(0);
+    expect(garbledTextRatio("   \t\n  ")).toBe(0);
+    expect(isLikelyGarbled("")).toBe(false);
+    expect(isLikelyGarbled("   ")).toBe(false);
+  });
+
+  it("counts code points, not code units, for astral characters", () => {
+    // Emoji (astral, not suspect) mixed with clean text stays clean.
+    const text = "Hello 👋 world 🌍 this is fine";
+    expect(garbledTextRatio(text)).toBe(0);
+  });
+
+  it("trips on a realistically garbled CJK extraction", () => {
+    // Simulates a broken ToUnicode CMap: PUA glyph codes interleaved with
+    // replacement chars, the kind of output the fast path emits for an
+    // unmappable CJK font.
+    const garbled =
+      String.fromCodePoint(0xe010, 0xe011, 0xfffd, 0xe012, 0xfffd, 0xe013) + "";
+    expect(isLikelyGarbled(garbled)).toBe(true);
+  });
+
+  it("honors a custom threshold", () => {
+    const text = "abcd�"; // ratio 0.2
+    expect(garbledTextRatio(text)).toBeCloseTo(0.2);
+    expect(isLikelyGarbled(text)).toBe(false);
+    expect(isLikelyGarbled(text, 0.1)).toBe(true);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -41,6 +41,7 @@ import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
+import { garbledTextRatio, GARBLED_TEXT_THRESHOLD } from "./textQuality";
 
 /** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
 function getIneligibleReason(
@@ -323,12 +324,29 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         }
 
         if (eligible && pdfResult.markdown) {
-          const html = await safeMarkdownToHtml(
-            pdfResult.markdown,
-            logger,
-            meta.id,
-          );
-          result = { markdown: pdfResult.markdown, html };
+          // Quality gate (auto mode only): the Rust path classified this as a
+          // clean TextBased extraction, but a broken or missing ToUnicode CMap
+          // can still yield mojibake (U+FFFD, PUA, or control chars) that passes
+          // the "is not empty" check. When the extracted text looks garbled,
+          // leave `result` unset so we fall through to the OCR/MU fallback,
+          // which recovers the real characters. Never override an explicit fast
+          // or ocr mode.
+          const garbledRatio =
+            mode === "auto" ? garbledTextRatio(pdfResult.markdown) : 0;
+          if (garbledRatio >= GARBLED_TEXT_THRESHOLD) {
+            logger.info("PDF text layer appears garbled; falling back to OCR", {
+              garbledRatio,
+              threshold: GARBLED_TEXT_THRESHOLD,
+              url: meta.rewrittenUrl ?? meta.url,
+            });
+          } else {
+            const html = await safeMarkdownToHtml(
+              pdfResult.markdown,
+              logger,
+              meta.id,
+            );
+            result = { markdown: pdfResult.markdown, html };
+          }
         }
       } catch (error) {
         if (error instanceof PDFOCRRequiredError) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/textQuality.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/textQuality.ts
@@ -1,0 +1,62 @@
+// Heuristics for detecting a broken or garbled embedded PDF text layer.
+//
+// Some PDFs (commonly CJK documents) carry an embedded text layer whose font
+// has a missing or broken `ToUnicode` CMap. The fast text extractor still
+// produces a string that isn't empty for these, but the glyphs map to
+// mojibake (U+FFFD replacement characters, Private Use Area codepoints, or
+// control bytes) rather than real characters. Auto mode treats any output that
+// isn't empty as a successful extraction, so the OCR fallback that would
+// recover the text never runs. These helpers give auto mode a quality signal
+// in addition to quantity.
+
+/**
+ * Returns the fraction (0..1) of "suspect" characters in the input.
+ * High values indicate a broken/garbled text layer (e.g. bad ToUnicode CMap).
+ *
+ * Ordinary whitespace is excluded from the denominator so that layout
+ * whitespace doesn't dilute the ratio.
+ */
+export function garbledTextRatio(text: string): number {
+  if (!text) return 0;
+
+  let suspect = 0;
+  let counted = 0;
+
+  for (const ch of text) {
+    // Iterates by code point rather than by code unit.
+    const cp = ch.codePointAt(0)!;
+
+    // Skip ordinary whitespace from the denominator.
+    if (cp === 0x09 || cp === 0x0a || cp === 0x0d || cp === 0x20) continue;
+    counted++;
+
+    const isReplacement = cp === 0xfffd; // �
+    const isPUA =
+      (cp >= 0xe000 && cp <= 0xf8ff) || // BMP PUA
+      (cp >= 0xf0000 && cp <= 0xffffd) || // Plane 15
+      (cp >= 0x100000 && cp <= 0x10fffd); // Plane 16
+    const isControl =
+      (cp <= 0x1f && cp !== 0x09 && cp !== 0x0a && cp !== 0x0d) || // C0
+      (cp >= 0x7f && cp <= 0x9f); // DEL + C1
+
+    if (isReplacement || isPUA || isControl) suspect++;
+  }
+
+  return counted === 0 ? 0 : suspect / counted;
+}
+
+// Conservative: only flag when garbling is clearly dominant, to avoid
+// regressing clean PDFs (OCR is slower and costlier). Tuned high so that
+// legitimately symbol heavy PDFs (math, emoji, dingbats) don't trip the gate.
+export const GARBLED_TEXT_THRESHOLD = 0.3;
+
+/**
+ * Returns true when the extracted text looks like a broken text layer rather
+ * than real content, based on the ratio of suspect codepoints.
+ */
+export function isLikelyGarbled(
+  text: string,
+  threshold = GARBLED_TEXT_THRESHOLD,
+): boolean {
+  return garbledTextRatio(text) >= threshold;
+}


### PR DESCRIPTION
Fixes #3784

## Problem
Some CJK PDFs ship an embedded text layer whose font has a broken or missing
ToUnicode CMap. The Rust path still sees a text layer, classifies the file as
TextBased, and serves the fast extraction. That text isn't empty but it's
garbled (U+FFFD, Private Use Area, and control characters). Auto mode treats
anything that isn't empty as a success, so it never falls through to OCR, which
is exactly what would recover the real characters.

## Fix
Add a text quality gate. In auto mode only, after the Rust extraction, compute
the fraction of suspect codepoints in the markdown. When it crosses a
conservative threshold the result is dropped so the existing OCR fallback runs.
Explicit fast and ocr modes are untouched.

## Testing
Unit tests for the detector: clean ASCII, clean Chinese, U+FFFD heavy, PUA
heavy, control chars, symbol heavy non regression, whitespace, astral
characters, and a custom threshold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto mode now falls back to OCR when the fast PDF text extraction looks garbled (e.g., U+FFFD, PUA, or control chars). Fixes unreadable output from CJK PDFs with broken ToUnicode CMaps. Fixes #3784.

- **Bug Fixes**
  - Added a text quality gate in auto mode using `garbledTextRatio` and a conservative `GARBLED_TEXT_THRESHOLD` (0.3); if tripped, we discard the fast-path result and let the existing OCR/MU fallback run. Explicit `fast` and `ocr` modes are unchanged.
  - Added unit tests covering clean ASCII/Chinese and garbled cases (U+FFFD, PUA, control chars), plus whitespace handling, astral chars, and custom thresholds.

<sup>Written for commit 3f87c9a69f04e64731545126443cbac2a1932944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

