### PR TITLE
[codex] Serialize v1 crawl snips

### DIFF
--- a/apps/api/src/__tests__/snips/v1/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v1/crawl.test.ts
@@ -155,7 +155,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     3 * scrapeTimeout + 3 * 5000,
   );
 
-  it.concurrent(
+  it(
     "ongoing crawls endpoint works",
     async () => {
       const beforeCrawl = new Date();
@@ -241,7 +241,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
   //     }
   // }, 300000);
 
-  it.concurrent(
+  it(
     "crawlEntireDomain parameter works",
     async () => {
       const res = await crawl(
@@ -261,7 +261,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     5 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "crawlEntireDomain takes precedence over allowBackwardLinks",
     async () => {
       const res = await crawl(
@@ -282,7 +282,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     5 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "backward compatibility - allowBackwardLinks still works",
     async () => {
       const res = await crawl(
@@ -302,7 +302,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     5 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "allowSubdomains parameter works",
     async () => {
       const res = await crawl(
@@ -322,7 +322,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     5 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "allowSubdomains blocks subdomains when false",
     async () => {
       const res = await crawl(
@@ -345,7 +345,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     5 * scrapeTimeout,
   );
 
-  it.concurrent(
+  it(
     "allowSubdomains correctly allows same registrable domain using PSL",
     async () => {
       const res = await crawl(
@@ -395,7 +395,7 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
   //   expect(response.body.details[0].path).toEqual(["url"]);
   // });
 
-  it.concurrent("accepts crawl when URL depth equals maxDepth", async () => {
+  it("accepts crawl when URL depth equals maxDepth", async () => {
     const response = await crawlStart(
       {
         url: base,
@@ -410,25 +410,22 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Crawl tests", () => {
     expect(typeof response.body.id).toBe("string");
   });
 
-  it.concurrent(
-    "accepts crawl when URL depth is less than maxDepth",
-    async () => {
-      const response = await crawlStart(
-        {
-          url: base,
-          maxDepth: 5,
-          limit: 5,
-        },
-        identity,
-      );
+  it("accepts crawl when URL depth is less than maxDepth", async () => {
+    const response = await crawlStart(
+      {
+        url: base,
+        maxDepth: 5,
+        limit: 5,
+      },
+      identity,
+    );
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body.success).toBe(true);
-      expect(typeof response.body.id).toBe("string");
-    },
-  );
+    expect(response.statusCode).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(typeof response.body.id).toBe("string");
+  });
 
-  it.concurrent(
+  it(
     "filters out non-web protocol links (telnet, ftp, ssh, file, mailto)",
     async () => {
       const res = await crawl(


### PR DESCRIPTION
## Summary
- serialize the remaining live v1 crawl snips that still used `it.concurrent`
- keep UUID validation concurrency and existing website gating unchanged

## Why
Recent Server Test Suite runs 28555115347 and 28555452214 both failed in `src/__tests__/snips/v1/crawl.test.ts > Crawl tests > works` with `expected 0 to be greater than 0` in the self-hosted `playwright, no-proxy, searxng, openai, postgres` matrix. PR #3925 serialized the first top-level crawl cases, but the same `Crawl tests` block still launched later crawl cases concurrently against the same local test site and fallback self-hosted identity.

## Validation
- `pnpm exec prettier --check src/__tests__/snips/v1/crawl.test.ts`
- `pnpm build`
- `git diff --check`
- `TEST_SUITE_SELF_HOSTED=true TEST_SUITE_WEBSITE=http://127.0.0.1:4321 TEST_API_KEY=test TEST_TEAM_ID=bypass pnpm harness pnpm vitest run src/__tests__/snips/v1/crawl.test.ts` reached harness setup and API build, then failed because the local Docker daemon is not running at `unix:///Users/gregomoricz/.docker/run/docker.sock`

Labels `codex` and `codex-automation` were not added because they do not exist in the repo label list.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize remaining v1 crawl tests to run sequentially and stop concurrent hits on the same local test site, stabilizing the self-hosted matrix.

- **Bug Fixes**
  - Replaced it.concurrent with it for the remaining v1 crawl snips in apps/api/src/__tests__/snips/v1/crawl.test.ts.
  - Preserved UUID validation concurrency and existing website gating.

<sup>Written for commit 2daf4b0b1c1c6f95cd568e7b8143bb4d5ffd2577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

