### PR TITLE
fix(js-sdk): include ignoreRobotsTxt in crawl payload

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.29.2",
+  "version": "4.29.3",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { startCrawl } from "../../../v2/methods/crawl";
+
+describe("v2.crawl unit", () => {
+  test("startCrawl forwards ignoreRobotsTxt in request payload", async () => {
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { success: true, id: "crawl-job", url: "https://example.com" },
+    });
+
+    await startCrawl({ post } as any, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+
+    expect(post).toHaveBeenCalledWith("/v2/crawl", {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+  });
+
+  test("startCrawl omits ignoreRobotsTxt when not set", async () => {
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { success: true, id: "crawl-job", url: "https://example.com" },
+    });
+
+    await startCrawl({ post } as any, {
+      url: "https://example.com",
+    });
+
+    expect(post).toHaveBeenCalledWith("/v2/crawl", {
+      url: "https://example.com",
+    });
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,6 +28,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;


### PR DESCRIPTION
## Summary

`crawl()` and `startCrawl()` in the JS SDK silently dropped the `ignoreRobotsTxt` option: it is declared in `CrawlOptions` and supported by the API, but was never written into the request body. This wires the field into the crawl payload so it reaches `POST /v2/crawl`.

## Root cause

`prepareCrawlPayload()` in `apps/js-sdk/firecrawl/src/v2/methods/crawl.ts` builds the request body field by field. It has a line for `robotsUserAgent` but none for `ignoreRobotsTxt`, even though both were added to `CrawlOptions` together. `robotsUserAgent` had its own missing-payload line fixed in #3403; `ignoreRobotsTxt` sat on the adjacent line and was missed. Because the field was never copied into `data`, the request went out without it and the crawl behaved as if the option was never passed. The Python SDK forwards this field, so the two SDKs disagreed.

## Fix

Add one line forwarding `request.ignoreRobotsTxt` into the payload, placed next to `robotsUserAgent` and guarded by the same `!= null` check every sibling field uses. This keeps the `undefined` case out of the body (matching the existing pattern) rather than always sending the key. Version bumped to 4.29.3, matching the patch-bump convention of #3403.

## Test plan

Added `apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts` (mirroring `extract.unit.test.ts`): a mocked `HttpClient.post` captures the payload. One test asserts `ignoreRobotsTxt: true` reaches the `/v2/crawl` body; one asserts it is omitted when unset. The first test fails on the base branch (payload lacks the field) and passes with the fix.

```
$ NODE_OPTIONS=--experimental-vm-modules npx jest --verbose src/__tests__/unit/v2/crawl.unit.test.ts
PASS src/__tests__/unit/v2/crawl.unit.test.ts
  v2.crawl unit
    ok startCrawl forwards ignoreRobotsTxt in request payload
    ok startCrawl omits ignoreRobotsTxt when not set
Tests:       2 passed, 2 total
```

`npx tsup` builds cleanly (JS + DTS). `tsc --noEmit` reports no errors in the changed file; the 8 pre-existing errors in `feedback.ts`, `monitor.ts`, and `validation.ts` are present on the base branch and untouched here.

Fixes #3940


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward `ignoreRobotsTxt` in JS SDK crawl requests so `/v2/crawl` respects the option. Aligns behavior with the API and Python SDK; addresses #3940.

- **Bug Fixes**
  - Send `ignoreRobotsTxt` in the crawl payload when provided.
  - Add unit tests to verify the field is forwarded or omitted correctly.
  - Bump `@mendable/firecrawl-js` to 4.29.3.

<sup>Written for commit 24ccd73c507be6cd9e0ddc06440495cf9888bf6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

