### PR TITLE
feat(api/search): turn highlights on by default, cap the pass at 300ms

### DIFF
--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -21,6 +21,7 @@ import {
   SearchRequestInput,
   toV2CrawlerOptions,
 } from "../../../controllers/v2/types";
+import { searchRequestSchema as searchRequestSchemaV1 } from "../../../controllers/v1/types";
 import {
   createMonitorSchema,
   updateMonitorSchema,
@@ -1119,6 +1120,11 @@ describe("V2 Types Validation", () => {
       };
 
       const result = searchRequestSchema.parse(input);
+      expect(result.highlights).toBe(true);
+    });
+
+    it("should default highlights to true on v1", () => {
+      const result = searchRequestSchemaV1.parse({ query: "test" });
       expect(result.highlights).toBe(true);
     });
 

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1113,6 +1113,25 @@ describe("V2 Types Validation", () => {
       expect(result.enterprise).toEqual(["default", "zdr"]);
     });
 
+    it("should default highlights to true", () => {
+      const input: SearchRequestInput = {
+        query: "test",
+      };
+
+      const result = searchRequestSchema.parse(input);
+      expect(result.highlights).toBe(true);
+    });
+
+    it("should allow opting out of highlights", () => {
+      const input: SearchRequestInput = {
+        query: "test",
+        highlights: false,
+      };
+
+      const result = searchRequestSchema.parse(input);
+      expect(result.highlights).toBe(false);
+    });
+
     it("should accept search scrapeOptions with query format", () => {
       const input: SearchRequestInput = {
         query: "test",

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -190,6 +190,7 @@ export async function searchController(
         location: req.body.location,
         sources: [{ type: "web" }], // v1 only supports web
         scrapeOptions: shouldScrape ? scrapeOptions : undefined,
+        highlights: req.body.highlights,
         timeout: req.body.timeout,
         enterprise: teamEnterprise,
       },

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1321,7 +1321,6 @@ export type TeamFlags = {
   // POST /v2/search/:jobId/feedback returns 403 TEAM_OPTED_OUT when true.
   searchFeedbackOptOut?: boolean;
   researchBeta?: boolean;
-  highlightsBeta?: boolean;
   enrichBeta?: boolean;
   // routes the team's new queue work to the FoundationDB backend
   nuqFdb?: boolean;
@@ -1556,6 +1555,11 @@ export const searchRequestSchema = z
     integration: integrationSchema.optional().transform(val => val || null),
     timeout: z.int().positive().finite().prefault(60000),
     ignoreInvalidURLs: z.boolean().optional().prefault(false),
+    // Replace each result's description with query-relevant highlights pulled
+    // from our index (last 30 days). On by default (pass false to opt out);
+    // falls back to the provider description when the URL isn't indexed or the
+    // highlights pass exceeds its latency budget.
+    highlights: z.boolean().optional().prefault(true),
     __searchPreviewToken: z.string().optional(),
     scrapeOptions: baseScrapeOptions
       .extend({

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1549,7 +1549,6 @@ export type TeamFlags = {
   debugBranding?: boolean;
   maxBrowserSessions?: number;
   researchBeta?: boolean;
-  highlightsBeta?: boolean;
   menuBeta?: boolean;
   enrichBeta?: boolean;
 } | null;

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1936,10 +1936,11 @@ export const searchRequestSchema = z
     timeout: z.int().positive().finite().prefault(60000),
     ignoreInvalidURLs: z.boolean().optional().prefault(false),
     asyncScraping: z.boolean().optional().prefault(false),
-    // Experimental: replace each result's snippet with query-relevant
-    // highlights pulled from our index (last 30 days), out-of-line from
-    // scrapeURL. Falls back to the provider snippet when the URL isn't indexed.
-    highlights: z.boolean().optional().prefault(false),
+    // Replace each result's snippet with query-relevant highlights pulled from
+    // our index (last 30 days), out-of-line from scrapeURL. On by default
+    // (pass false to opt out); falls back to the provider snippet when the URL
+    // isn't indexed or the highlights pass exceeds its latency budget.
+    highlights: z.boolean().optional().prefault(true),
     __searchPreviewToken: z.string().optional(),
     scrapeOptions: baseScrapeOptions
       .extend({

--- a/apps/api/src/scraper/scrapeURL/transformers/menu.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/menu.ts
@@ -12,8 +12,8 @@ export async function fetchMenu(
   }
 
   // Beta gate: during beta the menu format is limited to teams with the menuBeta
-  // flag. Fail closed and silent (mirrors highlightsBeta) -- a team without the
-  // flag gets no menu field, no error, and no engine call.
+  // flag. Fail closed and silent -- a team without the flag gets no menu field,
+  // no error, and no engine call.
   if (meta.internalOptions?.teamFlags?.menuBeta !== true) {
     meta.logger.info("menu format requested without menuBeta flag; skipping");
     return document;

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -190,19 +190,15 @@ export async function executeSearch(
   }
 
   // Highlights: replace provider snippets with index-backed highlights. On by
-  // default for v2 search requests (the schema prefaults `highlights` to true;
-  // v1 never sets it). Gated on (1) the request not opting out, (2) the team's
-  // highlightsBeta flag, and (3) all required envs being present (index DB,
-  // GCS, model). Any gate failing => silently keep the provider snippets. The
-  // whole pass runs under a hard latency budget (see HIGHLIGHTS_TIMEOUT_MS).
+  // default for search requests (the v1 and v2 schemas prefault `highlights`
+  // to true). Gated on (1) the request not opting out and (2) all required
+  // envs being present (index DB, GCS, model). Any gate failing => silently
+  // keep the provider snippets. The whole pass runs under a hard latency
+  // budget (see HIGHLIGHTS_TIMEOUT_MS).
   // Runs after scraping (mergeScrapedContent rebuilds the result objects, so
   // highlight mutations must come last to survive). Uses the user's original
   // query, not the domain-filtered upstream query.
-  if (
-    options.highlights &&
-    flags?.highlightsBeta === true &&
-    highlightsEnvReady()
-  ) {
+  if (options.highlights && highlightsEnvReady()) {
     await applySearchHighlights(searchResponse, query, logger);
   }
 

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -189,10 +189,12 @@ export async function executeSearch(
     }
   }
 
-  // Experimental highlights beta: replace provider snippets with index-backed
-  // highlights. Gated on (1) the request opting in, (2) the team's highlightsBeta
-  // flag, and (3) all required envs being present (index DB, GCS, model). Any
-  // gate failing => silently keep the provider snippets.
+  // Highlights: replace provider snippets with index-backed highlights. On by
+  // default for v2 search requests (the schema prefaults `highlights` to true;
+  // v1 never sets it). Gated on (1) the request not opting out, (2) the team's
+  // highlightsBeta flag, and (3) all required envs being present (index DB,
+  // GCS, model). Any gate failing => silently keep the provider snippets. The
+  // whole pass runs under a hard latency budget (see HIGHLIGHTS_TIMEOUT_MS).
   // Runs after scraping (mergeScrapedContent rebuilds the result objects, so
   // highlight mutations must come last to survive). Uses the user's original
   // query, not the domain-filtered upstream query.

--- a/apps/api/src/search/highlight-model.test.ts
+++ b/apps/api/src/search/highlight-model.test.ts
@@ -99,4 +99,64 @@ describe("generateHighlights", () => {
     expect(out).toBeNull();
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it("cancels the request when the external signal aborts, logging at debug", async () => {
+    const fetchMock = vi.fn().mockImplementation(
+      (_url, init: { signal: AbortSignal }) =>
+        new Promise((_, reject) => {
+          const abort = () =>
+            reject(
+              new DOMException("This operation was aborted", "AbortError"),
+            );
+          if (init.signal.aborted) abort();
+          else init.signal.addEventListener("abort", abort, { once: true });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const external = new AbortController();
+    const promise = generateHighlights("q", "md", {
+      logger,
+      signal: external.signal,
+    });
+    external.abort();
+
+    const out = await promise;
+
+    expect(out).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      "query highlights failed",
+      expect.objectContaining({
+        canonicalLog: "search/highlights",
+        aborted: true,
+        elapsedMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it("returns null without warning when called with an already-aborted signal", async () => {
+    const fetchMock = vi.fn().mockImplementation(
+      (_url, init: { signal: AbortSignal }) =>
+        new Promise((_, reject) => {
+          if (init.signal.aborted) {
+            reject(
+              new DOMException("This operation was aborted", "AbortError"),
+            );
+          }
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const external = new AbortController();
+    external.abort();
+
+    const out = await generateHighlights("q", "md", {
+      logger,
+      signal: external.signal,
+    });
+
+    expect(out).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/search/highlight-model.ts
+++ b/apps/api/src/search/highlight-model.ts
@@ -36,15 +36,22 @@ interface HighlightResult {
  * Generate query highlights for one page by sending its full markdown and the
  * query to the highlight model service. Returns the service's highlight entries
  * plus the reassembled markdown, or null when the call fails (so callers can
- * keep the provider snippet).
+ * keep the provider snippet). An aborted `opts.signal` (the caller's overall
+ * highlights deadline) cancels the request.
  */
 export async function generateHighlights(
   query: string,
   markdown: string,
-  opts: { logger: Logger },
+  opts: { logger: Logger; signal?: AbortSignal },
 ): Promise<HighlightResult | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const onExternalAbort = () => controller.abort();
+  if (opts.signal?.aborted) {
+    controller.abort();
+  } else {
+    opts.signal?.addEventListener("abort", onExternalAbort, { once: true });
+  }
   const start = Date.now();
   try {
     const res = await fetch(`${config.HIGHLIGHT_MODEL_URL}/highlight`, {
@@ -76,12 +83,18 @@ export async function generateHighlights(
 
     return { highlights, markdown: data.markdown ?? "" };
   } catch (error) {
-    opts.logger.warn("query highlights failed", {
+    // An external abort means the caller's overall highlights deadline fired —
+    // expected under load, so keep it at debug; real failures stay warnings.
+    const level = opts.signal?.aborted ? "debug" : "warn";
+    opts.logger[level]("query highlights failed", {
       canonicalLog: "search/highlights",
       error: error instanceof Error ? error.message : String(error),
+      aborted: opts.signal?.aborted ?? false,
+      elapsedMs: Date.now() - start,
     });
     return null;
   } finally {
     clearTimeout(timer);
+    opts.signal?.removeEventListener("abort", onExternalAbort);
   }
 }

--- a/apps/api/src/search/highlights.test.ts
+++ b/apps/api/src/search/highlights.test.ts
@@ -1,0 +1,151 @@
+vi.mock("../config", () => ({
+  config: {
+    GCS_INDEX_BUCKET_NAME: "test-bucket",
+    HIGHLIGHT_MODEL_URL: "https://highlight.test",
+    HIGHLIGHT_MODEL_TOKEN: "secret-token",
+  },
+}));
+
+vi.mock("../services", () => ({
+  useIndex: true,
+  normalizeURLForIndex: (url: string) => url,
+  hashURL: () => "url-hash",
+  getIndexFromGCS: vi.fn().mockResolvedValue({
+    html: "<html><body><p>indexed page content</p></body></html>",
+  }),
+}));
+
+vi.mock("../db/rpc", () => ({
+  indexGetRecent5: vi
+    .fn()
+    .mockResolvedValue([
+      { id: "index-entry", status: 200, created_at: "2026-07-01T00:00:00Z" },
+    ]),
+}));
+
+vi.mock("../lib/html-to-markdown", () => ({
+  parseMarkdown: vi.fn().mockResolvedValue("indexed page content"),
+}));
+
+vi.mock("../scraper/scrapeURL/lib/removeUnwantedElements", () => ({
+  htmlTransform: vi.fn().mockResolvedValue("<p>indexed page content</p>"),
+}));
+
+vi.mock("./highlight-model", () => ({
+  generateHighlights: vi.fn(),
+}));
+
+import type { SearchV2Response } from "../lib/entities";
+import { applySearchHighlights } from "./highlights";
+import { generateHighlights } from "./highlight-model";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+} as any;
+logger.child.mockReturnValue(logger);
+
+function makeResponse(): SearchV2Response {
+  return {
+    web: [
+      {
+        url: "https://example.com",
+        title: "Example",
+        description: "provider snippet",
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("applySearchHighlights", () => {
+  it("replaces snippets and canonical-logs time taken at debug when within the timeout", async () => {
+    vi.mocked(generateHighlights).mockResolvedValue({
+      highlights: [],
+      markdown: "relevant highlight",
+    });
+
+    const response = makeResponse();
+    const out = await applySearchHighlights(response, "query", logger);
+
+    expect(out).toEqual({
+      attempted: 1,
+      indexHits: 1,
+      replaced: 1,
+      timedOut: false,
+    });
+    expect(response.web![0].description).toBe("relevant highlight");
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Search highlights applied",
+      expect.objectContaining({
+        canonicalLog: "search/highlights",
+        attempted: 1,
+        indexHits: 1,
+        replaced: 1,
+        timedOut: false,
+        timeTakenMs: expect.any(Number),
+        timeoutMs: 300,
+      }),
+    );
+  });
+
+  it("keeps provider snippets and warns when the 300ms cap fires", async () => {
+    // Model call resolves only well past the cap (or on abort).
+    vi.mocked(generateHighlights).mockImplementation(
+      (_query, _markdown, opts) =>
+        new Promise(resolve => {
+          const late = setTimeout(
+            () => resolve({ highlights: [], markdown: "too late" }),
+            2000,
+          );
+          opts.signal?.addEventListener("abort", () => {
+            clearTimeout(late);
+            resolve(null);
+          });
+        }),
+    );
+
+    const response = makeResponse();
+    const out = await applySearchHighlights(response, "query", logger);
+
+    expect(out.timedOut).toBe(true);
+    expect(out.replaced).toBe(0);
+    expect(response.web![0].description).toBe("provider snippet");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Search highlights timed out",
+      expect.objectContaining({
+        canonicalLog: "search/highlights",
+        timedOut: true,
+        timeTakenMs: expect.any(Number),
+        timeoutMs: 300,
+      }),
+    );
+  });
+
+  it("canonical-logs time taken even when there is nothing to highlight", async () => {
+    const out = await applySearchHighlights({ web: [] }, "query", logger);
+
+    expect(out).toEqual({
+      attempted: 0,
+      indexHits: 0,
+      replaced: 0,
+      timedOut: false,
+    });
+    expect(generateHighlights).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Search highlights applied",
+      expect.objectContaining({
+        canonicalLog: "search/highlights",
+        attempted: 0,
+        timeTakenMs: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/apps/api/src/search/highlights.test.ts
+++ b/apps/api/src/search/highlights.test.ts
@@ -38,6 +38,8 @@ vi.mock("./highlight-model", () => ({
 import type { SearchV2Response } from "../lib/entities";
 import { applySearchHighlights } from "./highlights";
 import { generateHighlights } from "./highlight-model";
+import { indexGetRecent5 } from "../db/rpc";
+import { getIndexFromGCS } from "../services";
 
 const logger = {
   info: vi.fn(),
@@ -127,6 +129,38 @@ describe("applySearchHighlights", () => {
         timeoutMs: 300,
       }),
     );
+  });
+
+  it("stops the index pipeline at the next stage boundary after timeout", async () => {
+    // The index DB lookup only resolves past the cap; the dangling work must
+    // bail at the abort checkpoint instead of fetching from GCS and parsing.
+    vi.mocked(indexGetRecent5).mockImplementationOnce(
+      () =>
+        new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve([
+                {
+                  id: "index-entry",
+                  status: 200,
+                  created_at: "2026-07-01T00:00:00Z",
+                },
+              ] as any),
+            450,
+          ),
+        ),
+    );
+
+    const response = makeResponse();
+    const out = await applySearchHighlights(response, "query", logger);
+
+    expect(out.timedOut).toBe(true);
+    expect(response.web![0].description).toBe("provider snippet");
+
+    // Let the dangling lookup resolve, then confirm downstream stages never ran.
+    await new Promise(resolve => setTimeout(resolve, 300));
+    expect(getIndexFromGCS).not.toHaveBeenCalled();
+    expect(generateHighlights).not.toHaveBeenCalled();
   });
 
   it("canonical-logs time taken even when there is nothing to highlight", async () => {

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -16,6 +16,12 @@ import { config } from "../config";
 // How far back into the index we're willing to reach for highlight source text.
 const HIGHLIGHTS_INDEX_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+// Hard cap on the whole highlights pass. Highlights run on every search by
+// default, so they must never add more than this to search latency — when the
+// deadline fires we abort the in-flight model calls, keep every provider
+// snippet, and log a warning.
+const HIGHLIGHTS_TIMEOUT_MS = 300;
+
 /**
  * Whether the deployment has every dependency the highlights beta needs: the
  * index DB (to find cached content), the GCS index bucket (to fetch it), and the
@@ -127,12 +133,22 @@ async function getIndexedMarkdownForURL(
  * markdown is sent to the highlight model service, which returns the selected
  * highlights reassembled into a single markdown document. Mutates `response` in
  * place. Results not in the index keep their original snippet.
+ *
+ * The whole pass is capped at HIGHLIGHTS_TIMEOUT_MS: past the deadline every
+ * result keeps its provider snippet, even if some highlights came back in time.
+ * Time taken is always canonical-logged — debug when within the deadline, warn
+ * when it fires.
  */
 export async function applySearchHighlights(
   response: SearchV2Response,
   query: string,
   logger: Logger,
-): Promise<{ attempted: number; indexHits: number; replaced: number }> {
+): Promise<{
+  attempted: number;
+  indexHits: number;
+  replaced: number;
+  timedOut: boolean;
+}> {
   const start = Date.now();
 
   // Collect every result we could highlight, each with a setter for its snippet
@@ -159,47 +175,99 @@ export async function applySearchHighlights(
 
   const attempted = targets.length;
   if (attempted === 0) {
-    return { attempted, indexHits: 0, replaced: 0 };
-  }
-
-  // Look up indexed markdown for every URL in parallel, keeping the markdown for
-  // each hit so we can send it to the highlight model service.
-  const markdowns = await Promise.all(
-    targets.map(t => getIndexedMarkdownForURL(t.url, logger)),
-  );
-  const hits: {
-    apply: (h: string) => void;
-    markdown: string;
-  }[] = [];
-  markdowns.forEach((markdown, i) => {
-    if (!markdown) return;
-    hits.push({ apply: targets[i].apply, markdown });
-  });
-  const indexHits = hits.length;
-
-  // Send each hit's full markdown to the highlight model service in parallel and
-  // use the reassembled markdown it returns as the snippet.
-  let replaced = 0;
-  if (indexHits > 0) {
-    const results = await Promise.all(
-      hits.map(h => generateHighlights(query, h.markdown, { logger })),
-    );
-    results.forEach((result, i) => {
-      if (!result) return;
-      const snippet = result.markdown;
-      if (snippet.trim() !== "") {
-        hits[i].apply(snippet);
-        replaced++;
-      }
+    logger.debug("Search highlights applied", {
+      canonicalLog: "search/highlights",
+      attempted,
+      indexHits: 0,
+      replaced: 0,
+      timedOut: false,
+      timeTakenMs: Date.now() - start,
+      timeoutMs: HIGHLIGHTS_TIMEOUT_MS,
     });
+    return { attempted, indexHits: 0, replaced: 0, timedOut: false };
   }
 
-  logger.info("Search highlights applied", {
+  // Race the pass against the deadline. On timeout, abort the in-flight model
+  // calls and bail without touching the response — the dangling work can't
+  // mutate it, because all snippet mutations happen below, and only when the
+  // work wins the race.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HIGHLIGHTS_TIMEOUT_MS);
+
+  let indexHits = 0;
+  let replaced = 0;
+  let timedOut = false;
+  try {
+    const work = (async () => {
+      // Look up indexed markdown for every URL in parallel, keeping the
+      // markdown for each hit so we can send it to the highlight model service.
+      const markdowns = await Promise.all(
+        targets.map(t => getIndexedMarkdownForURL(t.url, logger)),
+      );
+      const hits: {
+        apply: (h: string) => void;
+        markdown: string;
+      }[] = [];
+      markdowns.forEach((markdown, i) => {
+        if (!markdown) return;
+        hits.push({ apply: targets[i].apply, markdown });
+      });
+
+      // Send each hit's full markdown to the highlight model service in
+      // parallel and use the reassembled markdown it returns as the snippet.
+      const results = await Promise.all(
+        hits.map(h =>
+          generateHighlights(query, h.markdown, {
+            logger,
+            signal: controller.signal,
+          }),
+        ),
+      );
+
+      return { hits, results };
+    })();
+
+    const finished = await Promise.race([
+      work,
+      new Promise<null>(resolve =>
+        controller.signal.addEventListener("abort", () => resolve(null), {
+          once: true,
+        }),
+      ),
+    ]);
+
+    if (finished === null) {
+      timedOut = true;
+    } else {
+      indexHits = finished.hits.length;
+      finished.results.forEach((result, i) => {
+        if (!result) return;
+        const snippet = result.markdown;
+        if (snippet.trim() !== "") {
+          finished.hits[i].apply(snippet);
+          replaced++;
+        }
+      });
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const timeTakenMs = Date.now() - start;
+  const logFields = {
+    canonicalLog: "search/highlights",
     attempted,
     indexHits,
     replaced,
-    timeTakenMs: Date.now() - start,
-  });
+    timedOut,
+    timeTakenMs,
+    timeoutMs: HIGHLIGHTS_TIMEOUT_MS,
+  };
+  if (timedOut) {
+    logger.warn("Search highlights timed out", logFields);
+  } else {
+    logger.debug("Search highlights applied", logFields);
+  }
 
-  return { attempted, indexHits, replaced };
+  return { attempted, indexHits, replaced, timedOut };
 }

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -49,13 +49,17 @@ const ERROR_COUNT_TO_REGISTER = 3;
 /**
  * Fetch the most recent indexed markdown for a URL within the last 30 days.
  * Returns null when the URL isn't in the index (or the lookup fails) so callers
- * can fall back to the provider snippet.
+ * can fall back to the provider snippet. An aborted `signal` (the overall
+ * highlights deadline) makes it bail with null at the next stage boundary —
+ * the individual DB/GCS/parse calls aren't cancelable, but this keeps a
+ * timed-out pass from continuing through the remaining expensive stages.
  */
 async function getIndexedMarkdownForURL(
   url: string,
   logger: Logger,
+  signal?: AbortSignal,
 ): Promise<string | null> {
-  if (!useIndex) {
+  if (!useIndex || signal?.aborted) {
     return null;
   }
 
@@ -79,7 +83,7 @@ async function getIndexedMarkdownForURL(
       min_age_ms: null,
     });
 
-    if (!rows || rows.length === 0) {
+    if (!rows || rows.length === 0 || signal?.aborted) {
       return null;
     }
 
@@ -96,7 +100,7 @@ async function getIndexedMarkdownForURL(
       logger.child({ module: "search/highlights", method: "getIndexFromGCS" }),
       { indexCreatedAt: selected.created_at },
     );
-    if (!doc || !doc.html) {
+    if (!doc || !doc.html || signal?.aborted) {
       return null;
     }
 
@@ -114,6 +118,9 @@ async function getIndexedMarkdownForURL(
       includeTags: [],
       excludeTags: [],
     } as unknown as ScrapeOptions);
+    if (signal?.aborted) {
+      return null;
+    }
 
     const markdown = await parseMarkdown(cleanedHtml, { logger });
     return markdown && markdown.trim() !== "" ? markdown : null;
@@ -202,8 +209,13 @@ export async function applySearchHighlights(
       // Look up indexed markdown for every URL in parallel, keeping the
       // markdown for each hit so we can send it to the highlight model service.
       const markdowns = await Promise.all(
-        targets.map(t => getIndexedMarkdownForURL(t.url, logger)),
+        targets.map(t =>
+          getIndexedMarkdownForURL(t.url, logger, controller.signal),
+        ),
       );
+      if (controller.signal.aborted) {
+        return { hits: [], results: [] };
+      }
       const hits: {
         apply: (h: string) => void;
         markdown: string;

--- a/apps/dot-net-sdk/Firecrawl.Tests/ModelsTests.cs
+++ b/apps/dot-net-sdk/Firecrawl.Tests/ModelsTests.cs
@@ -88,7 +88,8 @@ public class ModelsTests
             Location = "US",
             Tbs = "qdr:w",
             IncludeDomains = new() { "firecrawl.dev" },
-            ExcludeDomains = new() { "example.com" }
+            ExcludeDomains = new() { "example.com" },
+            Highlights = false
         };
 
         var json = JsonSerializer.Serialize(options, JsonOptions);
@@ -97,6 +98,19 @@ public class ModelsTests
         Assert.Contains("\"tbs\":\"qdr:w\"", json);
         Assert.Contains("\"includeDomains\":[\"firecrawl.dev\"]", json);
         Assert.Contains("\"excludeDomains\":[\"example.com\"]", json);
+        Assert.Contains("\"highlights\":false", json);
+    }
+
+    [Fact]
+    public void SearchOptions_Highlights_OmittedWhenNull()
+    {
+        var options = new SearchOptions
+        {
+            Limit = 5
+        };
+
+        var json = JsonSerializer.Serialize(options, JsonOptions);
+        Assert.DoesNotContain("highlights", json);
     }
 
     [Fact]

--- a/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
+++ b/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>firecrawl-sdk</PackageId>
-    <Version>1.9.0</Version>
+    <Version>1.10.0</Version>
     <Authors>Firecrawl</Authors>
     <Company>Firecrawl</Company>
     <Description>.NET SDK for the Firecrawl API - web scraping, crawling, and data extraction</Description>

--- a/apps/dot-net-sdk/Firecrawl/FirecrawlClient.cs
+++ b/apps/dot-net-sdk/Firecrawl/FirecrawlClient.cs
@@ -714,7 +714,7 @@ public class FirecrawlClient
     // INTERNAL UTILITIES
     // ================================================================
 
-    private const string SdkOrigin = "dotnet-sdk@1.7.1";
+    private const string SdkOrigin = "dotnet-sdk@1.10.0";
 
     private static Dictionary<string, object> BuildBody(object? options)
     {

--- a/apps/dot-net-sdk/Firecrawl/Models/SearchOptions.cs
+++ b/apps/dot-net-sdk/Firecrawl/Models/SearchOptions.cs
@@ -56,6 +56,14 @@ public class SearchOptions
     public string? Country { get; set; }
 
     /// <summary>
+    /// Replace each result's description with query-relevant highlights from
+    /// Firecrawl's index (on by default; set to false to opt out).
+    /// </summary>
+    [JsonPropertyName("highlights")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Highlights { get; set; }
+
+    /// <summary>
     /// Enterprise search options. Use <c>["zdr"]</c> for end-to-end Zero Data
     /// Retention or <c>["anon"]</c> for anonymized search. Must be enabled for your team.
     /// </summary>

--- a/apps/elixir-sdk/README.md
+++ b/apps/elixir-sdk/README.md
@@ -11,7 +11,7 @@ Add `firecrawl` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:firecrawl, "~> 1.4"}
+    {:firecrawl, "~> 1.9"}
   ]
 end
 ```
@@ -77,7 +77,12 @@ All params are passed as keyword lists with snake_case keys. Invalid keys, missi
 {:ok, response} = Firecrawl.map_urls(url: "https://example.com")
 
 # Search
-{:ok, response} = Firecrawl.search_and_scrape(query: "firecrawl web scraping")
+# `highlights` replaces each result's description with query-relevant
+# highlights from Firecrawl's index (on by default; set to false to opt out).
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping",
+  highlights: false
+)
 
 # Check crawl status
 {:ok, response} = Firecrawl.get_crawl_status("job-uuid")

--- a/apps/elixir-sdk/generate.exs
+++ b/apps/elixir-sdk/generate.exs
@@ -145,7 +145,7 @@ defmodule Firecrawl.Generator do
       @type response :: {:ok, Req.Response.t()} | {:error, Exception.t() | Firecrawl.Error.t()}
 
       @base_url "#{base_url}"
-      @sdk_origin "elixir-sdk@1.6.1"
+      @sdk_origin "elixir-sdk@1.9.0"
 
       defp client(opts) do
         api_key =

--- a/apps/elixir-sdk/lib/firecrawl.ex
+++ b/apps/elixir-sdk/lib/firecrawl.ex
@@ -41,7 +41,7 @@ defmodule Firecrawl do
   @type response :: {:ok, Req.Response.t()} | {:error, Exception.t() | Firecrawl.Error.t()}
 
   @base_url "https://api.firecrawl.dev/v2"
-  @sdk_origin "elixir-sdk@1.6.1"
+  @sdk_origin "elixir-sdk@1.9.0"
 
   defp client(opts) do
     api_key =
@@ -1149,6 +1149,7 @@ defmodule Firecrawl do
     country: [type: :string, doc: "ISO country code for geo-targeting search results (e.g. `US`). For best results, set both this and the `location` parameter."],
     enterprise: [type: {:list, :string}, doc: "Enterprise search options for Zero Data Retention (ZDR). Use `[\"zdr\"]` for end-to-end ZDR (10 credits / 10 results) or `[\"anon\"]` for anonymized ZDR (2 credits / 10 results). Must be enabled for your team."],
     exclude_domains: [type: {:list, :string}, doc: "Domains to exclude from search results."],
+    highlights: [type: :boolean, doc: "Replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set to false to opt out)."],
     ignore_invalid_urls: [type: :boolean, doc: "Excludes URLs from the search results that are invalid for other Firecrawl endpoints. This helps reduce errors if you are piping data from search into other Firecrawl API endpoints."],
     include_domains: [type: {:list, :string}, doc: "Domains to include in search results."],
     limit: [type: :integer, doc: "Maximum number of results to return"],
@@ -1160,7 +1161,7 @@ defmodule Firecrawl do
     timeout: [type: :integer, doc: "Timeout in milliseconds"]
   ])
 
-  @search_and_scrape_key_mapping %{categories: "categories", country: "country", enterprise: "enterprise", exclude_domains: "excludeDomains", ignore_invalid_urls: "ignoreInvalidURLs", include_domains: "includeDomains", limit: "limit", location: "location", query: "query", scrape_options: "scrapeOptions", sources: "sources", tbs: "tbs", timeout: "timeout"}
+  @search_and_scrape_key_mapping %{categories: "categories", country: "country", enterprise: "enterprise", exclude_domains: "excludeDomains", highlights: "highlights", ignore_invalid_urls: "ignoreInvalidURLs", include_domains: "includeDomains", limit: "limit", location: "location", query: "query", scrape_options: "scrapeOptions", sources: "sources", tbs: "tbs", timeout: "timeout"}
 
   @doc """
   Search and optionally scrape search results

--- a/apps/elixir-sdk/mix.exs
+++ b/apps/elixir-sdk/mix.exs
@@ -1,7 +1,7 @@
 defmodule Firecrawl.MixProject do
   use Mix.Project
 
-  @version "1.8.0"
+  @version "1.9.0"
   @source_url "https://github.com/firecrawl/firecrawl/tree/main/apps/elixir-sdk"
 
   def project do

--- a/apps/elixir-sdk/test/firecrawl_test.exs
+++ b/apps/elixir-sdk/test/firecrawl_test.exs
@@ -317,6 +317,76 @@ defmodule FirecrawlTest do
     assert body["urls"] == ["https://example.com"]
   end
 
+  test "search serializes highlights when set" do
+    parent = self()
+
+    adapter = fn request ->
+      send(parent, {:request, request})
+
+      resp = Req.Response.new(
+        status: 200,
+        headers: %{"content-type" => ["application/json"]},
+        body: Jason.encode!(%{"success" => true, "data" => %{}})
+      )
+
+      {request, resp}
+    end
+
+    assert {:ok, %Req.Response{status: 200}} =
+             Firecrawl.search_and_scrape(
+               [query: "firecrawl", highlights: false],
+               api_key: "test-key",
+               adapter: adapter
+             )
+
+    assert_receive {:request, request}
+
+    body =
+      cond do
+        is_binary(request.body) -> Jason.decode!(request.body)
+        is_map(request.body) -> request.body
+        true -> request.options[:json]
+      end
+
+    assert body["highlights"] == false
+    assert body["query"] == "firecrawl"
+  end
+
+  test "search omits highlights when unset" do
+    parent = self()
+
+    adapter = fn request ->
+      send(parent, {:request, request})
+
+      resp = Req.Response.new(
+        status: 200,
+        headers: %{"content-type" => ["application/json"]},
+        body: Jason.encode!(%{"success" => true, "data" => %{}})
+      )
+
+      {request, resp}
+    end
+
+    assert {:ok, %Req.Response{status: 200}} =
+             Firecrawl.search_and_scrape(
+               [query: "firecrawl"],
+               api_key: "test-key",
+               adapter: adapter
+             )
+
+    assert_receive {:request, request}
+
+    body =
+      cond do
+        is_binary(request.body) -> Jason.decode!(request.body)
+        is_map(request.body) -> request.body
+        true -> request.options[:json]
+      end
+
+    refute Map.has_key?(body, "highlights")
+    assert body["query"] == "firecrawl"
+  end
+
   test "all expected API functions are defined with bang variants" do
     functions = Firecrawl.__info__(:functions)
 

--- a/apps/go-sdk/README.md
+++ b/apps/go-sdk/README.md
@@ -253,6 +253,10 @@ results, err := client.Search(ctx, "firecrawl web scraping", &firecrawl.SearchOp
 })
 ```
 
+By default, each result's description is replaced with query-relevant
+highlights from Firecrawl's index. Set `Highlights: firecrawl.Bool(false)` to
+keep the provider descriptions instead.
+
 ### Agent
 
 Run an AI-powered agent to extract structured data.

--- a/apps/go-sdk/options.go
+++ b/apps/go-sdk/options.go
@@ -173,6 +173,10 @@ type SearchOptions struct {
 	Timeout           *int           `json:"timeout,omitempty"`
 	ScrapeOptions     *ScrapeOptions `json:"scrapeOptions,omitempty"`
 	Integration       *string        `json:"integration,omitempty"`
+	// Highlights replaces each result's description with query-relevant
+	// highlights from Firecrawl's index (on by default; set to false to opt
+	// out).
+	Highlights *bool `json:"highlights,omitempty"`
 }
 
 // AgentOptions configures an agent request.

--- a/apps/go-sdk/options_test.go
+++ b/apps/go-sdk/options_test.go
@@ -64,6 +64,32 @@ func TestScrapeOptionsPreservesStringFormats(t *testing.T) {
 	}
 }
 
+func TestSearchOptionsSerializesHighlights(t *testing.T) {
+	payload, err := json.Marshal(SearchOptions{
+		Highlights: Bool(false),
+	})
+	if err != nil {
+		t.Fatalf("Marshal SearchOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"highlights":false`) {
+		t.Fatalf("serialized highlights = %s, want to contain %q", payload, `"highlights":false`)
+	}
+}
+
+func TestSearchOptionsOmitsUnsetHighlights(t *testing.T) {
+	payload, err := json.Marshal(SearchOptions{
+		Limit: Int(5),
+	})
+	if err != nil {
+		t.Fatalf("Marshal SearchOptions: %v", err)
+	}
+
+	if strings.Contains(string(payload), "highlights") {
+		t.Fatalf("serialized SearchOptions = %s, want highlights omitted when unset", payload)
+	}
+}
+
 func TestScrapeOptionsSerializesRedactPII(t *testing.T) {
 	payload, err := json.Marshal(ScrapeOptions{
 		RedactPII: Bool(true),

--- a/apps/go-sdk/version.go
+++ b/apps/go-sdk/version.go
@@ -9,4 +9,4 @@ package firecrawl
 // Bump this when preparing a new release. The publish-go-sdk GitHub workflow
 // reads this value and creates the corresponding monorepo-prefixed tag on
 // merge to main.
-const Version = "1.8.0"
+const Version = "1.9.0"

--- a/apps/java-sdk/README.md
+++ b/apps/java-sdk/README.md
@@ -82,13 +82,13 @@ Before using the Java SDK, ensure you have the following installed:
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-implementation("com.firecrawl:firecrawl-java:1.6.0")
+implementation("com.firecrawl:firecrawl-java:1.12.0")
 ```
 
 ### Gradle (Groovy)
 
 ```groovy
-implementation 'com.firecrawl:firecrawl-java:1.6.0'
+implementation 'com.firecrawl:firecrawl-java:1.12.0'
 ```
 
 ### Maven
@@ -97,7 +97,7 @@ implementation 'com.firecrawl:firecrawl-java:1.6.0'
 <dependency>
     <groupId>com.firecrawl</groupId>
     <artifactId>firecrawl-java</artifactId>
-    <version>1.6.0</version>
+    <version>1.12.0</version>
 </dependency>
 ```
 
@@ -324,12 +324,13 @@ for (Map<String, Object> link : data.getLinks()) {
 
 ### Search
 
-Search the web and optionally scrape results.
+Search the web and optionally scrape results. By default, each result's description is replaced with query-relevant highlights from Firecrawl's index; pass `.highlights(false)` to keep the provider descriptions.
 
 ```java
 SearchData results = client.search("firecrawl",
     SearchOptions.builder()
         .limit(10)
+        .highlights(false) // optional: opt out of index highlights
         .build());
 
 if (results.getWeb() != null) {
@@ -430,14 +431,14 @@ gradle build
 
 ```bash
 gradle jar
-# Output: build/libs/firecrawl-java-1.6.0.jar
+# Output: build/libs/firecrawl-java-1.12.0.jar
 ```
 
 ### Install Locally
 
 ```bash
 gradle publishToMavenLocal
-# Now available as: com.firecrawl:firecrawl-java:1.6.0 in local Maven repository
+# Now available as: com.firecrawl:firecrawl-java:1.12.0 in local Maven repository
 ```
 
 ## Running Tests

--- a/apps/java-sdk/build.gradle.kts
+++ b/apps/java-sdk/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.firecrawl"
-version = "1.11.0"
+version = "1.12.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ForkJoinPool;
 public class FirecrawlClient {
 
     private static final String DEFAULT_API_URL = "https://api.firecrawl.dev";
-    private static final String SDK_ORIGIN = "java-sdk@1.9.1";
+    private static final String SDK_ORIGIN = "java-sdk@1.12.0";
     private static final long DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
     private static final int DEFAULT_MAX_RETRIES = 3;
     private static final double DEFAULT_BACKOFF_FACTOR = 0.5;

--- a/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java
@@ -17,6 +17,7 @@ public class SearchOptions {
     private String tbs;
     private String location;
     private Boolean ignoreInvalidURLs;
+    private Boolean highlights;
     private Integer timeout;
     private ScrapeOptions scrapeOptions;
     private String integration;
@@ -31,6 +32,7 @@ public class SearchOptions {
     public String getTbs() { return tbs; }
     public String getLocation() { return location; }
     public Boolean getIgnoreInvalidURLs() { return ignoreInvalidURLs; }
+    public Boolean getHighlights() { return highlights; }
     public Integer getTimeout() { return timeout; }
     public ScrapeOptions getScrapeOptions() { return scrapeOptions; }
     public String getIntegration() { return integration; }
@@ -46,6 +48,7 @@ public class SearchOptions {
         private String tbs;
         private String location;
         private Boolean ignoreInvalidURLs;
+        private Boolean highlights;
         private Integer timeout;
         private ScrapeOptions scrapeOptions;
         private String integration;
@@ -68,6 +71,8 @@ public class SearchOptions {
         public Builder location(String location) { this.location = location; return this; }
         /** Ignore invalid URLs in results. */
         public Builder ignoreInvalidURLs(Boolean ignoreInvalidURLs) { this.ignoreInvalidURLs = ignoreInvalidURLs; return this; }
+        /** Replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set to false to opt out). */
+        public Builder highlights(Boolean highlights) { this.highlights = highlights; return this; }
         /** Timeout in milliseconds. */
         public Builder timeout(Integer timeout) { this.timeout = timeout; return this; }
         /** Scrape options applied to search result pages. */
@@ -85,6 +90,7 @@ public class SearchOptions {
             o.tbs = this.tbs;
             o.location = this.location;
             o.ignoreInvalidURLs = this.ignoreInvalidURLs;
+            o.highlights = this.highlights;
             o.timeout = this.timeout;
             o.scrapeOptions = this.scrapeOptions;
             o.integration = this.integration;

--- a/apps/java-sdk/src/test/java/com/firecrawl/FirecrawlClientTest.java
+++ b/apps/java-sdk/src/test/java/com/firecrawl/FirecrawlClientTest.java
@@ -103,6 +103,33 @@ class FirecrawlClientTest {
     }
 
     @Test
+    void testSearchOptionsHighlightsSerializedWhenSet() throws Exception {
+        SearchOptions options = SearchOptions.builder()
+                .limit(5)
+                .highlights(false)
+                .build();
+
+        assertFalse(options.getHighlights());
+
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        String json = mapper.writeValueAsString(options);
+        assertTrue(json.contains("\"highlights\":false"));
+    }
+
+    @Test
+    void testSearchOptionsHighlightsOmittedWhenUnset() throws Exception {
+        SearchOptions options = SearchOptions.builder()
+                .limit(5)
+                .build();
+
+        assertNull(options.getHighlights());
+
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        String json = mapper.writeValueAsString(options);
+        assertFalse(json.contains("highlights"));
+    }
+
+    @Test
     void testCrawlOptionsBuilder() {
         CrawlOptions options = CrawlOptions.builder()
                 .limit(100)

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.29.2",
+  "version": "4.30.0",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { search } from "../../../v2/methods/search";
+
+function makeHttp() {
+  return {
+    post: jest.fn().mockResolvedValue({
+      status: 200,
+      data: { success: true, data: { web: [] } },
+    }),
+  };
+}
+
+describe("v2.search unit", () => {
+  test("serializes highlights when set to false", async () => {
+    const http = makeHttp();
+
+    await search(http as any, { query: "firecrawl", highlights: false });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/search",
+      { query: "firecrawl", highlights: false },
+      {},
+    );
+  });
+
+  test("serializes highlights when set to true", async () => {
+    const http = makeHttp();
+
+    await search(http as any, { query: "firecrawl", highlights: true });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/search",
+      { query: "firecrawl", highlights: true },
+      {},
+    );
+  });
+
+  test("omits highlights from payload when not set", async () => {
+    const http = makeHttp();
+
+    await search(http as any, { query: "firecrawl" });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/search",
+      { query: "firecrawl" },
+      {},
+    );
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect("highlights" in payload).toBe(false);
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v1/index.ts
+++ b/apps/js-sdk/firecrawl/src/v1/index.ts
@@ -405,6 +405,11 @@ export interface SearchParams {
   location?: string;
   origin?: string;
   timeout?: number;
+  /**
+   * Replace each result's description with query-relevant highlights from
+   * Firecrawl's index (on by default; set false to opt out).
+   */
+  highlights?: boolean;
   scrapeOptions?: ScrapeParams;
 }
 
@@ -786,6 +791,10 @@ export default class FirecrawlApp {
       timeout: params?.timeout ?? 60000,
       scrapeOptions: params?.scrapeOptions ?? { formats: [] },
     };
+
+    if (params?.highlights !== undefined) {
+      jsonData.highlights = params.highlights;
+    }
 
     if (jsonData?.scrapeOptions?.extract?.schema) {
       jsonData = {

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -36,6 +36,7 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.location != null) payload.location = req.location;
   if (req.ignoreInvalidURLs != null)
     payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
+  if (req.highlights != null) payload.highlights = req.highlights;
   if (req.timeout != null) payload.timeout = req.timeout;
   if (req.integration && req.integration.trim())
     payload.integration = req.integration.trim();

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -673,6 +673,11 @@ export interface SearchRequest {
   tbs?: string;
   location?: string;
   ignoreInvalidURLs?: boolean;
+  /**
+   * Replace each result's description with query-relevant highlights from
+   * Firecrawl's index (on by default; set false to opt out).
+   */
+  highlights?: boolean;
   timeout?: number; // ms
   scrapeOptions?: ScrapeOptions;
   /**

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Firecrawl PHP SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-07-06
+
+### Added
+- Search: optional `highlights` option on `SearchOptions`. Replace each
+  result's description with query-relevant highlights from Firecrawl's index
+  (on by default; set to `false` to opt out).
+
 ## [1.3.0] - 2026-05-12
 
 ### Added

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -223,6 +223,7 @@ use Firecrawl\Models\SearchOptions;
 
 $result = $client->search('firecrawl web scraping', SearchOptions::with(
     limit: 5,
+    highlights: false, // optional: opt out of query-relevant highlights (on by default)
 ));
 
 foreach ($result->getWeb() as $item) {

--- a/apps/php-sdk/src/Models/SearchOptions.php
+++ b/apps/php-sdk/src/Models/SearchOptions.php
@@ -24,6 +24,7 @@ final class SearchOptions
         private readonly ?string $integration = null,
         private readonly ?array $includeDomains = null,
         private readonly ?array $excludeDomains = null,
+        private readonly ?bool $highlights = null,
     ) {}
 
     /**
@@ -31,6 +32,8 @@ final class SearchOptions
      * @param list<mixed>|null $categories
      * @param list<string>|null $includeDomains
      * @param list<string>|null $excludeDomains
+     * @param bool|null $highlights Replace each result's description with query-relevant
+     *     highlights from Firecrawl's index (on by default; set to false to opt out).
      */
     public static function with(
         ?array $sources = null,
@@ -44,10 +47,12 @@ final class SearchOptions
         ?string $integration = null,
         ?array $includeDomains = null,
         ?array $excludeDomains = null,
+        ?bool $highlights = null,
     ): self {
         return new self(
             $sources, $categories, $limit, $tbs, $location, $ignoreInvalidURLs,
             $timeout, $scrapeOptions, $integration, $includeDomains, $excludeDomains,
+            $highlights,
         );
     }
 
@@ -63,6 +68,7 @@ final class SearchOptions
             'tbs' => $this->tbs,
             'location' => $this->location,
             'ignoreInvalidURLs' => $this->ignoreInvalidURLs,
+            'highlights' => $this->highlights,
             'timeout' => $this->timeout,
             'scrapeOptions' => $this->scrapeOptions?->toArray(),
             'integration' => $this->integration,

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.8.0';
+    public const SDK_VERSION = '1.9.0';
 }

--- a/apps/php-sdk/tests/Unit/ModelsTest.php
+++ b/apps/php-sdk/tests/Unit/ModelsTest.php
@@ -13,6 +13,7 @@ use Firecrawl\Models\HighlightsFormat;
 use Firecrawl\Models\QueryFormat;
 use Firecrawl\Models\QuestionFormat;
 use Firecrawl\Models\ScrapeOptions;
+use Firecrawl\Models\SearchOptions;
 use Firecrawl\Models\Monitor;
 use Firecrawl\Models\MonitorCheck;
 
@@ -436,4 +437,28 @@ it('passes through a search target result on MonitorCheck', function (): void {
     expect($results[0]['searchCredits'])->toBe(7);
     expect($results[0]['judgeCredits'])->toBe(2);
     expect($results[0]['resultsJudged'])->toBe(7);
+});
+
+it('serializes highlights in SearchOptions when set', function (): void {
+    $options = SearchOptions::with(
+        limit: 5,
+        highlights: false,
+    );
+
+    expect($options->toArray())->toMatchArray([
+        'limit' => 5,
+        'highlights' => false,
+    ]);
+
+    expect(SearchOptions::with(highlights: true)->toArray())->toMatchArray([
+        'highlights' => true,
+    ]);
+});
+
+it('omits highlights from SearchOptions when unset', function (): void {
+    $options = SearchOptions::with(
+        limit: 5,
+    );
+
+    expect(array_key_exists('highlights', $options->toArray()))->toBeFalse();
 });

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.31.0"
+__version__ = "4.32.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_aio_search_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_aio_search_request_preparation.py
@@ -10,6 +10,20 @@ class TestAsyncSearchRequestPreparation:
         assert data["query"] == "test query"
         assert "ignore_invalid_urls" not in data
         assert "scrape_options" not in data
+        assert "highlights" not in data
+
+    def test_highlights_serialization(self):
+        # Explicit False (opt out) is included
+        data = _prepare_search_request(SearchRequest(query="test", highlights=False))
+        assert data["highlights"] is False
+
+        # Explicit True is included
+        data = _prepare_search_request(SearchRequest(query="test", highlights=True))
+        assert data["highlights"] is True
+
+        # Unset (None) is omitted so the SDK never sends a default
+        data = _prepare_search_request(SearchRequest(query="test", highlights=None))
+        assert "highlights" not in data
 
     def test_all_fields_conversion(self):
         scrape_opts = ScrapeOptions(

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_request_preparation.py
@@ -20,6 +20,27 @@ class TestSearchRequestPreparation:
         assert "ignore_invalid_urls" not in data
         assert "scrape_options" not in data
 
+        # highlights must be omitted when not set (server default applies)
+        assert "highlights" not in data
+
+    def test_highlights_serialization(self):
+        """Test that highlights is serialized as-is when set and omitted when unset."""
+        # Explicit False (opt out) is included
+        request = SearchRequest(query="test", highlights=False)
+        data = _prepare_search_request(request)
+        assert "highlights" in data
+        assert data["highlights"] is False
+
+        # Explicit True is included
+        request = SearchRequest(query="test", highlights=True)
+        data = _prepare_search_request(request)
+        assert data["highlights"] is True
+
+        # Unset (None) is omitted so the SDK never sends a default
+        request = SearchRequest(query="test", highlights=None)
+        data = _prepare_search_request(request)
+        assert "highlights" not in data
+
     def test_all_fields_conversion(self):
         """Test request preparation with all possible fields."""
         scrape_opts = ScrapeOptions(

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_validation.py
@@ -117,6 +117,7 @@ class TestSearchValidation:
             tbs="qdr:w",
             location="US",
             ignore_invalid_urls=False,
+            highlights=False,
             timeout=30000
         )
         validated = _validate_search_request(request)
@@ -192,6 +193,7 @@ class TestSearchRequestModel:
         request = SearchRequest(query="test")
         assert request.limit == 5
         assert request.ignore_invalid_urls is None  # No default in model
+        assert request.highlights is None  # No default in model; server defaults to on
         assert request.timeout == 300000
         assert request.sources is None
         assert request.tbs is None

--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -351,6 +351,7 @@ class V1SearchParams(pydantic.BaseModel):
     lang: Optional[str] = "en"
     country: Optional[str] = "us"
     location: Optional[str] = None
+    highlights: Optional[bool] = None
     origin: Optional[str] = "api"
     timeout: Optional[int] = 60000
     scrapeOptions: Optional[V1ScrapeOptions] = None
@@ -697,6 +698,7 @@ class V1FirecrawlApp:
             lang: Optional[str] = None,
             country: Optional[str] = None,
             location: Optional[str] = None,
+            highlights: Optional[bool] = None,
             timeout: Optional[int] = 30000,
             scrape_options: Optional[V1ScrapeOptions] = None,
             **kwargs) -> V1SearchResponse:
@@ -709,8 +711,9 @@ class V1FirecrawlApp:
             tbs (Optional[str]): Time filter (e.g. "qdr:d")
             filter (Optional[str]): Custom result filter
             lang (Optional[str]): Language code (default: "en")
-            country (Optional[str]): Country code (default: "us") 
+            country (Optional[str]): Country code (default: "us")
             location (Optional[str]): Geo-targeting
+            highlights: Replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set False to opt out)
             timeout (Optional[int]): Request timeout in milliseconds
             scrape_options (Optional[ScrapeOptions]): Result scraping configuration
             **kwargs: Additional keyword arguments for future compatibility
@@ -744,11 +747,13 @@ class V1FirecrawlApp:
             search_params['country'] = country
         if location is not None:
             search_params['location'] = location
+        if highlights is not None:
+            search_params['highlights'] = highlights
         if timeout is not None:
             search_params['timeout'] = timeout
         if scrape_options is not None:
             search_params['scrapeOptions'] = scrape_options.dict(by_alias=True, exclude_none=True)
-        
+
         # Add any additional kwargs
         search_params.update(kwargs)
         _integration = search_params.get('integration')
@@ -5205,6 +5210,7 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             lang: Optional[str] = None,
             country: Optional[str] = None,
             location: Optional[str] = None,
+            highlights: Optional[bool] = None,
             timeout: Optional[int] = 30000,
             scrape_options: Optional[V1ScrapeOptions] = None,
             params: Optional[Union[Dict[str, Any], V1SearchParams]] = None,
@@ -5218,8 +5224,9 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             tbs (Optional[str]): Time filter (e.g. "qdr:d")
             filter (Optional[str]): Custom result filter
             lang (Optional[str]): Language code (default: "en")
-            country (Optional[str]): Country code (default: "us") 
+            country (Optional[str]): Country code (default: "us")
             location (Optional[str]): Geo-targeting
+            highlights: Replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set False to opt out)
             timeout (Optional[int]): Request timeout in milliseconds
             scrape_options (Optional[ScrapeOptions]): Result scraping configuration
             params (Optional[Union[Dict[str, Any], SearchParams]]): Additional search parameters
@@ -5256,11 +5263,13 @@ class AsyncV1FirecrawlApp(V1FirecrawlApp):
             search_params['country'] = country
         if location is not None:
             search_params['location'] = location
+        if highlights is not None:
+            search_params['highlights'] = highlights
         if timeout is not None:
             search_params['timeout'] = timeout
         if scrape_options is not None:
             search_params['scrapeOptions'] = scrape_options.dict(by_alias=True, exclude_none=True)
-        
+
         # Add any additional kwargs
         search_params.update(kwargs)
 

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -389,6 +389,7 @@ class FirecrawlClient:
         tbs: Optional[str] = None,
         location: Optional[str] = None,
         ignore_invalid_urls: Optional[bool] = None,
+        highlights: Optional[bool] = None,
         timeout: Optional[int] = None,
         scrape_options: Optional[ScrapeOptions] = None,
         integration: Optional[str] = None,
@@ -402,6 +403,7 @@ class FirecrawlClient:
             limit: Maximum number of results to return (default: 5)
             tbs: Time-based search filter
             location: Location string for search
+            highlights: Replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set False to opt out)
             timeout: Request timeout in milliseconds (default: 300000)
             page_options: Options for scraping individual pages
             enterprise: Enterprise search options. Use ["zdr"] for end-to-end
@@ -421,6 +423,7 @@ class FirecrawlClient:
             tbs=tbs,
             location=location,
             ignore_invalid_urls=ignore_invalid_urls,
+            highlights=highlights,
             timeout=timeout,
             scrape_options=scrape_options,
             integration=integration,

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1568,6 +1568,7 @@ class SearchRequest(BaseModel):
     tbs: Optional[str] = None
     location: Optional[str] = None
     ignore_invalid_urls: Optional[bool] = None
+    highlights: Optional[bool] = None
     timeout: Optional[int] = 300000
     scrape_options: Optional[ScrapeOptions] = None
     # Enterprise search options. Use ["zdr"] for end-to-end Zero Data

--- a/apps/ruby-sdk/README.md
+++ b/apps/ruby-sdk/README.md
@@ -182,6 +182,11 @@ results.web&.each { |r| puts r["url"] }
 # With options
 results = client.search("latest news",
   Firecrawl::Models::SearchOptions.new(limit: 5, location: "US"))
+
+# Highlights replace each result's description with query-relevant highlights
+# from Firecrawl's index (on by default; set highlights: false to opt out)
+results = client.search("latest news",
+  Firecrawl::Models::SearchOptions.new(highlights: false))
 ```
 
 ### Agent

--- a/apps/ruby-sdk/lib/firecrawl/models/search_options.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/search_options.rb
@@ -7,6 +7,7 @@ module Firecrawl
       FIELDS = %i[
         sources categories include_domains exclude_domains limit tbs location
         ignore_invalid_urls timeout scrape_options integration enterprise
+        highlights
       ].freeze
 
       attr_reader(*FIELDS)
@@ -31,6 +32,9 @@ module Firecrawl
           # Enterprise search options. Use ["zdr"] for end-to-end Zero Data
           # Retention or ["anon"] for anonymized search. Must be enabled for your team.
           "enterprise" => enterprise,
+          # Replace each result's description with query-relevant highlights from
+          # Firecrawl's index (on by default; set to false to opt out).
+          "highlights" => highlights,
         }.compact
       end
     end

--- a/apps/ruby-sdk/lib/firecrawl/version.rb
+++ b/apps/ruby-sdk/lib/firecrawl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Firecrawl
-  VERSION = "1.10.0"
+  VERSION = "1.11.0"
 end

--- a/apps/ruby-sdk/test/firecrawl/client_test.rb
+++ b/apps/ruby-sdk/test/firecrawl/client_test.rb
@@ -751,6 +751,20 @@ class ClientTest < Minitest::Test
     assert_equal "qdr:w", h["tbs"]
     assert_equal ["firecrawl.dev"], h["includeDomains"]
     assert_equal ["example.com"], h["excludeDomains"]
+    refute_includes h, "highlights"
+  end
+
+  def test_search_options_highlights_serialized_when_set
+    opts = Firecrawl::Models::SearchOptions.new(highlights: false)
+    assert_equal false, opts.to_h["highlights"]
+
+    opts = Firecrawl::Models::SearchOptions.new(highlights: true)
+    assert_equal true, opts.to_h["highlights"]
+  end
+
+  def test_search_options_highlights_omitted_when_unset
+    opts = Firecrawl::Models::SearchOptions.new(limit: 3)
+    refute_includes opts.to_h, "highlights"
   end
 
   def test_agent_options_to_h

--- a/apps/rust-sdk/CHANGELOG.md
+++ b/apps/rust-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+## [2.12.0] - 2026-07-06
+
+### Added
+
+- Added `SearchOptions.highlights` (`Option<bool>`): replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set to false to opt out).
+
 ## [2.5.0] - 2026-05-12
 
 ### Added

--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecrawl"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "mockito",
  "reqwest",

--- a/apps/rust-sdk/Cargo.toml
+++ b/apps/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecrawl"
-version = "2.11.0"
+version = "2.12.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://www.firecrawl.dev/"

--- a/apps/rust-sdk/README.md
+++ b/apps/rust-sdk/README.md
@@ -7,7 +7,7 @@ To install the Firecrawl Rust SDK, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-firecrawl = "2.5.0"
+firecrawl = "2.12.0"
 tokio = { version = "^1", features = ["full"] }
 ```
 

--- a/apps/rust-sdk/src/search.rs
+++ b/apps/rust-sdk/src/search.rs
@@ -38,6 +38,9 @@ pub struct SearchOptions {
     /// Whether to ignore invalid URLs in results.
     pub ignore_invalid_urls: Option<bool>,
 
+    /// Replace each result's description with query-relevant highlights from Firecrawl's index (on by default; set to false to opt out).
+    pub highlights: Option<bool>,
+
     /// Timeout in milliseconds.
     pub timeout: Option<u32>,
 
@@ -410,6 +413,29 @@ mod tests {
 
         assert!(result.is_err());
         mock.assert();
+    }
+
+    #[test]
+    fn test_search_options_highlights_serialization() {
+        // When set, highlights must appear in the request body under the "highlights" key.
+        let options = SearchOptions {
+            highlights: Some(false),
+            ..Default::default()
+        };
+        let body = serde_json::to_value(SearchRequest {
+            query: "test".to_string(),
+            options,
+        })
+        .unwrap();
+        assert_eq!(body.get("highlights"), Some(&json!(false)));
+
+        // When unset, highlights must be omitted from the request body entirely.
+        let body = serde_json::to_value(SearchRequest {
+            query: "test".to_string(),
+            options: SearchOptions::default(),
+        })
+        .unwrap();
+        assert!(body.get("highlights").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

### API
- **Highlights are now on by default for search — all teams.** `highlights` prefaults to `true` in both the v1 and v2 search request schemas; pass `highlights: false` to opt out. The `highlightsBeta` team flag gate is removed (the unused flag is dropped from `TeamFlags` in v1/v2 types); only the env gates remain (index DB, GCS, model URL/token).
- **Hard 300ms cap on the whole highlights pass.** Since it runs on regular search traffic, the pass races a 300ms deadline: when it fires, in-flight model calls are aborted and every result keeps its provider snippet (`description` for web, `snippet` for news) — late completions can't mutate the response.
- **Time taken is always canonical-logged** (`canonicalLog: "search/highlights"`, `timeTakenMs`): `debug` level when the pass finishes within the budget, `warn` ("Search highlights timed out") when the cap fires. Per-page model-call failures also log `elapsedMs`; external-deadline aborts log at `debug` instead of `warn` to avoid noise.

### SDKs
Optional `highlights` boolean added to search params in all 9 SDKs, always omitted from the request body when unset (server default applies), each with a minor version bump:

| SDK | Version | Notes |
|---|---|---|
| js-sdk | 4.29.2 → 4.30.0 | v1 + v2 clients |
| python-sdk | 4.31.0 → 4.32.0 | v1 + v2 clients, sync + async |
| go-sdk | 1.8.0 → 1.9.0 | |
| rust-sdk | 2.11.0 → 2.12.0 | |
| ruby-sdk | 1.10.0 → 1.11.0 | |
| php-sdk | 1.8.0 → 1.9.0 | |
| java-sdk | 1.11.0 → 1.12.0 | stale origin/README versions also aligned |
| dot-net-sdk | 1.9.0 → 1.10.0 | stale origin string also aligned |
| elixir-sdk | 1.8.0 → 1.9.0 | stale @sdk_origin also aligned |

## Tests

- `src/search/highlights.test.ts` (new): happy path replaces snippets + debug canonical log; 300ms cap keeps provider snippets + warn canonical log; zero-target case still logs time taken.
- `src/search/highlight-model.test.ts`: external abort signal cancels the request and logs at debug; already-aborted signal returns null without warning.
- `src/__tests__/snips/v2/types-validation.test.ts`: v1 and v2 schemas default `highlights` to `true`; explicit `false` opts out.
- SDK unit tests for set → serialized / unset → omitted in js, python, go, rust, ruby, php, java, dot-net, elixir (each suite run locally where the toolchain was available: js/python/go/rust natively, php/elixir via Docker, java via openjdk@21, ruby via standalone minitest; dot-net verified by review — no local CLI).
- E2E: existing v1/v2 search snips exercise the default-on path end-to-end (highlight output itself is index-dependent, so behavior specifics are unit-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)