### PR TITLE
fix(api): retry Fire Engine proxy tunnel errors

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
@@ -18,6 +18,7 @@ import { MockState } from "../../lib/mock";
 import { fireEngineURL } from "./scrape";
 import { getDocFromGCS } from "../../../../lib/gcs-jobs";
 import { Meta } from "../..";
+import { shouldRetryChromeProxyErrorWithStealth } from "./chromeError";
 
 const browserCookieSchema = z
   .object({
@@ -210,7 +211,13 @@ export async function fireEngineCheckStatus(
     ) {
       const code = status.error.split("Chrome error: ")[1];
 
-      if (
+      if (shouldRetryChromeProxyErrorWithStealth(code, meta)) {
+        logger.info(
+          "Chrome proxy error received from Fire Engine. Adding stealthProxy flag.",
+          { errorCode: code, jobId },
+        );
+        throw new AddFeatureError(["stealthProxy"]);
+      } else if (
         code.includes("ERR_CERT_") ||
         code.includes("ERR_SSL_") ||
         code.includes("ERR_BAD_SSL_")

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/chromeError.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/chromeError.test.ts
@@ -1,0 +1,125 @@
+import { Logger } from "winston";
+
+import { Meta } from "../..";
+import { AddFeatureError, SiteError } from "../../error";
+import { MockState } from "../../lib/mock";
+import { fireEngineCheckStatus } from "./checkStatus";
+import { fireEngineScrape } from "./scrape";
+
+const baseUrl = "http://fire-engine.test";
+
+function makeLogger() {
+  const logger = {
+    child: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+function makeMeta(featureFlags: string[] = []) {
+  return {
+    options: {
+      proxy: "auto",
+      skipTlsVerification: false,
+    },
+    featureFlags: new Set(featureFlags),
+  } as unknown as Meta;
+}
+
+function makeMock(
+  url: string,
+  method: "GET" | "POST",
+  body: Record<string, unknown>,
+): MockState {
+  return {
+    requests: [
+      {
+        time: 0,
+        options: {
+          url,
+          method,
+          ignoreResponse: false,
+          ignoreFailure: false,
+          tryCount: 3,
+        },
+        result: {
+          status: 200,
+          headers: {},
+          body: JSON.stringify(body),
+        },
+      },
+    ],
+    tracker: {},
+  };
+}
+
+describe("Fire Engine Chrome proxy errors", () => {
+  it("retries immediate scrape tunnel failures with stealth proxy", async () => {
+    const mock = makeMock(`${baseUrl}/scrape`, "POST", {
+      error:
+        "Failed to scrape the content, err: Error: Chrome error: ERR_TUNNEL_CONNECTION_FAILED",
+    });
+
+    const error = await fireEngineScrape(
+      makeMeta(),
+      makeLogger(),
+      {
+        engine: "chrome-cdp",
+        url: "https://example.com/proxy-error-test",
+      },
+      mock,
+      undefined,
+      baseUrl,
+    ).catch(error => error);
+
+    expect(error).toBeInstanceOf(AddFeatureError);
+    expect(error.featureFlags).toEqual(["stealthProxy"]);
+  });
+
+  it("retries deferred status proxy connection failures with stealth proxy", async () => {
+    const mock = makeMock(`${baseUrl}/scrape/job-1`, "GET", {
+      jobId: "job-1",
+      state: "failed",
+      processing: false,
+      error:
+        "Failed to scrape the content, err: Error: Chrome error: ERR_PROXY_CONNECTION_FAILED",
+    });
+
+    const error = await fireEngineCheckStatus(
+      makeMeta(),
+      makeLogger(),
+      "job-1",
+      mock,
+      undefined,
+      baseUrl,
+    ).catch(error => error);
+
+    expect(error).toBeInstanceOf(AddFeatureError);
+    expect(error.featureFlags).toEqual(["stealthProxy"]);
+  });
+
+  it("does not retry proxy Chrome errors once stealth proxy is already enabled", async () => {
+    const mock = makeMock(`${baseUrl}/scrape`, "POST", {
+      error:
+        "Failed to scrape the content, err: Error: Chrome error: ERR_TUNNEL_CONNECTION_FAILED",
+    });
+
+    await expect(
+      fireEngineScrape(
+        makeMeta(["stealthProxy"]),
+        makeLogger(),
+        {
+          engine: "chrome-cdp",
+          url: "https://example.com/proxy-error-test",
+        },
+        mock,
+        undefined,
+        baseUrl,
+      ),
+    ).rejects.toBeInstanceOf(SiteError);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/chromeError.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/chromeError.ts
@@ -1,0 +1,22 @@
+type ProxyRetryMeta = {
+  options: {
+    proxy?: unknown;
+  };
+  featureFlags: Set<string>;
+};
+
+const CHROME_PROXY_ERROR_CODES = [
+  "ERR_TUNNEL_CONNECTION_FAILED",
+  "ERR_PROXY_CONNECTION_FAILED",
+];
+
+export function shouldRetryChromeProxyErrorWithStealth(
+  errorCode: string,
+  meta: ProxyRetryMeta,
+) {
+  return (
+    meta.options.proxy === "auto" &&
+    !meta.featureFlags.has("stealthProxy") &&
+    CHROME_PROXY_ERROR_CODES.some(code => errorCode.includes(code))
+  );
+}

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -17,6 +17,7 @@ import {
   UnsupportedFileError,
 } from "../../error";
 import { Meta } from "../..";
+import { shouldRetryChromeProxyErrorWithStealth } from "./chromeError";
 
 import { config } from "../../../../config";
 
@@ -248,7 +249,13 @@ export async function fireEngineScrape<
     ) {
       const code = status.error.split("Chrome error: ")[1];
 
-      if (
+      if (shouldRetryChromeProxyErrorWithStealth(code, meta)) {
+        logger.info(
+          "Chrome proxy error received from Fire Engine. Adding stealthProxy flag.",
+          { errorCode: code },
+        );
+        throw new AddFeatureError(["stealthProxy"]);
+      } else if (
         code.includes("ERR_CERT_") ||
         code.includes("ERR_SSL_") ||
         code.includes("ERR_BAD_SSL_")


### PR DESCRIPTION
## Summary

Retry Fire Engine Chrome proxy tunnel failures through the existing `stealthProxy` feature-toggle path when the request is using automatic proxy selection. This lets transient basic-proxy tunnel setup errors fall back to the stronger proxy mode instead of surfacing immediately as a scrape failure.

The retry is applied to both immediate scrape responses and deferred status polling responses, with focused tests covering retry and terminal already-stealth behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry Fire Engine Chrome proxy tunnel failures by falling back to stealth proxy when using automatic proxy selection. This reduces transient tunnel errors from becoming scrape failures.

- **Bug Fixes**
  - When `proxy: "auto"`, detect `ERR_TUNNEL_CONNECTION_FAILED` and `ERR_PROXY_CONNECTION_FAILED` and retry by enabling `stealthProxy` (skipped if already enabled).
  - Applied to both `fireEngineScrape` and `fireEngineCheckStatus` using a shared helper, with targeted unit tests to cover both paths.

<sup>Written for commit 5081849f4fa80fdc1dba2ed55461465b8d585001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

