### PR TITLE
feat(api): admin endpoint to clear the IP restriction allowlist cache

### DIFF
--- a/apps/api/src/controllers/v0/admin/ip-restriction-cache-clear.ts
+++ b/apps/api/src/controllers/v0/admin/ip-restriction-cache-clear.ts
@@ -9,18 +9,20 @@ export async function ipRestrictionCacheClearController(
   res: Response,
 ) {
   try {
-    const team_id: string = req.body.team_id;
+    const team_id = req.body?.team_id;
 
-    if (!team_id) {
+    if (typeof team_id !== "string" || team_id.length === 0) {
       return res.status(400).json({ error: "team_id is required" });
     }
 
     await clearIpRestrictionCache(team_id);
 
-    logger.info(`IP restriction allowlist cache cleared for team ${team_id}`);
+    logger.info("IP restriction allowlist cache cleared", { team_id });
     res.json({ ok: true });
   } catch (error) {
-    logger.error(`Error clearing IP restriction cache via API route: ${error}`);
+    logger.error("Error clearing IP restriction cache via API route", {
+      error,
+    });
     res.status(500).json({ error: "Internal server error" });
   }
 }

--- a/apps/api/src/controllers/v0/admin/ip-restriction-cache-clear.ts
+++ b/apps/api/src/controllers/v0/admin/ip-restriction-cache-clear.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import { clearIpRestrictionCache } from "../../../lib/ip-restriction";
+import { logger } from "../../../lib/logger";
+
+// Called by the dashboard after it writes ip_restriction_config so allowlist
+// edits take effect immediately instead of after the 60s cache TTL.
+export async function ipRestrictionCacheClearController(
+  req: Request,
+  res: Response,
+) {
+  try {
+    const team_id: string = req.body.team_id;
+
+    if (!team_id) {
+      return res.status(400).json({ error: "team_id is required" });
+    }
+
+    await clearIpRestrictionCache(team_id);
+
+    logger.info(`IP restriction allowlist cache cleared for team ${team_id}`);
+    res.json({ ok: true });
+  } catch (error) {
+    logger.error(`Error clearing IP restriction cache via API route: ${error}`);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/apps/api/src/lib/ip-restriction.ts
+++ b/apps/api/src/lib/ip-restriction.ts
@@ -2,7 +2,7 @@ import { BlockList, isIP } from "node:net";
 import { eq } from "drizzle-orm";
 import { dbRr } from "../db/connection";
 import * as schema from "../db/schema";
-import { getValue, setValue } from "../services/redis";
+import { deleteKey, getValue, setValue } from "../services/redis";
 import { logger } from "./logger";
 import type { TeamFlags } from "../controllers/v1/types";
 
@@ -11,6 +11,12 @@ const ALLOWLIST_CACHE_TTL_SECONDS = 60;
 
 const allowlistCacheKey = (teamId: string) =>
   `ip-restriction-allowlist:${teamId}`;
+
+// Invalidates the cached allowlist so dashboard edits apply immediately
+// (admin route ip-restriction-cache-clear).
+export async function clearIpRestrictionCache(teamId: string): Promise<void> {
+  await deleteKey(allowlistCacheKey(teamId));
+}
 
 // Express hands IPv4 clients back as IPv4-mapped IPv6 (::ffff:1.2.3.4) when
 // the socket is dual-stack; compare in IPv4 form so allowlist entries match.

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { redisHealthController } from "../controllers/v0/admin/redis-health";
 import { autumnHealthController } from "../controllers/v0/admin/autumn-health";
 import { authMiddleware, checkCreditsMiddleware, wrap } from "./shared";
 import { acucCacheClearController } from "../controllers/v0/admin/acuc-cache-clear";
+import { ipRestrictionCacheClearController } from "../controllers/v0/admin/ip-restriction-cache-clear";
 import { checkFireEngine } from "../controllers/v0/admin/check-fire-engine";
 import { indexQueuePrometheus } from "../controllers/v0/admin/index-queue-prometheus";
 import { triggerPrecrawl } from "../controllers/v0/admin/precrawl";
@@ -38,6 +39,11 @@ if (config.BULL_AUTH_KEY) {
   adminRouter.post(
     `/admin/${config.BULL_AUTH_KEY}/acuc-cache-clear`,
     wrap(acucCacheClearController),
+  );
+
+  adminRouter.post(
+    `/admin/${config.BULL_AUTH_KEY}/ip-restriction-cache-clear`,
+    wrap(ipRestrictionCacheClearController),
   );
 
   adminRouter.get(


### PR DESCRIPTION
POST `/admin/{BULL_AUTH_KEY}/ip-restriction-cache-clear` with `{"team_id": "<uuid>"}` drops the 60s Redis cache of a team's IP allowlist, so dashboard edits to `ip_restriction_config` take effect immediately instead of after the TTL. Mirrors the existing `acuc-cache-clear` endpoint exactly.

The dashboard calls this best-effort after writing the allowlist (firecrawl-web#2719); the TTL remains the fallback if the call fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin endpoint to clear a team’s IP restriction allowlist cache so dashboard updates apply immediately. Mirrors `acuc-cache-clear`; the 60s TTL remains the fallback.

- **New Features**
  - POST `/admin/{BULL_AUTH_KEY}/ip-restriction-cache-clear` with body `{ "team_id": "<uuid>" }` invalidates the team’s allowlist cache.
  - Adds `clearIpRestrictionCache(teamId)` to delete `ip-restriction-allowlist:<teamId>` in Redis.

- **Bug Fixes**
  - Returns 400 with `{ error: "team_id is required" }` when `team_id` is missing or empty, and uses structured log context.

<sup>Written for commit 2de7bccb6b54c85d29aa5e333a07686d778e9359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

