### PR TITLE
feat(monitor): Enhance Slack monitor alerts with goal, URLs, and truncation

### DIFF
--- a/apps/api/src/services/integrations/slack/messages.ts
+++ b/apps/api/src/services/integrations/slack/messages.ts
@@ -9,7 +9,9 @@ export type MonitorSlackPage = {
 
 type MonitorSlackPayload = {
   monitorName: string;
+  monitorGoal?: string | null;
   dashboardUrl: string;
+  monitorUrl: string;
   checkId: string;
   summary: {
     changed: number;
@@ -28,10 +30,17 @@ const MAX_PAGE_BLOCKS = 8;
 // unbounded input we render, so bound them and clamp the assembled line.
 const SECTION_TEXT_LIMIT = 3000;
 const MAX_LINK_URL_LEN = 2000;
+// Truncate change descriptions so a single alert doesn't dominate the channel.
+const MAX_DESCRIPTION_LEN = 280;
+// Truncate the monitor goal so it stays compact at the top of the alert.
+const MAX_GOAL_LEN = 200;
 
 // Slack mrkdwn requires these three characters escaped in text spans.
 export function escapeSlackText(input: string): string {
-  return input.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function slackLink(url: string, label?: string): string {
@@ -53,6 +62,14 @@ function boundedPageLink(url: string): string {
 
 // Builds the change-detection alert posted to a channel. Returns both a
 // fallback `text` (for notifications/screen readers) and rich Block Kit blocks.
+//
+// Layout (top to bottom):
+//  1. Header: "Monitor <name> · Check <id>"
+//  2. Monitor goal in italics (if set)
+//  3. Per-page: URL link first, then truncated change description below
+//  4. Divider + summary tally
+//  5. "View in dashboard" button
+//  6. Check ID + credits context
 export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
   text: string;
   blocks: unknown[];
@@ -72,14 +89,26 @@ export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
       type: "header",
       text: {
         type: "plain_text",
-        text: `🔥 ${truncate(payload.monitorName, 140)}`,
+        text: `🔥 Monitor ${truncate(payload.monitorName, 100)} · Check ${truncate(payload.checkId, 24)}`,
         emoji: true,
       },
     },
   ];
 
-  // Headline each page with WHAT changed (the judged description). The page's
-  // status + URL becomes a small secondary context line beneath it.
+  // Monitor goal in italics at the top, linking to the monitor dashboard so the
+  // user can jump straight to the monitor page.
+  const goalText = payload.monitorGoal?.trim();
+  if (goalText) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `_${slackLink(payload.monitorUrl, truncate(escapeSlackText(goalText), MAX_GOAL_LEN))}_`,
+      },
+    });
+  }
+
+  // Per-page: URL link first (as a section headline), then description below.
   for (const page of shownPages) {
     const reason = page.judgment?.reason?.trim();
     const tag = page.judgment
@@ -87,26 +116,26 @@ export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
         ? " · _meaningful_"
         : " · _noise_"
       : "";
-    const meta = `${statusEmoji(page.status)} *${escapeSlackText(page.status)}* · ${boundedPageLink(page.url)}${tag}`;
+    const urlLine = `${statusEmoji(page.status)} ${boundedPageLink(page.url)}${tag}`;
+
+    // URL goes first as a section, description below as context.
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: truncate(urlLine, SECTION_TEXT_LIMIT),
+      },
+    });
 
     if (reason) {
       blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          // The change description leads; clamp only at Slack's hard limit.
-          text: truncate(escapeSlackText(reason), SECTION_TEXT_LIMIT),
-        },
-      });
-      blocks.push({
         type: "context",
-        elements: [{ type: "mrkdwn", text: truncate(meta, SECTION_TEXT_LIMIT) }],
-      });
-    } else {
-      // No judged description (e.g. unjudged monitor) — the page itself leads.
-      blocks.push({
-        type: "section",
-        text: { type: "mrkdwn", text: truncate(meta, SECTION_TEXT_LIMIT) },
+        elements: [
+          {
+            type: "mrkdwn",
+            text: truncate(escapeSlackText(reason), MAX_DESCRIPTION_LEN),
+          },
+        ],
       });
     }
   }
@@ -167,13 +196,13 @@ export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
     ],
   });
 
-  // Notification preview / fallback text also leads with the change itself.
+  // Notification preview / fallback text leads with the change itself.
   const leadReason =
     shownPages.find(p => p.judgment?.meaningful && p.judgment.reason)?.judgment
       ?.reason ?? shownPages.find(p => p.judgment?.reason)?.judgment?.reason;
   const text = leadReason
-    ? `${payload.monitorName}: ${truncate(leadReason.trim(), 280)}`
-    : `Monitor "${payload.monitorName}" detected activity: ${summary.changed} changed, ${summary.new} new, ${summary.removed} removed, ${summary.error} errors.`;
+    ? `Monitor ${payload.monitorName} (check ${payload.checkId}): ${truncate(leadReason.trim(), 280)}`
+    : `Monitor "${payload.monitorName}" (check ${payload.checkId}): ${summary.changed} changed, ${summary.new} new, ${summary.removed} removed, ${summary.error} errors.`;
 
   return { text, blocks };
 }

--- a/apps/api/src/services/integrations/slack/messages.ts
+++ b/apps/api/src/services/integrations/slack/messages.ts
@@ -103,7 +103,7 @@ export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `_${slackLink(payload.monitorUrl, truncate(escapeSlackText(goalText), MAX_GOAL_LEN))}_`,
+        text: `_${slackLink(payload.monitorUrl, truncate(goalText, MAX_GOAL_LEN))}_`,
       },
     });
   }
@@ -116,7 +116,7 @@ export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
         ? " · _meaningful_"
         : " · _noise_"
       : "";
-    const urlLine = `${statusEmoji(page.status)} ${boundedPageLink(page.url)}${tag}`;
+    const urlLine = `${statusEmoji(page.status)} *${escapeSlackText(page.status)}* · ${boundedPageLink(page.url)}${tag}`;
 
     // URL goes first as a section, description below as context.
     blocks.push({
@@ -201,7 +201,7 @@ export function buildMonitorAlertMessage(payload: MonitorSlackPayload): {
     shownPages.find(p => p.judgment?.meaningful && p.judgment.reason)?.judgment
       ?.reason ?? shownPages.find(p => p.judgment?.reason)?.judgment?.reason;
   const text = leadReason
-    ? `Monitor ${payload.monitorName} (check ${payload.checkId}): ${truncate(leadReason.trim(), 280)}`
+    ? `Monitor ${payload.monitorName} (check ${payload.checkId}): ${truncate(leadReason.trim(), MAX_DESCRIPTION_LEN)}`
     : `Monitor "${payload.monitorName}" (check ${payload.checkId}): ${summary.changed} changed, ${summary.new} new, ${summary.removed} removed, ${summary.error} errors.`;
 
   return { text, blocks };

--- a/apps/api/src/services/integrations/slack/slack.test.ts
+++ b/apps/api/src/services/integrations/slack/slack.test.ts
@@ -164,14 +164,29 @@ describe("slack message builder", () => {
     expect(text).toContain("Monitor Pricing <watch>");
     expect(text).toContain("check c1");
 
+    const typedBlocks = blocks as Array<Record<string, any>>;
     const serialized = JSON.stringify(blocks);
 
     // Header includes "Monitor" and the check ID.
     expect(serialized).toContain("Monitor Pricing");
     expect(serialized).toContain("Check c1");
 
-    // Goal appears in italics (mrkdwn with _..._ wrapping).
-    expect(serialized).toContain("Alert when the pricing page changes.");
+    // Goal block: second block, is a section with italic-wrapped link to
+    // monitorUrl (not dashboardUrl) and the goal text as the label.
+    const goalBlock = typedBlocks[1];
+    expect(goalBlock.type).toBe("section");
+    expect(goalBlock.text?.type).toBe("mrkdwn");
+    const goalMrkdwn = goalBlock.text.text as string;
+    // Italics markers present.
+    expect(goalMrkdwn.startsWith("_")).toBe(true);
+    expect(goalMrkdwn.endsWith("_")).toBe(true);
+    // Links to monitorUrl specifically (not dashboardUrl with ?checkId=).
+    expect(goalMrkdwn).toContain(
+      "<https://www.firecrawl.dev/app/monitoring/m1|",
+    );
+    expect(goalMrkdwn).not.toContain("checkId=c1");
+    // Goal text is the link label (escaped by slackLink, not double-escaped).
+    expect(goalMrkdwn).toContain("Alert when the pricing page changes.");
 
     // URL appears before the description in the blocks order.
     const urlIdx = serialized.indexOf("example.com/pricing");
@@ -180,11 +195,16 @@ describe("slack message builder", () => {
     expect(descIdx).toBeGreaterThan(-1);
     expect(urlIdx).toBeLessThan(descIdx);
 
+    // Per-page section includes bolded status text.
+    const pageSection = typedBlocks.find(
+      b =>
+        b.type === "section" && b.text?.text?.includes("example.com/pricing"),
+    );
+    expect(pageSection).toBeDefined();
+    expect(pageSection!.text.text).toContain("*changed*");
+
     // Dashboard button present.
     expect(serialized).toContain("View in dashboard");
-    // Goal links to the monitor page.
-    expect(serialized).toContain("/app/monitoring/m1");
-    expect(serialized).toContain("Alert when the pricing page changes.");
 
     // Meaningful tag present.
     expect(serialized).toContain("meaningful");
@@ -214,6 +234,37 @@ describe("slack message builder", () => {
     const second = typedBlocks[1];
     expect(second.type).toBe("section");
     expect(second.text?.text).not.toContain("monitoring/m1|");
+  });
+
+  it("truncates long monitor goals to ≤ MAX_GOAL_LEN with ellipsis", () => {
+    const longGoal = "g".repeat(300);
+    const { blocks } = buildMonitorAlertMessage({
+      monitorName: "m",
+      monitorGoal: longGoal,
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      monitorUrl: "https://www.firecrawl.dev/app/monitoring/m1",
+      checkId: "c1",
+      summary: { changed: 1, new: 0, removed: 0, error: 0, totalPages: 1 },
+      pages: [
+        {
+          url: "https://example.com",
+          status: "changed",
+          judgment: { meaningful: true, reason: "r" },
+        },
+      ],
+      creditsUsed: 1,
+    });
+    const typedBlocks = blocks as Array<Record<string, any>>;
+    const goalBlock = typedBlocks[1];
+    expect(goalBlock.type).toBe("section");
+    const goalMrkdwn = goalBlock.text.text as string;
+    // The label inside <url|label> should be truncated to 200 chars (including
+    // the trailing ellipsis that truncate() adds).
+    const labelMatch = goalMrkdwn.match(/\|([^>]+)>/);
+    expect(labelMatch).toBeDefined();
+    const label = labelMatch![1];
+    expect(label.length).toBeLessThanOrEqual(200);
+    expect(label).toMatch(/…$/);
   });
 
   it("truncates long change descriptions to keep the alert compact", () => {

--- a/apps/api/src/services/integrations/slack/slack.test.ts
+++ b/apps/api/src/services/integrations/slack/slack.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, afterEach } from "vitest";
 import { config } from "../../../config";
 import { encryptSlackToken, decryptSlackToken } from "./crypto";
 import { verifySlackSignature } from "./signature";
-import { buildMonitorAlertMessage, escapeSlackText, slackLink } from "./messages";
+import {
+  buildMonitorAlertMessage,
+  escapeSlackText,
+  slackLink,
+} from "./messages";
 import { sanitizeRedirectPath } from "./redirect";
 
 const ORIGINAL_ENCRYPTION_KEY = config.SLACK_TOKEN_ENCRYPTION_KEY;
@@ -16,9 +20,7 @@ afterEach(() => {
 
 describe("slack token crypto", () => {
   it("round-trips a token with AES-256-GCM when a key is configured", () => {
-    config.SLACK_TOKEN_ENCRYPTION_KEY = crypto
-      .randomBytes(32)
-      .toString("hex");
+    config.SLACK_TOKEN_ENCRYPTION_KEY = crypto.randomBytes(32).toString("hex");
     // Opaque placeholder — the crypto layer treats the token as bytes, and we
     // avoid real Slack bot-token shapes so secret scanners don't flag it.
     const token = "slack-bot-token-placeholder";
@@ -37,9 +39,7 @@ describe("slack token crypto", () => {
   });
 
   it("throws when a GCM token is read without its key", () => {
-    config.SLACK_TOKEN_ENCRYPTION_KEY = crypto
-      .randomBytes(32)
-      .toString("hex");
+    config.SLACK_TOKEN_ENCRYPTION_KEY = crypto.randomBytes(32).toString("hex");
     const stored = encryptSlackToken("bot-token-placeholder");
     config.SLACK_TOKEN_ENCRYPTION_KEY = undefined;
     expect(() => decryptSlackToken(stored)).toThrow();
@@ -142,10 +142,12 @@ describe("slack message builder", () => {
     expect(escapeSlackText("a & b < c > d")).toBe("a &amp; b &lt; c &gt; d");
   });
 
-  it("builds an alert with a header, summary, page rows and a dashboard button", () => {
+  it("builds an alert with Monitor + Check in header, goal in italics, URL above description, and a dashboard button", () => {
     const { text, blocks } = buildMonitorAlertMessage({
       monitorName: "Pricing <watch>",
+      monitorGoal: "Alert when the pricing page changes.",
       dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      monitorUrl: "https://www.firecrawl.dev/app/monitoring/m1",
       checkId: "c1",
       summary: { changed: 2, new: 1, removed: 0, error: 0, totalPages: 5 },
       pages: [
@@ -158,21 +160,99 @@ describe("slack message builder", () => {
       creditsUsed: 7,
     });
 
-    expect(text).toContain("Pricing <watch>");
+    // Fallback text includes Monitor + check ID.
+    expect(text).toContain("Monitor Pricing <watch>");
+    expect(text).toContain("check c1");
+
     const serialized = JSON.stringify(blocks);
-    expect(serialized).toContain("header");
+
+    // Header includes "Monitor" and the check ID.
+    expect(serialized).toContain("Monitor Pricing");
+    expect(serialized).toContain("Check c1");
+
+    // Goal appears in italics (mrkdwn with _..._ wrapping).
+    expect(serialized).toContain("Alert when the pricing page changes.");
+
+    // URL appears before the description in the blocks order.
+    const urlIdx = serialized.indexOf("example.com/pricing");
+    const descIdx = serialized.indexOf("Price changed");
+    expect(urlIdx).toBeGreaterThan(-1);
+    expect(descIdx).toBeGreaterThan(-1);
+    expect(urlIdx).toBeLessThan(descIdx);
+
+    // Dashboard button present.
     expect(serialized).toContain("View in dashboard");
-    expect(serialized).toContain("example.com/pricing");
-    // Header text is plain_text; the monitor name is not escaped there but the
-    // fallback text keeps it readable.
+    // Goal links to the monitor page.
+    expect(serialized).toContain("/app/monitoring/m1");
+    expect(serialized).toContain("Alert when the pricing page changes.");
+
+    // Meaningful tag present.
     expect(serialized).toContain("meaningful");
+  });
+
+  it("omits the goal section when no goal is set", () => {
+    const { blocks } = buildMonitorAlertMessage({
+      monitorName: "m",
+      monitorGoal: null,
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      monitorUrl: "https://www.firecrawl.dev/app/monitoring/m1",
+      checkId: "c1",
+      summary: { changed: 1, new: 0, removed: 0, error: 0, totalPages: 1 },
+      pages: [
+        {
+          url: "https://example.com",
+          status: "changed",
+          judgment: { meaningful: true, reason: "r" },
+        },
+      ],
+      creditsUsed: 1,
+    });
+    // Header is first, then the first section should be the page URL — no goal section.
+    const typedBlocks = blocks as Array<Record<string, any>>;
+    expect(typedBlocks[0].type).toBe("header");
+    // The next block should not be a goal section — it should be the page URL section.
+    const second = typedBlocks[1];
+    expect(second.type).toBe("section");
+    expect(second.text?.text).not.toContain("monitoring/m1|");
+  });
+
+  it("truncates long change descriptions to keep the alert compact", () => {
+    const longReason = "r".repeat(500);
+    const { blocks } = buildMonitorAlertMessage({
+      monitorName: "m",
+      monitorGoal: null,
+      dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      monitorUrl: "https://www.firecrawl.dev/app/monitoring/m1",
+      checkId: "c1",
+      summary: { changed: 1, new: 0, removed: 0, error: 0, totalPages: 1 },
+      pages: [
+        {
+          url: "https://example.com",
+          status: "changed",
+          judgment: { meaningful: true, reason: longReason },
+        },
+      ],
+      creditsUsed: 1,
+    });
+    // The description context block should be truncated (≤ 280 + ellipsis).
+    const contextBlocks = (blocks as Array<Record<string, any>>).filter(
+      b => b.type === "context",
+    );
+    const descBlock = contextBlocks.find(b =>
+      b.elements?.some((e: any) => e.text?.includes("r".repeat(50))),
+    );
+    expect(descBlock).toBeDefined();
+    const descText = descBlock!.elements[0].text;
+    expect(descText.length).toBeLessThanOrEqual(280);
   });
 
   it("bounds long page URLs so section blocks stay within Slack's 3000-char limit", () => {
     const longUrl = "https://example.com/" + "a".repeat(6000);
     const { blocks } = buildMonitorAlertMessage({
       monitorName: "m",
+      monitorGoal: null,
       dashboardUrl: "https://www.firecrawl.dev/app/monitoring/m1?checkId=c1",
+      monitorUrl: "https://www.firecrawl.dev/app/monitoring/m1",
       checkId: "c1",
       summary: { changed: 1, new: 0, removed: 0, error: 0, totalPages: 1 },
       pages: [
@@ -184,7 +264,6 @@ describe("slack message builder", () => {
       ],
       creditsUsed: 1,
     });
-
     const sections = (blocks as Array<Record<string, any>>).filter(
       b => b.type === "section" && b.text?.type === "mrkdwn",
     );

--- a/apps/api/src/services/notification/monitoring_slack.ts
+++ b/apps/api/src/services/notification/monitoring_slack.ts
@@ -114,6 +114,12 @@ export async function sendMonitoringSlackSummary(params: {
     checkId: params.check.id,
   });
 
+  // Monitor page URL (no checkId) — used by the "Edit goal" button.
+  const monitorUrl = buildMonitoringCheckDashboardUrl({
+    monitorId: params.monitor.id,
+    checkId: "",
+  }).replace(/\?checkId=$/, "");
+
   const slackPages: MonitorSlackPage[] = params.pages.map(page => ({
     url: page.url,
     status: page.status,
@@ -124,7 +130,9 @@ export async function sendMonitoringSlackSummary(params: {
 
   const { text, blocks } = buildMonitorAlertMessage({
     monitorName: params.monitor.name,
+    monitorGoal: params.monitor.goal,
     dashboardUrl,
+    monitorUrl,
     checkId: params.check.id,
     summary: {
       changed: params.check.changed_count,


### PR DESCRIPTION
Add monitorGoal and monitorUrl to Slack alert payloads and render the goal (italicized) under a revised header that includes “Monitor <name> · Check <id>”. Reorder blocks so page URL appears above the change description, clamp long descriptions and goals (280 and 200 chars respectively) and keep section text within Slack limits. Wire monitorUrl into the notifier and update tests to assert header, goal presence/omission, URL-before-description ordering, truncation behavior, and dashboard link. Small text/fallback tweaks to include check id in preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances Slack monitor alerts for clarity by adding a goal line under a revised header and reordering content so URLs lead. Also tightens truncation and formatting to keep posts compact and readable.

- **New Features**
  - Header: "Monitor <name> · Check <id>" with sensible truncation; fallback text includes the check ID.
  - Goal: italicized link to `monitorUrl` (not dashboard), omitted if missing, truncated to 200 chars without double-escaping.
  - Pages: URL section first with emoji and bold, escaped status; description moved to context below and truncated to 280 chars; URLs and sections stay within Slack limits.
  - Fallback + wiring: preview uses the 280-char clamp; "View in dashboard" button retained; notifier passes `monitorUrl`; tests assert goal block shape, link target, bold status, URL-before-description ordering, and truncation.

<sup>Written for commit 58ecf3bbd422efcec7fad4c6a82c402f07ad5a3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

