### PR TITLE
fix(nuq): deploy complete PG and FDB worker topologies

### DIFF
--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -1,0 +1,32 @@
+name: Helm Chart Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docker-compose.yaml"
+      - "examples/kubernetes/firecrawl-helm/**"
+      - ".github/workflows/test-helm.yml"
+
+concurrency:
+  group: ci=${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  topology:
+    name: NuQ topology render smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.19.0
+      - name: Install test dependency
+        run: python3 -m pip install --disable-pip-version-check PyYAML==6.0.3
+      - name: Lint chart
+        run: helm lint examples/kubernetes/firecrawl-helm
+      - name: Test rendered topologies
+        run: python3 examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
+      - name: Test Docker Compose topology env
+        run: python3 examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py

--- a/apps/api/src/__tests__/nuq-fdb/topology.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/topology.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
+import { config } from "../../config";
+import { isFdbConfigured } from "../../services/worker/nuq-fdb/client";
 import { resolveNuqServiceTopology } from "../../services/worker/nuq-service-topology";
+
+const originalBackend = config.NUQ_BACKEND;
+const originalClusterFile = config.FDB_CLUSTER_FILE;
+
+afterEach(() => {
+  config.NUQ_BACKEND = originalBackend;
+  config.FDB_CLUSTER_FILE = originalClusterFile;
+});
 
 describe("NuQ service topology", () => {
   test("pg-only starts PG consumers and PG maintenance", () => {
@@ -18,6 +28,24 @@ describe("NuQ service topology", () => {
       fdbMaintenance: false,
       fdbCrawlFinished: false,
     });
+  });
+
+  test("explicit PG mode ignores an available FDB cluster", () => {
+    const topology = resolveNuqServiceTopology({
+      backend: "pg",
+      fdbClusterFile: "/etc/foundationdb/fdb.cluster",
+      scrapeWorkerCount: 3,
+    });
+
+    expect(topology.fdbConfigured).toBe(false);
+    expect(topology.pgScrapeWorkers).toBe(3);
+    expect(topology.fdbScrapeWorkers).toBe(0);
+    expect(topology.fdbMaintenance).toBe(false);
+    expect(topology.fdbCrawlFinished).toBe(false);
+
+    config.NUQ_BACKEND = "pg";
+    config.FDB_CLUSTER_FILE = "/etc/foundationdb/fdb.cluster";
+    expect(isFdbConfigured()).toBe(false);
   });
 
   test("an FDB cluster file enables mixed PG and FDB consumers", () => {

--- a/apps/api/src/__tests__/nuq-fdb/topology.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/topology.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { resolveNuqServiceTopology } from "../../services/worker/nuq-service-topology";
+
+describe("NuQ service topology", () => {
+  test("pg-only starts PG consumers and PG maintenance", () => {
+    expect(
+      resolveNuqServiceTopology({
+        scrapeWorkerCount: 3,
+      }),
+    ).toEqual({
+      forcedFdb: false,
+      fdbConfigured: false,
+      postgres: true,
+      pgScrapeWorkers: 3,
+      fdbScrapeWorkers: 0,
+      pgPrefetch: true,
+      pgReconciler: true,
+      fdbMaintenance: false,
+      fdbCrawlFinished: false,
+    });
+  });
+
+  test("an FDB cluster file enables mixed PG and FDB consumers", () => {
+    expect(
+      resolveNuqServiceTopology({
+        fdbClusterFile: "/etc/foundationdb/fdb.cluster",
+        scrapeWorkerCount: 3,
+      }),
+    ).toEqual({
+      forcedFdb: false,
+      fdbConfigured: true,
+      postgres: true,
+      pgScrapeWorkers: 3,
+      fdbScrapeWorkers: 3,
+      pgPrefetch: true,
+      pgReconciler: true,
+      fdbMaintenance: true,
+      fdbCrawlFinished: true,
+    });
+  });
+
+  test("forced FDB starts no PG-only services", () => {
+    expect(
+      resolveNuqServiceTopology({
+        backend: "fdb",
+        scrapeWorkerCount: 3,
+      }),
+    ).toEqual({
+      forcedFdb: true,
+      fdbConfigured: true,
+      postgres: false,
+      pgScrapeWorkers: 0,
+      fdbScrapeWorkers: 3,
+      pgPrefetch: false,
+      pgReconciler: false,
+      fdbMaintenance: true,
+      fdbCrawlFinished: true,
+    });
+  });
+
+  test("FDB maintenance and completion remain enabled at zero scrape replicas", () => {
+    const topology = resolveNuqServiceTopology({
+      backend: "fdb",
+      scrapeWorkerCount: 0,
+    });
+
+    expect(topology.fdbScrapeWorkers).toBe(0);
+    expect(topology.fdbMaintenance).toBe(true);
+    expect(topology.fdbCrawlFinished).toBe(true);
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -205,7 +205,7 @@ const configSchema = z.object({
 
   // Worker Configuration
   WORKER_PORT: z.coerce.number().default(3005),
-  NUQ_WORKER_PORT: z.coerce.number().default(3000).catch(3000), // todo: investigate why .catch is needed
+  NUQ_WORKER_PORT: z.coerce.number().default(3005).catch(3005), // todo: investigate why .catch is needed
   NUQ_WORKER_START_PORT: z.coerce.number().default(3006),
   NUQ_WORKER_COUNT: z.coerce.number().default(5),
   NUQ_PREFETCH_WORKER_PORT: z.coerce.number().default(3011).catch(3011), // todo: investigate why .catch is needed

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -131,6 +131,9 @@ const configSchema = z.object({
   NUQ_RABBITMQ_URL: z.string().optional(),
   FDB_CLUSTER_FILE: emptyStringAsUndefined(z.string()),
   NUQ_BACKEND: emptyStringAsUndefined(z.enum(["pg", "fdb"])),
+  NUQ_FDB_WORKER_MODE: emptyStringAsDefault(
+    z.enum(["all", "scrape", "maintenance", "crawl-finished"]).default("all"),
+  ),
   NUQ_FDB_READY_SHARDS: emptyStringAsDefault(
     z.coerce.number().int().positive().default(2048),
   ),

--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -712,6 +712,8 @@ async function waitForFdb(
 }
 
 async function setupFdb(): Promise<Services["fdb"]> {
+  if (config.NUQ_BACKEND === "pg") return undefined;
+
   // A cluster file without forced-FDB mode is the mixed/team-flag topology.
   // It needs FDB consumers even though unflagged traffic continues to use PG.
   if (

--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -940,6 +940,11 @@ async function startServices(command?: string[]): Promise<Services> {
         NUQ_REDUCE_NOISE: "true",
         NUQ_POD_NAME: `nuq-fdb-${mode}-0`,
         NUQ_FDB_WORKER_MODE: mode,
+        // Harness FDB namespaces have no pre-compat writers. Production uses
+        // the two-release activation procedure documented in the Helm chart.
+        ...(mode === "maintenance"
+          ? { NUQ_FDB_METRICS_V2_ACTIVATE: "true" }
+          : {}),
       },
     );
   const nuqFdbMaintenanceWorker = topology.fdbMaintenance

--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import * as net from "net";
 import { basename, join } from "path";
 import { HTML_TO_MARKDOWN_PATH } from "./natives";
+import { resolveNuqServiceTopology } from "./services/worker/nuq-service-topology";
 
 const childProcesses = new Set<ChildProcess>();
 const stopping = new WeakSet<ChildProcess>(); // processes we're intentionally stopping
@@ -46,6 +47,8 @@ interface Services {
   nuqWorkers: ProcessResult[];
   nuqPrefetchWorker?: ProcessResult;
   nuqReconcilerWorker?: ProcessResult;
+  nuqFdbMaintenanceWorker?: ProcessResult;
+  nuqFdbCrawlFinishedWorker?: ProcessResult;
   extractWorker?: ProcessResult;
   indexWorker?: ProcessResult;
   command?: ProcessResult;
@@ -116,8 +119,6 @@ const WORKER_PORT = config.WORKER_PORT;
 const EXTRACT_WORKER_PORT = config.EXTRACT_WORKER_PORT;
 const NUQ_WORKER_START_PORT = config.NUQ_WORKER_START_PORT;
 const NUQ_WORKER_COUNT = config.NUQ_WORKER_COUNT;
-const NUQ_PREFETCH_WORKER_PORT = NUQ_WORKER_START_PORT + NUQ_WORKER_COUNT;
-const NUQ_RECONCILER_WORKER_PORT = NUQ_PREFETCH_WORKER_PORT + 1;
 
 // PostgreSQL credentials (with defaults for backward compatibility)
 const POSTGRES_USER = config.POSTGRES_USER;
@@ -711,8 +712,13 @@ async function waitForFdb(
 }
 
 async function setupFdb(): Promise<Services["fdb"]> {
-  // FDB is only needed when the FDB queue backend is in play
-  if (config.NUQ_BACKEND !== "fdb" && !process.env.NUQ_FDB_TESTS) {
+  // A cluster file without forced-FDB mode is the mixed/team-flag topology.
+  // It needs FDB consumers even though unflagged traffic continues to use PG.
+  if (
+    config.NUQ_BACKEND !== "fdb" &&
+    !config.FDB_CLUSTER_FILE &&
+    !process.env.NUQ_FDB_TESTS
+  ) {
     return undefined;
   }
 
@@ -816,14 +822,28 @@ async function installDependencies() {
 }
 
 async function startServices(command?: string[]): Promise<Services> {
-  // Setup NUQ PostgreSQL container if needed
-  const nuqPostgres = await setupNuqPostgres();
+  const requestedTopology = resolveNuqServiceTopology({
+    backend: config.NUQ_BACKEND,
+    fdbClusterFile: config.FDB_CLUSTER_FILE,
+    scrapeWorkerCount: NUQ_WORKER_COUNT,
+  });
 
-  // Setup NUQ RabbitMQ container if needed
+  // Forced FDB does not need the PG queue database. Mixed mode keeps it for
+  // unflagged teams and for already-pinned PG crawls while they drain.
+  const nuqPostgres = requestedTopology.postgres
+    ? await setupNuqPostgres()
+    : undefined;
+
+  // RabbitMQ is also used for wakeups by the FDB implementation.
   const nuqRabbitMQ = await setupNuqRabbitMQ();
 
-  // Setup FoundationDB container if the FDB queue backend is enabled
+  // setupFdb may create a local cluster and populate FDB_CLUSTER_FILE.
   const fdb = await setupFdb();
+  const topology = resolveNuqServiceTopology({
+    backend: config.NUQ_BACKEND,
+    fdbClusterFile: config.FDB_CLUSTER_FILE,
+    scrapeWorkerCount: NUQ_WORKER_COUNT,
+  });
 
   logger.section("Starting services");
 
@@ -862,50 +882,99 @@ async function startServices(command?: string[]): Promise<Services> {
     },
   );
 
-  const nuqWorkers = Array.from({ length: NUQ_WORKER_COUNT }, (_, i) =>
-    execForward(
-      `${config.NUQ_BACKEND === "fdb" ? "nuq-fdb-worker" : "nuq-worker"}-${i}`,
-      process.argv[2] === "--start-docker"
-        ? `node dist/src/services/worker/${config.NUQ_BACKEND === "fdb" ? "nuq-fdb-worker" : "nuq-worker"}.js`
-        : `pnpm ${config.NUQ_BACKEND === "fdb" ? "nuq-fdb-worker" : "nuq-worker"}:production`,
-      {
-        NUQ_WORKER_PORT: String(NUQ_WORKER_START_PORT + i),
-        NUQ_REDUCE_NOISE: "true",
-        NUQ_POD_NAME: `${config.NUQ_BACKEND === "fdb" ? "nuq-fdb-worker" : "nuq-worker"}-${i}`,
-      },
-    ),
+  const startNuqWorkers = (
+    serviceName: "nuq-worker" | "nuq-fdb-worker",
+    count: number,
+    portOffset: number,
+  ) =>
+    Array.from({ length: count }, (_, i) =>
+      execForward(
+        `${serviceName}-${i}`,
+        process.argv[2] === "--start-docker"
+          ? `node dist/src/services/worker/${serviceName}.js`
+          : `pnpm ${serviceName}:production`,
+        {
+          NUQ_WORKER_PORT: String(NUQ_WORKER_START_PORT + portOffset + i),
+          NUQ_REDUCE_NOISE: "true",
+          NUQ_POD_NAME: `${serviceName}-${i}`,
+          ...(serviceName === "nuq-fdb-worker"
+            ? { NUQ_FDB_WORKER_MODE: "scrape" }
+            : {}),
+        },
+      ),
+    );
+
+  const pgNuqWorkers = startNuqWorkers(
+    "nuq-worker",
+    topology.pgScrapeWorkers,
+    0,
   );
+  const fdbNuqWorkers = startNuqWorkers(
+    "nuq-fdb-worker",
+    topology.fdbScrapeWorkers,
+    topology.pgScrapeWorkers,
+  );
+  const nuqWorkers = [...pgNuqWorkers, ...fdbNuqWorkers];
+  const nextNuqPort =
+    NUQ_WORKER_START_PORT +
+    topology.pgScrapeWorkers +
+    topology.fdbScrapeWorkers;
+  const nuqPrefetchWorkerPort = nextNuqPort;
+  const nuqReconcilerWorkerPort = nextNuqPort + 1;
+  const nuqFdbMaintenanceWorkerPort = nextNuqPort + 2;
+  const nuqFdbCrawlFinishedWorkerPort = nextNuqPort + 3;
 
-  const nuqPrefetchWorker =
-    config.NUQ_BACKEND === "fdb"
-      ? undefined
-      : execForward(
-          "nuq-prefetch-worker",
-          process.argv[2] === "--start-docker"
-            ? "node dist/src/services/worker/nuq-prefetch-worker.js"
-            : "pnpm nuq-prefetch-worker:production",
-          {
-            NUQ_PREFETCH_WORKER_PORT: String(NUQ_PREFETCH_WORKER_PORT),
-            NUQ_REDUCE_NOISE: "true",
-            NUQ_POD_NAME: "nuq-prefetch-worker-0",
-            NUQ_PREFETCH_REPLICAS: String(1),
-          },
-        );
+  const startFdbControlWorker = (
+    mode: "maintenance" | "crawl-finished",
+    port: number,
+  ) =>
+    execForward(
+      `nuq-fdb-${mode}`,
+      process.argv[2] === "--start-docker"
+        ? "node dist/src/services/worker/nuq-fdb-worker.js"
+        : "pnpm nuq-fdb-worker:production",
+      {
+        NUQ_WORKER_PORT: String(port),
+        NUQ_REDUCE_NOISE: "true",
+        NUQ_POD_NAME: `nuq-fdb-${mode}-0`,
+        NUQ_FDB_WORKER_MODE: mode,
+      },
+    );
+  const nuqFdbMaintenanceWorker = topology.fdbMaintenance
+    ? startFdbControlWorker("maintenance", nuqFdbMaintenanceWorkerPort)
+    : undefined;
+  const nuqFdbCrawlFinishedWorker = topology.fdbCrawlFinished
+    ? startFdbControlWorker("crawl-finished", nuqFdbCrawlFinishedWorkerPort)
+    : undefined;
 
-  const nuqReconcilerWorker =
-    config.NUQ_BACKEND === "fdb"
-      ? undefined
-      : execForward(
-          "nuq-reconciler",
-          process.argv[2] === "--start-docker"
-            ? "node dist/src/services/worker/nuq-reconciler-worker.js"
-            : "pnpm nuq-reconciler-worker:production",
-          {
-            NUQ_RECONCILER_WORKER_PORT: String(NUQ_RECONCILER_WORKER_PORT),
-            NUQ_REDUCE_NOISE: "true",
-            NUQ_POD_NAME: "nuq-reconciler-worker-0",
-          },
-        );
+  const nuqPrefetchWorker = topology.pgPrefetch
+    ? execForward(
+        "nuq-prefetch-worker",
+        process.argv[2] === "--start-docker"
+          ? "node dist/src/services/worker/nuq-prefetch-worker.js"
+          : "pnpm nuq-prefetch-worker:production",
+        {
+          NUQ_PREFETCH_WORKER_PORT: String(nuqPrefetchWorkerPort),
+          NUQ_REDUCE_NOISE: "true",
+          NUQ_POD_NAME: "nuq-prefetch-worker-0",
+          NUQ_PREFETCH_REPLICAS: String(1),
+        },
+      )
+    : undefined;
+
+  const nuqReconcilerWorker = topology.pgReconciler
+    ? execForward(
+        "nuq-reconciler",
+        process.argv[2] === "--start-docker"
+          ? "node dist/src/services/worker/nuq-reconciler-worker.js"
+          : "pnpm nuq-reconciler-worker:production",
+        {
+          NUQ_RECONCILER_WORKER_PORT: String(nuqReconcilerWorkerPort),
+          NUQ_REDUCE_NOISE: "true",
+          NUQ_POD_NAME: "nuq-reconciler-worker-0",
+        },
+      )
+    : undefined;
 
   const indexWorker = config.USE_DB_AUTHENTICATION
     ? execForward(
@@ -942,6 +1011,8 @@ async function startServices(command?: string[]): Promise<Services> {
     nuqWorkers,
     nuqPrefetchWorker,
     nuqReconcilerWorker,
+    nuqFdbMaintenanceWorker,
+    nuqFdbCrawlFinishedWorker,
     indexWorker,
     extractWorker,
     command: commandProcess,
@@ -960,6 +1031,8 @@ async function stopDevelopmentServices(services: Services) {
     ...services.nuqWorkers.map(w => w.process),
     services.nuqPrefetchWorker?.process,
     services.nuqReconcilerWorker?.process,
+    services.nuqFdbMaintenanceWorker?.process,
+    services.nuqFdbCrawlFinishedWorker?.process,
     services.indexWorker?.process,
     services.extractWorker?.process,
     services.command?.process,
@@ -1133,6 +1206,10 @@ async function waitForTermination(services: Services): Promise<void> {
     promises.push(services.nuqPrefetchWorker.promise);
   if (services.nuqReconcilerWorker)
     promises.push(services.nuqReconcilerWorker.promise);
+  if (services.nuqFdbMaintenanceWorker)
+    promises.push(services.nuqFdbMaintenanceWorker.promise);
+  if (services.nuqFdbCrawlFinishedWorker)
+    promises.push(services.nuqFdbCrawlFinishedWorker.promise);
 
   promises.push(...services.nuqWorkers.map(w => w.promise));
 

--- a/apps/api/src/services/worker/nuq-fdb-worker-process.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker-process.test.ts
@@ -1,0 +1,188 @@
+import { EventEmitter } from "node:events";
+import type { Server } from "node:http";
+import request from "supertest";
+import { describe, expect, test, vi } from "vitest";
+import {
+  createNuqFdbWorkerOptions,
+  type NuqFdbWorkerComponent,
+  type NuqFdbWorkerMode,
+} from "./nuq-fdb-worker-service";
+import { runNuqWorker, type WorkerQueue } from "./nuq-worker-runner";
+
+vi.mock("./scrape-worker", () => ({ processJobInternal: vi.fn() }));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const MAINTENANCE_METRICS = `nuq_fdb_queue_scrape_job_count{status="queued"} 1
+nuq_fdb_queue_crawl_finished_job_count{status="queued"} 2
+firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds{queue="scrape",index="delay",partition="0"} 3
+`;
+
+function controlledComponent(name: string) {
+  const completion = deferred<void>();
+  let healthy = true;
+  const component: NuqFdbWorkerComponent = {
+    name,
+    stop: vi.fn(() => {
+      healthy = false;
+    }),
+    forceStop: vi.fn(),
+    done: completion.promise,
+    isHealthy: () => healthy,
+    metrics: () =>
+      name === "maintenance" ? MAINTENANCE_METRICS : `${name}_metric 1\n`,
+  };
+  return { component, completion };
+}
+
+function makeScrapeQueue(dequeue: Promise<null>): WorkerQueue {
+  return {
+    getJobToProcess: vi.fn(() => dequeue),
+    renewLock: vi.fn().mockResolvedValue(true),
+    jobFinish: vi.fn().mockResolvedValue(true),
+    jobFail: vi.fn().mockResolvedValue(true),
+  };
+}
+
+type RunningWorker = {
+  server: Server;
+  signals: EventEmitter;
+  exitCode: Promise<number>;
+  running: Promise<void>;
+};
+
+async function startWorker(
+  mode: NuqFdbWorkerMode,
+  options: {
+    dependencyReady: () => boolean;
+    scrapeDequeue: Promise<null>;
+    maintenance: ReturnType<typeof controlledComponent>;
+    crawlFinished: ReturnType<typeof controlledComponent>;
+    shutdownGraceMs?: number;
+  },
+): Promise<RunningWorker> {
+  const workerOptions = createNuqFdbWorkerOptions(mode, {
+    scrapeQueue: makeScrapeQueue(options.scrapeDequeue),
+    healthCheck: async () => options.dependencyReady(),
+    startMaintenance: () => options.maintenance.component,
+    startCrawlFinished: () => options.crawlFinished.component,
+  });
+  workerOptions.shutdownGraceMs = options.shutdownGraceMs ?? 1_000;
+
+  const signals = new EventEmitter();
+  const listening = deferred<Server>();
+  const exited = deferred<number>();
+  const running = runNuqWorker(workerOptions, {
+    initialize: async () => undefined,
+    signalSource: signals,
+    port: 0,
+    onServerStarted: server => listening.resolve(server),
+    exit: code => exited.resolve(code),
+  });
+
+  return {
+    server: await listening.promise,
+    signals,
+    exitCode: exited.promise,
+    running,
+  };
+}
+
+describe.each<NuqFdbWorkerMode>([
+  "all",
+  "scrape",
+  "maintenance",
+  "crawl-finished",
+])("NuQ FDB %s process lifecycle", mode => {
+  test("keeps live backend-independent and flips ready through SIGTERM drain", async () => {
+    let dependencyReady = true;
+    const scrapeDequeue = deferred<null>();
+    const maintenance = controlledComponent("maintenance");
+    const crawlFinished = controlledComponent("crawl-finished");
+    const worker = await startWorker(mode, {
+      dependencyReady: () => dependencyReady,
+      scrapeDequeue: scrapeDequeue.promise,
+      maintenance,
+      crawlFinished,
+    });
+
+    await request(worker.server).get("/ready").expect(200, "OK");
+    await request(worker.server).get("/health").expect(200, "OK");
+    const metrics = await request(worker.server).get("/metrics").expect(200);
+    const runsMaintenance = mode === "all" || mode === "maintenance";
+    const runsCrawlFinished = mode === "all" || mode === "crawl-finished";
+    expect(metrics.text.includes("nuq_fdb_queue_scrape_job_count")).toBe(
+      runsMaintenance,
+    );
+    expect(
+      metrics.text.includes("nuq_fdb_queue_crawl_finished_job_count"),
+    ).toBe(runsMaintenance);
+    expect(
+      metrics.text.includes("firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds"),
+    ).toBe(runsMaintenance);
+    expect(metrics.text.includes("crawl-finished_metric")).toBe(
+      runsCrawlFinished,
+    );
+
+    dependencyReady = false;
+    await request(worker.server).get("/live").expect(200, "OK");
+    await request(worker.server).get("/ready").expect(503, "Not Ready");
+    dependencyReady = true;
+
+    worker.signals.emit("SIGTERM");
+    await request(worker.server).get("/ready").expect(503, "Not Ready");
+    await request(worker.server).get("/live").expect(200, "OK");
+
+    scrapeDequeue.resolve(null);
+    maintenance.completion.resolve();
+    crawlFinished.completion.resolve();
+    await expect(worker.exitCode).resolves.toBe(0);
+    await worker.running;
+  });
+});
+
+describe("NuQ worker fatal and deadline lifecycle", () => {
+  test("exits nonzero when a required loop dies", async () => {
+    const scrapeDequeue = deferred<null>();
+    const maintenance = controlledComponent("maintenance");
+    const crawlFinished = controlledComponent("crawl-finished");
+    const worker = await startWorker("crawl-finished", {
+      dependencyReady: () => true,
+      scrapeDequeue: scrapeDequeue.promise,
+      maintenance,
+      crawlFinished,
+    });
+
+    crawlFinished.completion.reject(new Error("required loop died"));
+    await expect(worker.exitCode).resolves.toBe(1);
+    await worker.running;
+  });
+
+  test("forces an over-deadline component and exits after bounded drain", async () => {
+    const scrapeDequeue = deferred<null>();
+    const maintenance = controlledComponent("maintenance");
+    const crawlFinished = controlledComponent("crawl-finished");
+    const worker = await startWorker("maintenance", {
+      dependencyReady: () => true,
+      scrapeDequeue: scrapeDequeue.promise,
+      maintenance,
+      crawlFinished,
+      shutdownGraceMs: 200,
+    });
+
+    worker.signals.emit("SIGTERM");
+    await request(worker.server).get("/ready").expect(503, "Not Ready");
+    await request(worker.server).get("/live").expect(200, "OK");
+    await expect(worker.exitCode).resolves.toBe(0);
+    expect(maintenance.component.forceStop).toHaveBeenCalledOnce();
+    await worker.running;
+  });
+});

--- a/apps/api/src/services/worker/nuq-fdb-worker-service.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker-service.test.ts
@@ -1,0 +1,133 @@
+import request from "supertest";
+import { describe, expect, test, vi } from "vitest";
+import {
+  createNuqFdbWorkerOptions,
+  type NuqFdbWorkerComponent,
+  type NuqFdbWorkerMode,
+} from "./nuq-fdb-worker-service";
+import { createNuqWorkerHttpApp } from "./nuq-worker-http";
+import type { WorkerQueue } from "./nuq-worker-runner";
+
+const scrapeQueue: WorkerQueue = {
+  getJobToProcess: vi.fn().mockResolvedValue(null),
+  renewLock: vi.fn().mockResolvedValue(true),
+  jobFinish: vi.fn().mockResolvedValue(true),
+  jobFail: vi.fn().mockResolvedValue(true),
+};
+
+function component(name: string): NuqFdbWorkerComponent {
+  return {
+    name,
+    stop: vi.fn(),
+    forceStop: vi.fn(),
+    done: new Promise<void>(() => {}),
+    isHealthy: vi.fn(() => true),
+    metrics: vi.fn(() => `${name}_metric 1\n`),
+  };
+}
+
+describe.each<{
+  mode: NuqFdbWorkerMode;
+  scrape: boolean;
+  maintenance: boolean;
+  crawlFinished: boolean;
+}>([
+  { mode: "scrape", scrape: true, maintenance: false, crawlFinished: false },
+  {
+    mode: "maintenance",
+    scrape: false,
+    maintenance: true,
+    crawlFinished: false,
+  },
+  {
+    mode: "crawl-finished",
+    scrape: false,
+    maintenance: false,
+    crawlFinished: true,
+  },
+  { mode: "all", scrape: true, maintenance: true, crawlFinished: true },
+])("NuQ FDB $mode mode", ({ mode, scrape, maintenance, crawlFinished }) => {
+  test("exposes deterministic per-mode live, ready, and drain behavior", async () => {
+    let dependencyReady = true;
+    let draining = false;
+    const maintenanceLoop = component("maintenance");
+    const crawlFinishedLoop = component("crawl-finished");
+    const options = createNuqFdbWorkerOptions(mode, {
+      scrapeQueue,
+      healthCheck: async () => dependencyReady,
+      startMaintenance: () => maintenanceLoop,
+      startCrawlFinished: () => crawlFinishedLoop,
+    });
+    await options.beforeStart?.();
+    const app = createNuqWorkerHttpApp({
+      isDraining: () => draining,
+      dependencyReady: options.healthCheck,
+      requiredLoopsReady: () =>
+        options.requiredLoops?.().every(loop => loop.isHealthy()) ?? true,
+      metrics: () => options.metrics?.() ?? "",
+    });
+
+    await request(app).get("/ready").expect(200, "OK");
+    dependencyReady = false;
+    await request(app).get("/live").expect(200, "OK");
+    await request(app).get("/ready").expect(503, "Not Ready");
+
+    dependencyReady = true;
+    if (maintenance) {
+      vi.mocked(maintenanceLoop.isHealthy!).mockReturnValue(false);
+      await request(app).get("/ready").expect(503, "Not Ready");
+      vi.mocked(maintenanceLoop.isHealthy!).mockReturnValue(true);
+    }
+    if (crawlFinished) {
+      vi.mocked(crawlFinishedLoop.isHealthy!).mockReturnValue(false);
+      await request(app).get("/ready").expect(503, "Not Ready");
+      vi.mocked(crawlFinishedLoop.isHealthy!).mockReturnValue(true);
+    }
+
+    draining = true;
+    await request(app).get("/ready").expect(503, "Not Ready");
+    await request(app).get("/live").expect(200, "OK");
+  });
+
+  test("starts and supervises exactly its required topology", async () => {
+    const maintenanceLoop = component("maintenance");
+    const crawlFinishedLoop = component("crawl-finished");
+    const startMaintenance = vi.fn(() => maintenanceLoop);
+    const startCrawlFinished = vi.fn(() => crawlFinishedLoop);
+    const options = createNuqFdbWorkerOptions(mode, {
+      scrapeQueue,
+      healthCheck: vi.fn().mockResolvedValue(true),
+      startMaintenance,
+      startCrawlFinished,
+    });
+
+    await options.beforeStart?.();
+
+    expect(options.queue === scrapeQueue).toBe(scrape);
+    expect(startMaintenance).toHaveBeenCalledTimes(maintenance ? 1 : 0);
+    expect(startCrawlFinished).toHaveBeenCalledTimes(crawlFinished ? 1 : 0);
+    expect(options.requiredLoops?.().map(loop => loop.name)).toEqual([
+      ...(maintenance ? ["maintenance"] : []),
+      ...(crawlFinished ? ["crawl-finished"] : []),
+    ]);
+
+    const metrics = await options.metrics?.();
+    expect(metrics).toContain(maintenance ? "maintenance_metric 1" : "");
+    expect(metrics).toContain(crawlFinished ? "crawl-finished_metric 1" : "");
+    expect(maintenanceLoop.metrics).toHaveBeenCalledTimes(maintenance ? 1 : 0);
+    expect(crawlFinishedLoop.metrics).toHaveBeenCalledTimes(
+      crawlFinished ? 1 : 0,
+    );
+
+    await options.onShutdownRequested?.();
+    expect(maintenanceLoop.stop).toHaveBeenCalledTimes(maintenance ? 1 : 0);
+    expect(crawlFinishedLoop.stop).toHaveBeenCalledTimes(crawlFinished ? 1 : 0);
+    await options.onShutdownDeadline?.();
+    expect(maintenanceLoop.forceStop).toHaveBeenCalledTimes(
+      maintenance ? 1 : 0,
+    );
+    expect(crawlFinishedLoop.forceStop).toHaveBeenCalledTimes(
+      crawlFinished ? 1 : 0,
+    );
+  });
+});

--- a/apps/api/src/services/worker/nuq-fdb-worker-service.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker-service.ts
@@ -1,0 +1,86 @@
+import type { RunNuqWorkerOptions, WorkerQueue } from "./nuq-worker-runner";
+import type { RequiredWorkerLoop } from "./nuq-worker-runtime";
+
+export type NuqFdbWorkerMode =
+  | "all"
+  | "scrape"
+  | "maintenance"
+  | "crawl-finished";
+
+export type NuqFdbWorkerComponent = {
+  name: string;
+  stop(): void;
+  forceStop?(): void;
+  done: Promise<void>;
+  isHealthy(): boolean;
+  metrics?(): string | Promise<string>;
+};
+
+export type NuqFdbWorkerDependencies = {
+  scrapeQueue: WorkerQueue;
+  healthCheck: () => Promise<boolean>;
+  startMaintenance: () => NuqFdbWorkerComponent;
+  startCrawlFinished: () => NuqFdbWorkerComponent;
+};
+
+const idleQueue: WorkerQueue = {
+  async getJobToProcess() {
+    return null;
+  },
+  async renewLock() {
+    return false;
+  },
+  async jobFinish() {
+    return false;
+  },
+  async jobFail() {
+    return false;
+  },
+};
+
+export function createNuqFdbWorkerOptions(
+  mode: NuqFdbWorkerMode,
+  dependencies: NuqFdbWorkerDependencies,
+): RunNuqWorkerOptions {
+  const runsScrapes = mode === "all" || mode === "scrape";
+  const runsMaintenance = mode === "all" || mode === "maintenance";
+  const runsCrawlFinished = mode === "all" || mode === "crawl-finished";
+  const components: NuqFdbWorkerComponent[] = [];
+
+  return {
+    serviceName: mode === "all" ? "nuq-fdb-worker" : `nuq-fdb-worker-${mode}`,
+    queue: runsScrapes ? dependencies.scrapeQueue : idleQueue,
+    healthCheck: dependencies.healthCheck,
+    beforeStart: () => {
+      if (runsMaintenance) {
+        components.push(dependencies.startMaintenance());
+      }
+      if (runsCrawlFinished) {
+        components.push(dependencies.startCrawlFinished());
+      }
+    },
+    requiredLoops: () =>
+      components.map(
+        (component): RequiredWorkerLoop => ({
+          name: component.name,
+          done: component.done,
+          isHealthy: () => component.isHealthy(),
+        }),
+      ),
+    metrics: async () => {
+      const metrics = await Promise.all(
+        components.map(component => component.metrics?.() ?? ""),
+      );
+      return metrics.filter(Boolean).join("\n");
+    },
+    onShutdownRequested: () => {
+      for (const component of components) component.stop();
+    },
+    drain: async () => {
+      await Promise.all(components.map(component => component.done));
+    },
+    onShutdownDeadline: () => {
+      for (const component of components) component.forceStop?.();
+    },
+  };
+}

--- a/apps/api/src/services/worker/nuq-fdb-worker.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker.ts
@@ -1,20 +1,20 @@
 import "dotenv/config";
 import "../sentry";
 import { setSentryServiceTag } from "../sentry";
+import { config } from "../../config";
 import { logger as _logger } from "../../lib/logger";
 import { getCrawl } from "../../lib/crawl-redis";
 import { finishCrawlSuper } from "./crawl-logic";
 import {
   crawlFinishedQueueFdb,
   getNuqFdbSweeper,
+  nuqFdbGetMetrics,
   nuqFdbHealthCheck,
   nuqFdbSweeperGetMetrics,
   scrapeQueueFdb,
 } from "./nuq-fdb";
-import {
-  isLegacyFdbWorkerLive,
-  startCrawlFinishedLoop,
-} from "./nuq-fdb-worker-runtime";
+import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
+import { createNuqFdbWorkerOptions } from "./nuq-fdb-worker-service";
 import { runNuqWorker } from "./nuq-worker-runner";
 import type { NuQJob } from "./nuq";
 
@@ -49,25 +49,25 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
 }
 
 (async () => {
-  setSentryServiceTag("nuq-fdb-worker");
-
-  let crawlFinishedLoop: ReturnType<typeof startCrawlFinishedLoop> | null =
-    null;
-
-  await runNuqWorker({
-    serviceName: "nuq-fdb-worker",
-    queue: scrapeQueueFdb as any,
-    healthCheck: () => nuqFdbHealthCheck(),
-    livenessCheck: () => isLegacyFdbWorkerLive(crawlFinishedLoop),
-    // These are process-local metrics. Queue-wide FDB ranges are deliberately
-    // not scanned from every worker's Prometheus scrape callback.
-    metrics: () =>
-      [crawlFinishedLoop?.metrics() ?? "", nuqFdbSweeperGetMetrics()]
-        .filter(Boolean)
-        .join("\n"),
-    beforeStart: () => {
-      getNuqFdbSweeper().start();
-      crawlFinishedLoop = startCrawlFinishedLoop({
+  let serviceName = "nuq-fdb-worker";
+  const workerOptions = createNuqFdbWorkerOptions(config.NUQ_FDB_WORKER_MODE, {
+    scrapeQueue: scrapeQueueFdb as any,
+    healthCheck: nuqFdbHealthCheck,
+    startMaintenance: () => {
+      const sweeper = getNuqFdbSweeper();
+      sweeper.start();
+      return {
+        name: "maintenance",
+        stop: () => sweeper.stop(),
+        forceStop: () => sweeper.forceStop(),
+        done: sweeper.done,
+        isHealthy: () => sweeper.isHealthy(),
+        metrics: async () =>
+          `${await nuqFdbGetMetrics()}${nuqFdbSweeperGetMetrics()}`,
+      };
+    },
+    startCrawlFinished: () => {
+      const loop = startCrawlFinishedLoop({
         queue: crawlFinishedQueueFdb as any,
         processJob: processFinishCrawlJobInternal,
         logger: _logger.child({
@@ -78,24 +78,22 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
           if (reason === "shutdown") return;
           _logger.error(
             "Worker lost crawl-finished ownership; terminating stale process",
-            { module: "nuq-fdb-worker", reason },
+            { module: serviceName, reason },
           );
           setImmediate(() => process.exit(1));
         },
       });
-    },
-    onShutdownRequested: () => {
-      // Stop both dequeue loops immediately, then let their in-flight jobs keep
-      // renewing and drain within runNuqWorker's bounded grace period.
-      crawlFinishedLoop?.stop();
-      getNuqFdbSweeper().stop();
-    },
-    drain: async () => {
-      await Promise.all([crawlFinishedLoop?.done, getNuqFdbSweeper().done]);
-    },
-    onShutdownDeadline: () => {
-      crawlFinishedLoop?.forceStop();
-      getNuqFdbSweeper().forceStop();
+      return {
+        name: "crawl-finished",
+        stop: () => loop.stop(),
+        forceStop: () => loop.forceStop(),
+        done: loop.done,
+        isHealthy: () => loop.isHealthy(),
+        metrics: () => loop.metrics(),
+      };
     },
   });
+  serviceName = workerOptions.serviceName;
+  setSentryServiceTag(serviceName);
+  await runNuqWorker(workerOptions);
 })();

--- a/apps/api/src/services/worker/nuq-fdb/client.ts
+++ b/apps/api/src/services/worker/nuq-fdb/client.ts
@@ -29,6 +29,7 @@ export function getNuqFdbDatabase(): Database {
 }
 
 export function isFdbConfigured(): boolean {
+  if (config.NUQ_BACKEND === "pg") return false;
   return !!config.FDB_CLUSTER_FILE || config.NUQ_BACKEND === "fdb";
 }
 

--- a/apps/api/src/services/worker/nuq-service-topology.ts
+++ b/apps/api/src/services/worker/nuq-service-topology.ts
@@ -25,7 +25,9 @@ export function resolveNuqServiceTopology(options: {
   }
 
   const forcedFdb = options.backend === "fdb";
-  const fdbConfigured = forcedFdb || Boolean(options.fdbClusterFile);
+  const forcedPg = options.backend === "pg";
+  const fdbConfigured =
+    !forcedPg && (forcedFdb || Boolean(options.fdbClusterFile));
 
   return {
     forcedFdb,

--- a/apps/api/src/services/worker/nuq-service-topology.ts
+++ b/apps/api/src/services/worker/nuq-service-topology.ts
@@ -1,0 +1,44 @@
+export type NuqBackend = "pg" | "fdb";
+
+export type NuqServiceTopology = {
+  forcedFdb: boolean;
+  fdbConfigured: boolean;
+  postgres: boolean;
+  pgScrapeWorkers: number;
+  fdbScrapeWorkers: number;
+  pgPrefetch: boolean;
+  pgReconciler: boolean;
+  fdbMaintenance: boolean;
+  fdbCrawlFinished: boolean;
+};
+
+export function resolveNuqServiceTopology(options: {
+  backend?: NuqBackend;
+  fdbClusterFile?: string;
+  scrapeWorkerCount: number;
+}): NuqServiceTopology {
+  if (!Number.isInteger(options.scrapeWorkerCount)) {
+    throw new Error("NuQ scrape worker count must be an integer");
+  }
+  if (options.scrapeWorkerCount < 0) {
+    throw new Error("NuQ scrape worker count cannot be negative");
+  }
+
+  const forcedFdb = options.backend === "fdb";
+  const fdbConfigured = forcedFdb || Boolean(options.fdbClusterFile);
+
+  return {
+    forcedFdb,
+    fdbConfigured,
+    postgres: !forcedFdb,
+    pgScrapeWorkers: forcedFdb ? 0 : options.scrapeWorkerCount,
+    fdbScrapeWorkers: fdbConfigured ? options.scrapeWorkerCount : 0,
+    pgPrefetch: !forcedFdb,
+    pgReconciler: !forcedFdb,
+    // These are deliberately independent of scrape worker count. FDB delayed
+    // work, expired leases, and crawl completion must continue to make
+    // progress while scrape consumers are scaled to zero during a drain.
+    fdbMaintenance: fdbConfigured,
+    fdbCrawlFinished: fdbConfigured,
+  };
+}

--- a/apps/api/src/services/worker/nuq-worker-http.test.ts
+++ b/apps/api/src/services/worker/nuq-worker-http.test.ts
@@ -1,0 +1,110 @@
+import request from "supertest";
+import { describe, expect, test, vi } from "vitest";
+import { createNuqWorkerHttpApp } from "./nuq-worker-http";
+
+function makeState() {
+  let draining = false;
+  let dependencyReady = true;
+  let requiredLoopsReady = true;
+
+  const app = createNuqWorkerHttpApp({
+    isDraining: () => draining,
+    dependencyReady: async () => dependencyReady,
+    requiredLoopsReady: () => requiredLoopsReady,
+    metrics: async () => "worker_metric 1\n",
+  });
+
+  return {
+    app,
+    setDraining(value: boolean) {
+      draining = value;
+    },
+    setDependencyReady(value: boolean) {
+      dependencyReady = value;
+    },
+    setRequiredLoopsReady(value: boolean) {
+      requiredLoopsReady = value;
+    },
+  };
+}
+
+describe("NuQ worker HTTP lifecycle", () => {
+  test("keeps liveness backend-independent during an outage", async () => {
+    const state = makeState();
+    state.setDependencyReady(false);
+
+    await request(state.app).get("/live").expect(200, "OK");
+    await request(state.app).get("/ready").expect(503, "Not Ready");
+    await request(state.app).get("/health").expect(503, "Not Ready");
+  });
+
+  test("readiness requires every local required loop", async () => {
+    const state = makeState();
+    state.setRequiredLoopsReady(false);
+
+    await request(state.app).get("/live").expect(200, "OK");
+    await request(state.app).get("/ready").expect(503, "Not Ready");
+  });
+
+  test("drain flips readiness immediately without changing liveness", async () => {
+    const state = makeState();
+
+    await request(state.app).get("/ready").expect(200, "OK");
+    state.setDraining(true);
+    await request(state.app).get("/ready").expect(503, "Not Ready");
+    await request(state.app).get("/live").expect(200, "OK");
+  });
+
+  test("turns required-loop health errors into unready responses", async () => {
+    const onReadinessError = vi.fn();
+    const app = createNuqWorkerHttpApp({
+      isDraining: () => false,
+      dependencyReady: async () => true,
+      requiredLoopsReady: () => {
+        throw new Error("loop state unavailable");
+      },
+      metrics: () => "",
+      onReadinessError,
+    });
+
+    await request(app).get("/live").expect(200, "OK");
+    await request(app).get("/ready").expect(503, "Not Ready");
+    expect(onReadinessError).toHaveBeenCalledOnce();
+  });
+
+  test("turns dependency errors into unready responses", async () => {
+    const onReadinessError = vi.fn();
+    const app = createNuqWorkerHttpApp({
+      isDraining: () => false,
+      dependencyReady: async () => {
+        throw new Error("FDB unavailable");
+      },
+      metrics: () => "",
+      onReadinessError,
+    });
+
+    await request(app).get("/live").expect(200, "OK");
+    await request(app).get("/ready").expect(503, "Not Ready");
+    expect(onReadinessError).toHaveBeenCalledOnce();
+  });
+
+  test("serves metrics and isolates collection errors", async () => {
+    const state = makeState();
+    const response = await request(state.app).get("/metrics").expect(200);
+    expect(response.text).toBe("worker_metric 1\n");
+
+    const onMetricsError = vi.fn();
+    const failingApp = createNuqWorkerHttpApp({
+      isDraining: () => false,
+      dependencyReady: async () => true,
+      metrics: async () => {
+        throw new Error("metrics unavailable");
+      },
+      onMetricsError,
+    });
+    await request(failingApp)
+      .get("/metrics")
+      .expect(500, "Metrics unavailable");
+    expect(onMetricsError).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/services/worker/nuq-worker-http.ts
+++ b/apps/api/src/services/worker/nuq-worker-http.ts
@@ -1,0 +1,86 @@
+import Express, {
+  type Express as ExpressApplication,
+  type Request,
+  type Response,
+} from "express";
+
+export type NuqWorkerHttpOptions = {
+  isDraining: () => boolean;
+  dependencyReady: () => Promise<boolean>;
+  requiredLoopsReady?: () => boolean;
+  metrics: () => string | Promise<string>;
+  readinessTimeoutMs?: number;
+  onReadinessError?: (error: unknown) => void;
+  onMetricsError?: (error: unknown) => void;
+};
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Creates the shared worker HTTP surface. Liveness intentionally has no
+ * dependency checks: Kubernetes must not restart a healthy process merely
+ * because FoundationDB (or another queue backend) is temporarily unavailable.
+ */
+export function createNuqWorkerHttpApp(
+  options: NuqWorkerHttpOptions,
+): ExpressApplication {
+  const app = Express();
+
+  app.get("/live", (_req, res) => {
+    res.status(200).send("OK");
+  });
+
+  const readiness = async (_req: Request, res: Response) => {
+    try {
+      if (options.isDraining() || options.requiredLoopsReady?.() === false) {
+        res.status(503).send("Not Ready");
+        return;
+      }
+
+      const ready = await withTimeout(
+        options.dependencyReady(),
+        options.readinessTimeoutMs ?? 1_000,
+        "NuQ dependency readiness check",
+      );
+      res.status(ready ? 200 : 503).send(ready ? "OK" : "Not Ready");
+    } catch (error) {
+      options.onReadinessError?.(error);
+      res.status(503).send("Not Ready");
+    }
+  };
+
+  app.get("/ready", readiness);
+  // Compatibility for existing probes and operators. New deployments use the
+  // explicit live/ready endpoints.
+  app.get("/health", readiness);
+
+  app.get("/metrics", async (_req, res) => {
+    try {
+      res.contentType("text/plain").send(await options.metrics());
+    } catch (error) {
+      options.onMetricsError?.(error);
+      res.status(500).send("Metrics unavailable");
+    }
+  });
+
+  return app;
+}

--- a/apps/api/src/services/worker/nuq-worker-runner.ts
+++ b/apps/api/src/services/worker/nuq-worker-runner.ts
@@ -4,7 +4,7 @@ import { jobDurationSeconds } from "../../lib/job-metrics";
 import { processJobInternal } from "./scrape-worker";
 import { NuQJob } from "./nuq";
 import { register } from "prom-client";
-import Express from "express";
+import { createNuqWorkerHttpApp } from "./nuq-worker-http";
 import { initializeBlocklist } from "../../scraper/WebScraper/utils/blocklist";
 import { initializeEngineForcing } from "../../scraper/WebScraper/utils/engine-forcing";
 import type { Server } from "http";
@@ -12,9 +12,11 @@ import {
   nextIdlePollDelay,
   runLeasedJob,
   settleDrain,
+  superviseRequiredWorkerLoops,
   waitForAbortableDelay,
   withOperationTimeout,
   type QueueOperationOptions,
+  type RequiredWorkerLoop,
 } from "./nuq-worker-runtime";
 
 export type WorkerQueue = {
@@ -44,6 +46,37 @@ export type WorkerQueue = {
   ): Promise<boolean>;
 };
 
+export type WorkerSignalSource = {
+  on(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+  off(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+};
+
+export type RunNuqWorkerHost = {
+  initialize?: () => void | Promise<void>;
+  signalSource?: WorkerSignalSource;
+  port?: number;
+  onServerStarted?: (server: Server) => void;
+  exit?: (code: number) => void;
+};
+
+export type RunNuqWorkerOptions = {
+  serviceName: string;
+  queue: WorkerQueue;
+  healthCheck: () => Promise<boolean>;
+  /** @deprecated Use requiredLoops. */
+  livenessCheck?: () => boolean;
+  requiredLoops?: () => readonly RequiredWorkerLoop[];
+  metrics?: () => string | Promise<string>;
+  beforeStart?: () => void | Promise<void>;
+  onShutdownRequested?: () => void | Promise<void>;
+  drain?: () => void | Promise<void>;
+  onShutdownDeadline?: () => void | Promise<void>;
+  beforeShutdown?: () => void | Promise<void>;
+  shutdown?: () => void | Promise<void>;
+  shutdownGraceMs?: number;
+  processJob?: (job: NuQJob<any, any>, signal: AbortSignal) => Promise<any>;
+};
+
 async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -71,36 +104,35 @@ function closeServer(server: Server) {
   });
 }
 
-export async function runNuqWorker(options: {
-  serviceName: string;
-  queue: WorkerQueue;
-  healthCheck: () => Promise<boolean>;
-  livenessCheck?: () => boolean;
-  metrics?: () => string | Promise<string>;
-  beforeStart?: () => void | Promise<void>;
-  onShutdownRequested?: () => void | Promise<void>;
-  drain?: () => void | Promise<void>;
-  onShutdownDeadline?: () => void | Promise<void>;
-  beforeShutdown?: () => void | Promise<void>;
-  shutdown?: () => void | Promise<void>;
-  shutdownGraceMs?: number;
-  processJob?: (job: NuQJob<any, any>, signal: AbortSignal) => Promise<any>;
-}) {
+export async function runNuqWorker(
+  options: RunNuqWorkerOptions,
+  host: RunNuqWorkerHost = {},
+) {
+  const signalSource = host.signalSource ?? process;
+  const exit = host.exit ?? ((code: number) => process.exit(code));
+
   try {
-    await initializeBlocklist();
-    initializeEngineForcing();
+    if (host.initialize) {
+      await host.initialize();
+    } else {
+      await initializeBlocklist();
+      initializeEngineForcing();
+    }
     await options.beforeStart?.();
   } catch (error) {
     _logger.error("Failed to initialize NuQ worker", {
       module: options.serviceName,
       error,
     });
-    process.exit(1);
+    exit(1);
+    return;
   }
 
   let isShuttingDown = false;
   let shutdownStartedAt: number | null = null;
   let activeJobs = 0;
+  let fatalRequiredLoopError: unknown = null;
+  const requiredLoops = options.requiredLoops?.() ?? [];
   const idleController = new AbortController();
   const forceActiveJobController = new AbortController();
   let resolveShutdownRequested!: () => void;
@@ -108,58 +140,38 @@ export async function runNuqWorker(options: {
     resolveShutdownRequested = resolve;
   });
 
-  const app = Express();
-
-  app.get("/metrics", async (_, res) => {
-    try {
+  const app = createNuqWorkerHttpApp({
+    isDraining: () => isShuttingDown,
+    dependencyReady: options.healthCheck,
+    requiredLoopsReady: () =>
+      requiredLoops.every(requiredLoop => requiredLoop.isHealthy()) &&
+      (options.livenessCheck?.() ?? true),
+    metrics: async () => {
       const localMetrics = options.metrics ? await options.metrics() : "";
       const runtimeMetrics = `# HELP firecrawl_nuq_worker_active_jobs Number of jobs executing in this worker process\n# TYPE firecrawl_nuq_worker_active_jobs gauge\nfirecrawl_nuq_worker_active_jobs{service="${options.serviceName}"} ${activeJobs}\n`;
-      res
-        .contentType("text/plain")
-        .send(
-          localMetrics + "\n" + runtimeMetrics + (await register.metrics()),
-        );
-    } catch (error) {
+      return localMetrics + "\n" + runtimeMetrics + (await register.metrics());
+    },
+    onReadinessError: error => {
+      _logger.warn("NuQ worker readiness check failed", {
+        module: options.serviceName,
+        error,
+      });
+    },
+    onMetricsError: error => {
       _logger.warn("NuQ worker metrics collection failed", {
         module: options.serviceName,
         error,
       });
-      res.status(500).send("Metrics unavailable");
-    }
-  });
-  app.get("/health", async (_, res) => {
-    try {
-      if (options.livenessCheck && !options.livenessCheck()) {
-        res.status(500).send("Not OK");
-        return;
-      }
-      if (await withTimeout(options.healthCheck(), 1000, "NuQ health check")) {
-        res.status(200).send("OK");
-      } else {
-        res.status(500).send("Not OK");
-      }
-    } catch (error) {
-      _logger.warn("NuQ worker health check failed", {
-        module: options.serviceName,
-        error,
-      });
-      res.status(500).send("Not OK");
-    }
+    },
   });
 
-  const server = app.listen(config.NUQ_WORKER_PORT, (error?: Error) => {
-    if (error) {
-      _logger.error("Failed to start NuQ worker metrics server", {
-        module: options.serviceName,
-        error,
-        port: config.NUQ_WORKER_PORT,
-      });
-      throw error;
-    }
-
+  const port = host.port ?? config.NUQ_WORKER_PORT;
+  const server = app.listen(port, () => {
     _logger.info("NuQ worker metrics server started", {
       module: options.serviceName,
+      port,
     });
+    host.onServerStarted?.(server);
   });
 
   function requestShutdown() {
@@ -176,8 +188,22 @@ export async function runNuqWorker(options: {
     });
   }
 
-  process.on("SIGINT", requestShutdown);
-  process.on("SIGTERM", requestShutdown);
+  signalSource.on("SIGINT", requestShutdown);
+  signalSource.on("SIGTERM", requestShutdown);
+
+  superviseRequiredWorkerLoops(
+    requiredLoops,
+    () => isShuttingDown,
+    (loop, error) => {
+      fatalRequiredLoopError = error;
+      _logger.error("NuQ worker required loop failed", {
+        module: options.serviceName,
+        loop,
+        error,
+      });
+      requestShutdown();
+    },
+  );
 
   const loop = (async () => {
     let idleBaseMs = 500;
@@ -246,7 +272,7 @@ export async function runNuqWorker(options: {
             // processJobInternal does not yet accept an AbortSignal. Exiting the
             // single-job worker is the only hard cancellation boundary that
             // prevents the stale owner from continuing crawl/scrape effects.
-            setImmediate(() => process.exit(1));
+            setImmediate(() => exit(1));
           },
           process: signal =>
             options.processJob
@@ -333,8 +359,8 @@ export async function runNuqWorker(options: {
     drained,
   });
 
-  process.off("SIGINT", requestShutdown);
-  process.off("SIGTERM", requestShutdown);
+  signalSource.off("SIGINT", requestShutdown);
+  signalSource.off("SIGTERM", requestShutdown);
 
   const remainingShutdownMs = () =>
     shutdownStartedAt === null
@@ -372,5 +398,5 @@ export async function runNuqWorker(options: {
   }
 
   _logger.info("NuQ worker shut down", { module: options.serviceName });
-  process.exit(0);
+  exit(fatalRequiredLoopError === null ? 0 : 1);
 }

--- a/apps/api/src/services/worker/nuq-worker-runtime.test.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.test.ts
@@ -3,6 +3,7 @@ import {
   nextIdlePollDelay,
   runLeasedJob,
   settleDrain,
+  superviseRequiredWorkerLoops,
   type RuntimeLogger,
 } from "./nuq-worker-runtime";
 import {
@@ -266,6 +267,54 @@ describe("NuQ worker lease lifecycle", () => {
     });
     expect(q.jobFinish).not.toHaveBeenCalled();
     expect(q.jobFail).not.toHaveBeenCalled();
+  });
+});
+
+describe("required worker loop supervision", () => {
+  test("treats an unexpected required-loop stop as fatal", async () => {
+    const stopped = deferred<void>();
+    const onFatal = vi.fn();
+
+    superviseRequiredWorkerLoops(
+      [
+        {
+          name: "crawl-finished",
+          isHealthy: () => true,
+          done: stopped.promise,
+        },
+      ],
+      () => false,
+      onFatal,
+    );
+
+    stopped.resolve();
+    await stopped.promise;
+    await Promise.resolve();
+    expect(onFatal).toHaveBeenCalledOnce();
+    expect(onFatal.mock.calls[0][0]).toBe("crawl-finished");
+    expect(onFatal.mock.calls[0][1]).toBeInstanceOf(Error);
+  });
+
+  test("ignores required-loop completion after drain begins", async () => {
+    const stopped = deferred<void>();
+    const onFatal = vi.fn();
+
+    superviseRequiredWorkerLoops(
+      [
+        {
+          name: "maintenance",
+          isHealthy: () => false,
+          done: stopped.promise,
+        },
+      ],
+      () => true,
+      onFatal,
+    );
+
+    stopped.resolve();
+    await stopped.promise;
+    await Promise.resolve();
+    expect(onFatal).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/worker/nuq-worker-runtime.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.ts
@@ -7,6 +7,34 @@ export type RuntimeLogger = {
   error: (message: string, meta?: Record<string, unknown>) => void;
 };
 
+export type RequiredWorkerLoop = {
+  name: string;
+  isHealthy: () => boolean;
+  done: Promise<void>;
+};
+
+export function superviseRequiredWorkerLoops(
+  requiredLoops: readonly RequiredWorkerLoop[],
+  isShuttingDown: () => boolean,
+  onFatal: (loopName: string, error: unknown) => void,
+): void {
+  for (const requiredLoop of requiredLoops) {
+    void requiredLoop.done.then(
+      () => {
+        if (isShuttingDown()) return;
+        onFatal(
+          requiredLoop.name,
+          new Error(`Required loop ${requiredLoop.name} stopped unexpectedly`),
+        );
+      },
+      error => {
+        if (isShuttingDown()) return;
+        onFatal(requiredLoop.name, error);
+      },
+    );
+  }
+}
+
 export type QueueOperationOptions = { timeoutMs: number };
 
 export type LeasedJobQueue = {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,11 +55,12 @@ x-common-env: &common-env
   SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT}
   SEARXNG_ENGINES: ${SEARXNG_ENGINES}
   SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES}
-  # Set FDB_CLUSTER_FILE=/var/fdb/fdb.cluster for every FDB-capable topology.
-  # Leave NUQ_BACKEND unset for mixed routing, or set it to fdb to force FDB.
-  # NUQ_BACKEND=pg with no cluster file remains explicitly PG-only.
-  NUQ_BACKEND: ${NUQ_BACKEND}
-  FDB_CLUSTER_FILE: ${FDB_CLUSTER_FILE:-}
+  # Compose defaults to explicit PG mode while wiring the shared FDB cluster
+  # file for opt-in modes. Set NUQ_BACKEND= (empty) for mixed/team-flag
+  # routing, or NUQ_BACKEND=fdb to force FDB. NUQ_BACKEND=pg always remains
+  # PG-only even though the cluster file is available.
+  NUQ_BACKEND: ${NUQ_BACKEND-pg}
+  FDB_CLUSTER_FILE: ${FDB_CLUSTER_FILE-/var/fdb/fdb.cluster}
 
 services:
   playwright-service:
@@ -173,10 +174,9 @@ services:
         max-file: "3"
         compress: "true"
 
-  # FoundationDB queue backend (experimental). Set
-  # FDB_CLUSTER_FILE=/var/fdb/fdb.cluster to enable mixed/team-flag routing;
-  # also set NUQ_BACKEND=fdb to force all queue traffic onto FDB. The API
-  # container reads the shared cluster file from the fdb-cluster-file volume.
+  # FoundationDB queue backend (experimental). Compose wires its shared
+  # cluster file automatically. Set NUQ_BACKEND= (empty) for mixed/team-flag
+  # routing or NUQ_BACKEND=fdb to force all queue traffic onto FDB.
   foundationdb:
     image: foundationdb/foundationdb:7.3.63
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,9 +55,11 @@ x-common-env: &common-env
   SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT}
   SEARXNG_ENGINES: ${SEARXNG_ENGINES}
   SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES}
-  # Set NUQ_BACKEND=fdb to run the queue on FoundationDB instead of Postgres
+  # Set FDB_CLUSTER_FILE=/var/fdb/fdb.cluster for every FDB-capable topology.
+  # Leave NUQ_BACKEND unset for mixed routing, or set it to fdb to force FDB.
+  # NUQ_BACKEND=pg with no cluster file remains explicitly PG-only.
   NUQ_BACKEND: ${NUQ_BACKEND}
-  FDB_CLUSTER_FILE: ${NUQ_BACKEND:+/var/fdb/fdb.cluster}
+  FDB_CLUSTER_FILE: ${FDB_CLUSTER_FILE:-}
 
 services:
   playwright-service:
@@ -171,9 +173,10 @@ services:
         max-file: "3"
         compress: "true"
 
-  # FoundationDB queue backend (experimental). Enable by setting
-  # NUQ_BACKEND=fdb; the api container reads the shared cluster file from the
-  # fdb-cluster-file volume. Replaces nuq-postgres once stable.
+  # FoundationDB queue backend (experimental). Set
+  # FDB_CLUSTER_FILE=/var/fdb/fdb.cluster to enable mixed/team-flag routing;
+  # also set NUQ_BACKEND=fdb to force all queue traffic onto FDB. The API
+  # container reads the shared cluster file from the fdb-cluster-file volume.
   foundationdb:
     image: foundationdb/foundationdb:7.3.63
     environment:

--- a/examples/kubernetes/firecrawl-helm/Chart.yaml
+++ b/examples/kubernetes/firecrawl-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: firecrawl
 description: A Helm chart for deploying the Firecrawl application
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/examples/kubernetes/firecrawl-helm/README.md
+++ b/examples/kubernetes/firecrawl-helm/README.md
@@ -66,7 +66,9 @@ A safe migration is:
 2. Enable FDB routing gradually for selected teams while both consumer sets
    remain available. Existing crawls stay pinned to their original backend.
 3. Stop new PG routing and wait for PG active, delayed, and crawl-finished work
-   to drain before switching to `fdb`.
+   to drain before switching to `fdb`. Persistent PG queue volumes are retained
+   across this switch as a rollback safeguard and must be deleted manually only
+   after they are no longer needed.
 4. Keep `nuqFdb.maintenanceWorker.replicaCount` and
    `nuqFdb.crawlFinishedWorker.replicaCount` at one or more. The chart rejects
    zero for these control loops. `nuqFdb.scrapeWorker.replicaCount=0` is safe

--- a/examples/kubernetes/firecrawl-helm/README.md
+++ b/examples/kubernetes/firecrawl-helm/README.md
@@ -62,21 +62,36 @@ HELM_NO_PLUGINS=1 helm upgrade firecrawl . \
 
 A safe migration is:
 
-1. Deploy `mixed` and verify the three FDB deployments are healthy.
-2. Enable FDB routing gradually for selected teams while both consumer sets
+1. Deploy release A in `mixed` mode with
+   `NUQ_FDB_METRICS_V2_ACTIVATE=false` (the default). Freeze new FDB admission
+   and migration expansion, retain the current FDB replica floor, and verify
+   the three FDB deployments are healthy.
+2. Drain every pre-compatible API, queue writer, group completer, and sweeper.
+   Before activation, maintenance `/metrics` intentionally exposes only
+   `firecrawl_nuq_fdb_metrics_ready 0`; queue/HPA series are absent so scaling
+   holds its existing replica count.
+3. Deploy release B with
+   `--set config.extra.NUQ_FDB_METRICS_V2_ACTIVATE=true`. Maintenance performs
+   bounded generation backfill. Keep admission expansion and HPA changes frozen
+   until `/metrics` reports `firecrawl_nuq_fdb_metrics_ready 1` and includes
+   both `nuq_fdb_queue_scrape_job_count` and
+   `nuq_fdb_queue_crawl_finished_job_count`.
+4. Enable FDB routing gradually for selected teams while both consumer sets
    remain available. Existing crawls stay pinned to their original backend.
-3. Stop new PG routing and wait for PG active, delayed, and crawl-finished work
+5. Stop new PG routing and wait for PG active, delayed, and crawl-finished work
    to drain before switching to `fdb`. Persistent PG queue volumes are retained
    across this switch as a rollback safeguard and must be deleted manually only
    after they are no longer needed.
-4. Keep `nuqFdb.maintenanceWorker.replicaCount` and
+6. Keep `nuqFdb.maintenanceWorker.replicaCount` and
    `nuqFdb.crawlFinishedWorker.replicaCount` at one or more. The chart rejects
    zero for these control loops. `nuqFdb.scrapeWorker.replicaCount=0` is safe
    during a deliberate scrape-consumer drain because maintenance and crawl
    completion remain independently available.
 
-To roll back routing, return to `mixed` first so both backends have consumers;
-do not switch directly to `pg` while FDB-pinned work remains.
+To roll back routing, first disable activation and let the compatible release
+invalidate metric readiness, then return to `mixed` before deploying older
+code. Never run a pre-compatible writer against an active metric generation,
+and do not switch directly to `pg` while FDB-pinned work remains.
 
 ## Deploy
 

--- a/examples/kubernetes/firecrawl-helm/README.md
+++ b/examples/kubernetes/firecrawl-helm/README.md
@@ -5,8 +5,9 @@ This chart deploys Firecrawl on Kubernetes with:
 - `api`
 - `worker` (queue-worker)
 - `extract-worker`
-- `nuq-worker`
-- `nuq-prefetch-worker`
+- PG and/or FoundationDB NuQ scrape workers (selected by `nuq.mode`)
+- `nuq-prefetch-worker` and `nuq-reconciler-worker` in PG-capable modes
+- dedicated FDB maintenance and crawl-finished workers in FDB-capable modes
 - `cclog-worker`
 - `playwright-service`
 - `redis`
@@ -32,6 +33,48 @@ Important fields:
 - `resources.enabled` enables/disables all container resource requests/limits.
   Default: `false`.
 - `rabbitmq.enabled`, `extractWorker.enabled`, `nuqPrefetchWorker.enabled`, `cclogWorker.enabled` to toggle components.
+
+## NuQ queue topology and safe rollout
+
+`nuq.mode` selects the worker topology:
+
+| Mode    | PG scrape / prefetch / reconciler | FDB scrape / maintenance / completion | Typical use                            |
+| ------- | --------------------------------- | ------------------------------------- | -------------------------------------- |
+| `pg`    | yes                               | no                                    | Default PG-only deployment             |
+| `mixed` | yes                               | yes                                   | Gradual team-flag rollout and PG drain |
+| `fdb`   | no                                | yes                                   | Forced FDB after PG work is drained    |
+
+For `mixed` or `fdb`, create a Secret containing the FoundationDB cluster
+file, then reference its name. Keep the cluster file out of values files and
+source control:
+
+```bash
+kubectl create secret generic firecrawl-fdb-cluster \
+  --from-file=fdb.cluster=/secure/path/fdb.cluster \
+  -n firecrawl
+
+HELM_NO_PLUGINS=1 helm upgrade firecrawl . \
+  --reuse-values \
+  --set nuq.mode=mixed \
+  --set nuqFdb.clusterFile.existingSecret=firecrawl-fdb-cluster \
+  -n firecrawl
+```
+
+A safe migration is:
+
+1. Deploy `mixed` and verify the three FDB deployments are healthy.
+2. Enable FDB routing gradually for selected teams while both consumer sets
+   remain available. Existing crawls stay pinned to their original backend.
+3. Stop new PG routing and wait for PG active, delayed, and crawl-finished work
+   to drain before switching to `fdb`.
+4. Keep `nuqFdb.maintenanceWorker.replicaCount` and
+   `nuqFdb.crawlFinishedWorker.replicaCount` at one or more. The chart rejects
+   zero for these control loops. `nuqFdb.scrapeWorker.replicaCount=0` is safe
+   during a deliberate scrape-consumer drain because maintenance and crawl
+   completion remain independently available.
+
+To roll back routing, return to `mixed` first so both backends have consumers;
+do not switch directly to `pg` while FDB-pinned work remains.
 
 ## Deploy
 
@@ -97,14 +140,14 @@ docker buildx build --platform linux/amd64,linux/arm64 --push \
 
 ```bash
 HELM_NO_PLUGINS=1 helm package . --destination /tmp/helm-packages
-HELM_NO_PLUGINS=1 helm push /tmp/helm-packages/firecrawl-0.2.0.tgz oci://registry-1.docker.io/winkkgmbh
+HELM_NO_PLUGINS=1 helm push /tmp/helm-packages/firecrawl-0.3.0.tgz oci://registry-1.docker.io/winkkgmbh
 ```
 
 Install from OCI:
 
 ```bash
 HELM_NO_PLUGINS=1 helm upgrade --install firecrawl oci://registry-1.docker.io/winkkgmbh/firecrawl \
-  --version 0.2.0 \
+  --version 0.3.0 \
   -n firecrawl --create-namespace \
   -f values.yaml \
   -f overlays/prod/values.yaml

--- a/examples/kubernetes/firecrawl-helm/templates/_helpers.tpl
+++ b/examples/kubernetes/firecrawl-helm/templates/_helpers.tpl
@@ -42,6 +42,9 @@ unflagged and draining teams while also running FDB consumers.
   {{- if hasKey $.Values.config.extra $key -}}
     {{- fail (printf "config.extra.%s is managed by nuq.mode and cannot be overridden" $key) -}}
   {{- end -}}
+  {{- if hasKey $.Values.secret.extra $key -}}
+    {{- fail (printf "secret.extra.%s is managed by nuq.mode and cannot be overridden" $key) -}}
+  {{- end -}}
 {{- end -}}
 {{- if include "firecrawl.fdbEnabled" . -}}
   {{- if not .Values.nuqFdb.clusterFile.existingSecret -}}
@@ -53,11 +56,14 @@ unflagged and draining teams while also running FDB consumers.
   {{- if not .Values.nuqFdb.clusterFile.mountPath -}}
     {{- fail "nuqFdb.clusterFile.mountPath is required for mixed and fdb modes" -}}
   {{- end -}}
-  {{- if lt (int .Values.nuqFdb.maintenanceWorker.replicaCount) 1 -}}
-    {{- fail "nuqFdb.maintenanceWorker.replicaCount must be at least 1" -}}
+  {{- if not (regexMatch "^[0-9]+$" (printf "%v" .Values.nuqFdb.scrapeWorker.replicaCount)) -}}
+    {{- fail "nuqFdb.scrapeWorker.replicaCount must be a nonnegative integer" -}}
   {{- end -}}
-  {{- if lt (int .Values.nuqFdb.crawlFinishedWorker.replicaCount) 1 -}}
-    {{- fail "nuqFdb.crawlFinishedWorker.replicaCount must be at least 1" -}}
+  {{- if not (regexMatch "^[1-9][0-9]*$" (printf "%v" .Values.nuqFdb.maintenanceWorker.replicaCount)) -}}
+    {{- fail "nuqFdb.maintenanceWorker.replicaCount must be a positive integer" -}}
+  {{- end -}}
+  {{- if not (regexMatch "^[1-9][0-9]*$" (printf "%v" .Values.nuqFdb.crawlFinishedWorker.replicaCount)) -}}
+    {{- fail "nuqFdb.crawlFinishedWorker.replicaCount must be a positive integer" -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/examples/kubernetes/firecrawl-helm/templates/_helpers.tpl
+++ b/examples/kubernetes/firecrawl-helm/templates/_helpers.tpl
@@ -47,6 +47,12 @@ unflagged and draining teams while also running FDB consumers.
   {{- if not .Values.nuqFdb.clusterFile.existingSecret -}}
     {{- fail "nuqFdb.clusterFile.existingSecret is required for mixed and fdb modes" -}}
   {{- end -}}
+  {{- if not .Values.nuqFdb.clusterFile.key -}}
+    {{- fail "nuqFdb.clusterFile.key is required for mixed and fdb modes" -}}
+  {{- end -}}
+  {{- if not .Values.nuqFdb.clusterFile.mountPath -}}
+    {{- fail "nuqFdb.clusterFile.mountPath is required for mixed and fdb modes" -}}
+  {{- end -}}
   {{- if lt (int .Values.nuqFdb.maintenanceWorker.replicaCount) 1 -}}
     {{- fail "nuqFdb.maintenanceWorker.replicaCount must be at least 1" -}}
   {{- end -}}
@@ -54,4 +60,29 @@ unflagged and draining teams while also running FDB consumers.
     {{- fail "nuqFdb.crawlFinishedWorker.replicaCount must be at least 1" -}}
   {{- end -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "firecrawl.fdbClusterFilePath" -}}
+{{- printf "%s/fdb.cluster" (trimSuffix "/" .Values.nuqFdb.clusterFile.mountPath) -}}
+{{- end -}}
+
+{{- define "firecrawl.fdbVolumeMounts" -}}
+{{- if include "firecrawl.fdbEnabled" . }}
+volumeMounts:
+  - name: fdb-cluster-file
+    mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+    readOnly: true
+{{- end }}
+{{- end -}}
+
+{{- define "firecrawl.fdbVolumes" -}}
+{{- if include "firecrawl.fdbEnabled" . }}
+volumes:
+  - name: fdb-cluster-file
+    secret:
+      secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+      items:
+        - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+          path: fdb.cluster
+{{- end }}
 {{- end -}}

--- a/examples/kubernetes/firecrawl-helm/templates/_helpers.tpl
+++ b/examples/kubernetes/firecrawl-helm/templates/_helpers.tpl
@@ -16,3 +16,42 @@ Return the fully qualified name of the chart.
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve and validate the NuQ deployment mode. "mixed" keeps PG consumers for
+unflagged and draining teams while also running FDB consumers.
+*/}}
+{{- define "firecrawl.nuqMode" -}}
+{{- $mode := default "pg" .Values.nuq.mode -}}
+{{- if not (has $mode (list "pg" "mixed" "fdb")) -}}
+{{- fail "nuq.mode must be one of: pg, mixed, fdb" -}}
+{{- end -}}
+{{- $mode -}}
+{{- end -}}
+
+{{- define "firecrawl.fdbEnabled" -}}
+{{- if ne (include "firecrawl.nuqMode" .) "pg" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "firecrawl.pgEnabled" -}}
+{{- if ne (include "firecrawl.nuqMode" .) "fdb" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "firecrawl.validateNuqTopology" -}}
+{{- range $key := list "NUQ_BACKEND" "FDB_CLUSTER_FILE" "NUQ_FDB_WORKER_MODE" -}}
+  {{- if hasKey $.Values.config.extra $key -}}
+    {{- fail (printf "config.extra.%s is managed by nuq.mode and cannot be overridden" $key) -}}
+  {{- end -}}
+{{- end -}}
+{{- if include "firecrawl.fdbEnabled" . -}}
+  {{- if not .Values.nuqFdb.clusterFile.existingSecret -}}
+    {{- fail "nuqFdb.clusterFile.existingSecret is required for mixed and fdb modes" -}}
+  {{- end -}}
+  {{- if lt (int .Values.nuqFdb.maintenanceWorker.replicaCount) 1 -}}
+    {{- fail "nuqFdb.maintenanceWorker.replicaCount must be at least 1" -}}
+  {{- end -}}
+  {{- if lt (int .Values.nuqFdb.crawlFinishedWorker.replicaCount) 1 -}}
+    {{- fail "nuqFdb.crawlFinishedWorker.replicaCount must be at least 1" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/examples/kubernetes/firecrawl-helm/templates/cclog-worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/cclog-worker-deployment.yaml
@@ -42,13 +42,7 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
-          {{- if include "firecrawl.fdbEnabled" . }}
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- end }}
+          {{- include "firecrawl.fdbVolumeMounts" . | nindent 10 }}
           {{- if and .Values.resources.enabled .Values.cclogWorker.resources }}
           resources:
             {{- toYaml .Values.cclogWorker.resources | nindent 12 }}
@@ -71,13 +65,5 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if include "firecrawl.fdbEnabled" . }}
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
-      {{- end }}
+      {{- include "firecrawl.fdbVolumes" . | nindent 6 }}
 {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/cclog-worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/cclog-worker-deployment.yaml
@@ -42,6 +42,13 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
+          {{- if include "firecrawl.fdbEnabled" . }}
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- end }}
           {{- if and .Values.resources.enabled .Values.cclogWorker.resources }}
           resources:
             {{- toYaml .Values.cclogWorker.resources | nindent 12 }}
@@ -64,4 +71,13 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+      {{- if include "firecrawl.fdbEnabled" . }}
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+      {{- end }}
 {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
   CCLOG_WORKER_PORT: {{ default (printf "%v" .Values.cclogWorker.port) .Values.config.CCLOG_WORKER_PORT | quote }}
   NUQ_WORKER_COUNT: {{ default (printf "%v" .Values.nuqWorker.replicaCount) .Values.config.NUQ_WORKER_COUNT | quote }}
   NUQ_BACKEND: {{ if eq $nuqMode "fdb" }}"fdb"{{ else if eq $nuqMode "pg" }}"pg"{{ else }}""{{ end }}
-  FDB_CLUSTER_FILE: {{ if $fdbEnabled }}{{ .Values.nuqFdb.clusterFile.mountPath | quote }}{{ else }}""{{ end }}
+  FDB_CLUSTER_FILE: {{ if $fdbEnabled }}{{ include "firecrawl.fdbClusterFilePath" . | quote }}{{ else }}""{{ end }}
   REDIS_URL: {{ default $redisDefault .Values.config.REDIS_URL | quote }}
   REDIS_RATE_LIMIT_URL: {{ default $redisDefault .Values.config.REDIS_RATE_LIMIT_URL | quote }}
   PLAYWRIGHT_MICROSERVICE_URL: {{ default $playwrightDefault .Values.config.PLAYWRIGHT_MICROSERVICE_URL | quote }}

--- a/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/configmap.yaml
@@ -1,4 +1,8 @@
+{{- include "firecrawl.validateNuqTopology" . -}}
 {{- $fullname := include "firecrawl.fullname" . -}}
+{{- $nuqMode := include "firecrawl.nuqMode" . -}}
+{{- $fdbEnabled := include "firecrawl.fdbEnabled" . -}}
+{{- $pgEnabled := include "firecrawl.pgEnabled" . -}}
 {{- $redisDefault := printf "redis://%s-redis:%v" $fullname .Values.service.redis.port -}}
 {{- $playwrightDefault := printf "http://%s-playwright:%v/scrape" $fullname .Values.service.playwright.port -}}
 {{- $pgUser := default "postgres" .Values.nuqPostgres.auth.username -}}
@@ -6,6 +10,9 @@
 {{- $pgDb := default "postgres" .Values.nuqPostgres.auth.database -}}
 {{- $nuqDbDefault := printf "postgresql://%s:%s@%s-nuq-postgres:5432/%s" $pgUser $pgPassword $fullname $pgDb -}}
 {{- $nuqDbUrl := default $nuqDbDefault .Values.config.NUQ_DATABASE_URL -}}
+{{- if not $pgEnabled -}}
+  {{- $nuqDbUrl = default "" .Values.config.NUQ_DATABASE_URL -}}
+{{- end -}}
 {{- $rabbitMqDefault := printf "amqp://%s-rabbitmq:%v" $fullname .Values.service.rabbitmq.port -}}
 {{- $apiHostDefault := printf "%s-api" $fullname -}}
 {{- $apiPortDefault := printf "%v" .Values.service.api.port -}}
@@ -21,8 +28,11 @@ data:
   EXTRACT_WORKER_PORT: {{ default (printf "%v" .Values.extractWorker.port) .Values.config.EXTRACT_WORKER_PORT | quote }}
   NUQ_WORKER_PORT: {{ default (printf "%v" .Values.nuqWorker.port) .Values.config.NUQ_WORKER_PORT | quote }}
   NUQ_PREFETCH_WORKER_PORT: {{ default (printf "%v" .Values.nuqPrefetchWorker.port) .Values.config.NUQ_PREFETCH_WORKER_PORT | quote }}
+  NUQ_RECONCILER_WORKER_PORT: {{ default (printf "%v" .Values.nuqReconcilerWorker.port) .Values.config.NUQ_RECONCILER_WORKER_PORT | quote }}
   CCLOG_WORKER_PORT: {{ default (printf "%v" .Values.cclogWorker.port) .Values.config.CCLOG_WORKER_PORT | quote }}
   NUQ_WORKER_COUNT: {{ default (printf "%v" .Values.nuqWorker.replicaCount) .Values.config.NUQ_WORKER_COUNT | quote }}
+  NUQ_BACKEND: {{ if eq $nuqMode "fdb" }}"fdb"{{ else if eq $nuqMode "pg" }}"pg"{{ else }}""{{ end }}
+  FDB_CLUSTER_FILE: {{ if $fdbEnabled }}{{ .Values.nuqFdb.clusterFile.mountPath | quote }}{{ else }}""{{ end }}
   REDIS_URL: {{ default $redisDefault .Values.config.REDIS_URL | quote }}
   REDIS_RATE_LIMIT_URL: {{ default $redisDefault .Values.config.REDIS_RATE_LIMIT_URL | quote }}
   PLAYWRIGHT_MICROSERVICE_URL: {{ default $playwrightDefault .Values.config.PLAYWRIGHT_MICROSERVICE_URL | quote }}

--- a/examples/kubernetes/firecrawl-helm/templates/deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/deployment.yaml
@@ -39,13 +39,7 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
-          {{- if include "firecrawl.fdbEnabled" . }}
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- end }}
+          {{- include "firecrawl.fdbVolumeMounts" . | nindent 10 }}
           {{- if and .Values.resources.enabled .Values.api.resources }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
@@ -68,12 +62,4 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if include "firecrawl.fdbEnabled" . }}
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
-      {{- end }}
+      {{- include "firecrawl.fdbVolumes" . | nindent 6 }}

--- a/examples/kubernetes/firecrawl-helm/templates/deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/deployment.yaml
@@ -39,6 +39,13 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
+          {{- if include "firecrawl.fdbEnabled" . }}
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- end }}
           {{- if and .Values.resources.enabled .Values.api.resources }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
@@ -61,3 +68,12 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+      {{- if include "firecrawl.fdbEnabled" . }}
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+      {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/extract-worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/extract-worker-deployment.yaml
@@ -42,13 +42,7 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
-          {{- if include "firecrawl.fdbEnabled" . }}
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- end }}
+          {{- include "firecrawl.fdbVolumeMounts" . | nindent 10 }}
           {{- if and .Values.resources.enabled .Values.extractWorker.resources }}
           resources:
             {{- toYaml .Values.extractWorker.resources | nindent 12 }}
@@ -71,13 +65,5 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if include "firecrawl.fdbEnabled" . }}
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
-      {{- end }}
+      {{- include "firecrawl.fdbVolumes" . | nindent 6 }}
 {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/extract-worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/extract-worker-deployment.yaml
@@ -42,6 +42,13 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
+          {{- if include "firecrawl.fdbEnabled" . }}
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- end }}
           {{- if and .Values.resources.enabled .Values.extractWorker.resources }}
           resources:
             {{- toYaml .Values.extractWorker.resources | nindent 12 }}
@@ -64,4 +71,13 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+      {{- if include "firecrawl.fdbEnabled" . }}
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+      {{- end }}
 {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-fdb-worker-deployments.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-fdb-worker-deployments.yaml
@@ -4,12 +4,10 @@
   (dict "role" "maintenance" "settings" .Values.nuqFdb.maintenanceWorker "heapMb" 1024 "graceSeconds" 60)
   (dict "role" "crawl-finished" "settings" .Values.nuqFdb.crawlFinishedWorker "heapMb" 2048 "graceSeconds" 180)
 -}}
-{{- range $index, $spec := $workers }}
-{{- if gt $index 0 }}
+{{- range $spec := $workers }}
+{{- $role := $spec.role }}
+{{- $worker := $spec.settings }}
 ---
-{{- end }}
-{{- $role := $spec.role -}}
-{{- $worker := $spec.settings -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,7 +64,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /live
               port: {{ $worker.port | int }}
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -74,7 +72,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: {{ $worker.port | int }}
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-fdb-worker-deployments.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-fdb-worker-deployments.yaml
@@ -1,64 +1,73 @@
 {{- if include "firecrawl.fdbEnabled" . }}
+{{- $workers := list
+  (dict "role" "scrape" "settings" .Values.nuqFdb.scrapeWorker "heapMb" 3072 "graceSeconds" 180)
+  (dict "role" "maintenance" "settings" .Values.nuqFdb.maintenanceWorker "heapMb" 1024 "graceSeconds" 60)
+  (dict "role" "crawl-finished" "settings" .Values.nuqFdb.crawlFinishedWorker "heapMb" 2048 "graceSeconds" 180)
+-}}
+{{- range $index, $spec := $workers }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+{{- $role := $spec.role -}}
+{{- $worker := $spec.settings -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "firecrawl.fullname" . }}-nuq-fdb-scrape-worker
+  name: {{ include "firecrawl.fullname" $ }}-nuq-fdb-{{ $role }}-worker
   labels:
-    app: {{ include "firecrawl.name" . }}-nuq-fdb-scrape-worker
+    app: {{ include "firecrawl.name" $ }}-nuq-fdb-{{ $role }}-worker
 spec:
+  {{- if eq $role "scrape" }}
   # Zero is valid during a controlled drain. Maintenance and crawl completion
-  # are separate deployments below and remain available.
-  replicas: {{ .Values.nuqFdb.scrapeWorker.replicaCount }}
+  # are independent deployments and remain available.
+  {{- end }}
+  replicas: {{ $worker.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "firecrawl.name" . }}-nuq-fdb-scrape-worker
+      app: {{ include "firecrawl.name" $ }}-nuq-fdb-{{ $role }}-worker
   template:
     metadata:
       labels:
-        app: {{ include "firecrawl.name" . }}-nuq-fdb-scrape-worker
+        app: {{ include "firecrawl.name" $ }}-nuq-fdb-{{ $role }}-worker
     spec:
-      {{- if .Values.image.dockerSecretEnabled }}
+      {{- if $.Values.image.dockerSecretEnabled }}
       imagePullSecrets:
-        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+        {{- toYaml $.Values.imagePullSecrets | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 180
+      terminationGracePeriodSeconds: {{ $spec.graceSeconds }}
       containers:
-        - name: nuq-fdb-scrape-worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+        - name: nuq-fdb-{{ $role }}-worker
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command: [ "node" ]
-          args: [ "--max-old-space-size=3072", "dist/src/services/worker/nuq-fdb-worker.js" ]
+          args: [ {{ printf "--max-old-space-size=%v" $spec.heapMb | quote }}, "dist/src/services/worker/nuq-fdb-worker.js" ]
           ports:
-            - containerPort: {{ .Values.nuqFdb.scrapeWorker.port | int }}
+            - containerPort: {{ $worker.port | int }}
           env:
             - name: FLY_PROCESS_GROUP
-              value: "nuq-fdb-scrape-worker"
+              value: {{ printf "nuq-fdb-%s-worker" $role | quote }}
             - name: NUQ_FDB_WORKER_MODE
-              value: "scrape"
+              value: {{ $role | quote }}
             - name: NUQ_WORKER_PORT
-              value: {{ .Values.nuqFdb.scrapeWorker.port | quote }}
+              value: {{ $worker.port | quote }}
             - name: NUQ_POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
           envFrom:
             - configMapRef:
-                name: {{ include "firecrawl.fullname" . }}-config
+                name: {{ include "firecrawl.fullname" $ }}-config
             - secretRef:
-                name: {{ include "firecrawl.fullname" . }}-secret
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- if and .Values.resources.enabled .Values.nuqFdb.scrapeWorker.resources }}
+                name: {{ include "firecrawl.fullname" $ }}-secret
+          {{- include "firecrawl.fdbVolumeMounts" $ | nindent 10 }}
+          {{- if and $.Values.resources.enabled $worker.resources }}
           resources:
-            {{- toYaml .Values.nuqFdb.scrapeWorker.resources | nindent 12 }}
+            {{- toYaml $worker.resources | nindent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.nuqFdb.scrapeWorker.port | int }}
+              port: {{ $worker.port | int }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -66,172 +75,11 @@ spec:
           readinessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.nuqFdb.scrapeWorker.port | int }}
+              port: {{ $worker.port | int }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "firecrawl.fullname" . }}-nuq-fdb-maintenance-worker
-  labels:
-    app: {{ include "firecrawl.name" . }}-nuq-fdb-maintenance-worker
-spec:
-  replicas: {{ .Values.nuqFdb.maintenanceWorker.replicaCount }}
-  selector:
-    matchLabels:
-      app: {{ include "firecrawl.name" . }}-nuq-fdb-maintenance-worker
-  template:
-    metadata:
-      labels:
-        app: {{ include "firecrawl.name" . }}-nuq-fdb-maintenance-worker
-    spec:
-      {{- if .Values.image.dockerSecretEnabled }}
-      imagePullSecrets:
-        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
-      {{- end }}
-      terminationGracePeriodSeconds: 60
-      containers:
-        - name: nuq-fdb-maintenance-worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "node" ]
-          args: [ "--max-old-space-size=1024", "dist/src/services/worker/nuq-fdb-worker.js" ]
-          ports:
-            - containerPort: {{ .Values.nuqFdb.maintenanceWorker.port | int }}
-          env:
-            - name: FLY_PROCESS_GROUP
-              value: "nuq-fdb-maintenance-worker"
-            - name: NUQ_FDB_WORKER_MODE
-              value: "maintenance"
-            - name: NUQ_WORKER_PORT
-              value: {{ .Values.nuqFdb.maintenanceWorker.port | quote }}
-            - name: NUQ_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          envFrom:
-            - configMapRef:
-                name: {{ include "firecrawl.fullname" . }}-config
-            - secretRef:
-                name: {{ include "firecrawl.fullname" . }}-secret
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- if and .Values.resources.enabled .Values.nuqFdb.maintenanceWorker.resources }}
-          resources:
-            {{- toYaml .Values.nuqFdb.maintenanceWorker.resources | nindent 12 }}
-          {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.nuqFdb.maintenanceWorker.port | int }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.nuqFdb.maintenanceWorker.port | int }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "firecrawl.fullname" . }}-nuq-fdb-crawl-finished-worker
-  labels:
-    app: {{ include "firecrawl.name" . }}-nuq-fdb-crawl-finished-worker
-spec:
-  replicas: {{ .Values.nuqFdb.crawlFinishedWorker.replicaCount }}
-  selector:
-    matchLabels:
-      app: {{ include "firecrawl.name" . }}-nuq-fdb-crawl-finished-worker
-  template:
-    metadata:
-      labels:
-        app: {{ include "firecrawl.name" . }}-nuq-fdb-crawl-finished-worker
-    spec:
-      {{- if .Values.image.dockerSecretEnabled }}
-      imagePullSecrets:
-        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
-      {{- end }}
-      terminationGracePeriodSeconds: 180
-      containers:
-        - name: nuq-fdb-crawl-finished-worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "node" ]
-          args: [ "--max-old-space-size=2048", "dist/src/services/worker/nuq-fdb-worker.js" ]
-          ports:
-            - containerPort: {{ .Values.nuqFdb.crawlFinishedWorker.port | int }}
-          env:
-            - name: FLY_PROCESS_GROUP
-              value: "nuq-fdb-crawl-finished-worker"
-            - name: NUQ_FDB_WORKER_MODE
-              value: "crawl-finished"
-            - name: NUQ_WORKER_PORT
-              value: {{ .Values.nuqFdb.crawlFinishedWorker.port | quote }}
-            - name: NUQ_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          envFrom:
-            - configMapRef:
-                name: {{ include "firecrawl.fullname" . }}-config
-            - secretRef:
-                name: {{ include "firecrawl.fullname" . }}-secret
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- if and .Values.resources.enabled .Values.nuqFdb.crawlFinishedWorker.resources }}
-          resources:
-            {{- toYaml .Values.nuqFdb.crawlFinishedWorker.resources | nindent 12 }}
-          {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.nuqFdb.crawlFinishedWorker.port | int }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.nuqFdb.crawlFinishedWorker.port | int }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
+      {{- include "firecrawl.fdbVolumes" $ | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-fdb-worker-deployments.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-fdb-worker-deployments.yaml
@@ -1,0 +1,237 @@
+{{- if include "firecrawl.fdbEnabled" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "firecrawl.fullname" . }}-nuq-fdb-scrape-worker
+  labels:
+    app: {{ include "firecrawl.name" . }}-nuq-fdb-scrape-worker
+spec:
+  # Zero is valid during a controlled drain. Maintenance and crawl completion
+  # are separate deployments below and remain available.
+  replicas: {{ .Values.nuqFdb.scrapeWorker.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "firecrawl.name" . }}-nuq-fdb-scrape-worker
+  template:
+    metadata:
+      labels:
+        app: {{ include "firecrawl.name" . }}-nuq-fdb-scrape-worker
+    spec:
+      {{- if .Values.image.dockerSecretEnabled }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: nuq-fdb-scrape-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "node" ]
+          args: [ "--max-old-space-size=3072", "dist/src/services/worker/nuq-fdb-worker.js" ]
+          ports:
+            - containerPort: {{ .Values.nuqFdb.scrapeWorker.port | int }}
+          env:
+            - name: FLY_PROCESS_GROUP
+              value: "nuq-fdb-scrape-worker"
+            - name: NUQ_FDB_WORKER_MODE
+              value: "scrape"
+            - name: NUQ_WORKER_PORT
+              value: {{ .Values.nuqFdb.scrapeWorker.port | quote }}
+            - name: NUQ_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - configMapRef:
+                name: {{ include "firecrawl.fullname" . }}-config
+            - secretRef:
+                name: {{ include "firecrawl.fullname" . }}-secret
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- if and .Values.resources.enabled .Values.nuqFdb.scrapeWorker.resources }}
+          resources:
+            {{- toYaml .Values.nuqFdb.scrapeWorker.resources | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.nuqFdb.scrapeWorker.port | int }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.nuqFdb.scrapeWorker.port | int }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "firecrawl.fullname" . }}-nuq-fdb-maintenance-worker
+  labels:
+    app: {{ include "firecrawl.name" . }}-nuq-fdb-maintenance-worker
+spec:
+  replicas: {{ .Values.nuqFdb.maintenanceWorker.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "firecrawl.name" . }}-nuq-fdb-maintenance-worker
+  template:
+    metadata:
+      labels:
+        app: {{ include "firecrawl.name" . }}-nuq-fdb-maintenance-worker
+    spec:
+      {{- if .Values.image.dockerSecretEnabled }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: nuq-fdb-maintenance-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "node" ]
+          args: [ "--max-old-space-size=1024", "dist/src/services/worker/nuq-fdb-worker.js" ]
+          ports:
+            - containerPort: {{ .Values.nuqFdb.maintenanceWorker.port | int }}
+          env:
+            - name: FLY_PROCESS_GROUP
+              value: "nuq-fdb-maintenance-worker"
+            - name: NUQ_FDB_WORKER_MODE
+              value: "maintenance"
+            - name: NUQ_WORKER_PORT
+              value: {{ .Values.nuqFdb.maintenanceWorker.port | quote }}
+            - name: NUQ_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - configMapRef:
+                name: {{ include "firecrawl.fullname" . }}-config
+            - secretRef:
+                name: {{ include "firecrawl.fullname" . }}-secret
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- if and .Values.resources.enabled .Values.nuqFdb.maintenanceWorker.resources }}
+          resources:
+            {{- toYaml .Values.nuqFdb.maintenanceWorker.resources | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.nuqFdb.maintenanceWorker.port | int }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.nuqFdb.maintenanceWorker.port | int }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "firecrawl.fullname" . }}-nuq-fdb-crawl-finished-worker
+  labels:
+    app: {{ include "firecrawl.name" . }}-nuq-fdb-crawl-finished-worker
+spec:
+  replicas: {{ .Values.nuqFdb.crawlFinishedWorker.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "firecrawl.name" . }}-nuq-fdb-crawl-finished-worker
+  template:
+    metadata:
+      labels:
+        app: {{ include "firecrawl.name" . }}-nuq-fdb-crawl-finished-worker
+    spec:
+      {{- if .Values.image.dockerSecretEnabled }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: nuq-fdb-crawl-finished-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "node" ]
+          args: [ "--max-old-space-size=2048", "dist/src/services/worker/nuq-fdb-worker.js" ]
+          ports:
+            - containerPort: {{ .Values.nuqFdb.crawlFinishedWorker.port | int }}
+          env:
+            - name: FLY_PROCESS_GROUP
+              value: "nuq-fdb-crawl-finished-worker"
+            - name: NUQ_FDB_WORKER_MODE
+              value: "crawl-finished"
+            - name: NUQ_WORKER_PORT
+              value: {{ .Values.nuqFdb.crawlFinishedWorker.port | quote }}
+            - name: NUQ_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - configMapRef:
+                name: {{ include "firecrawl.fullname" . }}-config
+            - secretRef:
+                name: {{ include "firecrawl.fullname" . }}-secret
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- if and .Values.resources.enabled .Values.nuqFdb.crawlFinishedWorker.resources }}
+          resources:
+            {{- toYaml .Values.nuqFdb.crawlFinishedWorker.resources | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.nuqFdb.crawlFinishedWorker.port | int }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.nuqFdb.crawlFinishedWorker.port | int }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+{{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if include "firecrawl.pgEnabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,3 +72,4 @@ spec:
       port: 5432
       targetPort: 5432
   type: ClusterIP
+{{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-pvc.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "firecrawl.fullname" . }}-nuq-postgres-pvc
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app: {{ include "firecrawl.name" . }}-nuq-postgres
 spec:

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-pvc.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-postgres-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nuqPostgres.persistence.enabled }}
+{{- if and (include "firecrawl.pgEnabled" .) .Values.nuqPostgres.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-reconciler-worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-reconciler-worker-deployment.yaml
@@ -1,19 +1,19 @@
-{{- if and (include "firecrawl.pgEnabled" .) .Values.nuqPrefetchWorker.enabled }}
+{{- if and (include "firecrawl.pgEnabled" .) .Values.nuqReconcilerWorker.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "firecrawl.fullname" . }}-nuq-prefetch-worker
+  name: {{ include "firecrawl.fullname" . }}-nuq-reconciler-worker
   labels:
-    app: {{ include "firecrawl.name" . }}-nuq-prefetch-worker
+    app: {{ include "firecrawl.name" . }}-nuq-reconciler-worker
 spec:
-  replicas: {{ .Values.nuqPrefetchWorker.replicaCount | default 1 }}
+  replicas: {{ .Values.nuqReconcilerWorker.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "firecrawl.name" . }}-nuq-prefetch-worker
+      app: {{ include "firecrawl.name" . }}-nuq-reconciler-worker
   template:
     metadata:
       labels:
-        app: {{ include "firecrawl.name" . }}-nuq-prefetch-worker
+        app: {{ include "firecrawl.name" . }}-nuq-reconciler-worker
     spec:
       {{- if .Values.image.dockerSecretEnabled }}
       imagePullSecrets:
@@ -21,20 +21,18 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 60
       containers:
-        - name: nuq-prefetch-worker
+        - name: nuq-reconciler-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "node" ]
-          args: [ "--max-old-space-size=2048", "dist/src/services/worker/nuq-prefetch-worker.js" ]
+          args: [ "--max-old-space-size=1024", "dist/src/services/worker/nuq-reconciler-worker.js" ]
           ports:
-            - containerPort: {{ .Values.nuqPrefetchWorker.port | int }}
+            - containerPort: {{ .Values.nuqReconcilerWorker.port | int }}
           env:
             - name: FLY_PROCESS_GROUP
-              value: "nuq-prefetch-worker"
-            - name: NUQ_PREFETCH_WORKER_PORT
-              value: {{ .Values.nuqPrefetchWorker.port | quote }}
-            - name: NUQ_PREFETCH_REPLICAS
-              value: {{ .Values.nuqPrefetchWorker.replicaCount | quote }}
+              value: "nuq-reconciler-worker"
+            - name: NUQ_RECONCILER_WORKER_PORT
+              value: {{ .Values.nuqReconcilerWorker.port | quote }}
             - name: NUQ_POD_NAME
               valueFrom:
                 fieldRef:
@@ -44,26 +42,24 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
-          {{- if and .Values.resources.enabled .Values.nuqPrefetchWorker.resources }}
+          {{- if and .Values.resources.enabled .Values.nuqReconcilerWorker.resources }}
           resources:
-            {{- toYaml .Values.nuqPrefetchWorker.resources | nindent 12 }}
+            {{- toYaml .Values.nuqReconcilerWorker.resources | nindent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.nuqPrefetchWorker.port | int }}
+              port: {{ .Values.nuqReconcilerWorker.port | int }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-            successThreshold: 1
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.nuqPrefetchWorker.port | int }}
+              port: {{ .Values.nuqReconcilerWorker.port | int }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-            successThreshold: 1
             failureThreshold: 3
 {{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/nuq-worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/nuq-worker-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if include "firecrawl.pgEnabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,3 +74,4 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+{{- end }}

--- a/examples/kubernetes/firecrawl-helm/templates/worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/worker-deployment.yaml
@@ -41,13 +41,7 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
-          {{- if include "firecrawl.fdbEnabled" . }}
-          volumeMounts:
-            - name: fdb-cluster-file
-              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
-              subPath: fdb.cluster
-              readOnly: true
-          {{- end }}
+          {{- include "firecrawl.fdbVolumeMounts" . | nindent 10 }}
           {{- if and .Values.resources.enabled .Values.worker.resources }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
@@ -61,12 +55,4 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if include "firecrawl.fdbEnabled" . }}
-      volumes:
-        - name: fdb-cluster-file
-          secret:
-            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
-            items:
-              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
-                path: fdb.cluster
-      {{- end }}
+      {{- include "firecrawl.fdbVolumes" . | nindent 6 }}

--- a/examples/kubernetes/firecrawl-helm/templates/worker-deployment.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/worker-deployment.yaml
@@ -41,6 +41,13 @@ spec:
                 name: {{ include "firecrawl.fullname" . }}-config
             - secretRef:
                 name: {{ include "firecrawl.fullname" . }}-secret
+          {{- if include "firecrawl.fdbEnabled" . }}
+          volumeMounts:
+            - name: fdb-cluster-file
+              mountPath: {{ .Values.nuqFdb.clusterFile.mountPath | quote }}
+              subPath: fdb.cluster
+              readOnly: true
+          {{- end }}
           {{- if and .Values.resources.enabled .Values.worker.resources }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
@@ -54,3 +61,12 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
+      {{- if include "firecrawl.fdbEnabled" . }}
+      volumes:
+        - name: fdb-cluster-file
+          secret:
+            secretName: {{ .Values.nuqFdb.clusterFile.existingSecret | quote }}
+            items:
+              - key: {{ .Values.nuqFdb.clusterFile.key | quote }}
+                path: fdb.cluster
+      {{- end }}

--- a/examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py
@@ -43,15 +43,15 @@ class ComposeTopologySmokeTest(unittest.TestCase):
     def test_pg_only(self) -> None:
         environment = api_environment(backend="pg", cluster_file=None)
         self.assertEqual(environment["NUQ_BACKEND"], "pg")
-        self.assertEqual(environment["FDB_CLUSTER_FILE"], "")
+        self.assertEqual(environment["FDB_CLUSTER_FILE"], CLUSTER_FILE)
 
     def test_mixed(self) -> None:
-        environment = api_environment(backend=None, cluster_file=CLUSTER_FILE)
+        environment = api_environment(backend="", cluster_file=None)
         self.assertEqual(environment["NUQ_BACKEND"], "")
         self.assertEqual(environment["FDB_CLUSTER_FILE"], CLUSTER_FILE)
 
     def test_forced_fdb(self) -> None:
-        environment = api_environment(backend="fdb", cluster_file=CLUSTER_FILE)
+        environment = api_environment(backend="fdb", cluster_file=None)
         self.assertEqual(environment["NUQ_BACKEND"], "fdb")
         self.assertEqual(environment["FDB_CLUSTER_FILE"], CLUSTER_FILE)
 

--- a/examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py
@@ -40,6 +40,11 @@ def api_environment(*, backend: Optional[str], cluster_file: Optional[str]) -> d
 
 
 class ComposeTopologySmokeTest(unittest.TestCase):
+    def test_unset_backend_defaults_to_pg(self) -> None:
+        environment = api_environment(backend=None, cluster_file=None)
+        self.assertEqual(environment["NUQ_BACKEND"], "pg")
+        self.assertEqual(environment["FDB_CLUSTER_FILE"], CLUSTER_FILE)
+
     def test_pg_only(self) -> None:
         environment = api_environment(backend="pg", cluster_file=None)
         self.assertEqual(environment["NUQ_BACKEND"], "pg")

--- a/examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/compose_topology_smoke.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Smoke-test the Docker Compose env contract consumed by the harness."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Optional
+import unittest
+
+COMPOSE_FILE = Path(__file__).resolve().parents[4] / "docker-compose.yaml"
+CLUSTER_FILE = "/var/fdb/fdb.cluster"
+
+
+def api_environment(*, backend: Optional[str], cluster_file: Optional[str]) -> dict:
+    env = os.environ.copy()
+    for key in ("NUQ_BACKEND", "FDB_CLUSTER_FILE"):
+        env.pop(key, None)
+    if backend is not None:
+        env["NUQ_BACKEND"] = backend
+    if cluster_file is not None:
+        env["FDB_CLUSTER_FILE"] = cluster_file
+
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--file",
+            str(COMPOSE_FILE),
+            "config",
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(result.stdout)["services"]["api"]["environment"]
+
+
+class ComposeTopologySmokeTest(unittest.TestCase):
+    def test_pg_only(self) -> None:
+        environment = api_environment(backend="pg", cluster_file=None)
+        self.assertEqual(environment["NUQ_BACKEND"], "pg")
+        self.assertEqual(environment["FDB_CLUSTER_FILE"], "")
+
+    def test_mixed(self) -> None:
+        environment = api_environment(backend=None, cluster_file=CLUSTER_FILE)
+        self.assertEqual(environment["NUQ_BACKEND"], "")
+        self.assertEqual(environment["FDB_CLUSTER_FILE"], CLUSTER_FILE)
+
+    def test_forced_fdb(self) -> None:
+        environment = api_environment(backend="fdb", cluster_file=CLUSTER_FILE)
+        self.assertEqual(environment["NUQ_BACKEND"], "fdb")
+        self.assertEqual(environment["FDB_CLUSTER_FILE"], CLUSTER_FILE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
@@ -48,6 +48,16 @@ class TopologySmokeTest(unittest.TestCase):
         self.assertIn(executable, container["args"])
         env = {item["name"]: item.get("value") for item in container["env"]}
         self.assertEqual(env["NUQ_FDB_WORKER_MODE"], mode)
+        self.assertEqual(env["NUQ_WORKER_PORT"], "3005")
+        self.assertEqual(container["ports"], [{"containerPort": 3005}])
+        self.assertEqual(
+            container["livenessProbe"]["httpGet"],
+            {"path": "/live", "port": 3005},
+        )
+        self.assertEqual(
+            container["readinessProbe"]["httpGet"],
+            {"path": "/ready", "port": 3005},
+        )
 
     def assert_fdb_mount(self, deployment: dict) -> None:
         pod_spec = deployment["spec"]["template"]["spec"]

--- a/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
@@ -55,7 +55,7 @@ class TopologySmokeTest(unittest.TestCase):
         self.assertTrue(
             any(
                 mount["name"] == "fdb-cluster-file"
-                and mount["mountPath"] == "/etc/foundationdb/fdb.cluster"
+                and mount["mountPath"] == "/etc/foundationdb"
                 for mount in mounts
             )
         )
@@ -92,7 +92,13 @@ class TopologySmokeTest(unittest.TestCase):
         self.assertEqual(config["FDB_CLUSTER_FILE"], "")
 
     def test_mixed(self) -> None:
-        documents = render("mixed", "--set", "cclogWorker.enabled=true")
+        documents = render(
+            "mixed",
+            "--set",
+            "cclogWorker.enabled=true",
+            "--set",
+            "nuqPostgres.persistence.enabled=true",
+        )
         rendered = deployments(documents)
         self.assertIn(PREFIX + "nuq-worker", rendered)
         self.assertIn(PREFIX + "nuq-fdb-scrape-worker", rendered)
@@ -115,6 +121,14 @@ class TopologySmokeTest(unittest.TestCase):
             "nuq-fdb-crawl-finished-worker",
         ):
             self.assert_fdb_mount(rendered[PREFIX + workload])
+        pvc = next(
+            document
+            for document in documents
+            if document.get("kind") == "PersistentVolumeClaim"
+        )
+        self.assertEqual(
+            pvc["metadata"]["annotations"]["helm.sh/resource-policy"], "keep"
+        )
         config = config_map(documents)["data"]
         self.assertEqual(config["NUQ_BACKEND"], "")
         self.assertEqual(

--- a/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
@@ -149,7 +149,7 @@ class TopologySmokeTest(unittest.TestCase):
         config = config_map(documents)["data"]
         self.assertEqual(config["NUQ_BACKEND"], "fdb")
 
-    def test_fdb_control_plane_cannot_scale_to_zero(self) -> None:
+    def assert_invalid_fdb_value(self, value: str, message: str) -> None:
         command = [
             "helm",
             "template",
@@ -160,11 +160,26 @@ class TopologySmokeTest(unittest.TestCase):
             "--set",
             "nuqFdb.clusterFile.existingSecret=fdb-cluster-file",
             "--set",
-            "nuqFdb.maintenanceWorker.replicaCount=0",
+            value,
         ]
         result = subprocess.run(command, capture_output=True, text=True)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("must be at least 1", result.stderr)
+        self.assertIn(message, result.stderr)
+
+    def test_fdb_control_plane_cannot_scale_to_zero(self) -> None:
+        for worker in ("maintenanceWorker", "crawlFinishedWorker"):
+            with self.subTest(worker=worker):
+                self.assert_invalid_fdb_value(
+                    f"nuqFdb.{worker}.replicaCount=0", "must be a positive integer"
+                )
+
+    def test_fdb_scrape_replicas_must_be_nonnegative_integers(self) -> None:
+        for replicas in ("-1", "-0.5", "banana"):
+            with self.subTest(replicas=replicas):
+                self.assert_invalid_fdb_value(
+                    f"nuqFdb.scrapeWorker.replicaCount={replicas}",
+                    "must be a nonnegative integer",
+                )
 
 
 if __name__ == "__main__":

--- a/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
+++ b/examples/kubernetes/firecrawl-helm/tests/topology_smoke.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Render smoke tests for the supported NuQ deployment topologies."""
+
+from pathlib import Path
+import subprocess
+import unittest
+
+import yaml
+
+CHART = Path(__file__).resolve().parents[1]
+PREFIX = "smoke-firecrawl-"
+
+
+def render(mode: str, *extra: str) -> list[dict]:
+    command = ["helm", "template", "smoke", str(CHART), "--set", f"nuq.mode={mode}"]
+    if mode != "pg":
+        command += [
+            "--set",
+            "nuqFdb.clusterFile.existingSecret=fdb-cluster-file",
+        ]
+    command += list(extra)
+    output = subprocess.run(command, check=True, capture_output=True, text=True)
+    return [doc for doc in yaml.safe_load_all(output.stdout) if doc]
+
+
+def deployments(documents: list[dict]) -> dict[str, dict]:
+    return {
+        doc["metadata"]["name"]: doc
+        for doc in documents
+        if doc.get("kind") == "Deployment"
+    }
+
+
+def config_map(documents: list[dict]) -> dict:
+    return next(
+        doc
+        for doc in documents
+        if doc.get("kind") == "ConfigMap"
+        and doc["metadata"]["name"] == PREFIX + "config"
+    )
+
+
+class TopologySmokeTest(unittest.TestCase):
+    def assert_worker_mode(
+        self, deployment: dict, mode: str, executable: str
+    ) -> None:
+        container = deployment["spec"]["template"]["spec"]["containers"][0]
+        self.assertIn(executable, container["args"])
+        env = {item["name"]: item.get("value") for item in container["env"]}
+        self.assertEqual(env["NUQ_FDB_WORKER_MODE"], mode)
+
+    def assert_fdb_mount(self, deployment: dict) -> None:
+        pod_spec = deployment["spec"]["template"]["spec"]
+        mounts = pod_spec["containers"][0].get("volumeMounts", [])
+        self.assertTrue(
+            any(
+                mount["name"] == "fdb-cluster-file"
+                and mount["mountPath"] == "/etc/foundationdb/fdb.cluster"
+                for mount in mounts
+            )
+        )
+        volume = next(
+            item for item in pod_spec["volumes"] if item["name"] == "fdb-cluster-file"
+        )
+        self.assertEqual(volume["secret"]["secretName"], "fdb-cluster-file")
+
+    def assert_fdb_control_plane(self, rendered: dict[str, dict]) -> None:
+        for role in ("maintenance", "crawl-finished"):
+            name = f"{PREFIX}nuq-fdb-{role}-worker"
+            deployment = rendered[name]
+            self.assertGreaterEqual(deployment["spec"]["replicas"], 1)
+            self.assert_worker_mode(
+                deployment,
+                role,
+                "dist/src/services/worker/nuq-fdb-worker.js",
+            )
+
+    def test_pg_only(self) -> None:
+        documents = render("pg")
+        rendered = deployments(documents)
+        self.assertIn(PREFIX + "nuq-worker", rendered)
+        pg_container = rendered[PREFIX + "nuq-worker"]["spec"]["template"]["spec"][
+            "containers"
+        ][0]
+        self.assertIn("dist/src/services/worker/nuq-worker.js", pg_container["args"])
+        self.assertIn(PREFIX + "nuq-prefetch-worker", rendered)
+        self.assertIn(PREFIX + "nuq-reconciler-worker", rendered)
+        self.assertIn(PREFIX + "nuq-postgres", rendered)
+        self.assertFalse(any("nuq-fdb" in name for name in rendered))
+        config = config_map(documents)["data"]
+        self.assertEqual(config["NUQ_BACKEND"], "pg")
+        self.assertEqual(config["FDB_CLUSTER_FILE"], "")
+
+    def test_mixed(self) -> None:
+        documents = render("mixed", "--set", "cclogWorker.enabled=true")
+        rendered = deployments(documents)
+        self.assertIn(PREFIX + "nuq-worker", rendered)
+        self.assertIn(PREFIX + "nuq-fdb-scrape-worker", rendered)
+        self.assert_worker_mode(
+            rendered[PREFIX + "nuq-fdb-scrape-worker"],
+            "scrape",
+            "dist/src/services/worker/nuq-fdb-worker.js",
+        )
+        self.assertIn(PREFIX + "nuq-prefetch-worker", rendered)
+        self.assertIn(PREFIX + "nuq-reconciler-worker", rendered)
+        self.assertIn(PREFIX + "nuq-postgres", rendered)
+        self.assert_fdb_control_plane(rendered)
+        for workload in (
+            "api",
+            "worker",
+            "extract-worker",
+            "cclog-worker",
+            "nuq-fdb-scrape-worker",
+            "nuq-fdb-maintenance-worker",
+            "nuq-fdb-crawl-finished-worker",
+        ):
+            self.assert_fdb_mount(rendered[PREFIX + workload])
+        config = config_map(documents)["data"]
+        self.assertEqual(config["NUQ_BACKEND"], "")
+        self.assertEqual(
+            config["FDB_CLUSTER_FILE"], "/etc/foundationdb/fdb.cluster"
+        )
+
+    def test_forced_fdb_allows_zero_scrape_replicas(self) -> None:
+        documents = render(
+            "fdb", "--set", "nuqFdb.scrapeWorker.replicaCount=0"
+        )
+        rendered = deployments(documents)
+        self.assertNotIn(PREFIX + "nuq-worker", rendered)
+        self.assertNotIn(PREFIX + "nuq-prefetch-worker", rendered)
+        self.assertNotIn(PREFIX + "nuq-reconciler-worker", rendered)
+        self.assertNotIn(PREFIX + "nuq-postgres", rendered)
+        self.assertEqual(rendered[PREFIX + "nuq-fdb-scrape-worker"]["spec"]["replicas"], 0)
+        self.assert_fdb_control_plane(rendered)
+        config = config_map(documents)["data"]
+        self.assertEqual(config["NUQ_BACKEND"], "fdb")
+
+    def test_fdb_control_plane_cannot_scale_to_zero(self) -> None:
+        command = [
+            "helm",
+            "template",
+            "smoke",
+            str(CHART),
+            "--set",
+            "nuq.mode=fdb",
+            "--set",
+            "nuqFdb.clusterFile.existingSecret=fdb-cluster-file",
+            "--set",
+            "nuqFdb.maintenanceWorker.replicaCount=0",
+        ]
+        result = subprocess.run(command, capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be at least 1", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/kubernetes/firecrawl-helm/values.yaml
+++ b/examples/kubernetes/firecrawl-helm/values.yaml
@@ -58,7 +58,7 @@ nuqFdb:
   clusterFile:
     existingSecret: ""
     key: fdb.cluster
-    mountPath: /etc/foundationdb/fdb.cluster
+    mountPath: /etc/foundationdb
   scrapeWorker:
     replicaCount: 5
     port: 3014

--- a/examples/kubernetes/firecrawl-helm/values.yaml
+++ b/examples/kubernetes/firecrawl-helm/values.yaml
@@ -61,7 +61,7 @@ nuqFdb:
     mountPath: /etc/foundationdb
   scrapeWorker:
     replicaCount: 5
-    port: 3014
+    port: 3005
     resources:
       requests:
         memory: "3G"
@@ -72,8 +72,8 @@ nuqFdb:
   # Keep these fixed control deployments at one or more replicas even when
   # scrape consumers are drained to zero.
   maintenanceWorker:
-    replicaCount: 1
-    port: 3015
+    replicaCount: 2
+    port: 3005
     resources:
       requests:
         memory: "512Mi"
@@ -82,8 +82,8 @@ nuqFdb:
         memory: "1Gi"
         cpu: "500m"
   crawlFinishedWorker:
-    replicaCount: 1
-    port: 3016
+    replicaCount: 2
+    port: 3005
     resources:
       requests:
         memory: "1G"

--- a/examples/kubernetes/firecrawl-helm/values.yaml
+++ b/examples/kubernetes/firecrawl-helm/values.yaml
@@ -36,6 +36,11 @@ extractWorker:
       memory: "3G"
       cpu: "1000m"
 
+# Queue topology: pg, mixed (team-flag rollout), or fdb (forced FDB).
+nuq:
+  mode: pg
+
+# PostgreSQL scrape consumers. Used by pg and mixed modes.
 nuqWorker:
   replicaCount: 5
   port: 3006
@@ -46,6 +51,46 @@ nuqWorker:
     limits:
       memory: "4G"
       cpu: "1000m"
+
+# FoundationDB consumers and control loops. The cluster file must be supplied
+# through an existing Secret in mixed/fdb modes; do not put it in values.yaml.
+nuqFdb:
+  clusterFile:
+    existingSecret: ""
+    key: fdb.cluster
+    mountPath: /etc/foundationdb/fdb.cluster
+  scrapeWorker:
+    replicaCount: 5
+    port: 3014
+    resources:
+      requests:
+        memory: "3G"
+        cpu: "1000m"
+      limits:
+        memory: "4G"
+        cpu: "1000m"
+  # Keep these fixed control deployments at one or more replicas even when
+  # scrape consumers are drained to zero.
+  maintenanceWorker:
+    replicaCount: 1
+    port: 3015
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "250m"
+      limits:
+        memory: "1Gi"
+        cpu: "500m"
+  crawlFinishedWorker:
+    replicaCount: 1
+    port: 3016
+    resources:
+      requests:
+        memory: "1G"
+        cpu: "500m"
+      limits:
+        memory: "2G"
+        cpu: "1000m"
 
 nuqPrefetchWorker:
   enabled: true
@@ -63,6 +108,18 @@ cclogWorker:
   enabled: false
   replicaCount: 1
   port: 3013
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+nuqReconcilerWorker:
+  enabled: true
+  replicaCount: 1
+  port: 3012
   resources:
     requests:
       memory: "512Mi"
@@ -144,6 +201,7 @@ config:
   EXTRACT_WORKER_PORT: "3004"
   NUQ_WORKER_PORT: "3006"
   NUQ_PREFETCH_WORKER_PORT: "3011"
+  NUQ_RECONCILER_WORKER_PORT: "3012"
   CCLOG_WORKER_PORT: "3013"
   NUQ_WORKER_COUNT: "5"
   USE_DB_AUTHENTICATION: "false"


### PR DESCRIPTION
## Summary

- keep one `nuq-fdb-worker.ts` entrypoint and select `all`, `scrape`, `maintenance`, or `crawl-finished` behavior with `NUQ_FDB_WORKER_MODE`
- deploy scrape, maintenance, and crawl-finished as separate same-image Helm workloads; scrape may scale to zero while both control workloads remain at one or more replicas
- provide shared port-3005 `/live`, `/ready`, `/health`, and `/metrics` behavior with backend-independent liveness, dependency/required-loop/drain-aware readiness, bounded shutdown, and fatal required-loop supervision
- compose maintenance metrics from the corrected bounded core collector and scan-free sweeper collector without duplicate collectors
- document the two-release metric activation gate: hold replica floors and freeze cutovers while `metrics_ready=0`, then activate/backfill and require both queue families before enabling HPA or migration expansion

## Dependency chain

1. #3980 — worker runtime (`mogery/nuq-fdb-worker-runtime`)
2. #3984 — rollout-safe bounded core metrics (`mogery/nuq-fdb-core-correctness`)
3. #3982 — supervised sweeper lifecycle and scan-free lag metrics (`mogery/nuq-fdb-sweeper-lifecycle`)
4. #3981 — deployment topology and final runtime integration (this PR)

This PR is stacked directly on #3982 and remains draft while the dependency chain and final CI settle.

## Validation

- 61 integrated Vitest tests covering runtime, HTTP lifecycle, all four worker modes, bounded queue metrics, sweeper metrics/lifecycle, and topology
- `pnpm build`
- `pnpm knip`
- 9 Helm/Compose topology smoke tests
- `helm lint examples/kubernetes/firecrawl-helm`
- independent integrated review: approved with no blockers

## Health and shutdown contract

- `/live` remains 200 while the process exists, including dependency outage, normal SIGTERM drain, and fatal-loop bounded cleanup
- `/ready` and compatibility `/health` return 503 as soon as draining or a required loop fails
- fatal required-loop failure performs bounded cleanup and then exits 1; process exit, not a transient liveness failure, drives restart

## Rollout notes

Release A keeps `NUQ_FDB_METRICS_V2_ACTIVATE=false`, freezes new FDB cutovers, retains existing replica floors, and drains all pre-compatible writers and control loops. Before readiness, maintenance metrics intentionally expose only `firecrawl_nuq_fdb_metrics_ready 0`.

Release B enables activation, performs bounded generation backfill, and must report `firecrawl_nuq_fdb_metrics_ready 1` plus both `nuq_fdb_queue_scrape_job_count` and `nuq_fdb_queue_crawl_finished_job_count` before HPA or migration expansion is enabled. Before rollback to pre-compatible code, invalidate both queue metric controls.
