### PR TITLE
Clarify pnpm test command in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,4 +137,4 @@ This will start Redis, the API server, and workers automatically in the correct 
 
 ## Tests:
 
-The best way to do this is run the test with `npm run test:snips`.
+The best way to do this is run the test with `pnpm run test:snips` from the `apps/api` directory.


### PR DESCRIPTION
Summary:
- Aligns the CONTRIBUTING test command with the pnpm-based setup documented earlier in the file.
- Notes that `pnpm run test:snips` should be run from `apps/api`.

Testing:
- Verified `apps/api/package.json` defines the `test:snips` script.
- Documentation-only change; tests were not run.

AI assistance: This documentation fix was prepared with AI assistance and reviewed before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the test command in CONTRIBUTING. Use `pnpm run test:snips` from `apps/api` to match the `pnpm` setup and avoid confusion.

<sup>Written for commit 664ba23589d249f308ec50c4bb509a31c4c2a6a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

