### PR TITLE
Add agent quickstart docs for all five SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,178 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` hex package **v1.7.2**, `firecrawl/apps/elixir-sdk`) and the v2 OpenAPI spec. The Elixir client is auto-generated from the OpenAPI spec; function names match exactly.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+{:firecrawl, "~> 1.0"}
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# or pass api_key per call
+{:ok, res} = Firecrawl.search_and_scrape([query: "firecrawl webhooks"], api_key: "fc-your-api-key")
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  sources: [:web, :news],
+  limit: 10,
+  tbs: "qdr:m",
+  scrape_options: [
+    formats: ["markdown", "links"],
+    only_main_content: true
+  ]
+)
+```
+
+### Parameters
+
+- `query` — string, required. The search query. Use `site:example.com` to limit results.
+- `sources` — list of atoms/strings or maps. Values: `:web`, `:news`, `:images`.
+- `categories` — list of atoms/strings or maps. Values: `:github`, `:research`, `:pdf`.
+- `include_domains` — list of strings. Restrict results to these domains.
+- `exclude_domains` — list of strings. Exclude these domains.
+- `limit` — integer. Maximum number of results.
+- `tbs` — string. Time-based search filter (e.g. `qdr:d`, `qdr:w`).
+- `location` — string. Geographic location for localized results.
+- `country` — string. ISO 3166-1 alpha-2 country code (e.g. `"US"`).
+- `ignore_invalid_urls` — boolean. Drop unscrappable URLs.
+- `timeout` — integer. Request timeout in milliseconds.
+- `enterprise` — list of strings. Enterprise ZDR options: `"zdr"` or `"anon"`.
+- `scrape_options` — keyword list. Scrape each search result (see Scrape parameters).
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    "links",
+    %{type: "json", prompt: "Extract plan names and prices."}
+  ],
+  only_main_content: true,
+  wait_for: 1000,
+  actions: [
+    %{type: "click", selector: "#accept"},
+    %{type: "wait", milliseconds: 750},
+    %{type: "scrape"}
+  ]
+)
+```
+
+### Parameters
+
+- `url` — string, required. The URL to scrape.
+- `formats` — list of format strings or maps.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`
+  - Maps: `%{type: "json", prompt: ..., schema: ...}`, `%{type: "screenshot", fullPage: true, quality: 80, viewport: %{width: 1280, height: 720}}`, `%{type: "changeTracking", modes: ["git-diff"], tag: "..."}`, `%{type: "question", question: "..."}`, `%{type: "highlights", query: "..."}`
+- `headers` — map. Custom request headers.
+- `include_tags` — list of strings. HTML tags to include.
+- `exclude_tags` — list of strings. HTML tags to exclude.
+- `only_main_content` — boolean. Strip nav, footer, and boilerplate.
+- `timeout` — integer. Timeout in milliseconds. Range: 1000–300000. Default: 60000.
+- `wait_for` — integer. Wait for the page to render (milliseconds).
+- `mobile` — boolean. Use a mobile viewport.
+- `parsers` — list of strings or maps. Values: `"pdf"`, `%{type: "pdf", mode: "fast" | "auto" | "ocr", maxPages: integer}`.
+- `actions` — list of action maps. Pre-scrape browser actions: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`.
+- `location` — keyword list with `country:` and `languages:`. Geo and language-aware scraping.
+- `skip_tls_verification` — boolean. Skip TLS verification.
+- `remove_base64_images` — boolean. Drop base64 images from markdown.
+- `block_ads` — boolean. Ad and cookie popup blocking.
+- `proxy` — atom. Values: `:basic`, `:enhanced`, `:auto`.
+- `max_age` — integer. Accept cached data up to this age (milliseconds). Default: 2 days.
+- `min_age` — integer. Only check cache (milliseconds). Set to `1` for any cached data.
+- `store_in_cache` — boolean. Cache the result.
+- `lockdown` — boolean. Serve only from cache; 404 on cache miss.
+- `redact_pii` — boolean. Redact personally identifiable information.
+- `profile` — keyword list with `name:` and optional `save_changes:`. Persistent browser profile.
+- `zero_data_retention` — boolean. Enable zero data retention for this scrape.
+
+## Interact
+
+### Why use it
+
+Use interact when a page requires browser actions or code execution after a scrape starts. The Elixir SDK exposes code-based interactions only — there is no `prompt` parameter.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
+  "<scrapeJobId>",
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+```
+
+### Parameters
+
+- `job_id` — string, required. Scrape job ID.
+- `code` — string, required. Code to run in the browser session.
+- `language` — atom or string. Values: `:python`, `:node`, `:bash`.
+- `timeout` — integer. Execution timeout in seconds.
+- `origin` — string. Optional origin label for execution telemetry.
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])` ends the browser session. A bang variant `stop_interactive_scrape_browser_session!/2` is also available.
+
+## Notes
+
+- The Elixir client is auto-generated from the OpenAPI spec. Function names match the spec directly.
+- Each function has a bang (`!`) variant that raises on error instead of returning `{:error, _}`.
+- The SDK does not support `prompt`-based interactions — only `code` is accepted.
+- Parameters use `snake_case` in Elixir; automatically camelCased for JSON serialization.
+- Proxy value `:stealth` is not available in the Elixir SDK — only `:basic`, `:enhanced`, and `:auto` are confirmed.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,202 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-java` **v1.10.2**, `firecrawl/apps/java-sdk`) and the v2 OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.10.2</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.10.2")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+
+SearchOptions options = SearchOptions.builder()
+    .sources(List.of("web", "news"))
+    .limit(10)
+    .tbs("qdr:m")
+    .scrapeOptions(
+        ScrapeOptions.builder()
+            .formats(List.of("markdown", "links"))
+            .onlyMainContent(true)
+            .build()
+    )
+    .build();
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries", options);
+List<Map<String, Object>> web = results.getWeb();
+```
+
+### Parameters
+
+- `query` — String, required. The search query. Use `site:example.com` to limit results.
+- `options.sources` — `List` of source strings or maps. Values: `"web"`, `"news"`, `"images"`.
+- `options.categories` — `List` of category strings or maps. Values: `"github"`, `"research"`, `"pdf"`.
+- `options.includeDomains` — `List<String>`. Restrict results to these domains. Cannot combine with `excludeDomains`.
+- `options.excludeDomains` — `List<String>`. Exclude these domains. Cannot combine with `includeDomains`.
+- `options.limit` — Integer. Maximum number of results.
+- `options.tbs` — String. Time-based search filter (e.g. `qdr:d`, `qdr:w`).
+- `options.location` — String. Geographic location for localized results.
+- `options.ignoreInvalidURLs` — Boolean. Drop unscrappable URLs.
+- `options.timeout` — Integer. Request timeout in milliseconds.
+- `options.scrapeOptions` — `ScrapeOptions`. Scrape each search result (see Scrape parameters).
+
+### Return value
+
+`SearchData` exposes `getWeb()`, `getNews()`, and `getImages()` (each `List<Map<String, Object>>`, may be null). Do not treat `SearchData` as a directly iterable list.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
+
+ScrapeOptions options = ScrapeOptions.builder()
+    .formats(List.of(
+        "markdown",
+        "links",
+        JsonFormat.builder().prompt("Extract plan names and prices.").build()
+    ))
+    .onlyMainContent(true)
+    .waitFor(1000)
+    .actions(List.of(
+        Map.of("type", "click", "selector", "#accept"),
+        Map.of("type", "wait", "milliseconds", 750),
+        Map.of("type", "scrape")
+    ))
+    .build();
+
+Document doc = client.scrape("https://example.com/pricing", options);
+```
+
+### Parameters
+
+- `url` — String, required. The URL to scrape.
+- `options.formats` — `List` of format strings or format maps.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Objects: `JsonFormat.builder().prompt(...).schema(...).build()`, or maps for screenshot/changeTracking/attributes
+- `options.headers` — `Map<String, String>`. Custom request headers.
+- `options.includeTags` — `List<String>`. HTML tags to include.
+- `options.excludeTags` — `List<String>`. HTML tags to exclude.
+- `options.onlyMainContent` — Boolean. Strip nav, footer, and boilerplate.
+- `options.timeout` — Integer. Timeout in milliseconds.
+- `options.waitFor` — Integer. Wait for the page to render (milliseconds).
+- `options.mobile` — Boolean. Use a mobile viewport.
+- `options.parsers` — `List<Object>`. Values: `"pdf"`, `Map.of("type", "pdf", "maxPages", n)`.
+- `options.actions` — `List<Map<String, Object>>`. Pre-scrape browser actions: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`.
+- `options.location` — `LocationConfig` with `country` and `languages`.
+- `options.skipTlsVerification` — Boolean. Skip TLS verification.
+- `options.removeBase64Images` — Boolean. Drop base64 images from markdown.
+- `options.blockAds` — Boolean. Ad and cookie popup blocking.
+- `options.proxy` — String. Values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom proxy URL.
+- `options.maxAge` — Long. Accept cached data up to this age (milliseconds).
+- `options.storeInCache` — Boolean. Cache the result.
+- `options.lockdown` — Boolean. Serve only from cache; 404 on cache miss.
+- `options.redactPII` — Boolean. Redact personally identifiable information.
+
+## Interact
+
+### Why use it
+
+Use interact when a page requires browser actions or code execution after a scrape starts. The Java SDK exposes code-based interactions only — there is no `prompt` parameter.
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` — default language `"node"`, API default timeout
+- `client.interact(jobId, code, language, timeout)` — timeout in seconds (1–300), null for API default
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+BrowserExecuteResponse result = client.interact(
+    "<scrapeJobId>",
+    "console.log(await page.title());",
+    "node",
+    60
+);
+```
+
+### Parameters
+
+- `jobId` — String, required. Scrape job ID.
+- `code` — String, required. Code to run in the browser session.
+- `language` — String. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+- `timeout` — Integer. Execution timeout in seconds (1–300). Null for API default (30 seconds).
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` ends the browser session. Returns `BrowserDeleteResponse` with `isSuccess()`, `getSessionDurationMs()`, `getCreditsBilled()`, `getError()`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- The Java SDK does not support `prompt`-based interactions — only `code` is accepted.
+- Use `JsonFormat.builder()` for type-safe JSON extraction format configuration.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,201 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` **v4.28.2**, `firecrawl/apps/js-sdk/firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+  // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL or cloud default
+});
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  sources: ["web", "news"],
+  limit: 10,
+  tbs: "qdr:m",
+  scrapeOptions: {
+    formats: ["markdown", "links"],
+    onlyMainContent: true,
+  },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+### Parameters
+
+- `query` — string, required. The search query. Use `site:example.com` to limit results to a domain.
+- `options.sources` — array of `"web" | "news" | "images"` or `{ type: "web" | "news" | "images" }`. Controls which result buckets are returned.
+- `options.categories` — array of `"github" | "research" | "pdf"` or `{ type: ... }`. Filters results by category.
+- `options.includeDomains` — `string[]`. Restrict results to these domains. Cannot combine with `excludeDomains`.
+- `options.excludeDomains` — `string[]`. Exclude these domains from results. Cannot combine with `includeDomains`.
+- `options.limit` — number. Maximum number of results.
+- `options.tbs` — string. Time-based search filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `options.location` — string. Geographic location for localized results.
+- `options.ignoreInvalidURLs` — boolean. Drop URLs that cannot be scraped by other endpoints.
+- `options.timeout` — number. Request timeout in milliseconds.
+- `options.scrapeOptions` — `ScrapeOptions`. Scrape each search result (see Scrape parameters for fields).
+
+### Return value
+
+`SearchData` has optional arrays. Each entry is a lightweight result or a full `Document` when `scrapeOptions` hydrated the hit:
+
+- `web` — web index hits
+- `news` — news hits
+- `images` — image hits
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Access results via `result.web`, `result.news`, `result.images`.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    "links",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+  waitFor: 1000,
+  actions: [
+    { type: "click", selector: "#accept" },
+    { type: "wait", milliseconds: 750 },
+    { type: "scrape" },
+  ],
+});
+```
+
+### Parameters
+
+- `url` — string, required. The URL to scrape.
+- `options.formats` — array of format strings or format objects. Output formats to include.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Objects: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?, prompt?, tag? }`, `{ type: "attributes", selectors: [{ selector, attribute }] }`
+  - Plain string `"json"` is rejected by the SDK — use `{ type: "json", prompt?, schema? }`.
+- `options.headers` — `Record<string, string>`. Custom request headers.
+- `options.includeTags` — `string[]`. HTML tags to include.
+- `options.excludeTags` — `string[]`. HTML tags to exclude.
+- `options.onlyMainContent` — boolean. Strip nav, footer, and boilerplate.
+- `options.timeout` — number. Timeout in milliseconds. Range: 1000–300000.
+- `options.waitFor` — number. Wait for the page to render (milliseconds).
+- `options.mobile` — boolean. Use a mobile viewport.
+- `options.parsers` — array of `"pdf"` or `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`.
+- `options.actions` — array of action objects. Pre-scrape browser actions.
+  - `{ type: "wait", milliseconds?, selector? }`
+  - `{ type: "click", selector }`
+  - `{ type: "write", text }`
+  - `{ type: "press", key }`
+  - `{ type: "scroll", direction: "up" | "down", selector? }`
+  - `{ type: "scrape" }`
+  - `{ type: "screenshot", fullPage?, quality?, viewport? }`
+  - `{ type: "executeJavascript", script }`
+  - `{ type: "pdf", format?, landscape?, scale? }`
+- `options.location` — `{ country?: string, languages?: string[] }`. Geo and language-aware scraping.
+- `options.skipTlsVerification` — boolean. Skip TLS verification.
+- `options.removeBase64Images` — boolean. Drop base64 images from markdown output.
+- `options.fastMode` — boolean. Faster scrapes with reduced fidelity.
+- `options.blockAds` — boolean. Ad and cookie popup blocking.
+- `options.proxy` — `"basic" | "stealth" | "enhanced" | "auto"` or custom proxy URL string.
+- `options.maxAge` — number. Accept cached data up to this age (milliseconds).
+- `options.minAge` — number. Only check cache, never trigger fresh scrape (milliseconds). Set to `1` for any cached data.
+- `options.storeInCache` — boolean. Cache the result.
+- `options.lockdown` — boolean. Serve only from cache; 404 on cache miss.
+- `options.redactPII` — boolean or `{ mode?, entities?, replaceStyle? }`. Redact personally identifiable information.
+- `options.profile` — `{ name: string, saveChanges?: boolean }`. Persistent browser profile shared across scrapes and interactions.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrapeId`). The SDK requires at least one of `code` or `prompt`. For flows beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId from scrape response");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+```
+
+### Parameters
+
+- `jobId` — string, required. Scrape job ID from `document.metadata.scrapeId`.
+- `args.code` — string. Code to run in the browser session (Playwright `page` usage in `node` runtime).
+- `args.prompt` — string. Natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty (SDK throws otherwise).
+- `args.language` — `"python" | "node" | "bash"`. Default: `"node"`.
+- `args.timeout` — number. Execution timeout in seconds (1–300).
+
+### Stop session
+
+`client.stopInteraction(jobId)` ends the browser session. Returns `{ success, sessionDurationMs?, creditsBilled?, error? }`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+- API key is optional — scrape, search, and interact can fall back to keyless free tier.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json`
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,197 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py` **v4.22.1**, `firecrawl/apps/python-sdk`) and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client in `firecrawl/v2/client.py` unless noted.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```py
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+# client = Firecrawl(api_key="fc-...", api_url="https://api.firecrawl.dev")
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```py
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    sources=["web", "news"],
+    limit=10,
+    tbs="qdr:m",
+    scrape_options=ScrapeOptions(
+        formats=["markdown", "links"],
+        only_main_content=True,
+    ),
+)
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+### Parameters
+
+- `query` — str, required. The search query. Use `site:example.com` to limit results to a domain.
+- `sources` — list of `"web" | "news" | "images"` or `Source` objects. Controls which result buckets are returned.
+- `categories` — list of `"github" | "research" | "pdf"` or `Category` objects. Filters results by category.
+- `include_domains` — list of str. Restrict results to these domains. Cannot combine with `exclude_domains`.
+- `exclude_domains` — list of str. Exclude these domains from results. Cannot combine with `include_domains`.
+- `limit` — int. Maximum number of results. Default: `5`.
+- `tbs` — str. Time-based search filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `location` — str. Geographic location for localized results.
+- `ignore_invalid_urls` — bool. Drop URLs that cannot be scraped by other endpoints.
+- `timeout` — int. Request timeout in milliseconds. Default: `300000`.
+- `scrape_options` — `ScrapeOptions`. Scrape each search result (see Scrape parameters for fields).
+
+### Return value
+
+`SearchData` has optional lists. Each entry is a lightweight result or a full `Document` when `scrape_options` hydrated the hit:
+
+- `web` — web hits (`SearchResultWeb` or `Document`)
+- `news` — news hits (`SearchResultNews` or `Document`)
+- `images` — image hits (`SearchResultImages` or `Document`)
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Access results via `result.web`, `result.news`, `result.images`.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```py
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        "links",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+    wait_for=1000,
+    actions=[
+        {"type": "click", "selector": "#accept"},
+        {"type": "wait", "milliseconds": 750},
+        {"type": "scrape"},
+    ],
+)
+```
+
+### Parameters
+
+- `url` — str, required. The URL to scrape.
+- `formats` — list of format strings or format dicts. Output formats to include.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Dicts: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": [...], "schema": ..., "prompt": ..., "tag": ...}`, `{"type": "attributes", "selectors": [{"selector": ..., "attribute": ...}]}`
+- `headers` — dict of str to str. Custom request headers.
+- `include_tags` — list of str. HTML tags to include.
+- `exclude_tags` — list of str. HTML tags to exclude.
+- `only_main_content` — bool. Strip nav, footer, and boilerplate.
+- `timeout` — int. Timeout in milliseconds. Range: 1000–300000.
+- `wait_for` — int. Wait for the page to render (milliseconds).
+- `mobile` — bool. Use a mobile viewport.
+- `parsers` — list of `"pdf"` or `{"type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": int}`.
+- `actions` — list of action dicts. Pre-scrape browser actions.
+  - `{"type": "wait", "milliseconds": ..., "selector": ...}`
+  - `{"type": "click", "selector": ...}`
+  - `{"type": "write", "text": ...}`
+  - `{"type": "press", "key": ...}`
+  - `{"type": "scroll", "direction": "up" | "down", "selector": ...}`
+  - `{"type": "scrape"}`
+  - `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`
+  - `{"type": "executeJavascript", "script": ...}`
+  - `{"type": "pdf", "format": ..., "landscape": ..., "scale": ...}`
+- `location` — dict with `country` and `languages`. Geo and language-aware scraping.
+- `skip_tls_verification` — bool. Skip TLS verification.
+- `remove_base64_images` — bool. Drop base64 images from markdown output.
+- `fast_mode` — bool. Faster scrapes with reduced fidelity.
+- `block_ads` — bool. Ad and cookie popup blocking.
+- `proxy` — `"basic" | "stealth" | "enhanced" | "auto"`.
+- `max_age` — int. Accept cached data up to this age (milliseconds).
+- `store_in_cache` — bool. Cache the result.
+- `lockdown` — bool. Serve only from cache; 404 on cache miss.
+- `profile` — dict with `name` (str) and optional `save_changes` (bool). Persistent browser profile.
+
+## Interact
+
+### Why use it
+
+Use interact when a page requires browser actions or code execution after a scrape starts.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+`prompt` is keyword-only. At least one of `code` or `prompt` must be non-empty.
+
+### Example
+
+```py
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id from scrape response")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+```
+
+### Parameters
+
+- `job_id` — str, required. Scrape job ID from `document.metadata.scrape_id`.
+- `code` — str. Code to run in the browser session. Optional if `prompt` is set.
+- `prompt` — str, keyword-only. Natural-language instruction for the browser agent. Optional if `code` is set.
+- `language` — `"python" | "node" | "bash"`. Default: `"node"`.
+- `timeout` — int. Execution timeout in seconds (1–300).
+
+### Stop session
+
+`client.stop_interaction(job_id)` ends the browser session. Returns `BrowserDeleteResponse` with `success`, optional `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- API key is optional — scrape, search, and interact can fall back to keyless free tier.
+- `min_age` is available on `ScrapeOptions` passed as `scrape_options` to `client.search`, but `client.scrape` does not accept `min_age`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/pyproject.toml`
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,203 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate **v2.10.0**, `firecrawl/apps/rust-sdk`) and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, SearchSource, ScrapeOptions, Format};
+
+let options = SearchOptions {
+    sources: Some(vec![SearchSource::Web, SearchSource::News]),
+    limit: Some(10),
+    tbs: Some("qdr:m".to_string()),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Links]),
+        only_main_content: Some(true),
+        ..Default::default()
+    }),
+    ..Default::default()
+};
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", options)
+    .await?;
+```
+
+### Parameters
+
+- `query` — `impl AsRef<str>`, required. The search query. Use `site:example.com` to limit results.
+- `options.sources` — `Vec<SearchSource>`. Values: `Web`, `News`, `Images`.
+- `options.categories` — `Vec<SearchCategory>`. Values: `Github`, `Research`, `Pdf`.
+- `options.include_domains` — `Vec<String>`. Restrict results to these domains.
+- `options.exclude_domains` — `Vec<String>`. Exclude these domains.
+- `options.limit` — `u32`. Maximum number of results.
+- `options.tbs` — `String`. Time-based search filter (e.g. `qdr:d`, `qdr:w`).
+- `options.location` — `String`. Geographic location for localized results.
+- `options.ignore_invalid_urls` — `bool`. Drop unscrappable URLs.
+- `options.timeout` — `u32`. Request timeout in milliseconds.
+- `options.scrape_options` — `ScrapeOptions`. Scrape each search result (see Scrape parameters).
+
+### Return value
+
+`SearchResponse` contains `success: bool`, `data: SearchData`, and `warning: Option<String>`. `SearchData` has:
+
+- `web` — `Option<Vec<SearchResultOrDocument>>` (each is `WebResult(...)` or `Document(...)`)
+- `news` — `Option<Vec<SearchResultNews>>`
+- `images` — `Option<Vec<SearchResultImage>>`
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions, Action};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Links, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".to_string()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        wait_for: Some(1000),
+        actions: Some(vec![
+            Action::Click { selector: "#accept".to_string() },
+            Action::Wait { milliseconds: Some(750), selector: None },
+            Action::Scrape,
+        ]),
+        ..Default::default()
+    })
+    .await?;
+```
+
+### Parameters
+
+- `url` — `impl AsRef<str>`, required. The URL to scrape.
+- `options.formats` — `Vec<Format>`. Values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`.
+- `options.headers` — `HashMap<String, String>`. Custom request headers.
+- `options.include_tags` — `Vec<String>`. HTML tags to include.
+- `options.exclude_tags` — `Vec<String>`. HTML tags to exclude.
+- `options.only_main_content` — `bool`. Strip nav, footer, and boilerplate.
+- `options.timeout` — `u32`. Timeout in milliseconds.
+- `options.wait_for` — `u32`. Wait for the page to render (milliseconds).
+- `options.mobile` — `bool`. Use a mobile viewport.
+- `options.parsers` — `Vec<ParserConfig>`. Values: `Simple("pdf".to_string())`, `Pdf { parser_type, max_pages }`.
+- `options.actions` — `Vec<Action>`. Pre-scrape browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`.
+- `options.location` — `LocationConfig` with `country` and `languages`.
+- `options.skip_tls_verification` — `bool`. Skip TLS verification.
+- `options.remove_base64_images` — `bool`. Drop base64 images from markdown.
+- `options.fast_mode` — `bool`. Faster scrapes with reduced fidelity.
+- `options.block_ads` — `bool`. Ad and cookie popup blocking.
+- `options.proxy` — `ProxyType`. Values: `Basic`, `Stealth`, `Enhanced`, `Auto`.
+- `options.max_age` — `u32`. Accept cached data up to this age (milliseconds).
+- `options.min_age` — `u32`. Only check cache (milliseconds). Set to `1` for any cached data.
+- `options.store_in_cache` — `bool`. Cache the result.
+- `options.lockdown` — `bool`. Serve only from cache.
+- `options.redact_pii` — `bool`. Redact personally identifiable information.
+- `options.profile` — `ProfileConfig` with `name` and optional `save_changes`.
+- `options.json_options` — `JsonOptions` with `schema`, `system_prompt`, `prompt`.
+- `options.screenshot_options` — `ScreenshotOptions` with `full_page`, `quality`, `viewport`.
+- `options.change_tracking_options` — `ChangeTrackingOptions` with `modes` (`GitDiff`, `Json`), `schema`, `prompt`, `tag`.
+- `options.attribute_selectors` — `Vec<AttributeSelector>` with `selector` and `attribute`.
+
+## Interact
+
+### Why use it
+
+Use interact when a page requires browser actions or code execution after a scrape starts. At least one of `code` or `prompt` must be non-empty.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions};
+
+let result = client
+    .interact(
+        "<scrapeJobId>",
+        ScrapeExecuteOptions {
+            prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+```
+
+### Parameters
+
+- `job_id` — `impl AsRef<str>`, required. Scrape job ID.
+- `options.code` — `Option<String>`. Code to run in the browser session.
+- `options.prompt` — `Option<String>`. Natural-language instruction for the browser agent.
+- `options.language` — `ScrapeExecuteLanguage`. Values: `Python`, `Node`, `Bash`. Default: `Node`.
+- `options.timeout` — `u32`. Execution timeout in seconds (1–300).
+
+### Stop session
+
+`client.stop_interaction(job_id)` ends the browser session. Returns `ScrapeBrowserDeleteResponse` with `success`, optional `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- `ScrapeOptions` includes dedicated `json_options`, `screenshot_options`, and `change_tracking_options` for advanced formats.
+- `search_and_scrape(query, limit)` is a convenience helper that calls `search` with default `ScrapeOptions` and returns `Vec<Document>`.
+- v2 SDK exports all types at the crate root: `use firecrawl::Client`.
+- Deprecated format: `Format::Query(QueryFormat)` — use `Format::Question()` or `Format::Highlights()` instead.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/lib.rs`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart doc per SDK language: **Node.js**, **Python**, **Rust**, **Java**, **Elixir**
- Each file covers `search`, `scrape`, and `interact` endpoints with every confirmed parameter from SDK source and v2 OpenAPI spec
- Generated from latest SDK source code (JS v4.28.2, Python v4.22.1, Rust v2.10.0, Java v1.10.2, Elixir v1.7.2)

## Important: Target repository

**These files are intended for `firecrawl-docs/agent-quickstart/`**, not `firecrawl/docs/agent-quickstart/`. They are staged here because the GitHub integration used by this session lacks write access to `firecrawl/firecrawl-docs`. Please move the 5 `.mdx` files from `docs/agent-quickstart/` to the `firecrawl-docs` repo's `agent-quickstart/` directory when merging.

## Files

- `docs/agent-quickstart/node.mdx` — Node.js/TypeScript quickstart
- `docs/agent-quickstart/python.mdx` — Python quickstart
- `docs/agent-quickstart/rust.mdx` — Rust quickstart
- `docs/agent-quickstart/java.mdx` — Java quickstart
- `docs/agent-quickstart/elixir.mdx` — Elixir quickstart

## Test plan

- [ ] Review each file for accuracy against current SDK source
- [ ] Move files to `firecrawl-docs/agent-quickstart/` and verify Mintlify renders correctly
- [ ] Confirm all parameter lists match latest SDK versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173desXLsUaQDK8MpoxBLkF

---
_Generated by [Claude Code](https://claude.ai/code/session_0173desXLsUaQDK8MpoxBLkF)_