### PR TITLE
fix(api): lazy data layer capability checks

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,7 +38,6 @@ import { initializeEngineForcing } from "./scraper/WebScraper/utils/engine-forci
 import responseTime from "response-time";
 import { shutdownWebhookQueue } from "./services/webhook";
 import { shutdownIndexerQueue } from "./services/indexing/indexer-queue";
-import { warmDataLayerCapabilities } from "./lib/data-layer";
 
 const { createBullBoard } = require("@bull-board/api");
 const { BullMQAdapter } = require("@bull-board/api/bullMQAdapter");
@@ -120,7 +119,6 @@ async function startServer(port = DEFAULT_PORT) {
   try {
     await initializeBlocklist();
     initializeEngineForcing();
-    await warmDataLayerCapabilities();
   } catch (error) {
     logger.error("Failed to initialize API startup dependencies", {
       error,

--- a/apps/api/src/lib/data-layer.test.ts
+++ b/apps/api/src/lib/data-layer.test.ts
@@ -12,7 +12,6 @@ import {
   isSuccessfulDataLayerStatusCode,
   isSupportedDataLayerFormatRequest,
   setDataLayerCapabilitiesForTest,
-  warmDataLayerCapabilities,
 } from "./data-layer";
 
 vi.mock("undici", () => ({
@@ -66,25 +65,6 @@ describe("data layer routing", () => {
     await expect(
       isDataLayerSupportedUrl("https://profiles.example/person/example-person"),
     ).resolves.toBe(false);
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("warms capabilities before request-time URL checks", async () => {
-    clearDataLayerCapabilitiesForTest();
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        ttlSeconds: 300,
-        domains: ["profiles.example"],
-      }),
-    } as Awaited<ReturnType<typeof fetch>>);
-
-    await warmDataLayerCapabilities();
-    await expect(
-      isDataLayerSupportedUrl("https://profiles.example/person/example-person"),
-    ).resolves.toBe(true);
 
     expect(fetch).toHaveBeenCalledTimes(1);
   });

--- a/apps/api/src/lib/data-layer.ts
+++ b/apps/api/src/lib/data-layer.ts
@@ -131,19 +131,6 @@ async function getDataLayerCapabilities(): Promise<DataLayerCapabilities | null>
   return capabilities;
 }
 
-export async function warmDataLayerCapabilities(): Promise<void> {
-  if (!config.FIRE_ENGINE_BETA_URL) {
-    return;
-  }
-
-  const capabilities = await getDataLayerCapabilities();
-  rootLogger.info("Data layer capabilities warmup completed", {
-    available: capabilities !== null,
-    domains: capabilities?.domains.size ?? 0,
-    baseDomains: capabilities?.baseDomains.size ?? 0,
-  });
-}
-
 function dataLayerCapabilitiesMatchUrl(
   capabilities: DataLayerCapabilities,
   inputUrl: string,

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -21,7 +21,6 @@ import Express from "express";
 import { robustFetch } from "../scraper/scrapeURL/lib/fetch";
 import { initializeBlocklist } from "../scraper/WebScraper/utils/blocklist";
 import { initializeEngineForcing } from "../scraper/WebScraper/utils/engine-forcing";
-import { warmDataLayerCapabilities } from "../lib/data-layer";
 import { crawlFinishedQueue, NuQJob, scrapeQueue } from "./worker/nuq";
 import { finishCrawlSuper } from "./worker/crawl-logic";
 import { getCrawl } from "../lib/crawl-redis";
@@ -466,7 +465,6 @@ app.listen(workerPort, (error?: Error) => {
   });
 
   initializeEngineForcing();
-  await warmDataLayerCapabilities();
 
   if (config.USE_DB_AUTHENTICATION && !config.DISABLE_MONITORING) {
     monitorSchedulerInterval = setInterval(() => {

--- a/apps/api/src/services/worker/nuq-worker-runner.ts
+++ b/apps/api/src/services/worker/nuq-worker-runner.ts
@@ -7,7 +7,6 @@ import { register } from "prom-client";
 import Express from "express";
 import { initializeBlocklist } from "../../scraper/WebScraper/utils/blocklist";
 import { initializeEngineForcing } from "../../scraper/WebScraper/utils/engine-forcing";
-import { warmDataLayerCapabilities } from "../../lib/data-layer";
 
 export type WorkerQueue = {
   getJobToProcess(logger?: any): Promise<NuQJob<any, any> | null>;
@@ -59,7 +58,6 @@ export async function runNuqWorker(options: {
   try {
     await initializeBlocklist();
     initializeEngineForcing();
-    await warmDataLayerCapabilities();
     await options.beforeStart?.();
   } catch (error) {
     _logger.error("Failed to initialize NuQ worker", {


### PR DESCRIPTION
## Summary

This removes data-layer capability warmup from API and worker startup so capability discovery stays lazy, cached, and tied to eligible routed requests. The request-time behavior is unchanged, but deploys and restarts no longer fan out capability checks across every process.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make data-layer capability checks lazy by removing all startup warmups in the API and worker processes. This prevents fan-out checks on deploys and restarts while keeping request-time behavior the same.

- **Bug Fixes**
  - Removed `warmDataLayerCapabilities` and its startup calls in the API server and workers.
  - Updated tests to drop warmup coverage.

<sup>Written for commit c5e78c8b42ea2fe2aa7bc002cedf02bd45e5d5bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

