### PR TITLE
Support PgUp/PgDn for ingestion numeric inputs

### DIFF
--- a/apps/ui/ingestion-ui/src/components/ingestion.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestion.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, FormEvent, useEffect } from "react";
+import { useState, ChangeEvent, FormEvent, useEffect, KeyboardEvent } from "react";
 import {
   Card,
   CardHeader,
@@ -323,6 +323,29 @@ export default function FirecrawlComponent() {
     setCurrentPage(newPage);
   };
 
+  const handleNumberInputPageKeyDown = (
+    e: KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (e.key !== "PageUp" && e.key !== "PageDown") {
+      return;
+    }
+
+    const { name, value } = e.currentTarget;
+    const currentValue = value === "" ? 0 : Number(value);
+    if (Number.isNaN(currentValue)) {
+      return;
+    }
+
+    const nextValue =
+      e.key === "PageUp" ? currentValue + 10 : Math.max(0, currentValue - 10);
+    e.preventDefault();
+
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: String(nextValue),
+    }));
+  };
+
   const paginatedUrls = crawledUrls.slice(
     (currentPage - 1) * urlsPerPage,
     currentPage * urlsPerPage
@@ -432,11 +455,15 @@ export default function FirecrawlComponent() {
                       Limit *
                     </Label>
                     <Input
+                      type="number"
                       id="limit"
                       name="limit"
+                      min="0"
+                      step="1"
                       placeholder="10"
                       value={formData.limit}
                       onChange={handleChange}
+                      onKeyDown={handleNumberInputPageKeyDown}
                     />
                   </div>
                   <div>
@@ -447,11 +474,15 @@ export default function FirecrawlComponent() {
                       Max depth
                     </Label>
                     <Input
+                      type="number"
                       id="maxDepth"
                       name="maxDepth"
+                      min="0"
+                      step="1"
                       placeholder="5"
                       value={formData.maxDepth}
                       onChange={handleChange}
+                      onKeyDown={handleNumberInputPageKeyDown}
                     />
                   </div>
                 </div>

--- a/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, FormEvent, useEffect } from "react";
+import { useState, ChangeEvent, FormEvent, useEffect, KeyboardEvent } from "react";
 import {
   Card,
   CardHeader,
@@ -142,6 +142,37 @@ export default function FirecrawlComponentV1() {
       // Automatically check "Crawl Sub-pages" if limit or search have content
       if (name === "limit" || name === "search") {
         newData.crawlSubPages = !!value || !!newData.limit || !!newData.search;
+      }
+
+      return newData;
+    });
+  };
+
+  const handleNumberInputPageKeyDown = (
+    e: KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (e.key !== "PageUp" && e.key !== "PageDown") {
+      return;
+    }
+
+    const { name, value } = e.currentTarget;
+    const currentValue = value === "" ? 0 : Number(value);
+    if (Number.isNaN(currentValue)) {
+      return;
+    }
+
+    const nextValue =
+      e.key === "PageUp" ? currentValue + 10 : Math.max(0, currentValue - 10);
+    e.preventDefault();
+
+    setFormData((prevData) => {
+      const newData = {
+        ...prevData,
+        [name]: String(nextValue),
+      };
+
+      if (name === "limit") {
+        newData.crawlSubPages = !!newData.limit || !!newData.search;
       }
 
       return newData;
@@ -442,11 +473,15 @@ export default function FirecrawlComponentV1() {
                       Limit *
                     </Label>
                     <Input
+                      type="number"
                       id="limit"
                       name="limit"
+                      min="0"
+                      step="1"
                       placeholder="10"
                       value={formData.limit}
                       onChange={handleChange}
+                      onKeyDown={handleNumberInputPageKeyDown}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Add PgUp/PgDn keyboard handling for V0 `Limit` and `Max depth` inputs
- Add PgUp/PgDn keyboard handling for V1 `Limit` input
- Convert those fields to numeric inputs with `min="0"` and `step="1"`
- Preserve V1 behavior that enables crawl sub-pages when limit is set

Fixes: #3935 

<img width="1251" height="813" alt="image" src="https://github.com/user-attachments/assets/533b63fd-9aac-436e-a15b-4482f37604c5" />

<img width="1217" height="783" alt="image" src="https://github.com/user-attachments/assets/ceb34d3f-2972-4b1a-a2c8-b5da276a1bce" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PgUp/PgDn keyboard support for ingestion inputs and converts them to numeric fields to speed entry and avoid invalid values.

- **New Features**
  - V0: `Limit` and `Max depth` are now numeric (`min=0`). PgUp/PgDn changes the value by ±10 and clamps at 0.
  - V1: `Limit` is now numeric (`min=0`). PgUp/PgDn changes the value by ±10 and clamps at 0.
  - V1: Keeps prior behavior by toggling `crawlSubPages` when `limit` changes (including PgUp/PgDn).

<sup>Written for commit 3f0b3b3d4be53048f328d6c8a5020ca0127b697b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

