### PR TITLE
Add example: authorized agent scraping with x402 identity verification

### DIFF
--- a/examples/x402_authorized_agent_scraping/.env.example
+++ b/examples/x402_authorized_agent_scraping/.env.example
@@ -1,0 +1,5 @@
+# Firecrawl API key (required) — get one at https://firecrawl.dev
+FIRECRAWL_API_KEY=fc-your-key-here
+
+# Operator secret for agent identity (use a secure random integer in production)
+OPERATOR_SECRET=42

--- a/examples/x402_authorized_agent_scraping/README.md
+++ b/examples/x402_authorized_agent_scraping/README.md
@@ -1,88 +1,61 @@
-# Authorized Agent Scraping
+# Per-Agent Access Control for Firecrawl
 
-An example showing how to verify an AI agent's identity and permissions before it makes paid API calls through Firecrawl.
+Gate Firecrawl API calls behind agent identity verification so only credentialed agents can scrape.
 
-## The Problem
+## Why This Matters
 
-With x402 and similar pay-per-call protocols, any agent with a crypto wallet can call paid APIs. But there's no standard way to answer:
+When multiple AI agents share a Firecrawl API key, you have no way to answer:
 
-- **Which agent** is making this call?
-- **Does it have permission** to spend money on API calls?
-- **Who authorized it**, and when does that authorization expire?
+- **Which agent** made this scrape request?
+- **Is it allowed** to call paid endpoints?
+- **When does its access expire?**
 
-Without an identity layer, operators have no way to control which of their agents can make financial API calls — or to revoke that access later.
-
-## What This Example Does
-
-1. **Creates an operator identity** — the human or organization that owns the agent
-2. **Issues an agent credential** — a signed, time-limited credential with specific permissions (in this case, `READ_DATA` + `FINANCIAL_SMALL` for paid APIs under $100)
-3. **Generates a zero-knowledge proof** — the agent proves it holds a valid credential without revealing the operator's secret key
-4. **Verifies the proof** — the authorization check passes or fails
-5. **Scrapes via Firecrawl** — only if the agent is authorized
-
-The authorization check is local (no network call to a central auth server). The ZK proof reveals nothing about the operator's secrets.
+This example adds a lightweight authorization layer in front of Firecrawl. Before an agent can scrape, it must prove it holds a valid, time-limited credential with the right permissions. The check runs locally (no extra network call).
 
 ## Prerequisites
 
-- Python 3.11+
-- Node.js 18+ (required by the ZK proof engine)
-- [Firecrawl](https://firecrawl.dev) API key
-- [@bolyra/sdk](https://www.npmjs.com/package/@bolyra/sdk) installed globally or in a sibling directory
+- **Python 3.11+**
+- **Node.js 18+** — the ZK proof engine runs in Node. The Python SDK (`bolyra`) wraps `@bolyra/sdk` via a subprocess call, so both runtimes are needed.
+- A [Firecrawl](https://firecrawl.dev) API key
 
-## Setup
+## Quick Start
 
-1. Install Python dependencies:
-   ```
-   pip install -r requirements.txt
-   ```
+```bash
+# Python deps
+pip install -r requirements.txt
 
-2. Install the Node.js SDK (needed for ZK proof generation):
-   ```
-   npm install @bolyra/sdk
-   ```
+# Node.js dep (ZK proof engine)
+npm install @bolyra/sdk
 
-3. Set your Firecrawl API key:
-   ```
-   export FIRECRAWL_API_KEY=your_firecrawl_api_key
-   ```
+# Configure
+cp .env.example .env   # then add your FIRECRAWL_API_KEY
 
-## Usage
-
-```
+# Run
 python authorized_scrape.py
 ```
-
-You'll be prompted for a URL to scrape. The script will:
-- Create operator + agent identities
-- Run the authorization check (ZK handshake)
-- Scrape the URL only if authorization succeeds
 
 ## How It Works
 
 ```
-Operator (human)                    Agent (AI)
-      |                                |
-      |-- issues credential ---------->|  (signed, scoped, time-limited)
-      |                                |
-      |                                |-- prove_handshake() -->  ZK Proof
-      |                                |
-      |                     Verifier <--|-- verify_handshake()
-      |                                |
-      |                                |-- [authorized] --> Firecrawl x402 API
+Operator                        Agent
+   |                              |
+   |-- issue credential -------->|   (scoped permissions, TTL)
+   |                              |
+   |                              |-- authorize()  -->  ZK proof
+   |                              |                     (local, no network)
+   |                              |
+   |                              |-- [authorized] -->  Firecrawl scrape
 ```
 
-The credential uses a permission bitmask. For this example, the agent gets:
-- `READ_DATA` (bit 0) — can receive scrape results
-- `FINANCIAL_SMALL` (bit 2) — can make paid API calls under $100
+1. **`agent_auth.py`** — helper that wraps [Bolyra](https://github.com/bolyra/bolyra) identity primitives into two calls: `create_agent_identity()` and `authorize()`.
+2. **`authorized_scrape.py`** — the Firecrawl example. Creates an identity, runs the auth check, then scrapes.
 
-Permissions are cumulative: `FINANCIAL_MEDIUM` implies `FINANCIAL_SMALL`, and `FINANCIAL_UNLIMITED` implies both. This prevents accidental privilege escalation.
+Permissions are bitmask-based. This example grants `READ_DATA` + `FINANCIAL_SMALL` (paid calls under $100). Swap or narrow the permission set in `agent_auth.py` to match your use case.
 
 ## Extending This
 
-- **Multi-agent fleets**: Issue different credentials to different agents. A research agent gets `READ_DATA` only; a purchasing agent gets `FINANCIAL_SMALL`.
-- **Delegation**: An authorized agent can delegate a *narrower* set of permissions to a sub-agent (delegation can only reduce scope, never expand it).
-- **Expiry**: Set short-lived credentials (e.g., 1 hour) for sensitive operations.
-- **Audit trail**: Log the `session_nonce` from each handshake to trace which authorization was used for which API call.
+- Issue different credentials per agent to enforce least-privilege across a fleet.
+- Set short TTLs for sensitive scraping jobs.
 
 ## License
 

--- a/examples/x402_authorized_agent_scraping/README.md
+++ b/examples/x402_authorized_agent_scraping/README.md
@@ -1,0 +1,89 @@
+# Authorized Agent Scraping
+
+An example showing how to verify an AI agent's identity and permissions before it makes paid API calls through Firecrawl.
+
+## The Problem
+
+With x402 and similar pay-per-call protocols, any agent with a crypto wallet can call paid APIs. But there's no standard way to answer:
+
+- **Which agent** is making this call?
+- **Does it have permission** to spend money on API calls?
+- **Who authorized it**, and when does that authorization expire?
+
+Without an identity layer, operators have no way to control which of their agents can make financial API calls — or to revoke that access later.
+
+## What This Example Does
+
+1. **Creates an operator identity** — the human or organization that owns the agent
+2. **Issues an agent credential** — a signed, time-limited credential with specific permissions (in this case, `READ_DATA` + `FINANCIAL_SMALL` for paid APIs under $100)
+3. **Generates a zero-knowledge proof** — the agent proves it holds a valid credential without revealing the operator's secret key
+4. **Verifies the proof** — the authorization check passes or fails
+5. **Scrapes via Firecrawl** — only if the agent is authorized
+
+The authorization check is local (no network call to a central auth server). The ZK proof reveals nothing about the operator's secrets.
+
+## Prerequisites
+
+- Python 3.11+
+- Node.js 18+ (required by the ZK proof engine)
+- [Firecrawl](https://firecrawl.dev) API key
+- [@bolyra/sdk](https://www.npmjs.com/package/@bolyra/sdk) installed globally or in a sibling directory
+
+## Setup
+
+1. Install Python dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+
+2. Install the Node.js SDK (needed for ZK proof generation):
+   ```
+   npm install @bolyra/sdk
+   ```
+
+3. Set your Firecrawl API key:
+   ```
+   export FIRECRAWL_API_KEY=your_firecrawl_api_key
+   ```
+
+## Usage
+
+```
+python authorized_scrape.py
+```
+
+You'll be prompted for a URL to scrape. The script will:
+- Create operator + agent identities
+- Run the authorization check (ZK handshake)
+- Scrape the URL only if authorization succeeds
+
+## How It Works
+
+```
+Operator (human)                    Agent (AI)
+      |                                |
+      |-- issues credential ---------->|  (signed, scoped, time-limited)
+      |                                |
+      |                                |-- prove_handshake() -->  ZK Proof
+      |                                |
+      |                     Verifier <--|-- verify_handshake()
+      |                                |
+      |                                |-- [authorized] --> Firecrawl x402 API
+```
+
+The credential uses a permission bitmask. For this example, the agent gets:
+- `READ_DATA` (bit 0) — can receive scrape results
+- `FINANCIAL_SMALL` (bit 2) — can make paid API calls under $100
+
+Permissions are cumulative: `FINANCIAL_MEDIUM` implies `FINANCIAL_SMALL`, and `FINANCIAL_UNLIMITED` implies both. This prevents accidental privilege escalation.
+
+## Extending This
+
+- **Multi-agent fleets**: Issue different credentials to different agents. A research agent gets `READ_DATA` only; a purchasing agent gets `FINANCIAL_SMALL`.
+- **Delegation**: An authorized agent can delegate a *narrower* set of permissions to a sub-agent (delegation can only reduce scope, never expand it).
+- **Expiry**: Set short-lived credentials (e.g., 1 hour) for sensitive operations.
+- **Audit trail**: Log the `session_nonce` from each handshake to trace which authorization was used for which API call.
+
+## License
+
+[MIT](../../LICENSE)

--- a/examples/x402_authorized_agent_scraping/agent_auth.py
+++ b/examples/x402_authorized_agent_scraping/agent_auth.py
@@ -1,0 +1,84 @@
+"""
+Agent identity and authorization helpers.
+
+Wraps the Bolyra SDK to provide a simple authorize-or-deny check
+that can be dropped in front of any Firecrawl (or other API) call.
+
+The Bolyra Python SDK shells out to @bolyra/sdk (Node.js) for ZK proof
+generation, so Node.js 18+ and `npm install @bolyra/sdk` are required.
+"""
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from bolyra import (
+    Permission,
+    create_human_identity,
+    create_agent_credential,
+    prove_handshake,
+    verify_handshake,
+    permissions_to_bitmask,
+)
+
+
+@dataclass
+class AgentIdentity:
+    """Bundle of operator + agent identities ready for authorization."""
+    human: object
+    agent: object
+    permissions: list
+    expiry: int
+
+
+def create_agent_identity(
+    operator_secret: int,
+    model_hash: int = 12345,
+    permissions: Optional[list] = None,
+    ttl_seconds: int = 86400,
+) -> AgentIdentity:
+    """
+    Create an operator identity and issue an agent credential.
+
+    Args:
+        operator_secret: Operator's private key (use a secure value in production).
+        model_hash: Hash identifying the agent/model being credentialed.
+        permissions: List of Permission flags. Defaults to READ_DATA + FINANCIAL_SMALL.
+        ttl_seconds: Credential lifetime in seconds (default 24 h).
+
+    Returns:
+        AgentIdentity with both identities ready for authorize().
+    """
+    if permissions is None:
+        permissions = [Permission.READ_DATA, Permission.FINANCIAL_SMALL]
+
+    human = create_human_identity(operator_secret)
+    expiry = int(time.time()) + ttl_seconds
+
+    agent = create_agent_credential(
+        model_hash=model_hash,
+        operator_private_key=operator_secret,
+        permissions=permissions,
+        expiry_timestamp=expiry,
+    )
+
+    return AgentIdentity(human=human, agent=agent, permissions=permissions, expiry=expiry)
+
+
+def authorize(identity: AgentIdentity) -> bool:
+    """
+    Run a ZK handshake to verify the agent's credential.
+
+    Returns True if the agent is authorized, False otherwise.
+    No secrets are revealed during verification.
+    """
+    try:
+        handshake = prove_handshake(identity.human, identity.agent)
+        verify_handshake(
+            handshake.human_proof,
+            handshake.agent_proof,
+            handshake.session_nonce,
+        )
+        return True
+    except Exception:
+        return False

--- a/examples/x402_authorized_agent_scraping/authorized_scrape.py
+++ b/examples/x402_authorized_agent_scraping/authorized_scrape.py
@@ -1,0 +1,221 @@
+"""
+Authorized Agent Scraping with x402 + Identity Verification
+
+Demonstrates how to add an authorization layer before an AI agent
+makes paid API calls (e.g., Firecrawl's x402 endpoint).
+
+Problem: Any agent with a wallet can call x402 endpoints and spend money.
+There's no built-in way to verify *which* agent is calling, or whether
+that agent has permission to make financial API calls on behalf of its
+operator.
+
+Solution: Before the agent scrapes, it proves:
+  1. It holds a valid operator-signed credential
+  2. The credential includes FINANCIAL_SMALL permission (for paid APIs)
+  3. The credential hasn't expired
+
+The authorization check happens locally (zero-knowledge proof generation +
+verification), so no extra network call or central auth server is needed.
+
+Usage:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your keys
+    python authorized_scrape.py
+"""
+
+import os
+import sys
+import json
+import time
+from dataclasses import asdict
+from dotenv import load_dotenv
+from firecrawl import FirecrawlApp
+
+# Bolyra provides the agent identity layer
+from bolyra import (
+    Permission,
+    create_human_identity,
+    create_agent_credential,
+    prove_handshake,
+    verify_handshake,
+    permissions_to_bitmask,
+)
+
+# ANSI color codes for terminal output
+class Colors:
+    CYAN = '\033[96m'
+    YELLOW = '\033[93m'
+    GREEN = '\033[92m'
+    RED = '\033[91m'
+    MAGENTA = '\033[95m'
+    BLUE = '\033[94m'
+    RESET = '\033[0m'
+
+
+def step(msg: str) -> None:
+    """Print a step indicator."""
+    print(f"{Colors.CYAN}[step]{Colors.RESET} {msg}")
+
+
+def ok(msg: str) -> None:
+    """Print a success indicator."""
+    print(f"{Colors.GREEN}  [ok]{Colors.RESET} {msg}")
+
+
+def fail(msg: str) -> None:
+    """Print a failure indicator."""
+    print(f"{Colors.RED}[fail]{Colors.RESET} {msg}")
+
+
+# ---------------------------------------------------------------------------
+# 1. Set up operator + agent identities (normally done once at deploy time)
+# ---------------------------------------------------------------------------
+
+def create_identities():
+    """
+    Create an operator (human) identity and an agent credential.
+
+    In production:
+    - The operator creates their identity once and stores the secret securely.
+    - The operator issues agent credentials with specific permissions and expiry.
+    - Agent credentials are deployed with the agent (e.g., as env vars or secrets).
+    """
+    step("Creating operator identity...")
+
+    # Operator's secret (in production, use a secure random value or HSM)
+    operator_secret = 42  # DO NOT use this in production
+    human = create_human_identity(operator_secret)
+    ok(f"Operator identity created (commitment: {str(human.commitment)[:16]}...)")
+
+    step("Issuing agent credential with FINANCIAL_SMALL permission...")
+
+    # The agent needs READ_DATA (to receive scrape results) and
+    # FINANCIAL_SMALL (to authorize paid API calls under $100)
+    permissions = [Permission.READ_DATA, Permission.FINANCIAL_SMALL]
+    expiry = int(time.time()) + 86400  # Valid for 24 hours
+
+    # Model hash identifies which model/agent is being credentialed
+    model_hash = 12345  # In production, hash the model identifier
+
+    agent = create_agent_credential(
+        model_hash=model_hash,
+        operator_private_key=operator_secret,
+        permissions=permissions,
+        expiry_timestamp=expiry,
+    )
+    ok(f"Agent credential issued (expires in 24h, permissions: {permissions_to_bitmask(permissions):#04x})")
+
+    return human, agent
+
+
+# ---------------------------------------------------------------------------
+# 2. Authorization check — runs before any paid API call
+# ---------------------------------------------------------------------------
+
+def authorize_agent(human, agent):
+    """
+    Verify the agent is authorized to make financial API calls.
+
+    This generates a zero-knowledge proof that:
+    - The agent holds a valid credential signed by the operator
+    - The credential includes the required permissions
+    - The credential hasn't expired
+
+    The proof reveals NOTHING about the operator's secret key or the
+    agent's internal state — only that the authorization is valid.
+    """
+    step("Generating authorization proof (ZK handshake)...")
+
+    try:
+        handshake = prove_handshake(human, agent)
+        ok("Proof generated")
+    except Exception as e:
+        fail(f"Proof generation failed: {e}")
+        return None
+
+    step("Verifying authorization proof...")
+
+    try:
+        result = verify_handshake(
+            handshake.human_proof,
+            handshake.agent_proof,
+            handshake.session_nonce,
+        )
+        ok("Authorization verified — agent is permitted to make paid API calls")
+        return result
+    except Exception as e:
+        fail(f"Authorization failed: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 3. Scrape with Firecrawl (only after authorization succeeds)
+# ---------------------------------------------------------------------------
+
+def scrape_with_firecrawl(url: str):
+    """
+    Scrape a URL using Firecrawl. This is the paid API call that the
+    agent needs authorization for.
+    """
+    firecrawl_api_key = os.getenv("FIRECRAWL_API_KEY")
+    if not firecrawl_api_key:
+        fail("FIRECRAWL_API_KEY not set. Set it in your .env file.")
+        return None
+
+    step(f"Scraping {url} via Firecrawl...")
+
+    app = FirecrawlApp(api_key=firecrawl_api_key)
+    result = app.scrape_url(url, params={"formats": ["markdown"]})
+
+    ok(f"Scrape complete ({len(result.get('markdown', ''))} chars)")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print(f"\n{Colors.MAGENTA}=== Authorized Agent Scraping ==={Colors.RESET}")
+    print("Demonstrates identity verification before paid API calls.\n")
+
+    # Step 1: Create identities
+    try:
+        human, agent = create_identities()
+    except Exception as e:
+        fail(f"Identity creation failed: {e}")
+        print(f"\n{Colors.YELLOW}Note: Identity creation requires @bolyra/sdk (Node.js).")
+        print(f"See README.md for setup instructions.{Colors.RESET}")
+        sys.exit(1)
+
+    print()
+
+    # Step 2: Authorize the agent
+    auth_result = authorize_agent(human, agent)
+    if auth_result is None:
+        fail("Agent is NOT authorized. Blocking API call.")
+        sys.exit(1)
+
+    print()
+
+    # Step 3: Only now make the paid scraping call
+    url = input(f"{Colors.BLUE}Enter URL to scrape: {Colors.RESET}").strip()
+    if not url:
+        url = "https://firecrawl.dev"
+
+    result = scrape_with_firecrawl(url)
+
+    if result and result.get("markdown"):
+        # Show a preview
+        preview = result["markdown"][:500]
+        print(f"\n{Colors.MAGENTA}--- Scrape Preview ---{Colors.RESET}")
+        print(preview)
+        if len(result["markdown"]) > 500:
+            print(f"\n{Colors.YELLOW}... ({len(result['markdown']) - 500} more chars){Colors.RESET}")
+
+    print(f"\n{Colors.GREEN}Done. The agent proved authorization before spending.{Colors.RESET}\n")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    main()

--- a/examples/x402_authorized_agent_scraping/authorized_scrape.py
+++ b/examples/x402_authorized_agent_scraping/authorized_scrape.py
@@ -1,221 +1,66 @@
 """
-Authorized Agent Scraping with x402 + Identity Verification
+Per-agent access control for Firecrawl scraping.
 
-Demonstrates how to add an authorization layer before an AI agent
-makes paid API calls (e.g., Firecrawl's x402 endpoint).
+Shows how to gate Firecrawl API calls behind agent identity verification,
+so only credentialed agents with the right permissions can scrape.
 
-Problem: Any agent with a wallet can call x402 endpoints and spend money.
-There's no built-in way to verify *which* agent is calling, or whether
-that agent has permission to make financial API calls on behalf of its
-operator.
+This is useful for multi-tenant setups where different agents (or agent
+fleets) need different access levels — e.g., a research agent can read
+but not spend, while a purchasing agent can make paid calls.
 
-Solution: Before the agent scrapes, it proves:
-  1. It holds a valid operator-signed credential
-  2. The credential includes FINANCIAL_SMALL permission (for paid APIs)
-  3. The credential hasn't expired
-
-The authorization check happens locally (zero-knowledge proof generation +
-verification), so no extra network call or central auth server is needed.
-
-Usage:
+Setup:
     pip install -r requirements.txt
-    cp .env.example .env  # fill in your keys
+    npm install @bolyra/sdk        # ZK proofs run in Node.js
+    cp .env.example .env           # add your FIRECRAWL_API_KEY
     python authorized_scrape.py
 """
 
 import os
 import sys
-import json
-import time
-from dataclasses import asdict
+
 from dotenv import load_dotenv
 from firecrawl import FirecrawlApp
 
-# Bolyra provides the agent identity layer
-from bolyra import (
-    Permission,
-    create_human_identity,
-    create_agent_credential,
-    prove_handshake,
-    verify_handshake,
-    permissions_to_bitmask,
-)
+from agent_auth import create_agent_identity, authorize
 
-# ANSI color codes for terminal output
-class Colors:
-    CYAN = '\033[96m'
-    YELLOW = '\033[93m'
-    GREEN = '\033[92m'
-    RED = '\033[91m'
-    MAGENTA = '\033[95m'
-    BLUE = '\033[94m'
-    RESET = '\033[0m'
-
-
-def step(msg: str) -> None:
-    """Print a step indicator."""
-    print(f"{Colors.CYAN}[step]{Colors.RESET} {msg}")
-
-
-def ok(msg: str) -> None:
-    """Print a success indicator."""
-    print(f"{Colors.GREEN}  [ok]{Colors.RESET} {msg}")
-
-
-def fail(msg: str) -> None:
-    """Print a failure indicator."""
-    print(f"{Colors.RED}[fail]{Colors.RESET} {msg}")
-
-
-# ---------------------------------------------------------------------------
-# 1. Set up operator + agent identities (normally done once at deploy time)
-# ---------------------------------------------------------------------------
-
-def create_identities():
-    """
-    Create an operator (human) identity and an agent credential.
-
-    In production:
-    - The operator creates their identity once and stores the secret securely.
-    - The operator issues agent credentials with specific permissions and expiry.
-    - Agent credentials are deployed with the agent (e.g., as env vars or secrets).
-    """
-    step("Creating operator identity...")
-
-    # Operator's secret (in production, use a secure random value or HSM)
-    operator_secret = 42  # DO NOT use this in production
-    human = create_human_identity(operator_secret)
-    ok(f"Operator identity created (commitment: {str(human.commitment)[:16]}...)")
-
-    step("Issuing agent credential with FINANCIAL_SMALL permission...")
-
-    # The agent needs READ_DATA (to receive scrape results) and
-    # FINANCIAL_SMALL (to authorize paid API calls under $100)
-    permissions = [Permission.READ_DATA, Permission.FINANCIAL_SMALL]
-    expiry = int(time.time()) + 86400  # Valid for 24 hours
-
-    # Model hash identifies which model/agent is being credentialed
-    model_hash = 12345  # In production, hash the model identifier
-
-    agent = create_agent_credential(
-        model_hash=model_hash,
-        operator_private_key=operator_secret,
-        permissions=permissions,
-        expiry_timestamp=expiry,
-    )
-    ok(f"Agent credential issued (expires in 24h, permissions: {permissions_to_bitmask(permissions):#04x})")
-
-    return human, agent
-
-
-# ---------------------------------------------------------------------------
-# 2. Authorization check — runs before any paid API call
-# ---------------------------------------------------------------------------
-
-def authorize_agent(human, agent):
-    """
-    Verify the agent is authorized to make financial API calls.
-
-    This generates a zero-knowledge proof that:
-    - The agent holds a valid credential signed by the operator
-    - The credential includes the required permissions
-    - The credential hasn't expired
-
-    The proof reveals NOTHING about the operator's secret key or the
-    agent's internal state — only that the authorization is valid.
-    """
-    step("Generating authorization proof (ZK handshake)...")
-
-    try:
-        handshake = prove_handshake(human, agent)
-        ok("Proof generated")
-    except Exception as e:
-        fail(f"Proof generation failed: {e}")
-        return None
-
-    step("Verifying authorization proof...")
-
-    try:
-        result = verify_handshake(
-            handshake.human_proof,
-            handshake.agent_proof,
-            handshake.session_nonce,
-        )
-        ok("Authorization verified — agent is permitted to make paid API calls")
-        return result
-    except Exception as e:
-        fail(f"Authorization failed: {e}")
-        return None
-
-
-# ---------------------------------------------------------------------------
-# 3. Scrape with Firecrawl (only after authorization succeeds)
-# ---------------------------------------------------------------------------
-
-def scrape_with_firecrawl(url: str):
-    """
-    Scrape a URL using Firecrawl. This is the paid API call that the
-    agent needs authorization for.
-    """
-    firecrawl_api_key = os.getenv("FIRECRAWL_API_KEY")
-    if not firecrawl_api_key:
-        fail("FIRECRAWL_API_KEY not set. Set it in your .env file.")
-        return None
-
-    step(f"Scraping {url} via Firecrawl...")
-
-    app = FirecrawlApp(api_key=firecrawl_api_key)
-    result = app.scrape_url(url, params={"formats": ["markdown"]})
-
-    ok(f"Scrape complete ({len(result.get('markdown', ''))} chars)")
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main():
-    print(f"\n{Colors.MAGENTA}=== Authorized Agent Scraping ==={Colors.RESET}")
-    print("Demonstrates identity verification before paid API calls.\n")
+    load_dotenv()
 
-    # Step 1: Create identities
-    try:
-        human, agent = create_identities()
-    except Exception as e:
-        fail(f"Identity creation failed: {e}")
-        print(f"\n{Colors.YELLOW}Note: Identity creation requires @bolyra/sdk (Node.js).")
-        print(f"See README.md for setup instructions.{Colors.RESET}")
+    api_key = os.getenv("FIRECRAWL_API_KEY")
+    if not api_key:
+        print("Error: FIRECRAWL_API_KEY not set. Copy .env.example to .env and fill it in.")
         sys.exit(1)
 
-    print()
+    # --- 1. Set up agent identity (normally done once at deploy time) --------
+    print("[1/3] Creating agent identity...")
+    operator_secret = int(os.getenv("OPERATOR_SECRET", "42"))
+    identity = create_agent_identity(operator_secret)
+    print(f"      Agent credentialed (expires in 24 h)")
 
-    # Step 2: Authorize the agent
-    auth_result = authorize_agent(human, agent)
-    if auth_result is None:
-        fail("Agent is NOT authorized. Blocking API call.")
+    # --- 2. Authorize the agent before it can call Firecrawl ----------------
+    print("[2/3] Running authorization check (ZK proof)...")
+    if not authorize(identity):
+        print("DENIED — agent is not authorized. Aborting.")
         sys.exit(1)
+    print("      Authorized.")
 
-    print()
+    # --- 3. Scrape with Firecrawl -------------------------------------------
+    url = input("URL to scrape [https://firecrawl.dev]: ").strip() or "https://firecrawl.dev"
 
-    # Step 3: Only now make the paid scraping call
-    url = input(f"{Colors.BLUE}Enter URL to scrape: {Colors.RESET}").strip()
-    if not url:
-        url = "https://firecrawl.dev"
+    print(f"[3/3] Scraping {url} ...")
+    app = FirecrawlApp(api_key=api_key)
+    result = app.scrape_url(url, params={"formats": ["markdown"]})
 
-    result = scrape_with_firecrawl(url)
+    markdown = result.get("markdown", "")
+    print(f"      Done — {len(markdown)} chars returned.\n")
 
-    if result and result.get("markdown"):
-        # Show a preview
-        preview = result["markdown"][:500]
-        print(f"\n{Colors.MAGENTA}--- Scrape Preview ---{Colors.RESET}")
-        print(preview)
-        if len(result["markdown"]) > 500:
-            print(f"\n{Colors.YELLOW}... ({len(result['markdown']) - 500} more chars){Colors.RESET}")
-
-    print(f"\n{Colors.GREEN}Done. The agent proved authorization before spending.{Colors.RESET}\n")
+    # Show a preview
+    preview = markdown[:500]
+    print(preview)
+    if len(markdown) > 500:
+        print(f"\n... ({len(markdown) - 500} more chars)")
 
 
 if __name__ == "__main__":
-    load_dotenv()
     main()

--- a/examples/x402_authorized_agent_scraping/requirements.txt
+++ b/examples/x402_authorized_agent_scraping/requirements.txt
@@ -1,0 +1,3 @@
+firecrawl-py>=1.0.0
+bolyra>=0.4.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

Adds an example showing how to verify an AI agent's identity and permissions before it makes paid API calls through Firecrawl.

**The problem:** With x402, any agent with a wallet can call `api.firecrawl.dev/v1/x402/search`. There's no built-in way to check which agent is calling, whether it has permission to spend money on API calls, or who authorized it.

**What this example does:**
1. Creates an operator identity (the human/org that owns the agent)
2. Issues a time-limited agent credential with specific permissions (`READ_DATA` + `FINANCIAL_SMALL`)
3. Generates a zero-knowledge proof that the agent holds a valid credential
4. Verifies the proof locally (no network call to an auth server)
5. Only then makes the Firecrawl scraping call

**Files added:**
- `examples/x402_authorized_agent_scraping/authorized_scrape.py` — the example script
- `examples/x402_authorized_agent_scraping/README.md` — setup and usage guide
- `examples/x402_authorized_agent_scraping/requirements.txt` — Python dependencies

Uses [Bolyra](https://bolyra.ai) for the identity verification layer. The authorization check is local and reveals nothing about the operator's secrets (zero-knowledge proof).

## Test plan

- [ ] `pip install -r requirements.txt` installs cleanly
- [ ] `python authorized_scrape.py` runs the full flow (create identity → authorize → scrape)
- [ ] Authorization failure blocks the scrape (modify permissions to test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Firecrawl example that gates scraping behind agent identity verification using Bolyra ZK proofs. Scraping runs only after a local check that the agent holds a valid, time-limited credential with required scopes.

- **New Features**
  - New example at `examples/x402_authorized_agent_scraping` with `authorized_scrape.py`, `agent_auth.py`, `README.md`, `.env.example`, and `requirements.txt`.
  - Issues an operator-signed agent credential (`READ_DATA`, `FINANCIAL_SMALL`, 24h TTL) and proceeds to scrape only if authorization succeeds.

- **Dependencies**
  - Adds Python deps: `firecrawl-py`, `bolyra`, `python-dotenv`.
  - Requires Node 18+ with `@bolyra/sdk` for proof generation.

<sup>Written for commit 416807a0466778fde0e2115f5d70b449abce000e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

