### PR TITLE
[codex] Refactor scrape engine selection

### DIFF
--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -114,17 +114,7 @@ function getSyntheticFilename(file: UploadedParseFile): string {
   return `${file.filename}.html`;
 }
 
-function getParseForceEngine(
-  kind: UploadedParseFileKind,
-): "fetch" | "pdf" | "document" {
-  if (kind === "pdf") {
-    return "pdf";
-  }
-
-  if (kind === "document") {
-    return "document";
-  }
-
+function getParseForceEngine(kind: UploadedParseFileKind): "fetch" {
   return "fetch";
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/document/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/document/index.ts
@@ -105,14 +105,33 @@ function isValidDocumentContentType(contentType: string | null): boolean {
   return validTypes.some(type => ct.includes(type));
 }
 
-export async function scrapeDocument(meta: Meta): Promise<EngineScrapeResult> {
+export async function scrapeDocument(
+  meta: Meta,
+  sourceResult?: EngineScrapeResult,
+): Promise<EngineScrapeResult> {
   let response: Response;
   let buffer: Buffer;
   let proxyUsed: "basic" | "stealth" = "basic";
   let tempFilePath: string | null = null;
 
   try {
-    if (meta.documentPrefetch !== undefined && meta.documentPrefetch !== null) {
+    if (sourceResult?.bodyBuffer) {
+      const headers = new Headers();
+      if (sourceResult.contentType) {
+        headers.set("Content-Type", sourceResult.contentType);
+      }
+
+      response = {
+        url: sourceResult.url,
+        status: sourceResult.statusCode,
+        headers,
+      } as Response;
+      buffer = sourceResult.bodyBuffer;
+      proxyUsed = sourceResult.proxyUsed;
+    } else if (
+      meta.documentPrefetch !== undefined &&
+      meta.documentPrefetch !== null
+    ) {
       // Use prefetched document
       tempFilePath = meta.documentPrefetch.filePath;
       buffer = await readFile(tempFilePath);

--- a/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
@@ -99,6 +99,7 @@ export async function scrapeURLWithFetch(
   let response: {
     url: string;
     body: string;
+    bodyBuffer: Buffer;
     status: number;
     headers: [string, string][];
   };
@@ -127,6 +128,7 @@ export async function scrapeURLWithFetch(
     response = {
       url: meta.fetchPrefetch.url ?? meta.rewrittenUrl ?? meta.url,
       body: text,
+      bodyBuffer: meta.fetchPrefetch.bodyBuffer,
       status: meta.fetchPrefetch.status,
       headers: meta.fetchPrefetch.contentType
         ? [["content-type", meta.fetchPrefetch.contentType]]
@@ -185,6 +187,7 @@ export async function scrapeURLWithFetch(
       response = {
         url: x.url,
         body: text,
+        bodyBuffer: buf,
         status: x.status,
         headers: [...x.headers],
       };
@@ -223,6 +226,7 @@ export async function scrapeURLWithFetch(
     contentType:
       (response.headers.find(x => x[0].toLowerCase() === "content-type") ??
         [])[1] ?? undefined,
+    bodyBuffer: response.bodyBuffer,
 
     proxyUsed: "basic",
   };

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { robustFetch } from "../../lib/fetch";
 import {
   ActionError,
-  AddFeatureError,
   EngineError,
   SiteError,
   SSLError,
@@ -13,6 +12,7 @@ import {
   DNSResolutionError,
   FEPageLoadFailed,
   ProxySelectionError,
+  EnhancedProxyRequiredError,
 } from "../../error";
 import { MockState } from "../../lib/mock";
 import { fireEngineURL } from "./scrape";
@@ -202,7 +202,7 @@ export async function fireEngineCheckStatus(
         "Scrape job signaled retryWithStealth. Adding stealthProxy flag.",
         { jobId },
       );
-      throw new AddFeatureError(["stealthProxy"]);
+      throw new EnhancedProxyRequiredError();
     }
     if (
       typeof status.error === "string" &&

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -211,7 +211,6 @@ async function performFireEngineScrape<
 
     if (status.file) {
       const content = status.file.content;
-      delete status.file;
       status.content = Buffer.from(content, "base64").toString("utf8"); // TODO: handle other encodings via Content-Type tag
     }
 
@@ -442,6 +441,9 @@ export async function scrapeURLWithFireEngineChromeCDP(
       url: response.url ?? meta.url,
 
       html: response.content,
+      bodyBuffer: response.file?.content
+        ? Buffer.from(response.file.content, "base64")
+        : undefined,
       error: response.pageError,
       statusCode: response.pageStatusCode,
 
@@ -527,6 +529,9 @@ export async function scrapeURLWithFireEngineTLSClient(
       url: response.url ?? meta.url,
 
       html: response.content,
+      bodyBuffer: response.file?.content
+        ? Buffer.from(response.file.content, "base64")
+        : undefined,
       error: response.pageError,
       statusCode: response.pageStatusCode,
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -7,7 +7,6 @@ import { MockState } from "../../lib/mock";
 import { getDocFromGCS } from "../../../../lib/gcs-jobs";
 import {
   ActionError,
-  AddFeatureError,
   DNSResolutionError,
   EngineError,
   FEPageLoadFailed,
@@ -15,6 +14,7 @@ import {
   SSLError,
   SiteError,
   UnsupportedFileError,
+  EnhancedProxyRequiredError,
 } from "../../error";
 import { Meta } from "../..";
 
@@ -240,7 +240,7 @@ export async function fireEngineScrape<
       logger.info(
         "Scrape signaled retryWithStealth. Adding stealthProxy flag.",
       );
-      throw new AddFeatureError(["stealthProxy"]);
+      throw new EnhancedProxyRequiredError();
     }
     if (
       typeof status.error === "string" &&

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -154,6 +154,8 @@ export type EngineScrapeResult = {
   };
 
   contentType?: string;
+  bodyBuffer?: Buffer;
+  binaryFilePath?: string;
 
   youtubeTranscriptContent?: any;
   postprocessorsUsed?: string[];
@@ -244,8 +246,8 @@ const engineOptions: {
       waitFor: true, // through actions transform
       screenshot: true, // through actions transform
       "screenshot@fullScreen": true, // through actions transform
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: true,
       video: true,
       atsv: false,
@@ -265,8 +267,8 @@ const engineOptions: {
       waitFor: true, // through actions transform
       screenshot: true, // through actions transform
       "screenshot@fullScreen": true, // through actions transform
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: true,
       video: true,
       atsv: false,
@@ -307,8 +309,8 @@ const engineOptions: {
       waitFor: true, // through actions transform
       screenshot: true, // through actions transform
       "screenshot@fullScreen": true, // through actions transform
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: true,
       video: true,
       atsv: false,
@@ -328,8 +330,8 @@ const engineOptions: {
       waitFor: true, // through actions transform
       screenshot: true, // through actions transform
       "screenshot@fullScreen": true, // through actions transform
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: true,
       video: true,
       atsv: false,
@@ -349,8 +351,8 @@ const engineOptions: {
       waitFor: true,
       screenshot: false,
       "screenshot@fullScreen": false,
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: false,
       video: false,
       atsv: false,
@@ -370,8 +372,8 @@ const engineOptions: {
       waitFor: false,
       screenshot: false,
       "screenshot@fullScreen": false,
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: true,
       video: true,
       atsv: true,
@@ -391,8 +393,8 @@ const engineOptions: {
       waitFor: false,
       screenshot: false,
       "screenshot@fullScreen": false,
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: true,
       video: true,
       atsv: true,
@@ -412,8 +414,8 @@ const engineOptions: {
       waitFor: false,
       screenshot: false,
       "screenshot@fullScreen": false,
-      pdf: false,
-      document: false,
+      pdf: true,
+      document: true,
       audio: false,
       video: false,
       atsv: false,
@@ -750,14 +752,4 @@ export async function scrapeURLWithEngine(
   };
 
   return await fn(_meta);
-}
-
-export function getEngineMaxReasonableTime(meta: Meta, engine: Engine): number {
-  const mrt = engineMRTs[engine];
-  // shan't happen - mogery
-  if (mrt === undefined) {
-    meta.logger.warn("No MRT for engine", { engine });
-    return 30000;
-  }
-  return mrt(meta);
 }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -11,7 +11,10 @@ import {
   RemoveFeatureError,
   EngineUnsuccessfulError,
 } from "../../error";
-import { open, readFile, unlink } from "node:fs/promises";
+import { open, readFile, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
 import type { Response } from "undici";
 import { AbortManagerThrownError } from "../../lib/abortManager";
 import {
@@ -54,13 +57,28 @@ function getIneligibleReason(
   return null;
 }
 
-export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
+export async function scrapePDF(
+  meta: Meta,
+  sourceResult?: EngineScrapeResult,
+): Promise<EngineScrapeResult> {
   const shouldParse = shouldParsePDF(meta.options.parsers);
   const maxPages = getPDFMaxPages(meta.options.parsers);
   const mode: PDFMode = getPDFMode(meta.options.parsers);
 
   if (!shouldParse) {
-    if (meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null) {
+    if (sourceResult?.bodyBuffer) {
+      const content = sourceResult.bodyBuffer.toString("base64");
+      return {
+        url: sourceResult.url,
+        statusCode: sourceResult.statusCode,
+
+        html: content,
+        markdown: content,
+
+        contentType: sourceResult.contentType ?? "application/pdf",
+        proxyUsed: sourceResult.proxyUsed,
+      };
+    } else if (meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null) {
       const content = (await readFile(meta.pdfPrefetch.filePath)).toString(
         "base64",
       );
@@ -113,19 +131,49 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     }
   }
 
+  let shouldCleanupTempFile = true;
   const { response, tempFilePath } =
-    meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null
-      ? { response: meta.pdfPrefetch, tempFilePath: meta.pdfPrefetch.filePath }
-      : await downloadFile(
-          meta.id,
-          meta.rewrittenUrl ?? meta.url,
-          meta.options.skipTlsVerification,
-          {
-            headers: meta.options.headers,
-            signal: meta.abort.asSignal(),
-          },
-          PDF_DOWNLOAD_MAX_FILE_SIZE,
-        );
+    sourceResult?.binaryFilePath !== undefined
+      ? (() => {
+          shouldCleanupTempFile = false;
+          return {
+            response: {
+              url: sourceResult.url,
+              status: sourceResult.statusCode,
+            },
+            tempFilePath: sourceResult.binaryFilePath,
+          };
+        })()
+      : sourceResult?.bodyBuffer !== undefined
+        ? await (async (bodyBuffer: Buffer) => {
+            const tempFilePath = path.join(
+              tmpdir(),
+              `tempFile-${meta.id}-${randomUUID()}.pdf`,
+            );
+            await writeFile(tempFilePath, bodyBuffer);
+            return {
+              response: {
+                url: sourceResult.url,
+                status: sourceResult.statusCode,
+              },
+              tempFilePath,
+            };
+          })(sourceResult.bodyBuffer)
+        : meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null
+          ? {
+              response: meta.pdfPrefetch,
+              tempFilePath: meta.pdfPrefetch.filePath,
+            }
+          : await downloadFile(
+              meta.id,
+              meta.rewrittenUrl ?? meta.url,
+              meta.options.skipTlsVerification,
+              {
+                headers: meta.options.headers,
+                signal: meta.abort.asSignal(),
+              },
+              PDF_DOWNLOAD_MAX_FILE_SIZE,
+            );
 
   try {
     // Validate the downloaded file is actually a PDF by checking magic bytes
@@ -614,14 +662,16 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     };
   } finally {
     // Always clean up temp file after we're done with it
-    try {
-      await unlink(tempFilePath);
-    } catch (error) {
-      // Ignore errors when cleaning up temp files
-      meta.logger?.warn("Failed to clean up temporary PDF file", {
-        error,
-        tempFilePath,
-      });
+    if (shouldCleanupTempFile) {
+      try {
+        await unlink(tempFilePath);
+      } catch (error) {
+        // Ignore errors when cleaning up temp files
+        meta.logger?.warn("Failed to clean up temporary PDF file", {
+          error,
+          tempFilePath,
+        });
+      }
     }
   }
 }

--- a/apps/api/src/scraper/scrapeURL/engines/utils/downloadFile.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/downloadFile.ts
@@ -2,7 +2,6 @@ import path from "path";
 import os from "os";
 import { createWriteStream, promises as fs } from "node:fs";
 import {
-  AddFeatureError,
   DNSResolutionError,
   EngineError,
   SiteError,

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -1,70 +1,63 @@
 import { Logger } from "winston";
-import { AddFeatureError, UnsupportedFileError } from "../../error";
+import { UnsupportedFileError } from "../../error";
 import { FireEngineCheckStatusSuccess } from "../fire-engine/checkStatus";
-import path from "path";
-import os from "os";
-import { writeFile } from "fs/promises";
-import { Meta } from "../..";
+type SpecialtyFileType = "pdf" | "document";
 
-async function feResToFilePrefetch(
-  logger: Logger,
-  feRes: FireEngineCheckStatusSuccess | undefined,
-  fileExtension: string,
-  fileType: string,
-  contentType?: string,
-): Promise<Meta["pdfPrefetch"] | Meta["documentPrefetch"]> {
-  if (!feRes?.file) {
-    logger.warn(`No file in ${fileType} prefetch`);
+const documentTypes = [
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+  "application/msword",
+  "application/rtf",
+  "text/rtf",
+  "application/vnd.oasis.opendocument.text",
+];
+
+export function detectSpecialtyFileType(
+  contentType: string | undefined,
+  feRes?: FireEngineCheckStatusSuccess,
+): SpecialtyFileType | null {
+  if (!contentType) {
     return null;
   }
 
-  const filePath = path.join(
-    os.tmpdir(),
-    `tempFile-${crypto.randomUUID()}.${fileExtension}`,
+  const normalizedContentType = contentType.toLowerCase();
+  const isDocument = documentTypes.some(type =>
+    normalizedContentType.startsWith(type),
   );
-  await writeFile(filePath, Buffer.from(feRes.file.content, "base64"));
+  const isPdf =
+    normalizedContentType === "application/pdf" ||
+    normalizedContentType.startsWith("application/pdf;");
+  const isOctetStream = normalizedContentType === "application/octet-stream";
 
-  return {
-    status: feRes.pageStatusCode,
-    url: feRes.url,
-    filePath,
-    proxyUsed: feRes.usedMobileProxy ? "stealth" : "basic",
-    contentType,
-  };
-}
-
-async function feResToPdfPrefetch(
-  logger: Logger,
-  feRes: FireEngineCheckStatusSuccess | undefined,
-): Promise<Meta["pdfPrefetch"]> {
-  return feResToFilePrefetch(logger, feRes, "pdf", "pdf");
-}
-
-async function feResToDocumentPrefetch(
-  logger: Logger,
-  feRes: FireEngineCheckStatusSuccess | undefined,
-  contentType: string,
-): Promise<Meta["documentPrefetch"]> {
-  // Determine file extension from content type
-  let extension = "tmp";
-  if (contentType.includes("wordprocessingml")) {
-    // Modern .docx format (Office Open XML)
-    extension = "docx";
-  } else if (contentType.includes("msword")) {
-    // Legacy .doc format (OLE2/CFB binary)
-    extension = "doc";
-  } else if (
-    contentType.includes("spreadsheetml") ||
-    contentType.includes("ms-excel")
-  ) {
-    extension = "xlsx";
-  } else if (contentType.includes("opendocument.text")) {
-    extension = "odt";
-  } else if (contentType.includes("rtf")) {
-    extension = "rtf";
+  if (isDocument) {
+    return "document";
   }
 
-  return feResToFilePrefetch(logger, feRes, extension, "document", contentType);
+  if (isPdf) {
+    return "pdf";
+  }
+
+  if (isOctetStream) {
+    const isZipSignature =
+      feRes?.file?.content.startsWith("UEsD") ||
+      feRes?.content.startsWith("PK");
+    const isOleSignature =
+      feRes?.file?.content.startsWith("0M8R4K") ||
+      feRes?.content.startsWith("\xD0\xCF\x11\xE0");
+    const isPdfSignature =
+      feRes?.file?.content.startsWith("JVBERi0") ||
+      feRes?.content.startsWith("%PDF-");
+
+    if (isZipSignature || isOleSignature) {
+      return "document";
+    }
+    if (isPdfSignature) {
+      return "pdf";
+    }
+  }
+
+  return null;
 }
 
 export async function specialtyScrapeCheck(
@@ -83,77 +76,8 @@ export async function specialtyScrapeCheck(
     return;
   }
 
-  const documentTypes = [
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "application/vnd.ms-excel",
-    "application/msword",
-    "application/rtf",
-    "text/rtf",
-    "application/vnd.oasis.opendocument.text",
-  ];
-
-  const isDocument = documentTypes.some(type => contentType.startsWith(type));
-  const isPdf =
-    contentType === "application/pdf" ||
-    contentType.startsWith("application/pdf;");
-  const isOctetStream = contentType === "application/octet-stream";
-
-  // Check for document types first (before PDF to prioritize documents)
-  if (isDocument) {
-    throw new AddFeatureError(
-      ["document"],
-      undefined,
-      await feResToDocumentPrefetch(logger, feRes, contentType),
-    );
-  }
-
-  // Check for octet-stream with document signature
-  // Modern Office files (.docx, .xlsx) are ZIP archives starting with "PK" (base64: "UEsD")
-  // Legacy Office files (.doc, .xls) are OLE2/CFB files starting with D0 CF 11 E0 (base64: "0M8R4K")
-  if (isOctetStream) {
-    const isZipSignature =
-      feRes?.file?.content.startsWith("UEsD") ||
-      feRes?.content.startsWith("PK");
-    const isOleSignature =
-      feRes?.file?.content.startsWith("0M8R4K") ||
-      feRes?.content.startsWith("\xD0\xCF\x11\xE0");
-
-    if (isZipSignature) {
-      throw new AddFeatureError(
-        ["document"],
-        undefined,
-        await feResToDocumentPrefetch(logger, feRes, contentType),
-      );
-    }
-    if (isOleSignature) {
-      // OLE2 signature is shared by .doc/.xls/.ppt files
-      // Only override to application/msword if URL suggests it's a .doc file
-      const url = feRes?.url?.toLowerCase() ?? "";
-      const isDocUrl = url.endsWith(".doc") || url.includes(".doc?");
-      const effectiveContentType = isDocUrl
-        ? "application/msword"
-        : contentType;
-      throw new AddFeatureError(
-        ["document"],
-        undefined,
-        await feResToDocumentPrefetch(logger, feRes, effectiveContentType),
-      );
-    }
-  }
-
-  // Check for PDF
-  if (isPdf) {
-    throw new AddFeatureError(["pdf"], await feResToPdfPrefetch(logger, feRes));
-  }
-
-  // Check for octet-stream with PDF signature
-  if (
-    isOctetStream &&
-    (feRes?.file?.content.startsWith("JVBERi0") ||
-      feRes?.content.startsWith("%PDF-"))
-  ) {
-    throw new AddFeatureError(["pdf"], await feResToPdfPrefetch(logger, feRes));
+  if (detectSpecialtyFileType(contentType, feRes)) {
+    return;
   }
 
   // Reject unsupported binary content types (images, video, audio, archives, etc.)

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -90,6 +90,12 @@ export class RemoveFeatureError extends Error {
   }
 }
 
+export class EnhancedProxyRequiredError extends Error {
+  constructor(message = "Enhanced proxy is required for this scrape") {
+    super(message);
+  }
+}
+
 export class SSLError extends TransportableError {
   constructor(public skipTlsVerification: boolean) {
     super(
@@ -584,27 +590,11 @@ export class FEPageLoadFailed extends Error {
   }
 }
 
-export class EngineSnipedError extends Error {
-  name = "EngineSnipedError";
-
-  constructor() {
-    super("Engine got sniped");
-  }
-}
-
 export class EngineUnsuccessfulError extends Error {
   name = "EngineUnsuccessfulError";
 
   constructor(engine: Engine) {
     super(`Engine ${engine} was unsuccessful`);
-  }
-}
-
-export class WaterfallNextEngineSignal extends Error {
-  name = "WaterfallNextEngineSignal";
-
-  constructor() {
-    super("Waterfall next engine");
   }
 }
 

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -19,7 +19,6 @@ import {
   Engine,
   EngineScrapeResult,
   FeatureFlag,
-  getEngineMaxReasonableTime,
   scrapeURLWithEngine,
   shouldUseIndex,
 } from "./engines";
@@ -47,13 +46,12 @@ import {
   PDFPrefetchFailed,
   DocumentPrefetchFailed,
   FEPageLoadFailed,
-  EngineSnipedError,
-  WaterfallNextEngineSignal,
   EngineUnsuccessfulError,
   ProxySelectionError,
   ScrapeRetryLimitError,
   BrandingNotSupportedError,
   XTwitterConfigurationError,
+  EnhancedProxyRequiredError,
 } from "./error";
 import { ScrapeRetryTracker } from "./retryTracker";
 import { executeTransformers } from "./transformers";
@@ -87,6 +85,10 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { detectSpecialtyFileType } from "./engines/utils/specialtyHandler";
+import { isPdfBuffer } from "./engines/pdf/pdfUtils";
+import { scrapePDF } from "./engines/pdf";
+import { scrapeDocument } from "./engines/document";
 
 export type ScrapeUrlResponse =
   | {
@@ -384,6 +386,13 @@ async function buildMetaObject(
         proxyUsed: "basic",
         contentType: contentType || "application/pdf",
       };
+      fetchPrefetch = {
+        url: prefetchUrl,
+        status: 200,
+        bodyBuffer: buffer,
+        proxyUsed: "basic",
+        contentType: contentType || "application/pdf",
+      };
     } else if (isDocumentUpload(filename, contentType)) {
       const ext = path.extname(filename).toLowerCase();
       const fallbackExtension =
@@ -397,6 +406,15 @@ async function buildMetaObject(
         filePath,
         status: 200,
         url: prefetchUrl,
+        proxyUsed: "basic",
+        contentType:
+          contentType ||
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      };
+      fetchPrefetch = {
+        url: prefetchUrl,
+        status: 200,
+        bodyBuffer: buffer,
         proxyUsed: "basic",
         contentType:
           contentType ||
@@ -500,7 +518,7 @@ const MAX_HTML_SIZE_FOR_MARKDOWN_CHECK = 300 * 1024; // 300KB
 async function scrapeURLLoopIter(
   meta: Meta,
   engine: Engine,
-  snipeAbort,
+  snipeAbort?: AbortInstance,
 ): Promise<EngineScrapeResult> {
   const abort = meta.abort.child(snipeAbort);
   try {
@@ -511,6 +529,14 @@ async function scrapeURLLoopIter(
       },
       engine,
     );
+
+    if (getSpecialtyFileType(meta, engineResult) !== null) {
+      meta.logger.info("Scrape via " + engine + " returned specialty file.", {
+        contentType: engineResult.contentType,
+        statusCode: engineResult.statusCode,
+      });
+      return engineResult;
+    }
 
     const hasMarkdown = hasFormatOfType(meta.options.formats, "markdown");
     const hasChangeTracking = hasFormatOfType(
@@ -601,7 +627,7 @@ async function scrapeURLLoopIter(
           length: engineResult.html?.trim().length ?? 0,
         },
       );
-      throw new AddFeatureError(["stealthProxy"]);
+      throw new EnhancedProxyRequiredError();
     }
 
     // NOTE: TODO: what to do when status code is bad is tough...
@@ -624,16 +650,110 @@ async function scrapeURLLoopIter(
   }
 }
 
-class WrappedEngineError extends Error {
-  name = "WrappedEngineError";
-  public engine: Engine;
-  public error: any;
-
-  constructor(engine: Engine, error: any) {
-    super("WrappedEngineError");
-    this.engine = engine;
-    this.error = error;
+function getSpecialtyFileType(
+  meta: Meta,
+  engineResult: EngineScrapeResult,
+): "pdf" | "document" | null {
+  const detectedFromContentType = detectSpecialtyFileType(
+    engineResult.contentType?.toLowerCase(),
+  );
+  if (detectedFromContentType !== null) {
+    return detectedFromContentType;
   }
+
+  if (engineResult.bodyBuffer && isPdfBuffer(engineResult.bodyBuffer)) {
+    return "pdf";
+  }
+
+  if (meta.featureFlags.has("document")) {
+    return "document";
+  }
+
+  if (meta.featureFlags.has("pdf")) {
+    return "pdf";
+  }
+
+  return null;
+}
+
+async function runSpecialtyProcessor(
+  meta: Meta,
+  engineResult: EngineScrapeResult,
+): Promise<EngineScrapeResult> {
+  const specialtyType = getSpecialtyFileType(meta, engineResult);
+  if (specialtyType === "pdf") {
+    return await scrapePDF(
+      {
+        ...meta,
+        logger: meta.logger.child({ method: "postprocessors/pdf" }),
+      },
+      engineResult,
+    );
+  }
+  if (specialtyType === "document") {
+    return await scrapeDocument(
+      {
+        ...meta,
+        logger: meta.logger.child({ method: "postprocessors/document" }),
+      },
+      engineResult,
+    );
+  }
+  return engineResult;
+}
+
+function isIndexEngine(engine: Engine): boolean {
+  return engine === "index" || engine === "index;documents";
+}
+
+function isLegacySpecialtyEngine(engine: Engine): boolean {
+  return engine === "pdf" || engine === "document";
+}
+
+function getEnhancedEngine(engine: Engine): Engine | null {
+  switch (engine) {
+    case "fire-engine;chrome-cdp":
+      return "fire-engine;chrome-cdp;stealth";
+    case "fire-engine(retry);chrome-cdp":
+      return "fire-engine(retry);chrome-cdp;stealth";
+    case "fire-engine;tlsclient":
+      return "fire-engine;tlsclient;stealth";
+    default:
+      return null;
+  }
+}
+
+function selectMainEngine(
+  fallbackList: {
+    engine: Engine;
+    unsupportedFeatures: Set<FeatureFlag>;
+  }[],
+): {
+  engine: Engine;
+  unsupportedFeatures: Set<FeatureFlag>;
+} | null {
+  const mainCandidates = fallbackList.filter(
+    x => !isIndexEngine(x.engine) && !isLegacySpecialtyEngine(x.engine),
+  );
+
+  const preferredOrder: Engine[] = [
+    "x-twitter",
+    "wikipedia",
+    "fire-engine;chrome-cdp",
+    "playwright",
+    "fetch",
+    "fire-engine;tlsclient",
+    "fire-engine(retry);chrome-cdp",
+  ];
+
+  for (const engine of preferredOrder) {
+    const candidate = mainCandidates.find(x => x.engine === engine);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return mainCandidates[0] ?? null;
 }
 
 async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
@@ -692,231 +812,90 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
       "engine.fallback_list": fallbackList.map(f => f.engine).join(","),
     });
 
-    const snipeAbortController = new AbortController();
-    const snipeAbort: AbortInstance = {
-      signal: snipeAbortController.signal,
-      tier: "engine",
-      throwable() {
-        return new EngineSnipedError();
-      },
-    };
-
-    type EngineBundlePromise = {
-      engine: Engine;
-      unsupportedFeatures: Set<FeatureFlag>;
-      promise: Promise<EngineScrapeResultWithContext>;
-    };
-
-    const remainingEngines = [...fallbackList];
-    let enginePromises: EngineBundlePromise[] = [];
     const enginesAttempted: string[] = [];
-
     meta.abort.throwIfAborted();
-
     let result: EngineScrapeResultWithContext | null = null;
 
-    while (remainingEngines.length > 0) {
-      const { engine, unsupportedFeatures } = remainingEngines.shift()!;
+    for (const { engine, unsupportedFeatures } of fallbackList.filter(x =>
+      isIndexEngine(x.engine),
+    )) {
       enginesAttempted.push(engine);
-
-      const waitUntilWaterfall =
-        getEngineMaxReasonableTime(meta, engine) +
-        config.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS;
-
-      if (
-        !isFinite(waitUntilWaterfall) ||
-        isNaN(waitUntilWaterfall) ||
-        waitUntilWaterfall <= 0
-      ) {
-        meta.logger.warn("Invalid waitUntilWaterfall value", {
-          waitUntilWaterfall,
-          timeout: meta.options.timeout,
-          actions: !!meta.options.actions,
-          hasJson: !!meta.options.formats?.find(x => x.type === "json"),
-          remainingEngines: remainingEngines.length,
-        });
-      }
-
-      meta.logger.info("Scraping via " + engine + "...", {
-        waitUntilWaterfall,
-      });
-
-      enginePromises.push({
-        engine,
-        unsupportedFeatures,
-        promise: (async () => {
-          try {
-            return {
-              engine,
-              unsupportedFeatures,
-              result: await scrapeURLLoopIter(meta, engine, snipeAbort),
-            };
-          } catch (error) {
-            throw new WrappedEngineError(engine, error);
-          }
-        })(),
-      });
-
-      while (true) {
-        let timeouts: NodeJS.Timeout[] = [];
-        try {
-          result = await Promise.race([
-            ...enginePromises.map(x => x.promise),
-            ...(remainingEngines.length > 0
-              ? [
-                  new Promise<EngineScrapeResultWithContext>((_, reject) => {
-                    timeouts.push(
-                      setTimeout(() => {
-                        reject(new WaterfallNextEngineSignal());
-                      }, waitUntilWaterfall),
-                    );
-                  }),
-                ]
-              : []),
-            new Promise<EngineScrapeResultWithContext>((_, reject) => {
-              timeouts.push(
-                setTimeout(() => {
-                  try {
-                    meta.abort.throwIfAborted();
-
-                    // Fallback error if above doesn't throw
-                    const usingDefaultTimeout =
-                      meta.abort.scrapeTimeout() === undefined;
-                    throw new ScrapeJobTimeoutError(
-                      usingDefaultTimeout
-                        ? "Scrape timed out due to maximum length of 5 minutes"
-                        : "Scrape timed out",
-                    );
-                  } catch (error) {
-                    reject(error);
-                  }
-                }, meta.abort.scrapeTimeout() ?? 300000),
-              );
-            }),
-          ]);
-          break;
-        } catch (error) {
-          if (error instanceof WrappedEngineError) {
-            if (error.engine === "x-twitter") {
-              meta.logger.warn("X/Twitter scrape failed fatally.", {
-                error: error.error,
-              });
-              throw error.error;
-            } else if (error.error instanceof EngineError) {
-              meta.logger.warn(
-                "Engine " + error.engine + " could not scrape the page.",
-                {
-                  error: error.error,
-                },
-              );
-            } else if (error.error instanceof IndexMissError) {
-              meta.logger.warn(
-                "Engine " +
-                  error.engine +
-                  " could not find the page in the index.",
-                {
-                  error: error.error,
-                },
-              );
-            } else if (
-              error.error instanceof AddFeatureError ||
-              error.error instanceof RemoveFeatureError ||
-              error.error instanceof SiteError ||
-              error.error instanceof SSLError ||
-              error.error instanceof DNSResolutionError ||
-              error.error instanceof ActionError ||
-              error.error instanceof UnsupportedFileError ||
-              error.error instanceof PDFAntibotError ||
-              error.error instanceof PDFOCRRequiredError ||
-              error.error instanceof DocumentAntibotError ||
-              error.error instanceof PDFInsufficientTimeError ||
-              error.error instanceof ProxySelectionError ||
-              error.error instanceof NoCachedDataError ||
-              error.error instanceof AgentIndexOnlyError ||
-              error.error instanceof XTwitterConfigurationError
-            ) {
-              throw error.error;
-            } else if (error.error instanceof LLMRefusalError) {
-              meta.logger.warn("LLM refusal encountered", {
-                error: error.error,
-              });
-              throw error.error;
-            } else if (error.error instanceof FEPageLoadFailed) {
-              // This is the internal timeout bug on f-e and should be treated as an EngineError.
-              meta.logger.warn("FEPageLoadFailed encountered", {
-                error: error.error,
-              });
-            } else if (error.error instanceof AbortManagerThrownError) {
-              if (error.error.tier === "engine") {
-                meta.logger.warn(
-                  "Engine " + error.engine + " timed out while scraping.",
-                  { error: error.error },
-                );
-              } else {
-                throw error.error;
-              }
-            } else {
-              meta.logger.warn(
-                "An unexpected error happened while scraping with " +
-                  error.engine +
-                  ".",
-                { error },
-              );
-            }
-
-            // Filter out the failed engine
-            enginePromises = enginePromises.filter(
-              x => x.engine !== error.engine,
-            );
-
-            // If we don't have any engines waterfalled, let's waterfall the next engine
-            if (enginePromises.length === 0) {
-              break;
-            }
-
-            // Otherwise, just keep racing
-          } else if (
-            error instanceof AddFeatureError ||
-            error instanceof RemoveFeatureError
-          ) {
-            throw error;
-          } else if (error instanceof WaterfallNextEngineSignal) {
-            // It's time to waterfall the next engine
-            break;
-          } else if (error instanceof ScrapeJobTimeoutError) {
-            throw error;
-          } else if (error instanceof AbortManagerThrownError) {
-            if (error.tier === "engine") {
-              meta.logger.warn(
-                "Engine-scoped timeout error received here. Weird!",
-                { error },
-              );
-            }
-
-            throw error;
-          } else {
-            meta.logger.warn("Unexpected error while racing engines", {
-              error,
-            });
-            throw error;
-          }
-        } finally {
-          for (const to of timeouts) {
-            clearTimeout(to);
-          }
-        }
-      }
-
-      if (result === null) {
-        meta.logger.info("Waterfalling to next engine...", {
-          waitUntilWaterfall,
-        });
-      } else {
+      meta.logger.info("Scraping via index preprocessor " + engine + "...");
+      try {
+        result = {
+          engine,
+          unsupportedFeatures,
+          result: await scrapeURLLoopIter(meta, engine),
+        };
         break;
+      } catch (error) {
+        if (error instanceof IndexMissError || error instanceof EngineError) {
+          meta.logger.info("Index preprocessor missed.", { engine, error });
+          continue;
+        }
+        throw error;
       }
     }
 
-    snipeAbortController.abort();
+    if (result === null) {
+      const mainEngine = selectMainEngine(fallbackList);
+      if (mainEngine === null) {
+        setSpanAttributes(span, {
+          "engine.no_engines_left": true,
+          "engine.engines_attempted": enginesAttempted.join(","),
+        });
+        if (meta.options.lockdown) {
+          throw new LockdownMissError();
+        }
+        throw new NoEnginesLeftError(fallbackList.map(x => x.engine));
+      }
+
+      const runMainEngine = async (
+        engine: Engine,
+        unsupportedFeatures: Set<FeatureFlag>,
+      ): Promise<EngineScrapeResultWithContext> => {
+        enginesAttempted.push(engine);
+        meta.logger.info("Scraping via main engine " + engine + "...");
+        return {
+          engine,
+          unsupportedFeatures,
+          result: await scrapeURLLoopIter(meta, engine),
+        };
+      };
+
+      try {
+        result = await runMainEngine(
+          mainEngine.engine,
+          mainEngine.unsupportedFeatures,
+        );
+      } catch (error) {
+        if (error instanceof EnhancedProxyRequiredError) {
+          const enhancedEngine = getEnhancedEngine(mainEngine.engine);
+          if (enhancedEngine === null) {
+            throw error;
+          }
+
+          meta.logger.info("Retrying main engine with enhanced proxy.", {
+            engine: mainEngine.engine,
+            enhancedEngine,
+          });
+          meta.featureFlags = new Set([...meta.featureFlags, "stealthProxy"]);
+          result = await runMainEngine(enhancedEngine, new Set());
+        } else if (
+          error instanceof EngineUnsuccessfulError ||
+          error instanceof EngineError ||
+          error instanceof FEPageLoadFailed
+        ) {
+          setSpanAttributes(span, {
+            "engine.no_engines_left": true,
+            "engine.engines_attempted": enginesAttempted.join(","),
+          });
+          throw new NoEnginesLeftError(fallbackList.map(x => x.engine));
+        } else {
+          throw error;
+        }
+      }
+    }
 
     if (result === null) {
       setSpanAttributes(span, {
@@ -940,7 +919,10 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
     });
 
     meta.winnerEngine = result.engine;
-    let engineResult: EngineScrapeResult = result.result;
+    let engineResult: EngineScrapeResult = await runSpecialtyProcessor(
+      meta,
+      result.result,
+    );
     meta.audioCookies = (
       engineResult as { audioCookies?: BrowserCookie[] }
     ).audioCookies;

--- a/apps/api/src/scraper/scrapeURL/scrapeURL.control-flow.test.ts
+++ b/apps/api/src/scraper/scrapeURL/scrapeURL.control-flow.test.ts
@@ -1,0 +1,256 @@
+import "dotenv/config";
+import type { Mock } from "vitest";
+
+import { config } from "../../config";
+config.ENV = "test";
+
+import { scrapeOptions } from "../../controllers/v2/types";
+import { CostTracking } from "../../lib/cost-tracking";
+import { EngineError } from "./error";
+
+const {
+  buildFallbackListMock,
+  scrapeURLWithEngineMock,
+  scrapePDFMock,
+  scrapeDocumentMock,
+} = vi.hoisted(() => ({
+  buildFallbackListMock: vi.fn(),
+  scrapeURLWithEngineMock: vi.fn(),
+  scrapePDFMock: vi.fn(),
+  scrapeDocumentMock: vi.fn(),
+}));
+
+vi.mock("./engines", async importOriginal => {
+  const actual = await importOriginal<typeof import("./engines")>();
+  return {
+    ...actual,
+    buildFallbackList: buildFallbackListMock,
+    scrapeURLWithEngine: scrapeURLWithEngineMock,
+    shouldUseIndex: vi.fn(() => false),
+  };
+});
+
+vi.mock("./postprocessors", () => ({
+  postprocessors: [],
+}));
+
+vi.mock("./transformers", () => ({
+  executeTransformers: vi.fn((_meta, document) => document),
+}));
+
+vi.mock("./engines/pdf", async importOriginal => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    scrapePDF: scrapePDFMock,
+  };
+});
+
+vi.mock("./engines/document", async importOriginal => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    scrapeDocument: scrapeDocumentMock,
+  };
+});
+
+vi.mock("../../lib/html-to-markdown", () => ({
+  parseMarkdown: vi.fn(async html => html),
+}));
+
+import { scrapeURL } from ".";
+
+function engineResult(overrides: Record<string, unknown> = {}) {
+  return {
+    url: "https://example.com",
+    html: "<main>ok</main>",
+    statusCode: 200,
+    proxyUsed: "basic",
+    ...overrides,
+  };
+}
+
+describe("scrapeURL main engine control flow", () => {
+  beforeEach(() => {
+    buildFallbackListMock.mockReset();
+    scrapeURLWithEngineMock.mockReset();
+    scrapePDFMock.mockReset();
+    scrapeDocumentMock.mockReset();
+  });
+
+  it("does not waterfall to another main engine when the selected main engine fails", async () => {
+    buildFallbackListMock.mockResolvedValue([
+      { engine: "fire-engine;chrome-cdp", unsupportedFeatures: new Set() },
+      { engine: "fetch", unsupportedFeatures: new Set() },
+    ]);
+    scrapeURLWithEngineMock.mockRejectedValue(new EngineError("failed"));
+
+    const out = await scrapeURL(
+      "test:no-waterfall",
+      "https://example.com",
+      scrapeOptions.parse({ maxAge: 0 }),
+      { teamId: "test" },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(false);
+    expect(scrapeURLWithEngineMock).toHaveBeenCalledTimes(1);
+    expect(scrapeURLWithEngineMock.mock.calls[0][1]).toBe(
+      "fire-engine;chrome-cdp",
+    );
+  });
+
+  it("retries the selected main engine with enhanced proxy when required", async () => {
+    buildFallbackListMock.mockResolvedValue([
+      { engine: "fire-engine;chrome-cdp", unsupportedFeatures: new Set() },
+      { engine: "fetch", unsupportedFeatures: new Set() },
+    ]);
+    (scrapeURLWithEngineMock as Mock)
+      .mockResolvedValueOnce(
+        engineResult({
+          html: "<main>blocked</main>",
+          statusCode: 403,
+          proxyUsed: "basic",
+        }),
+      )
+      .mockResolvedValueOnce(
+        engineResult({
+          html: "<main>enhanced ok</main>",
+          statusCode: 200,
+          proxyUsed: "stealth",
+        }),
+      );
+
+    const out = await scrapeURL(
+      "test:enhanced-retry",
+      "https://example.com",
+      scrapeOptions.parse({ maxAge: 0, proxy: "auto" }),
+      { teamId: "test" },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(true);
+    expect(scrapeURLWithEngineMock).toHaveBeenCalledTimes(2);
+    expect(scrapeURLWithEngineMock.mock.calls.map(call => call[1])).toEqual([
+      "fire-engine;chrome-cdp",
+      "fire-engine;chrome-cdp;stealth",
+    ]);
+  });
+
+  it("runs PDF processing on binary content returned by the main engine", async () => {
+    buildFallbackListMock.mockResolvedValue([
+      { engine: "fetch", unsupportedFeatures: new Set() },
+      { engine: "pdf", unsupportedFeatures: new Set() },
+    ]);
+    const fetchedPdf = engineResult({
+      html: "%PDF-1.4",
+      bodyBuffer: Buffer.from("%PDF-1.4"),
+      contentType: "application/pdf",
+    });
+    scrapeURLWithEngineMock.mockResolvedValue(fetchedPdf);
+    scrapePDFMock.mockResolvedValue(
+      engineResult({
+        markdown: "processed pdf",
+        html: "<main>processed pdf</main>",
+        contentType: "application/pdf",
+      }),
+    );
+
+    const out = await scrapeURL(
+      "test:pdf-postprocessor",
+      "https://example.com/file.pdf",
+      scrapeOptions.parse({ maxAge: 0 }),
+      { teamId: "test" },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(true);
+    expect(scrapeURLWithEngineMock).toHaveBeenCalledTimes(1);
+    expect(scrapeURLWithEngineMock.mock.calls[0][1]).toBe("fetch");
+    expect(scrapePDFMock).toHaveBeenCalledWith(expect.any(Object), fetchedPdf);
+  });
+
+  it("passes uploaded PDF bytes to the configured main engine", async () => {
+    buildFallbackListMock.mockResolvedValue([
+      { engine: "fetch", unsupportedFeatures: new Set() },
+    ]);
+    const fetchedPdf = engineResult({
+      html: "%PDF-1.4",
+      bodyBuffer: Buffer.from("%PDF-1.4"),
+      contentType: "application/pdf",
+    });
+    scrapeURLWithEngineMock.mockResolvedValue(fetchedPdf);
+    scrapePDFMock.mockResolvedValue(
+      engineResult({
+        markdown: "uploaded pdf",
+        html: "<main>uploaded pdf</main>",
+        contentType: "application/pdf",
+      }),
+    );
+
+    const uploadedBuffer = Buffer.from("%PDF-1.4 uploaded");
+    const out = await scrapeURL(
+      "test:uploaded-pdf",
+      "https://parse.firecrawl.dev/uploads/upload.pdf",
+      scrapeOptions.parse({ maxAge: 0 }),
+      {
+        teamId: "test",
+        forceEngine: "fetch",
+        uploadedFile: {
+          filename: "upload.pdf",
+          contentType: "application/pdf",
+          buffer: uploadedBuffer,
+          kind: "pdf",
+        },
+      },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(true);
+    expect(scrapeURLWithEngineMock).toHaveBeenCalledTimes(1);
+    expect(scrapeURLWithEngineMock.mock.calls[0][0].fetchPrefetch).toEqual(
+      expect.objectContaining({
+        bodyBuffer: uploadedBuffer,
+        contentType: "application/pdf",
+      }),
+    );
+  });
+
+  it("runs document processing on binary content returned by the main engine", async () => {
+    buildFallbackListMock.mockResolvedValue([
+      { engine: "fetch", unsupportedFeatures: new Set() },
+      { engine: "document", unsupportedFeatures: new Set() },
+    ]);
+    const fetchedDocument = engineResult({
+      html: "PK fake docx",
+      bodyBuffer: Buffer.from("PK fake docx"),
+      contentType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    scrapeURLWithEngineMock.mockResolvedValue(fetchedDocument);
+    scrapeDocumentMock.mockResolvedValue(
+      engineResult({
+        markdown: "processed document",
+        html: "<main>processed document</main>",
+        contentType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      }),
+    );
+
+    const out = await scrapeURL(
+      "test:document-postprocessor",
+      "https://example.com/file.docx",
+      scrapeOptions.parse({ maxAge: 0 }),
+      { teamId: "test" },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(true);
+    expect(scrapeURLWithEngineMock).toHaveBeenCalledTimes(1);
+    expect(scrapeURLWithEngineMock.mock.calls[0][1]).toBe("fetch");
+    expect(scrapeDocumentMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      fetchedDocument,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace scrapeURL engine waterfalling with index preprocessing plus one selected main engine
- normalize enhanced-proxy retry through a dedicated error and retry the same main engine family with enhanced proxy
- move PDF/document handling behind post-main-engine processing while preserving binary bytes from the main engine
- add focused scrapeURL control-flow tests

## Validation
- pnpm build
- pnpm vitest run src/scraper/scrapeURL/scrapeURL.control-flow.test.ts

## Notes
- Attempted narrow parser snips through pnpm harness; local harness did not reach meaningful scrape assertions due TEST_SUITE_WEBSITE/self-hosted setup and then API connection readiness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors scrape engine selection to remove engine waterfalling by running index-only preprocessors first and then a single chosen main engine. Adds automatic enhanced-proxy retries and moves PDF/document parsing to post-processing using binary bytes from the main engine.

- **Refactors**
  - Replace waterfall with index preprocessors, then one main engine chosen in priority order (x-twitter → wikipedia → fire-engine;chrome-cdp → playwright → fetch → fire-engine;tlsclient → fire-engine(retry);chrome-cdp).
  - Normalize enhanced-proxy retry via `EnhancedProxyRequiredError`, retrying the same engine with `;stealth` and enabling `stealthProxy`.
  - Post-process PDF/document after the main engine; `scrapePDF`/`scrapeDocument` accept `sourceResult` and preserve `bodyBuffer`/content type (temp-file handling when needed).
  - Propagate binary bytes: uploads feed `fetchPrefetch.bodyBuffer`; `fetch` and `fire-engine` populate `bodyBuffer` for downstream processors.
  - Simplify specialty detection (PDF/document) via content type/magic bytes; legacy `pdf`/`document` engines are not selected as main engines.

- **New Features**
  - Added `scrapeURL.control-flow.test.ts` covering main-engine selection (no waterfall), enhanced-proxy retry, and PDF/document post-processing.

<sup>Written for commit b75a6dd88af54996dc1ebb836802573b9041cb65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

