### PR TITLE
fix(sentry): stop reporting non-actionable errors

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/fetch.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/fetch.ts
@@ -137,7 +137,6 @@ export async function robustFetch<
       if (error instanceof AbortManagerThrownError) {
         throw error;
       } else if (!ignoreFailure) {
-        Sentry.captureException(error);
         if (tryCount > 1) {
           logger.debug(
             "Request failed, trying " + (tryCount - 1) + " more times",
@@ -150,6 +149,9 @@ export async function robustFetch<
             mock,
           });
         } else {
+          // Only report once retries are exhausted — transient failures that
+          // succeed on retry were flooding Sentry with one event per attempt.
+          Sentry.captureException(error);
           logger.debug("Request failed", {
             params: logParams,
             error,

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -38,6 +38,14 @@ function sanitizeString(value: string | null | undefined): string | null {
   return value.replace(nullByteRegex, "");
 }
 
+// drizzle-orm 1.0 wraps pg errors in DrizzleQueryError; the SQLSTATE lives on
+// error.cause.code, not error.code.
+function isConstraintViolation(error: unknown): boolean {
+  const code = (error as any)?.cause?.code ?? ((error as any)?.code as unknown);
+  // 23503 foreign_key_violation, 23505 unique_violation
+  return code === "23503" || code === "23505";
+}
+
 const tableMap: Record<string, PgTable> = {
   requests: schema.requests,
   scrapes: schema.scrapes,
@@ -112,25 +120,26 @@ async function robustInsert(
       });
     } else {
       logger.error("Failed to insert into database", { attempts });
-      // Report to Sentry with context
-      Sentry.captureException(
-        attempts[attempts.length - 1]?.error ||
-          new Error("Database insert failed after 10 attempts"),
-        {
-          tags: {
-            table,
-            operation: "robustInsert",
+      const lastError = attempts[attempts.length - 1]?.error;
+      // Constraint violations (missing parent request row, duplicate key)
+      // are known data races, not actionable bugs — logs only, no Sentry.
+      if (!isConstraintViolation(lastError)) {
+        Sentry.captureException(
+          lastError || new Error("Database insert failed after 10 attempts"),
+          {
+            tags: {
+              table,
+              operation: "robustInsert",
+            },
+            extra: {
+              table,
+              data: JSON.stringify(data).substring(0, 500), // Limit size
+              attempts: 10,
+              lastError: lastError ? JSON.stringify(lastError) : null,
+            },
           },
-          extra: {
-            table,
-            data: JSON.stringify(data).substring(0, 500), // Limit size
-            attempts: 10,
-            lastError: attempts[attempts.length - 1]?.error
-              ? JSON.stringify(attempts[attempts.length - 1].error)
-              : null,
-          },
-        },
-      );
+        );
+      }
     }
   } else {
     const start = Date.now();
@@ -141,18 +150,19 @@ async function robustInsert(
     } catch (error) {
       attempts.push({ error, timeMs: Date.now() - start, backoffMs: 0 });
       logger.error("Failed to insert into database", { attempts });
-      // Report to Sentry
-      Sentry.captureException(error, {
-        tags: {
-          table,
-          operation: "robustInsert",
-          force: "false",
-        },
-        extra: {
-          table,
-          data: JSON.stringify(data).substring(0, 500), // Limit size
-        },
-      });
+      if (!isConstraintViolation(error)) {
+        Sentry.captureException(error, {
+          tags: {
+            table,
+            operation: "robustInsert",
+            force: "false",
+          },
+          extra: {
+            table,
+            data: JSON.stringify(data).substring(0, 500), // Limit size
+          },
+        });
+      }
     }
   }
 }

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -178,6 +178,7 @@ function startHeartbeat(
     });
 
   const promise = (async () => {
+    let loopError: unknown = null;
     try {
       while (!stopped) {
         await mirrorSlotAcquire(teamId, holderId, mirrorState).catch(() => {
@@ -198,11 +199,19 @@ function startHeartbeat(
     } catch (error) {
       if (!stopped) {
         _logger.error("Error in semaphore heartbeat loop", { error });
+        loopError = error;
       }
     }
 
+    // Must always reject: withSemaphore races this promise against the job,
+    // so a resolution would be mistaken for the job's result. Preserve the
+    // TransportableError so callers surface a timeout instead of a 500.
     return Promise.reject(
-      new Error("heartbeat loop stopped unexpectedly"),
+      loopError instanceof TransportableError
+        ? loopError
+        : new TransportableError("SCRAPE_TIMEOUT", "heartbeat_stopped", {
+            cause: loopError ?? undefined,
+          }),
     ) as never;
   })();
 


### PR DESCRIPTION
## What

Three targeted changes to stop the api project's top recurring Sentry noise (~9k events/week combined, on top of the 5% client-side error sampling):

1. **`robustInsert` (log_job.ts)**: skip Sentry capture for FK/unique constraint violations (SQLSTATE 23503/23505). These are known races on the partitioned logging tables (child `searches`/`scrapes` insert landing before/without the parent `requests` row — API-WQ, API-WS). They're still logged. Note: drizzle-orm 1.0 wraps pg errors in `DrizzleQueryError`, so the SQLSTATE is read from `error.cause.code`.
2. **`robustFetch` (fetch.ts)**: move `Sentry.captureException` so it only fires when retries are exhausted. Previously every failed attempt emitted an event even when the retry succeeded — `TypeError: fetch failed` (API-5P) was 4.4k events/week against arbitrary target sites.
3. **`startHeartbeat` (team-semaphore.ts)**: the heartbeat loop discarded its real `TransportableError(SCRAPE_TIMEOUT)` and rejected with a generic `Error("heartbeat loop stopped unexpectedly")` sentinel (API-KS/API-KX, 2.7k/week). It now rejects with the original transportable error, so the request surfaces a proper timeout instead of an unknown 500, and `beforeSend` already ignores `SCRAPE_TIMEOUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Sentry noise by stopping non-actionable reports in the API. Cuts ~9k events/week and returns proper timeouts instead of 500s.

- **Bug Fixes**
  - Database logging: Skip Sentry capture for SQLSTATE 23503/23505 constraint violations from known logging-table races; still logs locally. Note: `drizzle-orm` wraps `pg` errors, so we read `error.cause.code`.
  - Fetch retries: Only call `Sentry.captureException` after retries are exhausted to avoid one event per failed attempt that later succeeds.
  - Heartbeat: Reject with the original `TransportableError(SCRAPE_TIMEOUT)` instead of a generic error, so callers see a timeout and `beforeSend` filters it.

<sup>Written for commit 8cad3ed4d4eb6204629af8ad3be637970e8c5f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

