### PR TITLE
chore(sdks): bump go/php/rust/java/elixir for search monitor support

### DIFF
--- a/apps/elixir-sdk/mix.exs
+++ b/apps/elixir-sdk/mix.exs
@@ -1,7 +1,7 @@
 defmodule Firecrawl.MixProject do
   use Mix.Project
 
-  @version "1.7.2"
+  @version "1.8.0"
   @source_url "https://github.com/firecrawl/firecrawl/tree/main/apps/elixir-sdk"
 
   def project do

--- a/apps/go-sdk/version.go
+++ b/apps/go-sdk/version.go
@@ -9,4 +9,4 @@ package firecrawl
 // Bump this when preparing a new release. The publish-go-sdk GitHub workflow
 // reads this value and creates the corresponding monorepo-prefixed tag on
 // merge to main.
-const Version = "1.7.2"
+const Version = "1.8.0"

--- a/apps/java-sdk/build.gradle.kts
+++ b/apps/java-sdk/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.firecrawl"
-version = "1.10.2"
+version = "1.11.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.7.1';
+    public const SDK_VERSION = '1.8.0';
 }

--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecrawl"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "mockito",
  "reqwest",

--- a/apps/rust-sdk/Cargo.toml
+++ b/apps/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecrawl"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://www.firecrawl.dev/"


### PR DESCRIPTION
These five SDKs received search monitor target support (#82973) without a follow-up version bump; js/python/ruby/dotnet were already bumped (#3919). Minor bumps to match that wave:
- go 1.7.2 -> 1.8.0
- php 1.7.1 -> 1.8.0 (also releases the menu scrape format)
- rust 2.10.0 -> 2.11.0
- java 1.10.2 -> 1.11.0
- elixir 1.7.2 -> 1.8.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release minor version bumps for the Go, PHP, Rust, Java, and Elixir SDKs to ship search monitor target support. Aligns with the earlier JS/Python/Ruby/.NET bumps; PHP also releases the menu scrape format.

- **Dependencies**
  - Go: 1.7.2 → 1.8.0
  - PHP: 1.7.1 → 1.8.0 (includes menu scrape format)
  - Rust: 2.10.0 → 2.11.0
  - Java: 1.10.2 → 1.11.0
  - Elixir: 1.7.2 → 1.8.0

<sup>Written for commit 88d9c9da2782663ae8b207be55765b6d0a4b956e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

