### PR TITLE
feat(helm): allow external Redis, PostgreSQL and RabbitMQ

### DIFF
--- a/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
@@ -7,8 +7,11 @@
   {{- $redisResolved = $redisInCluster -}}
 {{- else if .Values.redis.external.url -}}
   {{- $redisResolved = .Values.redis.external.url -}}
+{{- else if .Values.config.REDIS_URL -}}
+  {{- /* legacy override via config.REDIS_URL — honour it, skip fail */}}
+  {{- $redisResolved = .Values.config.REDIS_URL -}}
 {{- else -}}
-  {{- fail "redis.enabled is false but redis.external.url is not set. Please provide an external Redis URL." -}}
+  {{- fail "redis.enabled is false but no Redis URL is configured. Set redis.external.url or config.REDIS_URL." -}}
 {{- end -}}
 {{- $redisRateLimitResolved := default $redisResolved .Values.redis.external.rateLimitUrl -}}
 
@@ -28,8 +31,11 @@
   {{- $extPgDb := default "postgres" .Values.nuqPostgres.external.database -}}
   {{- $extPgPort := default 5432 .Values.nuqPostgres.external.port -}}
   {{- $nuqDbResolved = printf "postgresql://%s:%s@%s:%v/%s" $extPgUser $extPgPass .Values.nuqPostgres.external.host $extPgPort $extPgDb -}}
+{{- else if .Values.config.NUQ_DATABASE_URL -}}
+  {{- /* legacy override via config.NUQ_DATABASE_URL — honour it, skip fail */}}
+  {{- $nuqDbResolved = .Values.config.NUQ_DATABASE_URL -}}
 {{- else -}}
-  {{- fail "nuqPostgres.enabled is false but neither nuqPostgres.external.url nor nuqPostgres.external.host is set. Please provide external PostgreSQL connection details." -}}
+  {{- fail "nuqPostgres.enabled is false but no PostgreSQL URL is configured. Set nuqPostgres.external.url, nuqPostgres.external.host, or config.NUQ_DATABASE_URL." -}}
 {{- end -}}
 {{- $nuqDbUrl := default $nuqDbResolved .Values.config.NUQ_DATABASE_URL -}}
 
@@ -40,8 +46,11 @@
   {{- $rabbitMqResolved = $rabbitMqInCluster -}}
 {{- else if .Values.rabbitmq.external.url -}}
   {{- $rabbitMqResolved = .Values.rabbitmq.external.url -}}
+{{- else if .Values.config.NUQ_RABBITMQ_URL -}}
+  {{- /* legacy override via config.NUQ_RABBITMQ_URL — honour it, skip fail */}}
+  {{- $rabbitMqResolved = .Values.config.NUQ_RABBITMQ_URL -}}
 {{- else -}}
-  {{- fail "rabbitmq.enabled is false but rabbitmq.external.url is not set. Please provide an external RabbitMQ URL." -}}
+  {{- fail "rabbitmq.enabled is false but no RabbitMQ URL is configured. Set rabbitmq.external.url or config.NUQ_RABBITMQ_URL." -}}
 {{- end -}}
 
 {{- $apiHostDefault := printf "%s-api" $fullname -}}

--- a/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
@@ -1,12 +1,49 @@
 {{- $fullname := include "firecrawl.fullname" . -}}
-{{- $redisDefault := printf "redis://%s-redis:%v" $fullname .Values.service.redis.port -}}
-{{- $playwrightDefault := printf "http://%s-playwright:%v/scrape" $fullname .Values.service.playwright.port -}}
+
+{{- /* ── Redis URL resolution ── */}}
+{{- $redisInCluster := printf "redis://%s-redis:%v" $fullname .Values.service.redis.port -}}
+{{- $redisResolved := "" -}}
+{{- if .Values.redis.enabled -}}
+  {{- $redisResolved = $redisInCluster -}}
+{{- else if .Values.redis.external.url -}}
+  {{- $redisResolved = .Values.redis.external.url -}}
+{{- else -}}
+  {{- fail "redis.enabled is false but redis.external.url is not set. Please provide an external Redis URL." -}}
+{{- end -}}
+{{- $redisRateLimitResolved := default $redisResolved .Values.redis.external.rateLimitUrl -}}
+
+{{- /* ── PostgreSQL URL resolution ── */}}
 {{- $pgUser := default "postgres" .Values.nuqPostgres.auth.username -}}
 {{- $pgPassword := default "password" .Values.nuqPostgres.auth.password -}}
 {{- $pgDb := default "postgres" .Values.nuqPostgres.auth.database -}}
-{{- $nuqDbDefault := printf "postgresql://%s:%s@%s-nuq-postgres:5432/%s" $pgUser $pgPassword $fullname $pgDb -}}
-{{- $nuqDbUrl := default $nuqDbDefault .Values.config.NUQ_DATABASE_URL -}}
-{{- $rabbitMqDefault := printf "amqp://%s-rabbitmq:%v" $fullname .Values.service.rabbitmq.port -}}
+{{- $nuqDbInCluster := printf "postgresql://%s:%s@%s-nuq-postgres:5432/%s" $pgUser $pgPassword $fullname $pgDb -}}
+{{- $nuqDbResolved := "" -}}
+{{- if .Values.nuqPostgres.enabled -}}
+  {{- $nuqDbResolved = $nuqDbInCluster -}}
+{{- else if .Values.nuqPostgres.external.url -}}
+  {{- $nuqDbResolved = .Values.nuqPostgres.external.url -}}
+{{- else if .Values.nuqPostgres.external.host -}}
+  {{- $extPgUser := default "postgres" .Values.nuqPostgres.external.username -}}
+  {{- $extPgPass := .Values.nuqPostgres.external.password -}}
+  {{- $extPgDb := default "postgres" .Values.nuqPostgres.external.database -}}
+  {{- $extPgPort := default 5432 .Values.nuqPostgres.external.port -}}
+  {{- $nuqDbResolved = printf "postgresql://%s:%s@%s:%v/%s" $extPgUser $extPgPass .Values.nuqPostgres.external.host $extPgPort $extPgDb -}}
+{{- else -}}
+  {{- fail "nuqPostgres.enabled is false but neither nuqPostgres.external.url nor nuqPostgres.external.host is set. Please provide external PostgreSQL connection details." -}}
+{{- end -}}
+{{- $nuqDbUrl := default $nuqDbResolved .Values.config.NUQ_DATABASE_URL -}}
+
+{{- /* ── RabbitMQ URL resolution ── */}}
+{{- $rabbitMqInCluster := printf "amqp://%s-rabbitmq:%v" $fullname .Values.service.rabbitmq.port -}}
+{{- $rabbitMqResolved := "" -}}
+{{- if .Values.rabbitmq.enabled -}}
+  {{- $rabbitMqResolved = $rabbitMqInCluster -}}
+{{- else if .Values.rabbitmq.external.url -}}
+  {{- $rabbitMqResolved = .Values.rabbitmq.external.url -}}
+{{- else -}}
+  {{- fail "rabbitmq.enabled is false but rabbitmq.external.url is not set. Please provide an external RabbitMQ URL." -}}
+{{- end -}}
+
 {{- $apiHostDefault := printf "%s-api" $fullname -}}
 {{- $apiPortDefault := printf "%v" .Values.service.api.port -}}
 apiVersion: v1
@@ -22,12 +59,12 @@ data:
   NUQ_WORKER_PORT: {{ default (printf "%v" .Values.nuqWorker.port) .Values.config.NUQ_WORKER_PORT | quote }}
   NUQ_PREFETCH_WORKER_PORT: {{ default (printf "%v" .Values.nuqPrefetchWorker.port) .Values.config.NUQ_PREFETCH_WORKER_PORT | quote }}
   NUQ_WORKER_COUNT: {{ default (printf "%v" .Values.nuqWorker.replicaCount) .Values.config.NUQ_WORKER_COUNT | quote }}
-  REDIS_URL: {{ default $redisDefault .Values.config.REDIS_URL | quote }}
-  REDIS_RATE_LIMIT_URL: {{ default $redisDefault .Values.config.REDIS_RATE_LIMIT_URL | quote }}
-  PLAYWRIGHT_MICROSERVICE_URL: {{ default $playwrightDefault .Values.config.PLAYWRIGHT_MICROSERVICE_URL | quote }}
+  REDIS_URL: {{ default $redisResolved .Values.config.REDIS_URL | quote }}
+  REDIS_RATE_LIMIT_URL: {{ default $redisRateLimitResolved .Values.config.REDIS_RATE_LIMIT_URL | quote }}
+  PLAYWRIGHT_MICROSERVICE_URL: {{ default (printf "http://%s-playwright:%v/scrape" $fullname .Values.service.playwright.port) .Values.config.PLAYWRIGHT_MICROSERVICE_URL | quote }}
   NUQ_DATABASE_URL: {{ $nuqDbUrl | quote }}
   NUQ_DATABASE_URL_LISTEN: {{ default $nuqDbUrl .Values.config.NUQ_DATABASE_URL_LISTEN | quote }}
-  NUQ_RABBITMQ_URL: {{ default $rabbitMqDefault .Values.config.NUQ_RABBITMQ_URL | quote }}
+  NUQ_RABBITMQ_URL: {{ default $rabbitMqResolved .Values.config.NUQ_RABBITMQ_URL | quote }}
   USE_DB_AUTHENTICATION: {{ .Values.config.USE_DB_AUTHENTICATION | quote }}
   IS_KUBERNETES: {{ .Values.config.IS_KUBERNETES | quote }}
   ENV: {{ .Values.config.ENV | quote }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nuqPostgres.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,3 +72,4 @@ spec:
       port: 5432
       targetPort: 5432
   type: ClusterIP
+{{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-pvc.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nuqPostgres.persistence.enabled }}
+{{- if and .Values.nuqPostgres.enabled .Values.nuqPostgres.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/examples/kubernetes/firecrawl-helm/templates/redis-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/redis-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,3 +34,4 @@ spec:
               secretKeyRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
                 key: REDIS_PASSWORD
+{{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/redis-service.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/redis-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,3 +11,4 @@ spec:
     - protocol: TCP
       port: {{ .Values.service.redis.port }}
       targetPort: {{ .Values.service.redis.port }}
+{{- end }}

--- a/examples/kubernetes/firecrawl-helm/values.yaml
+++ b/examples/kubernetes/firecrawl-helm/values.yaml
@@ -60,6 +60,8 @@ nuqPrefetchWorker:
       cpu: "1000m"
 
 nuqPostgres:
+  # Set to false to disable the in-cluster PostgreSQL deployment and use an external instance instead.
+  enabled: true
   replicaCount: 1
   image:
     repository: docker.io/winkkgmbh/nuq-postgres
@@ -80,8 +82,20 @@ nuqPostgres:
     enabled: false
     size: 10Gi
     storageClass: ""
+  # External PostgreSQL configuration — used when nuqPostgres.enabled is false.
+  external:
+    # Full connection URL (takes precedence over individual fields if set).
+    # e.g. "postgresql://user:password@my-postgres-host:5432/mydb"
+    url: ""
+    # Individual connection fields (used to build the URL when url is empty).
+    host: ""
+    port: 5432
+    username: postgres
+    password: ""
+    database: postgres
 
 rabbitmq:
+  # Set to false to disable the in-cluster RabbitMQ deployment and provide an external URL instead.
   enabled: true
   image: rabbitmq:3-management
   replicaCount: 1
@@ -92,6 +106,10 @@ rabbitmq:
     limits:
       memory: "1Gi"
       cpu: "500m"
+  # External RabbitMQ configuration — used when rabbitmq.enabled is false.
+  external:
+    # Full AMQP URL. e.g. "amqp://user:password@my-rabbitmq-host:5672/vhost"
+    url: ""
 
 image:
   repository: docker.io/winkkgmbh/firecrawl
@@ -106,8 +124,16 @@ playwright:
   replicaCount: 1
 
 redis:
+  # Set to false to disable the in-cluster Redis deployment and use an external instance instead.
+  enabled: true
   image: redis:alpine
   replicaCount: 1
+  # External Redis configuration — used when redis.enabled is false.
+  external:
+    # Full Redis URL. e.g. "redis://:password@my-redis-host:6379"
+    url: ""
+    # Separate rate-limit Redis URL (falls back to url if not set).
+    rateLimitUrl: ""
 
 service:
   api:


### PR DESCRIPTION
Closes #3827

- Add redis.enabled toggle and redis.external.{url,rateLimitUrl}
- Add nuqPostgres.enabled toggle and nuqPostgres.external config
- Add rabbitmq.external.url for when rabbitmq.enabled is false
- Wrap Redis deployment+service with if redis.enabled
- Wrap nuq-postgres deployment+service+PVC with if nuqPostgres.enabled
- configmap.yaml resolves URLs conditionally; fails loudly if external service is disabled but no external URL is provided

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for external Redis, PostgreSQL, and RabbitMQ in the Helm chart so you can disable in-cluster services and point to managed endpoints. Templates resolve URLs automatically, honor legacy `config.*` overrides, and fail fast if external config is missing.

- **New Features**
  - Redis: `redis.enabled` toggle and `redis.external.{url,rateLimitUrl}`; deployment/service wrapped with `if`; ConfigMap sets `REDIS_URL` and `REDIS_RATE_LIMIT_URL`.
  - PostgreSQL: `nuqPostgres.enabled` toggle and `nuqPostgres.external` (either `url` or host/port/username/password/database); deployment/service/PVC gated by `enabled`; ConfigMap sets `NUQ_DATABASE_URL` (and default for `NUQ_DATABASE_URL_LISTEN`).
  - RabbitMQ: `rabbitmq.external.url` used when `rabbitmq.enabled` is false; ConfigMap sets `NUQ_RABBITMQ_URL`.
  - Validation: honors `config.REDIS_URL`, `config.NUQ_DATABASE_URL`, and `config.NUQ_RABBITMQ_URL` before failing if an external service is disabled without required URL/config.

- **Migration**
  - External Redis: set `redis.enabled: false` and `redis.external.url` (optional `rateLimitUrl`).
  - External PostgreSQL: set `nuqPostgres.enabled: false` and either `nuqPostgres.external.url` or the individual connection fields.
  - External RabbitMQ: set `rabbitmq.enabled: false` and `rabbitmq.external.url`.
  - You can still override via `config.*` (e.g., `NUQ_DATABASE_URL`) if needed.

<sup>Written for commit 9e93062fb31447b9cae5baf307b3f5d858d3e372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

