### PR TITLE
feat(monitor): improve web monitors emails

### DIFF
--- a/apps/api/src/services/notification/monitoring_email.test.ts
+++ b/apps/api/src/services/notification/monitoring_email.test.ts
@@ -233,6 +233,52 @@ describe("monitoring email URLs", () => {
     expect(html).toContain("found a new match");
     expect(html).toContain("Errors: 1");
   });
+
+  it("leads with errors (not '0 new matches') for an error-only search check", () => {
+    const html = buildHtml({
+      monitorId: "m1",
+      monitorName: "AI news",
+      checkId: "c1",
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      summary: {
+        changed: 0,
+        new: 0,
+        same: 8,
+        removed: 0,
+        error: 2,
+        totalPages: 8,
+      },
+      pages: [{ url: "https://example.com", status: "error" }],
+      creditsUsed: 1,
+      isSearch: true,
+    });
+    expect(html).toContain("ran into 2 errors while checking results");
+    expect(html).not.toContain("0 new matches");
+    // errors still appear in the breakdown
+    expect(html).toContain("Errors: 2");
+  });
+
+  it("uses singular error phrasing for a single error-only search check", () => {
+    const html = buildHtml({
+      monitorId: "m1",
+      monitorName: "AI news",
+      checkId: "c1",
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      summary: {
+        changed: 0,
+        new: 0,
+        same: 5,
+        removed: 0,
+        error: 1,
+        totalPages: 6,
+      },
+      pages: [{ url: "https://example.com", status: "error" }],
+      creditsUsed: 1,
+      isSearch: true,
+    });
+    expect(html).toContain("ran into an error while checking results");
+    expect(html).not.toContain("new match");
+  });
 });
 
 describe("buildConfirmationHtml", () => {

--- a/apps/api/src/services/notification/monitoring_email.test.ts
+++ b/apps/api/src/services/notification/monitoring_email.test.ts
@@ -341,6 +341,7 @@ describe("sendMonitoringEmailSummary", () => {
     goal?: string | null;
     emailEnabled?: boolean;
     recipients?: string[];
+    status?: string;
     pages: Array<{
       status: string;
       meaningful?: boolean | null;
@@ -364,10 +365,12 @@ describe("sendMonitoringEmailSummary", () => {
       } as any,
       check: {
         id: "check-1",
+        status: opts.status ?? "completed",
         changed_count: opts.pages.filter(p => p.status === "changed").length,
         new_count: opts.pages.filter(p => p.status === "new").length,
         removed_count: opts.pages.filter(p => p.status === "removed").length,
         error_count: opts.pages.filter(p => p.status === "error").length,
+        error: opts.status === "failed" ? "scrape failed" : null,
       } as any,
       pages: opts.pages.map((p, i) => ({
         url: `https://example.com/${i}`,
@@ -384,6 +387,28 @@ describe("sendMonitoringEmailSummary", () => {
       })),
     };
   }
+
+  it("does not send email summaries for failed checks", async () => {
+    mockListRecipients.mockResolvedValue([
+      fakeRecipient("a@b.com", "confirmed"),
+    ]);
+
+    const result = await sendMonitoringEmailSummary(
+      buildArgs({
+        emailEnabled: true,
+        status: "failed",
+        pages: [{ status: "error" }],
+      }),
+    );
+
+    expect(result).toEqual({
+      attempted: false,
+      success: true,
+      recipients: [],
+    });
+    expect(mockListRecipients).not.toHaveBeenCalled();
+    expect(mockResendSend).not.toHaveBeenCalled();
+  });
 
   describe("judgment gating", () => {
     beforeEach(() => {

--- a/apps/api/src/services/notification/monitoring_email.test.ts
+++ b/apps/api/src/services/notification/monitoring_email.test.ts
@@ -12,7 +12,7 @@ const {
   mockResendSend: vi.fn(),
 }));
 
-vi.mock("../monitoring/email_recipients", async (importOriginal) => {
+vi.mock("../monitoring/email_recipients", async importOriginal => {
   const actual =
     await importOriginal<typeof import("../monitoring/email_recipients")>();
   return {
@@ -135,6 +135,7 @@ describe("monitoring email URLs", () => {
       summary: {
         changed: 1,
         new: 0,
+        same: 0,
         removed: 0,
         error: 0,
         totalPages: 1,
@@ -166,11 +167,71 @@ describe("monitoring email URLs", () => {
       monitorName: "M",
       checkId: "c1",
       dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
-      summary: { changed: 0, new: 1, removed: 0, error: 0, totalPages: 1 },
+      summary: {
+        changed: 0,
+        new: 1,
+        same: 0,
+        removed: 0,
+        error: 0,
+        totalPages: 1,
+      },
       pages: [{ url: "https://example.com", status: "new" }],
       creditsUsed: 1,
     });
     expect(html).not.toContain("Unsubscribe from this monitor");
+  });
+
+  it("renders search monitors as matches/already-seen/checked, not the change breakdown", () => {
+    const html = buildHtml({
+      monitorId: "m1",
+      monitorName: "AI news",
+      checkId: "c1",
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      summary: {
+        changed: 0,
+        new: 2,
+        same: 6,
+        removed: 0,
+        error: 0,
+        totalPages: 8,
+      },
+      pages: [{ url: "https://example.com", status: "new" }],
+      creditsUsed: 1,
+      isSearch: true,
+    });
+    // search-appropriate language
+    expect(html).toContain("found 2 new matches");
+    expect(html).toContain("Matches: 2");
+    expect(html).toContain("Already seen: 6");
+    expect(html).toContain("Checked: 8");
+    // the scrape/crawl-only rows are gone
+    expect(html).not.toContain("Removed:");
+    expect(html).not.toContain("Changed:");
+    expect(html).not.toContain("Total pages checked:");
+    // no errors → no error row
+    expect(html).not.toContain("Errors:");
+  });
+
+  it("uses singular match phrasing and shows errors only when present (search)", () => {
+    const html = buildHtml({
+      monitorId: "m1",
+      monitorName: "AI news",
+      checkId: "c1",
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      summary: {
+        changed: 0,
+        new: 1,
+        same: 3,
+        removed: 0,
+        error: 1,
+        totalPages: 8,
+      },
+      pages: [{ url: "https://example.com", status: "new" }],
+      creditsUsed: 1,
+      isSearch: true,
+    });
+    expect(html).toContain("found a new match");
+    expect(html).toContain("Errors: 1");
   });
 });
 

--- a/apps/api/src/services/notification/monitoring_email.test.ts
+++ b/apps/api/src/services/notification/monitoring_email.test.ts
@@ -212,7 +212,7 @@ describe("monitoring email URLs", () => {
     expect(html).not.toContain("Errors:");
   });
 
-  it("uses singular match phrasing and shows errors only when present (search)", () => {
+  it("uses singular match phrasing and hides page errors (search)", () => {
     const html = buildHtml({
       monitorId: "m1",
       monitorName: "AI news",
@@ -226,15 +226,20 @@ describe("monitoring email URLs", () => {
         error: 1,
         totalPages: 8,
       },
-      pages: [{ url: "https://example.com", status: "new" }],
+      pages: [
+        { url: "https://example.com/new", status: "new" },
+        { url: "https://example.com/failed", status: "error" },
+      ],
       creditsUsed: 1,
       isSearch: true,
     });
     expect(html).toContain("found a new match");
-    expect(html).toContain("Errors: 1");
+    expect(html).not.toContain("Errors:");
+    expect(html).toContain("https://example.com/new");
+    expect(html).not.toContain("https://example.com/failed");
   });
 
-  it("leads with errors (not '0 new matches') for an error-only search check", () => {
+  it("does not render error details for an error-only search check", () => {
     const html = buildHtml({
       monitorId: "m1",
       monitorName: "AI news",
@@ -252,13 +257,14 @@ describe("monitoring email URLs", () => {
       creditsUsed: 1,
       isSearch: true,
     });
-    expect(html).toContain("ran into 2 errors while checking results");
+    expect(html).not.toContain("ran into");
     expect(html).not.toContain("0 new matches");
-    // errors still appear in the breakdown
-    expect(html).toContain("Errors: 2");
+    expect(html).not.toContain("Errors:");
+    expect(html).not.toContain("Top pages:");
+    expect(html).not.toContain("https://example.com");
   });
 
-  it("uses singular error phrasing for a single error-only search check", () => {
+  it("does not render singular error details for an error-only search check", () => {
     const html = buildHtml({
       monitorId: "m1",
       monitorName: "AI news",
@@ -276,8 +282,11 @@ describe("monitoring email URLs", () => {
       creditsUsed: 1,
       isSearch: true,
     });
-    expect(html).toContain("ran into an error while checking results");
+    expect(html).not.toContain("ran into");
     expect(html).not.toContain("new match");
+    expect(html).not.toContain("Errors:");
+    expect(html).not.toContain("Top pages:");
+    expect(html).not.toContain("https://example.com");
   });
 });
 
@@ -397,6 +406,27 @@ describe("sendMonitoringEmailSummary", () => {
       buildArgs({
         emailEnabled: true,
         status: "failed",
+        pages: [{ status: "error" }],
+      }),
+    );
+
+    expect(result).toEqual({
+      attempted: false,
+      success: true,
+      recipients: [],
+    });
+    expect(mockListRecipients).not.toHaveBeenCalled();
+    expect(mockResendSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send email summaries for error-only checks", async () => {
+    mockListRecipients.mockResolvedValue([
+      fakeRecipient("a@b.com", "confirmed"),
+    ]);
+
+    const result = await sendMonitoringEmailSummary(
+      buildArgs({
+        emailEnabled: true,
         pages: [{ status: "error" }],
       }),
     );

--- a/apps/api/src/services/notification/monitoring_email.ts
+++ b/apps/api/src/services/notification/monitoring_email.ts
@@ -506,6 +506,15 @@ export async function sendMonitoringEmailSummary(params: {
     return { attempted: false, success: true, recipients: [] };
   }
 
+  if (params.check.status === "failed") {
+    logger.info("Skipping monitoring email summary; check failed", {
+      monitorId: params.monitor.id,
+      checkId: params.check.id,
+      error: params.check.error,
+    });
+    return { attempted: false, success: true, recipients: [] };
+  }
+
   if (
     params.check.changed_count +
       params.check.new_count +

--- a/apps/api/src/services/notification/monitoring_email.ts
+++ b/apps/api/src/services/notification/monitoring_email.ts
@@ -233,11 +233,22 @@ export function buildHtml(payload: MonitoringEmailPayload): string {
   // Search monitors find results; scrape/crawl monitors track page changes — so the
   // intro line + breakdown read differently for each. Search never produces
   // changed/removed, so those rows are dropped in favour of matches/already-seen/checked.
-  const activityLine = payload.isSearch
-    ? payload.summary.new === 1
-      ? "found a new match"
-      : `found ${payload.summary.new} new matches`
-    : "detected activity";
+  let activityLine: string;
+  if (!payload.isSearch) {
+    activityLine = "detected activity";
+  } else if (payload.summary.new > 0) {
+    activityLine =
+      payload.summary.new === 1
+        ? "found a new match"
+        : `found ${payload.summary.new} new matches`;
+  } else {
+    // A search email with no new matches only fires because of scrape errors, so
+    // lead with those instead of the misleading "found 0 new matches".
+    activityLine =
+      payload.summary.error === 1
+        ? "ran into an error while checking results"
+        : `ran into ${payload.summary.error} errors while checking results`;
+  }
   const summaryItems = payload.isSearch
     ? `  <li>Matches: ${payload.summary.new}</li>
   <li>Already seen: ${payload.summary.same}</li>

--- a/apps/api/src/services/notification/monitoring_email.ts
+++ b/apps/api/src/services/notification/monitoring_email.ts
@@ -79,12 +79,17 @@ export type MonitoringEmailPayload = {
   summary: {
     changed: number;
     new: number;
+    same: number;
     removed: number;
     error: number;
     totalPages: number;
   };
   pages: MonitoringEmailPage[];
   creditsUsed: number | null;
+  // Search monitors only ever produce new/same/error (never changed/removed), so the
+  // summary is rendered as matches / already seen / checked instead of the
+  // scrape/crawl change breakdown.
+  isSearch?: boolean;
   // When omitted, the footer drops the unsubscribe row.
   unsubscribeUrl?: string;
 };
@@ -172,6 +177,15 @@ You're receiving this because you opted in to Firecrawl monitor alerts at this a
 </p>`;
 }
 
+// Search pages are matches, not tracked-page transitions — relabel new/same for the
+// email so a search alert reads "match" / "already seen" instead of "new" / "same".
+function pageStatusLabel(status: string, isSearch: boolean): string {
+  if (!isSearch) return status;
+  if (status === "new") return "match";
+  if (status === "same") return "already seen";
+  return status;
+}
+
 export function buildHtml(payload: MonitoringEmailPayload): string {
   const sortedPages = [...payload.pages].sort((a, b) => {
     const aMeaningful = a.judgment?.meaningful === true ? 0 : 1;
@@ -199,7 +213,7 @@ export function buildHtml(payload: MonitoringEmailPayload): string {
           ? renderDiffBlock(page.diffText)
           : "";
       const pageError = userFacingPageError(page.error);
-      return `<li style="margin:0 0 14px;"><strong>${escapeHtml(page.status)}</strong>${badge}: <a href="${url}">${url}</a>${
+      return `<li style="margin:0 0 14px;"><strong>${escapeHtml(pageStatusLabel(page.status, payload.isSearch ?? false))}</strong>${badge}: <a href="${url}">${url}</a>${
         pageError ? ` &mdash; ${escapeHtml(pageError)}` : ""
       }${reason}${diffBlock}</li>`;
     })
@@ -216,14 +230,32 @@ export function buildHtml(payload: MonitoringEmailPayload): string {
       ? `Changed: ${payload.summary.changed} (${meaningfulCount} meaningful, ${noiseCount} noise)`
       : `Changed: ${payload.summary.changed}`;
 
-  return `Hey there,<br/>
-<p>Your Firecrawl monitor <strong>${escapeHtml(payload.monitorName)}</strong> detected activity.</p>
-<ul>
-  <li>${changedLine}</li>
+  // Search monitors find results; scrape/crawl monitors track page changes — so the
+  // intro line + breakdown read differently for each. Search never produces
+  // changed/removed, so those rows are dropped in favour of matches/already-seen/checked.
+  const activityLine = payload.isSearch
+    ? payload.summary.new === 1
+      ? "found a new match"
+      : `found ${payload.summary.new} new matches`
+    : "detected activity";
+  const summaryItems = payload.isSearch
+    ? `  <li>Matches: ${payload.summary.new}</li>
+  <li>Already seen: ${payload.summary.same}</li>
+  <li>Checked: ${payload.summary.totalPages}</li>${
+    payload.summary.error > 0
+      ? `\n  <li>Errors: ${payload.summary.error}</li>`
+      : ""
+  }`
+    : `  <li>${changedLine}</li>
   <li>New: ${payload.summary.new}</li>
   <li>Removed: ${payload.summary.removed}</li>
   <li>Errors: ${payload.summary.error}</li>
-  <li>Total pages checked: ${payload.summary.totalPages}</li>
+  <li>Total pages checked: ${payload.summary.totalPages}</li>`;
+
+  return `Hey there,<br/>
+<p>Your Firecrawl monitor <strong>${escapeHtml(payload.monitorName)}</strong> ${activityLine}.</p>
+<ul>
+${summaryItems}
 </ul>
 ${pageItems ? `<p>Top pages:</p><ul>${pageItems}</ul>` : ""}
 <p><a href="${dashboardUrl}">View this check in the dashboard</a></p>
@@ -575,12 +607,16 @@ export async function sendMonitoringEmailSummary(params: {
         summary: {
           changed: params.check.changed_count,
           new: params.check.new_count,
+          same: params.check.same_count,
           removed: params.check.removed_count,
           error: params.check.error_count,
           totalPages: params.check.total_pages,
         },
         pages: params.pages,
         creditsUsed: params.check.actual_credits,
+        isSearch:
+          (params.monitor.targets?.length ?? 0) > 0 &&
+          (params.monitor.targets ?? []).every(t => t.type === "search"),
         unsubscribeUrl: buildRecipientUnsubscribeUrl(recipient.token),
       };
 

--- a/apps/api/src/services/notification/monitoring_email.ts
+++ b/apps/api/src/services/notification/monitoring_email.ts
@@ -187,7 +187,9 @@ function pageStatusLabel(status: string, isSearch: boolean): string {
 }
 
 export function buildHtml(payload: MonitoringEmailPayload): string {
-  const sortedPages = [...payload.pages].sort((a, b) => {
+  const sortedPages = payload.pages.filter(page => page.status !== "error");
+
+  sortedPages.sort((a, b) => {
     const aMeaningful = a.judgment?.meaningful === true ? 0 : 1;
     const bMeaningful = b.judgment?.meaningful === true ? 0 : 1;
     return aMeaningful - bMeaningful;
@@ -242,25 +244,15 @@ export function buildHtml(payload: MonitoringEmailPayload): string {
         ? "found a new match"
         : `found ${payload.summary.new} new matches`;
   } else {
-    // A search email with no new matches only fires because of scrape errors, so
-    // lead with those instead of the misleading "found 0 new matches".
-    activityLine =
-      payload.summary.error === 1
-        ? "ran into an error while checking results"
-        : `ran into ${payload.summary.error} errors while checking results`;
+    activityLine = "detected activity";
   }
   const summaryItems = payload.isSearch
     ? `  <li>Matches: ${payload.summary.new}</li>
   <li>Already seen: ${payload.summary.same}</li>
-  <li>Checked: ${payload.summary.totalPages}</li>${
-    payload.summary.error > 0
-      ? `\n  <li>Errors: ${payload.summary.error}</li>`
-      : ""
-  }`
+  <li>Checked: ${payload.summary.totalPages}</li>`
     : `  <li>${changedLine}</li>
   <li>New: ${payload.summary.new}</li>
   <li>Removed: ${payload.summary.removed}</li>
-  <li>Errors: ${payload.summary.error}</li>
   <li>Total pages checked: ${payload.summary.totalPages}</li>`;
 
   return `Hey there,<br/>
@@ -518,8 +510,7 @@ export async function sendMonitoringEmailSummary(params: {
   if (
     params.check.changed_count +
       params.check.new_count +
-      params.check.removed_count +
-      params.check.error_count <=
+      params.check.removed_count <=
     0
   ) {
     logger.info("Skipping monitoring email summary; no changes detected", {


### PR DESCRIPTION
Add support for search-style monitors in the monitoring email renderer. Introduces summary.same and an optional isSearch flag on MonitoringEmailPayload, a pageStatusLabel helper to relabel page statuses for search monitors, and conditional rendering in buildHtml so search alerts show "Matches / Already seen / Checked" (with singular/plural phrasing and errors only shown when present) instead of the scrape/crawl change breakdown. Also map same_count and detect isSearch in sendMonitoringEmailSummary, and update tests to cover the new fields and behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves monitoring emails for search monitors with match-based wording, clearer counts, and safer error handling. Skips sending summaries for failed or error-only checks.

- **New Features**
  - Added `summary.same` and optional `isSearch` to `MonitoringEmailPayload`.
  - Search emails now show Matches/Already seen/Checked with singular/plural phrasing; hide error rows and error pages; use an error-focused line when there are no new matches.
  - Auto-detect `isSearch` and map `same_count` in `sendMonitoringEmailSummary`; tests updated.

- **Bug Fixes**
  - Skip monitoring email summaries for failed or error-only checks (with tests).

<sup>Written for commit d0a96ce0867eba36a57f79d54ff86cbf51b8cd5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

