### PR TITLE
test(api): add headroom for v1 JSON prompt snips

### DIFF
--- a/apps/api/src/__tests__/snips/v1/json-extract-format.test.ts
+++ b/apps/api/src/__tests__/snips/v1/json-extract-format.test.ts
@@ -83,7 +83,7 @@ describeIf(TEST_PRODUCTION || (HAS_AI && ALLOW_TEST_SUITE_WEBSITE))(
           expect(response.json).toBeUndefined();
           expect(response.extract.mainHeading).toBeDefined();
         },
-        scrapeTimeout,
+        scrapeTimeout * 2,
       );
     });
 
@@ -150,7 +150,7 @@ describeIf(TEST_PRODUCTION || (HAS_AI && ALLOW_TEST_SUITE_WEBSITE))(
           expect(response.extract).toBeUndefined();
           expect(response.json.mainHeading).toBeDefined();
         },
-        scrapeTimeout,
+        scrapeTimeout * 2,
       );
     });
 


### PR DESCRIPTION
## Summary
- Give the v1 JSON/extract custom-prompt backward-compat snips `scrapeTimeout * 2` test headroom.
- Keep the API request timeout at `scrapeTimeout`, so the scrape deadline remains unchanged while Vitest no longer kills the case at the same deadline boundary.

## Validation
- `pnpm build`
- `git diff --check`
- `pnpm harness pnpm vitest run src/__tests__/snips/v1/json-extract-format.test.ts` *(blocked locally after build: Docker daemon not running, so harness could not start the NUQ container)*

Evidence run: 28417439328 (`Self-hosted environment tests (fetch, no-proxy, searxng, openai, fdb)` timed out in the custom-prompt JSON case at exactly 90000ms).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase test headroom for v1 JSON/extract custom-prompt snips by doubling the Vitest case timeout to `scrapeTimeout * 2`. The API call still uses `scrapeTimeout`, so scrape timing is unchanged and boundary-timeout failures are avoided.

<sup>Written for commit 208855a0050a4238376b341d2dd1edd91d2018fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

