### PR TITLE
chore(ruby-sdk): expose created_at, completed_at, duration on job models

### DIFF
--- a/apps/ruby-sdk/lib/firecrawl/models/batch_scrape_job.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/batch_scrape_job.rb
@@ -5,7 +5,7 @@ module Firecrawl
     # Status and results of a batch scrape job.
     class BatchScrapeJob
       attr_reader :id, :status, :total, :completed, :credits_used,
-                  :expires_at, :next_url
+                  :expires_at, :created_at, :completed_at, :duration, :next_url
       attr_accessor :data
 
       def initialize(raw)
@@ -15,6 +15,9 @@ module Firecrawl
         @completed = raw["completed"].to_i
         @credits_used = raw["creditsUsed"]
         @expires_at = raw["expiresAt"]
+        @created_at = raw["createdAt"]
+        @completed_at = raw["completedAt"]
+        @duration = raw["duration"]&.to_f
         @next_url = raw["next"]
         @data = (raw["data"] || []).map { |d| Document.new(d) }
       end

--- a/apps/ruby-sdk/lib/firecrawl/models/crawl_job.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/crawl_job.rb
@@ -5,7 +5,7 @@ module Firecrawl
     # Status and results of a crawl job.
     class CrawlJob
       attr_reader :id, :status, :total, :completed, :credits_used,
-                  :expires_at, :next_url
+                  :expires_at, :created_at, :completed_at, :duration, :next_url
       attr_accessor :data
 
       def initialize(raw)
@@ -15,6 +15,9 @@ module Firecrawl
         @completed = raw["completed"].to_i
         @credits_used = raw["creditsUsed"]
         @expires_at = raw["expiresAt"]
+        @created_at = raw["createdAt"]
+        @completed_at = raw["completedAt"]
+        @duration = raw["duration"]&.to_f
         @next_url = raw["next"]
         @data = (raw["data"] || []).map { |d| Document.new(d) }
       end


### PR DESCRIPTION
## What
Exposes three new read-only attributes on `Firecrawl::Models::CrawlJob` and `Firecrawl::Models::BatchScrapeJob`:

- `created_at`   → from API `createdAt`
- `completed_at` → from API `completedAt`
- `duration`     → from API `duration` (Float seconds, or `nil` when absent)

## Why
The Firecrawl API already returns these fields on crawl / batch-scrape status responses (see `apps/api/src/controllers/v2/crawl-status.ts:397-401`), but the Ruby SDK models weren't reading them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose job timestamps and duration on `Firecrawl::Models::CrawlJob` and `Firecrawl::Models::BatchScrapeJob` so clients can read them from status responses. Keeps the Ruby SDK aligned with the Firecrawl API.

- **New Features**
  - Adds read-only attributes: created_at, completed_at, duration.
  - Maps to API fields: createdAt, completedAt, duration; duration is a Float (seconds) or nil.

<sup>Written for commit a7ab68c611ae6d9fa96c1a3fd73a897b41c93b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

