### PR TITLE
fix(api): return crawl status immediately after create when Postgres group lags

### DIFF
--- a/apps/api/src/__tests__/snips/v1/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v1/crawl.test.ts
@@ -77,6 +77,29 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
   );
 
   it.concurrent(
+    "returns crawl status immediately after creation (no 'Job not found' race, #2662)",
+    async () => {
+      const startRes = await crawlStart({ url: base, limit: 1 }, identity);
+      expect(startRes.statusCode).toBe(200);
+      expect(startRes.body.id).toBeDefined();
+
+      // Query status immediately. This must not 404 with "Job not found" even
+      // when the Postgres crawl group has not yet caught up with the Redis
+      // crawl record created by the POST above. See issue #2662.
+      const statusRes = await request(TEST_API_URL)
+        .get(`/v1/crawl/${startRes.body.id}`)
+        .set("Authorization", `Bearer ${identity.apiKey}`)
+        .send();
+
+      expect(statusRes.statusCode).toBe(200);
+      expect(statusRes.body.success).toBe(true);
+      expect(statusRes.body.error).not.toBe("Job not found");
+      expect(statusRes.body).toHaveProperty("status");
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
     "works with ignoreSitemap: true",
     async () => {
       const results = await crawl(

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -183,7 +183,16 @@ export async function crawlStatusController(
   );
   const sc = await getCrawl(req.params.jobId);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  // Verify the crawl exists and belongs to this team. Ownership must come from
+  // a team-scoped source: groupAnyJob (Postgres, team-scoped) or sc (Redis,
+  // team-scoped). `group` alone is not team-scoped, and the Postgres-backed
+  // group can briefly lag behind the Redis crawl record right after creation,
+  // so a missing `group` must not by itself return 404 for a crawl that
+  // demonstrably exists for this team.
+  // See https://github.com/firecrawl/firecrawl/issues/2662.
+  const teamOwnsCrawl =
+    !!groupAnyJob || (!!sc && sc.team_id === req.auth.team_id);
+  if (!teamOwnsCrawl) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
 
@@ -211,9 +220,13 @@ export async function crawlStatusController(
   } = {
     status: sc?.cancelled
       ? "cancelled"
-      : group.status === "active"
-        ? "scraping"
-        : group.status,
+      : !group
+        ? crawlError
+          ? "failed"
+          : "scraping"
+        : group.status === "active"
+          ? "scraping"
+          : group.status,
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -204,7 +204,16 @@ export async function crawlStatusController(
   );
   const sc = await getCrawl(req.params.jobId);
 
-  if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
+  // Verify the crawl exists and belongs to this team. Ownership must come from
+  // a team-scoped source: groupAnyJob (Postgres, team-scoped) or sc (Redis,
+  // team-scoped). `group` alone is not team-scoped, and the Postgres-backed
+  // group can briefly lag behind the Redis crawl record right after creation,
+  // so a missing `group` must not by itself return 404 for a crawl that
+  // demonstrably exists for this team.
+  // See https://github.com/firecrawl/firecrawl/issues/2662.
+  const teamOwnsCrawl =
+    !!groupAnyJob || (!!sc && sc.team_id === req.auth.team_id);
+  if (!teamOwnsCrawl) {
     return res.status(404).json({ success: false, error: "Job not found" });
   }
 
@@ -232,9 +241,13 @@ export async function crawlStatusController(
   } = {
     status: sc?.cancelled
       ? "cancelled"
-      : group.status === "active"
-        ? "scraping"
-        : group.status,
+      : !group
+        ? crawlError
+          ? "failed"
+          : "scraping"
+        : group.status === "active"
+          ? "scraping"
+          : group.status,
     completed: numericStats.completed ?? 0,
     total:
       (numericStats.completed ?? 0) +


### PR DESCRIPTION
## Problem

Fixes #2662. Querying crawl status immediately after creating a crawl returns `{"success": false, "error": "Job not found"}` even though `POST /v1/crawl` returned a valid `id`. Retrying after ~1–3s succeeds.

## Root cause

In `crawl-status.ts` (v1 and v2), the controller 404s here:

```ts
if (!group || (!groupAnyJob && (!sc || sc.team_id !== req.auth.team_id))) {
  return res.status(404).json({ success: false, error: "Job not found" });
}
```

`group` comes from the **Postgres-backed** `crawlGroup.getGroup()`, while `sc` (the crawl record) is written to **Redis** synchronously at creation. Right after `POST /crawl`, the Redis record exists but the Postgres group can still be lagging — so `!group` short-circuits to a 404 for a crawl that demonstrably exists for the team. This forces every client to implement retry logic, breaking the contract that a returned `id` is immediately queryable.

## Fix

- Verify **team ownership** from a team-scoped source — `groupAnyJob` (Postgres, team-scoped) or the Redis crawl record `sc` — instead of requiring `group` (which isn't team-scoped and can lag). Security is unchanged: a crawl is only served if `groupAnyJob` exists or `sc.team_id` matches the caller.
- Derive status gracefully when `group` hasn't propagated yet: report `scraping` (or `failed` if a kickoff error is recorded) rather than dereferencing a missing group.

Applied identically to v1 and v2.

## Test

Adds a regression test (`snips/v1/crawl.test.ts`): create a crawl, then immediately `GET /v1/crawl/{id}` and assert `200` / `success: true` / not `"Job not found"`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return crawl status immediately after creation, removing the "Job not found" race when the Postgres crawl group lags behind Redis (v1 and v2). Fixes #2662 and avoids client-side retries.

- **Bug Fixes**
  - Verify team ownership from team-scoped sources: `groupAnyJob` (Postgres) or the Redis crawl record. Do not require the non-team-scoped `group`.
  - If `group` hasn’t propagated, return a status instead of 404: "scraping" by default, or "failed" when a kickoff error exists (still respects "cancelled").
  - Add a regression test to assert `GET /v1/crawl/{id}` succeeds immediately after `POST /v1/crawl`.

<sup>Written for commit 56b96ced4bddc09159bd2a2deb9ce987e0f79d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

