### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/docs/agent-quickstart/elixir.mdx
+++ b/docs/agent-quickstart/elixir.mdx
@@ -1,0 +1,182 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`:firecrawl` hex package) and the v2 OpenAPI spec. Function names are generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+{:firecrawl, "~> 1.8"}
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# or pass api_key per call
+{:ok, res} = Firecrawl.search_and_scrape([query: "example"], api_key: "fc-your-api-key")
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  sources: [:web, :news],
+  limit: 10,
+  scrape_options: [
+    formats: ["markdown"],
+    only_main_content: true
+  ]
+)
+```
+
+### Parameters
+
+- `query` — string (required). The search query. Use `site:example.com` to limit results to a domain.
+- `sources` — list of atoms, strings, or maps. Controls which sources are searched. Values: `:web`, `:news`, `:images`, or `%{type: "web" | "news" | "images"}`.
+- `categories` — list of atoms, strings, or maps. Filters results by category. Values: `:github`, `:research`, `:pdf`, or `%{type: ...}`.
+- `include_domains` — list of strings. Restrict results to these domains.
+- `exclude_domains` — list of strings. Exclude results from these domains.
+- `limit` — integer. Cap the number of results.
+- `tbs` — string. Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `location` — string. Localized results.
+- `country` — string. ISO 3166-1 alpha-2 country targeting (e.g. `"US"`).
+- `ignore_invalid_urls` — boolean. Drop URLs that cannot be scraped by other endpoints.
+- `timeout` — integer. Request timeout in milliseconds.
+- `scrape_options` — keyword list. Scrape each search result (see Scrape parameters for fields).
+- `enterprise` — list of strings. `["zdr"]` for Zero Data Retention, `["anon"]` for anonymized search.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    "links",
+    %{type: "json", prompt: "Extract plan names and prices."}
+  ],
+  only_main_content: true,
+  wait_for: 1000
+)
+```
+
+### Parameters
+
+- `url` — string (required). The page URL to scrape.
+- `formats` — list of format strings or format maps. Requested output formats.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`
+  - Format map fields: `type`, `prompt`, `schema`, `modes`, `tag`, `fullPage`, `quality`, `viewport`
+- `headers` — map. Custom HTTP request headers.
+- `include_tags` — list of strings. Include only specific HTML tags.
+- `exclude_tags` — list of strings. Exclude specific HTML tags.
+- `only_main_content` — boolean. Strip nav, footer, and other boilerplate.
+- `timeout` — integer. Timeout in milliseconds. Min 1000, default 60000, max 300000.
+- `wait_for` — integer. Wait for the page to render (milliseconds).
+- `mobile` — boolean. Use a mobile viewport.
+- `parsers` — list. File parsing controls (e.g. `"pdf"` or `%{type: "pdf", mode: "auto", maxPages: 5}`).
+- `actions` — list of action maps. Pre-scrape browser actions.
+  - `%{type: "wait", milliseconds: int}` or `%{type: "wait", selector: "..."}`
+  - `%{type: "click", selector: "...", all: bool}`
+  - `%{type: "write", text: "..."}` — click to focus input first.
+  - `%{type: "press", key: "..."}`
+  - `%{type: "scroll", direction: "up" | "down"}`
+  - `%{type: "scrape"}`
+  - `%{type: "executeJavascript", script: "..."}`
+  - `%{type: "pdf", format: "A4", landscape: bool, scale: float}`
+- `location` — keyword list with `country:` and `languages:`. Geo or language-aware scraping.
+- `skip_tls_verification` — boolean. Skip TLS verification.
+- `remove_base64_images` — boolean. Drop base64 images from markdown output.
+- `block_ads` — boolean. Ad and cookie popup blocking.
+- `proxy` — atom. Proxy mode. Values: `:basic`, `:enhanced`, `:auto`.
+- `max_age` — integer. Cached data up to a maximum age (milliseconds).
+- `min_age` — integer. Cached data only if at least this old (milliseconds).
+- `store_in_cache` — boolean. Cache the result.
+- `lockdown` — boolean. Only serve cached results, never make outbound requests.
+- `redact_pii` — boolean. Redact personally identifiable information.
+- `zero_data_retention` — boolean. Enable zero data retention.
+- `profile` — keyword list with `name:` and optional `save_changes:`. Persistent browser profile.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code-based control of the browser session tied to a scrape job. The Elixir SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
+  "<scrapeJobId>",
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+```
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])`
+
+```elixir
+{:ok, res} = Firecrawl.stop_interactive_scrape_browser_session("<scrapeJobId>")
+```
+
+### Parameters
+
+- `job_id` — string (required). The scrape job ID.
+- `code` — string (required). Code to run in the browser session.
+- `language` — atom or string. Runtime language. Values: `:python`, `:node`, `:bash`. Use `:node` for JavaScript.
+- `timeout` — integer. Execution timeout in seconds.
+
+## Notes
+
+- The Elixir client is OpenAPI-generated; function names and parameter keys come from the spec.
+- Each public function has a bang (`!`) variant that raises on error instead of returning `{:error, _}`.
+- This SDK exposes code-based interactions only (no `prompt` parameter on `interact_with_scrape_browser_session`).
+- All functions accept a trailing `opts` keyword list with `:api_key` and `:base_url` overrides.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/java.mdx
+++ b/docs/agent-quickstart/java.mdx
@@ -1,0 +1,206 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-java`) and the v2 OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.11.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.11.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+- `client.search(query)` → `SearchData`
+- `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+
+SearchOptions options = SearchOptions.builder()
+    .sources(List.of("web", "news"))
+    .limit(10)
+    .scrapeOptions(
+        ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .onlyMainContent(true)
+            .build()
+    )
+    .build();
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries", options);
+List<Map<String, Object>> web = results.getWeb();
+```
+
+### Parameters
+
+- `query` — String (required). The search query. Use `site:example.com` to limit results to a domain.
+- `options.sources` — `List` of source strings or maps. Controls which result buckets are populated. Values: `"web"`, `"news"`, `"images"`.
+- `options.categories` — `List` of category strings or maps. Filters results by category. Values: `"github"`, `"research"`, `"pdf"`.
+- `options.includeDomains` — `List<String>`. Restrict results to these domains.
+- `options.excludeDomains` — `List<String>`. Exclude results from these domains.
+- `options.limit` — Integer. Cap the number of results.
+- `options.tbs` — String. Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `options.location` — String. Localized results.
+- `options.ignoreInvalidURLs` — Boolean. Drop URLs that cannot be scraped by other endpoints.
+- `options.timeout` — Integer. Request timeout in milliseconds.
+- `options.scrapeOptions` — `ScrapeOptions`. Scrape each search result (see Scrape parameters for fields).
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+- `client.scrape(url)` → `Document`
+- `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
+
+ScrapeOptions options = ScrapeOptions.builder()
+    .formats(List.of(
+        "markdown",
+        "links",
+        JsonFormat.builder().prompt("Extract plan names and prices.").build()
+    ))
+    .onlyMainContent(true)
+    .waitFor(1000)
+    .build();
+
+Document doc = client.scrape("https://example.com/pricing", options);
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+- `url` — String (required). The page URL to scrape.
+- `options.formats` — `List` of format strings or format maps. Requested output formats.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Format object fields: `type`, `prompt`, `schema`, `modes`, `tag`, `fullPage`, `quality`, `viewport`, `selectors`
+  - Use `JsonFormat.builder()` for JSON extraction.
+- `options.headers` — `Map<String, String>`. Custom HTTP request headers.
+- `options.includeTags` — `List<String>`. Include only specific HTML tags.
+- `options.excludeTags` — `List<String>`. Exclude specific HTML tags.
+- `options.onlyMainContent` — Boolean. Strip nav, footer, and other boilerplate.
+- `options.timeout` — Integer. Timeout in milliseconds.
+- `options.waitFor` — Integer. Wait for the page to render (milliseconds).
+- `options.mobile` — Boolean. Use a mobile viewport.
+- `options.parsers` — `List<Object>`. File parsing controls (e.g. `"pdf"` or `Map.of("type", "pdf", "maxPages", 5)`).
+- `options.actions` — `List<Map<String, Object>>`. Pre-scrape browser actions. Types: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `screenshot`, `executeJavascript`, `pdf`.
+- `options.location` — `LocationConfig`. Geo or language-aware scraping.
+- `options.skipTlsVerification` — Boolean. Skip TLS verification.
+- `options.removeBase64Images` — Boolean. Drop base64 images from markdown output.
+- `options.blockAds` — Boolean. Ad and cookie popup blocking.
+- `options.proxy` — String. Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL.
+- `options.maxAge` — Long. Cached data up to a maximum age (milliseconds).
+- `options.storeInCache` — Boolean. Cache the result.
+- `options.lockdown` — Boolean. Only serve cached results, never make outbound requests.
+- `options.redactPII` — Boolean. Redact personally identifiable information.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code-based control of the browser session tied to a scrape job. The Java SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` — uses default language `"node"`
+- `client.interact(jobId, code, language, timeout)` — `timeout` is seconds (1–300), null uses API default (30s)
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+BrowserExecuteResponse result = client.interact(
+    "<scrapeJobId>",
+    "console.log(await page.title());",
+    "node",
+    60
+);
+
+System.out.println(result.getStdout());
+```
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` → `BrowserDeleteResponse`
+
+```java
+import com.firecrawl.models.BrowserDeleteResponse;
+
+BrowserDeleteResponse stopped = client.stopInteractiveBrowser("<scrapeJobId>");
+```
+
+### Parameters
+
+- `jobId` — String (required). The scrape job ID.
+- `code` — String (required). Code to run in the browser session.
+- `language` — String. Runtime language. Values: `"python"`, `"node"`, `"bash"`. Default: `"node"`.
+- `timeout` — Integer. Execution timeout in seconds (1–300). Null uses the API default.
+
+## Notes
+
+- The Java SDK does not support `prompt`-based interactions — use `code` only.
+- Deprecated aliases: `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- `SearchData` result buckets are accessed via `getWeb()`, `getNews()`, `getImages()` — each is `List<Map<String, Object>>` and may be null.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/node.mdx
+++ b/docs/agent-quickstart/node.mdx
@@ -1,0 +1,204 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`@mendable/firecrawl-js`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+  // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL env var or cloud default
+});
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  sources: ["web", "news"],
+  limit: 10,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true,
+  },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
+
+### Parameters
+
+- `query` — string (required). The search query. Use `site:example.com` to limit results to a domain.
+- `options.sources` — array of `"web" | "news" | "images"` or `{ type: "web" | "news" | "images" }`. Controls which result buckets are populated.
+- `options.categories` — array of `"github" | "research" | "pdf"` or `{ type: ... }`. Filters results by category.
+- `options.includeDomains` — `string[]`. Restrict results to these domains. Cannot combine with `excludeDomains`.
+- `options.excludeDomains` — `string[]`. Exclude results from these domains. Cannot combine with `includeDomains`.
+- `options.limit` — number. Cap the number of results. Must be positive.
+- `options.tbs` — string. Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `options.location` — string. Localized results (e.g. `"San Francisco,California,United States"`).
+- `options.ignoreInvalidURLs` — boolean. Drop URLs that cannot be scraped by other endpoints.
+- `options.timeout` — number. Request timeout in milliseconds. Must be positive.
+- `options.scrapeOptions` — `ScrapeOptions`. Scrape each search result (see Scrape parameters for fields).
+- `options.enterprise` — `Array<"default" | "anon" | "zdr">`. Enterprise options. `"zdr"` = Zero Data Retention, `"anon"` = anonymized search.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    "links",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+  waitFor: 1000,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+- `url` — string (required). The page URL to scrape.
+- `options.formats` — array of format strings or format objects. Requested output formats.
+  - Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Object-only formats (require at least `type`):
+    - `{ type: "json", prompt?: string, schema?: object | ZodSchema }` — at least one of `prompt` or `schema` required. `"json"` as a plain string is rejected by the SDK.
+    - `{ type: "question", question: string }` — question-answer extraction.
+    - `{ type: "highlights", query: string }` — relevant source-text extraction.
+    - `{ type: "screenshot", fullPage?: boolean, quality?: number, viewport?: { width, height } }`
+    - `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?: object, prompt?: string, tag?: string }` — `modes` is required.
+    - `{ type: "attributes", selectors: Array<{ selector: string, attribute: string }> }`
+- `options.headers` — `Record<string, string>`. Custom HTTP request headers.
+- `options.includeTags` — `string[]`. Include only specific HTML tags.
+- `options.excludeTags` — `string[]`. Exclude specific HTML tags.
+- `options.onlyMainContent` — boolean. Strip nav, footer, and other boilerplate.
+- `options.timeout` — number. Timeout in milliseconds.
+- `options.waitFor` — number. Wait for the page to render (milliseconds).
+- `options.mobile` — boolean. Use a mobile viewport.
+- `options.parsers` — array. File parsing controls (e.g. `"pdf"` or `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`).
+- `options.actions` — array of action objects. Pre-scrape browser actions.
+  - `{ type: "wait", milliseconds?: number, selector?: string }`
+  - `{ type: "click", selector: string }`
+  - `{ type: "write", text: string }` — click to focus input first.
+  - `{ type: "press", key: string }`
+  - `{ type: "scroll", direction: "up" | "down", selector?: string }`
+  - `{ type: "scrape" }`
+  - `{ type: "screenshot", fullPage?: boolean, quality?: number, viewport?: object }`
+  - `{ type: "executeJavascript", script: string }`
+  - `{ type: "pdf", format?: string, landscape?: boolean, scale?: number }`
+- `options.location` — `{ country?: string, languages?: string[] }`. Geo or language-aware scraping.
+- `options.skipTlsVerification` — boolean. Skip TLS verification.
+- `options.removeBase64Images` — boolean. Drop base64 images from markdown output.
+- `options.fastMode` — boolean. Faster scrapes with reduced fidelity.
+- `options.blockAds` — boolean. Ad and cookie popup blocking.
+- `options.proxy` — `"basic" | "stealth" | "enhanced" | "auto"` or a custom proxy URL string.
+- `options.maxAge` — number. Cached data up to a maximum age (milliseconds).
+- `options.minAge` — number. Cached data only if at least this old (milliseconds).
+- `options.storeInCache` — boolean. Cache the result.
+- `options.lockdown` — boolean. Only serve cached results, never make outbound requests.
+- `options.redactPII` — `boolean | { mode?: "accurate" | "aggressive" | "fast", entities?: string[], replaceStyle?: "tag" | "mask" | "remove" }`. PII redaction.
+- `options.profile` — `{ name: string, saveChanges?: boolean }`. Persistent browser profile.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrapeId`). At least one of `code` or `prompt` is required. For flows beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId from scrape response");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+
+// Or with code:
+const codeResult = await client.interact(jobId, {
+  code: "console.log(await page.title());",
+  language: "node",
+  timeout: 60,
+});
+```
+
+### Stop session
+
+`client.stopInteraction(jobId)` → `Promise<ScrapeBrowserDeleteResponse>`
+
+### Parameters
+
+- `jobId` — string (required). The scrape job ID from `document.metadata.scrapeId`.
+- `args.code` — string. Code to run in the browser session (e.g. Playwright `page` usage).
+- `args.prompt` — string. Natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty (SDK throws otherwise).
+- `args.language` — `"python" | "node" | "bash"`. Runtime language. Default: `"node"`.
+- `args.timeout` — number. Execution timeout in seconds.
+
+## Notes
+
+- Deprecated client aliases: `scrapeUrl` → `scrape`; `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- The package declares **Node.js >= 22** in `engines`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json`
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/python.mdx
+++ b/docs/agent-quickstart/python.mdx
@@ -1,0 +1,203 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py`) and the v2 OpenAPI spec. Method names, parameters, and types match the v2 client in `firecrawl/v2/client.py`.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```py
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+# client = Firecrawl(api_key="fc-...", api_url="https://api.firecrawl.dev")
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```py
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    sources=["web", "news"],
+    limit=10,
+    scrape_options=ScrapeOptions(
+        formats=["markdown"],
+        only_main_content=True,
+    ),
+)
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
+
+### Parameters
+
+- `query` — str (required). The search query. Use `site:example.com` to limit results to a domain.
+- `sources` — list of `"web" | "news" | "images"` or `Source(type=...)` objects. Controls which result buckets are populated.
+- `categories` — list of `"github" | "research" | "pdf"` or `Category(type=...)` objects. Filters results by category.
+- `include_domains` — list of str. Restrict results to these domains. Cannot combine with `exclude_domains`.
+- `exclude_domains` — list of str. Exclude results from these domains. Cannot combine with `include_domains`.
+- `limit` — int. Cap the number of results. Default: `5`.
+- `tbs` — str. Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `location` — str. Localized results (e.g. `"San Francisco,California,United States"`). Note: this is a plain string, not the `Location` model used in scrape.
+- `ignore_invalid_urls` — bool. Drop URLs that cannot be scraped by other endpoints.
+- `timeout` — int. Request timeout in milliseconds. Default: `300000`.
+- `scrape_options` — `ScrapeOptions`. Scrape each search result (see Scrape parameters for fields).
+- `enterprise` — list of str. `["zdr"]` for Zero Data Retention, `["anon"]` for anonymized search.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```py
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        "links",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+    wait_for=1000,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+- `url` — str (required). The page URL to scrape.
+- `formats` — list of format strings or format dicts. Requested output formats.
+  - Plain strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Object-only formats (use a dict, not the plain string `"json"`):
+    - `{"type": "json", "prompt": "...", "schema": {...}}` — at least one of `prompt` or `schema` required.
+    - `{"type": "question", "question": "..."}`
+    - `{"type": "highlights", "query": "..."}`
+    - `{"type": "screenshot", "full_page": bool, "quality": int, "viewport": {"width": int, "height": int}}`
+    - `{"type": "changeTracking", "modes": ["git-diff" | "json"], "schema": ..., "prompt": ..., "tag": ...}` — `modes` is required.
+    - `{"type": "attributes", "selectors": [{"selector": "...", "attribute": "..."}]}`
+- `headers` — dict of str to str. Custom HTTP request headers.
+- `include_tags` — list of str. Include only specific HTML tags.
+- `exclude_tags` — list of str. Exclude specific HTML tags.
+- `only_main_content` — bool. Strip nav, footer, and other boilerplate.
+- `timeout` — int. Timeout in milliseconds.
+- `wait_for` — int. Wait for the page to render (milliseconds).
+- `mobile` — bool. Use a mobile viewport.
+- `parsers` — list. File parsing controls (e.g. `"pdf"` or `{"type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": int}`).
+- `actions` — list of action dicts. Pre-scrape browser actions.
+  - `{"type": "wait", "milliseconds": int}` or `{"type": "wait", "selector": "..."}`
+  - `{"type": "click", "selector": "..."}`
+  - `{"type": "write", "text": "..."}` — click to focus input first.
+  - `{"type": "press", "key": "..."}`
+  - `{"type": "scroll", "direction": "up" | "down", "selector": "..."}`
+  - `{"type": "scrape"}`
+  - `{"type": "screenshot", "full_page": bool, "quality": int, "viewport": dict}`
+  - `{"type": "executeJavascript", "script": "..."}`
+  - `{"type": "pdf", "format": "A4", "landscape": bool, "scale": float}`
+- `location` — dict with `country` and `languages` (e.g. `{"country": "US", "languages": ["en-US"]}`).
+- `skip_tls_verification` — bool. Skip TLS verification.
+- `remove_base64_images` — bool. Drop base64 images from markdown output.
+- `fast_mode` — bool. Faster scrapes with reduced fidelity.
+- `block_ads` — bool. Ad and cookie popup blocking.
+- `proxy` — str. Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`.
+- `max_age` — int. Cached data up to a maximum age (milliseconds).
+- `store_in_cache` — bool. Cache the result.
+- `lockdown` — bool. Only serve cached results, never make outbound requests.
+- `redact_pii` — `bool | RedactPIIOptions`. PII redaction.
+- `profile` — dict with `name` and optional `save_changes` (e.g. `{"name": "my-session", "save_changes": True}`).
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. At least one of `code` or `prompt` is required. `prompt` is keyword-only.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+### Example
+
+```py
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id from scrape response")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+
+# Or with code:
+code_result = client.interact(
+    job_id,
+    code="print(await page.title())",
+    language="python",
+    timeout=60,
+)
+```
+
+### Stop session
+
+`client.stop_interaction(job_id)` → `BrowserDeleteResponse`
+
+### Parameters
+
+- `job_id` — str (required). The scrape job ID from `document.metadata.scrape_id`.
+- `code` — str. Code to run in the browser session (positional, optional if `prompt` is set).
+- `prompt` — str (keyword-only). Natural-language instruction for the browser agent (optional if `code` is set).
+- `language` — `"python" | "node" | "bash"`. Runtime language. Default: `"node"`.
+- `timeout` — int. Execution timeout in seconds (1–300).
+
+## Notes
+
+- Deprecated aliases: `scrape_url` → `scrape`; `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- `AsyncFirecrawl` (aliased as `AsyncFirecrawlApp`) is available for async usage with the same method signatures.
+- `ScrapeOptions` passed as `scrape_options` to `client.search` supports an additional `min_age` parameter not available on `client.scrape` directly.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/pyproject.toml`
+- `firecrawl/apps/python-sdk/firecrawl/__init__.py`
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/methods/search.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/methods/scrape.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs/agent-quickstart/rust.mdx
+++ b/docs/agent-quickstart/rust.mdx
@@ -1,0 +1,204 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate) and the v2 OpenAPI spec.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, SearchSource, ScrapeOptions, Format};
+
+let options = SearchOptions {
+    sources: Some(vec![SearchSource::Web, SearchSource::News]),
+    limit: Some(10),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        only_main_content: Some(true),
+        ..Default::default()
+    }),
+    ..Default::default()
+};
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", options)
+    .await?;
+```
+
+### Parameters
+
+- `query` — `impl AsRef<str>` (required). The search query. Use `site:example.com` to limit results to a domain.
+- `options.sources` — `Vec<SearchSource>`. Controls which result buckets are populated. Values: `Web`, `News`, `Images`.
+- `options.categories` — `Vec<SearchCategory>`. Filters results by category. Values: `Github`, `Research`, `Pdf`.
+- `options.include_domains` — `Vec<String>`. Restrict results to these domains.
+- `options.exclude_domains` — `Vec<String>`. Exclude results from these domains.
+- `options.limit` — `u32`. Cap the number of results. Default: 5, max: 20.
+- `options.tbs` — `String`. Time-based filter (e.g. `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+- `options.location` — `String`. Localized results.
+- `options.ignore_invalid_urls` — `bool`. Drop URLs that cannot be scraped by other endpoints.
+- `options.timeout` — `u32`. Request timeout in milliseconds.
+- `options.scrape_options` — `ScrapeOptions`. Scrape each search result (see Scrape parameters for fields).
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Links, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".to_string()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        wait_for: Some(1000),
+        ..Default::default()
+    })
+    .await?;
+```
+
+### Parameters
+
+- `url` — `impl AsRef<str>` (required). The page URL to scrape.
+- `options.formats` — `Vec<Format>`. Requested output formats. Values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`.
+- `options.headers` — `HashMap<String, String>`. Custom HTTP request headers.
+- `options.include_tags` — `Vec<String>`. Include only specific HTML tags.
+- `options.exclude_tags` — `Vec<String>`. Exclude specific HTML tags.
+- `options.only_main_content` — `bool`. Strip nav, footer, and other boilerplate.
+- `options.timeout` — `u32`. Timeout in milliseconds.
+- `options.wait_for` — `u32`. Wait for the page to render (milliseconds).
+- `options.mobile` — `bool`. Use a mobile viewport.
+- `options.parsers` — `Vec<ParserConfig>`. File parsing controls. Values: `ParserConfig::Simple("pdf")` or `ParserConfig::Pdf { parser_type, max_pages }`.
+- `options.actions` — `Vec<Action>`. Pre-scrape browser actions. Types: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `Screenshot`, `ExecuteJavascript`, `Pdf`.
+- `options.location` — `LocationConfig`. Geo or language-aware scraping. Fields: `country`, `languages`.
+- `options.skip_tls_verification` — `bool`. Skip TLS verification.
+- `options.remove_base64_images` — `bool`. Drop base64 images from markdown output.
+- `options.fast_mode` — `bool`. Faster scrapes with reduced fidelity.
+- `options.block_ads` — `bool`. Ad and cookie popup blocking.
+- `options.proxy` — `ProxyType`. Proxy mode. Values: `Basic`, `Stealth`, `Enhanced`, `Auto`.
+- `options.max_age` — `u32`. Cached data up to a maximum age (milliseconds).
+- `options.min_age` — `u32`. Cached data only if at least this old (milliseconds).
+- `options.store_in_cache` — `bool`. Cache the result.
+- `options.lockdown` — `bool`. Only serve cached results, never make outbound requests.
+- `options.redact_pii` — `bool`. Redact personally identifiable information.
+- `options.profile` — `ProfileConfig`. Persistent browser profile. Fields: `name`, `save_changes`.
+- `options.json_options` — `JsonOptions`. Configure JSON extraction. Fields: `schema`, `system_prompt`, `prompt`.
+- `options.screenshot_options` — `ScreenshotOptions`. Configure screenshot output. Fields: `full_page`, `quality`, `viewport`.
+- `options.change_tracking_options` — `ChangeTrackingOptions`. Configure change tracking. Fields: `modes` (`GitDiff` or `Json`), `schema`, `prompt`, `tag`.
+- `options.attribute_selectors` — `Vec<AttributeSelector>`. Attribute extraction. Fields: `selector`, `attribute`.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. At least one of `code` or `prompt` must be non-empty; otherwise the SDK returns `FirecrawlError::Misuse`.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+
+let result = client
+    .interact(
+        "<scrapeJobId>",
+        ScrapeExecuteOptions {
+            prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+// Or with code:
+let code_result = client
+    .interact(
+        "<scrapeJobId>",
+        ScrapeExecuteOptions {
+            code: Some("console.log(await page.title());".to_string()),
+            language: Some(ScrapeExecuteLanguage::Node),
+            timeout: Some(60),
+            ..Default::default()
+        },
+    )
+    .await?;
+```
+
+### Stop session
+
+```rust
+let stopped = client.stop_interaction("<scrapeJobId>").await?;
+```
+
+### Parameters
+
+- `job_id` — `impl AsRef<str>` (required). The scrape job ID.
+- `options.code` — `Option<String>`. Code to run in the browser session.
+- `options.prompt` — `Option<String>`. Natural-language instruction for the browser agent.
+- `options.language` — `ScrapeExecuteLanguage`. Runtime language. Values: `Python`, `Node`, `Bash`. Default: `Node`.
+- `options.timeout` — `u32`. Execution timeout in seconds.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- `ScrapeOptions` uses dedicated sub-option structs (`json_options`, `screenshot_options`, `change_tracking_options`) rather than embedding config in format objects.
+- `search_and_scrape(query, limit)` is a convenience helper that calls `search` with default `ScrapeOptions` and returns `Vec<Document>`.
+- v2 SDK exports all types at the crate root: `use firecrawl::Client` (not `use firecrawl::v2::Client`).
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/lib.rs`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language (Node.js, Python, Rust, Java, Elixir) under `docs/agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with confirmed parameters, realistic examples, and migration notes
- Generated from SDK source code and the v2 OpenAPI spec — no invented parameters or behaviors

## Details

Each quickstart follows a consistent structure:
- **Install** — exact package install command
- **Authenticate** — minimal auth example
- **When To Use What** — decision guide for search vs scrape vs interact
- **Search / Scrape / Interact** — each with: why to use it, preferred SDK method, working example, and complete parameter reference
- **Notes** — language-specific caveats, deprecated aliases, SDK quirks
- **Source Of Truth** — exact source files used

Parameters were cross-referenced against:
1. SDK source code (primary authority)
2. v2 OpenAPI spec (`firecrawl-docs/api-reference/v2-openapi.json`)
3. Existing `agent-source-of-truth/` docs (secondary reference only)

New parameters confirmed in current SDK source but absent from existing source-of-truth docs have been included: `lockdown`, `redactPII`, `includeDomains`/`excludeDomains`, `enterprise`, and others.

## Note on target repository

These files are intended for the `firecrawl-docs` repo under `agent-quickstart/`. Write access to `firecrawl-docs` was unavailable during this automated session (GitHub integration returned 403). The files are placed under `docs/agent-quickstart/` here as a staging area — they should be moved to `firecrawl-docs/agent-quickstart/` before merging.

## Test plan

- [ ] Verify each quickstart renders correctly as a Mintlify docs page
- [ ] Spot-check parameter lists against current SDK source
- [ ] Move files to `firecrawl-docs` repo before final merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVEtEUrNY4VKKzZBrFgwCg)_