### PR TITLE
gzip decompression

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -26,6 +26,7 @@ import {
   ProxySelectionError,
 } from "../../error";
 import * as Sentry from "@sentry/node";
+import { gunzipSync } from "node:zlib";
 import { specialtyScrapeCheck } from "../utils/specialtyHandler";
 import { fireEngineDelete } from "./delete";
 import { MockState } from "../../lib/mock";
@@ -42,6 +43,8 @@ import { createHash } from "node:crypto";
 
 /** Default wait (ms) before running the branding script when user did not set waitFor. Lets the page settle so DOM/images are ready and reduces JS errors. */
 const BRANDING_DEFAULT_WAIT_MS = 2000;
+
+const MAX_GUNZIPPED_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
 // This function does not take `Meta` on purpose. It may not access any
 // meta values to construct the request -- that must be done by the
@@ -212,7 +215,21 @@ async function performFireEngineScrape<
     if (status.file) {
       const content = status.file.content;
       delete status.file;
-      status.content = Buffer.from(content, "base64").toString("utf8"); // TODO: handle other encodings via Content-Type tag
+      let buffer = Buffer.from(content, "base64");
+      // transparently decompress gzipped content
+      if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) {
+        try {
+          buffer = gunzipSync(buffer, {
+            maxOutputLength: MAX_GUNZIPPED_FILE_SIZE,
+          });
+        } catch (error) {
+          if (error instanceof RangeError) {
+            throw new UnsupportedFileError("File exceeds size limit");
+          }
+          logger.warn("Failed to gunzip fire-engine file content", { error });
+        }
+      }
+      status.content = buffer.toString("utf8"); // TODO: handle other encodings via Content-Type tag
     }
 
     fireEngineDelete(

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -226,7 +226,7 @@ async function performFireEngineScrape<
           if (error instanceof RangeError) {
             throw new UnsupportedFileError("File exceeds size limit");
           }
-          logger.warn("Failed to gunzip fire-engine file content", { error });
+          throw new UnsupportedFileError("Failed to decompress gzip content");
         }
       }
       status.content = buffer.toString("utf8"); // TODO: handle other encodings via Content-Type tag

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -163,7 +163,6 @@ export async function specialtyScrapeCheck(
     "audio/",
     "application/zip",
     "application/x-tar",
-    "application/gzip",
     "application/x-rar",
     "application/x-7z",
     "application/wasm",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add transparent gzip decompression for Fire Engine scraped files with a 50MB cap. Also routes `application/gzip` files through the engine; decompression failures now throw `UnsupportedFileError`.

- **New Features**
  - Detect and decompress gzipped payloads using `gunzipSync` from `node:zlib` when gzip magic bytes are present.
  - Enforce a 50MB max decompressed size; throw `UnsupportedFileError` on size limit or decompression failure.
  - Remove `application/gzip` from specialty exclusions so gzip files flow through the normal pipeline.

<sup>Written for commit c717bebc282493dd8426d25d9da21a82b7536277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

