### PR TITLE
fix(monitor): gate search results

### DIFF
--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -68,6 +68,8 @@ import { trackMonitorCheckStartedInterest } from "./interest";
 import { runSearchTarget, type ScrapeSearchResult } from "./search/run";
 import { verdictJsonSchema } from "./search/judge";
 import { computeGoalVersion } from "./search/dedupe";
+import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
+import { getACUCTeam } from "../../controllers/auth";
 import {
   reconstructKnownState,
   searchStatusToPageStatus,
@@ -715,6 +717,10 @@ async function runMonitorSearchTarget(params: {
     goalVersion,
   );
 
+  // Same blocklist gate prod scrapes use, applied per team (honors unblockedDomains).
+  const acuc = await getACUCTeam(monitor.team_id);
+  const teamFlags = acuc?.flags ?? null;
+
   const result = await runSearchTarget({
     monitor: {
       id: monitor.id,
@@ -743,6 +749,11 @@ async function runMonitorSearchTarget(params: {
         checkId: check.id,
         url,
         judgePrompt,
+      }),
+    isBlocked: url =>
+      isUrlBlocked(url, teamFlags, {
+        team_id: monitor.team_id,
+        origin: "monitor.search",
       }),
     goalVersion,
     knownPages,

--- a/apps/api/src/services/monitoring/search/run.test.ts
+++ b/apps/api/src/services/monitoring/search/run.test.ts
@@ -90,6 +90,7 @@ function run(
     knownEvents?: { key: string; label: string }[];
     goalVersion?: string;
     alertMode?: "first_match" | "every_new_result" | "material_dev";
+    isBlocked?: (url: string) => boolean;
   } = {},
 ) {
   return runSearchTarget({
@@ -101,6 +102,7 @@ function run(
     },
     monitorCheckId: "check-1",
     scrapePage: (...a: unknown[]) => scrapePageMock(...a),
+    isBlocked: over.isBlocked,
     goalVersion: over.goalVersion ?? "gv1",
     knownPages: over.knownPages ?? new Map(),
     knownEvents: over.knownEvents ?? [],
@@ -537,5 +539,27 @@ describe("domain scoping", () => {
     expect(out.resultCount).toBe(1);
     expect(out.sources.map(s => s.url)).toEqual(["https://news.com/openai"]);
     expect(scrapePageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocklisted URLs are dropped before scrape/judge/billing", async () => {
+    setSearchResults([
+      { url: "https://blocked.com/x", title: "blocked", description: "x" },
+      {
+        url: "https://news.com/openai",
+        title: "OpenAI files S-1",
+        description: "x",
+      },
+    ]);
+    setVerdictsByUrl({ "https://news.com/openai": verdict() });
+    const out = await run({
+      isBlocked: url => url.includes("blocked.com"),
+    });
+    expect(out.resultCount).toBe(1);
+    expect(out.sources.map(s => s.url)).toEqual(["https://news.com/openai"]);
+    expect(out.pageUpserts.map(p => p.url)).toEqual([
+      "https://news.com/openai",
+    ]);
+    expect(scrapePageMock).toHaveBeenCalledTimes(1);
+    expect(out.resultsJudged).toBe(1);
   });
 });

--- a/apps/api/src/services/monitoring/search/run.ts
+++ b/apps/api/src/services/monitoring/search/run.ts
@@ -259,6 +259,9 @@ export async function runSearchTarget(params: {
   target: SearchTargetInput;
   monitorCheckId: string;
   scrapePage: ScrapeSearchPage;
+  // Injected blocklist predicate (keeps this module free of worker/auth deps).
+  // Blocked URLs are dropped before scrape/judge/billing. Defaults to allow-all.
+  isBlocked?: (url: string) => boolean;
   goalVersion: string;
   knownPages: Map<string, KnownPage>;
   knownEvents: KnownEvent[];
@@ -266,6 +269,7 @@ export async function runSearchTarget(params: {
   logger: Logger;
 }): Promise<SearchTargetRunResult> {
   const { target, knownPages, goalVersion, logger } = params;
+  const isBlocked = params.isBlocked ?? (() => false);
   const judgeEnabled = params.monitor.judgeEnabled;
   const runStart = Date.now();
 
@@ -285,6 +289,7 @@ export async function runSearchTarget(params: {
   let skipped = 0;
   let matches = 0;
   let searchResultsBilled = 0;
+  let blocked = 0;
   let resultsJudged = 0;
   let judgeScrapeFailures = 0;
 
@@ -315,6 +320,10 @@ export async function runSearchTarget(params: {
     for (const r of results) {
       if (!r.url) continue;
       if (isExcludedDomain(r.url, target.excludeDomains)) continue;
+      if (isBlocked(r.url)) {
+        blocked += 1;
+        continue;
+      }
       const canonical = canonicalizeUrl(r.url);
       const existingIdx = seenThisRun.get(canonical);
       if (existingIdx !== undefined) {
@@ -335,6 +344,13 @@ export async function runSearchTarget(params: {
     }
   }
   resultCount = candidates.length;
+
+  if (blocked > 0) {
+    logger.info("search monitor: dropped blocklisted results before judging", {
+      blocked,
+      kept: resultCount,
+    });
+  }
 
   // An empty retrieval is indistinguishable from "nothing matched"; log to diagnose.
   if (resultCount === 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Search monitors now honor the prod blocklist and drop blocked URLs before scrape/judge/billing to cut costs and match scrape behavior. The blocklist is applied per team via ACUC flags, including `unblockedDomains`.

- **New Features**
  - Added `isBlocked` predicate to `runSearchTarget` (defaults to allow-all) to keep the module decoupled.
  - Wired `isUrlBlocked` using team flags from `getACUCTeam` and origin `monitor.search`.
  - Filter blocked results during candidate build and log blocked/kept counts.
  - Added a test to ensure blocked URLs are skipped before scrape/judge.

<sup>Written for commit fa591bf0834a18da414a9a55609ec17976c69c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

