### PR TITLE
Update enterprise control management links

### DIFF
--- a/apps/api/src/lib/ip-restriction.ts
+++ b/apps/api/src/lib/ip-restriction.ts
@@ -155,7 +155,7 @@ export async function checkIpRestriction(
 
   return {
     allowed: false,
-    error: `Request blocked: IP address ${clientIp ? normalizeIp(clientIp) : "unknown"} is not on this team's allowed IP list. Team admins can manage allowed IPs at https://www.firecrawl.dev/app/settings?tab=advanced`,
+    error: `Request blocked: IP address ${clientIp ? normalizeIp(clientIp) : "unknown"} is not on this team's allowed IP list. Team admins can manage allowed IPs at https://www.firecrawl.dev/app/enterprise-controls?tab=ip-restriction`,
     status: 403,
   };
 }

--- a/apps/api/src/lib/key-restriction.ts
+++ b/apps/api/src/lib/key-restriction.ts
@@ -8,8 +8,7 @@ import type { TeamFlags } from "../controllers/v1/types";
 // Propagation delay for dashboard edits to key_restriction_config.
 const CONFIG_CACHE_TTL_SECONDS = 60;
 
-const MANAGE_RESTRICTIONS_URL =
-  "https://www.firecrawl.dev/app/settings?tab=advanced";
+const MANAGE_RESTRICTIONS_URL = "https://www.firecrawl.dev/app/api-keys";
 
 const configCacheKey = (apiKeyId: number) => `key-restriction:${apiKeyId}`;
 


### PR DESCRIPTION
## Summary
- Update IP restriction error guidance to link to the Enterprise Controls IP Restriction tab.
- Update key restriction error guidance to link to the API Keys page.

## Testing
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated restriction error guidance to point to the correct management pages. IP restriction errors now link to https://www.firecrawl.dev/app/enterprise-controls?tab=ip-restriction; key restriction errors now link to https://www.firecrawl.dev/app/api-keys.

<sup>Written for commit abba5d1e6fc452d6be5d6b0feab8882dacdf4cac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

