### PR TITLE
fix(api): route low-quality PDF text to OCR

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = "0.1.0"
+pdf-inspector = "0.1.2"
 maud = "0.27.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/eligibility.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/eligibility.test.ts
@@ -1,0 +1,24 @@
+import { getIneligibleReason } from "../eligibility";
+
+const baseResult = {
+  pdfType: "TextBased",
+  confidence: 0.99,
+  isComplex: false,
+  markdown: "hello",
+  pagesNeedingOcr: [],
+};
+
+describe("getIneligibleReason", () => {
+  it("accepts clean text-based PDFs", () => {
+    expect(getIneligibleReason(baseResult)).toBeNull();
+  });
+
+  it("rejects text-based PDFs with pages that need OCR", () => {
+    expect(
+      getIneligibleReason({
+        ...baseResult,
+        pagesNeedingOcr: [2, 5],
+      }),
+    ).toBe("pages_needing_ocr=2");
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/eligibility.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/eligibility.ts
@@ -1,0 +1,22 @@
+type PdfExtractionEligibilityInput = {
+  pdfType: string;
+  confidence: number;
+  isComplex: boolean;
+  markdown?: string | null;
+  pagesNeedingOcr?: readonly number[] | null;
+};
+
+/** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
+export function getIneligibleReason(
+  result: PdfExtractionEligibilityInput,
+): string | null {
+  if (result.pdfType !== "TextBased") return `pdfType=${result.pdfType}`;
+  if (result.confidence < 0.95) return `confidence=${result.confidence}`;
+  if (result.isComplex) return "complex layout (tables/columns)";
+  if (result.pagesNeedingOcr && result.pagesNeedingOcr.length > 0) {
+    return `pages_needing_ocr=${result.pagesNeedingOcr.length}`;
+  }
+  if (!result.markdown?.length)
+    return "empty markdown (unexpected for TextBased)";
+  return null;
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -41,18 +41,7 @@ import { scrapePDFWithParsePDF } from "./pdfParse";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
-
-/** Check if the PDF is eligible for Rust extraction, returning a rejection reason or null. */
-function getIneligibleReason(
-  result: ReturnType<typeof processPdf>,
-): string | null {
-  if (result.pdfType !== "TextBased") return `pdfType=${result.pdfType}`;
-  if (result.confidence < 0.95) return `confidence=${result.confidence}`;
-  if (result.isComplex) return "complex layout (tables/columns)";
-  if (!result.markdown?.length)
-    return "empty markdown (unexpected for TextBased)";
-  return null;
-}
+import { getIneligibleReason } from "./eligibility";
 
 export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
   const shouldParse = shouldParsePDF(meta.options.parsers);
@@ -266,6 +255,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           pageCount: pdfResult.pageCount,
           confidence: pdfResult.confidence,
           isComplex: pdfResult.isComplex,
+          pagesNeedingOcr: pdfResult.pagesNeedingOcr.length,
           markdownLength: pdfResult.markdown?.length ?? 0,
           url: meta.rewrittenUrl ?? meta.url,
           mode,
@@ -278,6 +268,11 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
 
         const ineligibleReason = getIneligibleReason(pdfResult);
         const eligible = !ineligibleReason;
+        const ocrPageCount = pdfResult.pagesNeedingOcr.length;
+        const ocrPageRatio =
+          pdfResult.pageCount > 0
+            ? Math.round((ocrPageCount * 100) / pdfResult.pageCount) / 100
+            : 0;
 
         logger.info("Rust PDF eligibility", {
           rust_pdf_eligible: eligible,
@@ -287,8 +282,27 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           isComplex: pdfResult.isComplex,
           pageCount: pdfResult.pageCount,
           confidence: pdfResult.confidence,
+          ocrPageCount,
+          ocrPageRatio,
           mode,
         });
+
+        if (ocrPageCount > 0 && pdfResult.pdfType === "TextBased") {
+          logger.info("PDF text quality requires OCR", {
+            event: "pdf_text_quality_ocr_required",
+            issue: "suspected_garbled_text",
+            issueSource: "pdf_inspector_pages_needing_ocr",
+            url: meta.rewrittenUrl ?? meta.url,
+            pdfType: pdfResult.pdfType,
+            pageCount: pdfResult.pageCount,
+            confidence: pdfResult.confidence,
+            isComplex: pdfResult.isComplex,
+            pagesNeedingOcr: pdfResult.pagesNeedingOcr,
+            ocrPageCount,
+            ocrPageRatio,
+            mode,
+          });
+        }
 
         // Shadow-compare when Rust produced meaningful output but wasn't
         // eligible for direct serving. Includes:
@@ -317,7 +331,8 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         if (
           mode === "fast" &&
           (pdfResult.pdfType === "Scanned" ||
-            pdfResult.pdfType === "ImageBased")
+            pdfResult.pdfType === "ImageBased" ||
+            ocrPageCount > 0)
         ) {
           throw new PDFOCRRequiredError(pdfResult.pdfType);
         }

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -400,9 +400,17 @@ export class ZDRViolationError extends TransportableError {
 
 export class PDFOCRRequiredError extends TransportableError {
   constructor(public pdfType: string) {
+    const description =
+      pdfType === "Scanned"
+        ? "scanned"
+        : pdfType === "ImageBased"
+          ? "image-based"
+          : pdfType === "Mixed"
+            ? "mixed text/image-based"
+            : "text-based but contains pages that require OCR";
     super(
       "SCRAPE_PDF_OCR_REQUIRED",
-      `This PDF is ${pdfType === "Scanned" ? "scanned" : "image-based"} and requires OCR for text extraction, but the requested PDF mode is "fast" which only supports text-based PDFs. To process this PDF, use mode "auto" (which falls back to OCR automatically) or mode "ocr" (which forces OCR processing). Example: parsers: [{ type: "pdf", mode: "auto" }]`,
+      `This PDF is ${description} and requires OCR for text extraction, but the requested PDF mode is "fast" which only supports fully text-based PDFs. To process this PDF, use mode "auto" (which falls back to OCR automatically) or mode "ocr" (which forces OCR processing). Example: parsers: [{ type: "pdf", mode: "auto" }]`,
     );
   }
 


### PR DESCRIPTION
## Summary

Routes pdf-inspector's `pagesNeedingOcr` signal into Firecrawl's Rust PDF eligibility decision so text-based PDFs with suspect extracted pages fall through to OCR instead of being served from native markdown. It logs a stable `pdf_text_quality_ocr_required` event only for `TextBased` PDFs and adds `issue: "suspected_garbled_text"` plus OCR page count, ratio, and affected pages for Google Cloud Logs review.

This also treats those pages as OCR-required in fast mode and updates the native pdf-inspector crate to `0.1.2`.