### PR TITLE
feat(api): threat protection config model, team flag, and org config API

### DIFF
--- a/apps/api/knip.config.ts
+++ b/apps/api/knip.config.ts
@@ -15,6 +15,9 @@ const config: KnipConfig = {
   ignore: [
     "native/**",
     "src/scraper/scrapeURL/engines/fire-engine/branding-script/**",
+    // Shared type contract co-owned by concurrent threat-protection branches;
+    // the provider/verdict types are consumed by the core-lib branch.
+    "src/lib/threat-protection/types.ts",
   ],
   ignoreDependencies: ["undici-types", "stripe"],
 };

--- a/apps/api/src/__tests__/snips/v2/team-threat-protection.test.ts
+++ b/apps/api/src/__tests__/snips/v2/team-threat-protection.test.ts
@@ -1,0 +1,155 @@
+import request from "supertest";
+import {
+  describeIf,
+  idmux,
+  Identity,
+  TEST_API_URL,
+  TEST_PRODUCTION,
+} from "../lib";
+import { THREAT_PROTECTION_POLICY_DEFAULTS } from "../../../lib/threat-protection/types";
+
+async function getConfigRaw(identity: Identity) {
+  return await request(TEST_API_URL)
+    .get("/v2/team/threat-protection")
+    .set("Authorization", `Bearer ${identity.apiKey}`);
+}
+
+async function putConfigRaw(body: unknown, identity: Identity) {
+  return await request(TEST_API_URL)
+    .put("/v2/team/threat-protection")
+    .set("Authorization", `Bearer ${identity.apiKey}`)
+    .set("Content-Type", "application/json")
+    .send(body as object);
+}
+
+// Requires DB authentication + idmux-provisioned team flags, which only exist
+// in the production test configuration.
+describeIf(TEST_PRODUCTION)("Team threat protection config API", () => {
+  describe("without the team flag", () => {
+    let identity: Identity;
+
+    beforeAll(async () => {
+      identity = await idmux({
+        name: "team-threat-protection/no-flag",
+      });
+    });
+
+    it("GET returns 403", async () => {
+      const res = await getConfigRaw(identity);
+      expect(res.statusCode).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain("enterprise feature");
+    });
+
+    it("PUT returns 403", async () => {
+      const res = await putConfigRaw({ mode: "normal" }, identity);
+      expect(res.statusCode).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain("enterprise feature");
+    });
+  });
+
+  describe("with the team flag", () => {
+    let identity: Identity;
+
+    beforeAll(async () => {
+      identity = await idmux({
+        name: "team-threat-protection/flagged",
+        flags: {
+          threatProtection: "allowed",
+        },
+      });
+    });
+
+    it("GET returns the default (unconfigured) effective config", async () => {
+      const res = await getConfigRaw(identity);
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toMatchObject({
+        mode: "off",
+        ...THREAT_PROTECTION_POLICY_DEFAULTS,
+        allowRequestOverrides: true,
+        siem: null,
+        configured: false,
+      });
+    });
+
+    it("PUT round-trips a full config document", async () => {
+      const doc = {
+        mode: "enhanced",
+        riskScoreThreshold: 60,
+        deniedCategories: ["Malicious", "Phishing"],
+        maxDomainAgeDays: 30,
+        blacklist: ["*.bad.example"],
+        whitelist: ["firecrawl.dev"],
+        blockedTlds: ["zip"],
+        blockedCountries: ["KP"],
+        failurePolicy: "open",
+        allowRequestOverrides: false,
+        siem: {
+          url: "https://siem.example.com/ingest",
+          secret: "test-secret",
+          events: "all",
+        },
+      };
+
+      const put = await putConfigRaw(doc, identity);
+      expect(put.statusCode).toBe(200);
+      expect(put.body.success).toBe(true);
+      expect(put.body.data).toMatchObject({
+        mode: "enhanced",
+        riskScoreThreshold: 60,
+        deniedCategories: ["Malicious", "Phishing"],
+        maxDomainAgeDays: 30,
+        blacklist: ["*.bad.example"],
+        whitelist: ["firecrawl.dev"],
+        blockedTlds: ["zip"],
+        blockedCountries: ["KP"],
+        failurePolicy: "open",
+        allowRequestOverrides: false,
+        configured: true,
+      });
+      // The SIEM secret must never be echoed back.
+      expect(put.body.data.siem).toEqual({
+        url: "https://siem.example.com/ingest",
+        events: "all",
+        secretSet: true,
+      });
+
+      const get = await getConfigRaw(identity);
+      expect(get.statusCode).toBe(200);
+      expect(get.body.data).toMatchObject({
+        mode: "enhanced",
+        riskScoreThreshold: 60,
+        configured: true,
+      });
+      expect(get.body.data.siem?.secretSet).toBe(true);
+      expect(JSON.stringify(get.body.data)).not.toContain("test-secret");
+    });
+
+    it("PUT is a full-document update (unspecified fields reset to defaults)", async () => {
+      const put = await putConfigRaw({ mode: "normal" }, identity);
+      expect(put.statusCode).toBe(200);
+      expect(put.body.data).toMatchObject({
+        mode: "normal",
+        ...THREAT_PROTECTION_POLICY_DEFAULTS,
+        allowRequestOverrides: true,
+        siem: null,
+        configured: true,
+      });
+    });
+
+    it("PUT rejects an invalid document with 400", async () => {
+      const res = await putConfigRaw(
+        {
+          mode: "enhanced",
+          riskScoreThreshold: 500,
+          blacklist: ["https://not-a-domain"],
+        },
+        identity,
+      );
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1302,6 +1302,7 @@ export type AuthCreditUsageChunk = {
 export type TeamFlags = {
   ignoreRobots?: "disabled" | "allowed" | "forced";
   customRobotsAgent?: "disabled" | "allowed";
+  threatProtection?: "disabled" | "allowed" | "forced";
   unblockedDomains?: string[];
   forceZDR?: boolean;
   allowZDR?: boolean;

--- a/apps/api/src/controllers/v2/team-threat-protection.ts
+++ b/apps/api/src/controllers/v2/team-threat-protection.ts
@@ -1,0 +1,130 @@
+import { Response } from "express";
+import { logger as _logger } from "../../lib/logger";
+import { RequestWithAuth } from "./types";
+import { getThreatProtection } from "../../lib/zdr-helpers";
+import { threatProtectionConfigSchema } from "../../lib/threat-protection/config";
+import {
+  getOrgIdForTeam,
+  getOrgThreatProtectionConfig,
+  resolveEffectivePolicy,
+  upsertOrgThreatProtectionConfig,
+  type OrgThreatProtectionConfig,
+} from "../../lib/threat-protection/store";
+
+const logger = _logger.child({ module: "team-threat-protection" });
+
+const SUPPORT_EMAIL = "support@firecrawl.com";
+
+function rejectWithoutFlag(
+  req: RequestWithAuth<any, any, any>,
+  res: Response,
+): boolean {
+  const mode = getThreatProtection(req.acuc?.flags);
+  if (mode !== "allowed" && mode !== "forced") {
+    res.status(403).json({
+      success: false,
+      error: `Threat protection is an enterprise feature and is not enabled for your team. Contact ${SUPPORT_EMAIL} to explore whether it can be enabled for your team.`,
+    });
+    return true;
+  }
+  return false;
+}
+
+async function resolveOrgId(
+  req: RequestWithAuth<any, any, any>,
+  res: Response,
+): Promise<string | null> {
+  const orgId = req.auth.org_id ?? (await getOrgIdForTeam(req.auth.team_id));
+  if (!orgId) {
+    logger.error("Failed to resolve org for team", {
+      teamId: req.auth.team_id,
+    });
+    res.status(500).json({
+      success: false,
+      error: "Failed to resolve the organization for this team.",
+    });
+    return null;
+  }
+  return orgId;
+}
+
+/**
+ * Effective config document served by GET and PUT. Always includes every
+ * policy field (defaults applied), so the dashboard can render the form
+ * without knowing the defaults. The SIEM secret is never echoed back.
+ */
+function serializeConfig(orgConfig: OrgThreatProtectionConfig | null) {
+  const policy = resolveEffectivePolicy(orgConfig);
+  return {
+    ...policy,
+    allowRequestOverrides: orgConfig?.allowRequestOverrides ?? true,
+    siem: orgConfig?.siem
+      ? {
+          url: orgConfig.siem.url,
+          events: orgConfig.siem.events,
+          secretSet: orgConfig.siem.secret !== null,
+        }
+      : null,
+    configured: orgConfig !== null,
+    updatedAt: orgConfig?.updatedAt ?? null,
+  };
+}
+
+function changedFields(
+  previous: OrgThreatProtectionConfig | null,
+  next: OrgThreatProtectionConfig,
+): string[] {
+  const before = serializeConfig(previous) as Record<string, unknown>;
+  const after = serializeConfig(next) as Record<string, unknown>;
+  return Object.keys(after).filter(
+    key =>
+      key !== "updatedAt" &&
+      key !== "configured" &&
+      JSON.stringify(before[key]) !== JSON.stringify(after[key]),
+  );
+}
+
+export async function getTeamThreatProtectionController(
+  req: RequestWithAuth,
+  res: Response,
+): Promise<void> {
+  if (rejectWithoutFlag(req, res)) return;
+
+  const orgId = await resolveOrgId(req, res);
+  if (!orgId) return;
+
+  const orgConfig = await getOrgThreatProtectionConfig(orgId);
+
+  res.status(200).json({
+    success: true,
+    data: serializeConfig(orgConfig),
+  });
+}
+
+export async function putTeamThreatProtectionController(
+  req: RequestWithAuth<{}, any, unknown>,
+  res: Response,
+): Promise<void> {
+  if (rejectWithoutFlag(req, res)) return;
+
+  const input = threatProtectionConfigSchema.parse(req.body);
+
+  const orgId = await resolveOrgId(req, res);
+  if (!orgId) return;
+
+  const previous = await getOrgThreatProtectionConfig(orgId);
+  const updated = await upsertOrgThreatProtectionConfig(orgId, input);
+
+  // Audit log — org-level security configuration change.
+  logger.info("Threat protection config updated", {
+    teamId: req.auth.team_id,
+    orgId,
+    mode: updated.policy.mode,
+    changedFields: changedFields(previous, updated),
+  });
+
+  res.status(200).json({
+    success: true,
+    data: serializeConfig(updated),
+  });
+}

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1534,6 +1534,7 @@ type Account = {
 export type TeamFlags = {
   ignoreRobots?: "disabled" | "allowed" | "forced";
   customRobotsAgent?: "disabled" | "allowed";
+  threatProtection?: "disabled" | "allowed" | "forced";
   unblockedDomains?: string[];
   forceZDR?: boolean;
   allowZDR?: boolean;

--- a/apps/api/src/db/schema/public.ts
+++ b/apps/api/src/db/schema/public.ts
@@ -593,6 +593,31 @@ export const teams = pgTable("teams", {
   org_id: uuid("org_id").notNull(),
 });
 
+// Org-scoped threat protection configuration (enterprise feature, gated by the
+// `threatProtection` team flag). One row per org; DDL is applied out-of-band.
+export const threat_protection_config = pgTable("threat_protection_config", {
+  id: uuid("id").notNull().defaultRandom(),
+  org_id: uuid("org_id").notNull().unique(),
+  mode: varchar("mode").notNull().default("off"),
+  risk_score_threshold: integer("risk_score_threshold").notNull().default(75),
+  denied_categories: text("denied_categories").array().notNull().default([]),
+  max_domain_age_days: integer("max_domain_age_days"),
+  blacklist: text("blacklist").array().notNull().default([]),
+  whitelist: text("whitelist").array().notNull().default([]),
+  blocked_tlds: text("blocked_tlds").array().notNull().default([]),
+  blocked_countries: text("blocked_countries").array().notNull().default([]),
+  failure_policy: varchar("failure_policy").notNull().default("closed"),
+  allow_request_overrides: boolean("allow_request_overrides")
+    .notNull()
+    .default(true),
+  siem_url: text("siem_url"),
+  siem_secret: text("siem_secret"),
+  // "blocked" | "all"
+  siem_events: varchar("siem_events"),
+  created_at: ts("created_at").notNull().defaultNow(),
+  updated_at: ts("updated_at").notNull().defaultNow(),
+});
+
 export const user_notifications = pgTable("user_notifications", {
   id: uuid("id").notNull().defaultRandom(),
   team_id: uuid("team_id"),

--- a/apps/api/src/lib/permissions.test.ts
+++ b/apps/api/src/lib/permissions.test.ts
@@ -1,0 +1,55 @@
+import { checkPermissions } from "./permissions";
+
+describe("checkPermissions — threat protection", () => {
+  const requestWithOption = { threatProtection: { mode: "normal" } };
+
+  it("allows requests without a threatProtection option regardless of flags", () => {
+    expect(checkPermissions({}, null)).toEqual({});
+    expect(checkPermissions({}, { threatProtection: "disabled" })).toEqual({});
+  });
+
+  it("rejects a per-request option when the flag is missing or disabled", () => {
+    expect(checkPermissions(requestWithOption, null).error).toMatch(
+      /enterprise feature/,
+    );
+    expect(
+      checkPermissions(requestWithOption, { threatProtection: "disabled" })
+        .error,
+    ).toMatch(/enterprise feature/);
+  });
+
+  it.each(["allowed", "forced"] as const)(
+    "allows a per-request option when the flag is %s",
+    mode => {
+      expect(
+        checkPermissions(requestWithOption, { threatProtection: mode }),
+      ).toEqual({});
+    },
+  );
+
+  it("rejects a per-request option when the org disables overrides", () => {
+    const result = checkPermissions(
+      requestWithOption,
+      { threatProtection: "allowed" },
+      { threatProtectionOrgConfig: { allowRequestOverrides: false } },
+    );
+    expect(result.error).toMatch(/overrides are disabled/);
+  });
+
+  it("allows a per-request option when the org config allows overrides", () => {
+    expect(
+      checkPermissions(
+        requestWithOption,
+        { threatProtection: "allowed" },
+        { threatProtectionOrgConfig: { allowRequestOverrides: true } },
+      ),
+    ).toEqual({});
+    expect(
+      checkPermissions(
+        requestWithOption,
+        { threatProtection: "allowed" },
+        { threatProtectionOrgConfig: null },
+      ),
+    ).toEqual({});
+  });
+});

--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -3,6 +3,7 @@ import {
   getScrapeZDR,
   getIgnoreRobots,
   getCustomRobotsAgent,
+  getThreatProtection,
 } from "./zdr-helpers";
 
 type LocationOptions = { country?: string };
@@ -17,6 +18,18 @@ interface APIRequest {
     ignoreRobotsTxt?: boolean;
     robotsUserAgent?: string;
   };
+  // Per-request threat protection policy override. The request schema ships
+  // with the enforcement PR; presence of any value gates on the team flag.
+  threatProtection?: unknown;
+}
+
+interface PermissionOptions {
+  /**
+   * Org-level threat protection config (or the relevant slice of it), if
+   * already loaded. When the org disables request overrides, any per-request
+   * threatProtection option is rejected.
+   */
+  threatProtectionOrgConfig?: { allowRequestOverrides: boolean } | null;
 }
 
 const SUPPORT_EMAIL = "support@firecrawl.com";
@@ -24,6 +37,7 @@ const SUPPORT_EMAIL = "support@firecrawl.com";
 export function checkPermissions(
   request: APIRequest,
   flags?: TeamFlags,
+  options?: PermissionOptions,
 ): { error?: string } {
   // zdr perms — scrapeZDR must be 'allowed' or 'forced' for request-scoped ZDR
   const scrapeMode = getScrapeZDR(flags);
@@ -57,6 +71,24 @@ export function checkPermissions(
     return {
       error: `The robotsUserAgent parameter is an enterprise feature. Contact ${SUPPORT_EMAIL} to explore whether it can be enabled for your team.`,
     };
+  }
+
+  // threat protection perms — the flag must be 'allowed' or 'forced' for any
+  // per-request threatProtection option, and the org must not have locked
+  // down request-level overrides.
+  if (request.threatProtection !== undefined) {
+    const threatMode = getThreatProtection(flags);
+    if (threatMode !== "allowed" && threatMode !== "forced") {
+      return {
+        error: `Threat protection is an enterprise feature and is not enabled for your team. Contact ${SUPPORT_EMAIL} to explore whether it can be enabled for your team.`,
+      };
+    }
+    if (options?.threatProtectionOrgConfig?.allowRequestOverrides === false) {
+      return {
+        error:
+          "Per-request threat protection overrides are disabled by your organization's threat protection configuration.",
+      };
+    }
   }
 
   // ip whitelist perms

--- a/apps/api/src/lib/threat-protection/config.test.ts
+++ b/apps/api/src/lib/threat-protection/config.test.ts
@@ -1,0 +1,260 @@
+import {
+  ALPHAMOUNTAIN_CATEGORIES,
+  DEFAULT_DENIED_CATEGORIES,
+  threatProtectionConfigSchema,
+  threatProtectionPolicySchema,
+} from "./config";
+import { THREAT_PROTECTION_POLICY_DEFAULTS } from "./types";
+
+describe("threatProtectionPolicySchema", () => {
+  it("applies defaults for a minimal document", () => {
+    const policy = threatProtectionPolicySchema.parse({ mode: "off" });
+    expect(policy).toEqual({
+      mode: "off",
+      ...THREAT_PROTECTION_POLICY_DEFAULTS,
+    });
+  });
+
+  it("accepts a full valid document", () => {
+    const policy = threatProtectionPolicySchema.parse({
+      mode: "enhanced",
+      riskScoreThreshold: 50,
+      deniedCategories: ["Malicious", "Phishing", "Gambling"],
+      maxDomainAgeDays: 30,
+      blacklist: ["bad.example.com", "*.malware.example"],
+      whitelist: ["example.com", "*.example.org"],
+      blockedTlds: ["zip", "mov"],
+      blockedCountries: ["KP", "IR"],
+      failurePolicy: "open",
+    });
+    expect(policy.mode).toBe("enhanced");
+    expect(policy.riskScoreThreshold).toBe(50);
+    expect(policy.maxDomainAgeDays).toBe(30);
+    expect(policy.failurePolicy).toBe("open");
+  });
+
+  it("rejects an invalid mode", () => {
+    expect(() =>
+      threatProtectionPolicySchema.parse({ mode: "paranoid" }),
+    ).toThrow();
+  });
+
+  it("rejects unknown keys", () => {
+    expect(() =>
+      threatProtectionPolicySchema.parse({ mode: "off", nope: true }),
+    ).toThrow();
+  });
+
+  describe("riskScoreThreshold", () => {
+    it.each([0, 100, 75])("accepts %d", value => {
+      expect(
+        threatProtectionPolicySchema.parse({
+          mode: "normal",
+          riskScoreThreshold: value,
+        }).riskScoreThreshold,
+      ).toBe(value);
+    });
+
+    it.each([-1, 101, 50.5])("rejects %d", value => {
+      expect(() =>
+        threatProtectionPolicySchema.parse({
+          mode: "normal",
+          riskScoreThreshold: value,
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("blacklist / whitelist globs", () => {
+    it("normalizes case and whitespace", () => {
+      const policy = threatProtectionPolicySchema.parse({
+        mode: "normal",
+        blacklist: ["  Bad.Example.COM ", "*.Evil.Example"],
+      });
+      expect(policy.blacklist).toEqual(["bad.example.com", "*.evil.example"]);
+    });
+
+    it.each([
+      "https://example.com",
+      "example.com/path",
+      "example.com:8080",
+      "*.",
+      "*",
+      "*.*.example.com",
+      "foo",
+      "ex ample.com",
+      "-bad-.example.com",
+      "exa_mple.com",
+    ])("rejects garbage entry %j with a clear message", entry => {
+      expect(() =>
+        threatProtectionPolicySchema.parse({
+          mode: "normal",
+          blacklist: [entry],
+        }),
+      ).toThrow(/Invalid domain entry/);
+    });
+  });
+
+  describe("blockedTlds", () => {
+    it("accepts and normalizes TLDs", () => {
+      const policy = threatProtectionPolicySchema.parse({
+        mode: "normal",
+        blockedTlds: ["ZIP", " mov "],
+      });
+      expect(policy.blockedTlds).toEqual(["zip", "mov"]);
+    });
+
+    it.each([".zip", "z!p", "co.uk", ""])("rejects %j", entry => {
+      expect(() =>
+        threatProtectionPolicySchema.parse({
+          mode: "normal",
+          blockedTlds: [entry],
+        }),
+      ).toThrow(/Invalid TLD/);
+    });
+  });
+
+  describe("blockedCountries", () => {
+    it("accepts and uppercases alpha-2 codes", () => {
+      const policy = threatProtectionPolicySchema.parse({
+        mode: "enhanced",
+        blockedCountries: ["us", "KP"],
+      });
+      expect(policy.blockedCountries).toEqual(["US", "KP"]);
+    });
+
+    it.each(["USA", "U", "1A", ""])("rejects %j", entry => {
+      expect(() =>
+        threatProtectionPolicySchema.parse({
+          mode: "enhanced",
+          blockedCountries: [entry],
+        }),
+      ).toThrow(/Invalid country code/);
+    });
+  });
+
+  describe("deniedCategories", () => {
+    it("accepts known alphaMountain categories", () => {
+      const policy = threatProtectionPolicySchema.parse({
+        mode: "enhanced",
+        deniedCategories: ["Malicious", "Scam/Illegal/Unethical"],
+      });
+      expect(policy.deniedCategories).toEqual([
+        "Malicious",
+        "Scam/Illegal/Unethical",
+      ]);
+    });
+
+    it.each(["Botnets", "malicious", "Totally Made Up"])(
+      "rejects unknown category %j",
+      entry => {
+        expect(() =>
+          threatProtectionPolicySchema.parse({
+            mode: "enhanced",
+            deniedCategories: [entry],
+          }),
+        ).toThrow(/Unknown content category/);
+      },
+    );
+  });
+
+  describe("maxDomainAgeDays", () => {
+    it("accepts null and positive integers", () => {
+      expect(
+        threatProtectionPolicySchema.parse({
+          mode: "enhanced",
+          maxDomainAgeDays: null,
+        }).maxDomainAgeDays,
+      ).toBeNull();
+      expect(
+        threatProtectionPolicySchema.parse({
+          mode: "enhanced",
+          maxDomainAgeDays: 90,
+        }).maxDomainAgeDays,
+      ).toBe(90);
+    });
+
+    it.each([0, -5, 2.5])("rejects %d", value => {
+      expect(() =>
+        threatProtectionPolicySchema.parse({
+          mode: "enhanced",
+          maxDomainAgeDays: value,
+        }),
+      ).toThrow();
+    });
+  });
+});
+
+describe("threatProtectionConfigSchema", () => {
+  it("applies defaults for allowRequestOverrides and siem", () => {
+    const config = threatProtectionConfigSchema.parse({ mode: "normal" });
+    expect(config.allowRequestOverrides).toBe(true);
+    expect(config.siem).toBeNull();
+  });
+
+  it("accepts a SIEM config", () => {
+    const config = threatProtectionConfigSchema.parse({
+      mode: "normal",
+      siem: {
+        url: "https://siem.example.com/ingest",
+        secret: "hunter2hunter2",
+        events: "all",
+      },
+    });
+    expect(config.siem).toEqual({
+      url: "https://siem.example.com/ingest",
+      secret: "hunter2hunter2",
+      events: "all",
+    });
+  });
+
+  it("defaults SIEM events to blocked and secret to null", () => {
+    const config = threatProtectionConfigSchema.parse({
+      mode: "normal",
+      siem: { url: "https://siem.example.com/ingest" },
+    });
+    expect(config.siem?.events).toBe("blocked");
+    expect(config.siem?.secret).toBeNull();
+  });
+
+  it("rejects non-http(s) SIEM urls", () => {
+    expect(() =>
+      threatProtectionConfigSchema.parse({
+        mode: "normal",
+        siem: { url: "ftp://siem.example.com" },
+      }),
+    ).toThrow();
+    expect(() =>
+      threatProtectionConfigSchema.parse({
+        mode: "normal",
+        siem: { url: "not a url" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid siem events values", () => {
+    expect(() =>
+      threatProtectionConfigSchema.parse({
+        mode: "normal",
+        siem: { url: "https://siem.example.com", events: "everything" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("category constants", () => {
+  it("DEFAULT_DENIED_CATEGORIES only contains known categories", () => {
+    const known = new Set<string>(ALPHAMOUNTAIN_CATEGORIES);
+    for (const category of DEFAULT_DENIED_CATEGORIES) {
+      expect(known.has(category)).toBe(true);
+    }
+  });
+
+  it("DEFAULT_DENIED_CATEGORIES validates against the schema", () => {
+    const policy = threatProtectionPolicySchema.parse({
+      mode: "enhanced",
+      deniedCategories: DEFAULT_DENIED_CATEGORIES,
+    });
+    expect(policy.deniedCategories).toEqual(DEFAULT_DENIED_CATEGORIES);
+  });
+});

--- a/apps/api/src/lib/threat-protection/config.ts
+++ b/apps/api/src/lib/threat-protection/config.ts
@@ -1,0 +1,268 @@
+import { z } from "zod";
+import {
+  THREAT_PROTECTION_POLICY_DEFAULTS,
+  type ThreatProtectionPolicy,
+} from "./types";
+
+// =========================================
+// alphaMountain content categories
+// =========================================
+
+/**
+ * Full list of alphaMountain content category names, as published at
+ * https://www.alphamountain.ai/categories/ (retrieved 2026-07-04).
+ *
+ * Keep this list in sync with the provider. `deniedCategories` in the
+ * threat protection policy is validated against it.
+ */
+export const ALPHAMOUNTAIN_CATEGORIES = [
+  "Abortion",
+  "Adult/Mature",
+  "Ads/Analytics",
+  "AI/ML Applications",
+  "Alcohol",
+  "Alternative Currency",
+  "Alternative Ideology",
+  "Anonymizers",
+  "Arts/Culture",
+  "Auctions/Classifieds",
+  "Audio",
+  "Brokerage/Trading",
+  "Business/Economy",
+  "Chat/IM/SMS",
+  "Child Pornography/Abuse",
+  "Content Servers",
+  "Dating/Personals",
+  "Digital Postcards",
+  "DNS over HTTP",
+  "Drugs/Controlled Substances",
+  "Dynamic DNS",
+  "Education",
+  "Email",
+  "Entertainment",
+  "Extreme/Gruesome",
+  "File Sharing/Storage",
+  "Finance",
+  "For Kids",
+  "Forums",
+  "Gambling",
+  "Games",
+  "Government/Legal",
+  "Hacking",
+  "Hate/Discrimination",
+  "Health",
+  "Hobbies/Recreation",
+  "Hosting",
+  "Humor/Comics",
+  "Information Technology",
+  "Information/Computer Security",
+  "Infrastructure/IOT",
+  "Job Search",
+  "Lingerie/Swimsuit",
+  "Local/Non-Routable",
+  "Login/Challenge",
+  "Malicious",
+  "Marijuana",
+  "Marketing/Merchandising",
+  "Media Sharing",
+  "Military",
+  "Mixed Content/Potentially Adult",
+  "Network Access/Captive Portal",
+  "News",
+  "Newly Registered",
+  "Non-Profit/Advocacy",
+  "Nudity",
+  "Parked Site",
+  "Peer-to-Peer (P2P)",
+  "Personal Sites/Blogs",
+  "Phishing",
+  "Piracy/Plagiarism",
+  "Politics/Opinion",
+  "Pornography",
+  "Potentially Unwanted Programs",
+  "Productivity Applications",
+  "Promotional Compensation",
+  "Real Estate",
+  "Reference",
+  "Religion",
+  "Remote Access",
+  "Restaurants/Food",
+  "Scam/Illegal/Unethical",
+  "Search Engines/Portals",
+  "Sex Education",
+  "Shopping",
+  "Social Networking",
+  "Society/Lifestyle",
+  "Software Downloads",
+  "Spam",
+  "Sports",
+  "Suspicious",
+  "Telephony",
+  "Tobacco",
+  "Translation",
+  "Travel",
+  "Unrated",
+  "URL Redirect",
+  "Vehicles",
+  "Video/Multimedia",
+  "Violence",
+  "Virtual Meetings",
+  "Weapons",
+] as const;
+
+const ALPHAMOUNTAIN_CATEGORY_SET = new Set<string>(ALPHAMOUNTAIN_CATEGORIES);
+
+/**
+ * Sensible security-focused default for `deniedCategories` in enhanced mode:
+ * clearly malicious categories plus the categories enterprise compliance
+ * teams most commonly deny.
+ */
+export const DEFAULT_DENIED_CATEGORIES: string[] = [
+  // Clearly malicious / abuse
+  "Malicious",
+  "Phishing",
+  "Spam",
+  "Suspicious",
+  "Scam/Illegal/Unethical",
+  "Hacking",
+  "Potentially Unwanted Programs",
+  "Child Pornography/Abuse",
+  // Common enterprise compliance denials
+  "Weapons",
+  "Violence",
+  "Hate/Discrimination",
+  "Extreme/Gruesome",
+  "Drugs/Controlled Substances",
+  "Gambling",
+  "Pornography",
+  "Nudity",
+  "Adult/Mature",
+  "Piracy/Plagiarism",
+];
+
+// =========================================
+// Field schemas
+// =========================================
+
+// One DNS label: alphanumeric, optionally with inner hyphens, max 63 chars.
+const DOMAIN_LABEL = "[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?";
+// Plain domain ("example.com", "sub.example.co.uk") or a single leading
+// wildcard label ("*.example.com"). No protocol, path, port, or inner "*".
+const DOMAIN_GLOB_REGEX = new RegExp(
+  `^(\\*\\.)?(?:${DOMAIN_LABEL}\\.)+${DOMAIN_LABEL}$`,
+);
+
+const domainGlobSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .refine(value => value.length <= 253 && DOMAIN_GLOB_REGEX.test(value), {
+    error: iss =>
+      `Invalid domain entry ${JSON.stringify(iss.input)}: must be a plain domain like "example.com" or a wildcard glob like "*.example.com" (no protocol, path, or port)`,
+  });
+
+const tldSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .refine(value => /^[a-z0-9]{1,63}$/.test(value), {
+    error: iss =>
+      `Invalid TLD ${JSON.stringify(iss.input)}: must be a lowercase alphanumeric TLD without the leading dot, e.g. "zip"`,
+  });
+
+const countryCodeSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .refine(value => /^[A-Z]{2}$/.test(value), {
+    error: iss =>
+      `Invalid country code ${JSON.stringify(iss.input)}: must be an ISO 3166-1 alpha-2 code, e.g. "US"`,
+  });
+
+const deniedCategorySchema = z
+  .string()
+  .refine(value => ALPHAMOUNTAIN_CATEGORY_SET.has(value), {
+    error: iss =>
+      `Unknown content category ${JSON.stringify(iss.input)}: must be one of the alphaMountain category names`,
+  });
+
+// =========================================
+// Policy + org config schemas
+// =========================================
+
+/**
+ * Field-for-field zod schema for {@link ThreatProtectionPolicy}. Every field
+ * except `mode` defaults to {@link THREAT_PROTECTION_POLICY_DEFAULTS}.
+ */
+export const threatProtectionPolicySchema = z.strictObject({
+  mode: z.enum(["off", "normal", "enhanced"]),
+  riskScoreThreshold: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.riskScoreThreshold),
+  deniedCategories: z
+    .array(deniedCategorySchema)
+    .max(ALPHAMOUNTAIN_CATEGORIES.length)
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.deniedCategories),
+  maxDomainAgeDays: z
+    .number()
+    .int()
+    .min(1)
+    .max(3650)
+    .nullable()
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.maxDomainAgeDays),
+  blacklist: z
+    .array(domainGlobSchema)
+    .max(1000)
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.blacklist),
+  whitelist: z
+    .array(domainGlobSchema)
+    .max(1000)
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.whitelist),
+  blockedTlds: z
+    .array(tldSchema)
+    .max(1000)
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.blockedTlds),
+  blockedCountries: z
+    .array(countryCodeSchema)
+    .max(250)
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.blockedCountries),
+  failurePolicy: z
+    .enum(["open", "closed"])
+    .prefault(THREAT_PROTECTION_POLICY_DEFAULTS.failurePolicy),
+});
+
+// Compile-time assertion that the schema output matches the shared contract
+// in ./types.ts — fails to typecheck if the two drift apart.
+const _policyContractCheck = (
+  x: z.infer<typeof threatProtectionPolicySchema>,
+): ThreatProtectionPolicy => x;
+void _policyContractCheck;
+
+const siemConfigSchema = z.strictObject({
+  url: z
+    .url({
+      protocol: /^https?$/,
+      error: "SIEM url must be a valid http(s) URL",
+    })
+    .max(2048),
+  secret: z.string().min(1).max(4096).nullable().prefault(null),
+  events: z.enum(["blocked", "all"]).prefault("blocked"),
+});
+
+/**
+ * Full org-level configuration document, as accepted by
+ * `PUT /v2/team/threat-protection`.
+ */
+export const threatProtectionConfigSchema = threatProtectionPolicySchema.extend(
+  {
+    allowRequestOverrides: z.boolean().prefault(true),
+    siem: siemConfigSchema.nullable().prefault(null),
+  },
+);
+
+export type ThreatProtectionConfigInput = z.infer<
+  typeof threatProtectionConfigSchema
+>;

--- a/apps/api/src/lib/threat-protection/store.test.ts
+++ b/apps/api/src/lib/threat-protection/store.test.ts
@@ -1,0 +1,98 @@
+import { resolveEffectivePolicy, OrgThreatProtectionConfig } from "./store";
+import {
+  THREAT_PROTECTION_POLICY_DEFAULTS,
+  ThreatProtectionPolicy,
+} from "./types";
+
+const orgPolicy: ThreatProtectionPolicy = {
+  mode: "enhanced",
+  riskScoreThreshold: 60,
+  deniedCategories: ["Malicious", "Phishing"],
+  maxDomainAgeDays: 30,
+  blacklist: ["*.bad.example"],
+  whitelist: ["example.com"],
+  blockedTlds: ["zip"],
+  blockedCountries: ["KP"],
+  failurePolicy: "open",
+};
+
+function makeOrgConfig(
+  overrides: Partial<OrgThreatProtectionConfig> = {},
+): OrgThreatProtectionConfig {
+  return {
+    orgId: "00000000-0000-0000-0000-000000000000",
+    policy: { ...orgPolicy },
+    allowRequestOverrides: true,
+    siem: null,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("resolveEffectivePolicy", () => {
+  it("returns mode off with defaults when there is no org config", () => {
+    expect(resolveEffectivePolicy(null)).toEqual({
+      mode: "off",
+      ...THREAT_PROTECTION_POLICY_DEFAULTS,
+    });
+  });
+
+  it("returns the org policy when there is no request override", () => {
+    expect(resolveEffectivePolicy(makeOrgConfig())).toEqual(orgPolicy);
+  });
+
+  it("does field-level replacement from the request override", () => {
+    const effective = resolveEffectivePolicy(makeOrgConfig(), {
+      riskScoreThreshold: 90,
+      blockedTlds: ["mov"],
+    });
+    expect(effective).toEqual({
+      ...orgPolicy,
+      riskScoreThreshold: 90,
+      blockedTlds: ["mov"],
+    });
+  });
+
+  it("replaces arrays wholesale instead of merging them", () => {
+    const effective = resolveEffectivePolicy(makeOrgConfig(), {
+      blacklist: ["*.other.example"],
+    });
+    expect(effective.blacklist).toEqual(["*.other.example"]);
+  });
+
+  it("ignores undefined fields in the override", () => {
+    const effective = resolveEffectivePolicy(makeOrgConfig(), {
+      riskScoreThreshold: undefined,
+      failurePolicy: "closed",
+    });
+    expect(effective.riskScoreThreshold).toBe(60);
+    expect(effective.failurePolicy).toBe("closed");
+  });
+
+  it("applies overrides on top of defaults when there is no org config", () => {
+    const effective = resolveEffectivePolicy(null, {
+      mode: "normal",
+      riskScoreThreshold: 10,
+    });
+    expect(effective).toEqual({
+      mode: "normal",
+      ...THREAT_PROTECTION_POLICY_DEFAULTS,
+      riskScoreThreshold: 10,
+    });
+  });
+
+  it("ignores the override when the org disables request overrides", () => {
+    const effective = resolveEffectivePolicy(
+      makeOrgConfig({ allowRequestOverrides: false }),
+      { mode: "off", riskScoreThreshold: 0 },
+    );
+    expect(effective).toEqual(orgPolicy);
+  });
+
+  it("does not mutate the org config", () => {
+    const orgConfig = makeOrgConfig();
+    resolveEffectivePolicy(orgConfig, { riskScoreThreshold: 1 });
+    expect(orgConfig.policy).toEqual(orgPolicy);
+  });
+});

--- a/apps/api/src/lib/threat-protection/store.ts
+++ b/apps/api/src/lib/threat-protection/store.ts
@@ -1,0 +1,205 @@
+import { eq } from "drizzle-orm";
+import { db, dbRr } from "../../db/connection";
+import * as schema from "../../db/schema";
+import { deleteKey, getValue, setValue } from "../../services/redis";
+import { logger as _logger } from "../logger";
+import {
+  THREAT_PROTECTION_POLICY_DEFAULTS,
+  type ThreatProtectionPolicy,
+} from "./types";
+import type { ThreatProtectionConfigInput } from "./config";
+
+const logger = _logger.child({ module: "threat-protection-store" });
+
+// Short TTL so config changes apply without a redeploy while keeping the
+// enforcement hot path off Postgres. Invalidated on write.
+const CACHE_TTL_SECONDS = 60;
+
+const cacheKey = (orgId: string) => `threat-protection-config:${orgId}`;
+
+interface OrgThreatProtectionSiemConfig {
+  url: string;
+  secret: string | null;
+  events: "blocked" | "all";
+}
+
+export interface OrgThreatProtectionConfig {
+  orgId: string;
+  policy: ThreatProtectionPolicy;
+  allowRequestOverrides: boolean;
+  siem: OrgThreatProtectionSiemConfig | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+type ThreatProtectionConfigRow =
+  typeof schema.threat_protection_config.$inferSelect;
+
+function rowToConfig(
+  row: ThreatProtectionConfigRow,
+): OrgThreatProtectionConfig {
+  return {
+    orgId: row.org_id,
+    policy: {
+      mode: row.mode === "normal" || row.mode === "enhanced" ? row.mode : "off",
+      riskScoreThreshold:
+        row.risk_score_threshold ??
+        THREAT_PROTECTION_POLICY_DEFAULTS.riskScoreThreshold,
+      deniedCategories: row.denied_categories ?? [],
+      maxDomainAgeDays: row.max_domain_age_days,
+      blacklist: row.blacklist ?? [],
+      whitelist: row.whitelist ?? [],
+      blockedTlds: row.blocked_tlds ?? [],
+      blockedCountries: row.blocked_countries ?? [],
+      failurePolicy: row.failure_policy === "open" ? "open" : "closed",
+    },
+    allowRequestOverrides: row.allow_request_overrides ?? true,
+    siem: row.siem_url
+      ? {
+          url: row.siem_url,
+          secret: row.siem_secret,
+          events: row.siem_events === "all" ? "all" : "blocked",
+        }
+      : null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Reads the org's threat protection config, with a short Redis cache
+ * (~60s TTL, negative results included) so the enforcement hot path
+ * doesn't hit Postgres per scrape. Invalidated by
+ * {@link upsertOrgThreatProtectionConfig}.
+ */
+export async function getOrgThreatProtectionConfig(
+  orgId: string,
+): Promise<OrgThreatProtectionConfig | null> {
+  const key = cacheKey(orgId);
+
+  try {
+    const cached = await getValue(key);
+    if (cached !== null) {
+      return JSON.parse(cached) as OrgThreatProtectionConfig | null;
+    }
+  } catch (error) {
+    logger.warn("Failed to read threat protection config cache", {
+      error,
+      orgId,
+    });
+  }
+
+  const rows = await dbRr
+    .select()
+    .from(schema.threat_protection_config)
+    .where(eq(schema.threat_protection_config.org_id, orgId))
+    .limit(1);
+
+  const config = rows[0] ? rowToConfig(rows[0]) : null;
+
+  try {
+    await setValue(key, JSON.stringify(config), CACHE_TTL_SECONDS);
+  } catch (error) {
+    logger.warn("Failed to write threat protection config cache", {
+      error,
+      orgId,
+    });
+  }
+
+  return config;
+}
+
+/**
+ * Full-document upsert of the org's threat protection config. Invalidates
+ * the read cache on success.
+ */
+export async function upsertOrgThreatProtectionConfig(
+  orgId: string,
+  config: ThreatProtectionConfigInput,
+): Promise<OrgThreatProtectionConfig> {
+  const values = {
+    org_id: orgId,
+    mode: config.mode,
+    risk_score_threshold: config.riskScoreThreshold,
+    denied_categories: config.deniedCategories,
+    max_domain_age_days: config.maxDomainAgeDays,
+    blacklist: config.blacklist,
+    whitelist: config.whitelist,
+    blocked_tlds: config.blockedTlds,
+    blocked_countries: config.blockedCountries,
+    failure_policy: config.failurePolicy,
+    allow_request_overrides: config.allowRequestOverrides,
+    siem_url: config.siem?.url ?? null,
+    siem_secret: config.siem?.secret ?? null,
+    siem_events: config.siem?.events ?? null,
+  };
+
+  const [row] = await db
+    .insert(schema.threat_protection_config)
+    .values(values)
+    .onConflictDoUpdate({
+      target: schema.threat_protection_config.org_id,
+      set: {
+        ...values,
+        updated_at: new Date().toISOString(),
+      },
+    })
+    .returning();
+
+  try {
+    await deleteKey(cacheKey(orgId));
+  } catch (error) {
+    logger.warn("Failed to invalidate threat protection config cache", {
+      error,
+      orgId,
+    });
+  }
+
+  return rowToConfig(row);
+}
+
+/**
+ * Resolves the org_id for a team. Used by the org-level config API when the
+ * auth chunk doesn't carry org_id.
+ */
+export async function getOrgIdForTeam(teamId: string): Promise<string | null> {
+  const rows = await dbRr
+    .select({ org_id: schema.teams.org_id })
+    .from(schema.teams)
+    .where(eq(schema.teams.id, teamId))
+    .limit(1);
+  return rows[0]?.org_id ?? null;
+}
+
+/**
+ * Computes the effective policy for a request.
+ *
+ * - No org config → mode "off" with defaults.
+ * - A request override does field-level replacement on top of the org policy,
+ *   unless the org locked overrides down (`allowRequestOverrides: false`),
+ *   in which case it is ignored (the request should already have been
+ *   rejected by `checkPermissions`; this is defense in depth).
+ */
+export function resolveEffectivePolicy(
+  orgConfig: OrgThreatProtectionConfig | null,
+  requestOverride?: Partial<ThreatProtectionPolicy>,
+): ThreatProtectionPolicy {
+  const base: ThreatProtectionPolicy = orgConfig
+    ? { ...orgConfig.policy }
+    : { mode: "off", ...THREAT_PROTECTION_POLICY_DEFAULTS };
+
+  if (!requestOverride || (orgConfig && !orgConfig.allowRequestOverrides)) {
+    return base;
+  }
+
+  for (const key of Object.keys(requestOverride) as Array<
+    keyof ThreatProtectionPolicy
+  >) {
+    const value = requestOverride[key];
+    if (value !== undefined) {
+      (base as unknown as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return base;
+}

--- a/apps/api/src/lib/threat-protection/types.ts
+++ b/apps/api/src/lib/threat-protection/types.ts
@@ -1,0 +1,75 @@
+// Shared type contract for the threat protection feature.
+// NOTE: concurrent in-flight branches create this exact file — do not modify without coordinating.
+
+export type ThreatProtectionMode = "off" | "normal" | "enhanced";
+
+export interface ThreatProtectionPolicy {
+  mode: ThreatProtectionMode;
+  /** Normalized 0-100; verdicts at or above this score are blocked. */
+  riskScoreThreshold: number;
+  /** Content category names (enhanced mode only). */
+  deniedCategories: string[];
+  /** Block domains registered more recently than this many days ago; null disables. Enhanced mode only. */
+  maxDomainAgeDays: number | null;
+  /** Exact domains or globs like "*.example.com". Blocks without a provider call. */
+  blacklist: string[];
+  /** Exact domains or globs. Allows without a provider call; wins over everything. */
+  whitelist: string[];
+  /** Lowercase TLDs without leading dot, e.g. "zip". Blocks without a provider call. */
+  blockedTlds: string[];
+  /** ISO 3166-1 alpha-2 country codes (enhanced mode only). */
+  blockedCountries: string[];
+  /** Behavior when the provider is unavailable: "closed" blocks, "open" allows. */
+  failurePolicy: "open" | "closed";
+}
+
+export const THREAT_PROTECTION_POLICY_DEFAULTS: Omit<
+  ThreatProtectionPolicy,
+  "mode"
+> = {
+  riskScoreThreshold: 75,
+  deniedCategories: [],
+  maxDomainAgeDays: null,
+  blacklist: [],
+  whitelist: [],
+  blockedTlds: [],
+  blockedCountries: [],
+  failurePolicy: "closed",
+};
+
+export type ThreatProvider = "google-web-risk" | "alphamountain";
+
+export interface RawVerdict {
+  provider: ThreatProvider;
+  /** Normalized 0-100, higher = riskier; null if the provider gave no score. */
+  riskScore: number | null;
+  /** Content category names (enhanced mode); Web Risk threat types mapped to category strings (normal mode). */
+  categories: string[];
+  /** Days since domain registration (enhanced mode only). */
+  domainAgeDays: number | null;
+  /** ISO 3166-1 alpha-2 (enhanced mode only). */
+  countryCode: string | null;
+  fromCache: boolean;
+  /** Raw provider payload, for security logging. */
+  raw: unknown;
+}
+
+export type ThreatDecisionRule =
+  | "whitelist"
+  | "blacklist"
+  | "blocked-tld"
+  | "blocked-country"
+  | "domain-age"
+  | "denied-category"
+  | "risk-score"
+  | "provider-failure"
+  | "default-allow";
+
+export interface ThreatDecision {
+  allowed: boolean;
+  rule: ThreatDecisionRule;
+  /** True if a provider verdict (fresh OR cached) was consulted — this drives billing (+2 normal / +3 enhanced). */
+  providerConsulted: boolean;
+  verdict: RawVerdict | null;
+  mode: ThreatProtectionMode;
+}

--- a/apps/api/src/lib/zdr-helpers.ts
+++ b/apps/api/src/lib/zdr-helpers.ts
@@ -69,6 +69,15 @@ export function getIgnoreRobots(flags: TeamFlags | undefined): OrgFlagMode {
 }
 
 /**
+ * Resolves the effective threat protection mode from team flags.
+ */
+export function getThreatProtection(flags: TeamFlags | undefined): OrgFlagMode {
+  if (flags?.threatProtection === "forced") return "forced";
+  if (flags?.threatProtection === "allowed") return "allowed";
+  return "disabled";
+}
+
+/**
  * Resolves the effective customRobotsAgent mode from team flags.
  * Only supports "disabled" (default) and "allowed" — no "forced" mode.
  */

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -60,6 +60,10 @@ import {
   browserWebhookDestroyedController,
 } from "../controllers/v2/browser";
 import { activityController } from "../controllers/v1/activity";
+import {
+  getTeamThreatProtectionController,
+  putTeamThreatProtectionController,
+} from "../controllers/v2/team-threat-protection";
 import { supportProxyController } from "../controllers/v2/support-proxy";
 import { createResearchRouter } from "../controllers/v2/research-proxy";
 import {
@@ -411,6 +415,18 @@ v2Router.get(
   "/team/activity",
   authMiddleware(RateLimiterMode.Account),
   wrap(activityController),
+);
+
+v2Router.get(
+  "/team/threat-protection",
+  authMiddleware(RateLimiterMode.Account),
+  wrap(getTeamThreatProtectionController),
+);
+
+v2Router.put(
+  "/team/threat-protection",
+  authMiddleware(RateLimiterMode.Account),
+  wrap(putTeamThreatProtectionController),
 );
 
 v2Router.post(


### PR DESCRIPTION
Configuration layer for the enterprise threat protection feature (ENG-4980, ENG-4988). Domain risk blocking for enterprise compliance requirements, with two provider-backed modes: "normal" (Google Web Risk, +2 credits/domain scanned) and "enhanced" (alphaMountain, +3 credits/domain scanned). This PR is independently mergeable; the provider clients + verdict engine land separately (`mogery/eng-4979-threat-protection-core-lib`), and enforcement wiring into the scrape pipeline comes in a later PR.

> **Note:** `apps/api/src/lib/threat-protection/types.ts` is a shared type contract also created (identically) by the in-flight core-lib branch so both merge cleanly — do not modify it without coordinating.

## Schema / DDL — ⚠️ run DDL before deploy

DDL is applied out-of-band. Run this **before deploying** (and on the test/staging database before CI can pass the flag-gated round-trip snips — see Tests below):

```sql
CREATE TABLE IF NOT EXISTS public.threat_protection_config (
  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
  org_id uuid NOT NULL UNIQUE,
  mode varchar NOT NULL DEFAULT 'off',
  risk_score_threshold integer NOT NULL DEFAULT 75,
  denied_categories text[] NOT NULL DEFAULT '{}',
  max_domain_age_days integer,
  blacklist text[] NOT NULL DEFAULT '{}',
  whitelist text[] NOT NULL DEFAULT '{}',
  blocked_tlds text[] NOT NULL DEFAULT '{}',
  blocked_countries text[] NOT NULL DEFAULT '{}',
  failure_policy varchar NOT NULL DEFAULT 'closed',
  allow_request_overrides boolean NOT NULL DEFAULT true,
  siem_url text,
  siem_secret text,
  siem_events varchar,
  created_at timestamptz NOT NULL DEFAULT now(),
  updated_at timestamptz NOT NULL DEFAULT now()
);
```

The matching drizzle table is in `apps/api/src/db/schema/public.ts`. Config is keyed by `org_id` (one row per org, `UNIQUE` drives the upsert).

## Team flag

`threatProtection?: "disabled" | "allowed" | "forced"` added to `TeamFlags` in both v1 and v2 types (delivered via the auth RPC like `ignoreRobots` / `scrapeZDR`), with a `getThreatProtection()` resolver in `zdr-helpers.ts`.

`checkPermissions()` now rejects any per-request `threatProtection` option with a 403-style error unless the flag is `allowed`/`forced`, and also when the org config has `allow_request_overrides = false` (org config passed as a new optional parameter — the per-request schema itself ships with the enforcement PR).

## API endpoints

### `GET /v2/team/threat-protection`
403 without the team flag. Otherwise returns the effective config (defaults applied), resolved to the authenticated team's org:

```json
{
  "success": true,
  "data": {
    "mode": "off",
    "riskScoreThreshold": 75,
    "deniedCategories": [],
    "maxDomainAgeDays": null,
    "blacklist": [],
    "whitelist": [],
    "blockedTlds": [],
    "blockedCountries": [],
    "failurePolicy": "closed",
    "allowRequestOverrides": true,
    "siem": null,
    "configured": false,
    "updatedAt": null
  }
}
```

When a SIEM sink is configured, `siem` is `{ "url": string, "events": "blocked" | "all", "secretSet": boolean }` — the secret is never echoed back.

### `PUT /v2/team/threat-protection`
Full-document update (unspecified fields reset to defaults), zod-validated (400 on invalid input), 403 without the flag. Invalidates the config cache and writes a structured audit log line (`team_id`, `org_id`, changed fields). Accepts:

```json
{
  "mode": "off" | "normal" | "enhanced",
  "riskScoreThreshold": 0-100,
  "deniedCategories": ["Malicious", ...],
  "maxDomainAgeDays": 1-3650 | null,
  "blacklist": ["example.com", "*.example.com", ...],
  "whitelist": ["example.com", "*.example.com", ...],
  "blockedTlds": ["zip", ...],
  "blockedCountries": ["KP", ...],
  "failurePolicy": "open" | "closed",
  "allowRequestOverrides": true,
  "siem": { "url": "https://...", "secret": "...", "events": "blocked" | "all" } | null
}
```

Only `mode` is required; everything else defaults. Responds with the same effective-config document as GET.

## Validation rules (`lib/threat-protection/config.ts`)

- **blacklist/whitelist**: plain domain (`example.com`) or single leading wildcard glob (`*.example.com`); trimmed + lowercased; no protocol/path/port/inner `*`; clear error message on garbage
- **riskScoreThreshold**: integer 0–100
- **blockedTlds**: lowercase alphanumeric, no leading dot; trimmed + lowercased
- **blockedCountries**: ISO 3166-1 alpha-2; trimmed + uppercased
- **deniedCategories**: validated against `ALPHAMOUNTAIN_CATEGORIES` (full provider category list, retrieved from the provider's public categories page 2026-07-04); `DEFAULT_DENIED_CATEGORIES` exports a security-focused default set (malware/phishing/spam-adjacent plus common compliance denials)
- **siem.url**: http(s) URL only
- Unknown keys rejected (`strictObject`)

## Store (`lib/threat-protection/store.ts`)

- `getOrgThreatProtectionConfig(orgId)` — read-through Redis cache, 60s TTL (negative results cached too), so config changes apply without redeploy while the enforcement hot path stays off Postgres; falls back to DB if Redis is unavailable
- `upsertOrgThreatProtectionConfig(orgId, config)` — full-document upsert on `org_id`, invalidates cache
- `resolveEffectivePolicy(orgConfig, requestOverride?)` — no org config → mode `"off"` + defaults; request override does field-level replacement; ignored (defense in depth) when the org locks overrides down

## Tests

- **Unit** (60 passing locally): zod accept/reject (invalid glob, bad country code, out-of-range threshold, unknown category, bad TLD, SIEM url), `resolveEffectivePolicy` merge semantics, `checkPermissions` threat-protection gating
- **Snips E2E** (`src/__tests__/snips/v2/team-threat-protection.test.ts`, gated `describeIf(TEST_PRODUCTION)`):
  - 403-without-flag for GET and PUT — **passing locally** against the harness
  - flag-gated GET/PUT round-trip, full-document-reset, and 400-on-invalid-body — the 400 case passes; the round-trip cases require the `threat_protection_config` table, so they **will fail in CI until the DDL above is applied to the test database**
- Typecheck and knip clean. `types.ts` is excluded in `knip.config.ts` since its provider/verdict types are consumed by the concurrent core-lib branch.

Refs ENG-4980, ENG-4988

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds org-level threat protection configuration with a team flag, GET/PUT API, strict validation, and a 60s Redis cache to support enterprise compliance. Addresses ENG-4980 and ENG-4988; provider clients and enforcement will land in follow-ups.

- New Features
  - Team flag `threatProtection` ("disabled" | "allowed" | "forced") with resolver.
  - `GET /v2/team/threat-protection` and `PUT /v2/team/threat-protection`: returns effective config; full-document update; 403 without the flag; SIEM secret never returned; audit-logged.
  - Validation: domain globs, TLDs, country codes; alphaMountain category list and default denies; strict object.
  - Store: read-through Redis cache (60s) with Postgres fallback; org-scoped upsert; effective policy merge with request overrides (respects `allowRequestOverrides`).
  - Permissions: `checkPermissions` rejects per-request `threatProtection` when not flagged or when org disables overrides.
  - Shared contract in `apps/api/src/lib/threat-protection/types.ts` (co-owned with the core-lib branch).

- Migration
  - Apply DDL to create `threat_protection_config` before deploy and in test/staging; CI round-trip tests depend on it.
  - No other changes; the feature is flag-gated.

<sup>Written for commit ef2334867c339adaa44bee4fc92cc449bdac606f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

