### PR TITLE
Fix README community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Pst. Hey, you, join our stargazers :)_
 - **Agent ready**: Connect Firecrawl to any AI agent or MCP client with a single command
 - **Media parsing**: Parse and extract content from web-hosted PDFs, DOCX, and more
 - **Actions**: Click, scroll, write, wait, and press before extracting content
-- **Open source**: Developed transparently and collaboratively — [join our community](https://github.com/firecrawl/firecrawl)
+- **Open source**: Developed transparently and collaboratively — [join our community](https://discord.gg/firecrawl)
 
 ---
 


### PR DESCRIPTION
Summary:
- Updates the README community link to point to the project Discord invite.
- Keeps the surrounding README content unchanged.

Testing:
- git diff --check

Fixes #3887

AI assistance: This documentation fix was prepared with AI assistance and reviewed before submission.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README community link to the official Discord invite (`https://discord.gg/firecrawl`) so users land in the right community space. Fixes #3887.

<sup>Written for commit 915737a5dcae1e537e5d76edb6b1a18b99f3e7ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

