### PR TITLE
fix(posthog): detect CLI surface via integration, not just origin

### DIFF
--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -202,6 +202,7 @@ export async function logRequest(request: LoggedRequest) {
     trackFirstSurfaceUse({
       teamId: request.team_id,
       origin: request.origin,
+      integration: request.integration,
       kind: request.kind,
       apiVersion: request.api_version,
       apiKeyId: request.api_key_id,

--- a/apps/api/src/services/posthog.ts
+++ b/apps/api/src/services/posthog.ts
@@ -48,7 +48,7 @@ function capturePostHog(
   })();
 }
 
-/** Normalized request surface, derived from the free-form `origin` field. */
+/** Normalized request surface, derived from the `origin` + `integration` fields. */
 type RequestSurface =
   | "playground"
   | "sdk"
@@ -59,18 +59,27 @@ type RequestSurface =
   | "other";
 
 /**
- * Map the free-form `origin` request field to a coarse surface category.
+ * Map a request's `origin` + `integration` fields to a coarse surface category.
  *
- * `origin` is client-set (defaults to "api"); these are the values observed in
- * practice. NOTE: confirm the exact strings sent by firecrawl-mcp and
- * firecrawl-cli — adjust the prefixes below if they differ.
+ * Both are client-set. `origin` (defaults to "api") carries the SDK
+ * (`*-sdk@ver`, `api-sdk`), MCP (`mcp` / `mcp-fastmcp`), playground (`website`),
+ * and `monitor`. The CLI is the exception: it sets `integration: "cli"` on every
+ * command but leaves `origin` at the "api" default on its high-volume commands
+ * (scrape/crawl/search/map/agent/parse/browser) — only feedback/interact/
+ * search-feedback also set `origin: "cli"`. So CLI must be detected via
+ * `integration`, or the bulk of CLI traffic is miscounted as `api`. (Verified
+ * against firecrawl/cli.)
  */
-function originToSurface(origin?: string | null): RequestSurface {
+function originToSurface(
+  origin?: string | null,
+  integration?: string | null,
+): RequestSurface {
   const o = (origin ?? "").toLowerCase();
+  const i = (integration ?? "").toLowerCase();
+  if (i === "cli" || o === "cli") return "cli";
   if (o === "website" || o.includes("playground")) return "playground";
   if (o.startsWith("mcp")) return "mcp";
-  if (o.startsWith("cli") || o.includes("firecrawl-cli")) return "cli";
-  if (o.includes("sdk")) return "sdk"; // e.g. "api-sdk"
+  if (o.includes("sdk")) return "sdk"; // e.g. "api-sdk", "js-sdk@x"
   if (o.startsWith("monitor")) return "monitor";
   if (o === "api") return "api";
   return "other";
@@ -128,11 +137,12 @@ async function resolveDistinctId(
 export function trackFirstSurfaceUse(args: {
   teamId: string;
   origin?: string | null;
+  integration?: string | null;
   kind: string;
   apiVersion: string;
   apiKeyId?: number | null;
 }): void {
-  const { teamId, origin, kind, apiVersion, apiKeyId } = args;
+  const { teamId, origin, integration, kind, apiVersion, apiKeyId } = args;
 
   // No PostHog key → capture is a no-op. Bail BEFORE the Redis SETNX so we don't
   // burn the dedup marker without emitting (which would lose the milestone for
@@ -144,7 +154,7 @@ export function trackFirstSurfaceUse(args: {
 
   void (async () => {
     try {
-      const surface = originToSurface(origin);
+      const surface = originToSurface(origin, integration);
       const key = `firecrawl:surface_first:${teamId}:${surface}`;
       // SET key 1 NX → "OK" only the very first time; null otherwise. Atomic.
       const isFirst = await redisEvictConnection.set(key, "1", "NX");
@@ -157,6 +167,7 @@ export function trackFirstSurfaceUse(args: {
       capturePostHog("api_surface_first_used", distinctId, {
         surface,
         raw_origin: origin ?? null,
+        raw_integration: integration ?? null,
         kind,
         api_version: apiVersion,
         team_id: teamId,


### PR DESCRIPTION
## Problem

`originToSurface()` in `apps/api/src/services/posthog.ts` classifies each request into a surface (playground/sdk/mcp/cli/api/monitor/other) for the `api_surface_first_used` milestone, but it looks at **`origin` only**. The firecrawl CLI identifies itself via **`integration: "cli"`**, and on its high-volume commands (scrape/crawl/search/map/agent/parse/browser) it leaves `origin` at the `"api"` default — only `feedback`/`interact`/`search-feedback` also set `origin: "cli"`.

Result: the bulk of CLI traffic is bucketed as `api`, so the CLI milestone is badly undercounted (the function's own comment even flagged "confirm the exact strings sent by firecrawl-cli").

## Fix

- `originToSurface(origin, integration)` now takes both fields and checks `integration === "cli"` first.
- Thread `request.integration` through `trackFirstSurfaceUse` and the `log_job` caller.
- Emit `raw_integration` on the event for debuggability.
- Drop the speculative `firecrawl-cli` origin match — no client sends that as an origin (it only appears as a config-dir path and in this function's old guess).

Verified against `firecrawl/cli` command sources: all 16 commands set `integration: "cli"`; only 3 also set `origin: "cli"`. Other surfaces are correctly origin-based (SDKs `*-sdk@ver`/`api-sdk`, MCP `mcp`/`mcp-fastmcp`, playground `website`, monitor `monitor`).

Scope: internal analytics classification only — no request-handling behavior changes. Single caller (`log_job`), no tests reference the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
