### PR TITLE
update(monitor): Guard paused search monitors and add finalize timeout

### DIFF
--- a/apps/api/src/controllers/v2/monitor.ts
+++ b/apps/api/src/controllers/v2/monitor.ts
@@ -443,6 +443,12 @@ export async function runMonitorController(
   if (!monitor) {
     return res.status(404).json({ success: false, error: "Monitor not found" });
   }
+  if (monitor.status === "paused") {
+    return res.status(409).json({
+      success: false,
+      error: "Monitor is paused. Resume it before running a check.",
+    });
+  }
   if (monitor.current_check_id) {
     return res.status(409).json({
       success: false,

--- a/apps/api/src/services/monitoring/jitter.ts
+++ b/apps/api/src/services/monitoring/jitter.ts
@@ -1,6 +1,10 @@
 import { createHash } from "crypto";
 
-const MAX_JITTER_MS = 5 * 60 * 1000;
+// Cap the spread at 30 min: enough that hourly monitors fan out across :00-:30
+// (instead of piling at :00 and starving the consumer) while a daily/weekly cron
+// still fires within tens of minutes of its intended time. Sub-hourly intervals
+// stay bounded by intervalMs/2 below.
+const MAX_JITTER_MS = 30 * 60 * 1000;
 
 export function monitorJitterOffsetMs(
   monitorId: string,

--- a/apps/api/src/services/monitoring/jitter.ts
+++ b/apps/api/src/services/monitoring/jitter.ts
@@ -1,10 +1,6 @@
 import { createHash } from "crypto";
 
-// Cap the spread at 30 min: enough that hourly monitors fan out across :00-:30
-// (instead of piling at :00 and starving the consumer) while a daily/weekly cron
-// still fires within tens of minutes of its intended time. Sub-hourly intervals
-// stay bounded by intervalMs/2 below.
-const MAX_JITTER_MS = 30 * 60 * 1000;
+const MAX_JITTER_MS = 5 * 60 * 1000;
 
 export function monitorJitterOffsetMs(
   monitorId: string,

--- a/apps/api/src/services/monitoring/queue.test.ts
+++ b/apps/api/src/services/monitoring/queue.test.ts
@@ -54,15 +54,27 @@ describe("monitoring queue (RabbitMQ wrapper)", () => {
     channelMock.sendToQueue.mockReturnValue(true);
   });
 
-  it("subscribes a consumer with per-consumer prefetch(1) and manual ack", async () => {
+  it("subscribes the default consumer with per-consumer prefetch(1) and manual ack", async () => {
     const q = await freshQueueModule();
     await q.consumeMonitorCheckJobs(vi.fn());
 
-    expect(channelMock.prefetch).toHaveBeenCalledWith(1);
+    // Default (scrape/crawl/page/site/batch) checks just enqueue async jobs, so 1
+    // is fine; global=false keeps the limit per-consumer on the shared channel.
+    expect(channelMock.prefetch).toHaveBeenCalledWith(1, false);
     expect(channelMock.consume).toHaveBeenCalledTimes(1);
     const [queue, , opts] = channelMock.consume.mock.calls[0];
     expect(queue).toBe("monitor.checks");
     expect(opts).toEqual({ noAck: false });
+  });
+
+  it("subscribes the search consumer with a higher prefetch so inline checks run concurrently", async () => {
+    const q = await freshQueueModule();
+    await q.consumeMonitorSearchCheckJobs(vi.fn());
+
+    // Search checks run inline for 15-50s, so prefetch(1) would serialize a burst.
+    expect(channelMock.prefetch).toHaveBeenCalledWith(3, false);
+    const [queue] = channelMock.consume.mock.calls[0];
+    expect(queue).toBe("monitor.checks.search");
   });
 
   it("dedups a repeat subscribe to the same queue (no duplicate consumer)", async () => {

--- a/apps/api/src/services/monitoring/queue.ts
+++ b/apps/api/src/services/monitoring/queue.ts
@@ -35,8 +35,16 @@ let consumeChannelPromise: Promise<amqp.Channel> | null = null;
 
 // Registry of consumers so a reconnect can re-attach them; the worker never produces,
 // so without this it goes permanently deaf after any RabbitMQ blip until restart.
-const registeredConsumers: Array<{ queue: string; handler: ConsumerHandler }> =
-  [];
+const registeredConsumers: Array<{
+  queue: string;
+  handler: ConsumerHandler;
+  prefetch: number;
+}> = [];
+// Search checks run inline (search + judge + scrapes) for 15-50s each, so a single
+// prefetch serializes them and a burst piles up behind one check. Let a worker run a
+// few concurrently; each still fans out SEARCH_SCRAPE_CONCURRENCY scrapes, so keep it
+// modest. Default (page/site/batch) checks just enqueue async jobs, so 1 is fine.
+const SEARCH_CHECK_PREFETCH = 3;
 // Queues with a live consumer on the CURRENT consume channel; cleared on drop so a
 // reconnect re-subscribes exactly once per queue and can't pile up duplicates.
 const subscribedQueues = new Set<string>();
@@ -109,8 +117,8 @@ function scheduleReconnect(delayMs: number): void {
   setTimeout(async () => {
     try {
       const ch = await getConsumeChannel();
-      for (const { queue, handler } of registeredConsumers) {
-        await subscribe(ch, queue, handler);
+      for (const { queue, handler, prefetch } of registeredConsumers) {
+        await subscribe(ch, queue, handler, prefetch);
       }
       reconnectInFlight = false;
       logger.info("Monitor queue reconnected; consumers re-subscribed", {
@@ -258,23 +266,26 @@ export async function addMonitorCheckJob(
 async function consumeQueue(
   queue: string,
   handler: ConsumerHandler,
+  prefetch: number,
 ): Promise<void> {
   if (!registeredConsumers.some(c => c.queue === queue)) {
-    registeredConsumers.push({ queue, handler });
+    registeredConsumers.push({ queue, handler, prefetch });
   }
   const ch = await getConsumeChannel();
-  await subscribe(ch, queue, handler);
+  await subscribe(ch, queue, handler, prefetch);
 }
 
 async function subscribe(
   ch: amqp.Channel,
   queue: string,
   handler: ConsumerHandler,
+  prefetch: number,
 ): Promise<void> {
   // Don't add a duplicate consumer if a reconnect re-subscribes an already-subscribed queue.
   if (subscribedQueues.has(queue)) return;
-  // Per-consumer prefetch (amqplib default) so search and default consumers don't block each other.
-  await ch.prefetch(1);
+  // Per-consumer prefetch (global=false) so the search and default consumers each get
+  // their own in-flight budget and don't block each other.
+  await ch.prefetch(prefetch, false);
 
   await ch.consume(
     queue,
@@ -314,11 +325,15 @@ async function subscribe(
 export async function consumeMonitorCheckJobs(
   handler: (data: MonitorCheckJobData) => Promise<void>,
 ): Promise<void> {
-  await consumeQueue(MONITOR_CHECK_QUEUE, handler);
+  await consumeQueue(MONITOR_CHECK_QUEUE, handler, 1);
 }
 
 export async function consumeMonitorSearchCheckJobs(
   handler: (data: MonitorCheckJobData) => Promise<void>,
 ): Promise<void> {
-  await consumeQueue(MONITOR_SEARCH_CHECK_QUEUE, handler);
+  await consumeQueue(
+    MONITOR_SEARCH_CHECK_QUEUE,
+    handler,
+    SEARCH_CHECK_PREFETCH,
+  );
 }

--- a/apps/api/src/services/monitoring/results.ts
+++ b/apps/api/src/services/monitoring/results.ts
@@ -2,9 +2,11 @@ import { NuQJob } from "../worker/nuq";
 import { ScrapeJobData } from "../../types";
 import { logger as _logger } from "../../lib/logger";
 import { createWebhookSender, WebhookEvent } from "../webhook";
+import { redisEvictConnection } from "../redis";
 import { computeAndPersistPageDiff } from "./diff-orchestrator";
 import { derivePageIsMeaningful } from "./page-events";
 import {
+  deleteMonitorCheckPages,
   getMonitorForUpdate,
   getMonitorPage,
   hashMonitorUrl,
@@ -13,6 +15,82 @@ import {
 } from "./store";
 
 const logger = _logger.child({ module: "monitoring-results" });
+
+// Per-(check, url) webhook claim. checkIds are unique per run, so this only needs
+// to outlive a job redelivery; we match runner.ts's notify-claim horizon.
+const MONITOR_PAGE_WEBHOOK_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+// Mirror runner.ts's claimMonitorNotification: a redelivered scrape job must not
+// re-send the MONITOR_PAGE webhook. Returns true only for the first claimant; a
+// redis hiccup degrades to "don't send" rather than throwing out of the caller
+// (the page row is already persisted and stays pollable).
+async function claimMonitorPageWebhook(
+  checkId: string,
+  url: string,
+): Promise<boolean> {
+  try {
+    const result = await redisEvictConnection.set(
+      `monitor-page-notify:${checkId}:${hashMonitorUrl(url).toString("hex")}`,
+      "1",
+      "EX",
+      MONITOR_PAGE_WEBHOOK_CLAIM_TTL_SECONDS,
+      "NX",
+    );
+    return result === "OK";
+  } catch (error) {
+    logger.warn("Failed to claim monitor page webhook", {
+      error,
+      checkId,
+      url,
+    });
+    return false;
+  }
+}
+
+// Idempotently record an error-status check page and (once) notify. Shared by the
+// scrape-failure path and the success path's diff/persist guard so a transient
+// failure still completes the reconciler's fan-in tally.
+async function persistMonitorCheckError(params: {
+  monitoring: NonNullable<ScrapeJobData["monitoring"]>;
+  teamId: string;
+  url: string;
+  scrapeId: string;
+  error: string;
+  statusCode?: number | null;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await deleteMonitorCheckPages({
+    checkId: params.monitoring.checkId,
+    targetId: params.monitoring.targetId,
+    url: params.url,
+  });
+  await insertMonitorCheckPages([
+    {
+      check_id: params.monitoring.checkId,
+      monitor_id: params.monitoring.monitorId,
+      team_id: params.teamId,
+      target_id: params.monitoring.targetId,
+      url: params.url,
+      status: "error",
+      current_scrape_id: params.scrapeId,
+      error: params.error,
+      status_code: params.statusCode ?? null,
+      metadata: params.metadata ?? null,
+    },
+  ]);
+
+  if (await claimMonitorPageWebhook(params.monitoring.checkId, params.url)) {
+    await sendMonitorPageWebhook({
+      teamId: params.teamId,
+      monitorId: params.monitoring.monitorId,
+      checkId: params.monitoring.checkId,
+      url: params.url,
+      status: "error",
+      currentScrapeId: params.scrapeId,
+      error: params.error,
+    });
+  }
+}
 
 function getDocumentUrl(doc: any, fallback: string): string {
   return doc?.metadata?.sourceURL ?? doc?.metadata?.url ?? doc?.url ?? fallback;
@@ -130,6 +208,52 @@ export async function recordMonitorScrapeSuccess(
   const targetCtFormat = Array.isArray(targetFormats)
     ? (targetFormats as any[]).find((f: any) => f?.type === "changeTracking")
     : undefined;
+  let diff: Awaited<ReturnType<typeof computeAndPersistPageDiff>>;
+  try {
+    diff = await computeAndPersistPageDiff({
+      teamId: job.data.team_id,
+      monitorId: monitoring.monitorId,
+      checkId: monitoring.checkId,
+      url,
+      scrapeId: job.id,
+      doc,
+      previous: previous
+        ? {
+            last_scrape_id: previous.last_scrape_id,
+            is_removed: previous.is_removed,
+          }
+        : null,
+      formats: targetFormats,
+      goal:
+        monitorForRun?.judge_enabled && monitorForRun?.goal
+          ? monitorForRun.goal
+          : null,
+      extractionPrompt: targetCtFormat?.prompt ?? null,
+    });
+  } catch (error) {
+    // A transient diff/persist failure (e.g. GCS) must not strand the check:
+    // still record an error page so the reconciler's fan-in tally completes
+    // instead of hanging until the stale reaper.
+    logger.warn("Failed to compute monitor page diff; recording error page", {
+      monitorId: monitoring.monitorId,
+      checkId: monitoring.checkId,
+      targetId: monitoring.targetId,
+      scrapeId: job.id,
+      url,
+      error,
+    });
+    await persistMonitorCheckError({
+      monitoring,
+      teamId: job.data.team_id,
+      url,
+      scrapeId: job.id,
+      error: error instanceof Error ? error.message : String(error),
+      statusCode: getDocumentStatusCode(doc),
+      metadata: { creditsUsed: doc?.metadata?.creditsUsed ?? null },
+    });
+    return;
+  }
+
   const {
     status,
     diffGcsKey,
@@ -139,47 +263,17 @@ export async function recordMonitorScrapeSuccess(
     diffText,
     diffJson,
     error,
-  } = await computeAndPersistPageDiff({
-    teamId: job.data.team_id,
-    monitorId: monitoring.monitorId,
-    checkId: monitoring.checkId,
-    url,
-    scrapeId: job.id,
-    doc,
-    previous: previous
-      ? {
-          last_scrape_id: previous.last_scrape_id,
-          is_removed: previous.is_removed,
-        }
-      : null,
-    formats: targetFormats,
-    goal:
-      monitorForRun?.judge_enabled && monitorForRun?.goal
-        ? monitorForRun.goal
-        : null,
-    extractionPrompt: targetCtFormat?.prompt ?? null,
-  });
+  } = diff;
 
-  await upsertMonitorPage({
-    monitorId: monitoring.monitorId,
-    teamId: job.data.team_id,
+  // Tally first (the reconciler's fan-in gate), durable baseline last: a crash
+  // between the two completes the check rather than poisoning the cross-run dedup
+  // baseline against an unrecorded page. The delete makes redelivery a replace,
+  // not a duplicate.
+  await deleteMonitorCheckPages({
+    checkId: monitoring.checkId,
     targetId: monitoring.targetId,
     url,
-    source: monitoring.source,
-    checkId: monitoring.checkId,
-    scrapeId: job.id,
-    status,
-    metadata: {
-      title: doc?.metadata?.title ?? null,
-      statusCode: getDocumentStatusCode(doc),
-      contentType: doc?.metadata?.contentType ?? null,
-      numPages: doc?.metadata?.numPages ?? null,
-      proxyUsed: doc?.metadata?.proxyUsed ?? null,
-      postprocessorsUsed: doc?.metadata?.postprocessorsUsed ?? null,
-      creditsUsed: doc?.metadata?.creditsUsed ?? null,
-    },
   });
-
   await insertMonitorCheckPages([
     {
       check_id: monitoring.checkId,
@@ -208,6 +302,26 @@ export async function recordMonitorScrapeSuccess(
     },
   ]);
 
+  await upsertMonitorPage({
+    monitorId: monitoring.monitorId,
+    teamId: job.data.team_id,
+    targetId: monitoring.targetId,
+    url,
+    source: monitoring.source,
+    checkId: monitoring.checkId,
+    scrapeId: job.id,
+    status,
+    metadata: {
+      title: doc?.metadata?.title ?? null,
+      statusCode: getDocumentStatusCode(doc),
+      contentType: doc?.metadata?.contentType ?? null,
+      numPages: doc?.metadata?.numPages ?? null,
+      proxyUsed: doc?.metadata?.proxyUsed ?? null,
+      postprocessorsUsed: doc?.metadata?.postprocessorsUsed ?? null,
+      creditsUsed: doc?.metadata?.creditsUsed ?? null,
+    },
+  });
+
   logger.info("Recorded monitor scrape result", {
     monitorId: monitoring.monitorId,
     checkId: monitoring.checkId,
@@ -220,18 +334,20 @@ export async function recordMonitorScrapeSuccess(
     judgmentMeaningful: judgment?.meaningful,
   });
 
-  await sendMonitorPageWebhook({
-    teamId: job.data.team_id,
-    monitorId: monitoring.monitorId,
-    checkId: monitoring.checkId,
-    url,
-    status,
-    previousScrapeId: previous?.last_scrape_id ?? null,
-    currentScrapeId: job.id,
-    judgment: judgment ?? null,
-    diffText: diffText ?? null,
-    diffJson: diffJson ?? null,
-  });
+  if (await claimMonitorPageWebhook(monitoring.checkId, url)) {
+    await sendMonitorPageWebhook({
+      teamId: job.data.team_id,
+      monitorId: monitoring.monitorId,
+      checkId: monitoring.checkId,
+      url,
+      status,
+      previousScrapeId: previous?.last_scrape_id ?? null,
+      currentScrapeId: job.id,
+      judgment: judgment ?? null,
+      diffText: diffText ?? null,
+      diffJson: diffJson ?? null,
+    });
+  }
 }
 
 export async function recordMonitorScrapeFailure(
@@ -242,22 +358,14 @@ export async function recordMonitorScrapeFailure(
   const monitoring = job.data.monitoring;
   if (!monitoring || job.data.mode !== "single_urls") return;
 
-  await insertMonitorCheckPages([
-    {
-      check_id: monitoring.checkId,
-      monitor_id: monitoring.monitorId,
-      team_id: job.data.team_id,
-      target_id: monitoring.targetId,
-      url: job.data.url,
-      url_hash: hashMonitorUrl(job.data.url),
-      status: "error",
-      current_scrape_id: job.id,
-      error: error instanceof Error ? error.message : String(error),
-      metadata: {
-        creditsUsed: creditsUsed ?? null,
-      },
-    },
-  ]);
+  await persistMonitorCheckError({
+    monitoring,
+    teamId: job.data.team_id,
+    url: job.data.url,
+    scrapeId: job.id,
+    error: error instanceof Error ? error.message : String(error),
+    metadata: { creditsUsed: creditsUsed ?? null },
+  });
 
   logger.info("Recorded monitor scrape failure", {
     monitorId: monitoring.monitorId,
@@ -265,16 +373,6 @@ export async function recordMonitorScrapeFailure(
     targetId: monitoring.targetId,
     scrapeId: job.id,
     url: job.data.url,
-    error: error instanceof Error ? error.message : String(error),
-  });
-
-  await sendMonitorPageWebhook({
-    teamId: job.data.team_id,
-    monitorId: monitoring.monitorId,
-    checkId: monitoring.checkId,
-    url: job.data.url,
-    status: "error",
-    currentScrapeId: job.id,
     error: error instanceof Error ? error.message : String(error),
   });
 }

--- a/apps/api/src/services/monitoring/results.ts
+++ b/apps/api/src/services/monitoring/results.ts
@@ -24,13 +24,37 @@ const MONITOR_PAGE_WEBHOOK_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
 // re-send the MONITOR_PAGE webhook. Returns true only for the first claimant; a
 // redis hiccup degrades to "don't send" rather than throwing out of the caller
 // (the page row is already persisted and stays pollable).
+function monitorPageNotifyKey(
+  checkId: string,
+  url: string,
+  kind: "page" | "error",
+): string {
+  return `monitor-page-notify:${checkId}:${hashMonitorUrl(url).toString(
+    "hex",
+  )}:${kind}`;
+}
+
+// Claims the right to send one MONITOR_PAGE webhook for a (check, url). The kind is
+// part of the key so a "page" (success/content) notification claims independently and
+// can't be suppressed by a prior "error" claim — otherwise a redelivery that flips
+// error->success would leave the consumer stuck on a stale error. The reverse is also
+// guarded: once a success was sent, an error is skipped so a redelivered failure can't
+// regress the consumer back to error. A redis hiccup degrades to "don't send" rather
+// than throwing out of the caller (the page row is already persisted and stays pollable).
 async function claimMonitorPageWebhook(
   checkId: string,
   url: string,
+  kind: "page" | "error",
 ): Promise<boolean> {
   try {
+    if (kind === "error") {
+      const pageSent = await redisEvictConnection.exists(
+        monitorPageNotifyKey(checkId, url, "page"),
+      );
+      if (pageSent) return false;
+    }
     const result = await redisEvictConnection.set(
-      `monitor-page-notify:${checkId}:${hashMonitorUrl(url).toString("hex")}`,
+      monitorPageNotifyKey(checkId, url, kind),
       "1",
       "EX",
       MONITOR_PAGE_WEBHOOK_CLAIM_TTL_SECONDS,
@@ -79,7 +103,13 @@ async function persistMonitorCheckError(params: {
     },
   ]);
 
-  if (await claimMonitorPageWebhook(params.monitoring.checkId, params.url)) {
+  if (
+    await claimMonitorPageWebhook(
+      params.monitoring.checkId,
+      params.url,
+      "error",
+    )
+  ) {
     await sendMonitorPageWebhook({
       teamId: params.teamId,
       monitorId: params.monitoring.monitorId,
@@ -334,7 +364,7 @@ export async function recordMonitorScrapeSuccess(
     judgmentMeaningful: judgment?.meaningful,
   });
 
-  if (await claimMonitorPageWebhook(monitoring.checkId, url)) {
+  if (await claimMonitorPageWebhook(monitoring.checkId, url, "page")) {
     await sendMonitorPageWebhook({
       teamId: job.data.team_id,
       monitorId: monitoring.monitorId,

--- a/apps/api/src/services/monitoring/runner.test.ts
+++ b/apps/api/src/services/monitoring/runner.test.ts
@@ -7,6 +7,7 @@ import {
   findCompletedSearchTargetRun,
   isMonitorCheckStale,
   MONITOR_CHECK_STALE_TIMEOUT_MS,
+  withFinalizeTimeout,
 } from "./runner";
 
 describe("monitoring runner", () => {
@@ -177,5 +178,39 @@ describe("findCompletedSearchTargetRun (redelivery idempotency)", () => {
     expect(findCompletedSearchTargetRun([], "t1")).toBeNull();
     expect(findCompletedSearchTargetRun("nope", "t1")).toBeNull();
     expect(findCompletedSearchTargetRun([null, "x", 5], "t1")).toBeNull();
+  });
+});
+
+describe("withFinalizeTimeout", () => {
+  it("resolves with the work result and never aborts on success", async () => {
+    let observed: boolean | undefined;
+    const result = await withFinalizeTimeout(async signal => {
+      observed = signal.aborted;
+      return "ok";
+    }, "fast work");
+    expect(result).toBe("ok");
+    expect(observed).toBe(false);
+  });
+
+  it("aborts the signal so stalled work stops issuing writes after a timeout", async () => {
+    const writes: number[] = [];
+    const promise = withFinalizeTimeout(
+      async signal => {
+        // Simulate a finalize tail that gates each write on the signal: the first
+        // write lands, then the timeout fires and the rest must be skipped.
+        for (let i = 0; i < 5; i++) {
+          if (signal.aborted) return;
+          writes.push(i);
+          await new Promise(resolve => setTimeout(resolve, 20));
+        }
+      },
+      "stalled tail",
+      10,
+    );
+
+    await expect(promise).rejects.toThrow(/exceeded 10ms/);
+    // Let any orphaned iterations run; they must observe the abort and stop.
+    await new Promise(resolve => setTimeout(resolve, 60));
+    expect(writes).toEqual([0]);
   });
 });

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -48,6 +48,7 @@ import {
   listRunningMonitorChecks,
   markMonitorRunning,
   updateMonitorCheck,
+  updateMonitorCheckIfRunning,
   updateMonitorScheduleAfterRun,
   upsertMonitorPage,
 } from "./store";
@@ -1050,20 +1051,24 @@ class MonitorFinalizeTimeoutError extends Error {
 }
 
 // Reject (not resolve) on timeout so a stalled write fails fast into the catch path.
-async function withFinalizeTimeout<T>(
-  work: () => Promise<T>,
+// The race rejects but can't truly cancel work(); we abort a signal so work() can
+// cooperatively stop issuing further writes, otherwise a stalled write may land
+// AFTER the catch has marked the check terminal — corrupting cross-run dedup state.
+export async function withFinalizeTimeout<T>(
+  work: (signal: AbortSignal) => Promise<T>,
   what: string,
   ms: number = MONITOR_FINALIZE_WRITE_TIMEOUT_MS,
 ): Promise<T> {
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new MonitorFinalizeTimeoutError(what, ms)),
-      ms,
-    );
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new MonitorFinalizeTimeoutError(what, ms));
+    }, ms);
   });
   try {
-    return await Promise.race([work(), timeout]);
+    return await Promise.race([work(controller.signal), timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }
@@ -1175,8 +1180,19 @@ async function runMonitorSearchTarget(params: {
     };
   });
 
-  await withFinalizeTimeout(async () => {
+  await withFinalizeTimeout(async signal => {
+    // Per-check rows first: idempotent (delete+insert replace) and not read across runs.
+    // Clear rows from a prior (crashed/redelivered) run so the insert is a replace, not a duplicate.
+    if (signal.aborted) return;
+    await deleteMonitorCheckPages({ checkId: check.id, targetId: target.id });
+    if (signal.aborted) return;
+    await insertMonitorCheckPages(pages);
+
+    // Durable cross-run dedup baseline last, so a timeout before this point leaves
+    // monitor_pages untouched and the next run re-alerts. Pass the signal so an
+    // orphaned write that outran the timeout can't baseline a now-failed check.
     for (let i = 0; i < pages.length; i++) {
+      if (signal.aborted) return;
       const page = pages[i];
       await upsertMonitorPage({
         monitorId: monitor.id,
@@ -1188,12 +1204,9 @@ async function runMonitorSearchTarget(params: {
         scrapeId: null,
         status: page.status,
         metadata: page.metadata as Record<string, unknown>,
+        abortSignal: signal,
       });
     }
-
-    // Clear rows from a prior (crashed/redelivered) run so the insert is a replace, not a duplicate.
-    await deleteMonitorCheckPages({ checkId: check.id, targetId: target.id });
-    await insertMonitorCheckPages(pages);
   }, "monitor search page-write tail");
 
   for (const page of pages) {
@@ -1362,10 +1375,14 @@ export async function processMonitorCheckJob(
         // Persist searchCompleted now so a crash/redelivery short-circuits via
         // findCompletedSearchTargetRun instead of re-running and re-billing.
         await withFinalizeTimeout(
-          () =>
-            updateMonitorCheck(check.id, {
-              target_results: targetResults,
-            }),
+          signal =>
+            signal.aborted
+              ? Promise.resolve(null)
+              : // Atomic guard: if this write outran the timeout and the catch
+                // already failed the check, no-op instead of stamping searchCompleted.
+                updateMonitorCheckIfRunning(check.id, {
+                  target_results: targetResults,
+                }),
           "monitor search searchCompleted flush",
         );
       }

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -1038,6 +1038,37 @@ async function enqueueMonitorCrawlTarget(params: {
 
 // Runs inline, persisting onto the same monitor_pages / monitor_check_pages
 // tables the reconciler tallies.
+// Bound the inline finalize writes: under write-pool exhaustion they can wait forever,
+// stranding the check until the 10-min reaper. Throw so the catch fails it fast instead.
+const MONITOR_FINALIZE_WRITE_TIMEOUT_MS = 60_000;
+
+class MonitorFinalizeTimeoutError extends Error {
+  constructor(what: string, ms: number) {
+    super(`${what} exceeded ${ms}ms`);
+    this.name = "MonitorFinalizeTimeoutError";
+  }
+}
+
+// Reject (not resolve) on timeout so a stalled write fails fast into the catch path.
+async function withFinalizeTimeout<T>(
+  work: () => Promise<T>,
+  what: string,
+  ms: number = MONITOR_FINALIZE_WRITE_TIMEOUT_MS,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new MonitorFinalizeTimeoutError(what, ms)),
+      ms,
+    );
+  });
+  try {
+    return await Promise.race([work(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function runMonitorSearchTarget(params: {
   monitor: MonitorRow;
   check: MonitorCheckRow;
@@ -1144,24 +1175,26 @@ async function runMonitorSearchTarget(params: {
     };
   });
 
-  for (let i = 0; i < pages.length; i++) {
-    const page = pages[i];
-    await upsertMonitorPage({
-      monitorId: monitor.id,
-      teamId: monitor.team_id,
-      targetId: target.id,
-      url: page.url,
-      source: "discovered",
-      checkId: check.id,
-      scrapeId: null,
-      status: page.status,
-      metadata: page.metadata as Record<string, unknown>,
-    });
-  }
+  await withFinalizeTimeout(async () => {
+    for (let i = 0; i < pages.length; i++) {
+      const page = pages[i];
+      await upsertMonitorPage({
+        monitorId: monitor.id,
+        teamId: monitor.team_id,
+        targetId: target.id,
+        url: page.url,
+        source: "discovered",
+        checkId: check.id,
+        scrapeId: null,
+        status: page.status,
+        metadata: page.metadata as Record<string, unknown>,
+      });
+    }
 
-  // Clear rows from a prior (crashed/redelivered) run so the insert is a replace, not a duplicate.
-  await deleteMonitorCheckPages({ checkId: check.id, targetId: target.id });
-  await insertMonitorCheckPages(pages);
+    // Clear rows from a prior (crashed/redelivered) run so the insert is a replace, not a duplicate.
+    await deleteMonitorCheckPages({ checkId: check.id, targetId: target.id });
+    await insertMonitorCheckPages(pages);
+  }, "monitor search page-write tail");
 
   for (const page of pages) {
     if (page.status !== "new" && page.status !== "error") continue;
@@ -1326,12 +1359,15 @@ export async function processMonitorCheckJob(
         targetRun.resultsJudged = searchResult.resultsJudged;
         // Set last, after credits are stamped, so the reconciler never finalizes with credits at 0.
         targetRun.searchCompleted = true;
-        // Persist now, not just at end-of-loop: the search work already happened,
-        // so a crash before the final flush would re-run and re-scrape everything;
-        // flushing searchCompleted lets findCompletedSearchTargetRun short-circuit.
-        await updateMonitorCheck(check.id, {
-          target_results: targetResults,
-        });
+        // Persist searchCompleted now so a crash/redelivery short-circuits via
+        // findCompletedSearchTargetRun instead of re-running and re-billing.
+        await withFinalizeTimeout(
+          () =>
+            updateMonitorCheck(check.id, {
+              target_results: targetResults,
+            }),
+          "monitor search searchCompleted flush",
+        );
       }
     }
 

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -35,6 +35,7 @@ import { createWebhookSender, WebhookEvent } from "../webhook";
 import { sendMonitorPageWebhook } from "./results";
 import { sendMonitoringEmailSummary } from "../notification/monitoring_email";
 import {
+  bulkUpsertMonitorPages,
   calculateMonitorCheckActualCredits,
   getMonitorCheck,
   getMonitorForUpdate,
@@ -779,7 +780,10 @@ async function billMonitorCheck(params: {
       autumnTrackInRequest: Boolean(params.lockId),
     },
     {
-      jobId: uuidv7(),
+      // Deterministic per check so a re-finalize (e.g. the reconciler re-running this
+      // check after the finalize lock TTL expired mid-finalize) re-enqueues the SAME
+      // job id and the billing queue dedups it instead of charging the team twice.
+      jobId: `monitor-bill:${params.check.id}`,
       priority: 10,
     },
   );
@@ -1189,24 +1193,24 @@ async function runMonitorSearchTarget(params: {
     await insertMonitorCheckPages(pages);
 
     // Durable cross-run dedup baseline last, so a timeout before this point leaves
-    // monitor_pages untouched and the next run re-alerts. Pass the signal so an
-    // orphaned write that outran the timeout can't baseline a now-failed check.
-    for (let i = 0; i < pages.length; i++) {
-      if (signal.aborted) return;
-      const page = pages[i];
-      await upsertMonitorPage({
-        monitorId: monitor.id,
-        teamId: monitor.team_id,
-        targetId: target.id,
+    // monitor_pages untouched and the next run re-alerts. One bulk upsert (~3 round-
+    // trips) instead of ~2N sequential pool acquisitions that stalled finalization;
+    // the signal lets an aborted finalize skip the write entirely.
+    await bulkUpsertMonitorPages({
+      monitorId: monitor.id,
+      teamId: monitor.team_id,
+      targetId: target.id,
+      checkId: check.id,
+      rows: pages.map(page => ({
         url: page.url,
-        source: "discovered",
-        checkId: check.id,
-        scrapeId: null,
+        urlHash: page.url_hash,
         status: page.status,
         metadata: page.metadata as Record<string, unknown>,
-        abortSignal: signal,
-      });
-    }
+        source: "discovered",
+        scrapeId: null,
+      })),
+      abortSignal: signal,
+    });
   }, "monitor search page-write tail");
 
   for (const page of pages) {

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -11,9 +11,7 @@ import {
   resolveNewGroupBackend,
 } from "../worker/nuq-router";
 import { ScrapeJobData } from "../../types";
-import { getJobFromGCS } from "../../lib/gcs-jobs";
 import { includesFormat } from "../../lib/format-utils";
-import { computeAndPersistPageDiff } from "./diff-orchestrator";
 import { normalizeMonitorFormats } from "./diff";
 import { autumnService } from "../autumn/autumn.service";
 import { getBillingQueue } from "../queue-service";
@@ -39,9 +37,7 @@ import {
   calculateMonitorCheckActualCredits,
   getMonitorCheck,
   getMonitorForUpdate,
-  getMonitorPage,
   countMonitorCheckPages,
-  hashMonitorUrl,
   insertMonitorCheckPages,
   deleteMonitorCheckPages,
   listActiveMonitorPages,
@@ -78,7 +74,6 @@ import {
 } from "./search/persist";
 
 const logger = _logger.child({ module: "monitoring-runner" });
-const poll = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 export { isMonitorCheckStale, MONITOR_CHECK_STALE_TIMEOUT_MS };
 
 const MONITOR_NOTIFY_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -244,16 +239,6 @@ function withMonitorScrapeDefaults(
   };
 }
 
-function getDocumentUrl(doc: any, fallback: string): string {
-  return doc?.metadata?.sourceURL ?? doc?.metadata?.url ?? doc?.url ?? fallback;
-}
-
-function getDocumentStatusCode(doc: any): number | null {
-  return typeof doc?.metadata?.statusCode === "number"
-    ? doc.metadata.statusCode
-    : null;
-}
-
 export function estimateActualCredits(doc: any, options?: any): number {
   // Prefer the credits the scrape path actually recorded when present.
   const creditsUsed = doc?.metadata?.creditsUsed;
@@ -269,67 +254,6 @@ export function estimateActualCredits(doc: any, options?: any): number {
   if (includesFormat(formats, "deterministicJson")) return 7;
   if (includesFormat(formats, "json")) return 5;
   return 1;
-}
-
-async function runSingleScrape(params: {
-  monitor: MonitorRow;
-  check: MonitorCheckRow;
-  target: MonitorTarget;
-  url: string;
-  requestId?: string;
-}): Promise<{ scrapeId: string; doc: any; credits: number }> {
-  const scrapeId = uuidv7();
-  const scrapeOptions = scrapeRequestSchema.parse({
-    url: params.url,
-    ...withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
-    origin: "monitor",
-  });
-
-  await logRequest({
-    id: scrapeId,
-    kind: "scrape",
-    api_version: "v2",
-    team_id: params.monitor.team_id,
-    origin: "monitor",
-    integration: null,
-    target_hint: params.url,
-    zeroDataRetention: false,
-    api_key_id: null,
-  });
-
-  const internalOptions = {
-    teamId: params.monitor.team_id,
-    saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
-    bypassBilling: true,
-    zeroDataRetention: false,
-  };
-  const job: NuQJob<ScrapeJobData> = {
-    id: scrapeId,
-    status: "active",
-    createdAt: new Date(),
-    priority: 20,
-    data: {
-      mode: "single_urls",
-      url: params.url,
-      team_id: params.monitor.team_id,
-      scrapeOptions,
-      internalOptions,
-      skipNuq: true,
-      origin: "monitor",
-      integration: null,
-      billing: { endpoint: "monitor", jobId: params.check.id },
-      requestId: params.requestId,
-      zeroDataRetention: false,
-      apiKeyId: null,
-    },
-  };
-
-  const doc = await processJobInternal(job);
-  return {
-    scrapeId,
-    doc,
-    credits: estimateActualCredits(doc, params.target.scrapeOptions),
-  };
 }
 
 // Deep-mode search-monitor page scrape, inline (skipNuq) so it bypasses scrape
@@ -397,339 +321,6 @@ async function scrapeSearchMonitorPage(params: {
     metadata: {
       publishedTime: doc.metadata?.publishedTime ?? null,
       modifiedTime: doc.metadata?.modifiedTime ?? null,
-    },
-  };
-}
-
-async function diffAndPersistPage(params: {
-  monitor: MonitorRow;
-  check: MonitorCheckRow;
-  target: MonitorTarget;
-  url: string;
-  scrapeId: string;
-  doc: any;
-  source: "explicit" | "discovered";
-  creditsUsed?: number;
-}): Promise<PageResult> {
-  const previous = await getMonitorPage({
-    monitorId: params.monitor.id,
-    targetId: params.target.id,
-    url: params.url,
-  });
-
-  const ctFormat = Array.isArray(params.target.scrapeOptions?.formats)
-    ? (params.target.scrapeOptions!.formats as any[]).find(
-        (f: any) => f?.type === "changeTracking",
-      )
-    : undefined;
-  const { status, diffGcsKey, diffTextBytes, diffJsonBytes, judgment, error } =
-    await computeAndPersistPageDiff({
-      teamId: params.monitor.team_id,
-      monitorId: params.monitor.id,
-      checkId: params.check.id,
-      url: params.url,
-      scrapeId: params.scrapeId,
-      doc: params.doc,
-      previous: previous
-        ? {
-            last_scrape_id: previous.last_scrape_id,
-            is_removed: previous.is_removed,
-          }
-        : null,
-      formats: params.target.scrapeOptions?.formats,
-      goal: params.monitor.judge_enabled ? params.monitor.goal : null,
-      extractionPrompt: ctFormat?.prompt ?? null,
-    });
-
-  await upsertMonitorPage({
-    monitorId: params.monitor.id,
-    teamId: params.monitor.team_id,
-    targetId: params.target.id,
-    url: params.url,
-    source: params.source,
-    checkId: params.check.id,
-    scrapeId: params.scrapeId,
-    status,
-    metadata: {
-      title: params.doc?.metadata?.title ?? null,
-      statusCode: getDocumentStatusCode(params.doc),
-      contentType: params.doc?.metadata?.contentType ?? null,
-      numPages: params.doc?.metadata?.numPages ?? null,
-      proxyUsed: params.doc?.metadata?.proxyUsed ?? null,
-      postprocessorsUsed: params.doc?.metadata?.postprocessorsUsed ?? null,
-      creditsUsed: params.creditsUsed ?? null,
-    },
-  });
-
-  return {
-    check_id: params.check.id,
-    monitor_id: params.monitor.id,
-    team_id: params.monitor.team_id,
-    target_id: params.target.id,
-    url: params.url,
-    url_hash: hashMonitorUrl(params.url),
-    status,
-    previous_scrape_id: previous?.last_scrape_id ?? null,
-    current_scrape_id: params.scrapeId,
-    diff_gcs_key: diffGcsKey,
-    diff_text_bytes: diffTextBytes,
-    diff_json_bytes: diffJsonBytes,
-    status_code: getDocumentStatusCode(params.doc),
-    ...(error ? { error } : {}),
-    metadata: {
-      title: params.doc?.metadata?.title ?? null,
-      contentType: params.doc?.metadata?.contentType ?? null,
-      numPages: params.doc?.metadata?.numPages ?? null,
-      proxyUsed: params.doc?.metadata?.proxyUsed ?? null,
-      postprocessorsUsed: params.doc?.metadata?.postprocessorsUsed ?? null,
-      creditsUsed: params.creditsUsed ?? null,
-    },
-    judgment,
-    emailStatus: status,
-  };
-}
-
-async function runScrapeTarget(params: {
-  monitor: MonitorRow;
-  check: MonitorCheckRow;
-  target: MonitorTarget;
-}): Promise<{ pages: PageResult[]; credits: number; targetResult: any }> {
-  if (params.target.type !== "scrape") {
-    return { pages: [], credits: 0, targetResult: null };
-  }
-
-  const pages: PageResult[] = [];
-  let credits = 0;
-
-  for (const url of params.target.urls) {
-    try {
-      const result = await runSingleScrape({
-        monitor: params.monitor,
-        check: params.check,
-        target: params.target,
-        url,
-      });
-      credits += result.credits;
-      pages.push(
-        await diffAndPersistPage({
-          monitor: params.monitor,
-          check: params.check,
-          target: params.target,
-          url,
-          scrapeId: result.scrapeId,
-          doc: result.doc,
-          source: "explicit",
-          creditsUsed: result.credits,
-        }),
-      );
-    } catch (error) {
-      pages.push({
-        check_id: params.check.id,
-        monitor_id: params.monitor.id,
-        team_id: params.monitor.team_id,
-        target_id: params.target.id,
-        url,
-        url_hash: hashMonitorUrl(url),
-        status: "error",
-        error: error instanceof Error ? error.message : String(error),
-        emailStatus: "error",
-      });
-    }
-  }
-
-  return {
-    pages,
-    credits,
-    targetResult: {
-      targetId: params.target.id,
-      type: params.target.type,
-      pages: pages.length,
-      credits,
-    },
-  };
-}
-
-async function runCrawlTarget(params: {
-  monitor: MonitorRow;
-  check: MonitorCheckRow;
-  target: MonitorTarget;
-}): Promise<{ pages: PageResult[]; credits: number; targetResult: any }> {
-  if (params.target.type !== "crawl") {
-    return { pages: [], credits: 0, targetResult: null };
-  }
-
-  const crawlId = uuidv7();
-  const body = crawlRequestSchema.parse({
-    url: params.target.url,
-    ...(params.target.crawlOptions ?? {}),
-    scrapeOptions: withMonitorScrapeDefaults(params.target.scrapeOptions ?? {}),
-    origin: "monitor",
-  }) as CrawlRequest;
-
-  await logRequest({
-    id: crawlId,
-    kind: "crawl",
-    api_version: "v2",
-    team_id: params.monitor.team_id,
-    origin: "monitor",
-    integration: null,
-    target_hint: body.url,
-    zeroDataRetention: false,
-    api_key_id: null,
-  });
-
-  const crawlerOptions = {
-    ...body,
-    url: undefined,
-    scrapeOptions: undefined,
-    prompt: undefined,
-  };
-
-  const sc: StoredCrawl = {
-    originUrl: body.url,
-    crawlerOptions: toV0CrawlerOptions(crawlerOptions),
-    scrapeOptions: body.scrapeOptions,
-    internalOptions: {
-      disableSmartWaitCache: true,
-      teamId: params.monitor.team_id,
-      saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
-      zeroDataRetention: false,
-      bypassBilling: true,
-    },
-    team_id: params.monitor.team_id,
-    createdAt: Date.now(),
-    maxConcurrency: body.maxConcurrency,
-    zeroDataRetention: false,
-  };
-
-  const crawler = crawlToCrawler(crawlId, sc, null);
-  try {
-    sc.robots = await crawler.getRobotsTxt(
-      body.scrapeOptions.skipTlsVerification,
-    );
-  } catch {
-    // Non-fatal robots fetch failure, same as the public crawl controller.
-  }
-
-  sc.queueBackend = await resolveNewGroupBackend(sc.team_id);
-  await crawlGroup.addGroup(crawlId, sc.team_id, 24 * 60 * 60 * 1000, {
-    backend: sc.queueBackend,
-    maxConcurrency: sc.maxConcurrency,
-    delaySeconds: sc.crawlerOptions?.delay,
-  });
-  await saveCrawl(crawlId, sc);
-  await markCrawlActive(crawlId);
-
-  await _addScrapeJobToBullMQ(
-    {
-      url: body.url,
-      mode: "kickoff",
-      team_id: params.monitor.team_id,
-      crawlerOptions,
-      scrapeOptions: sc.scrapeOptions,
-      internalOptions: sc.internalOptions,
-      origin: "monitor",
-      integration: null,
-      billing: { endpoint: "monitor", jobId: params.check.id },
-      crawl_id: crawlId,
-      v1: true,
-      zeroDataRetention: false,
-      apiKeyId: null,
-    },
-    uuidv7(),
-  );
-
-  const started = Date.now();
-  let status = "scraping";
-  let total = 0;
-  while (Date.now() - started < 30 * 60 * 1000) {
-    const group = await crawlGroup.getGroup(crawlId);
-    const stats = await scrapeQueue.getGroupNumericStats(crawlId, logger);
-    status = group?.status ?? "scraping";
-    total =
-      (stats.completed ?? 0) +
-      (stats.active ?? 0) +
-      (stats.queued ?? 0) +
-      (stats.backlog ?? 0);
-    if (status !== "active" && status !== "scraping") break;
-    await poll(1000);
-  }
-
-  const doneJobs = await scrapeQueue.getCrawlJobsForListing(
-    crawlId,
-    Math.max(total, 1),
-    0,
-    logger,
-  );
-
-  const pages: PageResult[] = [];
-  const seen = new Set<string>();
-  let credits = 0;
-
-  for (const job of doneJobs) {
-    const doc = job.returnvalue ?? (await getJobFromGCS(job.id))?.[0];
-    if (!doc) continue;
-    const url = getDocumentUrl(doc, (job.data as any)?.url ?? body.url);
-    seen.add(hashMonitorUrl(url).toString("hex"));
-    const pageCredits = estimateActualCredits(doc, body.scrapeOptions);
-    credits += pageCredits;
-    pages.push(
-      await diffAndPersistPage({
-        monitor: params.monitor,
-        check: params.check,
-        target: params.target,
-        url,
-        scrapeId: job.id,
-        doc,
-        source: "discovered",
-        creditsUsed: pageCredits,
-      }),
-    );
-  }
-
-  if (status === "completed") {
-    const previousPages = await listActiveMonitorPages({
-      monitorId: params.monitor.id,
-      targetId: params.target.id,
-    });
-    for (const previous of previousPages) {
-      if (seen.has(previous.url_hash.toString("hex"))) continue;
-      await upsertMonitorPage({
-        monitorId: params.monitor.id,
-        teamId: params.monitor.team_id,
-        targetId: params.target.id,
-        url: previous.url,
-        source: previous.source,
-        checkId: params.check.id,
-        scrapeId: previous.last_scrape_id,
-        status: "removed",
-        metadata: previous.metadata,
-      });
-      pages.push({
-        check_id: params.check.id,
-        monitor_id: params.monitor.id,
-        team_id: params.monitor.team_id,
-        target_id: params.target.id,
-        url: previous.url,
-        url_hash: previous.url_hash,
-        status: "removed",
-        previous_scrape_id: previous.last_scrape_id,
-        current_scrape_id: null,
-        emailStatus: "removed",
-      });
-    }
-  }
-
-  return {
-    pages,
-    credits,
-    targetResult: {
-      targetId: params.target.id,
-      type: params.target.type,
-      crawlId,
-      status,
-      pages: pages.length,
-      credits,
     },
   };
 }
@@ -1396,6 +987,23 @@ export async function processMonitorCheckJob(
       target_results: targetResults,
     });
   } catch (error) {
+    // Atomically flip running -> failed. Returns null when the check already
+    // reached a terminal status — i.e. the reconciler finalized it (completed,
+    // billed, lock confirmed) before this late catch ran. In that case we must
+    // not clobber its terminal state or release its now-confirmed credit lock;
+    // the reconciler already owns billing, notifications, and scheduling.
+    const failed = await updateMonitorCheckIfRunning(check.id, {
+      status: "failed",
+      finished_at: new Date().toISOString(),
+      billing_status: lockId ? "released" : "failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    if (!failed) {
+      throw error;
+    }
+    check = failed;
+
     if (lockId) {
       await autumnService.finalizeCreditsLock({
         lockId,
@@ -1407,13 +1015,6 @@ export async function processMonitorCheckJob(
         },
       });
     }
-
-    check = await updateMonitorCheck(check.id, {
-      status: "failed",
-      finished_at: new Date().toISOString(),
-      billing_status: lockId ? "released" : "failed",
-      error: error instanceof Error ? error.message : String(error),
-    });
 
     if (
       await claimMonitorNotification(check.id).catch(error => {
@@ -1724,10 +1325,16 @@ export async function reconcileRunningMonitorChecks(
 
       if (await failStaleMonitorCheck({ monitor, check })) continue;
 
+      // Snapshot from listRunningMonitorChecks; may be stale relative to the
+      // inline handler that is still writing this check.
       let targetResults = Array.isArray(check.target_results)
         ? ([...check.target_results] as any[])
         : [];
-      if (targetResults.length === 0) {
+      // True only when the persisted snapshot was empty and we rebuild the target
+      // runs from recorded pages. That is the only case it is safe to write back
+      // below: there is no live target_results to overwrite.
+      const recoveredFromEmpty = targetResults.length === 0;
+      if (recoveredFromEmpty) {
         targetResults = await recoverTargetRunsFromRecordedPages({
           monitor,
           check,
@@ -1749,7 +1356,13 @@ export async function reconcileRunningMonitorChecks(
           monitor,
         ))
       ) {
-        if (targetResults.length > 0) {
+        // Only persist target_results we recovered from an empty snapshot. Writing
+        // back a non-empty stale snapshot here can DOWNGRADE a searchCompleted=true
+        // that the inline handler persisted after this reconciler loaded its
+        // snapshot, reverting the marker and stranding the check until the stale
+        // reaper. The complete-path write below is safe: a search target can only
+        // be complete once its snapshot already carries searchCompleted=true.
+        if (recoveredFromEmpty && targetResults.length > 0) {
           await updateMonitorCheck(check.id, { target_results: targetResults });
         }
         continue;

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -374,7 +374,7 @@ async function billMonitorCheck(params: {
       // Deterministic per check so a re-finalize (e.g. the reconciler re-running this
       // check after the finalize lock TTL expired mid-finalize) re-enqueues the SAME
       // job id and the billing queue dedups it instead of charging the team twice.
-      jobId: `monitor-bill:${params.check.id}`,
+      jobId: `monitor-bill-${params.check.id}`,
       priority: 10,
     },
   );

--- a/apps/api/src/services/monitoring/search/run.ts
+++ b/apps/api/src/services/monitoring/search/run.ts
@@ -46,8 +46,15 @@ function evaluateSerpCandidate(
       knownCurrent?.lastCheckedAt &&
       Date.now() - Date.parse(knownCurrent.lastCheckedAt) > recheckMs,
   );
+  // A prior transient scrape failure (timeout / anti-bot / budget-exceeded) persists
+  // the URL as "skipped". Without this, reuse would re-emit "skipped" forever and the
+  // result is never re-scraped or re-judged — a real alert silently lost. Retry it.
+  const wasSkipped = knownCurrent?.lastStatus === "skipped";
   const isNewOrChanged =
-    !knownCurrent || knownCurrent.fingerprint !== fingerprint || dueForRecheck;
+    !knownCurrent ||
+    knownCurrent.fingerprint !== fingerprint ||
+    dueForRecheck ||
+    wasSkipped;
   return { canonical, fingerprint, knownCurrent, isNewOrChanged };
 }
 

--- a/apps/api/src/services/monitoring/store-bulk-upsert.test.ts
+++ b/apps/api/src/services/monitoring/store-bulk-upsert.test.ts
@@ -1,0 +1,62 @@
+// The db client is mocked so the abort/empty guards can assert no query is issued.
+// bulkUpsertMonitorPages' actual SQL behavior (the ON CONFLICT field rules) is
+// covered by the Docker integration test against a real Postgres — a mock can't
+// exercise the enum / CASE semantics, which is exactly where the prior bugs hid.
+const { dbInsert } = vi.hoisted(() => ({ dbInsert: vi.fn() }));
+
+vi.mock("../../db/connection", () => ({
+  db: { insert: dbInsert },
+  dbRr: { select: vi.fn() },
+  dbIndex: { select: vi.fn() },
+}));
+
+import { bulkUpsertMonitorPages } from "./store";
+
+const hash = (hex: string) => Buffer.from(hex, "hex");
+
+beforeEach(() => {
+  dbInsert.mockReset();
+});
+
+describe("bulkUpsertMonitorPages guards", () => {
+  it("writes nothing when the abort signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      bulkUpsertMonitorPages({
+        monitorId: "m1",
+        teamId: "t1",
+        targetId: "tg1",
+        checkId: "c1",
+        rows: [
+          {
+            url: "https://example.com/a",
+            urlHash: hash("aa"),
+            status: "new",
+            metadata: {},
+            source: "discovered",
+            scrapeId: null,
+          },
+        ],
+        abortSignal: controller.signal,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when there are no rows", async () => {
+    await expect(
+      bulkUpsertMonitorPages({
+        monitorId: "m1",
+        teamId: "t1",
+        targetId: "tg1",
+        checkId: "c1",
+        rows: [],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -886,23 +886,27 @@ export async function insertMonitorCheckPages(
   );
 }
 
-// Makes the inline search write idempotent: a redelivered check clears its prior
-// (check, target) rows before re-inserting, so crash-and-redeliver can't duplicate
-// pages. Partition-safe (no unique constraint needed).
+// Makes an inline write idempotent: a redelivered check clears its prior rows
+// before re-inserting, so crash-and-redeliver can't duplicate pages. Pass `url`
+// to scope the clear to a single page so the per-URL scrape path replaces only
+// its own row without clobbering sibling pages of the same target. Partition-safe
+// (no unique constraint needed).
 export async function deleteMonitorCheckPages(params: {
   checkId: string;
   targetId: string;
+  url?: string;
 }): Promise<void> {
+  const conditions = [
+    eq(schema.monitor_check_pages.check_id, params.checkId),
+    eq(schema.monitor_check_pages.target_id, params.targetId),
+  ];
+  if (params.url !== undefined) {
+    conditions.push(
+      eq(schema.monitor_check_pages.url_hash, hashMonitorUrl(params.url)),
+    );
+  }
   await run(
-    () =>
-      db
-        .delete(schema.monitor_check_pages)
-        .where(
-          and(
-            eq(schema.monitor_check_pages.check_id, params.checkId),
-            eq(schema.monitor_check_pages.target_id, params.targetId),
-          ),
-        ),
+    () => db.delete(schema.monitor_check_pages).where(and(...conditions)),
     "Failed to delete monitor check pages",
   );
 }

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import { v7 as uuidv7 } from "uuid";
-import { and, asc, count, desc, eq, isNull, ne } from "drizzle-orm";
+import { and, asc, count, desc, eq, isNull, ne, sql } from "drizzle-orm";
 import { db, dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { monitoringClaimDueMonitors } from "../../db/rpc";
@@ -1097,6 +1097,108 @@ export async function upsertMonitorPage(params: {
         .set(patch)
         .where(eq(schema.monitor_pages.id, existing.id)),
     "Failed to update monitor page",
+  );
+}
+
+type BulkUpsertMonitorPageRow = {
+  url: string;
+  urlHash?: Buffer;
+  status: "same" | "new" | "changed" | "removed" | "error";
+  metadata?: unknown;
+  source: "explicit" | "discovered";
+  scrapeId: string | null;
+};
+
+// Bulk equivalent of upsertMonitorPage: collapses an N-page upsert from ~2N
+// sequential round-trips (replica read + primary write per page) into ONE atomic
+// INSERT ... ON CONFLICT DO UPDATE keyed by the (monitor_id, target_id, url_hash)
+// unique index. Per-row field rules mirror upsertMonitorPage exactly, expressed in
+// the conflict set via `excluded` + CASE so no read is needed and Drizzle handles
+// the enum/jsonb column types (no hand-written casts that can drift from the schema).
+export async function bulkUpsertMonitorPages(params: {
+  monitorId: string;
+  teamId: string;
+  targetId: string;
+  checkId: string;
+  rows: BulkUpsertMonitorPageRow[];
+  // When finalize times out the caller aborts this signal; we then skip the whole
+  // write so an aborted finalize leaves monitor_pages untouched (no partial baseline).
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  if (params.abortSignal?.aborted) return;
+
+  // Dedup by url_hash (last wins) so a repeated URL can't double-insert, and sort
+  // by url_hash for a deterministic row-lock order.
+  const byHash = new Map<
+    string,
+    BulkUpsertMonitorPageRow & { urlHash: Buffer }
+  >();
+  for (const row of params.rows) {
+    const urlHash = row.urlHash ?? hashMonitorUrl(row.url);
+    byHash.set(urlHash.toString("hex"), { ...row, urlHash });
+  }
+  if (byHash.size === 0) return;
+  const rows = [...byHash.values()].sort((a, b) =>
+    a.urlHash.toString("hex") < b.urlHash.toString("hex") ? -1 : 1,
+  );
+
+  const now = new Date().toISOString();
+
+  // Build every row as if newly inserted; ON CONFLICT applies the existing-row
+  // rules via `excluded` + CASE so the whole upsert is ONE atomic statement — no
+  // separate read, no separate update — and Drizzle maps the enum/jsonb types from
+  // the schema, so there are no hand-written casts that can drift from the columns.
+  const values = rows.map(row => {
+    const isRemoved = row.status === "removed";
+    const isChangedOrNew = row.status === "changed" || row.status === "new";
+    return {
+      monitor_id: params.monitorId,
+      team_id: params.teamId,
+      target_id: params.targetId,
+      url: row.url,
+      url_hash: row.urlHash,
+      source: row.source,
+      first_seen_check_id: params.checkId,
+      last_seen_check_id: isRemoved ? null : params.checkId,
+      last_changed_check_id: isChangedOrNew ? params.checkId : null,
+      last_scrape_id: row.scrapeId,
+      last_status: row.status,
+      is_removed: isRemoved,
+      removed_at: isRemoved ? now : null,
+      metadata: row.metadata ?? null,
+      created_at: now,
+      updated_at: now,
+    };
+  });
+
+  if (params.abortSignal?.aborted) return;
+
+  await run(
+    () =>
+      db
+        .insert(schema.monitor_pages)
+        .values(values)
+        .onConflictDoUpdate({
+          target: [
+            schema.monitor_pages.monitor_id,
+            schema.monitor_pages.target_id,
+            schema.monitor_pages.url_hash,
+          ],
+          set: {
+            last_status: sql`excluded.last_status`,
+            is_removed: sql`excluded.is_removed`,
+            removed_at: sql`excluded.removed_at`,
+            // Preserve prior metadata when the new row carries none.
+            metadata: sql`coalesce(excluded.metadata, ${schema.monitor_pages.metadata})`,
+            // last_seen / last_scrape advance only when not removed; else preserved.
+            last_seen_check_id: sql`case when excluded.is_removed then ${schema.monitor_pages.last_seen_check_id} else excluded.last_seen_check_id end`,
+            last_scrape_id: sql`case when excluded.is_removed then ${schema.monitor_pages.last_scrape_id} else excluded.last_scrape_id end`,
+            // last_changed advances only on new/changed; first_seen is never touched.
+            last_changed_check_id: sql`case when excluded.last_status in ('new','changed') then excluded.last_changed_check_id else ${schema.monitor_pages.last_changed_check_id} end`,
+            updated_at: sql`excluded.updated_at`,
+          },
+        }),
+    "Failed to bulk upsert monitor pages",
   );
 }
 

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -840,6 +840,34 @@ export async function updateMonitorCheck(
   return data as MonitorCheckRow;
 }
 
+// Atomic variant of updateMonitorCheck that only writes while the check is still
+// running. A late finalize write that lost the race to the catch path (which marks
+// the check failed) becomes a no-op instead of stamping results/searchCompleted onto
+// an already-terminal check. Returns the row if it applied, else null.
+export async function updateMonitorCheckIfRunning(
+  checkId: string,
+  patch: Partial<MonitorCheckRow>,
+): Promise<MonitorCheckRow | null> {
+  const [data] = await run(
+    () =>
+      db
+        .update(schema.monitor_checks)
+        .set({
+          ...patch,
+          updated_at: new Date().toISOString(),
+        })
+        .where(
+          and(
+            eq(schema.monitor_checks.id, checkId),
+            eq(schema.monitor_checks.status, "running"),
+          ),
+        )
+        .returning(),
+    "Failed to update monitor check",
+  );
+  return (data as MonitorCheckRow) ?? null;
+}
+
 export async function insertMonitorCheckPages(
   pages: MonitorCheckPageInsert[],
 ): Promise<void> {
@@ -1003,6 +1031,9 @@ export async function upsertMonitorPage(params: {
   scrapeId: string | null;
   status: "same" | "new" | "changed" | "removed" | "error";
   metadata?: unknown;
+  // When the caller's finalize times out it aborts this signal; we then skip the
+  // write so an orphaned baseline can't poison the next run's dedup state.
+  abortSignal?: AbortSignal;
 }): Promise<void> {
   const now = new Date().toISOString();
 
@@ -1011,6 +1042,8 @@ export async function upsertMonitorPage(params: {
     targetId: params.targetId,
     url: params.url,
   });
+
+  if (params.abortSignal?.aborted) return;
 
   if (!existing) {
     await run(

--- a/apps/api/src/services/monitoring/types.ts
+++ b/apps/api/src/services/monitoring/types.ts
@@ -64,20 +64,30 @@ const searchTargetSchema = z.preprocess(
     }
     return value;
   },
-  z.strictObject({
-    id: z.string().uuid().optional(),
-    type: z.literal("search"),
-    queries: z.array(z.string().min(1).max(256)).min(1).max(12),
-    searchWindow: z
-      .enum(["5m", "15m", "1h", "6h", "24h", "7d"], {
-        error: "searchWindow must be one of: 5m, 15m, 1h, 6h, 24h, 7d",
-      })
-      .optional()
-      .default("24h"),
-    includeDomains: z.array(monitorDomainSchema).max(50).optional(),
-    excludeDomains: z.array(monitorDomainSchema).max(50).optional(),
-    maxResults: z.number().int().min(1).max(50).optional().default(10),
-  }),
+  z
+    .strictObject({
+      id: z.string().uuid().optional(),
+      type: z.literal("search"),
+      queries: z.array(z.string().min(1).max(256)).min(1).max(12),
+      searchWindow: z
+        .enum(["5m", "15m", "1h", "6h", "24h", "7d"], {
+          error: "searchWindow must be one of: 5m, 15m, 1h, 6h, 24h, 7d",
+        })
+        .optional()
+        .default("24h"),
+      includeDomains: z.array(monitorDomainSchema).max(50).optional(),
+      excludeDomains: z.array(monitorDomainSchema).max(50).optional(),
+      maxResults: z.number().int().min(1).max(50).optional().default(10),
+    })
+    .superRefine((target, ctx) => {
+      if (target.includeDomains?.length && target.excludeDomains?.length) {
+        ctx.addIssue({
+          code: "custom",
+          message: "includeDomains and excludeDomains are mutually exclusive",
+          path: ["excludeDomains"],
+        });
+      }
+    }),
 );
 
 const monitorTargetSchema = z.union([
@@ -229,6 +239,8 @@ export const updateMonitorSchema = createMonitorBaseSchema
     notification: monitorNotificationInner.optional(),
     // Drop the create-path .default(30): otherwise an omitting PATCH resets configured retention.
     retentionDays: z.number().int().positive().max(365).optional(),
+    // Drop the create-path .prefault("api") so an empty PATCH stays empty (the guard below fires).
+    origin: z.string().optional(),
   })
   .superRefine(rejectGoalClearedWithSearchTargets)
   .refine(x => Object.keys(x).length > 0, "Update body cannot be empty");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Blocks running paused monitors and adds a 60s finalize timeout with aborts to prevent stalled writes from corrupting dedup baselines. Also switches search finalize to a bulk upsert, runs search checks in parallel, hardens scrape/crawl recording, and closes finalize/reconciler races to avoid missed alerts and double work.

- **Bug Fixes**
  - Block running a paused monitor with 409; dedup billing via deterministic job id `monitor-bill-<checkId>`.
  - Treat previously “skipped” search results as new; forbid both `includeDomains` and `excludeDomains` in `searchTargetSchema`; keep `updateMonitorSchema.origin` unchanged on PATCH.
  - Scrape/crawl: on diff/persist failure, record an error page and send a single webhook via a per-(check,url,kind) claim; success and error notifications dedupe independently so an error can’t suppress a later success; replace existing per-URL rows to make redelivery idempotent.
  - Close races: don’t downgrade a fresh `searchCompleted`; catch path only updates when `status='running'` to avoid clobbering reconciler results.

- **Refactors**
  - Add `withFinalizeTimeout` (60s) with AbortSignal; bound finalize tails and guard the `searchCompleted` flush with `updateMonitorCheckIfRunning`.
  - Use `bulkUpsertMonitorPages` for search finalize; write per-check rows first and skip baseline writes if aborted; add URL-scoped `deleteMonitorCheckPages`.
  - Run the search consumer with `prefetch(3)` (default consumers remain at `prefetch(1)`); remove unused inline scrape/crawl runners.

<sup>Written for commit 55cea14a61ae2e7baf5e75b195b6ed3fda6547c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

