### PR TITLE
test(api): stabilize v1 crawl snip

### DIFF
--- a/apps/api/src/__tests__/snips/v1/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v1/crawl.test.ts
@@ -60,7 +60,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
   const baseUrl = new URL(base);
   const baseDomain = baseUrl.hostname;
 
-  it.concurrent(
+  it(
     "works",
     async () => {
       const results = await crawl(
@@ -76,7 +76,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     10 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "works with ignoreSitemap: true",
     async () => {
       const results = await crawl(
@@ -93,12 +93,12 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     10 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "filters URLs properly",
     async () => {
       const res = await crawl(
         {
-          url: base,
+          url: `${TEST_SUITE_WEBSITE}/blog`,
           includePaths: ["^/blog$"],
           limit: 10,
         },
@@ -140,7 +140,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
   //   10 * scrapeTimeout,
   // );
 
-  it.concurrent(
+  it(
     "delay parameter works",
     async () => {
       await crawl(


### PR DESCRIPTION
## Summary
- run the four flaky top-level v1 crawl snips serially instead of concurrently
- start the v1 includePaths crawl at `/blog`, matching the stable v2 coverage and avoiding source URL self-denial from `/`

## Failure evidence
- Run 28392593422: `src/__tests__/snips/v1/crawl.test.ts > Crawl tests > works` failed with `expected 0 to be greater than 0` at `src/__tests__/snips/v1/lib.ts:176`
- Run 28395338943: `works`, `works with ignoreSitemap: true`, `filters URLs properly`, and `delay parameter works` failed in the fetch/no-proxy self-hosted matrix with the same zero-result assertion
- Run 28452189895: repeated the same four-test failure family in the fetch/no-proxy self-hosted matrix

The failed logs also show the filtered v1 crawl source scrape denied at `/` because `includePaths` only allowed `/blog`, so the test could complete with zero successful pages depending on discovery timing.

## Validation
- `pnpm build` in `apps/api`: passed
- `git diff --check`: passed
- Focused harness attempted: `TEST_SUITE_SELF_HOSTED=true TEST_SUITE_WEBSITE=http://127.0.0.1:4321 TEST_API_KEY=test TEST_TEAM_ID=bypass SEARXNG_ENDPOINT=http://localhost:3434 HOST=0.0.0.0 USE_GO_MARKDOWN_PARSER=true ALLOW_LOCAL_WEBHOOKS=true ENV=test pnpm harness pnpm vitest run src/__tests__/snips/v1/crawl.test.ts`
  - blocked locally because Docker daemon is not running, after API install/build completed; CI self-hosted matrix should provide the decisive harness signal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky v1 crawl tests by running them serially and starting the includePaths crawl at /blog to prevent zero-result runs. This removes intermittent failures in the self-hosted fetch/no-proxy CI matrix.

- **Bug Fixes**
  - Run the four top-level v1 crawl tests serially (replace it.concurrent with it) to avoid racey discovery timing.
  - Start the includePaths test at /blog (not /) so the allowlist matches and pages are found.

<sup>Written for commit ac6434d1607045423f387de4779cab8e4ebd2e4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

