### PR TITLE
feat(api): support third-party OpenAI-compatible LLM endpoints for extraction

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -81,6 +81,7 @@
     "@ai-sdk/google-vertex": "^4.0.145",
     "@ai-sdk/groq": "^3.0.41",
     "@ai-sdk/openai": "3.0.71",
+    "@ai-sdk/openai-compatible": "2.0.50",
     "@ai-sdk/xai": "^3.0.83",
     "@bull-board/api": "^6.14.0",
     "@bull-board/express": "^6.14.0",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 3.0.71
         version: 3.0.71(zod@4.1.12)
+      '@ai-sdk/openai-compatible':
+        specifier: 2.0.50
+        version: 2.0.50(zod@4.1.12)
       '@ai-sdk/xai':
         specifier: ^3.0.83
         version: 3.0.83(zod@4.1.12)
@@ -522,6 +525,7 @@ packages:
 
   '@clickhouse/client-common@1.18.2':
     resolution: {integrity: sha512-J0SG6q9V31ydxonglpj9xhNRsUxCsF71iEZ784yldqMYwsHixj/9xHFDgBDX3DuMiDx/kPDfXnf+pimp08wIBA==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.18.2':
     resolution: {integrity: sha512-fuquQswRSHWM6D079ZeuGqkMOsqtcUPL06UdTnowmoeeYjVrqisfVmvnw8pc3OeKS4kVb91oygb/MfLDiMs0TQ==}

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -1,4 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { config } from "../config";
 import { createOllama } from "ollama-ai-provider-v2";
 import { anthropic } from "@ai-sdk/anthropic";
@@ -53,6 +54,17 @@ const providerList: Record<Provider, any> = {
   }),
 };
 
+// Third-party OpenAI-compatible endpoints (e.g. Z.AI/GLM) don't support the
+// OpenAI Responses API or json_schema structured outputs. The openai-compatible
+// provider uses Chat Completions + json_object mode, which they do support.
+const openaiCompatibleProvider = config.OPENAI_BASE_URL
+  ? createOpenAICompatible({
+      name: "openai-compatible",
+      baseURL: config.OPENAI_BASE_URL,
+      apiKey: config.OPENAI_API_KEY,
+    })
+  : null;
+
 export function getModel(name: string, provider: Provider = defaultProvider) {
   if (name === "gemini-2.5-pro") {
     name = "gemini-2.5-pro";
@@ -61,6 +73,13 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   // o3-mini returns empty text via the Responses API — force Chat Completions
   if (provider === "openai" && modelName.startsWith("o3-mini")) {
     return providerList.openai.chat(modelName);
+  }
+  // A custom OPENAI_BASE_URL means a third-party OpenAI-compatible endpoint
+  // (e.g. Z.AI/GLM). Route it through the openai-compatible provider, which uses
+  // Chat Completions + json_object mode (not the Responses API / json_schema
+  // structured outputs that the official OpenAI provider forces).
+  if (provider === "openai" && openaiCompatibleProvider) {
+    return openaiCompatibleProvider(modelName);
   }
   return providerList[provider](modelName);
 }

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -18,6 +18,7 @@ import {
   jsonSchema,
 } from "ai";
 import { getModel } from "../../../lib/generic-ai";
+import { config } from "../../../config";
 import { z } from "zod";
 import fs from "fs/promises";
 import Ajv from "ajv";
@@ -731,7 +732,13 @@ export async function generateCompletions({
           strictJsonSchema: true,
         },
       },
-      system: options.systemPrompt,
+      // Third-party OpenAI-compatible endpoints (e.g. Z.AI/GLM) get json_object
+      // mode but the schema is dropped by the SDK — so inject the exact schema
+      // that generateObject validates against into the system prompt.
+      system:
+        config.OPENAI_BASE_URL && schema && !(schema instanceof z.ZodType)
+          ? `${options.systemPrompt ?? ""}\n\nYou MUST respond with ONLY a single valid JSON object (no markdown code fences, no commentary) that strictly conforms to this JSON schema:\n${JSON.stringify(schema)}`
+          : options.systemPrompt,
       ...(schema && {
         schema: schema instanceof z.ZodType ? schema : jsonSchema(schema),
       }),


### PR DESCRIPTION
## Problem

Self-hosted Firecrawl's LLM extraction (`json` / `extract` formats) only works with OpenAI itself. When `OPENAI_BASE_URL` points at a third-party **OpenAI-compatible** endpoint — e.g. Z.AI/GLM, a local vLLM server, etc. — extraction fails for two reasons:

1. `@ai-sdk/openai` uses the **Responses API** (`POST /responses`), which returns **404** on endpoints that only implement `/chat/completions`.
2. Even over Chat Completions it requests **`json_schema` structured outputs**, which many compatible endpoints ignore — so the model returns prose and extraction comes back empty (`there was no json field in the result`).

## Fix

- **Route the `openai` provider through `@ai-sdk/openai-compatible`** when `OPENAI_BASE_URL` is set. That provider uses Chat Completions + `json_object` mode, which these endpoints support.
- **Inject the JSON schema into the system prompt** for custom endpoints in `generateObject`, because the SDK drops the schema for openai-compatible models (it warns *"JSON response format schema is only supported with structuredOutputs"*). The model then reliably returns schema-conforming JSON.
- Promote `@ai-sdk/openai-compatible` (already a transitive dependency) to a **direct dependency**.

## Result

Verified against Z.AI `glm-4.6` on a self-hosted instance — `json` extraction returns correct structured data, including nested objects and arrays, on real pages (e.g. Wikipedia articles), where it previously returned an empty result.

## Notes for maintainers

- The behavior is gated on `OPENAI_BASE_URL` being set (a custom base URL is treated as a compatible endpoint). If you'd prefer an explicit opt-in flag (e.g. `OPENAI_COMPATIBLE=true`), happy to adjust.
- No `test:snips` case is included since that path needs a live OpenAI-compatible endpoint + credentials in CI — guidance welcome on how you'd like it covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OpenAI-compatible LLM endpoints for extraction (`json` / `extract`) when `OPENAI_BASE_URL` is set. Self-hosted deployments using Z.AI/GLM or vLLM now return structured JSON instead of 404s or empty results.

- **New Features**
  - Route the `openai` provider through `@ai-sdk/openai-compatible` (Chat Completions + `json_object`) when `OPENAI_BASE_URL` is set.
  - Inject the JSON schema into the system prompt for compatible endpoints to ensure schema-conforming JSON.

- **Dependencies**
  - Add `@ai-sdk/openai-compatible` as a direct dependency.

<sup>Written for commit ff0feb4ccd8744e0e6f1ef98de90b7059d97a061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

