### PR TITLE
fix(sentry): drop high-volume low-value spans via ignoreSpans

### DIFF
--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -141,9 +141,6 @@ if (config.SENTRY_DSN) {
         : config.SENTRY_TRACE_SAMPLE_RATE;
     },
     sampleRate: config.SENTRY_ERROR_SAMPLE_RATE,
-    // Highest-volume spans in the org: pool connects, express plumbing, and
-    // the per-discovered-URL crawl lock. They carry no diagnostic value but
-    // dominate the span quota. Dropped client-side; children are re-parented.
     ignoreSpans: [
       /^pg-pool\.connect$/,
       /^firecrawl-redis-lock-url$/,

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -141,6 +141,15 @@ if (config.SENTRY_DSN) {
         : config.SENTRY_TRACE_SAMPLE_RATE;
     },
     sampleRate: config.SENTRY_ERROR_SAMPLE_RATE,
+    // Highest-volume spans in the org: pool connects, express plumbing, and
+    // the per-discovered-URL crawl lock. They carry no diagnostic value but
+    // dominate the span quota. Dropped client-side; children are re-parented.
+    ignoreSpans: [
+      /^pg-pool\.connect$/,
+      /^firecrawl-redis-lock-url$/,
+      { op: /^middleware\.express$/ },
+      { op: /^router\.express$/ },
+    ],
     serverName: config.NUQ_POD_NAME,
     environment: config.SENTRY_ENVIRONMENT,
     beforeSend(event, hint) {


### PR DESCRIPTION
## What

Adds `ignoreSpans` to the api Sentry init to stop shipping the four highest-volume span groups in the org:

| Span | 7d volume (extrapolated) |
|---|---|
| `pg-pool.connect` (auto pg integration) | 1.63B |
| `firecrawl-redis-lock-url` (custom, once per discovered URL in every crawl) | 1.52B |
| `middleware.express` (jsonParser/urlencodedParser/cors/responseTime/anonymous) | ~2.57B combined |
| `router.express` (route-matching layer spans) | ~864M combined |

Together these are ~25% of the api project's span volume, and none of them carry diagnostic value — the transaction itself already has the route and duration. Spans are dropped client-side by the SDK (`@sentry/node` v10 `ignoreSpans`), and children of dropped spans are re-parented, so trace trees stay intact.

## Why

Sentry span quota is being consumed too fast; the api project emits ~25.9B extrapolated spans/week and these plumbing spans dominate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Sentry span volume by ignoring high‑volume, low‑value spans in the API’s `@sentry/node` init while keeping trace trees intact via re‑parenting. Drops `pg-pool.connect`, `firecrawl-redis-lock-url`, and Express `middleware`/`router` spans to cut quota usage (~25%), and removes inline comments in the Sentry configuration.

<sup>Written for commit 527b704ade64cf59ab0a0fdf835c4d4a5eb5094a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

