### PR TITLE
docs(api): fix misattributed IPv4-mapped-IPv6 comment in ip-restriction

### DIFF
--- a/apps/api/src/lib/ip-restriction.ts
+++ b/apps/api/src/lib/ip-restriction.ts
@@ -12,8 +12,8 @@ const ALLOWLIST_CACHE_TTL_SECONDS = 60;
 const allowlistCacheKey = (teamId: string) =>
   `ip-restriction-allowlist:${teamId}`;
 
-// Express hands IPv4 clients back as IPv4-mapped IPv6 (::ffff:1.2.3.4) when
-// the socket is dual-stack; compare in IPv4 form so allowlist entries match.
+// A dual-stack listener (bound to ::) reports IPv4 clients as IPv4-mapped
+// IPv6 (::ffff:1.2.3.4); compare in IPv4 form so allowlist entries match.
 export function normalizeIp(ip: string): string {
   const trimmed = ip.trim();
   const lower = trimmed.toLowerCase();


### PR DESCRIPTION
Follow-up to #3952: the ::ffff: mapping comes from the dual-stack socket layer (listener bound to ::), not Express. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the inline comment in `apps/api/src/lib/ip-restriction.ts` to correctly attribute IPv4-mapped-IPv6 (::ffff:1.2.3.4) to the dual-stack listener (bound to ::), not Express.
No code behavior changes.

<sup>Written for commit 5ff57ccfe2a32309cd82db01d8a6f7c1a1ae08ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

