### PR TITLE
fix(api): harden NuQ worker lease lifecycle

### DIFF
--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -93,6 +93,7 @@ describeIf("NuQ FDB core", () => {
 
     const taken = await takeAll(queue, 1);
     expect(taken.length).toBe(1);
+    expect(taken[0].backend).toBe("fdb");
     expect(taken[0].id).toBe(id);
     expect(taken[0].lock).toBeDefined();
     expect(taken[0].data.url).toBe("https://example.com");
@@ -101,6 +102,7 @@ describeIf("NuQ FDB core", () => {
     expect(ok).toBe(true);
 
     const job = await queue.getJob(id);
+    expect(job?.backend).toBe("fdb");
     expect(job?.status).toBe("completed");
     if (expectInlineReturnvalue) {
       expect(job?.returnvalue).toEqual({ result: "yay" });
@@ -421,7 +423,9 @@ describeIf("NuQ FDB core", () => {
     let j = await queue.getJob(id);
     expect(j?.status).toBe("queued");
 
-    // worker that lost its lease can no longer finish
+    // Worker that lost its lease can neither renew nor finish. The conflictful
+    // renewal read also enforces this when renewal races the sweeper commit.
+    expect(await queue.renewLock(id, job.lock!)).toBe(false);
     expect(await queue.jobFinish(id, job.lock!, null)).toBe(false);
 
     // stall it to death

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -85,12 +85,16 @@ describeIf("NuQ router (forced FDB mode)", () => {
     expect(backloggedCount).toBe(0);
 
     const wait = scrapeQueue.waitForJob(jobId, 15_000);
+    const operation = { timeoutMs: 5_000 };
+    const takeSpy = vi.spyOn(scrapeQueueFdb, "getJobToProcess");
+    const renewSpy = vi.spyOn(scrapeQueueFdb, "renewLock");
+    const finishSpy = vi.spyOn(scrapeQueueFdb, "jobFinish");
 
     // routed take must find the FDB job without ever polling PG (no PG here)
     let taken: any = null;
     for (let i = 0; i < 10 && !taken; i++) {
       try {
-        taken = await scrapeQueue.getJobToProcess();
+        taken = await scrapeQueue.getJobToProcess(undefined, operation);
       } catch {
         // PG fallback poll can throw without a database; FDB must still win
       }
@@ -98,11 +102,36 @@ describeIf("NuQ router (forced FDB mode)", () => {
     expect(taken).not.toBeNull();
     expect(taken.id).toBe(jobId);
     expect((taken as any).backend).toBe("fdb");
+    expect(takeSpy).toHaveBeenCalledWith(expect.anything(), operation);
 
-    expect(await scrapeQueue.renewLock(jobId, taken.lock!)).toBe(true);
-    expect(await scrapeQueue.jobFinish(jobId, taken.lock!, { ok: true })).toBe(
-      true,
+    expect(
+      await scrapeQueue.renewLock(jobId, taken.lock!, undefined, operation),
+    ).toBe(true);
+    expect(renewSpy).toHaveBeenCalledWith(
+      jobId,
+      taken.lock!,
+      expect.anything(),
+      operation,
     );
+    expect(
+      await scrapeQueue.jobFinish(
+        jobId,
+        taken.lock!,
+        { ok: true },
+        undefined,
+        operation,
+      ),
+    ).toBe(true);
+    expect(finishSpy).toHaveBeenCalledWith(
+      jobId,
+      taken.lock!,
+      { ok: true },
+      expect.anything(),
+      operation,
+    );
+    takeSpy.mockRestore();
+    renewSpy.mockRestore();
+    finishSpy.mockRestore();
 
     await expect(wait).resolves.toBeDefined();
 

--- a/apps/api/src/services/worker/nuq-fdb-worker-runtime.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker-runtime.ts
@@ -1,0 +1,178 @@
+import type { NuQJob } from "./nuq";
+import {
+  nextIdlePollDelay,
+  retryWithBackoff,
+  runLeasedJob,
+  RuntimeLogger,
+  waitForAbortableDelay,
+  type FenceReason,
+  type LeasedJobQueue,
+} from "./nuq-worker-runtime";
+
+export type CrawlFinishedQueue = LeasedJobQueue & {
+  getJobToProcess(logger?: any): Promise<NuQJob<any, any> | null>;
+};
+
+export type CrawlFinishedLoop = {
+  stop(): void;
+  forceStop(): void;
+  readonly done: Promise<void>;
+  isHealthy(): boolean;
+  metrics(): string;
+};
+
+export function startCrawlFinishedLoop(options: {
+  queue: CrawlFinishedQueue;
+  processJob: (job: NuQJob<any, any>, signal: AbortSignal) => Promise<void>;
+  logger: RuntimeLogger;
+  renewIntervalMs?: number;
+  processAttempts?: number;
+  retryDelaysMs?: number[];
+  onFence?: (reason: FenceReason) => void;
+  idleOptions?: {
+    minMs?: number;
+    maxMs?: number;
+    jitterRatio?: number;
+    random?: () => number;
+  };
+}): CrawlFinishedLoop {
+  const stopController = new AbortController();
+  const forceController = new AbortController();
+  let state: "running" | "stopping" | "stopped" | "failed" = "running";
+  let activeJobs = 0;
+  let consecutiveProcessingErrors = 0;
+  let consecutiveDequeueErrors = 0;
+
+  const loop = (async () => {
+    let idleBaseMs = options.idleOptions?.minMs ?? 500;
+    let errorBaseMs = options.idleOptions?.minMs ?? 500;
+
+    while (!stopController.signal.aborted) {
+      let job: NuQJob<any, any> | null;
+      try {
+        job = await options.queue.getJobToProcess(options.logger);
+        consecutiveDequeueErrors = 0;
+        errorBaseMs = options.idleOptions?.minMs ?? 500;
+      } catch (error) {
+        consecutiveDequeueErrors++;
+        options.logger.error("Crawl-finished dequeue failed; retrying", {
+          error,
+          consecutiveDequeueErrors,
+        });
+        const idle = nextIdlePollDelay(errorBaseMs, options.idleOptions);
+        errorBaseMs = idle.nextBaseMs;
+        await waitForAbortableDelay(idle.delayMs, stopController.signal);
+        continue;
+      }
+
+      if (job === null) {
+        const idle = nextIdlePollDelay(idleBaseMs, options.idleOptions);
+        idleBaseMs = idle.nextBaseMs;
+        await waitForAbortableDelay(idle.delayMs, stopController.signal);
+        continue;
+      }
+
+      if (stopController.signal.aborted) {
+        options.logger.warn(
+          "Dequeued crawl-finished job during shutdown; leaving lease for recovery",
+          { jobId: job.id },
+        );
+        break;
+      }
+
+      idleBaseMs = options.idleOptions?.minMs ?? 500;
+      activeJobs = 1;
+      try {
+        const result = await runLeasedJob({
+          queue: options.queue,
+          job,
+          logger: options.logger,
+          renewIntervalMs: options.renewIntervalMs,
+          finalizationRetryDelaysMs: options.retryDelaysMs,
+          shutdownSignal: forceController.signal,
+          onFence: options.onFence,
+          process: signal =>
+            retryWithBackoff({
+              attempts: options.processAttempts ?? 3,
+              delaysMs: options.retryDelaysMs,
+              signal,
+              operation: attempt => {
+                options.logger.info?.("Processing crawl-finished job", {
+                  jobId: job!.id,
+                  attempt,
+                });
+                return options.processJob(job!, signal);
+              },
+              onRetry: (error, attempt, delayMs) => {
+                options.logger.warn(
+                  "Crawl-finished processing failed transiently; retrying",
+                  { jobId: job!.id, error, attempt, delayMs },
+                );
+              },
+            }),
+        });
+        if (result.status === "finalization-failed") {
+          consecutiveProcessingErrors++;
+          options.logger.error(
+            "Crawl-finished finalization exhausted retries; lease will recover",
+            { jobId: job.id, error: result.error },
+          );
+        } else if (result.status === "fenced") {
+          options.logger.warn("Crawl-finished job was fenced", {
+            jobId: job.id,
+            reason: result.reason,
+          });
+        } else if (result.status === "failed") {
+          consecutiveProcessingErrors++;
+        } else {
+          consecutiveProcessingErrors = 0;
+        }
+      } catch (error) {
+        // A malformed job or an unexpected runtime error must not terminate the
+        // supervisor. Leave the lease to the sweeper if it could not be failed.
+        consecutiveProcessingErrors++;
+        options.logger.error("Crawl-finished iteration failed; continuing", {
+          jobId: job.id,
+          error,
+          consecutiveProcessingErrors,
+        });
+      } finally {
+        activeJobs = 0;
+      }
+    }
+  })();
+
+  const done = loop.then(
+    () => {
+      state = "stopped";
+    },
+    error => {
+      state = "failed";
+      options.logger.error("Crawl-finished supervisor stopped unexpectedly", {
+        error,
+      });
+      throw error;
+    },
+  );
+
+  return {
+    stop() {
+      if (state !== "running") return;
+      state = "stopping";
+      stopController.abort();
+    },
+    forceStop() {
+      if (state === "stopped" || state === "failed") return;
+      state = "stopping";
+      stopController.abort();
+      forceController.abort();
+    },
+    done,
+    isHealthy() {
+      return state === "running";
+    },
+    metrics() {
+      return `# HELP firecrawl_nuq_fdb_crawl_finished_loop_alive Whether the local crawl-finished supervisor is alive\n# TYPE firecrawl_nuq_fdb_crawl_finished_loop_alive gauge\nfirecrawl_nuq_fdb_crawl_finished_loop_alive ${state === "running" ? 1 : 0}\n# HELP firecrawl_nuq_fdb_crawl_finished_active_jobs Crawl-finished jobs executing in this worker process\n# TYPE firecrawl_nuq_fdb_crawl_finished_active_jobs gauge\nfirecrawl_nuq_fdb_crawl_finished_active_jobs ${activeJobs}\n# HELP firecrawl_nuq_fdb_crawl_finished_consecutive_errors Consecutive local crawl-finished processing errors\n# TYPE firecrawl_nuq_fdb_crawl_finished_consecutive_errors gauge\nfirecrawl_nuq_fdb_crawl_finished_consecutive_errors ${consecutiveProcessingErrors}\n# HELP firecrawl_nuq_fdb_crawl_finished_dequeue_errors Consecutive local crawl-finished dequeue errors\n# TYPE firecrawl_nuq_fdb_crawl_finished_dequeue_errors gauge\nfirecrawl_nuq_fdb_crawl_finished_dequeue_errors ${consecutiveDequeueErrors}\n`;
+    },
+  };
+}

--- a/apps/api/src/services/worker/nuq-fdb-worker-runtime.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker-runtime.ts
@@ -5,12 +5,17 @@ import {
   runLeasedJob,
   RuntimeLogger,
   waitForAbortableDelay,
+  withOperationTimeout,
   type FenceReason,
   type LeasedJobQueue,
+  type QueueOperationOptions,
 } from "./nuq-worker-runtime";
 
 export type CrawlFinishedQueue = LeasedJobQueue & {
-  getJobToProcess(logger?: any): Promise<NuQJob<any, any> | null>;
+  getJobToProcess(
+    logger?: any,
+    operation?: QueueOperationOptions,
+  ): Promise<NuQJob<any, any> | null>;
 };
 
 export type CrawlFinishedLoop = {
@@ -50,7 +55,11 @@ export function startCrawlFinishedLoop(options: {
     while (!stopController.signal.aborted) {
       let job: NuQJob<any, any> | null;
       try {
-        job = await options.queue.getJobToProcess(options.logger);
+        job = await withOperationTimeout(
+          options.queue.getJobToProcess(options.logger, { timeoutMs: 5_000 }),
+          5_000,
+          "crawl-finished dequeue",
+        );
         consecutiveDequeueErrors = 0;
         errorBaseMs = options.idleOptions?.minMs ?? 500;
       } catch (error) {
@@ -148,10 +157,14 @@ export function startCrawlFinishedLoop(options: {
     },
     error => {
       state = "failed";
-      options.logger.error("Crawl-finished supervisor stopped unexpectedly", {
-        error,
-      });
-      throw error;
+      try {
+        options.logger.error("Crawl-finished supervisor stopped unexpectedly", {
+          error,
+        });
+      } catch {
+        // Logging must not turn the supervised failure into an unhandled
+        // rejection. The failed state remains visible through liveness.
+      }
     },
   );
 

--- a/apps/api/src/services/worker/nuq-fdb-worker.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import "../sentry";
 import { setSentryServiceTag } from "../sentry";
-import { config } from "../../config";
 import { logger as _logger } from "../../lib/logger";
 import { getCrawl } from "../../lib/crawl-redis";
 import { finishCrawlSuper } from "./crawl-logic";
@@ -11,6 +10,7 @@ import {
   nuqFdbHealthCheck,
   scrapeQueueFdb,
 } from "./nuq-fdb";
+import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
 import { runNuqWorker } from "./nuq-worker-runner";
 import type { NuQJob } from "./nuq";
 
@@ -44,94 +44,6 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
   await finishCrawlSuper(anyJob as any);
 }
 
-function startCrawlFinishedLoop() {
-  let shuttingDown = false;
-
-  const loop = (async () => {
-    let noJobTimeout = 1500;
-
-    while (!shuttingDown) {
-      const job = await crawlFinishedQueueFdb.getJobToProcess();
-
-      if (job === null) {
-        await new Promise(resolve => setTimeout(resolve, noJobTimeout));
-        if (!config.NUQ_RABBITMQ_URL) {
-          noJobTimeout = Math.min(noJobTimeout * 2, 10000);
-        }
-        continue;
-      }
-
-      noJobTimeout = 500;
-
-      const logger = _logger.child({
-        module: "nuq-fdb-worker",
-        method: "crawlFinishedLoop",
-        jobId: job.id,
-        crawlId: job.groupId,
-      });
-
-      logger.info("Acquired crawl finished job");
-
-      const lockRenewInterval = setInterval(async () => {
-        try {
-          logger.info("Renewing crawl finished lock");
-          if (
-            !(await crawlFinishedQueueFdb.renewLock(job.id, job.lock!, logger))
-          ) {
-            logger.warn("Failed to renew crawl finished lock");
-            clearInterval(lockRenewInterval);
-          }
-        } catch (error) {
-          logger.warn("Failed to renew crawl finished lock", { error });
-          clearInterval(lockRenewInterval);
-        }
-      }, 15000);
-
-      try {
-        await processFinishCrawlJobInternal(job as any);
-        if (
-          !(await crawlFinishedQueueFdb.jobFinish(
-            job.id,
-            job.lock!,
-            null,
-            logger,
-          ))
-        ) {
-          logger.warn("Could not update crawl finished job status");
-        }
-      } catch (error) {
-        logger.error("Crawl finished job failed", { error });
-        if (
-          !(await crawlFinishedQueueFdb.jobFail(
-            job.id,
-            job.lock!,
-            error instanceof Error ? error.message : JSON.stringify(error),
-            logger,
-          ))
-        ) {
-          logger.warn("Could not update crawl finished job status");
-        }
-      } finally {
-        clearInterval(lockRenewInterval);
-      }
-    }
-  })();
-
-  const done = loop.catch(error => {
-    _logger.error("Crawl finished loop stopped unexpectedly", {
-      module: "nuq-fdb-worker",
-      error,
-    });
-  });
-
-  return {
-    stop() {
-      shuttingDown = true;
-    },
-    done,
-  };
-}
-
 (async () => {
   setSentryServiceTag("nuq-fdb-worker");
 
@@ -142,17 +54,36 @@ function startCrawlFinishedLoop() {
     serviceName: "nuq-fdb-worker",
     queue: scrapeQueueFdb as any,
     healthCheck: () => nuqFdbHealthCheck(),
+    livenessCheck: () => crawlFinishedLoop?.isHealthy() ?? false,
+    // These are process-local metrics. Queue-wide FDB ranges are deliberately
+    // not scanned from every worker's Prometheus scrape callback.
+    metrics: () => crawlFinishedLoop?.metrics() ?? "",
     beforeStart: () => {
       getNuqFdbSweeper().start();
-      crawlFinishedLoop = startCrawlFinishedLoop();
+      crawlFinishedLoop = startCrawlFinishedLoop({
+        queue: crawlFinishedQueueFdb as any,
+        processJob: processFinishCrawlJobInternal,
+        logger: _logger.child({
+          module: "nuq-fdb-worker",
+          method: "crawlFinishedLoop",
+        }),
+        onFence: reason => {
+          if (reason === "shutdown") return;
+          _logger.error(
+            "Worker lost crawl-finished ownership; terminating stale process",
+            { module: "nuq-fdb-worker", reason },
+          );
+          setImmediate(() => process.exit(1));
+        },
+      });
     },
-    beforeShutdown: async () => {
+    onShutdownRequested: () => {
+      // Stop both dequeue loops immediately, then let their in-flight jobs keep
+      // renewing and drain within runNuqWorker's bounded grace period.
       crawlFinishedLoop?.stop();
-      try {
-        await crawlFinishedLoop?.done;
-      } finally {
-        getNuqFdbSweeper().stop();
-      }
     },
+    drain: () => crawlFinishedLoop?.done,
+    onShutdownDeadline: () => crawlFinishedLoop?.forceStop(),
+    shutdown: () => getNuqFdbSweeper().stop(),
   });
 })();

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -82,6 +82,8 @@ export type NuQJobStatusCompat =
   | "backlog";
 
 export type NuQFdbJob<Data = any, ReturnValue = any> = {
+  /** Intrinsic queue identity; direct FDB consumers must never run PG cleanup. */
+  backend: "fdb";
   id: string;
   status: NuQJobStatusCompat;
   createdAt: Date;
@@ -554,6 +556,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         }
 
         out.push({
+          backend: "fdb",
           id: j.id,
           status: placedStatus === "pending" ? "backlog" : "queued",
           createdAt: new Date(now),
@@ -763,6 +766,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       }
 
       return {
+        backend: "fdb" as const,
         id: e.i,
         status: "active" as const,
         createdAt: new Date(meta.c),
@@ -794,9 +798,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         tn.set(ks.lease(timeBucket(id), newExp, id), encodeJson({ l: lock }));
         // the lease index moved, keep the status record's expiry in sync for
         // observability; only the worker holding the lock writes this
-        const st = decodeJson<JobStatusRecord>(
-          await tn.snapshot().get(ks.jobStatus(id)),
-        );
+        // This must be a conflictful read. If the sweeper requeues between the
+        // read and commit, FDB retries us and the lock check fences this worker
+        // instead of recreating an active lease beside a ready queue entry.
+        const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));
         if (!st || st.s !== "active" || st.l !== lock) {
           throw new LockLostError();
         }
@@ -982,6 +987,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     }
 
     return {
+      backend: "fdb",
       id,
       status,
       createdAt: new Date(meta.c),

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import type { Transaction } from "foundationdb";
+import { TransactionOptionCode, type Transaction } from "foundationdb";
 import { Logger } from "winston";
 import { logger as _logger } from "../../../lib/logger";
 import { config } from "../../../config";
@@ -585,8 +585,20 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   public async getJobToProcess(
     logger: Logger = _logger,
+    operation?: { timeoutMs: number },
   ): Promise<NuQFdbJob<JobData, JobReturnValue> | null> {
     const startedAt = Date.now();
+    const operationDeadline = operation
+      ? startedAt + operation.timeoutMs
+      : null;
+    const remainingOperation = () => {
+      if (operationDeadline === null) return undefined;
+      const timeoutMs = operationDeadline - Date.now();
+      if (timeoutMs <= 0) {
+        throw new Error("FDB dequeue operation timed out");
+      }
+      return { timeoutMs };
+    };
     // blind random probes win at high occupancy (no coordination, conflicts
     // spread across shards); the occupancy scan below covers the sparse case
     const PROBES = 4;
@@ -595,7 +607,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     while (tried.size < PROBES) {
       const shard = Math.floor(Math.random() * READY_SHARDS);
       if (tried.has(shard)) continue;
-      const result = await this.takeFromShard(shard);
+      const result = await this.takeFromShard(shard, remainingOperation());
       if (result === "empty") {
         tried.add(shard);
         continue;
@@ -622,7 +634,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     }
 
     // sparse queue: find non-empty shards via their occupancy counters
+    const candidatesOperation = remainingOperation();
     const candidates = await this.db.doTn(async tn => {
+      if (candidatesOperation) {
+        tn.setOption(
+          TransactionOptionCode.Timeout,
+          candidatesOperation.timeoutMs,
+        );
+      }
       const r = this.ks.readyShardCountRange();
       const counts = await tn.snapshot().getRangeAll(r.begin, r.end);
       const nonEmpty: number[] = [];
@@ -644,7 +663,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       if (tried.has(shard)) continue;
       for (let attempt = 0; attempt < 4; attempt++) {
         fallbackAttempts++;
-        const result = await this.takeFromShard(shard);
+        const result = await this.takeFromShard(shard, remainingOperation());
         if (result === "empty") {
           fallbackEmpty++;
           break;
@@ -692,9 +711,12 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   private async takeFromShard(
     shard: number,
+    operation?: { timeoutMs: number },
   ): Promise<NuQFdbJob<JobData, JobReturnValue> | "empty" | "dropped"> {
     const ks = this.ks;
     return await this.db.doTn(async tn => {
+      if (operation)
+        tn.setOption(TransactionOptionCode.Timeout, operation.timeoutMs);
       const txc = newTxContext();
       const now = Date.now();
       const range = ks.readyShardRange(shard);
@@ -786,6 +808,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     id: string,
     lock: string,
     logger: Logger = _logger,
+    operation?: { timeoutMs: number },
   ): Promise<boolean> {
     const oldExp = this.leaseExps.get(id);
     if (oldExp === undefined) return false;
@@ -793,6 +816,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const newExp = Date.now() + (this.options.leaseMs ?? LEASE_MS);
     try {
       await this.db.doTn(async tn => {
+        if (operation)
+          tn.setOption(TransactionOptionCode.Timeout, operation.timeoutMs);
         // blind writes only; the sweeper validates the lock before reaping
         tn.clear(ks.lease(timeBucket(id), oldExp, id));
         tn.set(ks.lease(timeBucket(id), newExp, id), encodeJson({ l: lock }));
@@ -825,8 +850,16 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     lock: string,
     returnvalue: JobReturnValue | null,
     logger: Logger = _logger,
+    operation?: { timeoutMs: number },
   ): Promise<boolean> {
-    return this.finishOrFail(id, lock, "completed", returnvalue ?? null, null);
+    return this.finishOrFail(
+      id,
+      lock,
+      "completed",
+      returnvalue ?? null,
+      null,
+      operation,
+    );
   }
 
   public async jobFail(
@@ -834,8 +867,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     lock: string,
     failedReason: string,
     logger: Logger = _logger,
+    operation?: { timeoutMs: number },
   ): Promise<boolean> {
-    return this.finishOrFail(id, lock, "failed", null, failedReason);
+    return this.finishOrFail(id, lock, "failed", null, failedReason, operation);
   }
 
   private async finishOrFail(
@@ -844,9 +878,12 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     outcome: "completed" | "failed",
     returnvalue: any,
     failedReason: string | null,
+    operation?: { timeoutMs: number },
   ): Promise<boolean> {
     const ks = this.ks;
     const ok = await this.db.doTn(async tn => {
+      if (operation)
+        tn.setOption(TransactionOptionCode.Timeout, operation.timeoutMs);
       const txc = newTxContext();
       const now = Date.now();
       const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "crypto";
-import { TransactionOptionCode, type Transaction } from "foundationdb";
+import type {
+  Transaction,
+  TransactionOptionCode as FdbTransactionOptionCode,
+} from "foundationdb";
 import { Logger } from "winston";
 import { logger as _logger } from "../../../lib/logger";
 import { config } from "../../../config";
@@ -55,6 +58,12 @@ import {
   GroupJobIndexValue,
 } from "./ops";
 import { NuqFdbGroupOps } from "./groups";
+
+// FDB's stable transaction option code for TIMEOUT. Keep this local so merely
+// importing queue types does not eagerly load libfdb_c in PG-only processes.
+const TransactionOptionCode = {
+  Timeout: 500 as FdbTransactionOptionCode,
+};
 
 const DATA_CHUNK_BYTES = 90 * 1024;
 // FoundationDB caps transactions at 10,000,000 bytes of affected data. Keep

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -32,6 +32,7 @@ import {
   NuQFdbQueue,
   NuQFdbJob,
 } from "./nuq-fdb";
+import type { QueueOperationOptions } from "./nuq-worker-runtime";
 
 // Dual-backend router for the NuQ migration to FoundationDB. Exports the same
 // `scrapeQueue` / `crawlFinishedQueue` / `crawlGroup` names as ./nuq so call
@@ -328,11 +329,12 @@ class RoutedScrapeQueue {
 
   public async getJobToProcess(
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<NuQJob<ScrapeJobData> | null> {
     if (fdbQueueEnabled()) {
       try {
         const job = await optionalFdb(() =>
-          scrapeQueueFdb.getJobToProcess(logger),
+          scrapeQueueFdb.getJobToProcess(logger, operation),
         );
         if (job) {
           this.inflightBackend.set(job.id, "fdb");
@@ -352,11 +354,12 @@ class RoutedScrapeQueue {
     id: string,
     lock: string,
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<boolean> {
     if (this.backendFor(id) === "fdb") {
       try {
         return await optionalFdb(() =>
-          scrapeQueueFdb.renewLock(id, lock, logger),
+          scrapeQueueFdb.renewLock(id, lock, logger, operation),
         );
       } catch (error) {
         if (fdbForced()) throw error;
@@ -372,13 +375,14 @@ class RoutedScrapeQueue {
     lock: string,
     returnvalue: any | null,
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
     this.inflightBackend.delete(id);
     if (backend === "fdb") {
       try {
         return await optionalFdb(() =>
-          scrapeQueueFdb.jobFinish(id, lock, returnvalue, logger),
+          scrapeQueueFdb.jobFinish(id, lock, returnvalue, logger, operation),
         );
       } catch (error) {
         if (fdbForced()) throw error;
@@ -394,13 +398,14 @@ class RoutedScrapeQueue {
     lock: string,
     failedReason: string,
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
     this.inflightBackend.delete(id);
     if (backend === "fdb") {
       try {
         return await optionalFdb(() =>
-          scrapeQueueFdb.jobFail(id, lock, failedReason, logger),
+          scrapeQueueFdb.jobFail(id, lock, failedReason, logger, operation),
         );
       } catch (error) {
         if (fdbForced()) throw error;
@@ -554,11 +559,12 @@ class RoutedCrawlFinishedQueue {
 
   public async getJobToProcess(
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<NuQJob<any> | null> {
     if (fdbQueueEnabled()) {
       try {
         const job = await optionalFdb(() =>
-          crawlFinishedQueueFdb.getJobToProcess(logger),
+          crawlFinishedQueueFdb.getJobToProcess(logger, operation),
         );
         if (job) {
           this.inflightBackend.set(job.id, "fdb");
@@ -578,11 +584,12 @@ class RoutedCrawlFinishedQueue {
     id: string,
     lock: string,
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<boolean> {
     if (this.inflightBackend.get(id) === "fdb") {
       try {
         return await optionalFdb(() =>
-          crawlFinishedQueueFdb.renewLock(id, lock, logger),
+          crawlFinishedQueueFdb.renewLock(id, lock, logger, operation),
         );
       } catch (error) {
         if (fdbForced()) throw error;
@@ -598,13 +605,20 @@ class RoutedCrawlFinishedQueue {
     lock: string,
     returnvalue: any | null,
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.inflightBackend.get(id) ?? "pg";
     this.inflightBackend.delete(id);
     if (backend === "fdb") {
       try {
         return await optionalFdb(() =>
-          crawlFinishedQueueFdb.jobFinish(id, lock, returnvalue, logger),
+          crawlFinishedQueueFdb.jobFinish(
+            id,
+            lock,
+            returnvalue,
+            logger,
+            operation,
+          ),
         );
       } catch (error) {
         if (fdbForced()) throw error;
@@ -620,13 +634,20 @@ class RoutedCrawlFinishedQueue {
     lock: string,
     failedReason: string,
     logger: Logger = _logger,
+    operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.inflightBackend.get(id) ?? "pg";
     this.inflightBackend.delete(id);
     if (backend === "fdb") {
       try {
         return await optionalFdb(() =>
-          crawlFinishedQueueFdb.jobFail(id, lock, failedReason, logger),
+          crawlFinishedQueueFdb.jobFail(
+            id,
+            lock,
+            failedReason,
+            logger,
+            operation,
+          ),
         );
       } catch (error) {
         if (fdbForced()) throw error;

--- a/apps/api/src/services/worker/nuq-worker-runner.ts
+++ b/apps/api/src/services/worker/nuq-worker-runner.ts
@@ -7,6 +7,12 @@ import { register } from "prom-client";
 import Express from "express";
 import { initializeBlocklist } from "../../scraper/WebScraper/utils/blocklist";
 import { initializeEngineForcing } from "../../scraper/WebScraper/utils/engine-forcing";
+import type { Server } from "http";
+import {
+  nextIdlePollDelay,
+  runLeasedJob,
+  waitForAbortableDelay,
+} from "./nuq-worker-runtime";
 
 export type WorkerQueue = {
   getJobToProcess(logger?: any): Promise<NuQJob<any, any> | null>;
@@ -46,14 +52,26 @@ async function withTimeout<T>(
   }
 }
 
+function closeServer(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  });
+}
+
 export async function runNuqWorker(options: {
   serviceName: string;
   queue: WorkerQueue;
   healthCheck: () => Promise<boolean>;
+  livenessCheck?: () => boolean;
   metrics?: () => string | Promise<string>;
   beforeStart?: () => void | Promise<void>;
+  onShutdownRequested?: () => void | Promise<void>;
+  drain?: () => void | Promise<void>;
+  onShutdownDeadline?: () => void | Promise<void>;
   beforeShutdown?: () => void | Promise<void>;
   shutdown?: () => void | Promise<void>;
+  shutdownGraceMs?: number;
+  processJob?: (job: NuQJob<any, any>, signal: AbortSignal) => Promise<any>;
 }) {
   try {
     await initializeBlocklist();
@@ -68,17 +86,40 @@ export async function runNuqWorker(options: {
   }
 
   let isShuttingDown = false;
+  let shutdownStartedAt: number | null = null;
+  let activeJobs = 0;
+  const idleController = new AbortController();
+  const forceActiveJobController = new AbortController();
+  let resolveShutdownRequested!: () => void;
+  const shutdownRequested = new Promise<void>(resolve => {
+    resolveShutdownRequested = resolve;
+  });
 
   const app = Express();
 
   app.get("/metrics", async (_, res) => {
-    const localMetrics = options.metrics ? await options.metrics() : "";
-    res
-      .contentType("text/plain")
-      .send(localMetrics + "\n" + (await register.metrics()));
+    try {
+      const localMetrics = options.metrics ? await options.metrics() : "";
+      const runtimeMetrics = `# HELP firecrawl_nuq_worker_active_jobs Number of jobs executing in this worker process\n# TYPE firecrawl_nuq_worker_active_jobs gauge\nfirecrawl_nuq_worker_active_jobs{service="${options.serviceName}"} ${activeJobs}\n`;
+      res
+        .contentType("text/plain")
+        .send(
+          localMetrics + "\n" + runtimeMetrics + (await register.metrics()),
+        );
+    } catch (error) {
+      _logger.warn("NuQ worker metrics collection failed", {
+        module: options.serviceName,
+        error,
+      });
+      res.status(500).send("Metrics unavailable");
+    }
   });
   app.get("/health", async (_, res) => {
     try {
+      if (options.livenessCheck && !options.livenessCheck()) {
+        res.status(500).send("Not OK");
+        return;
+      }
       if (await withTimeout(options.healthCheck(), 1000, "NuQ health check")) {
         res.status(200).send("OK");
       } else {
@@ -108,103 +149,206 @@ export async function runNuqWorker(options: {
     });
   });
 
-  function shutdown() {
+  function requestShutdown() {
+    if (isShuttingDown) return;
     isShuttingDown = true;
-  }
-
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
-
-  let noJobTimeout = 1500;
-
-  while (!isShuttingDown) {
-    const job = await options.queue.getJobToProcess();
-
-    if (job === null) {
-      _logger.info("No jobs to process", { module: "nuq/metrics" });
-      await new Promise(resolve => setTimeout(resolve, noJobTimeout));
-      if (!config.NUQ_RABBITMQ_URL) {
-        noJobTimeout = Math.min(noJobTimeout * 2, 10000);
-      }
-      continue;
-    }
-
-    noJobTimeout = 500;
-
-    const logger = _logger.child({
-      module: options.serviceName,
-      scrapeId: job.id,
-      zeroDataRetention: job.data?.zeroDataRetention ?? false,
+    shutdownStartedAt = Date.now();
+    idleController.abort();
+    resolveShutdownRequested();
+    void Promise.resolve(options.onShutdownRequested?.()).catch(error => {
+      _logger.error("NuQ worker shutdown notification failed", {
+        module: options.serviceName,
+        error,
+      });
     });
+  }
 
-    logger.info("Acquired job");
+  process.on("SIGINT", requestShutdown);
+  process.on("SIGTERM", requestShutdown);
 
-    const lockRenewInterval = setInterval(async () => {
+  const loop = (async () => {
+    let idleBaseMs = 500;
+    let dequeueErrorBaseMs = 500;
+
+    while (!isShuttingDown) {
+      let job: NuQJob<any, any> | null;
       try {
-        logger.info("Renewing lock");
-        if (!(await options.queue.renewLock(job.id, job.lock!, logger))) {
-          logger.warn("Failed to renew lock");
-          clearInterval(lockRenewInterval);
-          return;
-        }
-        logger.info("Renewed lock");
+        job = await options.queue.getJobToProcess();
+        dequeueErrorBaseMs = 500;
       } catch (error) {
-        logger.warn("Failed to renew lock", { error });
-        clearInterval(lockRenewInterval);
+        _logger.error("Failed to dequeue NuQ job", {
+          module: options.serviceName,
+          error,
+        });
+        const idle = nextIdlePollDelay(dequeueErrorBaseMs);
+        dequeueErrorBaseMs = idle.nextBaseMs;
+        await waitForAbortableDelay(idle.delayMs, idleController.signal);
+        continue;
       }
-    }, 15000);
 
-    let processResult:
-      | { ok: true; data: Awaited<ReturnType<typeof processJobInternal>> }
-      | { ok: false; error: any };
+      if (job === null) {
+        const idle = nextIdlePollDelay(idleBaseMs);
+        idleBaseMs = idle.nextBaseMs;
+        await waitForAbortableDelay(idle.delayMs, idleController.signal);
+        continue;
+      }
 
-    const endJobTimer = jobDurationSeconds.startTimer({ type: job.data.mode });
+      if (isShuttingDown) {
+        _logger.warn(
+          "Dequeued a job while shutdown was requested; leaving its lease for recovery",
+          { module: options.serviceName, jobId: job.id },
+        );
+        break;
+      }
 
-    try {
-      processResult = { ok: true, data: await processJobInternal(job) };
-    } catch (error) {
-      processResult = { ok: false, error };
+      idleBaseMs = 500;
+
+      const logger = _logger.child({
+        module: options.serviceName,
+        scrapeId: job.id,
+        zeroDataRetention: job.data?.zeroDataRetention ?? false,
+      });
+
+      logger.info("Acquired job");
+      activeJobs = 1;
+      const endJobTimer = jobDurationSeconds.startTimer({
+        type: job.data.mode,
+      });
+      try {
+        const result = await runLeasedJob({
+          queue: options.queue,
+          job,
+          logger,
+          shutdownSignal: forceActiveJobController.signal,
+          onFence: reason => {
+            if (reason === "shutdown") return;
+            logger.error(
+              "Worker lost job ownership; terminating to abort stale side effects",
+              { reason },
+            );
+            // processJobInternal does not yet accept an AbortSignal. Exiting the
+            // single-job worker is the only hard cancellation boundary that
+            // prevents the stale owner from continuing crawl/scrape effects.
+            setImmediate(() => process.exit(1));
+          },
+          process: signal =>
+            options.processJob
+              ? options.processJob(job!, signal)
+              : processJobInternal(job!),
+        });
+
+        if (result.status === "completed") {
+          endJobTimer({ status: "success" });
+        } else {
+          endJobTimer({ status: "failed" });
+          if (result.status === "fenced") {
+            logger.warn("Job was fenced and will not be finalized", {
+              reason: result.reason,
+            });
+          }
+        }
+      } catch (error) {
+        endJobTimer({ status: "failed" });
+        logger.error("Unexpected NuQ job lifecycle failure; continuing", {
+          error,
+        });
+      } finally {
+        activeJobs = 0;
+      }
     }
+  })();
 
-    clearInterval(lockRenewInterval);
+  // Wait indefinitely during normal operation. Once shutdown is requested,
+  // stop dequeuing and let the active job retain/renew its lease while it drains.
+  await Promise.race([loop, shutdownRequested]);
+  let drained = false;
+  if (isShuttingDown) {
+    const drain = Promise.all([
+      loop,
+      Promise.resolve().then(() => options.drain?.()),
+    ]);
+    const graceController = new AbortController();
+    drained =
+      (await Promise.race([
+        drain.then(() => true),
+        waitForAbortableDelay(
+          Math.max(
+            0,
+            (options.shutdownGraceMs ?? 30_000) -
+              (shutdownStartedAt === null ? 0 : Date.now() - shutdownStartedAt),
+          ),
+          graceController.signal,
+        ).then(() => false),
+      ])) === true;
+    graceController.abort();
+  } else {
+    await loop;
+    drained = true;
+  }
 
-    if (processResult.ok) {
-      endJobTimer({ status: "success" });
-      if (
-        !(await options.queue.jobFinish(
-          job.id,
-          job.lock!,
-          processResult.data,
-          logger,
-        ))
-      ) {
-        logger.warn("Could not update job status");
-      }
-    } else {
-      endJobTimer({ status: "failed" });
-      if (
-        !(await options.queue.jobFail(
-          job.id,
-          job.lock!,
-          processResult.error instanceof Error
-            ? processResult.error.message
-            : typeof processResult.error === "string"
-              ? processResult.error
-              : JSON.stringify(processResult.error),
-          logger,
-        ))
-      ) {
-        logger.warn("Could not update job status");
-      }
+  if (!drained) {
+    _logger.warn("NuQ worker drain deadline exceeded; fencing active job", {
+      module: options.serviceName,
+    });
+    forceActiveJobController.abort();
+    try {
+      void Promise.resolve(options.onShutdownDeadline?.()).catch(error => {
+        _logger.error("NuQ worker deadline hook failed", {
+          module: options.serviceName,
+          error,
+        });
+      });
+    } catch (error) {
+      _logger.error("NuQ worker deadline hook failed", {
+        module: options.serviceName,
+        error,
+      });
     }
   }
 
-  _logger.info("NuQ worker shutting down", { module: options.serviceName });
-
-  server.close(async () => {
-    await options.beforeShutdown?.();
-    await options.shutdown?.();
-    _logger.info("NuQ worker shut down", { module: options.serviceName });
-    process.exit(0);
+  _logger.info("NuQ worker shutting down", {
+    module: options.serviceName,
+    drained,
   });
+
+  process.off("SIGINT", requestShutdown);
+  process.off("SIGTERM", requestShutdown);
+
+  const remainingShutdownMs = () =>
+    shutdownStartedAt === null
+      ? 10_000
+      : Math.max(
+          0,
+          (options.shutdownGraceMs ?? 30_000) -
+            (Date.now() - shutdownStartedAt),
+        );
+  try {
+    await withTimeout(
+      closeServer(server),
+      Math.min(10_000, remainingShutdownMs()),
+      "HTTP shutdown",
+    );
+  } catch (error) {
+    _logger.warn("NuQ worker HTTP shutdown did not complete cleanly", {
+      module: options.serviceName,
+      error,
+    });
+  }
+  try {
+    await withTimeout(
+      Promise.resolve(options.beforeShutdown?.()).then(() =>
+        options.shutdown?.(),
+      ),
+      Math.min(10_000, remainingShutdownMs()),
+      "worker cleanup",
+    );
+  } catch (error) {
+    _logger.error("NuQ worker cleanup failed", {
+      module: options.serviceName,
+      error,
+    });
+  }
+
+  _logger.info("NuQ worker shut down", { module: options.serviceName });
+  process.exit(0);
 }

--- a/apps/api/src/services/worker/nuq-worker-runner.ts
+++ b/apps/api/src/services/worker/nuq-worker-runner.ts
@@ -11,23 +11,36 @@ import type { Server } from "http";
 import {
   nextIdlePollDelay,
   runLeasedJob,
+  settleDrain,
   waitForAbortableDelay,
+  withOperationTimeout,
+  type QueueOperationOptions,
 } from "./nuq-worker-runtime";
 
 export type WorkerQueue = {
-  getJobToProcess(logger?: any): Promise<NuQJob<any, any> | null>;
-  renewLock(id: string, lock: string, logger?: any): Promise<boolean>;
+  getJobToProcess(
+    logger?: any,
+    operation?: QueueOperationOptions,
+  ): Promise<NuQJob<any, any> | null>;
+  renewLock(
+    id: string,
+    lock: string,
+    logger?: any,
+    operation?: QueueOperationOptions,
+  ): Promise<boolean>;
   jobFinish(
     id: string,
     lock: string,
     returnvalue: any | null,
     logger?: any,
+    operation?: QueueOperationOptions,
   ): Promise<boolean>;
   jobFail(
     id: string,
     lock: string,
     failedReason: string,
     logger?: any,
+    operation?: QueueOperationOptions,
   ): Promise<boolean>;
 };
 
@@ -173,7 +186,11 @@ export async function runNuqWorker(options: {
     while (!isShuttingDown) {
       let job: NuQJob<any, any> | null;
       try {
-        job = await options.queue.getJobToProcess();
+        job = await withOperationTimeout(
+          options.queue.getJobToProcess(undefined, { timeoutMs: 5_000 }),
+          5_000,
+          "job dequeue",
+        );
         dequeueErrorBaseMs = 500;
       } catch (error) {
         _logger.error("Failed to dequeue NuQ job", {
@@ -263,14 +280,19 @@ export async function runNuqWorker(options: {
   await Promise.race([loop, shutdownRequested]);
   let drained = false;
   if (isShuttingDown) {
-    const drain = Promise.all([
-      loop,
-      Promise.resolve().then(() => options.drain?.()),
-    ]);
+    const drain = settleDrain(
+      [loop, Promise.resolve().then(() => options.drain?.())],
+      error => {
+        _logger.error("NuQ worker drain failed", {
+          module: options.serviceName,
+          error,
+        });
+      },
+    );
     const graceController = new AbortController();
     drained =
       (await Promise.race([
-        drain.then(() => true),
+        drain,
         waitForAbortableDelay(
           Math.max(
             0,

--- a/apps/api/src/services/worker/nuq-worker-runtime.test.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.test.ts
@@ -1,0 +1,408 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  nextIdlePollDelay,
+  runLeasedJob,
+  type RuntimeLogger,
+} from "./nuq-worker-runtime";
+import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const logger: RuntimeLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function job() {
+  return {
+    backend: "fdb" as const,
+    id: "job-1",
+    data: { mode: "single_urls" },
+    lock: "lock-1",
+    status: "active" as const,
+    createdAt: new Date(),
+    priority: 0,
+  };
+}
+
+function queue(overrides: Record<string, unknown> = {}) {
+  return {
+    renewLock: vi.fn().mockResolvedValue(true),
+    jobFinish: vi.fn().mockResolvedValue(true),
+    jobFail: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("NuQ worker lease lifecycle", () => {
+  test("retries transient renewal errors with bounded backoff", async () => {
+    vi.useFakeTimers();
+    const processing = deferred<string>();
+    const renewLock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue(true);
+    const q = queue({ renewLock });
+
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      renewIntervalMs: 10,
+      renewalRetryDelaysMs: [5],
+      process: () => processing.promise,
+    });
+
+    await vi.advanceTimersByTimeAsync(15);
+    expect(renewLock).toHaveBeenCalledTimes(2);
+    processing.resolve("ok");
+
+    await expect(running).resolves.toEqual({ status: "completed" });
+    expect(q.jobFinish).toHaveBeenCalledTimes(1);
+  });
+
+  test("fences a hung renewal without starting an overlapping callback", async () => {
+    vi.useFakeTimers();
+    const renewLock = vi.fn(() => new Promise<boolean>(() => {}));
+    const q = queue({ renewLock });
+    const onFence = vi.fn();
+
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      renewIntervalMs: 10,
+      renewalTimeoutMs: 5,
+      onFence,
+      process: signal =>
+        new Promise((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    });
+
+    await vi.advanceTimersByTimeAsync(15);
+    await expect(running).resolves.toEqual({
+      status: "fenced",
+      reason: "renewal-failed",
+    });
+    expect(renewLock).toHaveBeenCalledTimes(1);
+    expect(onFence).toHaveBeenCalledWith("renewal-failed");
+  });
+
+  test("aborts and fences processing after confirmed lock loss", async () => {
+    vi.useFakeTimers();
+    const q = queue({ renewLock: vi.fn().mockResolvedValue(false) });
+    const onFence = vi.fn();
+    let observedAbort = false;
+
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      renewIntervalMs: 10,
+      onFence,
+      process: signal =>
+        new Promise((_, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              observedAbort = true;
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        }),
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(running).resolves.toEqual({
+      status: "fenced",
+      reason: "lock-lost",
+    });
+    expect(observedAbort).toBe(true);
+    expect(onFence).toHaveBeenCalledWith("lock-lost");
+    expect(q.jobFinish).not.toHaveBeenCalled();
+    expect(q.jobFail).not.toHaveBeenCalled();
+  });
+
+  test("awaits an overlapping renewal before finishing", async () => {
+    vi.useFakeTimers();
+    const processing = deferred<string>();
+    const renewal = deferred<boolean>();
+    const q = queue({ renewLock: vi.fn(() => renewal.promise) });
+
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      renewIntervalMs: 10,
+      process: () => processing.promise,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    processing.resolve("ok");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(q.jobFinish).not.toHaveBeenCalled();
+
+    renewal.resolve(true);
+    await expect(running).resolves.toEqual({ status: "completed" });
+    expect(q.jobFinish).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries transient finalization without overlapping renewal", async () => {
+    vi.useFakeTimers();
+    const jobFinish = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("commit unknown"))
+      .mockResolvedValue(true);
+    const q = queue({ jobFinish });
+
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      finalizationRetryDelaysMs: [5],
+      process: async () => "ok",
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(running).resolves.toEqual({ status: "completed" });
+    expect(jobFinish).toHaveBeenCalledTimes(2);
+    expect(q.renewLock).not.toHaveBeenCalled();
+  });
+
+  test("fences a hung finalization instead of wedging without renewals", async () => {
+    vi.useFakeTimers();
+    const jobFinish = vi.fn(() => new Promise<boolean>(() => {}));
+    const q = queue({ jobFinish });
+    const onFence = vi.fn();
+
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      finalizationTimeoutMs: 5,
+      onFence,
+      process: async () => "ok",
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(running).resolves.toEqual({
+      status: "fenced",
+      reason: "finalization-timeout",
+    });
+    expect(jobFinish).toHaveBeenCalledTimes(1);
+    expect(onFence).toHaveBeenCalledWith("finalization-timeout");
+  });
+
+  test("does not start work when the shutdown fence is already active", async () => {
+    const shutdown = new AbortController();
+    shutdown.abort();
+    const q = queue();
+    const process = vi.fn().mockResolvedValue("unexpected");
+
+    await expect(
+      runLeasedJob({
+        queue: q,
+        job: job(),
+        logger,
+        shutdownSignal: shutdown.signal,
+        process,
+      }),
+    ).resolves.toEqual({ status: "fenced", reason: "shutdown" });
+    expect(process).not.toHaveBeenCalled();
+    expect(q.renewLock).not.toHaveBeenCalled();
+    expect(q.jobFinish).not.toHaveBeenCalled();
+  });
+
+  test("forced shutdown aborts and fences an over-deadline job", async () => {
+    const shutdown = new AbortController();
+    const q = queue();
+    const running = runLeasedJob({
+      queue: q,
+      job: job(),
+      logger,
+      shutdownSignal: shutdown.signal,
+      process: signal =>
+        new Promise((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    });
+
+    shutdown.abort();
+    await expect(running).resolves.toEqual({
+      status: "fenced",
+      reason: "shutdown",
+    });
+    expect(q.jobFinish).not.toHaveBeenCalled();
+    expect(q.jobFail).not.toHaveBeenCalled();
+  });
+});
+
+describe("NuQ FDB worker supervision", () => {
+  test("keeps crawl-finished loop healthy through transient dequeue and finish failures", async () => {
+    vi.useFakeTimers();
+    const directFdbJob = job();
+    const getJobToProcess = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("FDB unavailable"))
+      .mockResolvedValueOnce(directFdbJob)
+      .mockResolvedValue(null);
+    const jobFinish = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("commit unknown"))
+      .mockResolvedValue(true);
+    const q = {
+      ...queue({ jobFinish }),
+      getJobToProcess,
+    };
+    const processJob = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient finalizer dependency"))
+      .mockResolvedValue(undefined);
+
+    const loop = startCrawlFinishedLoop({
+      queue: q,
+      processJob,
+      logger,
+      renewIntervalMs: 10_000,
+      processAttempts: 2,
+      retryDelaysMs: [5],
+      idleOptions: {
+        minMs: 10,
+        maxMs: 40,
+        jitterRatio: 0,
+        random: () => 0.5,
+      },
+    });
+
+    expect(loop.isHealthy()).toBe(true);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(processJob).toHaveBeenCalledTimes(2);
+    expect(processJob.mock.calls[0][0].backend).toBe("fdb");
+    expect(jobFinish).toHaveBeenCalledTimes(2);
+    expect(loop.isHealthy()).toBe(true);
+    expect(loop.metrics()).toContain(
+      "firecrawl_nuq_fdb_crawl_finished_loop_alive 1",
+    );
+
+    loop.stop();
+    await loop.done;
+    expect(loop.isHealthy()).toBe(false);
+  });
+
+  test("does not start a crawl-finished job returned after shutdown", async () => {
+    const dequeued = deferred<ReturnType<typeof job> | null>();
+    const q = {
+      ...queue(),
+      getJobToProcess: vi.fn(() => dequeued.promise),
+    };
+    const processJob = vi.fn().mockResolvedValue(undefined);
+    const loop = startCrawlFinishedLoop({ queue: q, processJob, logger });
+
+    loop.stop();
+    dequeued.resolve(job());
+    await loop.done;
+
+    expect(processJob).not.toHaveBeenCalled();
+    expect(q.jobFinish).not.toHaveBeenCalled();
+    expect(q.jobFail).not.toHaveBeenCalled();
+  });
+
+  test("keeps failed-processing metrics until a successful job", async () => {
+    vi.useFakeTimers();
+    const q = {
+      ...queue(),
+      getJobToProcess: vi
+        .fn()
+        .mockResolvedValueOnce(job())
+        .mockResolvedValue(null),
+    };
+    const loop = startCrawlFinishedLoop({
+      queue: q,
+      processJob: vi.fn().mockRejectedValue(new Error("permanent")),
+      processAttempts: 1,
+      logger,
+      idleOptions: { minMs: 10, maxMs: 10, jitterRatio: 0 },
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(loop.metrics()).toContain(
+      "firecrawl_nuq_fdb_crawl_finished_consecutive_errors 1",
+    );
+    loop.stop();
+    await loop.done;
+  });
+
+  test("force-stops an over-deadline crawl-finished job without finalizing", async () => {
+    const q = {
+      ...queue(),
+      getJobToProcess: vi
+        .fn()
+        .mockResolvedValueOnce(job())
+        .mockResolvedValue(null),
+    };
+    let processingStarted!: () => void;
+    const started = new Promise<void>(resolve => {
+      processingStarted = resolve;
+    });
+    const loop = startCrawlFinishedLoop({
+      queue: q,
+      logger,
+      processJob: (_job, signal) =>
+        new Promise((_, reject) => {
+          processingStarted();
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    });
+
+    await started;
+    loop.stop();
+    expect(loop.isHealthy()).toBe(false);
+    loop.forceStop();
+    await loop.done;
+    expect(q.jobFinish).not.toHaveBeenCalled();
+    expect(q.jobFail).not.toHaveBeenCalled();
+  });
+
+  test("uses exponential jittered idle polling independent of RabbitMQ", () => {
+    expect(
+      nextIdlePollDelay(500, {
+        minMs: 500,
+        maxMs: 10_000,
+        jitterRatio: 0.2,
+        random: () => 0,
+      }),
+    ).toEqual({ delayMs: 400, nextBaseMs: 1000 });
+    expect(
+      nextIdlePollDelay(10_000, {
+        minMs: 500,
+        maxMs: 10_000,
+        jitterRatio: 0.2,
+        random: () => 1,
+      }),
+    ).toEqual({ delayMs: 10_000, nextBaseMs: 10_000 });
+  });
+});

--- a/apps/api/src/services/worker/nuq-worker-runtime.test.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   nextIdlePollDelay,
   runLeasedJob,
+  settleDrain,
   type RuntimeLogger,
 } from "./nuq-worker-runtime";
 import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
@@ -103,6 +104,9 @@ describe("NuQ worker lease lifecycle", () => {
       reason: "renewal-failed",
     });
     expect(renewLock).toHaveBeenCalledTimes(1);
+    expect(renewLock).toHaveBeenCalledWith("job-1", "lock-1", logger, {
+      timeoutMs: 5,
+    });
     expect(onFence).toHaveBeenCalledWith("renewal-failed");
   });
 
@@ -210,6 +214,9 @@ describe("NuQ worker lease lifecycle", () => {
       reason: "finalization-timeout",
     });
     expect(jobFinish).toHaveBeenCalledTimes(1);
+    expect(jobFinish).toHaveBeenCalledWith("job-1", "lock-1", "ok", logger, {
+      timeoutMs: 5,
+    });
     expect(onFence).toHaveBeenCalledWith("finalization-timeout");
   });
 
@@ -298,6 +305,7 @@ describe("NuQ FDB worker supervision", () => {
 
     expect(loop.isHealthy()).toBe(true);
     await vi.advanceTimersByTimeAsync(20);
+    expect(getJobToProcess).toHaveBeenCalledWith(logger, { timeoutMs: 5_000 });
     expect(processJob).toHaveBeenCalledTimes(2);
     expect(processJob.mock.calls[0][0].backend).toBe("fdb");
     expect(jobFinish).toHaveBeenCalledTimes(2);
@@ -309,6 +317,47 @@ describe("NuQ FDB worker supervision", () => {
     loop.stop();
     await loop.done;
     expect(loop.isHealthy()).toBe(false);
+  });
+
+  test("turns an unexpected supervisor rejection into unhealthy state", async () => {
+    let errorCalls = 0;
+    const rejectingLogger: RuntimeLogger = {
+      ...logger,
+      error: () => {
+        errorCalls++;
+        throw new Error("logger transport failed");
+      },
+    };
+    const loop = startCrawlFinishedLoop({
+      queue: {
+        ...queue(),
+        getJobToProcess: vi.fn().mockRejectedValue(new Error("dequeue failed")),
+      },
+      processJob: vi.fn(),
+      logger: rejectingLogger,
+    });
+
+    await expect(loop.done).resolves.toBeUndefined();
+    expect(loop.isHealthy()).toBe(false);
+    expect(errorCalls).toBe(2);
+  });
+
+  test("bounds a hung dequeue so shutdown can settle", async () => {
+    vi.useFakeTimers();
+    const loop = startCrawlFinishedLoop({
+      queue: {
+        ...queue(),
+        getJobToProcess: vi.fn(
+          () => new Promise<ReturnType<typeof job> | null>(() => {}),
+        ),
+      },
+      processJob: vi.fn(),
+      logger,
+    });
+
+    loop.stop();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(loop.done).resolves.toBeUndefined();
   });
 
   test("does not start a crawl-finished job returned after shutdown", async () => {
@@ -385,6 +434,17 @@ describe("NuQ FDB worker supervision", () => {
     await loop.done;
     expect(q.jobFinish).not.toHaveBeenCalled();
     expect(q.jobFail).not.toHaveBeenCalled();
+  });
+
+  test("converts drain rejection into an undrained result", async () => {
+    const onError = vi.fn();
+    await expect(
+      settleDrain(
+        [Promise.resolve(), Promise.reject(new Error("drain failed"))],
+        onError,
+      ),
+    ).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledOnce();
   });
 
   test("uses exponential jittered idle polling independent of RabbitMQ", () => {

--- a/apps/api/src/services/worker/nuq-worker-runtime.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.ts
@@ -1,0 +1,306 @@
+import type { NuQJob } from "./nuq";
+
+export type RuntimeLogger = {
+  debug?: (message: string, meta?: Record<string, unknown>) => void;
+  info?: (message: string, meta?: Record<string, unknown>) => void;
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+  error: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+export type LeasedJobQueue = {
+  renewLock(id: string, lock: string, logger?: any): Promise<boolean>;
+  jobFinish(
+    id: string,
+    lock: string,
+    returnvalue: any | null,
+    logger?: any,
+  ): Promise<boolean>;
+  jobFail(
+    id: string,
+    lock: string,
+    failedReason: string,
+    logger?: any,
+  ): Promise<boolean>;
+};
+
+export type FenceReason =
+  | "lock-lost"
+  | "renewal-failed"
+  | "finalization-timeout"
+  | "shutdown";
+
+export type LeasedJobResult =
+  | { status: "completed" }
+  | { status: "failed" }
+  | { status: "fenced"; reason: FenceReason }
+  | { status: "finalization-failed"; error: unknown };
+
+const DEFAULT_RETRY_DELAYS_MS = [250, 500, 1000];
+
+export function waitForAbortableDelay(
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise(resolve => {
+    const timer = setTimeout(done, Math.max(0, delayMs));
+    function done() {
+      signal?.removeEventListener("abort", done);
+      clearTimeout(timer);
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}
+
+export function nextIdlePollDelay(
+  previousBaseMs: number,
+  options: {
+    minMs?: number;
+    maxMs?: number;
+    jitterRatio?: number;
+    random?: () => number;
+  } = {},
+): { delayMs: number; nextBaseMs: number } {
+  const minMs = options.minMs ?? 500;
+  const maxMs = options.maxMs ?? 10_000;
+  const jitterRatio = options.jitterRatio ?? 0.2;
+  const random = options.random ?? Math.random;
+  const base = Math.max(minMs, Math.min(maxMs, previousBaseMs));
+  const jitter = (random() * 2 - 1) * jitterRatio;
+  return {
+    delayMs: Math.min(maxMs, Math.max(0, Math.round(base * (1 + jitter)))),
+    nextBaseMs: Math.min(maxMs, base * 2),
+  };
+}
+
+export async function retryWithBackoff<T>(options: {
+  operation: (attempt: number) => Promise<T>;
+  attempts?: number;
+  delaysMs?: number[];
+  signal?: AbortSignal;
+  shouldRetry?: (error: unknown) => boolean;
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
+}): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  const delays = options.delaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (options.signal?.aborted) {
+      throw options.signal.reason ?? new Error("operation aborted");
+    }
+    try {
+      return await options.operation(attempt);
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts || options.shouldRetry?.(error) === false) break;
+      const delayMs = delays[Math.min(attempt - 1, delays.length - 1)] ?? 0;
+      options.onRetry?.(error, attempt, delayMs);
+      await waitForAbortableDelay(delayMs, options.signal);
+    }
+  }
+  throw lastError;
+}
+
+class OperationTimeoutError extends Error {}
+
+async function withOperationTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new OperationTimeoutError(
+                `${label} timed out after ${timeoutMs}ms`,
+              ),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function failureReason(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/**
+ * Runs a job while owning its lease. Renewals never overlap each other, and
+ * stop() waits for an in-flight renewal before finalization can begin.
+ */
+export async function runLeasedJob<T>(options: {
+  queue: LeasedJobQueue;
+  job: NuQJob<any, any>;
+  process: (signal: AbortSignal) => Promise<T>;
+  logger: RuntimeLogger;
+  shutdownSignal?: AbortSignal;
+  renewIntervalMs?: number;
+  renewalAttempts?: number;
+  renewalRetryDelaysMs?: number[];
+  renewalTimeoutMs?: number;
+  finalizationAttempts?: number;
+  finalizationRetryDelaysMs?: number[];
+  finalizationTimeoutMs?: number;
+  onFence?: (reason: FenceReason) => void;
+}): Promise<LeasedJobResult> {
+  const lock = options.job.lock;
+  if (!lock) throw new Error(`Job ${options.job.id} has no lock`);
+
+  const controller = new AbortController();
+  let fenceReason: FenceReason | null = null;
+  let renewTimer: NodeJS.Timeout | undefined;
+  let inFlightRenewal: Promise<void> | null = null;
+  let renewing = true;
+
+  const fence = (reason: FenceReason) => {
+    if (fenceReason !== null) return;
+    fenceReason = reason;
+    controller.abort(new Error(`Job fenced: ${reason}`));
+    options.onFence?.(reason);
+  };
+  const onShutdown = () => fence("shutdown");
+  options.shutdownSignal?.addEventListener("abort", onShutdown, { once: true });
+  if (options.shutdownSignal?.aborted) onShutdown();
+
+  const scheduleRenewal = () => {
+    if (!renewing || controller.signal.aborted) return;
+    renewTimer = setTimeout(() => {
+      inFlightRenewal = renew().finally(() => {
+        inFlightRenewal = null;
+        scheduleRenewal();
+      });
+    }, options.renewIntervalMs ?? 15_000);
+  };
+
+  const renew = async () => {
+    try {
+      const renewed = await retryWithBackoff({
+        attempts: options.renewalAttempts ?? 3,
+        delaysMs: options.renewalRetryDelaysMs,
+        signal: controller.signal,
+        shouldRetry: error => !(error instanceof OperationTimeoutError),
+        operation: async attempt => {
+          options.logger.info?.("Renewing job lock", { attempt });
+          return await withOperationTimeout(
+            options.queue.renewLock(options.job.id, lock, options.logger),
+            options.renewalTimeoutMs ?? 5_000,
+            "job lock renewal",
+          );
+        },
+        onRetry: (error, attempt, delayMs) => {
+          options.logger.warn("Job lock renewal failed transiently", {
+            error,
+            attempt,
+            delayMs,
+          });
+        },
+      });
+      if (!renewed) {
+        options.logger.warn("Job lock was lost");
+        fence("lock-lost");
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      options.logger.error("Job lock renewal retries exhausted", { error });
+      fence("renewal-failed");
+    }
+  };
+
+  const stopRenewals = async () => {
+    renewing = false;
+    if (renewTimer) clearTimeout(renewTimer);
+    await inFlightRenewal;
+  };
+
+  if (fenceReason !== null) {
+    options.shutdownSignal?.removeEventListener("abort", onShutdown);
+    return { status: "fenced", reason: fenceReason };
+  }
+
+  scheduleRenewal();
+
+  let processResult: { ok: true; data: T } | { ok: false; error: unknown };
+  try {
+    processResult = {
+      ok: true,
+      data: await options.process(controller.signal),
+    };
+  } catch (error) {
+    processResult = { ok: false, error };
+  }
+
+  await stopRenewals();
+  options.shutdownSignal?.removeEventListener("abort", onShutdown);
+
+  if (fenceReason !== null) {
+    return { status: "fenced", reason: fenceReason };
+  }
+
+  try {
+    const finalized = await retryWithBackoff({
+      attempts: options.finalizationAttempts ?? 3,
+      delaysMs: options.finalizationRetryDelaysMs,
+      shouldRetry: error => !(error instanceof OperationTimeoutError),
+      operation: async attempt => {
+        const finalization = processResult.ok
+          ? options.queue.jobFinish(
+              options.job.id,
+              lock,
+              processResult.data,
+              options.logger,
+            )
+          : options.queue.jobFail(
+              options.job.id,
+              lock,
+              failureReason(processResult.error),
+              options.logger,
+            );
+        const result = await withOperationTimeout(
+          finalization,
+          options.finalizationTimeoutMs ?? 10_000,
+          "job finalization",
+        );
+        if (!result) fence("lock-lost");
+        options.logger.debug?.("Finalized job", { attempt, result });
+        return result;
+      },
+      onRetry: (error, attempt, delayMs) => {
+        options.logger.warn("Job finalization failed transiently", {
+          error,
+          attempt,
+          delayMs,
+        });
+      },
+    });
+    if (!finalized || fenceReason !== null) {
+      return { status: "fenced", reason: "lock-lost" };
+    }
+    return { status: processResult.ok ? "completed" : "failed" };
+  } catch (error) {
+    if (error instanceof OperationTimeoutError) {
+      options.logger.error("Job finalization timed out; fencing worker", {
+        error,
+      });
+      fence("finalization-timeout");
+      return { status: "fenced", reason: "finalization-timeout" };
+    }
+    options.logger.error("Job finalization retries exhausted", { error });
+    return { status: "finalization-failed", error };
+  }
+}

--- a/apps/api/src/services/worker/nuq-worker-runtime.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.ts
@@ -7,19 +7,28 @@ export type RuntimeLogger = {
   error: (message: string, meta?: Record<string, unknown>) => void;
 };
 
+export type QueueOperationOptions = { timeoutMs: number };
+
 export type LeasedJobQueue = {
-  renewLock(id: string, lock: string, logger?: any): Promise<boolean>;
+  renewLock(
+    id: string,
+    lock: string,
+    logger?: any,
+    operation?: QueueOperationOptions,
+  ): Promise<boolean>;
   jobFinish(
     id: string,
     lock: string,
     returnvalue: any | null,
     logger?: any,
+    operation?: QueueOperationOptions,
   ): Promise<boolean>;
   jobFail(
     id: string,
     lock: string,
     failedReason: string,
     logger?: any,
+    operation?: QueueOperationOptions,
   ): Promise<boolean>;
 };
 
@@ -104,7 +113,7 @@ export async function retryWithBackoff<T>(options: {
 
 class OperationTimeoutError extends Error {}
 
-async function withOperationTimeout<T>(
+export async function withOperationTimeout<T>(
   operation: Promise<T>,
   timeoutMs: number,
   label: string,
@@ -127,6 +136,19 @@ async function withOperationTimeout<T>(
     ]);
   } finally {
     if (timer) clearTimeout(timer);
+  }
+}
+
+export async function settleDrain(
+  tasks: Promise<unknown>[],
+  onError: (error: unknown) => void,
+): Promise<boolean> {
+  try {
+    await Promise.all(tasks);
+    return true;
+  } catch (error) {
+    onError(error);
+    return false;
   }
 }
 
@@ -198,7 +220,9 @@ export async function runLeasedJob<T>(options: {
         operation: async attempt => {
           options.logger.info?.("Renewing job lock", { attempt });
           return await withOperationTimeout(
-            options.queue.renewLock(options.job.id, lock, options.logger),
+            options.queue.renewLock(options.job.id, lock, options.logger, {
+              timeoutMs: options.renewalTimeoutMs ?? 5_000,
+            }),
             options.renewalTimeoutMs ?? 5_000,
             "job lock renewal",
           );
@@ -264,12 +288,14 @@ export async function runLeasedJob<T>(options: {
               lock,
               processResult.data,
               options.logger,
+              { timeoutMs: options.finalizationTimeoutMs ?? 10_000 },
             )
           : options.queue.jobFail(
               options.job.id,
               lock,
               failureReason(processResult.error),
               options.logger,
+              { timeoutMs: options.finalizationTimeoutMs ?? 10_000 },
             );
         const result = await withOperationTimeout(
           finalization,


### PR DESCRIPTION
## Summary

- tag FoundationDB jobs intrinsically so direct FDB workers never run PostgreSQL/Redis completion paths
- serialize lease renewal with bounded retry/backoff, ownership fencing, hung-operation deadlines, and conflict-safe FDB renewal reads
- supervise crawl-finished processing with retry/backoff, local liveness metrics, jittered idle polling, and transient error recovery
- make worker shutdown stop dequeues immediately, drain both loops within one bounded grace period, and fence overdue work
- expose process-local FDB worker metrics without queue-wide scans

## Tests

- `pnpm exec vitest run src/services/worker/nuq-worker-runtime.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm knip`
- `pnpm exec prettier --check ...` (changed files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the NuQ worker lease lifecycle and shutdown flow to prevent stale ownership and wedged jobs, adds a supervised crawl-finished loop with local metrics, and propagates dequeue/renew/finalize deadlines from runners through the router into FDB transactions. Improves correctness under failures and isolates direct FDB workers from PG/Redis paths.

- **New Features**
  - Added `runLeasedJob` with serialized renewals, bounded retries/backoff, per-operation timeouts (dequeue/renew/finalize), and shutdown fencing.
  - Added `startCrawlFinishedLoop` supervisor with retry/backoff, jittered idle polling, bounded dequeue timeout, liveness tracking, and Prometheus metrics.
  - Upgraded `nuq-worker-runner` to drain within a bounded grace period, expose process-local metrics (active jobs), add a liveness check, and force-abort overdue work.
  - Worker terminates on ownership loss to prevent stale side effects.
  - Propagated `QueueOperationOptions` through `nuq-router` into FDB and set FDB transaction `Timeout` for dequeues/renewals/finalization.

- **Bug Fixes**
  - Tagged FDB jobs with `backend: "fdb"` so direct FDB workers never run PostgreSQL/Redis completion paths.
  - Made FDB renewal reads conflictful to fence workers racing the sweeper, preventing dual active/ready states.
  - Blocked renew/finish after lease loss and added timeouts to fence hung renewals, dequeues, and finalizations (now enforced via router → FDB transaction deadlines).
  - Added tests for deadline propagation, lease renewal/backoff, fencing, idle polling jitter, dequeue timeouts, supervisor health, and shutdown behavior.

<sup>Written for commit cfab7e6db7a797762198ffa9b8e9f99942d1ce55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

