### PR TITLE
Claude/railway build start sh 5jydqa

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# The root Dockerfile only builds apps/api — keep everything else out of the context.
+*
+!apps/api
+apps/api/**/node_modules/
+apps/api/**/dist/
+apps/api/**/target/
+apps/api/.env
+apps/api/**/*.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ RUN apt-get update && apt-get install -y \
 EXPOSE 8080
 WORKDIR /app
 
+# Bind to all interfaces so the platform's proxy can reach the server
+ENV HOST=0.0.0.0
+
 # Copy built application
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1
+# Root Dockerfile for platforms that build from the repository root (e.g. Railway).
+# It builds the API in apps/api — keep it in sync with apps/api/Dockerfile,
+# which is the same build with paths relative to apps/api instead.
+
+FROM node:22-slim AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+ENV CI=true
+
+RUN corepack enable
+
+# Build Go shared library
+FROM golang:1.24 AS go-build
+WORKDIR /app
+COPY apps/api/sharedLibs/go-html-to-md ./sharedLibs/go-html-to-md
+
+RUN cd sharedLibs/go-html-to-md && \
+    go mod download && \
+    go build -o libhtml-to-markdown.so -buildmode=c-shared html-to-markdown.go
+
+FROM base AS build
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    pkg-config \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path \
+    && chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+
+# Copy source files
+COPY apps/api/ ./
+
+# Install dependencies
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/native/target \
+    pnpm install --frozen-lockfile
+
+# Build the application
+RUN pnpm run build
+
+# Remove dev dependencies
+RUN pnpm prune --prod --ignore-scripts
+
+# Runtime stage
+FROM base AS runtime
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8080
+WORKDIR /app
+
+# Copy built application
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/native ./native
+
+# Copy Go shared library
+COPY --from=go-build /app/sharedLibs/go-html-to-md/libhtml-to-markdown.so ./sharedLibs/go-html-to-md/
+
+CMD ["node", "dist/src/harness.js", "--start-docker"]

--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -1,0 +1,50 @@
+# Deploying Firecrawl to Railway
+
+Firecrawl needs **three services** in your Railway project:
+
+| Service | Source |
+| --- | --- |
+| API + workers | This repo (root `Dockerfile`, picked up automatically) |
+| Redis | Railway's Redis database |
+| NUQ Postgres | `ghcr.io/firecrawl/nuq-postgres:latest` (custom image — see below) |
+
+A stock Postgres database will **not** work for NUQ: the queue schema
+requires the `pg_cron` extension (crawl completion is driven by a
+15-second cron job), which Railway's built-in Postgres doesn't ship.
+
+## 1. Redis
+
+Add Railway's Redis database to the project.
+
+## 2. NUQ Postgres
+
+Create an empty service and set its image to
+`ghcr.io/firecrawl/nuq-postgres:latest` (or deploy it from this repo by
+setting the service's root directory to `apps/nuq-postgres`). Then:
+
+- Attach a **volume** mounted at `/var/lib/postgresql/data`
+- Set the variable `POSTGRES_PASSWORD` to a strong password
+
+The image applies the queue schema (`nuq.sql`) automatically on first boot.
+
+## 3. API service
+
+Deploy this repo (root directory unset). Set these variables:
+
+```
+REDIS_URL=${{Redis.REDIS_URL}}?family=0
+NUQ_DATABASE_URL=postgresql://postgres:${{nuq-postgres.POSTGRES_PASSWORD}}@${{nuq-postgres.RAILWAY_PRIVATE_DOMAIN}}:5432/postgres
+USE_DB_AUTHENTICATION=false
+```
+
+Notes:
+
+- `?family=0` is required because Railway's private network is IPv6-only
+  and ioredis defaults to IPv4 DNS resolution.
+- `REDIS_RATE_LIMIT_URL` is optional — it falls back to `REDIS_URL`.
+- Railway injects `PORT` automatically and the server listens on it
+  (bound to `0.0.0.0` by the root Dockerfile). Generate a public domain
+  on this service to reach the API.
+- Optional extras: `PLAYWRIGHT_MICROSERVICE_URL` (JS rendering — deploy
+  `apps/playwright-service-ts` as another service), `OPENAI_API_KEY`
+  (LLM extraction), `BULL_AUTH_KEY` (queue dashboard auth).

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -259,4 +259,11 @@ const configSchema = z.object({
   NUQ_PREFETCH_WORKER_HEARTBEAT_URL: z.string().optional(),
 });
 
-export const config = configSchema.parse(process.env);
+const parsedConfig = configSchema.parse(process.env);
+
+// Deployments with a single Redis (e.g. one managed Redis add-on) only set
+// REDIS_URL — use it for rate limiting too unless a dedicated instance is
+// configured. (REDIS_EVICT_URL already falls back to REDIS_RATE_LIMIT_URL.)
+parsedConfig.REDIS_RATE_LIMIT_URL ??= parsedConfig.REDIS_URL;
+
+export const config = parsedConfig;

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a root Dockerfile and Railway config so `apps/api` builds and deploys from the monorepo root on Railway. Also documents the setup and makes single-Redis deployments work by default.

- **New Features**
  - Add root `Dockerfile`, `.dockerignore`, and `railway.json` to support Railway builds for `apps/api` (binds to `0.0.0.0`, exposes 8080, builds Go shared lib, includes Rust toolchain, prunes dev deps).
  - Add `RAILWAY.md` with steps for three Railway services: API, Redis, and NUQ Postgres (`ghcr.io/firecrawl/nuq-postgres:latest`), plus required env vars (include `?family=0` for `ioredis` IPv6 DNS).

- **Bug Fixes**
  - Default `REDIS_RATE_LIMIT_URL` to `REDIS_URL` to support deployments with a single Redis instance.

<sup>Written for commit 4e181e5f5ecb210212fdaab8c768236d990ade3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

