### PR TITLE
fix(python-sdk): map camelCase image/news fields in async search

### DIFF
--- a/apps/python-sdk/firecrawl/v2/methods/aio/search.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/search.py
@@ -9,7 +9,7 @@ from ...types import (
 )
 from ...utils.http_client_async import AsyncHttpClient
 from ...utils.error_handler import handle_response_error
-from ...utils.normalize import normalize_document_input
+from ...utils.normalize import normalize_document_input, _map_search_result_keys
 from ...utils.validation import validate_scrape_options, prepare_scrape_options
 
 T = TypeVar("T")
@@ -75,7 +75,19 @@ def _transform_array(arr: List[Any], result_type: Type[T]) -> List[Union[T, Docu
             ):
                 results.append(Document(**normalize_document_input(item)))
             else:
-                results.append(result_type(**item))
+                result_type_name = None
+                if result_type == SearchResultImages:
+                    result_type_name = "images"
+                elif result_type == SearchResultNews:
+                    result_type_name = "news"
+                elif result_type == SearchResultWeb:
+                    result_type_name = "web"
+
+                if result_type_name:
+                    normalized_item = _map_search_result_keys(item, result_type_name)
+                    results.append(result_type(**normalized_item))
+                else:
+                    results.append(result_type(**item))
         else:
             results.append(result_type(url=item))
     return results


### PR DESCRIPTION
### Problem

`AsyncFirecrawl.search(sources=["images"])` returns image results whose `image_url`, `image_width` and `image_height` are always `None` — the same symptom as #2200, which was fixed for the **sync** client in #2244.

The fix in #2244 added `_map_search_result_keys` and wired it into the sync transformer (`v2/methods/search.py::_transform_array`). The **async** transformer (`v2/methods/aio/search.py::_transform_array`) is a parallel copy that was never updated — it still does `result_type(**item)` directly, so the API's camelCase keys (`imageUrl`, `imageWidth`, `imageHeight`) don't map onto the snake_case model fields and get dropped.

### Reproduction (latest `firecrawl-py==4.30.4`)

Running both transformers on the exact camelCase payload the API returns:

```
SYNC  -> image_url='https://cdn.example.com/logo.png'  width=640  height=320
ASYNC -> image_url=None                                width=None height=None
```

`sync imports _map_search_result_keys:  True`
`async imports _map_search_result_keys: False`

### Fix

Mirror the sync `_transform_array` logic in the async module: import `_map_search_result_keys` and apply the same `images`/`news`/`web` key normalization before constructing the result model. After the change the async path returns populated `image_url`/`image_width`/`image_height` (and `image_url` for news), matching the sync client.

This is a behavior-only change scoped to the async search transformer; no public API changes.

Closes the async half of #2200.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes async search in `firecrawl-py` by mapping camelCase API fields to snake_case models so image/news results return the expected values. Aligns async behavior with the sync client; no public API changes.

- **Bug Fixes**
  - In `v2/methods/aio/search.py`, use `_map_search_result_keys` for `images`, `news`, and `web` before building result models.
  - Restores `image_url`, `image_width`, `image_height` for images and `image_url` for news in `AsyncFirecrawl.search(...)`.

<sup>Written for commit 5dd6a3edf186a8a6437c8951e4cace24062eb462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

