### PR TITLE
[codex] Stabilize attribute format scrape snips

### DIFF
--- a/apps/api/src/__tests__/snips/mocks/attribute-formats.json
+++ b/apps/api/src/__tests__/snips/mocks/attribute-formats.json
@@ -1,0 +1,42 @@
+[
+  {
+    "time": 1782920000000,
+    "options": {
+      "url": "https://example.com/attribute-fixture",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "https://example.com/attribute-fixture",
+      "body": "<!doctype html><html><head><title>Attribute Fixture</title></head><body><main><h1>Attribute Fixture</h1><article class=\"athing\" id=\"item-1\" data-testid=\"story-card\" data-view-component=\"true\">First story</article><article class=\"athing\" id=\"item-2\" data-testid=\"story-card-secondary\" data-view-component=\"true\">Second story</article><a class=\"athing\" id=\"item-link\" data-testid=\"story-link\" href=\"/story\">Story link</a></main></body></html>",
+      "status": 200,
+      "headers": [["content-type", "text/html; charset=utf-8"]]
+    }
+  },
+  {
+    "time": 1782920000001,
+    "options": {
+      "url": "http://localhost:3003/scrape",
+      "method": "POST",
+      "body": {
+        "url": "https://example.com/attribute-fixture",
+        "wait_after_load": 0,
+        "timeout": 90000,
+        "skip_tls_verification": false
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 3
+    },
+    "result": {
+      "status": 200,
+      "headers": [["content-type", "application/json"]],
+      "body": "{\"content\":\"<!doctype html><html><head><title>Attribute Fixture</title></head><body><main><h1>Attribute Fixture</h1><article class=\\\"athing\\\" id=\\\"item-1\\\" data-testid=\\\"story-card\\\" data-view-component=\\\"true\\\">First story</article><article class=\\\"athing\\\" id=\\\"item-2\\\" data-testid=\\\"story-card-secondary\\\" data-view-component=\\\"true\\\">Second story</article><a class=\\\"athing\\\" id=\\\"item-link\\\" data-testid=\\\"story-link\\\" href=\\\"/story\\\">Story link</a></main></body></html>\",\"pageStatusCode\":200,\"contentType\":\"text/html; charset=utf-8\"}"
+    }
+  }
+]

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -1832,16 +1832,18 @@ describe("Scrape tests", () => {
   );
 });
 
-// TODO: this is remote, how should we handle this? Production only or also self?
 describe("Attribute formats", () => {
   const base = TEST_SUITE_WEBSITE;
+  const attributeFixtureUrl = "https://example.com/attribute-fixture";
+  const attributeFixtureMock = "attribute-formats";
 
   concurrentIf(TEST_PRODUCTION || HAS_PROXY)(
     "should extract attributes from HTML elements",
     async () => {
       const response = await scrape(
         {
-          url: "https://news.ycombinator.com",
+          url: attributeFixtureUrl,
+          useMock: attributeFixtureMock,
           formats: [
             { type: "markdown" },
             {
@@ -1872,7 +1874,8 @@ describe("Attribute formats", () => {
     async () => {
       const response = await scrape(
         {
-          url: "https://github.com/microsoft/vscode",
+          url: attributeFixtureUrl,
+          useMock: attributeFixtureMock,
           formats: [
             {
               type: "attributes",
@@ -1907,7 +1910,8 @@ describe("Attribute formats", () => {
     async () => {
       const response = await scrape(
         {
-          url: "https://httpbin.org/html",
+          url: attributeFixtureUrl,
+          useMock: attributeFixtureMock,
           formats: [
             {
               type: "attributes",


### PR DESCRIPTION
## Summary\n- Replace remote HN/GitHub/httpbin pages in v2 attribute-format scrape snips with a deterministic scrapeURL mock fixture\n- Keep the assertions covering markdown + attribute extraction, multiple selectors, and empty selector results\n- Include fetch-engine and Playwright-service mock responses so proxy matrices do not depend on external page latency\n\n## Validation\n- pnpm exec prettier --check src/__tests__/snips/v2/scrape.test.ts src/__tests__/snips/mocks/attribute-formats.json\n- pnpm build\n- git diff --check\n- TEST_SUITE_SELF_HOSTED=true TEST_SUITE_WEBSITE=http://127.0.0.1:4321 TEST_API_KEY=test TEST_TEAM_ID=bypass PROXY_SERVER=http://127.0.0.1:9 pnpm harness pnpm vitest run src/__tests__/snips/v2/scrape.test.ts -t "Attribute formats" (blocked locally: Docker daemon unavailable at unix:///Users/gregomoricz/.docker/run/docker.sock)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes v2 attribute-format scrape tests by replacing external pages with a deterministic mock fixture and mocked scraper responses to remove network flakiness and latency dependence.

- **Refactors**
  - Added `apps/api/src/__tests__/snips/mocks/attribute-formats.json` with HTML and mock scrape responses.
  - Updated `scrape.test.ts` to use `https://example.com/attribute-fixture` with `useMock: "attribute-formats"` instead of HN/GitHub/httpbin.
  - Kept assertions for markdown + attribute extraction, multiple selectors, and empty selector results.

<sup>Written for commit 430862c043bc6ad2a68a0759d62488182d5fae37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

