### PR TITLE
feat(v2): blocks format + tableFormat for PDF parsing

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/parse-blocks-format.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/parse-blocks-format.test.ts
@@ -1,0 +1,40 @@
+import { getUnsupportedParseOptionError } from "../parse";
+
+const base = {
+  formats: [{ type: "blocks" }],
+} as any;
+
+describe("parse: blocks format gating", () => {
+  it("rejects blocks for non-PDF uploads", () => {
+    expect(
+      getUnsupportedParseOptionError({
+        ...base,
+        file: { kind: "document" },
+      }),
+    ).toMatch(/blocks format is only supported for PDF/);
+    expect(
+      getUnsupportedParseOptionError({
+        ...base,
+        file: { kind: "html" },
+      }),
+    ).toMatch(/blocks format is only supported for PDF/);
+  });
+
+  it("allows blocks for PDF uploads", () => {
+    expect(
+      getUnsupportedParseOptionError({
+        ...base,
+        file: { kind: "pdf" },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not reject when blocks not requested", () => {
+    expect(
+      getUnsupportedParseOptionError({
+        formats: [{ type: "markdown" }],
+        file: { kind: "document" },
+      } as any),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -151,7 +151,9 @@ function sanitizeParseRequestForLogs(
   };
 }
 
-function getUnsupportedParseOptionError(reqBody: ParseRequest): string | null {
+export function getUnsupportedParseOptionError(
+  reqBody: ParseRequest,
+): string | null {
   if (reqBody.actions !== undefined && reqBody.actions.length > 0) {
     return "Parse uploads do not support actions.";
   }
@@ -166,6 +168,15 @@ function getUnsupportedParseOptionError(reqBody: ParseRequest): string | null {
 
   if (hasFormatOfType(reqBody.formats, "changeTracking")) {
     return "Parse uploads do not support change tracking.";
+  }
+
+  // blocks come from the PDF pipeline only — document/HTML uploads have no
+  // layout-block producer.
+  if (
+    hasFormatOfType(reqBody.formats, "blocks") &&
+    reqBody.file?.kind !== "pdf"
+  ) {
+    return "The blocks format is only supported for PDF uploads.";
   }
 
   if (reqBody.waitFor !== undefined && reqBody.waitFor > 0) {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -446,6 +446,7 @@ type QueryFormatWithOptions = z.output<typeof queryFormatWithOptions>;
 
 export type FormatObject =
   | { type: "markdown" }
+  | { type: "blocks" }
   | { type: "html" }
   | { type: "rawHtml" }
   | { type: "links" }
@@ -469,10 +470,19 @@ const pdfModeSchema = z.enum(["fast", "auto", "ocr"]);
 
 export type PDFMode = z.infer<typeof pdfModeSchema>;
 
+const pdfTableFormatSchema = z.enum(["markdown", "html", "dynamic"]);
+
+export type PDFTableFormat = z.infer<typeof pdfTableFormatSchema>;
+
 const pdfParserWithOptions = z.strictObject({
   type: z.literal("pdf"),
   mode: pdfModeSchema.optional(),
   maxPages: z.int().positive().finite().max(10000).optional(),
+  // Table rendering in the parsed markdown: "markdown" (pipe tables,
+  // merged cells grid-expanded), "html" (structure-preserving <table>
+  // passthrough), or "dynamic" (HTML only when the table carries
+  // structure markdown cannot express). Forwarded to fire-pdf verbatim.
+  tableFormat: pdfTableFormatSchema.optional(),
   // Experimental: route this request through the fire-pdf async pipeline
   // (POST /jobs + poll) instead of the sync POST /ocr endpoint. Falls back
   // to sync on any async-path failure, so user-visible behavior is unchanged
@@ -520,6 +530,18 @@ export function getPDFMode(parsers?: Parsers): PDFMode {
     }
   }
   return "auto";
+}
+
+export function getPDFTableFormat(
+  parsers?: Parsers,
+): PDFTableFormat | undefined {
+  if (!parsers) return undefined;
+  for (const parser of parsers) {
+    if (typeof parser === "object" && parser.type === "pdf") {
+      return parser.tableFormat;
+    }
+  }
+  return undefined;
 }
 
 export function getFirePdfAsync(parsers?: Parsers): boolean {
@@ -622,6 +644,7 @@ const baseScrapeOptions = z.strictObject({
       z
         .union([
           z.strictObject({ type: z.literal("markdown") }),
+          z.strictObject({ type: z.literal("blocks") }),
           z.strictObject({ type: z.literal("html") }),
           z.strictObject({ type: z.literal("rawHtml") }),
           z.strictObject({ type: z.literal("links") }),
@@ -1203,11 +1226,45 @@ export const mapRequestSchema = strictWithMessage(mapRequestSchemaBase);
 export type MapRequest = z.infer<typeof mapRequestSchema>;
 export type MapRequestInput = z.input<typeof mapRequestSchema>;
 
+/**
+ * One typed layout block of a parsed PDF page (`formats: ["blocks"]`).
+ * Wire contract: fire-pdf docs/blocks-schema.md. `label` carries the raw
+ * layout-model label for forward-compat; unknown future `type` values
+ * must be tolerated by consumers.
+ */
+export type PDFBlock = {
+  id: string;
+  type: string;
+  label: string | null;
+  /** [x0, y0, x1, y1] normalized 0-1 to page width/height; null when the
+   * page had no dimension anchor. */
+  bbox: [number, number, number, number] | null;
+  content: string;
+  /** [start, end) char offsets into the document markdown; null when a
+   * post-assembly transform rewrote the fragment. */
+  markdown_span: [number, number] | null;
+  reading_order: number;
+  source: string;
+  confidence: { layout: number | null; ocr: number | null };
+};
+
+export type PDFBlockPage = {
+  /** 1-based, matches `<!-- page N -->` markers in the markdown. */
+  page: number;
+  width: number | null;
+  height: number | null;
+  status: "ok" | "partial" | "failed";
+  blocks: PDFBlock[];
+};
+
 export type Document = {
   title?: string;
   description?: string;
   url?: string;
   markdown?: string;
+  /** Per-page typed layout blocks — present only for PDF documents when
+   * `formats` includes `"blocks"`. */
+  blocks?: PDFBlockPage[];
   html?: string;
   rawHtml?: string;
   links?: string[];

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -7,6 +7,10 @@ import {
 } from "../controllers/v2/types";
 import { CostTracking } from "./cost-tracking";
 import { hasFormatOfType } from "./format-utils";
+// NOTE: the `blocks` format is intentionally NOT billed (product decision
+// 2026-07-03: blocks are free as the adoption driver for grounded
+// extraction). If a format-based charge is ever added here for it, that
+// decision needs explicit revisiting.
 import { TransportableError } from "./error";
 import { FeatureFlag } from "../scraper/scrapeURL/engines";
 import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -159,6 +159,9 @@ export type EngineScrapeResult = {
 
   pdfMetadata?: PdfMetadata;
 
+  /** Per-page typed layout blocks (PDF + fire-pdf only; `blocks` format). */
+  blocks?: import("../../../controllers/v2/types").PDFBlockPage[];
+
   cacheInfo?: {
     created_at: Date;
   };

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/blocksFormat.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/blocksFormat.test.ts
@@ -1,0 +1,84 @@
+import {
+  scrapeOptions,
+  getPDFTableFormat,
+  type PDFBlock,
+} from "../../../../../controllers/v2/types";
+import { resultResponseSchema } from "../fire-pdf/schema";
+
+describe("blocks format schema", () => {
+  it("accepts blocks as a string-shorthand format", () => {
+    const parsed = scrapeOptions.parse({ formats: ["markdown", "blocks"] });
+    expect(parsed.formats).toContainEqual({ type: "blocks" });
+  });
+
+  it("accepts blocks as an object format", () => {
+    const parsed = scrapeOptions.parse({ formats: [{ type: "blocks" }] });
+    expect(parsed.formats).toContainEqual({ type: "blocks" });
+  });
+
+  it("accepts tableFormat on the pdf parser", () => {
+    const parsed = scrapeOptions.parse({
+      parsers: [{ type: "pdf", tableFormat: "dynamic" }],
+    });
+    expect(getPDFTableFormat(parsed.parsers)).toBe("dynamic");
+  });
+
+  it("rejects unknown tableFormat values", () => {
+    expect(() =>
+      scrapeOptions.parse({
+        parsers: [{ type: "pdf", tableFormat: "csv" }],
+      }),
+    ).toThrow();
+  });
+
+  it("getPDFTableFormat returns undefined for bare pdf parser", () => {
+    expect(getPDFTableFormat(["pdf"] as any)).toBeUndefined();
+    expect(getPDFTableFormat(undefined)).toBeUndefined();
+  });
+});
+
+describe("fire-pdf result schema (async)", () => {
+  const v1 = {
+    schema_version: 1,
+    markdown: "# hi",
+    pages_processed: 2,
+    failed_pages: null,
+    partial_pages: null,
+  };
+
+  it("parses v1 results (no pages field)", () => {
+    const parsed = resultResponseSchema.parse(v1);
+    expect(parsed.pages).toBeUndefined();
+  });
+
+  it("parses v2 results with blocks pages, passing block fields through", () => {
+    const block: PDFBlock & { some_future_field: string } = {
+      id: "p1.b0",
+      type: "title",
+      label: "doc_title",
+      bbox: [0.1, 0.05, 0.9, 0.09],
+      content: "# T",
+      markdown_span: [0, 3],
+      reading_order: 0,
+      source: "native_text",
+      confidence: { layout: 0.97, ocr: null },
+      some_future_field: "must survive",
+    };
+    const parsed = resultResponseSchema.parse({
+      ...v1,
+      schema_version: 2,
+      pages: [
+        {
+          page: 1,
+          width: 1700,
+          height: 2200,
+          status: "ok",
+          blocks: [block],
+        },
+      ],
+    });
+    expect(parsed.pages).toHaveLength(1);
+    const page = parsed.pages![0] as any;
+    expect(page.blocks[0].some_future_field).toBe("must survive");
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -2,6 +2,8 @@ import { Meta } from "../../..";
 import { config } from "../../../../../config";
 import { fetch as undiciFetch } from "undici";
 import type { PDFProcessorResult } from "../types";
+import type { PDFBlockPage } from "../../../../../controllers/v2/types";
+import type { FirePdfRequestOptions } from "../firePDF";
 import type { PDFMode } from "../../../../../controllers/v2/types";
 import { safeMarkdownToHtml } from "../markdownToHtml";
 import { scrapePDFWithFirePDF } from "../firePDF";
@@ -29,19 +31,21 @@ export async function scrapePDFWithFirePDFAsync(
   pagesProcessed?: number,
   mode?: PDFMode,
   deps: FirePdfAsyncDeps = {},
+  firePdfOptions?: FirePdfRequestOptions,
 ): Promise<PDFProcessorResult> {
   const fetchImpl = deps.fetchImpl ?? undiciFetch;
   const fallbackImpl = deps.fallbackImpl ?? scrapePDFWithFirePDF;
   const sleep = deps.sleepImpl ?? defaultSleep;
   const now = deps.nowImpl ?? Date.now;
+  const includeBlocks = firePdfOptions?.includeBlocks === true;
+  const tableFormat = firePdfOptions?.tableFormat;
+  // blocks / non-default tableFormat bypass the PDF cache — mirrors the
+  // sync client (entries were written without these formats).
+  const cacheEligible = !includeBlocks && tableFormat === undefined;
 
-  const cached = await tryGetCached(
-    meta,
-    base64Content,
-    mode,
-    maxPages,
-    pagesProcessed,
-  );
+  const cached = cacheEligible
+    ? await tryGetCached(meta, base64Content, mode, maxPages, pagesProcessed)
+    : null;
   if (cached) return cached;
 
   meta.abort.throwIfAborted();
@@ -50,7 +54,14 @@ export async function scrapePDFWithFirePDFAsync(
   if (!baseUrl) {
     // Should be unreachable — call site checks this — but fall back rather
     // than crash if a route somehow bypasses the gate.
-    return fallbackImpl(meta, base64Content, maxPages, pagesProcessed, mode);
+    return fallbackImpl(
+      meta,
+      base64Content,
+      maxPages,
+      pagesProcessed,
+      mode,
+      firePdfOptions,
+    );
   }
 
   const overallStartedAt = now();
@@ -67,6 +78,8 @@ export async function scrapePDFWithFirePDFAsync(
     maxPages,
     pagesProcessed,
     mode,
+    includeBlocks,
+    tableFormat,
     deadlineAt,
     fetchImpl,
   });
@@ -117,7 +130,12 @@ export async function scrapePDFWithFirePDFAsync(
     markdown: fetched.markdown,
     html: await safeMarkdownToHtml(fetched.markdown, meta.logger, meta.id),
     pagesProcessed: pages,
+    ...(fetched.pages !== undefined && {
+      blocks: fetched.pages as unknown as PDFBlockPage[],
+    }),
   };
+
+  if (!cacheEligible) return processorResult;
 
   await maybeSaveResult({
     meta,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -45,11 +45,17 @@ export const pollResponseSchema = z.object({
 });
 
 export const resultResponseSchema = z.object({
-  schema_version: z.literal(1).optional(),
+  // v1 results carry schema_version 1 (or omit it); jobs submitted with
+  // include_blocks return schema_version 2 + `pages`. Non-strict so either
+  // generation of fire-pdf parses.
+  schema_version: z.union([z.literal(1), z.literal(2)]).optional(),
   markdown: z.string(),
   pages_processed: z.number().optional(),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),
+  // Per-page typed blocks (fire-pdf docs/blocks-schema.md). Loose on
+  // purpose — forward-compatible passthrough.
+  pages: z.array(z.looseObject({})).optional(),
 });
 
 export type PollResponse = z.infer<typeof pollResponseSchema>;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
@@ -1,5 +1,8 @@
 import type { Meta } from "../../..";
-import type { PDFMode } from "../../../../../controllers/v2/types";
+import type {
+  PDFMode,
+  PDFTableFormat,
+} from "../../../../../controllers/v2/types";
 import { fetch as undiciFetch } from "undici";
 import { AbortManagerThrownError } from "../../../lib/abortManager";
 import { firePdfAsyncSubmittedTotal } from "./metrics";
@@ -19,6 +22,8 @@ type SubmitArgs = {
   maxPages: number | undefined;
   pagesProcessed: number | undefined;
   mode: PDFMode | undefined;
+  includeBlocks: boolean | undefined;
+  tableFormat: PDFTableFormat | undefined;
   deadlineAt: string;
   fetchImpl: typeof undiciFetch;
 };
@@ -52,6 +57,8 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
       ...(pagesProcessed !== undefined && { pages_estimate: pagesProcessed }),
       ...(maxPages !== undefined && { max_pages: maxPages }),
       ...(mode !== undefined && { mode }),
+      ...(args.includeBlocks && { include_blocks: true }),
+      ...(args.tableFormat !== undefined && { tableFormat: args.tableFormat }),
     },
   };
 
@@ -77,20 +84,26 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
   if (status === 503) failAsync(meta, "http_503");
 
   if (status === 409) {
-    meta.logger.error("FirePDF async POST /jobs returned 409 scrape_id_conflict", {
-      scrapeId,
-      body: json,
-    });
+    meta.logger.error(
+      "FirePDF async POST /jobs returned 409 scrape_id_conflict",
+      {
+        scrapeId,
+        body: json,
+      },
+    );
     throw new Error(
       "fire-pdf async POST /jobs conflict: scrape_id reused with different inputs",
     );
   }
 
   if (status === 400) {
-    meta.logger.error("FirePDF async POST /jobs returned 400 validation error", {
-      scrapeId,
-      body: json,
-    });
+    meta.logger.error(
+      "FirePDF async POST /jobs returned 400 validation error",
+      {
+        scrapeId,
+        body: json,
+      },
+    );
     throw new Error("fire-pdf async POST /jobs validation error");
   }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -3,7 +3,11 @@ import { config } from "../../../../config";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
 import type { PDFProcessorResult } from "./types";
-import type { PDFMode } from "../../../../controllers/v2/types";
+import type {
+  PDFBlockPage,
+  PDFMode,
+  PDFTableFormat,
+} from "../../../../controllers/v2/types";
 import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
   createPdfCacheKey,
@@ -41,14 +45,24 @@ export function reconcilePageCountWithFirePdf(
   return Math.max(current, fromFirePdf);
 }
 
+export type FirePdfRequestOptions = {
+  /** Request per-page typed blocks (fire-pdf `include_blocks`). */
+  includeBlocks?: boolean;
+  /** Table rendering: markdown | html | dynamic (fire-pdf `tableFormat`). */
+  tableFormat?: PDFTableFormat;
+};
+
 export async function scrapePDFWithFirePDF(
   meta: Meta,
   base64Content: string,
   maxPages?: number,
   pagesProcessed?: number,
   mode?: PDFMode,
+  firePdfOptions?: FirePdfRequestOptions,
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
+  const includeBlocks = firePdfOptions?.includeBlocks === true;
+  const tableFormat = firePdfOptions?.tableFormat;
 
   // Cache layout:
   //   - `ocr` mode reads/writes a dedicated `…-ocr.json` bucket. ocr
@@ -62,8 +76,16 @@ export async function scrapePDFWithFirePDF(
   //     running fire-pdf again.
   //   - `fast` is bypassed entirely (hard cost ceiling — must fail on
   //     scanned PDFs, not serve a cached OCR result).
+  // blocks / non-default tableFormat responses bypass the PDF cache in both
+  // directions: existing entries were written without blocks (a hit would
+  // silently drop the requested format), and writing the variant would need
+  // a key split that isn't worth it until adoption justifies it.
   const cacheable =
-    mode !== "fast" && !maxPages && !meta.internalOptions.zeroDataRetention;
+    mode !== "fast" &&
+    !maxPages &&
+    !meta.internalOptions.zeroDataRetention &&
+    !includeBlocks &&
+    tableFormat === undefined;
   const ownVariant: string | undefined = mode === "ocr" ? "ocr" : undefined;
   const lookupVariants: (string | undefined)[] =
     mode === "ocr" ? ["ocr"] : [undefined, "ocr"];
@@ -154,6 +176,8 @@ export async function scrapePDFWithFirePDF(
       pdf_sha256: pdfSha256,
       source: "firecrawl",
       zdr,
+      ...(includeBlocks && { include_blocks: true }),
+      ...(tableFormat !== undefined && { tableFormat }),
       ...deadlineFields,
     },
     logger,
@@ -161,6 +185,10 @@ export async function scrapePDFWithFirePDF(
       markdown: z.string(),
       failed_pages: z.array(z.number()).nullable(),
       pages_processed: z.number().optional(),
+      // Present only when include_blocks was sent (fire-pdf blocks-schema
+      // v2). Loose on purpose: fire-pdf may add block fields — pass them
+      // through rather than strip/fail.
+      pages: z.array(z.looseObject({})).optional(),
     }),
     mock: meta.mock,
     abort: meta.abort.asSignal(),
@@ -183,6 +211,9 @@ export async function scrapePDFWithFirePDF(
     markdown: resp.markdown,
     html: await safeMarkdownToHtml(resp.markdown, logger, meta.id),
     pagesProcessed: pages,
+    ...(resp.pages !== undefined && {
+      blocks: resp.pages as unknown as PDFBlockPage[],
+    }),
   };
 
   if (cacheable) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -18,6 +18,7 @@ import {
   shouldParsePDF,
   getPDFMaxPages,
   getPDFMode,
+  getPDFTableFormat,
   getFirePdfAsync,
 } from "../../../../controllers/v2/types";
 import type { PDFMode } from "../../../../controllers/v2/types";
@@ -38,6 +39,7 @@ import { scrapePDFWithRunPodMU } from "./runpodMU";
 import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
 import { scrapePDFWithFirePDFAsync } from "./fire-pdf/async";
 import { scrapePDFWithParsePDF } from "./pdfParse";
+import { hasFormatOfType } from "../../../../lib/format-utils";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
@@ -58,6 +60,18 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
   const shouldParse = shouldParsePDF(meta.options.parsers);
   const maxPages = getPDFMaxPages(meta.options.parsers);
   const mode: PDFMode = getPDFMode(meta.options.parsers);
+  // blocks format requires fire-pdf: it is the only engine that produces
+  // per-page typed blocks. When requested we force the fire-pdf route
+  // (bypassing the Rust direct-serve path and the MinerU diversion). If
+  // fire-pdf itself fails, the normal fallback chain still runs and the
+  // document is returned WITHOUT blocks — degraded, never erroring the
+  // whole scrape over an output format.
+  const wantsBlocks = !!hasFormatOfType(meta.options.formats, "blocks");
+  const tableFormat = getPDFTableFormat(meta.options.parsers);
+  const firePdfOptions =
+    wantsBlocks || tableFormat !== undefined
+      ? { includeBlocks: wantsBlocks, tableFormat }
+      : undefined;
 
   if (!shouldParse) {
     if (meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null) {
@@ -169,7 +183,8 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     let shadowPagesNeedingOcr: number[] | undefined;
 
     const forceFirePDF =
-      !!meta.options.__forceFirePDF && !!config.FIRE_PDF_BASE_URL;
+      (!!meta.options.__forceFirePDF || wantsBlocks) &&
+      !!config.FIRE_PDF_BASE_URL;
     const rustEnabled = !!config.PDF_RUST_EXTRACT_ENABLE;
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
 
@@ -414,22 +429,30 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         // sync path.
         const useAsync = getFirePdfAsync(meta.options.parsers);
         try {
-          result = await (
-            useAsync ? scrapePDFWithFirePDFAsync : scrapePDFWithFirePDF
-          )(
-            {
-              ...meta,
-              logger: meta.logger.child({
-                method: useAsync
-                  ? "scrapePDF/firePDFAsync"
-                  : "scrapePDF/firePDF",
-              }),
-            },
-            base64Content,
-            maxPages,
-            effectivePageCount,
-            mode,
-          );
+          const firePdfMeta = {
+            ...meta,
+            logger: meta.logger.child({
+              method: useAsync ? "scrapePDF/firePDFAsync" : "scrapePDF/firePDF",
+            }),
+          };
+          result = await (useAsync
+            ? scrapePDFWithFirePDFAsync(
+                firePdfMeta,
+                base64Content,
+                maxPages,
+                effectivePageCount,
+                mode,
+                {},
+                firePdfOptions,
+              )
+            : scrapePDFWithFirePDF(
+                firePdfMeta,
+                base64Content,
+                maxPages,
+                effectivePageCount,
+                mode,
+                firePdfOptions,
+              ));
           effectivePageCount = reconcilePageCountWithFirePdf(
             effectivePageCount,
             result,
@@ -441,7 +464,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           ) {
             throw error;
           }
-          if (forceFirePDF) {
+          if (meta.options.__forceFirePDF) {
             meta.logger.error("FirePDF failed (forced, no fallback)", {
               method: "scrapePDF/firePDF",
               error,
@@ -609,6 +632,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       statusCode: response.status,
       html: result?.html ?? "",
       markdown: result?.markdown ?? "",
+      ...(result?.blocks !== undefined && { blocks: result.blocks }),
       pdfMetadata: {
         numPages: effectivePageCount,
         totalPages: totalPageCount,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -1,6 +1,16 @@
+import type { PDFBlockPage } from "../../../../controllers/v2/types";
+
 export type PDFProcessorResult = {
   html: string;
   markdown?: string;
+  /**
+   * Per-page typed layout blocks from fire-pdf (`include_blocks`). Only
+   * populated when the request asked for the `blocks` format AND the
+   * fire-pdf engine served it — the MinerU / pdf-parse fallbacks can't
+   * produce blocks, so consumers must treat absence as "engine couldn't",
+   * not an error.
+   */
+  blocks?: PDFBlockPage[];
   /**
    * Pages the underlying engine actually processed for this request.
    * Currently populated only by fire-pdf (via OcrSuccessBody.pages_processed).

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -981,6 +981,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
 
     let document: Document = {
       markdown: engineResult.markdown,
+      blocks: engineResult.blocks,
       rawHtml: engineResult.html,
       json: engineResult.json,
       screenshot: engineResult.screenshot,

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -378,6 +378,17 @@ function coerceFieldsToFormats(meta: Meta, document: Document): Document {
     );
   }
 
+  const hasBlocks = hasFormatOfType(meta.options.formats, "blocks");
+  if (!hasBlocks && document.blocks !== undefined) {
+    delete document.blocks;
+  } else if (hasBlocks && document.blocks === undefined) {
+    // Expected when the document wasn't a PDF, or when fire-pdf failed and
+    // a fallback engine served the request (blocks degrade, never error).
+    meta.logger.warn(
+      "Request had format: blocks, but there was no blocks field in the result.",
+    );
+  }
+
   if (!hasRawHtml && document.rawHtml !== undefined) {
     delete document.rawHtml;
   } else if (hasRawHtml && document.rawHtml === undefined) {


### PR DESCRIPTION
## What

- **`formats: ["blocks"]`** — per-page typed layout blocks for PDFs: `{ page, width, height, status, blocks: [{ id, type, label, bbox, content, markdown_span, reading_order, source, confidence }] }`, surfaced as `data.blocks`. Wire contract: fire-pdf blocks-schema v2 (`include_blocks`); `markdown_span` indexes into `data.markdown` for grounding.
- **`parsers: [{ type: "pdf", tableFormat: "markdown"|"html"|"dynamic" }]`** — table rendering passthrough.

## Behavior rules

- Blocks force the fire-pdf engine (Rust direct-serve + MinerU diversion bypassed — they can't produce blocks). fire-pdf hard-failure degrades to the normal fallback chain **without** blocks rather than erroring the scrape; `__forceFirePDF`'s no-fallback semantics unchanged.
- Non-PDF parse uploads reject the format (400 `PARSE_UNSUPPORTED_OPTIONS`).
- Blocks/tableFormat requests bypass the PDF result cache both ways (pre-existing entries lack the fields).
- **Billing: blocks are free** (product decision 2026-07-03; anchored with a comment in scrape-billing.ts).
- Both fire-pdf response generations parse (v1 no `pages`, v2 with); unknown block fields pass through for forward-compat.

## Tests

- New: schema acceptance (string + object form), tableFormat enum validation + rejection, `getPDFTableFormat`, v1/v2 result schema with future-field passthrough, parse-upload gating (7 + 3 tests).
- Full pdf engine suite 60/60; transformers suite green; `tsc --noEmit` clean (after `pnpm install` — local node_modules was missing `diff` pre-change).
- Not run locally: a live end-to-end through the local API (needs the full redis/queue harness); the fire-pdf side of the contract is deployed and verified in production, and the request/response mapping here is covered by schema tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJaCiHsyeknwQg7VaK5VfC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `blocks` format for PDFs and a `tableFormat` option on the `pdf` parser to expose per-page layout blocks and control table rendering via fire-pdf. Implements ENG-4956.

- **New Features**
  - `formats: ["blocks"]` returns `data.blocks` with per-page typed layout blocks.
  - `parsers: [{ type: "pdf", tableFormat: "markdown"|"html"|"dynamic" }]` is forwarded to fire-pdf.
  - Requests for `blocks` force the fire-pdf engine; on failure, fall back without blocks (no scrape error).
  - Non-PDF parse uploads reject `blocks` with 400 `PARSE_UNSUPPORTED_OPTIONS`.
  - `blocks` and `tableFormat` skip the PDF cache to avoid stale results.
  - Blocks are not billed.
  - Response schema supports fire-pdf v1/v2 and passes unknown block fields through.

<sup>Written for commit 400f27bdb66d9ba7f177a6ca2df3666d54b8f6a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

