### PR TITLE
feat(api): add Web Risk filtering for search

### DIFF
--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -78,6 +78,24 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
   );
 
   it.concurrent(
+    "rejects invalid filterRiskyURLs threat types",
+    async () => {
+      const res = await searchWithFailure(
+        {
+          query: "firecrawl",
+          filterRiskyURLs: {
+            threatTypes: ["NOT_A_THREAT_TYPE"] as any,
+          },
+        },
+        identity,
+      );
+
+      expect(res.error).toBe("Invalid request body");
+    },
+    60000,
+  );
+
+  it.concurrent(
     "works with scrape",
     async () => {
       const res = await search(

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -62,6 +62,7 @@ const configSchema = z.object({
   PREVIEW_TOKEN: z.string().optional(),
   SEARCH_PREVIEW_TOKEN: z.string().optional(),
   SEARCH_SERVICE_API_SECRET: z.string().optional(),
+  GOOGLE_WEB_RISK_API_KEY: z.string().optional(),
   SEARCH_FEEDBACK_MAX_AGE_SEC: z.coerce.number().int().positive().default(120),
   SEARCH_FEEDBACK_DAILY_CAP_CREDITS: z.coerce
     .number()

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -135,8 +135,10 @@ export async function searchController(
         ? projectSearchTotalCredits(
             {
               limit: req.body.limit,
+              sources: req.body.sources,
               enterprise: req.body.enterprise,
               scrapeOptions: req.body.scrapeOptions,
+              filterRiskyURLs: req.body.filterRiskyURLs,
             },
             req.acuc?.flags ?? null,
             zeroDataRetention,
@@ -173,6 +175,7 @@ export async function searchController(
         enterprise: req.body.enterprise,
         scrapeOptions: req.body.scrapeOptions,
         highlights: req.body.highlights,
+        filterRiskyURLs: req.body.filterRiskyURLs,
         timeout: req.body.timeout,
       },
       {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1888,6 +1888,26 @@ const searchDomainSchema = z
     "Domain must be a valid hostname without protocol or path",
   );
 
+const webRiskThreatTypeSchema = z.enum([
+  "MALWARE",
+  "SOCIAL_ENGINEERING",
+  "UNWANTED_SOFTWARE",
+  "SOCIAL_ENGINEERING_EXTENDED_COVERAGE",
+]);
+
+const filterRiskyURLsSchema = z.union([
+  z.boolean(),
+  z.strictObject({
+    enabled: z.boolean().optional().prefault(true),
+    threatTypes: z
+      .array(webRiskThreatTypeSchema)
+      .min(1)
+      .optional()
+      .prefault(["MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE"]),
+    failOpen: z.boolean().optional().prefault(true),
+  }),
+]);
+
 export const searchRequestSchema = z
   .strictObject({
     query: z.string(),
@@ -1938,6 +1958,7 @@ export const searchRequestSchema = z
     // highlights pulled from our index (last 30 days), out-of-line from
     // scrapeURL. Falls back to the provider snippet when the URL isn't indexed.
     highlights: z.boolean().optional().prefault(false),
+    filterRiskyURLs: filterRiskyURLsSchema.optional().prefault(false),
     __searchPreviewToken: z.string().optional(),
     scrapeOptions: baseScrapeOptions
       .extend({

--- a/apps/api/src/lib/keyless-credit-projection.ts
+++ b/apps/api/src/lib/keyless-credit-projection.ts
@@ -1,5 +1,6 @@
 import { ScrapeOptions, TeamFlags } from "../controllers/v2/types";
 import { hasFormatOfType } from "./format-utils";
+import { WEB_RISK_CREDITS_PER_SCANNED_URL } from "../search/web-risk";
 
 export function projectScrapeCredits(
   options: ScrapeOptions,
@@ -76,19 +77,35 @@ function projectSearchCredits(
 export function projectSearchTotalCredits(
   params: {
     limit: number;
+    sources?: Array<{ type: string } | string>;
     enterprise?: ("default" | "anon" | "zdr")[];
     scrapeOptions?: ScrapeOptions;
+    filterRiskyURLs?: boolean | { enabled?: boolean };
   },
   flags: TeamFlags,
   zeroDataRetention: boolean,
 ): number {
   const searchCredits = projectSearchCredits(params.limit, params.enterprise);
+  const sourceCount = new Set(
+    (params.sources ?? [{ type: "web" }]).map(s =>
+      typeof s === "string" ? s : s.type,
+    ),
+  ).size;
+  const riskFilterCredits =
+    params.filterRiskyURLs &&
+    (params.filterRiskyURLs === true ||
+      params.filterRiskyURLs.enabled !== false)
+      ? params.limit * sourceCount * WEB_RISK_CREDITS_PER_SCANNED_URL
+      : 0;
   const shouldScrape =
     params.scrapeOptions?.formats && params.scrapeOptions.formats.length > 0;
-  if (!shouldScrape || !params.scrapeOptions) return searchCredits;
+  if (!shouldScrape || !params.scrapeOptions) {
+    return searchCredits + riskFilterCredits;
+  }
 
   return (
     searchCredits +
+    riskFilterCredits +
     params.limit *
       projectScrapeCredits(params.scrapeOptions, flags, zeroDataRetention)
   );

--- a/apps/api/src/search/execute.test.ts
+++ b/apps/api/src/search/execute.test.ts
@@ -1,0 +1,97 @@
+vi.mock("../config", () => ({
+  config: {
+    GOOGLE_WEB_RISK_API_KEY: "test-key",
+  },
+}));
+
+vi.mock("./v2", () => ({
+  search: vi.fn(),
+}));
+
+vi.mock("../lib/tracking", () => ({
+  trackSearchRequest: vi.fn(() => Promise.resolve()),
+  trackSearchResults: vi.fn(() => Promise.resolve()),
+}));
+
+import type { Mock } from "vitest";
+import { executeSearch } from "./execute";
+import { search } from "./v2";
+
+const searchMock = search as Mock;
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as any;
+
+function mockWebRiskFetch(riskyUrls: Set<string>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: URL) => {
+      const scannedUrl = url.searchParams.get("uri");
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          scannedUrl && riskyUrls.has(scannedUrl)
+            ? { threat: { threatTypes: ["MALWARE"] } }
+            : {},
+        text: async () => "",
+      };
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("executeSearch", () => {
+  it("adds two search credits per URL scanned by Web Risk", async () => {
+    searchMock.mockResolvedValue({
+      web: [
+        {
+          url: "https://safe.example",
+          title: "safe",
+          description: "safe",
+        },
+        {
+          url: "https://bad.example",
+          title: "bad",
+          description: "bad",
+        },
+      ],
+    });
+    mockWebRiskFetch(new Set(["https://bad.example"]));
+
+    const result = await executeSearch(
+      {
+        query: "example",
+        limit: 10,
+        sources: [{ type: "web" }],
+        filterRiskyURLs: true,
+        timeout: 60_000,
+      },
+      {
+        teamId: "team-1",
+        origin: "api",
+        apiKeyId: 1,
+        flags: null,
+        requestId: "req-1",
+        jobId: "job-1",
+        apiVersion: "v2",
+      },
+      logger,
+    );
+
+    expect(result.response.web?.map(x => x.url)).toEqual([
+      "https://safe.example",
+    ]);
+    expect(result.totalResultsCount).toBe(1);
+    expect(result.searchCredits).toBe(6);
+    expect(result.totalCredits).toBe(6);
+  });
+});

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -16,6 +16,11 @@ import {
 import { applySearchHighlights, highlightsEnvReady } from "./highlights";
 import { trackSearchResults, trackSearchRequest } from "../lib/tracking";
 import type { BillingMetadata } from "../services/billing/types";
+import {
+  filterSearchResponseWithWebRisk,
+  FilterRiskyURLsOptions,
+  WEB_RISK_CREDITS_PER_SCANNED_URL,
+} from "./web-risk";
 
 interface SearchOptions {
   query: string;
@@ -32,6 +37,7 @@ interface SearchOptions {
   enterprise?: ("default" | "anon" | "zdr")[];
   scrapeOptions?: ScrapeOptions;
   highlights?: boolean;
+  filterRiskyURLs?: FilterRiskyURLsOptions;
   timeout: number;
 }
 
@@ -147,7 +153,30 @@ export async function executeSearch(
   const creditsPerTenResults = isZDR ? 10 : 2;
   const searchCredits =
     Math.ceil(totalResultsCount / 10) * creditsPerTenResults;
+  let riskFilterCredits = 0;
   let scrapeCredits = 0;
+
+  if (options.filterRiskyURLs) {
+    const filteringResult = await filterSearchResponseWithWebRisk(
+      searchResponse,
+      options.filterRiskyURLs,
+      logger,
+    );
+    searchResponse.web = filteringResult.response.web;
+    searchResponse.images = filteringResult.response.images;
+    searchResponse.news = filteringResult.response.news;
+    riskFilterCredits =
+      filteringResult.scannedUrls * WEB_RISK_CREDITS_PER_SCANNED_URL;
+    totalResultsCount =
+      (searchResponse.web?.length ?? 0) +
+      (searchResponse.images?.length ?? 0) +
+      (searchResponse.news?.length ?? 0);
+    logger.info("Google Web Risk filtering complete", {
+      scannedUrls: filteringResult.scannedUrls,
+      filteredUrls: filteringResult.filteredUrls,
+      riskFilterCredits,
+    });
+  }
 
   const shouldScrape =
     scrapeOptions?.formats && scrapeOptions.formats.length > 0;
@@ -209,6 +238,7 @@ export async function executeSearch(
         typeof f === "string" ? f : f.type,
       )
     : [];
+  const totalSearchCredits = searchCredits + riskFilterCredits;
 
   trackSearchRequest({
     searchId: context.jobId,
@@ -222,9 +252,9 @@ export async function executeSearch(
     country: options.country,
     sources: searchTypes,
     numResults: totalResultsCount,
-    searchCredits,
+    searchCredits: totalSearchCredits,
     scrapeCredits,
-    totalCredits: searchCredits + scrapeCredits,
+    totalCredits: totalSearchCredits + scrapeCredits,
     hasScrapeFormats: shouldScrape ?? false,
     scrapeFormats,
     isSuccessful: true,
@@ -245,9 +275,9 @@ export async function executeSearch(
   return {
     response: searchResponse,
     totalResultsCount,
-    searchCredits,
+    searchCredits: totalSearchCredits,
     scrapeCredits,
-    totalCredits: searchCredits + scrapeCredits,
+    totalCredits: totalSearchCredits + scrapeCredits,
     shouldScrape: shouldScrape ?? false,
   };
 }

--- a/apps/api/src/search/web-risk.test.ts
+++ b/apps/api/src/search/web-risk.test.ts
@@ -1,0 +1,110 @@
+vi.mock("../config", () => ({
+  config: {
+    GOOGLE_WEB_RISK_API_KEY: "test-key",
+  },
+}));
+
+import {
+  filterSearchResponseWithWebRisk,
+  normalizeFilterRiskyURLsOptions,
+} from "./web-risk";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as any;
+
+function mockWebRiskFetch(riskyUrls: Set<string>) {
+  const fetchMock = vi.fn(async (url: URL) => {
+    const scannedUrl = url.searchParams.get("uri");
+    return {
+      ok: true,
+      status: 200,
+      json: async () =>
+        scannedUrl && riskyUrls.has(scannedUrl)
+          ? { threat: { threatTypes: ["MALWARE"] } }
+          : {},
+      text: async () => "",
+    };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("filterSearchResponseWithWebRisk", () => {
+  it("filters risky search results and scans duplicate URLs once", async () => {
+    const fetchMock = mockWebRiskFetch(new Set(["https://bad.example"]));
+
+    const result = await filterSearchResponseWithWebRisk(
+      {
+        web: [
+          {
+            url: "https://safe.example",
+            title: "safe",
+            description: "safe",
+          },
+          {
+            url: "https://bad.example",
+            title: "bad",
+            description: "bad",
+          },
+        ],
+        news: [{ url: "https://bad.example", title: "bad news" }],
+      },
+      true,
+      logger,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.scannedUrls).toBe(2);
+    expect(result.filteredUrls).toBe(1);
+    expect(result.response.web?.map(x => x.url)).toEqual([
+      "https://safe.example",
+    ]);
+    expect(result.response.news).toEqual([]);
+  });
+
+  it("throws when failOpen is false and Google Web Risk errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        text: async () => "upstream failed",
+      })),
+    );
+
+    await expect(
+      filterSearchResponseWithWebRisk(
+        {
+          web: [
+            {
+              url: "https://safe.example",
+              title: "safe",
+              description: "safe",
+            },
+          ],
+        },
+        { failOpen: false },
+        logger,
+      ),
+    ).rejects.toThrow("Google Web Risk returned 500");
+  });
+});
+
+describe("normalizeFilterRiskyURLsOptions", () => {
+  it("uses safe defaults for boolean shorthand", () => {
+    expect(normalizeFilterRiskyURLsOptions(true)).toEqual({
+      enabled: true,
+      threatTypes: ["MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE"],
+      failOpen: true,
+    });
+  });
+});

--- a/apps/api/src/search/web-risk.ts
+++ b/apps/api/src/search/web-risk.ts
@@ -1,0 +1,171 @@
+import type { Logger } from "winston";
+import { config } from "../config";
+import type { SearchV2Response } from "../lib/entities";
+
+export const WEB_RISK_CREDITS_PER_SCANNED_URL = 2;
+
+export const DEFAULT_WEB_RISK_THREAT_TYPES = [
+  "MALWARE",
+  "SOCIAL_ENGINEERING",
+  "UNWANTED_SOFTWARE",
+] as const;
+
+export type WebRiskThreatType =
+  | (typeof DEFAULT_WEB_RISK_THREAT_TYPES)[number]
+  | "SOCIAL_ENGINEERING_EXTENDED_COVERAGE";
+
+export type FilterRiskyURLsOptions =
+  | boolean
+  | {
+      enabled?: boolean;
+      threatTypes?: WebRiskThreatType[];
+      failOpen?: boolean;
+    };
+
+type NormalizedFilterRiskyURLsOptions = {
+  enabled: boolean;
+  threatTypes: WebRiskThreatType[];
+  failOpen: boolean;
+};
+
+type GoogleWebRiskResponse = {
+  threat?: {
+    threatTypes?: WebRiskThreatType[];
+    expireTime?: string;
+  };
+};
+
+type UrlScanResult = {
+  url: string;
+  risky: boolean;
+  threatTypes: WebRiskThreatType[];
+};
+
+type WebRiskFilteringResult = {
+  response: SearchV2Response;
+  scannedUrls: number;
+  filteredUrls: number;
+};
+
+export function normalizeFilterRiskyURLsOptions(
+  options: FilterRiskyURLsOptions | undefined,
+): NormalizedFilterRiskyURLsOptions {
+  if (!options) {
+    return {
+      enabled: false,
+      threatTypes: [...DEFAULT_WEB_RISK_THREAT_TYPES],
+      failOpen: true,
+    };
+  }
+
+  if (options === true) {
+    return {
+      enabled: true,
+      threatTypes: [...DEFAULT_WEB_RISK_THREAT_TYPES],
+      failOpen: true,
+    };
+  }
+
+  return {
+    enabled: options.enabled ?? true,
+    threatTypes: options.threatTypes?.length
+      ? options.threatTypes
+      : [...DEFAULT_WEB_RISK_THREAT_TYPES],
+    failOpen: options.failOpen ?? true,
+  };
+}
+
+async function scanUrlWithGoogleWebRisk(
+  url: string,
+  threatTypes: WebRiskThreatType[],
+): Promise<UrlScanResult> {
+  if (!config.GOOGLE_WEB_RISK_API_KEY) {
+    throw new Error("GOOGLE_WEB_RISK_API_KEY is not configured");
+  }
+
+  const requestUrl = new URL("https://webrisk.googleapis.com/v1/uris:search");
+  requestUrl.searchParams.set("key", config.GOOGLE_WEB_RISK_API_KEY);
+  requestUrl.searchParams.set("uri", url);
+  for (const threatType of threatTypes) {
+    requestUrl.searchParams.append("threatTypes", threatType);
+  }
+
+  const response = await fetch(requestUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Google Web Risk returned ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  const body = (await response.json()) as GoogleWebRiskResponse;
+  const matchedThreatTypes = body.threat?.threatTypes ?? [];
+  return {
+    url,
+    risky: matchedThreatTypes.length > 0,
+    threatTypes: matchedThreatTypes,
+  };
+}
+
+function uniqueResultUrls(response: SearchV2Response): string[] {
+  const urls = [
+    ...(response.web ?? []).map(result => result.url),
+    ...(response.news ?? []).map(result => result.url).filter(Boolean),
+    ...(response.images ?? []).map(result => result.url).filter(Boolean),
+  ];
+
+  return [...new Set(urls)].filter((url): url is string => !!url);
+}
+
+export async function filterSearchResponseWithWebRisk(
+  response: SearchV2Response,
+  options: FilterRiskyURLsOptions | undefined,
+  logger: Logger,
+): Promise<WebRiskFilteringResult> {
+  const normalized = normalizeFilterRiskyURLsOptions(options);
+  if (!normalized.enabled) {
+    return { response, scannedUrls: 0, filteredUrls: 0 };
+  }
+
+  const urlsToScan = uniqueResultUrls(response);
+  if (urlsToScan.length === 0) {
+    return { response, scannedUrls: 0, filteredUrls: 0 };
+  }
+
+  let scanResults: UrlScanResult[];
+  try {
+    scanResults = await Promise.all(
+      urlsToScan.map(url =>
+        scanUrlWithGoogleWebRisk(url, normalized.threatTypes),
+      ),
+    );
+  } catch (error) {
+    if (normalized.failOpen) {
+      logger.warn("Google Web Risk filtering failed open", { error });
+      return { response, scannedUrls: 0, filteredUrls: 0 };
+    }
+
+    throw error;
+  }
+
+  const riskyUrls = new Set(
+    scanResults.filter(result => result.risky).map(result => result.url),
+  );
+  if (riskyUrls.size === 0) {
+    return { response, scannedUrls: scanResults.length, filteredUrls: 0 };
+  }
+
+  return {
+    response: {
+      ...response,
+      web: response.web?.filter(result => !riskyUrls.has(result.url)),
+      news: response.news?.filter(
+        result => !result.url || !riskyUrls.has(result.url),
+      ),
+      images: response.images?.filter(
+        result => !result.url || !riskyUrls.has(result.url),
+      ),
+    },
+    scannedUrls: scanResults.length,
+    filteredUrls: riskyUrls.size,
+  };
+}


### PR DESCRIPTION
## Summary
- add `filterRiskyURLs` to v2 search requests with boolean shorthand and configurable threat types / fail-open behavior
- scan unique returned search URLs through Google Web Risk before search scraping
- charge 2 credits per scanned URL through the search billing bucket and include it in keyless credit projection

## Tests
- `pnpm build`
- `pnpm vitest run src/search/web-risk.test.ts src/search/execute.test.ts`
- `pnpm harness jest src/__tests__/snips/v2/search.test.ts -t "rejects invalid filterRiskyURLs threat types"` blocked locally because Docker daemon is not running for the NUQ PostgreSQL harness container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Web Risk filtering to v2 search to block malicious result URLs and reflect the extra scanning cost in billing. Adds a new `filterRiskyURLs` option and charges 2 credits per scanned URL.

- **New Features**
  - `filterRiskyURLs` request option: boolean or object with `enabled`, `threatTypes`, `failOpen` (defaults to common threats and fail-open).
  - Scans unique URLs across `web`, `news`, and `images` via Google Web Risk and removes risky results.
  - Bills +2 credits per scanned URL; included in keyless credit projection and request/result tracking.
  - Schema validates threat types; controller and execute path wired; tests added.

- **Migration**
  - Set `GOOGLE_WEB_RISK_API_KEY` in the API environment.
  - To enable, pass `filterRiskyURLs: true` (or configure options). Off by default.

<sup>Written for commit d30f5cd46076c767aa0f776f444627f812e5dc7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

