### PR TITLE
fix(helm): nuq-postgres CrashLoopBackOff on PVs with lost+found

### DIFF
--- a/examples/kubernetes/firecrawl-helm/Chart.yaml
+++ b/examples/kubernetes/firecrawl-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: firecrawl
 description: A Helm chart for deploying the Firecrawl application
 type: application
-version: 0.2.0
+version: 0.2.1

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
@@ -20,8 +20,8 @@ spec:
       {{- end }}
       initContainers:
         - name: init-pgdata
-          image: busybox:1.36
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.nuqPostgres.initContainer.image | default "busybox:1.36" }}"
+          imagePullPolicy: {{ .Values.nuqPostgres.initContainer.pullPolicy | default "IfNotPresent" }}
           command:
             - sh
             - -c

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
@@ -18,6 +18,26 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
+      initContainers:
+        - name: init-pgdata
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /var/lib/postgresql/data
+              chown -R 999:999 /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql
       containers:
         - name: nuq-postgres
           image: "{{ .Values.nuqPostgres.image.repository }}:{{ .Values.nuqPostgres.image.tag | default "latest" }}"
@@ -29,11 +49,14 @@ spec:
               value: "{{ .Values.nuqPostgres.auth.password | default "password" }}"
             - name: POSTGRES_DB
               value: "{{ .Values.nuqPostgres.auth.database | default "postgres" }}"
+            - name: PGDATA
+              value: /var/lib/postgresql/data
           ports:
             - containerPort: 5432
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/postgresql/data
+              subPath: data
           {{- if .Values.resources.enabled }}
             {{- if .Values.nuqPostgres.resources }}
           resources:

--- a/examples/kubernetes/firecrawl-helm/values.yaml
+++ b/examples/kubernetes/firecrawl-helm/values.yaml
@@ -80,6 +80,9 @@ nuqPostgres:
     enabled: false
     size: 10Gi
     storageClass: ""
+  initContainer:
+    image: busybox:1.36
+    pullPolicy: IfNotPresent
 
 rabbitmq:
   enabled: true


### PR DESCRIPTION
## Summary

Fixes `nuq-postgres` pod entering `CrashLoopBackOff` when `nuqPostgres.persistence.enabled: true` and the underlying `PersistentVolume` isprovisioned on a filesystem whose root contains a `lost+found` directory (e.g. `ext4` from `rancher-local-path`, `rawfile-localpv`, etc.).All `nuq-worker` and `nuq-prefetch-worker` pods subsequently fail health checks with `ECONNREFUSED <nuq-postgres-service>:5432`.

## Issue

The chart's `nuq-postgres-deployment.yaml` mounts the PVC directly at `/var/lib/postgresql/data`:

```yaml
volumeMounts:
  - name: postgres-storage
    mountPath: /var/lib/postgresql/data
```

The mount exposes the **volume root** at that path. Any `ext4`-formatted volume (which is what every local-path provisioner creates) shipsa `lost+found/` directory at its root. On first boot, postgres runs `initdb -D $PGDATA` (default `PGDATA=/var/lib/postgresql/data`) and refuses:

```
initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
initdb: detail: It contains a lost+found directory, perhaps due to it being a mount point.
initdb: hint: Using a mount point directly as the data directory is not recommended.
                Create a subdirectory under the mount point.
```

The container exits, Kubernetes restarts it, the cycle repeats, and the pod never opens port `5432`. Every NuQ worker then logs:

```
"error":{"code":"ECONNREFUSED","message":"connect ECONNREFUSED 10.233.2.13:5432",...}
"level":"warn","message":"NuQ worker health check failed"
```

until it itself crash-loops and the whole NuQ subsystem is dead.

## Reproduction

1. Use a cluster with a StorageClass that backs volumes with `ext4` + `lost+found`. Examples: `rancher.io/local-path`, `local-path` (Rancher), `rawfile.csi.openebs.io` (`rawfile-localpv`), or any local-path-provisioner derivative.
2. `helm install firecrawl ./examples/kubernetes/firecrawl-helm -f values.yaml -f overlays/prod/values.yaml --set nuqPostgres.persistence.enabled=true --set nuqPostgres.persistence.size=10Gi`
3. `kubectl get pods -l app=firecrawl-nuq-postgres` → `CrashLoopBackOff`
4. `kubectl logs <nuq-postgres-pod> --previous` → shows the `initdb: directory "/var/lib/postgresql/data" exists but is not empty` error above.
5. `kubectl get pods -l app=firecrawl-nuq-worker` → all `CrashLoopBackOff` with `ECONNREFUSED` to the nuq-postgres service.

It does **not** reproduce on managed cloud disks (EBS, GCE PD, Azure Disk) because those are typically mounted directly without an ext4 in-container; it reproduces on any local PV provisioner, which is the default for bare-metal / single-node clusters and most dev environments.

## Fix

Three coordinated changes in `nuq-postgres-deployment.yaml`:

1. **`initContainer` (`init-pgdata`)** runs once with the PVC mounted at the parent path `/var/lib/postgresql` (so it sees the volume root, including `lost+found`). It creates `/var/lib/postgresql/data` and chowns it to uid 999 (the postgres user in the official postgres image).
2. **`PGDATA=/var/lib/postgresql/data`** env var on the main container so `initdb` writes into the freshly created subdirectory.
3. **`subPath: data`** on the main container's `volumeMount` so that mount targets only the `data/` subdir of the volume; `lost+found` remains in the volume root and is invisible at `/var/lib/postgresql/data` in the container.

`busybox:1.36` is used for the init step (≈5 MB, has `mkdir` and `chown`); no other values changes are required, and the initContainer exits immediately on every restart (idempotent because of `mkdir -p` and chowning the same path).

Bumps chart version `0.2.0 → 0.2.1`.

## Verification

Tested on a real cluster (k8s-internal) with `rawfile-localpv`. Before the fix: `nuq-postgres` `CrashLoopBackOff` (7 restarts), all 5 `nuq-worker` + `nuq-prefetch-worker` pods in `CrashLoopBackOff`, queue service dead. After `helm upgrade` to `0.2.1`: postgres `initdb` succeeds, pod reaches `Running`/Ready, all NuQ workers exit `CrashLoopBackOff` and start processing jobs. Existing PVC is reused — no data loss, no resync needed.

## Checklist

- [x] Chart version bumped (`0.2.0` → `0.2.1`)
- [x] No breaking values changes
- [x] Works with `nuqPostgres.persistence.enabled: true|false` (the `initContainer` runs against either the PVC or the `emptyDir`; both work because `lost+found` only exists on the PVC path)
- [x] Tested on `rawfile-localpv` and reproduces the original failure on `0.2.0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `nuq-postgres` CrashLoopBackOff on PVCs with a `lost+found` by using a dedicated data subdirectory, restoring worker health. Also makes the init container image configurable for air-gapped/private registry setups.

- **Bug Fixes**
  - Added `initContainer` to create/chown `/var/lib/postgresql/data`; image and pull policy are configurable via `.Values.nuqPostgres.initContainer.{image,pullPolicy}` (defaults `busybox:1.36`, `IfNotPresent`) to avoid `ImagePullBackOff`.
  - Set `PGDATA=/var/lib/postgresql/data` and mounted the PVC with `subPath: data` to hide `lost+found`.
  - Bumped chart version `0.2.0` → `0.2.1`.

<sup>Written for commit ca1231e03e6713fdb385b63a697e231b2c5e59e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

