### PR TITLE
fix(monitor): Preserve original URL case when storing search results

### DIFF
--- a/apps/api/src/services/monitoring/search/run.test.ts
+++ b/apps/api/src/services/monitoring/search/run.test.ts
@@ -5,6 +5,7 @@ import {
   buildJudgePrompt,
 } from "./judge";
 import { canonicalizeUrl, stableSerpFingerprint } from "./dedupe";
+import { hashMonitorUrl } from "../store";
 import { scrapeRequestSchema } from "../../../controllers/v2/types";
 
 // vi.mock is hoisted above declarations, so the mocks its factories reference
@@ -131,6 +132,22 @@ describe("runSearchTarget orchestration", () => {
     expect(out.pageUpserts[0].status).toBe("alert");
     expect(out.summary).toBe("1 match across 1 result.");
     expect(scrapePageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves original URL case in the stored page (paths/query params are case-sensitive)", async () => {
+    const mixedUrl = "https://example.com/watch?v=DAlfGz8tPc4";
+    setSearchResults([
+      { url: mixedUrl, title: "OpenAI reel", description: "clip" },
+    ]);
+    setVerdictsByUrl({ [mixedUrl]: verdict() });
+
+    const out = await run();
+
+    expect(out.pageUpserts[0].url).toBe(mixedUrl);
+    expect(out.sources[0].url).toBe(mixedUrl);
+    expect(out.pageUpserts[0].urlHash).toEqual(
+      hashMonitorUrl(canonicalizeUrl(mixedUrl)),
+    );
   });
 
   it("skips scrape/judge for an already-seen unchanged page (same goalVersion)", async () => {

--- a/apps/api/src/services/monitoring/search/run.ts
+++ b/apps/api/src/services/monitoring/search/run.ts
@@ -416,7 +416,7 @@ export async function runSearchTarget(params: {
       skipped += 1;
       sources.push({ url: c.url, title: c.title, status: "skipped" });
       pageUpserts.push({
-        url: canonical,
+        url: c.url,
         urlHash: hashMonitorUrl(canonical),
         status: "skipped",
         scraped: false,
@@ -442,7 +442,7 @@ export async function runSearchTarget(params: {
             : "watching";
       sources.push({ url: c.url, title: c.title, status: reusedStatus });
       pageUpserts.push({
-        url: canonical,
+        url: c.url,
         urlHash: hashMonitorUrl(canonical),
         status: reusedStatus,
         metadata: {
@@ -466,7 +466,7 @@ export async function runSearchTarget(params: {
         goalVersion,
         searchStatus: alreadyAlerted ? "already_seen" : "alert",
         eventKey: rawKey,
-        eventLabel: c.title || canonical,
+        eventLabel: c.title || c.url,
         query: c.query,
         matchedQueries: c.matchedQueries,
       };
@@ -478,7 +478,7 @@ export async function runSearchTarget(params: {
           eventKey: rawKey,
         });
         pageUpserts.push({
-          url: canonical,
+          url: c.url,
           urlHash: hashMonitorUrl(canonical),
           status: "already_seen",
           scraped: false,
@@ -497,7 +497,7 @@ export async function runSearchTarget(params: {
       } else {
         events.unshift({
           key: rawKey,
-          label: c.title || canonical,
+          label: c.title || c.url,
           satisfiedAt: eventSatisfiedAt,
           alertCount: eventAlertCount,
         });
@@ -509,7 +509,7 @@ export async function runSearchTarget(params: {
         eventKey: rawKey,
       });
       pageUpserts.push({
-        url: canonical,
+        url: c.url,
         urlHash: hashMonitorUrl(canonical),
         status: "alert",
         scraped: false,
@@ -609,7 +609,7 @@ export async function runSearchTarget(params: {
         ...baseMeta,
       });
       pageUpserts.push({
-        url: canonical,
+        url: c.url,
         urlHash: hashMonitorUrl(canonical),
         status: "ignored",
         scraped: depth === "deep",
@@ -625,7 +625,7 @@ export async function runSearchTarget(params: {
         ...baseMeta,
       });
       pageUpserts.push({
-        url: canonical,
+        url: c.url,
         urlHash: hashMonitorUrl(canonical),
         status: "watching",
         scraped: depth === "deep",
@@ -636,7 +636,7 @@ export async function runSearchTarget(params: {
 
     // Deterministic event key: dedup by canonical URL (no LLM event resolver).
     const eventKey = canonical;
-    const eventLabel = verdict.concept || canonical;
+    const eventLabel = verdict.concept || c.url;
 
     // Re-alert on every new result only in every_new_result mode; otherwise dedup.
     const alreadySatisfied =
@@ -652,7 +652,7 @@ export async function runSearchTarget(params: {
         ...baseMeta,
       });
       pageUpserts.push({
-        url: canonical,
+        url: c.url,
         urlHash: hashMonitorUrl(canonical),
         status: "already_seen",
         scraped: depth === "deep",
@@ -686,7 +686,7 @@ export async function runSearchTarget(params: {
       ...baseMeta,
     });
     pageUpserts.push({
-      url: canonical,
+      url: c.url,
       urlHash: hashMonitorUrl(canonical),
       status: "alert",
       scraped: depth === "deep",


### PR DESCRIPTION
Store the original result URL (c.url) instead of the canonicalized URL in pageUpserts/sources and event labels so path/query case is preserved. Update eventLabel to prefer verdict.concept or the original URL. Keep urlHash derived from the canonicalized URL via hashMonitorUrl. Add a test asserting original URL casing is preserved while urlHash matches the canonicalized hash. Adjust imports in the test accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves original URL casing in stored search results and event labels while keeping dedupe via the canonicalized URL hash. Fixes issues with case-sensitive paths and query params and makes event labels clearer.

- **Bug Fixes**
  - Store `c.url` in `pageUpserts` and `sources` instead of the canonical URL.
  - Set event labels to `verdict.concept` or the original URL; keep `urlHash` from the canonicalized URL via `hashMonitorUrl`.
  - Add a test to confirm casing is preserved and the hash matches the canonicalized URL.

<sup>Written for commit f84a2b0dfadf237fc8445292c7b7871e4f9b2d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

