### PR TITLE
fix(api): server.listen callback doesn't receive errors — move to server error event

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -125,13 +125,13 @@ async function startServer(port = DEFAULT_PORT) {
   // Attach WebSocket proxy to the Express app
   attachWsProxy(app);
 
-  const server = app.listen(Number(port), HOST, (error?: Error) => {
-    if (error) {
-      logger.error("Failed to start HTTP server", { error, port, host: HOST });
-      throw error;
-    }
-
+  const server = app.listen(Number(port), HOST, () => {
     logger.info(`Worker ${process.pid} listening on port ${port}`);
+  });
+
+  server.on("error", (error: Error) => {
+    logger.error("Failed to start HTTP server", { error, port, host: HOST });
+    process.exit(1);
   });
 
   const exitHandler = async () => {


### PR DESCRIPTION
While going through the Express 5 migration changes, noticed something odd in `apps/api/src/index.ts`.

The listen callback was changed to accept an `error` parameter:

```ts
app.listen(Number(port), HOST, (error?: Error) => {
  if (error) {
    logger.error("Failed to start HTTP server", { error, port, host: HOST });
    throw error;
  }
  ...
})
```

But Node.js `net.Server.listen()` callback doesn't work this way — it's only called when binding succeeds. Errors like `EADDRINUSE` or `EACCES` are emitted as `'error'` events on the server, they're never passed to the callback. So the `if (error)` block here can never run, its basically dead code.

This means if the server fails to bind (port already in use, permission denied etc.) the error event goes unhandled and the process crashes without any structured log entry.

Fix is straightforward — remove the dead parameter from the callback and add a proper `server.on('error', ...)` handler:

```ts
const server = app.listen(Number(port), HOST, () => {
  logger.info(`Worker ${process.pid} listening on port ${port}`);
});

server.on("error", (error: Error) => {
  logger.error("Failed to start HTTP server", { error, port, host: HOST });
  process.exit(1);
});
```

Tested locally by trying to start two instances on the same port — the error event fires correctly and logs the error before exiting. Previously it would just crash with an unhandled exception.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move HTTP server start error handling from the `app.listen` callback to the server `'error'` event to properly log bind failures and exit cleanly instead of crashing.

- **Bug Fixes**
  - Removed the unused `error` parameter from the `app.listen` callback (Node only calls it on success).
  - Added `server.on('error', ...)` to log `EADDRINUSE`/`EACCES` and exit with code 1.

<sup>Written for commit 741cccf5e8dd7815ca316b418ec0f0ae4b92291a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

