### PR TITLE
feat(go-sdk): add Profile option to ScrapeOptions

### DIFF
--- a/apps/go-sdk/README.md
+++ b/apps/go-sdk/README.md
@@ -144,15 +144,21 @@ fmt.Println(doc.Menu)
 
 Pass a `Profile` to preserve browser state (cookies, `localStorage`, session data)
 across scrapes. Scrapes that reuse the same profile name share that state, which is
-useful for staying logged in between requests without scripting interactions. Set
-`SaveChanges` to `false` to load an existing profile without persisting any changes
-made during the scrape (it defaults to `true`).
+useful for staying logged in between requests without scripting interactions.
 
 ```go
 doc, err := client.Scrape(ctx, "https://example.com/dashboard", &firecrawl.ScrapeOptions{
 	Formats: []string{"markdown"},
 	Profile: &firecrawl.ProfileConfig{Name: "my-profile"},
 })
+```
+
+`SaveChanges` controls whether browser state changed during the scrape is persisted
+back to the profile; it defaults to `true`. Since it is a `*bool`, use the
+`firecrawl.Bool` helper to load an existing profile without saving any changes:
+
+```go
+Profile: &firecrawl.ProfileConfig{Name: "my-profile", SaveChanges: firecrawl.Bool(false)},
 ```
 
 #### Interactive Browser

--- a/apps/go-sdk/README.md
+++ b/apps/go-sdk/README.md
@@ -140,6 +140,21 @@ if err != nil {
 fmt.Println(doc.Menu)
 ```
 
+### Persistent Browser Profile
+
+Pass a `Profile` to preserve browser state (cookies, `localStorage`, session data)
+across scrapes. Scrapes that reuse the same profile name share that state, which is
+useful for staying logged in between requests without scripting interactions. Set
+`SaveChanges` to `false` to load an existing profile without persisting any changes
+made during the scrape (it defaults to `true`).
+
+```go
+doc, err := client.Scrape(ctx, "https://example.com/dashboard", &firecrawl.ScrapeOptions{
+	Formats: []string{"markdown"},
+	Profile: &firecrawl.ProfileConfig{Name: "my-profile"},
+})
+```
+
 #### Interactive Browser
 
 Execute code in a scrape-bound browser session:

--- a/apps/go-sdk/options.go
+++ b/apps/go-sdk/options.go
@@ -91,6 +91,7 @@ type ScrapeOptions struct {
 	StoreInCache        *bool                    `json:"storeInCache,omitempty"`
 	Lockdown            *bool                    `json:"lockdown,omitempty"`
 	RedactPII           *bool                    `json:"redactPII,omitempty"`
+	Profile             *ProfileConfig           `json:"profile,omitempty"`
 	Integration         *string                  `json:"integration,omitempty"`
 	JsonOptions         *JsonOptions             `json:"jsonOptions,omitempty"`
 }
@@ -191,6 +192,17 @@ type AgentOptions struct {
 type LocationConfig struct {
 	Country   string   `json:"country,omitempty"`
 	Languages []string `json:"languages,omitempty"`
+}
+
+// ProfileConfig enables a persistent browser profile for a scrape. Scrapes that
+// reuse the same profile name share browser state such as cookies, localStorage,
+// and session data, which is useful for staying logged in across requests.
+type ProfileConfig struct {
+	// Name identifies the profile. Required (1-128 characters).
+	Name string `json:"name"`
+	// SaveChanges controls whether browser state changed during the scrape is
+	// persisted back to the profile. Defaults to true on the server when omitted.
+	SaveChanges *bool `json:"saveChanges,omitempty"`
 }
 
 // WebhookConfig configures webhook notifications.

--- a/apps/go-sdk/options_test.go
+++ b/apps/go-sdk/options_test.go
@@ -76,3 +76,29 @@ func TestScrapeOptionsSerializesRedactPII(t *testing.T) {
 		t.Fatalf("serialized redactPII = %s", payload)
 	}
 }
+
+func TestScrapeOptionsSerializesProfile(t *testing.T) {
+	payload, err := json.Marshal(ScrapeOptions{
+		Profile: &ProfileConfig{Name: "my-profile"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal ScrapeOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"profile":{"name":"my-profile"}`) {
+		t.Fatalf("serialized profile = %s, want to contain %s", payload, `"profile":{"name":"my-profile"}`)
+	}
+}
+
+func TestScrapeOptionsSerializesProfileSaveChanges(t *testing.T) {
+	payload, err := json.Marshal(ScrapeOptions{
+		Profile: &ProfileConfig{Name: "my-profile", SaveChanges: Bool(false)},
+	})
+	if err != nil {
+		t.Fatalf("Marshal ScrapeOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"profile":{"name":"my-profile","saveChanges":false}`) {
+		t.Fatalf("serialized profile = %s, want to contain %s", payload, `"profile":{"name":"my-profile","saveChanges":false}`)
+	}
+}


### PR DESCRIPTION
## What

Adds a `Profile` option to the Go SDK's `ScrapeOptions`, mirroring the `profile` field the `/v2` scrape API already accepts and that the Python, Rust, and Elixir SDKs already expose.

A new `ProfileConfig` type carries the profile `name` (required) and an optional `saveChanges` flag:

```go
doc, err := client.Scrape(ctx, "https://example.com/dashboard", &firecrawl.ScrapeOptions{
    Formats: []string{"markdown"},
    Profile: &firecrawl.ProfileConfig{Name: "my-profile"},
})
```

Scrapes that reuse the same profile name share browser state (cookies, `localStorage`, session data), so you can stay logged in across requests without scripting interactions. `SaveChanges` defaults to `true` on the server when omitted; set it to `false` to load a profile without persisting changes.

## Why

Closes #3458. The scrape API and the Python/Rust/Elixir SDKs support a persistent browser profile, but the Go SDK had no field for it — the only workaround was the heavier interactive `Browser` flow, which is overkill when you only need to carry session state between scrapes.

## Changes

- `options.go`: add the `ProfileConfig` type and a `Profile *ProfileConfig` field on `ScrapeOptions` (serializes to `profile`, omitted when unset).
- `options_test.go`: serialization tests covering `profile` with and without `saveChanges`.
- `README.md`: document the option with an example.

## Testing

`go test ./...`, `go vet ./...`, and `gofmt -l` all pass in `apps/go-sdk`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Profile option to the Go SDK’s `ScrapeOptions` to enable persistent browser profiles, so scrapes can share cookies, localStorage, and session state. This brings the Go SDK in line with the `/v2` scrape API and the Python/Rust/Elixir SDKs.

- **New Features**
  - Added `ProfileConfig` (`name` required, optional `saveChanges`) and `Profile *ProfileConfig` on `ScrapeOptions` (`json:"profile,omitempty"`).
  - Reuse browser state across scrapes; set `saveChanges=false` to avoid persisting changes.
  - Updated README with examples, including the `firecrawl.Bool(false)` pointer-helper for `SaveChanges`, and added serialization tests.

<sup>Written for commit bffbd7890a6b7507a44eaf7332d006b42e37da79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

