### PR TITLE
fix(js-sdk): forward ignoreRobotsTxt in v2 crawl payload

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { startCrawl } from "../../../v2/methods/crawl";
+
+describe("JS SDK v2 startCrawl payload", () => {
+  test("forwards ignoreRobotsTxt to the crawl request body", async () => {
+    const post = jest.fn(async () => ({
+      status: 200,
+      data: { success: true, id: "crawl-123", url: "https://example.com/crawl/crawl-123" },
+    }));
+
+    const http = { post } as any;
+    await startCrawl(http, { url: "https://example.com", ignoreRobotsTxt: true });
+
+    expect(post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({ ignoreRobotsTxt: true }),
+    );
+  });
+
+  test("omits ignoreRobotsTxt from the crawl request body when not provided", async () => {
+    const post = jest.fn(async () => ({
+      status: 200,
+      data: { success: true, id: "crawl-123", url: "https://example.com/crawl/crawl-123" },
+    }));
+
+    const http = { post } as any;
+    await startCrawl(http, { url: "https://example.com" });
+
+    const [, body] = post.mock.calls[0] as [string, Record<string, unknown>];
+    expect(body).not.toHaveProperty("ignoreRobotsTxt");
+  });
+
+  test("forwards ignoreRobotsTxt alongside robotsUserAgent", async () => {
+    const post = jest.fn(async () => ({
+      status: 200,
+      data: { success: true, id: "crawl-456", url: "https://example.com/crawl/crawl-456" },
+    }));
+
+    const http = { post } as any;
+    await startCrawl(http, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+      robotsUserAgent: "CustomBot/1.0",
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({
+        ignoreRobotsTxt: true,
+        robotsUserAgent: "CustomBot/1.0",
+      }),
+    );
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,6 +28,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;


### PR DESCRIPTION
## Summary
- `CrawlOptions.ignoreRobotsTxt` is declared in the v2 JS SDK types and the `/v2/crawl` API endpoint accepts it (`ignoreRobotsTxt: z.boolean().prefault(false)` in `apps/api/src/controllers/v2/types.ts`), but `prepareCrawlPayload()` in `apps/js-sdk/firecrawl/src/v2/methods/crawl.ts` never read it, so `client.crawl(url, { ignoreRobotsTxt: true })` silently dropped the flag and crawls stayed subject to robots.txt.
- Adds the missing forwarding line next to the existing `robotsUserAgent` forwarding (which already worked).
- Related to #3940.

## Test plan
- [x] Added `crawl.unit.test.ts` covering: flag forwarded when `true`, omitted from the body when not provided, and forwarded alongside `robotsUserAgent`.
- [x] Verified the new tests fail on the pre-fix code and pass after the fix.
- [x] `npx tsc --noEmit` and `npx tsup` build clean (no new errors introduced).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v2 JS SDK crawls dropping the `ignoreRobotsTxt` option. The flag is now forwarded to `/v2/crawl`, so callers can bypass robots.txt when they set it.

- **Bug Fixes**
  - Forward `ignoreRobotsTxt` in `prepareCrawlPayload()` next to `robotsUserAgent`.
  - Add unit tests verifying forwarding when true, omission when unset, and coexistence with `robotsUserAgent`.

<sup>Written for commit 47fe07c44ef973663c7abdf47a34eb2dd14f0060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

