### PR TITLE
fix(monitor): search-mon-updates

### DIFF
--- a/apps/api/src/services/monitoring/search/run.test.ts
+++ b/apps/api/src/services/monitoring/search/run.test.ts
@@ -259,6 +259,21 @@ describe("runSearchTarget orchestration", () => {
       expect(byStatus(status).metadata.searchStatus).toBe(status);
       expect(byStatus(status).scraped).toBe(true);
     }
+    expect(byStatus("alert").judgment).toMatchObject({
+      meaningful: true,
+      reason: "filing confirmed",
+      meaningfulChanges: [],
+    });
+    expect(byStatus("watching").judgment).toMatchObject({
+      meaningful: false,
+      reason: "filing confirmed",
+      meaningfulChanges: [],
+    });
+    expect(byStatus("ignored").judgment).toMatchObject({
+      meaningful: false,
+      reason: "filing confirmed",
+      meaningfulChanges: [],
+    });
   });
 
   it("re-evaluates a known page when the goalVersion changed (stale memory)", async () => {

--- a/apps/api/src/services/monitoring/search/run.test.ts
+++ b/apps/api/src/services/monitoring/search/run.test.ts
@@ -323,6 +323,11 @@ describe("runSearchTarget orchestration", () => {
     const seen = out.pageUpserts.find(u => u.status === "already_seen")!;
     expect(seen.scraped).toBe(true);
     expect(seen.metadata.searchStatus).toBe("already_seen");
+    expect(seen.judgment).toMatchObject({
+      meaningful: true,
+      reason: "filing confirmed",
+      meaningfulChanges: [],
+    });
   });
 
   it("uses the canonical URL as the event key (label is the verdict concept)", async () => {

--- a/apps/api/src/services/monitoring/search/run.ts
+++ b/apps/api/src/services/monitoring/search/run.ts
@@ -248,6 +248,18 @@ type SearchTargetRunResult = {
   }>;
 };
 
+function judgmentFromSearchVerdict(
+  verdict: SearchVerdict,
+  meaningful: boolean,
+): NonNullable<SearchTargetRunResult["pageUpserts"][number]["judgment"]> {
+  return {
+    meaningful,
+    confidence: "high",
+    reason: verdict.rationale,
+    meaningfulChanges: [],
+  };
+}
+
 export async function runSearchTarget(params: {
   monitor: {
     id: string;
@@ -605,6 +617,10 @@ export async function runSearchTarget(params: {
     resultsJudged += 1;
 
     const decision = verdictToDecision(verdict);
+    const meaningfulJudgment = judgmentFromSearchVerdict(
+      verdict,
+      decision === "notify",
+    );
 
     const baseMeta = {
       fingerprint,
@@ -630,6 +646,7 @@ export async function runSearchTarget(params: {
         status: "ignored",
         scraped: depth === "deep",
         metadata: { ...baseMeta, searchStatus: "ignored" },
+        judgment: meaningfulJudgment,
       });
       continue;
     }
@@ -646,6 +663,7 @@ export async function runSearchTarget(params: {
         status: "watching",
         scraped: depth === "deep",
         metadata: { ...baseMeta, searchStatus: "watching" },
+        judgment: meaningfulJudgment,
       });
       continue;
     }
@@ -673,6 +691,7 @@ export async function runSearchTarget(params: {
         status: "already_seen",
         scraped: depth === "deep",
         metadata: { ...eventMeta, searchStatus: "already_seen" },
+        judgment: meaningfulJudgment,
       });
       continue;
     }
@@ -713,12 +732,7 @@ export async function runSearchTarget(params: {
         eventAlertCount,
         eventLastAlertAt: nowIso,
       },
-      judgment: {
-        meaningful: true,
-        confidence: "high",
-        reason: verdict.rationale,
-        meaningfulChanges: [],
-      },
+      judgment: meaningfulJudgment,
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Attach a consistent judgment to all search monitoring results and centralize judgment creation. This fixes missing judgments for non-alert statuses and makes downstream handling simpler.

- **Bug Fixes**
  - Added `judgmentFromSearchVerdict()` and now include a high-confidence judgment for all statuses: alert, watching, ignored, already_seen.
  - meaningful is true only when the decision is notify; reason uses the verdict rationale; meaningfulChanges is empty.
  - Updated tests to assert judgments for alert, watching, ignored, and already_seen.

<sup>Written for commit b3677bdcc765449ef17ae06285387a57887ffb3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

