### PR TITLE
[codex] Stabilize self-hosted map redirect snip

### DIFF
--- a/apps/api/src/__tests__/snips/mocks/map-redirect.json
+++ b/apps/api/src/__tests__/snips/mocks/map-redirect.json
@@ -2,6 +2,22 @@
   {
     "time": 1782145899000,
     "options": {
+      "url": "http://www.firecrawl.dev/sitemap.xml",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "http://www.firecrawl.dev/sitemap.xml",
+      "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
+      "status": 200,
+      "headers": [["content-type", "application/xml"]]
+    }
+  },
+  {
+    "time": 1782145899001,
+    "options": {
       "url": "https://www.firecrawl.dev/sitemap.xml",
       "method": "GET",
       "ignoreResponse": false,
@@ -10,6 +26,54 @@
     },
     "result": {
       "url": "https://www.firecrawl.dev/sitemap.xml",
+      "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
+      "status": 200,
+      "headers": [["content-type", "application/xml"]]
+    }
+  },
+  {
+    "time": 1782145899002,
+    "options": {
+      "url": "http://127.0.0.1:4321/sitemap.xml",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "http://127.0.0.1:4321/sitemap.xml",
+      "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
+      "status": 200,
+      "headers": [["content-type", "application/xml"]]
+    }
+  },
+  {
+    "time": 1782145899003,
+    "options": {
+      "url": "http://0.0.0.0:4321/sitemap.xml",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "http://0.0.0.0:4321/sitemap.xml",
+      "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
+      "status": 200,
+      "headers": [["content-type", "application/xml"]]
+    }
+  },
+  {
+    "time": 1782145899004,
+    "options": {
+      "url": "http://0.0.0.1:4321/sitemap.xml",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "http://0.0.0.1:4321/sitemap.xml",
       "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>http://www.firecrawl.dev/</loc></url>\n  <url><loc>http://www.firecrawl.dev/about</loc></url>\n  <url><loc>http://www.firecrawl.dev/blog</loc></url>\n</urlset>",
       "status": 200,
       "headers": [["content-type", "application/xml"]]


### PR DESCRIPTION
## Summary
- expand the `map-redirect` scrape mock to include the sitemap URLs produced by redirect resolution in self-hosted CI
- cover the observed `http://0.0.0.1:4321/sitemap.xml` FDB-row target plus local/canonical Firecrawl variants

## Root cause
The v2 map redirect snip already uses `useMock: "map-redirect"`, but the mock only had `https://www.firecrawl.dev/sitemap.xml`. In the failing self-hosted FDB runs, redirect resolution produced `http://0.0.0.1:4321/sitemap.xml`, so the mocked sitemap fetch missed and the test returned zero links.

## Validation
- `jq 'length, [.[].options.url]' apps/api/src/__tests__/snips/mocks/map-redirect.json`
- `node -e '...'` fixture check for required sitemap variants and expected XML body
- `TEST_SUITE_SELF_HOSTED=true TEST_SUITE_WEBSITE=http://127.0.0.1:4321 TEST_API_KEY=test TEST_TEAM_ID=bypass pnpm harness pnpm vitest run src/__tests__/snips/v2/map.test.ts` (blocked locally: Docker daemon socket `/Users/gregomoricz/.docker/run/docker.sock` is unavailable)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes self-hosted CI by expanding the map-redirect sitemap mock to cover URLs produced by redirect resolution. Adds entries for http/https firecrawl.dev and local hosts (127.0.0.1:4321, 0.0.0.0:4321, 0.0.0.1:4321) so sitemap fetches hit and tests return links instead of zero.

<sup>Written for commit 7f662a87f7debcb000ae27609ba379a09d3d2a2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

