### PR TITLE
docs: point community link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Pst. Hey, you, join our stargazers :)_
 - **Agent ready**: Connect Firecrawl to any AI agent or MCP client with a single command
 - **Media parsing**: Parse and extract content from web-hosted PDFs, DOCX, and more
 - **Actions**: Click, scroll, write, wait, and press before extracting content
-- **Open source**: Developed transparently and collaboratively — [join our community](https://github.com/firecrawl/firecrawl)
+- **Open source**: Developed transparently and collaboratively — [join our community](https://discord.gg/firecrawl)
 
 ---
 


### PR DESCRIPTION
## Summary
- Updates the README's "join our community" link in the Why Firecrawl section to point to the Firecrawl Discord invite.

## Why this helps
- The link text invites readers to join the community, but it currently points back to the GitHub repository. The Discord invite is already used elsewhere in the README and is the more direct community destination.
- Closes #3887.

## Test Plan
- [x] git diff --check
- [x] Verified https://discord.gg/firecrawl redirects successfully to https://discord.com/invite/firecrawl and returns HTTP 200.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README community link to point to the Firecrawl Discord invite so readers can join directly. Replaces the GitHub repository link in the “Open source” bullet.

<sup>Written for commit 995657559a2bdd0812bbc72d821cd897abcffbde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

