### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,206 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Elixir SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.8"}
+  ]
+end
+```
+
+## Authenticate
+
+Configure the API key in your application config:
+
+```elixir
+config :firecrawl, api_key: "fc-YOUR-API-KEY"
+```
+
+Or pass it per-request via the options argument:
+
+```elixir
+Firecrawl.search_and_scrape([query: "test"], api_key: "fc-YOUR-API-KEY")
+```
+
+For self-hosted instances, set `base_url`:
+
+```elixir
+config :firecrawl, base_url: "https://your-instance.com/v2"
+```
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract page content in structured formats.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via code execution.
+
+## Search
+
+### Why use it
+
+Search lets you find web pages, news articles, or images matching a query without knowing any URLs upfront. Results can optionally be scraped inline by passing `scrape_options`.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+A bang variant `search_and_scrape!/2` raises on error instead of returning `{:error, ...}`.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping",
+  limit: 5
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+All passed as a keyword list (first argument):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `:string` (required) | The search query string. |
+| `sources` | `list` | Search sources: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list(string)` | Only include results from these domains. |
+| `exclude_domains` | `list(string)` | Exclude results from these domains. |
+| `limit` | `integer` | Maximum number of results. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"cdr:1,cd_min:MM/DD/YYYY,cd_max:MM/DD/YYYY"` for date range). |
+| `location` | `string` | Geographic location (e.g. `"San Francisco,California,United States"`). |
+| `country` | `string` | ISO country code for geo-targeting (e.g. `"US"`). |
+| `ignore_invalid_urls` | `boolean` | Skip invalid URLs instead of failing. |
+| `timeout` | `integer` | Request timeout in milliseconds. |
+| `scrape_options` | `keyword_list` | Options to scrape each result page inline. |
+| `enterprise` | `list(string)` | Enterprise options: `"zdr"` for Zero Data Retention, `"anon"` for anonymized search. |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in one or more formats (markdown, HTML, screenshot, JSON extraction, etc.). Use it when you know exactly which page you need.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+A bang variant `scrape_and_extract_from_url!/2` raises on error. For batch scraping, use `scrape_and_extract_from_urls/2`.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"]
+)
+
+IO.inspect(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+All passed as a keyword list (first argument):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `:string` (required) | The URL to scrape. |
+| `formats` | `list` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`, `"video"`, etc. Can also pass objects for structured formats. |
+| `headers` | `any` | Custom HTTP headers. |
+| `include_tags` | `list(string)` | Only include content from these HTML tags. |
+| `exclude_tags` | `list(string)` | Exclude content from these HTML tags. |
+| `only_main_content` | `boolean` | Extract only main content. |
+| `timeout` | `integer` | Request timeout in milliseconds. Min: `1000`, max: `300000`. |
+| `wait_for` | `integer` | Wait this many milliseconds after page load. |
+| `mobile` | `boolean` | Emulate a mobile device viewport. |
+| `parsers` | `list` | Parser configuration (e.g. `["pdf"]`). |
+| `actions` | `list` | Browser actions before scraping: wait, screenshot, click, write, press, scroll, scrape, executeJavascript, pdf. |
+| `location` | `keyword_list` | Geographic location with country and languages. |
+| `skip_tls_verification` | `boolean` | Skip TLS certificate verification. |
+| `remove_base64_images` | `boolean` | Remove base64-encoded images from markdown output. |
+| `block_ads` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy type. |
+| `max_age` | `integer` | Return cached result if younger than this many milliseconds. |
+| `min_age` | `integer` | Only check cache, never trigger a fresh scrape. |
+| `store_in_cache` | `boolean` | Cache the scrape result. |
+| `lockdown` | `boolean` | Serve only cached results. Returns 404 on cache miss. |
+| `redact_pii` | `boolean` | Redact personally identifiable information. |
+| `profile` | `keyword_list` | Persistent browser profile: `[name: "my-profile", save_changes: true]`. |
+| `zero_data_retention` | `boolean` | Enable zero data retention for this scrape. |
+
+## Interact
+
+### Why use it
+
+Interact lets you run code inside a live browser session bound to a previous scrape job. Use it for clicking buttons, filling forms, navigating, or any post-scrape automation.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])
+```
+
+A bang variant `interact_with_scrape_browser_session!/3` raises on error.
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "document.querySelector('button#load-more').click();",
+  language: :node
+)
+
+IO.inspect(result.body)
+
+# When done, stop the browser session
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+The `job_id` is the first positional argument. Remaining parameters are passed as a keyword list:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `String.t()` (required, positional) | The scrape job ID from a previous scrape operation. |
+| `code` | `:string` (required) | Code to execute in the browser sandbox. |
+| `language` | `:python \| :node \| :bash` | Execution language. Use `:node` for JavaScript, `:bash` for agent-browser CLI. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+
+## Notes
+
+- **Naming style**: All parameters use snake_case keyword lists, matching Elixir conventions.
+- **OpenAPI-generated client**: The Elixir SDK is auto-generated from the OpenAPI spec, so function names reflect the API operation IDs (`scrape_and_extract_from_url`, `search_and_scrape`, `interact_with_scrape_browser_session`).
+- **Return type**: All functions return `{:ok, Req.Response.t()} | {:error, Exception.t() | Firecrawl.Error.t()}`. Bang variants raise on error.
+- **No deprecated aliases**: The Elixir SDK does not have deprecated aliases — use the canonical function names listed above.
+- **Batch scraping**: Use `scrape_and_extract_from_urls/2` for scraping multiple URLs, which takes a `urls` list instead of a single `url`.
+- **Response format**: Responses are raw `Req.Response` structs. Access data via `response.body["data"]`.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,216 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Java SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+**Gradle (build.gradle.kts):**
+
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.11.0")
+```
+
+**Maven (pom.xml):**
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.11.0</version>
+</dependency>
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR-API-KEY")
+    .build();
+```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable or the `firecrawl.apiKey` system property. A convenience factory method is also available:
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract page content in structured formats.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via code execution.
+
+## Search
+
+### Why use it
+
+Search lets you find web pages, news articles, or images matching a query without knowing any URLs upfront. Results can optionally be scraped inline by passing `scrapeOptions`.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("firecrawl web scraping",
+    SearchOptions.builder()
+        .limit(5)
+        .build()
+);
+
+if (results.getWeb() != null) {
+    for (var item : results.getWeb()) {
+        System.out.println(item.get("title") + " " + item.get("url"));
+    }
+}
+```
+
+### Parameters
+
+`SearchOptions` fields (all optional, built via `SearchOptions.builder()`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sources` | `List<Object>` | Search sources: `"web"`, `"news"`, `"images"`. |
+| `categories` | `List<Object>` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Only include results from these domains. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `limit` | `Integer` | Maximum number of results. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Geographic location for search results. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs instead of failing. |
+| `timeout` | `Integer` | Request timeout in milliseconds. |
+| `scrapeOptions` | `ScrapeOptions` | Options to scrape each search result page inline. |
+| `integration` | `String` | Integration identifier for tracking. |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in one or more formats (markdown, HTML, screenshot, JSON extraction, etc.). Use it when you know exactly which page you need.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
+import java.util.List;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all optional, built via `ScrapeOptions.builder()`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`, `"video"`, etc. Can also pass format config maps for structured extraction. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | Only include content from these HTML tags. |
+| `excludeTags` | `List<String>` | Exclude content from these HTML tags. |
+| `onlyMainContent` | `Boolean` | Extract only main content. |
+| `timeout` | `Integer` | Request timeout in milliseconds. |
+| `waitFor` | `Integer` | Wait this many milliseconds after page load. |
+| `mobile` | `Boolean` | Emulate a mobile device viewport. |
+| `parsers` | `List<Object>` | Parser configuration (e.g. `"pdf"` or `{"type": "pdf", "maxPages": 10}`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions to execute before scraping. |
+| `location` | `LocationConfig` | Geographic location with country and languages. |
+| `skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `Boolean` | Remove base64-encoded images from markdown output. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Return cached result if younger than this many milliseconds. |
+| `storeInCache` | `Boolean` | Cache the scrape result. |
+| `lockdown` | `Boolean` | Serve only cached results. Returns error on cache miss. |
+| `redactPII` | `Boolean` | Redact personally identifiable information. |
+| `integration` | `String` | Integration identifier for tracking. |
+
+## Interact
+
+### Why use it
+
+Interact lets you run code inside a live browser session bound to a previous scrape job. Use it for clicking buttons, filling forms, navigating, or any post-scrape automation.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+```
+
+The method has three overloads with increasing specificity.
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com");
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "document.querySelector('button#load-more').click();",
+    "node",
+    30
+);
+
+System.out.println(result.getStdout());
+
+// When done, stop the browser session
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `String` (required) | The scrape job ID from a previous scrape operation. |
+| `code` | `String` (required) | Code to execute in the browser sandbox. |
+| `language` | `String` | Execution language: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: `30` (server-side). |
+
+## Notes
+
+- **Naming style**: All parameters use camelCase, matching Java conventions.
+- **Builder pattern**: `ScrapeOptions` and `SearchOptions` use the builder pattern (`ScrapeOptions.builder()...build()`).
+- **Async support**: All sync methods have async counterparts returning `CompletableFuture<T>`: `scrapeAsync()`, `searchAsync()`, `interactAsync()`.
+- **Deprecated aliases**: `scrapeExecute()` is deprecated in favor of `interact()`. `deleteScrapeBrowser()` is deprecated in favor of `stopInteractiveBrowser()`.
+- **Client options**: The builder supports `timeoutMs` (default: `300000`), `maxRetries` (default: `3`), `backoffFactor` (default: `0.5`), and `asyncExecutor`.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,181 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the JavaScript/TypeScript SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. If omitted, the client falls back to keyless free-tier mode (rate-limited per IP).
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract page content in structured formats.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via code or natural language.
+
+## Search
+
+### Why use it
+
+Search lets you find web pages, news articles, or images matching a query without knowing any URLs upfront. Results can optionally be scraped inline by passing `scrapeOptions`.
+
+### Preferred SDK method
+
+```typescript
+client.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await client.search("firecrawl web scraping", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.title, item.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` (required) | The search query string. |
+| `sources` | `("web" \| "news" \| "images")[]` | Search sources to query. Determines which result arrays are populated. |
+| `categories` | `("github" \| "research" \| "pdf")[]` | Filter results by category. |
+| `includeDomains` | `string[]` | Only include results from these domains. Cannot be combined with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot be combined with `includeDomains`. |
+| `limit` | `number` | Maximum number of results to return. Must be positive. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `string` | Geographic location for search results. |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs instead of failing. Useful when piping results into scrape. |
+| `timeout` | `number` | Request timeout in milliseconds. Must be positive. |
+| `scrapeOptions` | `ScrapeOptions` | Options to scrape each search result page inline. Accepts the same parameters as `scrape`. |
+| `enterprise` | `("default" \| "anon" \| "zdr")[]` | Enterprise search modes. Use `"zdr"` for Zero Data Retention or `"anon"` for anonymized search. |
+| `integration` | `string` | Integration identifier for tracking. |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in one or more formats (markdown, HTML, screenshot, JSON extraction, etc.). Use it when you know exactly which page you need.
+
+### Preferred SDK method
+
+```typescript
+client.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` (required) | The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Can also pass objects for structured formats like `{ type: "json", schema: {...} }`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send with the request. |
+| `includeTags` | `string[]` | Only include content from these HTML tags. |
+| `excludeTags` | `string[]` | Exclude content from these HTML tags. |
+| `onlyMainContent` | `boolean` | Extract only main content, excluding headers, navs, footers. |
+| `timeout` | `number` | Request timeout in milliseconds. |
+| `waitFor` | `number` | Wait this many milliseconds after page load before scraping. |
+| `mobile` | `boolean` | Emulate a mobile device viewport. |
+| `parsers` | `(string \| { type: "pdf"; mode?: "fast" \| "auto" \| "ocr"; maxPages?: number })[]` | Parser configuration. Include `"pdf"` to extract PDF content as markdown. |
+| `actions` | `ActionOption[]` | Browser actions to execute before scraping: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string; languages?: string[] }` | Geographic location for proxy routing and locale emulation. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64-encoded images from markdown output. |
+| `fastMode` | `boolean` | Enable fast scraping mode. |
+| `blockAds` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. `"auto"` retries with enhanced if basic fails. |
+| `maxAge` | `number` | Return cached result if younger than this many milliseconds. |
+| `minAge` | `number` | Only check cache, never trigger a fresh scrape. Value in milliseconds specifies minimum cache age. |
+| `storeInCache` | `boolean` | Cache the scrape result. |
+| `lockdown` | `boolean` | Serve only cached results. Returns 404 on cache miss. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact personally identifiable information from output. |
+| `profile` | `{ name: string; saveChanges?: boolean }` | Persistent browser profile for shared cookies and session state. |
+| `integration` | `string` | Integration identifier for tracking. |
+
+## Interact
+
+### Why use it
+
+Interact lets you run code or natural language prompts inside a live browser session bound to a previous scrape job. Use it for clicking buttons, filling forms, navigating, or any post-scrape automation.
+
+### Preferred SDK method
+
+```typescript
+client.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+
+const jobId = doc.metadata?.scrapeId;
+
+const result = await client.interact(jobId, {
+  code: "document.querySelector('button#load-more').click();",
+  language: "node",
+});
+
+console.log(result.output);
+
+// When done, stop the browser session
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `string` (required) | The scrape job ID from a previous scrape operation (`metadata.scrapeId`). |
+| `code` | `string` | Code to execute in the browser sandbox. Required if `prompt` is not provided. |
+| `prompt` | `string` | Natural language instruction for the browser agent. Required if `code` is not provided. |
+| `language` | `"python" \| "node" \| "bash"` | Execution language. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in milliseconds. |
+
+## Notes
+
+- **Naming style**: All parameters use camelCase.
+- **Deprecated aliases**: `scrapeUrl()` is deprecated in favor of `scrape()`. `scrapeExecute()` is deprecated in favor of `interact()`. `stopInteractiveBrowser()` and `deleteScrapeBrowser()` are deprecated in favor of `stopInteraction()`.
+- **Async by default**: All methods return Promises.
+- **Client initialization**: You can also pass just an API key string: `new Firecrawl("fc-YOUR-API-KEY")`.
+- **Retry logic**: The client supports `maxRetries` and `backoffFactor` options for automatic retry on transient failures.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,188 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Python SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-YOUR-API-KEY")
+```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. If omitted, the client falls back to keyless free-tier mode (rate-limited per IP).
+
+An async client is also available:
+
+```python
+from firecrawl import AsyncFirecrawl
+
+client = AsyncFirecrawl(api_key="fc-YOUR-API-KEY")
+```
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract page content in structured formats.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via code or natural language.
+
+## Search
+
+### Why use it
+
+Search lets you find web pages, news articles, or images matching a query without knowing any URLs upfront. Results can optionally be scraped inline by passing `scrape_options`.
+
+### Preferred SDK method
+
+```python
+client.search(query, **kwargs)
+```
+
+### Example
+
+```python
+results = client.search(
+    "firecrawl web scraping",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for item in results.web or []:
+    print(item.title, item.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` (required) | The search query string. |
+| `sources` | `list[str]` | Search sources: `"web"`, `"news"`, `"images"`. Determines which result arrays are populated. |
+| `categories` | `list[str]` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list[str]` | Only include results from these domains. Cannot be combined with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot be combined with `include_domains`. |
+| `limit` | `int` | Maximum number of results. Default: `5`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `str` | Geographic location for search results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs instead of failing. |
+| `timeout` | `int` | Request timeout in milliseconds. Default: `300000`. |
+| `scrape_options` | `ScrapeOptions` | Options to scrape each search result page inline. |
+| `enterprise` | `list[str]` | Enterprise options: `"zdr"` for Zero Data Retention, `"anon"` for anonymized search. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in one or more formats (markdown, HTML, screenshot, JSON extraction, etc.). Use it when you know exactly which page you need.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **kwargs)
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` (required) | The URL to scrape. |
+| `formats` | `list[FormatOption]` | Output formats: `"markdown"`, `"html"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"change_tracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Can also pass dicts for structured formats like `{"type": "json", "schema": {...}}`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers to send with the request. |
+| `include_tags` | `list[str]` | Only include content from these HTML tags. |
+| `exclude_tags` | `list[str]` | Exclude content from these HTML tags. |
+| `only_main_content` | `bool` | Extract only main content, excluding headers, navs, footers. |
+| `timeout` | `int` | Request timeout in milliseconds. |
+| `wait_for` | `int` | Wait this many milliseconds after page load before scraping. |
+| `mobile` | `bool` | Emulate a mobile device viewport. |
+| `parsers` | `list[str \| PDFParser]` | Parser configuration. Include `"pdf"` to extract PDF content as markdown. PDFParser accepts `mode` (`"fast"`, `"auto"`, `"ocr"`) and `max_pages`. |
+| `actions` | `list[Action]` | Browser actions to execute before scraping: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Geographic location with `country` and `languages` fields. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64-encoded images from markdown output. |
+| `fast_mode` | `bool` | Enable fast scraping mode. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Return cached result if younger than this many milliseconds. |
+| `min_age` | `int` | Only check cache, never trigger a fresh scrape. Value in milliseconds. |
+| `store_in_cache` | `bool` | Cache the scrape result. |
+| `lockdown` | `bool` | Serve only cached results. Returns 404 on cache miss. |
+| `redact_pii` | `bool \| RedactPIIOptions` | Redact personally identifiable information from output. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "my-profile", "saveChanges": True}`. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+## Interact
+
+### Why use it
+
+Interact lets you run code or natural language prompts inside a live browser session bound to a previous scrape job. Use it for clicking buttons, filling forms, navigating, or any post-scrape automation.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)
+```
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id
+
+result = client.interact(
+    job_id,
+    code="document.querySelector('button#load-more').click();",
+    language="node",
+)
+
+print(result.output)
+
+# When done, stop the browser session
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `str` (required) | The scrape job ID from a previous scrape operation. |
+| `code` | `str` | Code to execute in the browser sandbox. Required if `prompt` is not provided. |
+| `prompt` | `str` | Natural language instruction for the browser agent. Required if `code` is not provided. |
+| `language` | `"python" \| "node" \| "bash"` | Execution language. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+## Notes
+
+- **Naming style**: All parameters use snake_case, matching Python conventions.
+- **Format strings**: Both snake_case (`"raw_html"`, `"change_tracking"`) and camelCase (`"rawHtml"`, `"changeTracking"`) are accepted for format names.
+- **Deprecated aliases**: `scrape_execute()` is deprecated in favor of `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` are deprecated in favor of `stop_interaction()`.
+- **Async support**: `AsyncFirecrawl` provides identical methods with `async`/`await` support using `httpx` under the hood.
+- **Client options**: The client constructor accepts `timeout`, `max_retries` (default: `3`), and `backoff_factor` (default: `0.5`).
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,223 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Rust SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+```
+
+## Authenticate
+
+```rust
+use firecrawl::FirecrawlClient;
+
+let client = FirecrawlClient::new("fc-YOUR-API-KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = FirecrawlClient::new_selfhosted(
+    "https://your-instance.com",
+    Some("fc-YOUR-API-KEY"),
+)?;
+```
+
+The API key is optional for `scrape`, `search`, and `interact` — omitting it uses the keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **search** — Use when you start with a query and need to discover relevant URLs and content across the web.
+- **scrape** — Use when you already have a URL and want to extract page content in structured formats.
+- **interact** — Use when the page needs clicks, form fills, or post-scrape browser actions via code or natural language.
+
+## Search
+
+### Why use it
+
+Search lets you find web pages, news articles, or images matching a query without knowing any URLs upfront. Results can optionally be scraped inline by passing `scrape_options`.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+A convenience method `search_and_scrape(query, limit)` is also available for simple scrape-all-results use cases.
+
+### Example
+
+```rust
+use firecrawl::{FirecrawlClient, SearchOptions};
+
+let client = FirecrawlClient::new("fc-YOUR-API-KEY")?;
+
+let response = client.search("firecrawl web scraping", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are optional:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | `Option<u32>` | Maximum number of results to return. |
+| `sources` | `Option<Vec<SearchSource>>` | Search sources: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Filter by category: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Only include results from these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `Option<String>` | Geographic location for search results. |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs instead of failing. |
+| `timeout` | `Option<u32>` | Request timeout in milliseconds. |
+| `scrape_options` | `Option<ScrapeOptions>` | Options to scrape each search result page inline. |
+| `integration` | `Option<String>` | Integration identifier for tracking. |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in one or more formats (markdown, HTML, screenshot, JSON extraction, etc.). Use it when you know exactly which page you need.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+A convenience method `scrape_with_schema(url, schema, prompt)` is available for JSON extraction.
+
+### Example
+
+```rust
+use firecrawl::{FirecrawlClient, ScrapeOptions, Format};
+
+let client = FirecrawlClient::new("fc-YOUR-API-KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    ..Default::default()
+}).await?;
+
+if let Some(markdown) = doc.markdown {
+    println!("{}", markdown);
+}
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are optional:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`. Also supports `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | Only include content from these HTML tags. |
+| `exclude_tags` | `Option<Vec<String>>` | Exclude content from these HTML tags. |
+| `only_main_content` | `Option<bool>` | Extract only main content. |
+| `timeout` | `Option<u32>` | Request timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Wait this many milliseconds after page load. |
+| `mobile` | `Option<bool>` | Emulate a mobile device viewport. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser config. `ParserConfig::Simple("pdf")` or `ParserConfig::Pdf { mode, max_pages }`. |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Geographic location with `country` and `languages`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. |
+| `remove_base64_images` | `Option<bool>` | Remove base64-encoded images from markdown output. |
+| `fast_mode` | `Option<bool>` | Enable fast scraping mode. |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Return cached result if younger than this many milliseconds. |
+| `min_age` | `Option<u32>` | Only check cache, never trigger a fresh scrape. |
+| `store_in_cache` | `Option<bool>` | Cache the scrape result. |
+| `lockdown` | `Option<bool>` | Serve only cached results. Returns error on cache miss. |
+| `redact_pii` | `Option<bool>` | Redact personally identifiable information. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile with `name` and `save_changes`. |
+| `integration` | `Option<String>` | Integration identifier for tracking. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction options with `schema`, `system_prompt`, `prompt`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `full_page`, `quality`, `viewport`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking config: `modes`, `schema`, `prompt`, `tag`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction with `selector` and `attribute`. |
+
+## Interact
+
+### Why use it
+
+Interact lets you run code or natural language prompts inside a live browser session bound to a previous scrape job. Use it for clicking buttons, filling forms, navigating, or any post-scrape automation.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{FirecrawlClient, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = FirecrawlClient::new("fc-YOUR-API-KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.scrape_id.as_ref())
+    .expect("scrape_id required for interact");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some("document.querySelector('button#load-more').click();".into()),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.stdout);
+
+// When done, stop the browser session
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `code` | `Option<String>` | Code to execute in the browser sandbox. Required if `prompt` is not provided. |
+| `prompt` | `Option<String>` | Natural language instruction for the browser agent. Required if `code` is not provided. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Execution language: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+
+## Notes
+
+- **Naming style**: All struct fields use snake_case. The SDK handles serialization to camelCase for the API.
+- **Async runtime**: All methods are `async` and require a Tokio or equivalent async runtime.
+- **Deprecated aliases**: `scrape_execute()` is deprecated in favor of `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` are deprecated in favor of `stop_interaction()`.
+- **Origin header**: The SDK automatically sets the `origin` field to `"rust-sdk@{version}"` for telemetry.
+- **Error handling**: All methods return `Result<T, FirecrawlError>`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file covers the three core endpoints: `search`, `scrape`, and `interact`
- Every parameter is confirmed from SDK source code and cross-referenced against the OpenAPI spec
- Files are Mintlify-compatible MDX with consistent structure across all languages

## Details

Each quickstart includes:
- Install command and auth pattern
- "When to use what" decision guide (search vs scrape vs interact)
- For each endpoint: why to use it, preferred SDK method name, realistic example, and a complete parameter table
- Language-specific notes (naming conventions, deprecated aliases, async support)
- Source of truth references

**Note:** These files are intended for the `firecrawl-docs` repository (`agent-quickstart/` directory) but are staged here due to write permission limitations on the docs repo in this session. They should be moved to `firecrawl-docs` and the `docs.json` navigation should be updated to include the new "Agent Quickstarts" group.

## Test plan

- [ ] Verify each quickstart renders correctly in Mintlify
- [ ] Confirm parameter tables match current SDK source
- [ ] Move files to `firecrawl-docs` repo and update `docs.json` navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzygNGwHj8Jkp9XWwyTXUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzygNGwHj8Jkp9XWwyTXUJ)_