### PR TITLE
fix(js-sdk): include ignoreRobotsTxt in v2 crawl payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,4 @@ target/
 _local/
 
 
-apps/api/src/lib/scrape-interact/*.md
+apps/api/src/lib/scrape-interact/*.mdecho apps/js-sdk/firecrawl/package-lock.json

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { startCrawl } from "../../../v2/methods/crawl";
+
+describe("JS SDK v2 crawl payload", () => {
+  test("startCrawl forwards ignoreRobotsTxt to the request payload", async () => {
+    const post = jest.fn(
+      async (_url: string, _payload: Record<string, unknown>, _opts?: unknown) => ({
+        status: 200,
+        data: { success: true, id: "job-123", url: "https://api.firecrawl.dev/v2/crawl/job-123" },
+      }),
+    );
+
+    const http = { post } as any;
+    await startCrawl(http, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({
+        url: "https://example.com",
+        ignoreRobotsTxt: true,
+      }),
+    );
+  });
+
+  test("startCrawl omits ignoreRobotsTxt when not provided", async () => {
+    const post = jest.fn(
+      async (_url: string, _payload: Record<string, unknown>, _opts?: unknown) => ({
+        status: 200,
+        data: { success: true, id: "job-456", url: "https://api.firecrawl.dev/v2/crawl/job-456" },
+      }),
+    );
+
+    const http = { post } as any;
+    await startCrawl(http, { url: "https://example.com" });
+
+    const [, payload] = post.mock.calls[0];
+    expect(payload).not.toHaveProperty("ignoreRobotsTxt");
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,6 +28,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;


### PR DESCRIPTION
Fixes #3940 
## Root cause
\`ignoreRobotsTxt\` was added to \`CrawlOptions\` in #3375 but never wired into \`prepareCrawlPayload()\`. Its twin field \`robotsUserAgent\` had the same gap, caught separately in #3403 — this fixes the field #3403 missed.

## Change
- Forward \`ignoreRobotsTxt\` in \`prepareCrawlPayload()\` (\`crawl.ts\`)
- Add a regression test asserting the field is included when set and omitted when not

## Note
#3046 touches this same file as part of a broader \`robotsMode\` redesign but has been stale since March 2026. This is a minimal, independent fix regardless of that PR's outcome.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `ignoreRobotsTxt` is included in the JS SDK v2 crawl payload so the API respects this option. Also removes an accidental lockfile and ignores it going forward.

- **Bug Fixes**
  - Forward `ignoreRobotsTxt` in `prepareCrawlPayload()` for v2 crawls.
  - Add unit tests to assert inclusion/omission and add `apps/js-sdk/firecrawl/package-lock.json` to `.gitignore`.

<sup>Written for commit 2aeb99659aefa259d61d9db50392186e43f56208. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

