### PR TITLE
Fix formatting and update section titles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ _Pst. Hey, you, join our stargazers :)_
 
 ---
 
-## Quick Start
+## Quickstart
 
 Sign up at [firecrawl.dev](https://firecrawl.dev) to get your API key. Try the [playground](https://firecrawl.dev/playground) to test it out.
 
@@ -404,7 +404,7 @@ result = app.agent(
 - Research tasks where the agent needs to explore multiple paths
 - Critical data where accuracy is paramount
 
-Learn more about Spark models in our [Agent documentation](https://docs.firecrawl.dev/features/agent).
+Learn more about Spark models in [Agent documentation](https://docs.firecrawl.dev/features/agent).
 
 ### Crawl
 


### PR DESCRIPTION
Corrected formatting and capitalization in the README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized README wording and headings for clarity and consistency. Renamed "Quick Start" to "Quickstart" and simplified the Spark models link sentence to use neutral wording.

<sup>Written for commit cd8f434a3b511c2b629ba9127611bc27bf1eb527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

