### PR TITLE
fix(api): clamp invalid crawl-status pagination params

### DIFF
--- a/apps/api/src/__tests__/snips/v2/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v2/crawl.test.ts
@@ -61,6 +61,27 @@ describe("Crawl tests", () => {
   );
 
   concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
+    "clamps invalid crawl-status pagination params instead of erroring",
+    async () => {
+      const started = await crawlStart({ url: base, limit: 1 }, identity);
+      expect(started.statusCode).toBe(200);
+      const id = started.body.id;
+
+      // Malformed skip/limit previously reached Postgres as NaN/negative
+      // LIMIT/OFFSET and made the status endpoint return 500; they must now
+      // clamp to defaults and return 200.
+      for (const qs of ["skip=abc", "limit=abc", "skip=-5", "skip=abc&limit=-10"]) {
+        const res = await request(TEST_API_URL)
+          .get(`/v2/crawl/${encodeURIComponent(id)}?${qs}`)
+          .set("Authorization", `Bearer ${identity.apiKey}`)
+          .send();
+        expect(res.statusCode).toBe(200);
+      }
+    },
+    2 * scrapeTimeout,
+  );
+
+  concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
     "works with sitemap: skip",
     async () => {
       const results = await crawl(

--- a/apps/api/src/controllers/v1/crawl-status.ts
+++ b/apps/api/src/controllers/v1/crawl-status.ts
@@ -169,12 +169,13 @@ export async function crawlStatusController(
   res: Response<CrawlStatusResponse>,
   isBatch = false,
 ) {
-  const start =
-    typeof req.query.skip === "string" ? parseInt(req.query.skip, 10) : 0;
+  const skipParam = parseInt(req.query.skip as string, 10);
+  const start = Number.isNaN(skipParam) || skipParam < 0 ? 0 : skipParam;
+  const limitParam = parseInt(req.query.limit as string, 10);
   const end =
-    typeof req.query.limit === "string"
-      ? start + parseInt(req.query.limit, 10) - 1
-      : undefined;
+    Number.isNaN(limitParam) || limitParam < 1
+      ? undefined
+      : start + limitParam - 1;
 
   const group = await crawlGroup.getGroup(req.params.jobId);
   const groupAnyJob = await scrapeQueue.getGroupAnyJob(

--- a/apps/api/src/controllers/v2/crawl-status.ts
+++ b/apps/api/src/controllers/v2/crawl-status.ts
@@ -190,12 +190,13 @@ export async function crawlStatusController(
     });
   }
 
-  const start =
-    typeof req.query.skip === "string" ? parseInt(req.query.skip, 10) : 0;
+  const skipParam = parseInt(req.query.skip as string, 10);
+  const start = Number.isNaN(skipParam) || skipParam < 0 ? 0 : skipParam;
+  const limitParam = parseInt(req.query.limit as string, 10);
   const end =
-    typeof req.query.limit === "string"
-      ? start + parseInt(req.query.limit, 10) - 1
-      : undefined;
+    Number.isNaN(limitParam) || limitParam < 1
+      ? undefined
+      : start + limitParam - 1;
 
   const group = await crawlGroup.getGroup(req.params.jobId);
   const groupAnyJob = await scrapeQueue.getGroupAnyJob(


### PR DESCRIPTION
## What

Clamp invalid `skip` / `limit` pagination params on the crawl-status and batch-scrape-status endpoints (v1 and v2) instead of letting them reach Postgres as `NaN`/negative `LIMIT`/`OFFSET`.

## Why

`crawlStatusController` parses `skip`/`limit` with `parseInt` and no validation, then passes them into `scrapeQueue.getCrawlJobsForListing(...)` → parameterized `LIMIT $2 OFFSET $3`. Bad input crashes the query and returns **500** instead of handling it:

- `GET /v2/crawl/<id>?skip=abc` → `parseInt("abc") = NaN` → `OFFSET NaN` → `invalid input syntax for type integer: "NaN"`
- `?limit=abc` → `LIMIT NaN` → same
- `?skip=-5` → `OFFSET -5` → `OFFSET must not be negative`

This affects `/crawl/:jobId` and `/batch/scrape/:jobId` on **both v1 and v2** (all backed by `crawlStatusController`).

## Fix

Clamp exactly the way `controllers/v1/activity.ts` already does for its own `limit` — `NaN`/out-of-range falls back to defaults (`skip → 0`, `limit → default page size`). Valid inputs are byte-for-byte unchanged.

## Test

Adds an e2e snip in `crawl.test.ts` that starts a crawl and asserts `/v2/crawl/:id` with `skip=abc`, `limit=abc`, `skip=-5`, and `skip=abc&limit=-10` all return `200` (previously `500`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp invalid skip/limit pagination on crawl-status and batch-scrape-status (v1 and v2) to prevent Postgres errors and 500s. Bad params now fall back to defaults and return 200 with default paging.

- **Bug Fixes**
  - `skip`: NaN or < 0 → 0; `limit`: NaN or < 1 → default page size; valid values unchanged.
  - Applies to `/v1|v2/crawl/:jobId` and `/v1|v2/batch/scrape/:jobId`.
  - Added e2e tests to confirm 200 for malformed values (`skip=abc`, `limit=abc`, `skip=-5`, `skip=abc&limit=-10`).

<sup>Written for commit eae31a3d0d371e4b2cff0631106af2af82272da0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

