### PR TITLE
fix(api): scale NuQ FDB sweeper lifecycle

### DIFF
--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -1099,8 +1099,10 @@ describeIf("NuQ FDB core", () => {
 
   test("renewLock conflicts cleanly with a concurrent finish", async () => {
     const { queue, sweeper } = await makeCtx("renew-finish-race");
+    const ids: string[] = [];
     for (let i = 0; i < 20; i++) {
       const id = randomUUID();
+      ids.push(id);
       await queue.addJob(
         id,
         scrapeData(),
@@ -1114,7 +1116,12 @@ describeIf("NuQ FDB core", () => {
       ]);
       expect(finished).toBe(true);
       expect(typeof renewed).toBe("boolean");
-      await sweeper.sweepOnce();
+      expect((await queue.getJob(id))?.status).toBe("completed");
+    }
+    // One pass after all races is sufficient to prove none of the stale lease
+    // rows can resurrect any concurrently completed job.
+    await sweeper.sweepOnce();
+    for (const id of ids) {
       expect((await queue.getJob(id))?.status).toBe("completed");
     }
   }, 30_000);
@@ -1212,7 +1219,7 @@ describeIf("NuQ FDB core", () => {
     await finishedQueue.jobFinish(fin!.id, fin!.lock!, null);
   });
 
-  test("group cancellation persists its cursor past 25k stale index rows", async () => {
+  test("group cancellation drains past 25k stale index rows", async () => {
     const { queue, group, sweeper } = await makeCtx("cancel-stale-index");
     const db = getNuqFdbDatabase();
     const owner = freshOwner();
@@ -1243,11 +1250,12 @@ describeIf("NuQ FDB core", () => {
 
     expect(await group.cancelGroup(gid)).toBe(true);
     await sweeper.sweepOnce();
-    expect(await queue.getTeamPendingCount(owner)).toBe(1);
-    await getNuqFdbDatabase().doTn(async tn => {
-      expect(await tn.get(queue.ks.taskGroupCancel(gid))).toBeTruthy();
-    });
-    await sweeper.sweepOnce();
+    if ((await queue.getTeamPendingCount(owner)) > 0) {
+      await getNuqFdbDatabase().doTn(async tn => {
+        expect(await tn.get(queue.ks.taskGroupCancel(gid))).toBeTruthy();
+      });
+      await sweeper.sweepOnce();
+    }
 
     expect(await queue.getJob(pendingId)).toBeNull();
     expect(await queue.getTeamPendingCount(owner)).toBe(0);

--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -1599,7 +1599,7 @@ describeIf("NuQ FDB core", () => {
   });
 
   test("group TTL cleanup resumes after more than 40k members", async () => {
-    const { queue, group, sweeper } = await makeCtx("gttl");
+    const { queue, finishedQueue, group, sweeper } = await makeCtx("gttl");
     const owner = freshOwner();
     const gid = randomUUID();
     await group.addGroup(gid, owner, 1000); // 1s TTL
@@ -1615,6 +1615,10 @@ describeIf("NuQ FDB core", () => {
     await queue.jobFinish(j.id, j.lock!, null);
 
     expect((await group.getGroup(gid))?.status).toBe("completed");
+    const control = await finishedQueue.getJobToProcess();
+    expect(control?.groupId).toBe(gid);
+    await finishedQueue.jobFinish(control!.id, control!.lock!, null);
+
     for (let start = 0; start < 40_001; start += 5_000) {
       await getNuqFdbDatabase().doTn(async tn => {
         for (let i = start; i < Math.min(start + 5_000, 40_001); i++) {
@@ -1627,8 +1631,7 @@ describeIf("NuQ FDB core", () => {
     }
     await new Promise(resolve => setTimeout(resolve, 1100));
     await sweeper.sweepOnce();
-    expect(await group.getGroup(gid)).not.toBeNull();
-    await sweeper.sweepOnce();
+    if (await group.getGroup(gid)) await sweeper.sweepOnce();
 
     expect(await group.getGroup(gid)).toBeNull();
     expect(await queue.getJob(id)).toBeNull();

--- a/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
@@ -401,6 +401,53 @@ describeIf("NuQ FDB lifecycle scalability", () => {
     expect(await queue.getJob(secondJob)).toBeNull();
   }, 30_000);
 
+  test("partition protocol fences old singleton sweepers during rollout", async () => {
+    const { queue, finishedQueue } = await makeCtx("legacy-fence");
+    const sweeper = new NuqFdbSweeper([queue, finishedQueue]);
+    const id = randomUUID();
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(
+        queue.ks.jobMeta(id),
+        encodeJson({ c: 0, p: 0, o: "", f: 0, dc: 0 } satisfies JobMeta),
+      );
+      tn.set(
+        queue.ks.jobStatus(id),
+        encodeJson({ s: "cancelled", st: 0 } satisfies JobStatusRecord),
+      );
+      tn.set(queue.ks.jobExpiry(timeBucket(id), Date.now() - 1, id), EMPTY);
+      tn.set(
+        queue.ks.legacySweeperLock(),
+        encodeJson({ w: "old-owner", x: Date.now() + 60_000 }),
+      );
+    });
+
+    await sweeper.sweepOnce();
+    expect(await queue.hasJob(id)).toBe(true);
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(
+        queue.ks.legacySweeperLock(),
+        encodeJson({ w: "old-owner", x: Date.now() - 1 }),
+      );
+    });
+    await sweeper.sweepOnce();
+    expect(await queue.hasJob(id)).toBe(false);
+
+    const oldCouldAcquire = await getNuqFdbDatabase().doTn(async tn => {
+      const current = decodeJson<{ w: string; x: number }>(
+        await tn.get(queue.ks.legacySweeperLock()),
+      );
+      if (current && current.x > Date.now() && current.w !== "old-candidate") {
+        return false;
+      }
+      tn.set(
+        queue.ks.legacySweeperLock(),
+        encodeJson({ w: "old-candidate", x: Date.now() + 15_000 }),
+      );
+      return true;
+    });
+    expect(oldCouldAcquire).toBe(false);
+  }, 30_000);
+
   test("partition leases fail over and multiple sweepers drain disjoint buckets", async () => {
     const { queue, finishedQueue } = await makeCtx("partitions");
     const db = getNuqFdbDatabase();

--- a/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
@@ -1,0 +1,454 @@
+import { randomUUID } from "crypto";
+import { config } from "../../config";
+import { logger } from "../../lib/logger";
+import {
+  NuQFdbJobGroup,
+  NuQFdbQueue,
+  NuqFdbExternalSlots,
+  NuqFdbSweeper,
+} from "../../services/worker/nuq-fdb";
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+import {
+  GroupMeta,
+  JobMeta,
+  JobStatusRecord,
+  TIME_BUCKETS,
+  decodeJson,
+  encodeI64,
+  encodeJson,
+  timeBucket,
+} from "../../services/worker/nuq-fdb/keyspace";
+import { EMPTY } from "../../services/worker/nuq-fdb/ops";
+
+const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
+const RUN = randomUUID().slice(0, 8);
+const createdQueueNames: string[] = [];
+
+async function makeCtx(name: string) {
+  const queueName = `tl-${RUN}-${name}`;
+  const finishedName = `${queueName}-fin`;
+  createdQueueNames.push(queueName, finishedName);
+  const queue = new NuQFdbQueue(queueName, {
+    hasGroups: true,
+    finishedQueueName: finishedName,
+    leaseMs: 500,
+  });
+  const finishedQueue = new NuQFdbQueue(finishedName, { hasGroups: false });
+  const group = new NuQFdbJobGroup(queue.ks, queue.groupOps!);
+  const slots = new NuqFdbExternalSlots(queue.ks);
+  return {
+    queue,
+    finishedQueue,
+    group,
+    slots,
+    sweeper: new NuqFdbSweeper([queue, finishedQueue], [slots]),
+  };
+}
+
+const gate = (teamLimit: number) => ({
+  teamLimit,
+  queueCap: 1_000_000,
+});
+
+function scrapeData() {
+  return { mode: "single_urls", url: "https://example.com" };
+}
+
+async function rescheduleGroupExpiry(
+  queue: NuQFdbQueue,
+  gid: string,
+  status: GroupMeta["s"],
+): Promise<void> {
+  const db = getNuqFdbDatabase();
+  await db.doTn(async tn => {
+    const current = decodeJson<GroupMeta>(
+      await tn.get(queue.ks.groupMeta(gid)),
+    )!;
+    if (current.eg) {
+      const oldAt = current.s === "completed" ? current.x : current.a;
+      if (oldAt !== undefined) {
+        tn.clear(queue.ks.groupExpiry(oldAt, gid, current.eg));
+      }
+    }
+    const expiresAt = Date.now() - 1;
+    const generation = randomUUID();
+    const next: GroupMeta = {
+      ...current,
+      s: status,
+      eg: generation,
+      ...(status === "completed" ? { x: expiresAt } : { a: expiresAt }),
+    };
+    tn.set(queue.ks.groupMeta(gid), encodeJson(next));
+    tn.set(queue.ks.groupExpiry(expiresAt, gid, generation), EMPTY);
+  });
+}
+
+async function writeInBatches(
+  count: number,
+  write: (index: number, tn: any) => void,
+): Promise<void> {
+  const db = getNuqFdbDatabase();
+  for (let start = 0; start < count; start += 500) {
+    await db.doTn(async tn => {
+      for (let i = start; i < Math.min(count, start + 500); i++) write(i, tn);
+    });
+  }
+}
+
+describeIf("NuQ FDB lifecycle scalability", () => {
+  afterAll(async () => {
+    const fdb = getFdb();
+    const db = getNuqFdbDatabase();
+    for (const name of createdQueueNames) {
+      const range = fdb.tuple.range(["nuq", name]);
+      await db.doTn(async tn =>
+        tn.clearRange(range.begin as Buffer, range.end as Buffer),
+      );
+    }
+  });
+
+  test("external expiry is tenant-qualified and cannot reap a renewed generation", async () => {
+    const { queue, slots, sweeper } = await makeCtx("external-generation");
+    const owner = randomUUID();
+    const holder = "shared-holder";
+
+    await slots.acquire(owner, holder, -1);
+    let stale: [Buffer, Buffer] | undefined;
+    for (let bucket = 0; bucket < TIME_BUCKETS && !stale; bucket++) {
+      const range = slots.expiryScanRange(bucket, Date.now());
+      const rows = await getNuqFdbDatabase().doTn(async tn =>
+        tn.snapshot().getRangeAll(range.begin, range.end),
+      );
+      stale = rows[0] as [Buffer, Buffer] | undefined;
+    }
+    expect(stale).toBeDefined();
+
+    await slots.acquire(owner, holder, 60_000);
+    // Recreate the stale index row to model a sweeper snapshot racing renewal.
+    await getNuqFdbDatabase().doTn(async tn => tn.set(stale![0], stale![1]));
+    await sweeper.sweepOnce();
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
+
+    const otherOwner = randomUUID();
+    await slots.acquire(otherOwner, holder, -1);
+    await sweeper.sweepOnce();
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
+    expect(await queue.getTeamActiveCount(otherOwner)).toBe(0);
+    await slots.release(owner, holder);
+  }, 30_000);
+
+  test("renewable pass stays fenced while scanning past more than 25k stale rows", async () => {
+    const { queue, finishedQueue, group } = await makeCtx("cancel-25k");
+    const sweeper = new NuqFdbSweeper([queue, finishedQueue], [], {
+      lockTtlMs: 2_000,
+    });
+    const owner = randomUUID();
+    const gid = randomUUID();
+    await group.addGroup(gid, owner);
+
+    const staleCount = 25_100;
+    await writeInBatches(staleCount, (i, tn) => {
+      tn.set(
+        queue.ks.groupJob(gid, `000-stale-${String(i).padStart(6, "0")}`),
+        encodeJson({ m: 1, s: "pending" }),
+      );
+    });
+
+    const pendingId = "zzz-real-pending";
+    await queue.addJob(
+      pendingId,
+      scrapeData(),
+      {
+        ownerId: owner,
+        groupId: gid,
+        timesOutAt: new Date(Date.now() + 60_000),
+      },
+      gate(0),
+    );
+    expect(await group.cancelGroup(gid)).toBe(true);
+    const runningSweep = sweeper.sweepOnce();
+    const ownershipKey = queue.ks.sweeperPartition(
+      "group-cancel",
+      timeBucket(gid),
+    );
+    const waitDeadline = Date.now() + 15_000;
+    let ownershipStart: { w: string; g: string; x: number } | null = null;
+    while (!ownershipStart && Date.now() < waitDeadline) {
+      ownershipStart = await getNuqFdbDatabase().doTn(async tn =>
+        decodeJson<{ w: string; g: string; x: number }>(
+          await tn.get(ownershipKey),
+        ),
+      );
+      if (!ownershipStart)
+        await new Promise(resolve => setTimeout(resolve, 25));
+    }
+    expect(ownershipStart).not.toBeNull();
+    await new Promise(resolve => setTimeout(resolve, 2_500));
+    const ownershipBefore = await getNuqFdbDatabase().doTn(async tn =>
+      decodeJson<{ w: string; g: string; x: number }>(
+        await tn.get(ownershipKey),
+      ),
+    );
+    expect(ownershipBefore?.g).toBe(ownershipStart?.g);
+    expect(ownershipBefore?.x).toBeGreaterThan(Date.now());
+
+    const contender = new NuqFdbSweeper([queue, finishedQueue], [], {
+      lockTtlMs: 2_000,
+    });
+    const contenderSweep = contender.sweepOnce();
+    await Promise.all([runningSweep, contenderSweep]);
+
+    expect(await queue.getJob(pendingId)).toBeNull();
+    expect(await queue.getTeamPendingCount(owner)).toBe(0);
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(await tn.get(queue.ks.taskGroupCancel(gid))).toBeFalsy();
+      expect(await tn.get(queue.ks.groupCancelCursor(gid))).toBeFalsy();
+    });
+  }, 180_000);
+
+  test("group GC deletes every record beyond the former 40k tail", async () => {
+    const { queue, group, sweeper } = await makeCtx("gc-40k");
+    const owner = randomUUID();
+    const gid = randomUUID();
+    await group.addGroup(gid, owner);
+    await rescheduleGroupExpiry(queue, gid, "completed");
+
+    const memberCount = 40_100;
+    await writeInBatches(memberCount, (i, tn) => {
+      const id = `member-${String(i).padStart(6, "0")}`;
+      const meta: JobMeta = {
+        c: Date.now(),
+        p: 0,
+        o: owner,
+        g: gid,
+        f: 0,
+        dc: 0,
+      };
+      const status: JobStatusRecord = {
+        s: "completed",
+        st: 0,
+        fa: Date.now(),
+      };
+      tn.set(queue.ks.groupJob(gid, id), encodeJson({ m: 1, s: "completed" }));
+      tn.set(queue.ks.jobMeta(id), encodeJson(meta));
+      tn.set(queue.ks.jobStatus(id), encodeJson(status));
+    });
+
+    await sweeper.sweepOnce();
+    expect(await group.getGroup(gid)).toBeNull();
+    expect(await queue.getJob("member-040099")).toBeNull();
+  }, 120_000);
+
+  test("abandoned empty groups are cancelled and completed by their deadline", async () => {
+    const { queue, group, sweeper } = await makeCtx("abandoned");
+    const owner = randomUUID();
+    const gid = randomUUID();
+    await group.addGroup(gid, owner);
+    // Simulate an active group created before abandonment indexes existed.
+    await getNuqFdbDatabase().doTn(async tn => {
+      const current = decodeJson<GroupMeta>(
+        await tn.get(queue.ks.groupMeta(gid)),
+      )!;
+      tn.clear(queue.ks.groupExpiry(current.a!, gid, current.eg!));
+      const { a: _a, eg: _eg, ...legacy } = current;
+      tn.set(queue.ks.groupMeta(gid), encodeJson(legacy));
+    });
+    await sweeper.sweepOnce();
+    const backfilled = await getNuqFdbDatabase().doTn(async tn =>
+      decodeJson<GroupMeta>(await tn.get(queue.ks.groupMeta(gid))),
+    );
+    expect(backfilled?.a).toBeDefined();
+    expect(backfilled?.eg).toBeDefined();
+    await rescheduleGroupExpiry(queue, gid, "active");
+
+    for (let i = 0; i < 3; i++) await sweeper.sweepOnce();
+    expect((await group.getGroup(gid))?.status).toBe("completed");
+  }, 30_000);
+
+  test("group TTL never deletes queued or active crawl-finished control work", async () => {
+    const { queue, finishedQueue, group, sweeper } =
+      await makeCtx("finish-control");
+    const owner = randomUUID();
+    const gid = randomUUID();
+    await group.addGroup(gid, owner, 10);
+    const id = randomUUID();
+    await queue.addJob(
+      id,
+      scrapeData(),
+      { ownerId: owner, groupId: gid },
+      gate(10),
+    );
+    const member = await queue.getJobToProcess();
+    await queue.jobFinish(member!.id, member!.lock!, null);
+    const fid = await getNuqFdbDatabase().doTn(async tn =>
+      (await tn.get(queue.ks.groupFinishedJob(gid)))!.toString("utf8"),
+    );
+
+    await rescheduleGroupExpiry(queue, gid, "completed");
+    await sweeper.sweepOnce();
+    expect((await group.getGroup(gid))?.status).toBe("completed");
+    expect((await finishedQueue.getJob(fid))?.status).toBe("queued");
+
+    const control = await finishedQueue.getJobToProcess();
+    expect(control?.id).toBe(fid);
+    await rescheduleGroupExpiry(queue, gid, "completed");
+    await sweeper.sweepOnce();
+    expect(await group.getGroup(gid)).not.toBeNull();
+    expect((await finishedQueue.getJob(fid))?.status).toBe("active");
+
+    await finishedQueue.jobFinish(fid, control!.lock!, null);
+    await rescheduleGroupExpiry(queue, gid, "completed");
+    await sweeper.sweepOnce();
+    expect(await group.getGroup(gid)).toBeNull();
+  }, 30_000);
+
+  test("a concurrent team-limit generation cannot be cleared by an older raise", async () => {
+    const { queue, sweeper } = await makeCtx("raise-generation");
+    const owner = randomUUID();
+    await queue.addJobs(
+      Array.from({ length: 4 }, () => ({
+        id: randomUUID(),
+        data: scrapeData(),
+        options: {
+          ownerId: owner,
+          timesOutAt: new Date(Date.now() + 60_000),
+        },
+      })),
+      gate(1),
+    );
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(queue.ks.teamLimit(owner), encodeI64(2));
+      tn.set(queue.ks.taskTeamRaise(owner), encodeJson({ g: randomUUID() }));
+    });
+
+    await Promise.all([
+      sweeper.sweepOnce(),
+      queue.addJob(
+        randomUUID(),
+        scrapeData(),
+        { ownerId: owner, timesOutAt: new Date(Date.now() + 60_000) },
+        gate(3),
+      ),
+    ]);
+    await sweeper.sweepOnce();
+    expect(await queue.getTeamActiveCount(owner)).toBe(3);
+    expect(await queue.getTeamPendingCount(owner)).toBe(2);
+  }, 30_000);
+
+  test("historical zero team and key ledgers are indexed and collected", async () => {
+    const { queue, sweeper } = await makeCtx("ledger-gc");
+    const teamId = randomUUID();
+    const keyId = randomUUID();
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(queue.ks.teamLimit(teamId), encodeI64(10));
+      tn.set(queue.ks.teamActive(teamId), encodeI64(0));
+      tn.set(queue.ks.keyLimit(keyId), encodeI64(10));
+      tn.set(queue.ks.keyActive(keyId), encodeI64(0));
+    });
+
+    for (let i = 0; i < 3; i++) await sweeper.sweepOnce();
+    await getNuqFdbDatabase().doTn(async tn => {
+      // Cold limits remain to protect latent delayed/crawl-pending work;
+      // mutable zero counters and historical discovery tails are collected.
+      expect(await tn.get(queue.ks.teamLimit(teamId))).toBeTruthy();
+      expect(await tn.get(queue.ks.keyLimit(keyId))).toBeTruthy();
+      expect(await tn.get(queue.ks.teamActive(teamId))).toBeFalsy();
+      expect(await tn.get(queue.ks.keyActive(keyId))).toBeFalsy();
+      expect(await tn.get(queue.ks.teamActiveIndex(teamId))).toBeFalsy();
+      expect(await tn.get(queue.ks.keyLedgerIndex(keyId))).toBeFalsy();
+    });
+  }, 30_000);
+
+  test("group lifecycle buckets progress independently across replicas", async () => {
+    const { queue, group, sweeper } = await makeCtx("group-partitions");
+    const owner = randomUUID();
+    const firstGroup = randomUUID();
+    let secondGroup = randomUUID();
+    while (timeBucket(secondGroup) === timeBucket(firstGroup)) {
+      secondGroup = randomUUID();
+    }
+    const firstJob = randomUUID();
+    const secondJob = randomUUID();
+    for (const [gid, id] of [
+      [firstGroup, firstJob],
+      [secondGroup, secondJob],
+    ]) {
+      await group.addGroup(gid, owner);
+      await queue.addJob(
+        id,
+        scrapeData(),
+        {
+          ownerId: owner,
+          groupId: gid,
+          timesOutAt: new Date(Date.now() + 60_000),
+        },
+        gate(0),
+      );
+      await group.cancelGroup(gid);
+    }
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(
+        queue.ks.sweeperPartition("group-cancel", timeBucket(firstGroup)),
+        encodeJson({ w: "other", g: randomUUID(), x: Date.now() + 60_000 }),
+      );
+    });
+
+    await sweeper.sweepOnce();
+    expect(await queue.getJob(firstJob)).not.toBeNull();
+    expect(await queue.getJob(secondJob)).toBeNull();
+  }, 30_000);
+
+  test("partition leases fail over and multiple sweepers drain disjoint buckets", async () => {
+    const { queue, finishedQueue } = await makeCtx("partitions");
+    const db = getNuqFdbDatabase();
+    const count = 1_000;
+    await writeInBatches(count, (i, tn) => {
+      const id = `expired-${String(i).padStart(5, "0")}`;
+      tn.set(
+        queue.ks.jobMeta(id),
+        encodeJson({ c: 0, p: 0, o: "", f: 0, dc: 0 } satisfies JobMeta),
+      );
+      tn.set(
+        queue.ks.jobStatus(id),
+        encodeJson({ s: "cancelled", st: 0 } satisfies JobStatusRecord),
+      );
+      tn.set(queue.ks.jobExpiry(timeBucket(id), Date.now() - 1, id), EMPTY);
+    });
+
+    // Hold one known partition on behalf of a dead replica.
+    const blockedBucket = timeBucket("expired-00000");
+    await db.doTn(async tn => {
+      tn.set(
+        queue.ks.sweeperPartition("job-expiry", blockedBucket),
+        encodeJson({ w: "dead", g: randomUUID(), x: Date.now() + 60_000 }),
+      );
+    });
+
+    const a = new NuqFdbSweeper([queue, finishedQueue], [], {
+      lockTtlMs: 100,
+      maxPartitionsPerTick: 12,
+    });
+    const b = new NuqFdbSweeper([queue, finishedQueue], [], {
+      lockTtlMs: 100,
+      maxPartitionsPerTick: 12,
+    });
+    await Promise.all([a.sweepOnce(logger, 12), b.sweepOnce(logger, 12)]);
+    expect(await queue.hasJob("expired-00000")).toBe(true);
+
+    await db.doTn(async tn => {
+      tn.set(
+        queue.ks.sweeperPartition("job-expiry", blockedBucket),
+        encodeJson({ w: "dead", g: randomUUID(), x: Date.now() - 1 }),
+      );
+    });
+    for (let i = 0; i < 12; i++) {
+      await Promise.all([a.sweepOnce(logger, 12), b.sweepOnce(logger, 12)]);
+    }
+    for (const id of ["expired-00000", "expired-00500", "expired-00999"]) {
+      expect(await queue.hasJob(id)).toBe(false);
+    }
+  }, 60_000);
+});

--- a/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { vi } from "vitest";
 import { config } from "../../config";
 import { logger } from "../../lib/logger";
 import {
@@ -55,6 +56,13 @@ const gate = (teamLimit: number) => ({
 
 function scrapeData() {
   return { mode: "single_urls", url: "https://example.com" };
+}
+
+function idInTimeBucket(bucket: number): string {
+  for (let i = 0; ; i++) {
+    const id = `bucket-${bucket}-${i}`;
+    if (timeBucket(id) === bucket) return id;
+  }
 }
 
 async function rescheduleGroupExpiry(
@@ -446,6 +454,89 @@ describeIf("NuQ FDB lifecycle scalability", () => {
       return true;
     });
     expect(oldCouldAcquire).toBe(false);
+  }, 30_000);
+
+  test("overdue metrics use observed scans and reset after the partition drains", async () => {
+    const { queue } = await makeCtx("overdue-metric");
+    const sweeper = new NuqFdbSweeper([queue]);
+    const dueAt = Date.now() - 5_000;
+    const id = idInTimeBucket(0);
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(
+        queue.ks.delayed(0, dueAt, id),
+        encodeJson({ i: id, o: "", p: 0, f: 0, c: dueAt }),
+      );
+    });
+
+    await sweeper.sweepOnce();
+    const line = sweeper
+      .getMetrics()
+      .split("\n")
+      .find(value =>
+        value.includes(
+          `queue="${queue.queueName}",index="delay",partition="0"`,
+        ),
+      );
+    expect(line).toBeDefined();
+    expect(Number(line!.split(" ")[1])).toBeGreaterThanOrEqual(5);
+
+    const db = getNuqFdbDatabase();
+    const doTn = vi.spyOn(db, "doTn");
+    const readsBeforeCollection = doTn.mock.calls.length;
+    sweeper.getMetrics();
+    expect(doTn.mock.calls).toHaveLength(readsBeforeCollection);
+    doTn.mockRestore();
+
+    await sweeper.sweepOnce();
+    expect(sweeper.getMetrics()).not.toContain(
+      `queue="${queue.queueName}",index="delay",partition="0"`,
+    );
+  }, 30_000);
+
+  test("an ownership transfer removes the previous sweeper's stale label", async () => {
+    const { queue } = await makeCtx("overdue-transfer");
+    const dueAt = Date.now() - 5_000;
+    const id = idInTimeBucket(0);
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(
+        queue.ks.delayed(0, dueAt, id),
+        encodeJson({ i: id, o: "", p: 0, f: 0, c: dueAt }),
+      );
+    });
+
+    const previous = new NuqFdbSweeper([queue], [], { lockTtlMs: 2_000 });
+    await previous.sweepOnce(logger, 3);
+    expect(previous.getMetrics()).toContain(
+      `queue="${queue.queueName}",index="delay",partition="0"`,
+    );
+    const ownershipKey = queue.ks.sweeperPartition("delay", 0);
+    const firstGeneration = await getNuqFdbDatabase().doTn(async tn =>
+      decodeJson<{ g: string; x: number }>(await tn.get(ownershipKey)),
+    );
+
+    while (Date.now() <= firstGeneration!.x) {
+      await new Promise(resolve => setTimeout(resolve, 25));
+    }
+    await getNuqFdbDatabase().doTn(async tn => {
+      // New overdue work arriving at transfer time must be exported only by
+      // the next owner; the expired owner's earlier sample must disappear.
+      tn.set(
+        queue.ks.delayed(0, dueAt, id),
+        encodeJson({ i: id, o: "", p: 0, f: 0, c: dueAt }),
+      );
+    });
+    const next = new NuqFdbSweeper([queue], [], { lockTtlMs: 2_000 });
+    await next.sweepOnce(logger, 3);
+    const nextGeneration = await getNuqFdbDatabase().doTn(async tn =>
+      decodeJson<{ g: string }>(await tn.get(ownershipKey)),
+    );
+    expect(nextGeneration?.g).not.toBe(firstGeneration?.g);
+    expect(previous.getMetrics()).not.toContain(
+      `queue="${queue.queueName}",index="delay",partition="0"`,
+    );
+    expect(next.getMetrics()).toContain(
+      `queue="${queue.queueName}",index="delay",partition="0"`,
+    );
   }, 30_000);
 
   test("partition leases fail over and multiple sweepers drain disjoint buckets", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
@@ -148,6 +148,41 @@ describeIf("NuQ FDB lifecycle scalability", () => {
     await slots.release(owner, holder);
   }, 30_000);
 
+  test("malformed external expiry cleanup remains ownership-guarded", async () => {
+    const { queue, slots } = await makeCtx("external-malformed");
+    const owner = randomUUID();
+    await slots.acquire(owner, "live-holder", 60_000);
+
+    const holder = "malformed-holder";
+    const bucket = timeBucket(holder);
+    const expiresAt = Date.now() - 1_000;
+    const malformedKey = queue.ks.pack(["xsexp", bucket, expiresAt, holder]);
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.set(malformedKey, encodeJson({})),
+    );
+
+    const ownershipLost = new Error("ownership transferred");
+    let guardCalls = 0;
+    await expect(
+      slots.sweepExpiredBucket(Date.now(), bucket, async () => {
+        guardCalls++;
+        if (guardCalls === 2) throw ownershipLost;
+      }),
+    ).rejects.toBe(ownershipLost);
+    expect(guardCalls).toBe(2);
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(await tn.get(malformedKey)).toBeTruthy();
+    });
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
+
+    await slots.sweepExpiredBucket(Date.now(), bucket);
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(await tn.get(malformedKey)).toBeFalsy();
+    });
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
+    await slots.release(owner, "live-holder");
+  }, 30_000);
+
   test("renewable pass stays fenced while scanning past more than 25k stale rows", async () => {
     const { queue, finishedQueue, group } = await makeCtx("cancel-25k");
     const sweeper = new NuqFdbSweeper([queue, finishedQueue], [], {
@@ -491,6 +526,46 @@ describeIf("NuQ FDB lifecycle scalability", () => {
     expect(sweeper.getMetrics()).not.toContain(
       `queue="${queue.queueName}",index="delay",partition="0"`,
     );
+  }, 30_000);
+
+  test("claim and ingest expiry metrics use bounded ownership labels", async () => {
+    const { queue } = await makeCtx("overdue-ingest");
+    const sweeper = new NuqFdbSweeper([queue]);
+    const dueAt = Date.now() - 5_000;
+    await getNuqFdbDatabase().doTn(async tn => {
+      for (let i = 0; i < 3; i++) {
+        const claimOp = `claim-${i}`;
+        tn.set(queue.ks.claim(claimOp), EMPTY);
+        tn.set(queue.ks.claimExpiry(dueAt + i, claimOp), EMPTY);
+        tn.set(queue.ks.ingestExpiry(dueAt + i, `ingest-${i}`), EMPTY);
+      }
+    });
+
+    await sweeper.sweepOnce();
+    const metricLines = sweeper
+      .getMetrics()
+      .split("\n")
+      .filter(line => line.startsWith("firecrawl_nuq_fdb_sweeper_"));
+    expect(
+      metricLines.filter(line =>
+        line.includes(
+          `queue="${queue.queueName}",index="claim_expiry",partition="0"`,
+        ),
+      ),
+    ).toHaveLength(1);
+    expect(
+      metricLines.filter(line =>
+        line.includes(
+          `queue="${queue.queueName}",index="ingest_expiry",partition="0"`,
+        ),
+      ),
+    ).toHaveLength(1);
+    expect(metricLines.join("\n")).not.toContain("claim-0");
+    expect(metricLines.join("\n")).not.toContain("ingest-0");
+
+    await sweeper.sweepOnce();
+    expect(sweeper.getMetrics()).not.toContain('index="claim_expiry"');
+    expect(sweeper.getMetrics()).not.toContain('index="ingest_expiry"');
   }, 30_000);
 
   test("an ownership transfer removes the previous sweeper's stale label", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
@@ -593,7 +593,7 @@ describeIf("NuQ FDB lifecycle scalability", () => {
     await getNuqFdbDatabase().doTn(async tn => {
       for (let i = 0; i < 3; i++) {
         const claimOp = `claim-${i}`;
-        tn.set(queue.ks.claim(claimOp), EMPTY);
+        tn.set(queue.ks.claim(claimOp), encodeJson({ e: dueAt + i }));
         tn.set(queue.ks.claimExpiry(dueAt + i, claimOp), EMPTY);
         tn.set(queue.ks.ingestExpiry(dueAt + i, `ingest-${i}`), EMPTY);
       }

--- a/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/lifecycle-scalability.test.ts
@@ -17,6 +17,7 @@ import {
   JobMeta,
   JobStatusRecord,
   TIME_BUCKETS,
+  decodeI64,
   decodeJson,
   encodeI64,
   encodeJson,
@@ -402,6 +403,63 @@ describeIf("NuQ FDB lifecycle scalability", () => {
       expect(await tn.get(queue.ks.keyActive(keyId))).toBeFalsy();
       expect(await tn.get(queue.ks.teamActiveIndex(teamId))).toBeFalsy();
       expect(await tn.get(queue.ks.keyLedgerIndex(keyId))).toBeFalsy();
+    });
+  }, 30_000);
+
+  test("a staged ingest reservation keeps the team ledger live until release", async () => {
+    const { queue, sweeper } = await makeCtx("ledger-reservation");
+    const owner = randomUUID();
+    const id = randomUUID();
+    let publishStarted!: () => void;
+    let releasePublish!: () => void;
+    const started = new Promise<void>(resolve => {
+      publishStarted = resolve;
+    });
+    const blocked = new Promise<void>(resolve => {
+      releasePublish = resolve;
+    });
+    const originalPublish = (queue as any).publishIngestBatch.bind(queue);
+    const publish = vi
+      .spyOn(queue as any, "publishIngestBatch")
+      .mockImplementation(async (...args: unknown[]) => {
+        publishStarted();
+        await blocked;
+        return await originalPublish(...args);
+      });
+    const adding = queue.addJobs(
+      [
+        {
+          id,
+          data: scrapeData(),
+          options: { ownerId: owner },
+        },
+      ],
+      gate(10),
+    );
+
+    await started;
+    try {
+      await sweeper.sweepOnce();
+      await getNuqFdbDatabase().doTn(async tn => {
+        expect(
+          decodeI64(await tn.get(queue.ks.teamIngestReserved(owner))),
+        ).toBe(1);
+        expect(await tn.get(queue.ks.teamLedgerGcIndex(owner))).toBeTruthy();
+      });
+    } finally {
+      releasePublish();
+      await adding;
+      publish.mockRestore();
+    }
+
+    const job = await queue.getJobToProcess();
+    expect(job?.id).toBe(id);
+    await queue.jobFinish(job!.id, job!.lock!, null);
+    await sweeper.sweepOnce();
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(await tn.get(queue.ks.teamLimit(owner))).toBeTruthy();
+      expect(await tn.get(queue.ks.teamIngestReserved(owner))).toBeFalsy();
+      expect(await tn.get(queue.ks.teamLedgerGcIndex(owner))).toBeFalsy();
     });
   }, 30_000);
 

--- a/apps/api/src/services/worker/nuq-fdb-worker-runtime.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker-runtime.ts
@@ -26,6 +26,16 @@ export type CrawlFinishedLoop = {
   metrics(): string;
 };
 
+// The legacy worker has a single `/health` endpoint, so transient sweeper
+// health cannot be composed here without turning readiness failures into
+// liveness restarts. The deployment-mode worker adds sweeper health to
+// `/ready`; legacy liveness remains limited to its required finish loop.
+export function isLegacyFdbWorkerLive(
+  crawlFinishedLoop: Pick<CrawlFinishedLoop, "isHealthy"> | null,
+): boolean {
+  return crawlFinishedLoop?.isHealthy() ?? false;
+}
+
 export function startCrawlFinishedLoop(options: {
   queue: CrawlFinishedQueue;
   processJob: (job: NuQJob<any, any>, signal: AbortSignal) => Promise<void>;

--- a/apps/api/src/services/worker/nuq-fdb-worker.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker.ts
@@ -87,9 +87,17 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
       // Stop both dequeue loops immediately, then let their in-flight jobs keep
       // renewing and drain within runNuqWorker's bounded grace period.
       crawlFinishedLoop?.stop();
+      getNuqFdbSweeper().stop();
     },
-    drain: () => crawlFinishedLoop?.done,
-    onShutdownDeadline: () => crawlFinishedLoop?.forceStop(),
-    shutdown: () => getNuqFdbSweeper().stop(),
+    drain: async () => {
+      await Promise.all([
+        crawlFinishedLoop?.done,
+        getNuqFdbSweeper().done,
+      ]);
+    },
+    onShutdownDeadline: () => {
+      crawlFinishedLoop?.forceStop();
+      getNuqFdbSweeper().forceStop();
+    },
   });
 })();

--- a/apps/api/src/services/worker/nuq-fdb-worker.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker.ts
@@ -11,7 +11,10 @@ import {
   nuqFdbSweeperGetMetrics,
   scrapeQueueFdb,
 } from "./nuq-fdb";
-import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
+import {
+  isLegacyFdbWorkerLive,
+  startCrawlFinishedLoop,
+} from "./nuq-fdb-worker-runtime";
 import { runNuqWorker } from "./nuq-worker-runner";
 import type { NuQJob } from "./nuq";
 
@@ -55,9 +58,7 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
     serviceName: "nuq-fdb-worker",
     queue: scrapeQueueFdb as any,
     healthCheck: () => nuqFdbHealthCheck(),
-    livenessCheck: () =>
-      (crawlFinishedLoop?.isHealthy() ?? false) &&
-      getNuqFdbSweeper().isHealthy(),
+    livenessCheck: () => isLegacyFdbWorkerLive(crawlFinishedLoop),
     // These are process-local metrics. Queue-wide FDB ranges are deliberately
     // not scanned from every worker's Prometheus scrape callback.
     metrics: () =>
@@ -90,10 +91,7 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
       getNuqFdbSweeper().stop();
     },
     drain: async () => {
-      await Promise.all([
-        crawlFinishedLoop?.done,
-        getNuqFdbSweeper().done,
-      ]);
+      await Promise.all([crawlFinishedLoop?.done, getNuqFdbSweeper().done]);
     },
     onShutdownDeadline: () => {
       crawlFinishedLoop?.forceStop();

--- a/apps/api/src/services/worker/nuq-fdb-worker.ts
+++ b/apps/api/src/services/worker/nuq-fdb-worker.ts
@@ -8,6 +8,7 @@ import {
   crawlFinishedQueueFdb,
   getNuqFdbSweeper,
   nuqFdbHealthCheck,
+  nuqFdbSweeperGetMetrics,
   scrapeQueueFdb,
 } from "./nuq-fdb";
 import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
@@ -54,10 +55,15 @@ async function processFinishCrawlJobInternal(_job: NuQJob) {
     serviceName: "nuq-fdb-worker",
     queue: scrapeQueueFdb as any,
     healthCheck: () => nuqFdbHealthCheck(),
-    livenessCheck: () => crawlFinishedLoop?.isHealthy() ?? false,
+    livenessCheck: () =>
+      (crawlFinishedLoop?.isHealthy() ?? false) &&
+      getNuqFdbSweeper().isHealthy(),
     // These are process-local metrics. Queue-wide FDB ranges are deliberately
     // not scanned from every worker's Prometheus scrape callback.
-    metrics: () => crawlFinishedLoop?.metrics() ?? "",
+    metrics: () =>
+      [crawlFinishedLoop?.metrics() ?? "", nuqFdbSweeperGetMetrics()]
+        .filter(Boolean)
+        .join("\n"),
     beforeStart: () => {
       getNuqFdbSweeper().start();
       crawlFinishedLoop = startCrawlFinishedLoop({

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -41,6 +41,10 @@ export type NuQFdbJobGroupInstance = {
 };
 
 const DEFAULT_GROUP_TTL_MS = 86400000;
+// A group that is never populated, abandoned by its producer, or otherwise
+// never reaches normal completion must not live forever. This deadline is
+// independent of the post-completion retention TTL.
+export const ACTIVE_GROUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export class NuqFdbGroupOps {
   constructor(
@@ -112,9 +116,18 @@ export class NuqFdbGroupOps {
       return false;
     }
     const expiresAt = now + gMeta.t;
-    const updated: GroupMeta = { ...gMeta, s: "completed", x: expiresAt };
+    const expiryGeneration = randomUUID();
+    const updated: GroupMeta = {
+      ...gMeta,
+      s: "completed",
+      x: expiresAt,
+      eg: expiryGeneration,
+    };
     tn.set(this.ks.groupMeta(gid), encodeJson(updated));
-    tn.set(this.ks.groupExpiry(expiresAt, gid), EMPTY);
+    if (gMeta.a !== undefined && gMeta.eg) {
+      tn.clear(this.ks.groupExpiry(gMeta.a, gid, gMeta.eg));
+    }
+    tn.set(this.ks.groupExpiry(expiresAt, gid, expiryGeneration), EMPTY);
     tn.clear(this.ks.ongoingGroup(gMeta.o, gid));
     tn.clear(this.ks.taskGroupFinish(gid));
 
@@ -178,6 +191,8 @@ export class NuQFdbJobGroup {
       const existing = decodeJson<GroupMeta>(existingBuf);
       if (existing) return this.toInstance(id, existing);
       const now = Date.now();
+      const abandonmentDeadline = now + ACTIVE_GROUP_MAX_AGE_MS;
+      const expiryGeneration = randomUUID();
       const g: GroupMeta = {
         o: owner,
         c: now,
@@ -185,8 +200,14 @@ export class NuQFdbJobGroup {
         s: "active",
         m: opts?.maxConcurrency,
         d: opts?.delaySeconds,
+        a: abandonmentDeadline,
+        eg: expiryGeneration,
       };
       tn.set(this.ks.groupMeta(id), encodeJson(g));
+      tn.set(
+        this.ks.groupExpiry(abandonmentDeadline, id, expiryGeneration),
+        EMPTY,
+      );
       tn.set(this.ks.ongoingGroup(owner, id), encodeJson({ c: now }));
       return this.toInstance(id, g);
     });

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -89,3 +89,7 @@ export function getNuqFdbSweeper(): NuqFdbSweeper {
   }
   return sweeper;
 }
+
+export function nuqFdbSweeperGetMetrics(): string {
+  return getNuqFdbSweeper().getMetrics();
+}

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -108,7 +108,14 @@ export type GroupMeta = {
   s: "active" | "completed" | "cancelled";
   m?: number; // maxConcurrency
   d?: number; // delay seconds between job starts
-  x?: number; // expiresAt ms
+  x?: number; // completed-group expiresAt ms
+  a?: number; // active-group abandonment deadline ms
+  eg?: string; // generation of the currently scheduled expiry
+  z?: boolean; // abandonment deadline elapsed; force-drain nonterminal work
+};
+
+export type RaiseTask = {
+  g: string; // generation; protects a newer task from an older sweeper
 };
 
 export function encodeI64(n: number): Buffer {
@@ -256,6 +263,9 @@ export class NuqFdbKeyspace {
   teamRange() {
     return this.packRange(["t"]);
   }
+  teamLedgerRange(tid: string) {
+    return this.packRange(["t", tid]);
+  }
   teamActive(tid: string): Buffer {
     return this.pack(["t", tid, "active"]);
   }
@@ -264,6 +274,12 @@ export class NuqFdbKeyspace {
   }
   teamActiveIndexRange() {
     return this.packRange(["ta"]);
+  }
+  teamLedgerGcIndex(tid: string): Buffer {
+    return this.pack(["tgc", timeBucket(tid), tid]);
+  }
+  teamLedgerGcIndexRange(bucket: number) {
+    return this.packRange(["tgc", bucket]);
   }
   teamPendingCount(tid: string): Buffer {
     return this.pack(["t", tid, "pend"]);
@@ -297,6 +313,18 @@ export class NuqFdbKeyspace {
   keyActive(kid: string): Buffer {
     return this.pack(["k", kid, "active"]);
   }
+  keyLedgerIndex(kid: string): Buffer {
+    return this.pack(["ki2", timeBucket(kid), kid]);
+  }
+  keyLedgerIndexRange(bucket: number) {
+    return this.packRange(["ki2", bucket]);
+  }
+  keyGateRange() {
+    return this.packRange(["k"]);
+  }
+  keyRange(kid: string) {
+    return this.packRange(["k", kid]);
+  }
   keyPendingCount(kid: string): Buffer {
     return this.pack(["k", kid, "qn"]);
   }
@@ -315,6 +343,9 @@ export class NuqFdbKeyspace {
   // === Group (crawl) records
   groupMeta(gid: string): Buffer {
     return this.pack(["g", gid, "meta"]);
+  }
+  groupAllRange() {
+    return this.packRange(["g"]);
   }
   groupRemaining(gid: string): Buffer {
     return this.pack(["g", gid, "rem"]);
@@ -360,6 +391,12 @@ export class NuqFdbKeyspace {
   groupFinishedJob(gid: string): Buffer {
     return this.pack(["g", gid, "fjob"]);
   }
+  groupCancelCursor(gid: string): Buffer {
+    return this.pack(["g", gid, "ccur"]);
+  }
+  groupGcCursor(gid: string): Buffer {
+    return this.pack(["g", gid, "gccur"]);
+  }
   groupRange(gid: string) {
     return this.packRange(["g", gid]);
   }
@@ -368,6 +405,9 @@ export class NuqFdbKeyspace {
   }
   ongoingGroupRange(ownerId: string) {
     return this.packRange(["go", ownerId]);
+  }
+  ongoingGroupAllRange() {
+    return this.packRange(["go"]);
   }
 
   // === Ready shards
@@ -451,10 +491,16 @@ export class NuqFdbKeyspace {
       end: this.pack(["jexp", bucket, untilMs]),
     };
   }
-  groupExpiry(atMs: number, gid: string): Buffer {
-    return this.pack(["gexp", atMs, gid]);
+  groupExpiry(atMs: number, gid: string, generation: string = ""): Buffer {
+    return this.pack(["gexp2", timeBucket(gid), atMs, gid, generation]);
   }
-  groupExpiryScanRange(untilMs: number) {
+  groupExpiryScanRange(bucket: number, untilMs: number) {
+    return {
+      begin: this.pack(["gexp2", bucket]),
+      end: this.pack(["gexp2", bucket, untilMs]),
+    };
+  }
+  legacyGroupExpiryScanRange(untilMs: number) {
     return {
       begin: this.pack(["gexp"]),
       end: this.pack(["gexp", untilMs]),
@@ -462,32 +508,52 @@ export class NuqFdbKeyspace {
   }
 
   // === Task keys (blind-set, sweeper-drained)
+  // New tasks are hash-partitioned. The legacy ranges remain readable during
+  // rolling deployment so work written by an older replica is not lost.
   taskGroupFinish(gid: string): Buffer {
-    return this.pack(["task", "gfin", gid]);
+    return this.pack(["task2", "gfin", timeBucket(gid), gid]);
   }
-  taskGroupFinishRange() {
+  taskGroupFinishRange(bucket: number) {
+    return this.packRange(["task2", "gfin", bucket]);
+  }
+  legacyTaskGroupFinishRange() {
     return this.packRange(["task", "gfin"]);
   }
   taskGroupCancel(gid: string): Buffer {
-    return this.pack(["task", "gcancel", gid]);
+    return this.pack(["task2", "gcancel", timeBucket(gid), gid]);
   }
-  taskGroupCancelRange() {
+  taskGroupCancelRange(bucket: number) {
+    return this.packRange(["task2", "gcancel", bucket]);
+  }
+  legacyTaskGroupCancelRange() {
     return this.packRange(["task", "gcancel"]);
   }
   taskTeamRaise(tid: string): Buffer {
-    return this.pack(["task", "traise", tid]);
+    return this.pack(["task2", "traise", timeBucket(tid), tid]);
   }
-  taskTeamRaiseRange() {
+  taskTeamRaiseRange(bucket: number) {
+    return this.packRange(["task2", "traise", bucket]);
+  }
+  legacyTaskTeamRaiseRange() {
     return this.packRange(["task", "traise"]);
   }
   taskKeyRaise(kid: string): Buffer {
-    return this.pack(["task", "kraise", kid]);
+    return this.pack(["task2", "kraise", timeBucket(kid), kid]);
   }
-  taskKeyRaiseRange() {
+  taskKeyRaiseRange(bucket: number) {
+    return this.packRange(["task2", "kraise", bucket]);
+  }
+  legacyTaskKeyRaiseRange() {
     return this.packRange(["task", "kraise"]);
   }
-  sweeperLock(): Buffer {
+  legacySweeperLock(): Buffer {
     return this.pack(["sweep", "lock"]);
+  }
+  sweeperPartition(phase: string, partition: number): Buffer {
+    return this.pack(["sweep", phase, partition, "lock"]);
+  }
+  sweeperCursor(phase: string, partition: number): Buffer {
+    return this.pack(["sweep", phase, partition, "cursor"]);
   }
 
   unpackId(key: Buffer, indexFromEnd: number = 0): string {

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -263,9 +263,6 @@ export class NuqFdbKeyspace {
   teamRange() {
     return this.packRange(["t"]);
   }
-  teamLedgerRange(tid: string) {
-    return this.packRange(["t", tid]);
-  }
   teamActive(tid: string): Buffer {
     return this.pack(["t", tid, "active"]);
   }
@@ -321,9 +318,6 @@ export class NuqFdbKeyspace {
   }
   keyGateRange() {
     return this.packRange(["k"]);
-  }
-  keyRange(kid: string) {
-    return this.packRange(["k", kid]);
   }
   keyPendingCount(kid: string): Buffer {
     return this.pack(["k", kid, "qn"]);

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import type { Transaction } from "foundationdb";
 import { logger as _logger } from "../../../lib/logger";
 import {
@@ -24,6 +25,7 @@ import {
   NuqFdbMetricControl,
   NuqFdbMetricStatus,
   fnv1a,
+  RaiseTask,
 } from "./keyspace";
 
 export const ONE = encodeI64(1);
@@ -46,6 +48,7 @@ export function bumpTeamActive(
   // This is a compact presence index, not a second counter. Zero transitions
   // use setTeamActive below and remove the key entirely.
   if (delta > 0) tn.set(ks.teamActiveIndex(teamId), EMPTY);
+  tn.set(ks.teamLedgerGcIndex(teamId), EMPTY);
 }
 
 export function setTeamActive(
@@ -58,6 +61,21 @@ export function setTeamActive(
   tn.set(ks.teamActive(teamId), encodeI64(next));
   if (next === 0) tn.clear(ks.teamActiveIndex(teamId));
   else tn.set(ks.teamActiveIndex(teamId), EMPTY);
+  tn.set(ks.teamLedgerGcIndex(teamId), EMPTY);
+}
+
+export function bumpKeyActive(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  keyId: string,
+  delta: number,
+): void {
+  tn.add(ks.keyActive(keyId), encodeI64(delta));
+  tn.set(ks.keyLedgerIndex(keyId), EMPTY);
+}
+
+export function scheduleRaiseTask(tn: Transaction, key: Buffer): void {
+  tn.set(key, encodeJson({ g: randomUUID() } satisfies RaiseTask));
 }
 
 function decodeMetricControl(
@@ -185,6 +203,7 @@ export function appendTeamPending(
 ): PendingLoc {
   const shard = teamPendingShard(e.i);
   tn.set(ks.teamPendingKey(e.o, shard, e.p, e.c, e.i), encodeJson(e));
+  tn.set(ks.teamLedgerGcIndex(e.o), EMPTY);
   tn.add(ks.teamShardCount(e.o, shard), ONE);
   tn.add(ks.teamPendingCount(e.o), ONE);
   if (e.to !== undefined) {
@@ -199,6 +218,7 @@ export function appendKeyPending(
   e: QueueEntry,
 ): PendingLoc {
   tn.set(ks.keyPendingKey(e.k!, e.p, e.c, e.i), encodeJson(e));
+  tn.set(ks.keyLedgerIndex(e.k!), EMPTY);
   tn.add(ks.keyPendingCount(e.k!), ONE);
   tn.add(ks.teamPendingCount(e.o), ONE);
   if (e.to !== undefined) {
@@ -456,7 +476,7 @@ export async function releaseSlotsAndPromote(
     }
     if (keyOverLimit) {
       // limit-lowering convergence: swallow the slot instead of handing off
-      tn.add(ks.keyActive(e.k!), MINUS_ONE);
+      bumpKeyActive(tn, ks, e.k!, -1);
       keyHandedOff = true; // accounted for; don't decrement again below
     } else {
       const keyHead = await popKeyPending(tn, ks, e.k!);
@@ -518,7 +538,7 @@ export async function releaseSlotsAndPromote(
           const kLimit = kLimitBuf ? decodeI64(kLimitBuf) : Infinity;
           const kActive = decodeI64(await tn.get(ks.keyActive(j2.k!)));
           if (kActive < kLimit) {
-            tn.add(ks.keyActive(j2.k!), ONE);
+            bumpKeyActive(tn, ks, j2.k!, 1);
             hasKeySlot = true;
           }
         }
@@ -546,7 +566,7 @@ export async function releaseSlotsAndPromote(
   }
 
   if (holdsKey && !keyHandedOff) {
-    tn.add(ks.keyActive(e.k!), MINUS_ONE);
+    bumpKeyActive(tn, ks, e.k!, -1);
   }
 
   if (held.team) {
@@ -601,7 +621,7 @@ export async function admitThroughGates(
       await alignQueueMetricStatus(tn, ks, e.i);
       return;
     }
-    tn.add(ks.keyActive(e.k), ONE);
+    bumpKeyActive(tn, ks, e.k, 1);
   }
   await admitThroughTeamGate(tn, ks, e, txc);
 }

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -62,6 +62,9 @@ import {
   bumpGroupStatusCount,
   bumpTeamActive,
   alignQueueMetricStatus,
+  bumpQueueStatus,
+  bumpKeyActive,
+  scheduleRaiseTask,
   GroupJobIndexValue,
 } from "./ops";
 import { NuqFdbGroupOps } from "./groups";
@@ -735,8 +738,11 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         const stored = storedBuf ? decodeI64(storedBuf) : null;
         if (stored !== gate.teamLimit) {
           tn.set(ks.teamLimit(ownerId), encodeI64(gate.teamLimit));
+          // Also indexes teams whose configured limit is zero.
+          tn.add(ks.teamActiveIndex(ownerId), encodeI64(0));
+          tn.set(ks.teamLedgerGcIndex(ownerId), EMPTY);
           if (stored !== null && gate.teamLimit > stored) {
-            tn.set(ks.taskTeamRaise(ownerId), EMPTY);
+            scheduleRaiseTask(tn, ks.taskTeamRaise(ownerId));
           }
         }
 
@@ -754,8 +760,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         const stored = storedBuf ? decodeI64(storedBuf) : null;
         if (stored !== gate.key.limit) {
           tn.set(ks.keyLimit(keyId), encodeI64(gate.key.limit));
+          tn.set(ks.keyLedgerIndex(keyId), EMPTY);
           if (stored !== null && gate.key.limit > stored) {
-            tn.set(ks.taskKeyRaise(keyId), EMPTY);
+            scheduleRaiseTask(tn, ks.taskKeyRaise(keyId));
           }
         }
         // key limits are small by definition: always the strict read
@@ -888,7 +895,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         bumpTeamActive(tn, ks, ownerId, granted);
       }
       if (keyGranted > 0 && keyId !== null) {
-        tn.add(ks.keyActive(keyId), encodeI64(keyGranted));
+        bumpKeyActive(tn, ks, keyId, keyGranted);
       }
       for (const [gid, n] of crawlAcquired) {
         tn.add(ks.groupCrawlActive(gid), encodeI64(n));

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -62,7 +62,6 @@ import {
   bumpGroupStatusCount,
   bumpTeamActive,
   alignQueueMetricStatus,
-  bumpQueueStatus,
   bumpKeyActive,
   scheduleRaiseTask,
   GroupJobIndexValue,
@@ -647,6 +646,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           throw new QueueFullError(pending + reserved, opMeta.q);
         }
         tn.add(ks.teamIngestReserved(opMeta.o), encodeI64(gated));
+        tn.set(ks.teamLedgerGcIndex(opMeta.o), EMPTY);
         const storedBuf = await tn.get(ks.teamLimit(opMeta.o));
         const stored = storedBuf ? decodeI64(storedBuf) : null;
         if (stored !== opMeta.l) {

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import type { Transaction } from "foundationdb";
 import { getNuqFdbDatabase } from "./client";
 import {
@@ -19,7 +20,13 @@ import { bumpTeamActive, newTxContext, releaseSlotsAndPromote } from "./ops";
 
 type ExternalSlotRecord = {
   e: number; // expiry ms
+  g?: string; // renewal generation (absent on pre-generation records)
 };
+
+export type ExternalSlotSweepGuard = (tn: Transaction) => Promise<void>;
+
+const EXTERNAL_SWEEP_BATCH = 100;
+const EXTERNAL_SWEEP_BUDGET_MS = 5_000;
 
 export class NuqFdbExternalSlots {
   constructor(public readonly ks: NuqFdbKeyspace) {}
@@ -32,7 +39,22 @@ export class NuqFdbExternalSlots {
     return this.ks.pack(["xs", teamId, holderId]);
   }
 
-  private expiryKey(bucket: number, expMs: number, holderId: string): Buffer {
+  private expiryKey(
+    bucket: number,
+    expMs: number,
+    teamId: string,
+    holderId: string,
+    generation: string,
+  ): Buffer {
+    // Team is part of the identity: holder ids are only tenant-local.
+    return this.ks.pack(["xsexp", bucket, expMs, teamId, holderId, generation]);
+  }
+
+  private legacyExpiryKey(
+    bucket: number,
+    expMs: number,
+    holderId: string,
+  ): Buffer {
     return this.ks.pack(["xsexp", bucket, expMs, holderId]);
   }
 
@@ -55,22 +77,39 @@ export class NuqFdbExternalSlots {
     if (owner === null) return;
     const now = Date.now();
     const exp = now + ttlMs;
+    const generation = randomUUID();
     await this.db.doTn(async tn => {
       const existing = decodeJson<ExternalSlotRecord>(
         await tn.get(this.key(owner, holderId)),
       );
       if (existing) {
-        tn.clear(this.expiryKey(timeBucket(holderId), existing.e, holderId));
+        tn.clear(
+          existing.g
+            ? this.expiryKey(
+                timeBucket(`${owner}/${holderId}`),
+                existing.e,
+                owner,
+                holderId,
+                existing.g,
+              )
+            : this.legacyExpiryKey(timeBucket(holderId), existing.e, holderId),
+        );
       } else {
         bumpTeamActive(tn, this.ks, owner, 1);
       }
       tn.set(
         this.key(owner, holderId),
-        encodeJson({ e: exp } satisfies ExternalSlotRecord),
+        encodeJson({ e: exp, g: generation } satisfies ExternalSlotRecord),
       );
       tn.set(
-        this.expiryKey(timeBucket(holderId), exp, holderId),
-        encodeJson({ t: owner }),
+        this.expiryKey(
+          timeBucket(`${owner}/${holderId}`),
+          exp,
+          owner,
+          holderId,
+          generation,
+        ),
+        Buffer.alloc(0),
       );
     });
   }
@@ -94,7 +133,17 @@ export class NuqFdbExternalSlots {
     );
     if (!existing) return false;
     tn.clear(this.key(owner, holderId));
-    tn.clear(this.expiryKey(timeBucket(holderId), existing.e, holderId));
+    tn.clear(
+      existing.g
+        ? this.expiryKey(
+            timeBucket(`${owner}/${holderId}`),
+            existing.e,
+            owner,
+            holderId,
+            existing.g,
+          )
+        : this.legacyExpiryKey(timeBucket(holderId), existing.e, holderId),
+    );
     const entry: QueueEntry = {
       i: holderId,
       o: owner,
@@ -113,24 +162,65 @@ export class NuqFdbExternalSlots {
     return true;
   }
 
-  // Sweeper hook: releases slots whose holders stopped renewing.
-  public async sweepExpired(now: number, buckets: number): Promise<void> {
-    for (let b = 0; b < buckets; b++) {
-      const r = this.expiryScanRange(b, now);
-      const due = await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(r.begin, r.end, { limit: 50 }),
-      );
+  // Sweeper hook for one independently-owned time bucket. It drains due rows
+  // with bounded pagination rather than imposing a fixed per-pass ceiling.
+  public async sweepExpiredBucket(
+    now: number,
+    bucket: number,
+    guard?: ExternalSlotSweepGuard,
+  ): Promise<number> {
+    const startedAt = Date.now();
+    let processed = 0;
+    while (Date.now() - startedAt < EXTERNAL_SWEEP_BUDGET_MS) {
+      const r = this.expiryScanRange(bucket, now);
+      const due = await this.db.doTn(async tn => {
+        if (guard) await guard(tn);
+        return await tn
+          .snapshot()
+          .getRangeAll(r.begin, r.end, { limit: EXTERNAL_SWEEP_BATCH });
+      });
+      if (due.length === 0) break;
       for (const [key, value] of due) {
-        const holderId = this.ks.unpackId(key as Buffer);
-        const rec = decodeJson<{ t: string }>(value as Buffer);
-        if (!rec) continue;
+        const parts = this.ks.unpack(key as Buffer);
+        const exp = Number(parts[4]);
+        const legacy = parts.length === 6;
+        const legacyIndex = legacy
+          ? decodeJson<{ t: string }>(value as Buffer)
+          : null;
+        const owner = legacy ? legacyIndex?.t : String(parts[5]);
+        const holderId = String(parts[legacy ? 5 : 6]);
+        const generation = legacy ? undefined : String(parts[7]);
+        if (!owner) {
+          await this.db.doTn(async tn => tn.clear(key as Buffer));
+          continue;
+        }
         await this.db.doTn(async tn => {
-          // releaseInTxn validates the record still exists (and clears this
-          // index entry); if the holder renewed, just drop the stale entry
-          const released = await this.releaseInTxn(tn, rec.t, holderId);
-          if (!released) tn.clear(key as Buffer);
+          if (guard) await guard(tn);
+          const current = decodeJson<ExternalSlotRecord>(
+            await tn.get(this.key(owner, holderId)),
+          );
+          // A stale expiry generation must never release a renewed holder.
+          if (
+            !current ||
+            current.e !== exp ||
+            current.g !== generation ||
+            current.e > now
+          ) {
+            tn.clear(key as Buffer);
+            return;
+          }
+          await this.releaseInTxn(tn, owner, holderId);
         });
+        processed++;
       }
+      if (due.length < EXTERNAL_SWEEP_BATCH) break;
+    }
+    return processed;
+  }
+
+  public async sweepExpired(now: number, buckets: number): Promise<void> {
+    for (let bucket = 0; bucket < buckets; bucket++) {
+      await this.sweepExpiredBucket(now, bucket);
     }
   }
 }

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -24,6 +24,9 @@ type ExternalSlotRecord = {
 };
 
 export type ExternalSlotSweepGuard = (tn: Transaction) => Promise<void>;
+export type ExternalSlotSweepObserver = (
+  due: readonly [Buffer, Buffer][],
+) => void;
 
 const EXTERNAL_SWEEP_BATCH = 100;
 const EXTERNAL_SWEEP_BUDGET_MS = 5_000;
@@ -168,17 +171,19 @@ export class NuqFdbExternalSlots {
     now: number,
     bucket: number,
     guard?: ExternalSlotSweepGuard,
+    observeDue?: ExternalSlotSweepObserver,
   ): Promise<number> {
     const startedAt = Date.now();
     let processed = 0;
     while (Date.now() - startedAt < EXTERNAL_SWEEP_BUDGET_MS) {
       const r = this.expiryScanRange(bucket, now);
-      const due = await this.db.doTn(async tn => {
+      const due = (await this.db.doTn(async tn => {
         if (guard) await guard(tn);
         return await tn
           .snapshot()
           .getRangeAll(r.begin, r.end, { limit: EXTERNAL_SWEEP_BATCH });
-      });
+      })) as [Buffer, Buffer][];
+      observeDue?.(due);
       if (due.length === 0) break;
       for (const [key, value] of due) {
         const parts = this.ks.unpack(key as Buffer);

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -196,7 +196,10 @@ export class NuqFdbExternalSlots {
         const holderId = String(parts[legacy ? 5 : 6]);
         const generation = legacy ? undefined : String(parts[7]);
         if (!owner) {
-          await this.db.doTn(async tn => tn.clear(key as Buffer));
+          await this.db.doTn(async tn => {
+            if (guard) await guard(tn);
+            tn.clear(key as Buffer);
+          });
           continue;
         }
         await this.db.doTn(async tn => {

--- a/apps/api/src/services/worker/nuq-fdb/sweeper-lifecycle.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper-lifecycle.test.ts
@@ -1,0 +1,324 @@
+import type { Logger } from "winston";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NuqFdbKeyspace } from "./keyspace";
+import type { NuQFdbQueue } from "./queue";
+import { NuqFdbSweeper } from "./sweeper";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function makeSweeper(
+  options: ConstructorParameters<typeof NuqFdbSweeper>[2] = {},
+) {
+  const ks = { queueName: "lifecycle-test" } as NuqFdbKeyspace;
+  const queue = { ks } as NuQFdbQueue;
+  return { ks, sweeper: new NuqFdbSweeper([queue], [], options) };
+}
+
+function observeDelay(
+  sweeper: NuqFdbSweeper,
+  ks: NuqFdbKeyspace,
+  lifecycleGeneration?: number,
+) {
+  (sweeper as any).observeDue(
+    {
+      ks,
+      phase: "delay",
+      partition: 3,
+      generation: "test",
+      expiresAt: 10_000,
+      lifecycleGeneration,
+    },
+    "delay",
+    [[Buffer.alloc(0), Buffer.alloc(0)]],
+    () => 1_000,
+  );
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("NuqFdbSweeper lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("survives repeated native FDB failures and becomes healthy after recovery", async () => {
+    const { sweeper } = makeSweeper();
+    const outage = Object.assign(new Error("FDB unavailable"), { code: 1031 });
+    const sweepOnce = vi
+      .spyOn(sweeper, "sweepOnce")
+      .mockRejectedValueOnce(outage)
+      .mockRejectedValueOnce(outage)
+      .mockResolvedValue(undefined);
+
+    sweeper.start(10, logger);
+    const done = sweeper.done;
+    const settled = vi.fn();
+    void done.then(settled, settled);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sweepOnce).toHaveBeenCalledTimes(1);
+    expect(sweeper.isHealthy()).toBe(false);
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sweepOnce).toHaveBeenCalledTimes(2);
+    expect(sweeper.isHealthy()).toBe(false);
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sweepOnce).toHaveBeenCalledTimes(3);
+    expect(sweeper.isHealthy()).toBe(true);
+    expect(settled).not.toHaveBeenCalled();
+
+    sweeper.stop();
+    await expect(done).resolves.toBeUndefined();
+    expect(settled).toHaveBeenCalledOnce();
+  });
+
+  it("treats a separately classified programmer failure as fatal without an unhandled rejection", async () => {
+    const retryable = new Error("retryable test error");
+    const failure = new Error("invariant violated");
+    const classifyTickError = vi.fn((error: unknown) =>
+      error === retryable ? ("transient" as const) : ("fatal" as const),
+    );
+    const { ks, sweeper } = makeSweeper({ classifyTickError });
+    vi.spyOn(sweeper, "sweepOnce").mockRejectedValue(failure);
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    try {
+      observeDelay(sweeper, ks);
+      sweeper.start(10, logger);
+      const done = sweeper.done;
+      await vi.advanceTimersByTimeAsync(10);
+      await flushPromises();
+
+      expect(classifyTickError).toHaveBeenCalledWith(failure);
+      expect(sweeper.isHealthy()).toBe(false);
+      expect(sweeper.getMetrics(2_000)).not.toContain('index="delay"');
+      await expect(done).rejects.toBe(failure);
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
+  });
+
+  it("does not classify an unmarked generic error as transient by default", async () => {
+    const { sweeper } = makeSweeper();
+    const failure = new Error("generic failure");
+    vi.spyOn(sweeper, "sweepOnce").mockRejectedValue(failure);
+
+    sweeper.start(10, logger);
+    const done = sweeper.done;
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(done).rejects.toBe(failure);
+    expect(sweeper.isHealthy()).toBe(false);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(sweeper.sweepOnce).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "transient",
+      tickError: Object.assign(new Error("FDB unavailable"), { code: 1031 }),
+      loggingMethod: "warn" as const,
+    },
+    {
+      name: "fatal",
+      tickError: new Error("programmer failure"),
+      loggingMethod: "error" as const,
+    },
+  ])(
+    "fails the lifecycle when $name failure logging throws",
+    async ({ tickError, loggingMethod }) => {
+      const { sweeper } = makeSweeper();
+      const loggingFailure = new Error(`${loggingMethod} failed`);
+      const throwingLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        [loggingMethod]: vi.fn(() => {
+          throw loggingFailure;
+        }),
+      } as unknown as Logger;
+      const sweepOnce = vi
+        .spyOn(sweeper, "sweepOnce")
+        .mockRejectedValue(tickError);
+
+      sweeper.start(10, throwingLogger);
+      const done = sweeper.done;
+      await vi.advanceTimersByTimeAsync(10);
+
+      await expect(done).rejects.toBe(loggingFailure);
+      expect(sweeper.isHealthy()).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sweepOnce).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("fails the lifecycle if its injected classifier throws", async () => {
+    const classifierFailure = new Error("classifier failed");
+    const { sweeper } = makeSweeper({
+      classifyTickError: () => {
+        throw classifierFailure;
+      },
+    });
+    vi.spyOn(sweeper, "sweepOnce").mockRejectedValue(new Error("tick failed"));
+
+    sweeper.start(10, logger);
+    const done = sweeper.done;
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(done).rejects.toBe(classifierFailure);
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(sweeper.isHealthy()).toBe(false);
+  });
+
+  it("stops new ticks and settles done only after the in-flight pass", async () => {
+    const { sweeper } = makeSweeper();
+    const inFlight = deferred();
+    const sweepOnce = vi
+      .spyOn(sweeper, "sweepOnce")
+      .mockReturnValueOnce(inFlight.promise)
+      .mockResolvedValue(undefined);
+
+    sweeper.start(10, logger);
+    const firstDone = sweeper.done;
+    const settled = vi.fn();
+    void firstDone.then(settled);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sweepOnce).toHaveBeenCalledOnce();
+
+    sweeper.stop();
+    sweeper.stop();
+    expect(sweeper.isHealthy()).toBe(false);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(sweepOnce).toHaveBeenCalledOnce();
+    expect(settled).not.toHaveBeenCalled();
+
+    inFlight.resolve();
+    await expect(firstDone).resolves.toBeUndefined();
+    expect(settled).toHaveBeenCalledOnce();
+
+    sweeper.start(10, logger);
+    const restartedDone = sweeper.done;
+    sweeper.start(10, logger);
+    expect(restartedDone).not.toBe(firstDone);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sweepOnce).toHaveBeenCalledTimes(2);
+    sweeper.stop();
+    await expect(restartedDone).resolves.toBeUndefined();
+  });
+
+  it("does not let a stale renewal extend a restarted lifecycle's metric", async () => {
+    const { ks, sweeper } = makeSweeper();
+    let finishRenewal!: (expiresAt: number) => void;
+    const renewalTransaction = new Promise<number>(resolve => {
+      finishRenewal = resolve;
+    });
+    const doTn = vi.fn(() => renewalTransaction);
+    Object.defineProperty(sweeper as any, "db", {
+      get: () => ({ doTn }),
+    });
+
+    sweeper.start(100, logger);
+    const detachedDone = sweeper.done;
+    const oldGeneration = (sweeper as any).runGeneration as number;
+    const oldClaim = {
+      ks,
+      phase: "delay",
+      partition: 3,
+      generation: "old-claim",
+      expiresAt: 10_000,
+      lifecycleGeneration: oldGeneration,
+    };
+    const renewal = (sweeper as any).renewClaim(oldClaim) as Promise<void>;
+    expect(doTn).toHaveBeenCalledOnce();
+
+    sweeper.forceStop();
+    await detachedDone;
+    sweeper.start(100, logger);
+    const restartedDone = sweeper.done;
+    observeDelay(sweeper, ks, (sweeper as any).runGeneration);
+
+    finishRenewal(20_000);
+    await expect(renewal).rejects.toThrow();
+    expect(sweeper.getMetrics(10_001)).not.toContain('index="delay"');
+
+    sweeper.stop();
+    await restartedDone;
+  });
+
+  it("force-stops a generation and ignores its late state and metric mutations", async () => {
+    const { ks, sweeper } = makeSweeper();
+    const detachedPass = deferred();
+    const restartedPass = deferred();
+    let invocation = 0;
+    vi.spyOn(sweeper, "sweepOnce").mockImplementation(
+      async (_logger, _maxPartitions, lifecycleGeneration) => {
+        invocation++;
+        if (invocation === 1) {
+          await detachedPass.promise;
+          observeDelay(sweeper, ks, lifecycleGeneration);
+          return;
+        }
+        await restartedPass.promise;
+      },
+    );
+
+    sweeper.start(10, logger);
+    const detachedDone = sweeper.done;
+    const detachedSettled = vi.fn();
+    void detachedDone.then(detachedSettled);
+    await vi.advanceTimersByTimeAsync(10);
+    expect((sweeper as any).running).toBe(true);
+
+    sweeper.forceStop();
+    sweeper.forceStop();
+    await expect(detachedDone).resolves.toBeUndefined();
+    expect(detachedSettled).toHaveBeenCalledOnce();
+    expect(sweeper.isHealthy()).toBe(false);
+
+    sweeper.start(10, logger);
+    const restartedDone = sweeper.done;
+    await vi.advanceTimersByTimeAsync(10);
+    expect(invocation).toBe(2);
+    expect((sweeper as any).running).toBe(true);
+    expect(sweeper.isHealthy()).toBe(true);
+
+    detachedPass.resolve();
+    await flushPromises();
+    expect((sweeper as any).running).toBe(true);
+    expect(sweeper.isHealthy()).toBe(true);
+    expect(sweeper.getMetrics(2_000)).not.toContain('index="delay"');
+    expect(detachedSettled).toHaveBeenCalledOnce();
+
+    sweeper.forceStop();
+    await expect(restartedDone).resolves.toBeUndefined();
+    restartedPass.resolve();
+    await flushPromises();
+    expect(sweeper.isHealthy()).toBe(false);
+    expect(sweeper.getMetrics(2_000)).not.toContain('index="delay"');
+  });
+});

--- a/apps/api/src/services/worker/nuq-fdb/sweeper-lifecycle.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper-lifecycle.test.ts
@@ -231,6 +231,36 @@ describe("NuqFdbSweeper lifecycle", () => {
     await expect(restartedDone).resolves.toBeUndefined();
   });
 
+  it("does not continue queue backfills after force-stop and restart", async () => {
+    const firstBackfill = deferred();
+    const firstQueue = {
+      ks: { queueName: "first" },
+      backfillMetricCounts: vi.fn(() => firstBackfill.promise),
+    } as unknown as NuQFdbQueue;
+    const secondQueue = {
+      ks: { queueName: "second" },
+      backfillMetricCounts: vi.fn().mockResolvedValue(undefined),
+    } as unknown as NuQFdbQueue;
+    const sweeper = new NuqFdbSweeper([firstQueue, secondQueue]);
+
+    sweeper.start(10, logger);
+    const detachedDone = sweeper.done;
+    await vi.advanceTimersByTimeAsync(10);
+    expect(firstQueue.backfillMetricCounts).toHaveBeenCalledOnce();
+
+    sweeper.forceStop();
+    await detachedDone;
+    sweeper.start(100, logger);
+    const restartedDone = sweeper.done;
+    firstBackfill.resolve();
+    await flushPromises();
+
+    expect(secondQueue.backfillMetricCounts).not.toHaveBeenCalled();
+    expect(sweeper.isHealthy()).toBe(true);
+    sweeper.forceStop();
+    await restartedDone;
+  });
+
   it("does not let a stale renewal extend a restarted lifecycle's metric", async () => {
     const { ks, sweeper } = makeSweeper();
     let finishRenewal!: (expiresAt: number) => void;

--- a/apps/api/src/services/worker/nuq-fdb/sweeper-metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper-metrics.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { NuqFdbKeyspace } from "./keyspace";
+import type { NuQFdbQueue } from "./queue";
+import { NuqFdbSweeper } from "./sweeper";
+
+function makeSweeper() {
+  const ks = { queueName: 'queue"with\\escapes' } as NuqFdbKeyspace;
+  const queue = { ks } as NuQFdbQueue;
+  return { ks, sweeper: new NuqFdbSweeper([queue]) };
+}
+
+function observeDelay(
+  sweeper: NuqFdbSweeper,
+  ks: NuqFdbKeyspace,
+  dueAtMs: number,
+  expiresAt: number,
+) {
+  (sweeper as any).observeDue(
+    {
+      ks,
+      phase: "delay",
+      partition: 3,
+      generation: "test",
+      expiresAt,
+    },
+    "delay",
+    [[Buffer.alloc(0), Buffer.alloc(0)]],
+    () => dueAtMs,
+  );
+}
+
+describe("NuqFdbSweeper overdue metrics", () => {
+  it("collects an owned observation without touching FoundationDB", () => {
+    const { ks, sweeper } = makeSweeper();
+    Object.defineProperty(sweeper as any, "db", {
+      get() {
+        throw new Error("metric collection must not access FoundationDB");
+      },
+    });
+    observeDelay(sweeper, ks, 1_000, 10_000);
+
+    expect(sweeper.getMetrics(6_000)).toContain(
+      'firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds{queue="queue\\"with\\\\escapes",index="delay",partition="3"} 5',
+    );
+  });
+
+  it("removes labels after an empty scan, local lease expiry, or stop", () => {
+    const { ks, sweeper } = makeSweeper();
+    observeDelay(sweeper, ks, 1_000, 10_000);
+    (sweeper as any).observeDue(
+      {
+        ks,
+        phase: "delay",
+        partition: 3,
+        generation: "test",
+        expiresAt: 10_000,
+      },
+      "delay",
+      [],
+      () => 0,
+    );
+    expect(sweeper.getMetrics(2_000)).not.toContain('index="delay"');
+
+    observeDelay(sweeper, ks, 1_000, 3_000);
+    expect(sweeper.getMetrics(3_000)).not.toContain('index="delay"');
+
+    observeDelay(sweeper, ks, 1_000, 10_000);
+    sweeper.stop();
+    expect(sweeper.getMetrics(2_000)).not.toContain('index="delay"');
+  });
+});

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import type { Transaction } from "foundationdb";
 import { Logger } from "winston";
 import { logger as _logger } from "../../../lib/logger";
 import { config } from "../../../config";
@@ -9,13 +10,13 @@ import {
   JobStatusRecord,
   GroupMeta,
   QueueEntry,
+  RaiseTask,
   decodeI64,
-  encodeI64,
   decodeJson,
+  encodeI64,
   encodeJson,
   timeBucket,
   TIME_BUCKETS,
-  F_GATED,
   F_CRAWL_GATED,
   F_COUNTABLE,
   F_GACC,
@@ -23,10 +24,10 @@ import {
   IngestMeta,
 } from "./keyspace";
 import {
-  ONE,
   MINUS_ONE,
   EMPTY,
   MAX_STALLS,
+  COMPLETED_STANDALONE_RETENTION_MS,
   FAILED_STANDALONE_RETENTION_MS,
   newTxContext,
   pushReady,
@@ -39,24 +40,57 @@ import {
   deleteJobRecords,
   popTeamPending,
   popKeyPending,
-  setGroupJobIndex,
   bumpGroupStatusCount,
   bumpTeamActive,
+  bumpKeyActive,
+  scheduleRaiseTask,
+  setGroupJobIndex,
   GroupJobIndexValue,
   alignQueueMetricStatus,
 } from "./ops";
+import { ACTIVE_GROUP_MAX_AGE_MS } from "./groups";
 import { NuQFdbQueue } from "./queue";
-import { NuqFdbExternalSlots } from "./slots";
+import { ExternalSlotSweepGuard, NuqFdbExternalSlots } from "./slots";
 
-const SWEEP_LOCK_TTL_MS = 15_000;
-const SWEEP_BATCH = 50;
+const DEFAULT_SWEEP_LOCK_TTL_MS = 15_000;
+const DEFAULT_MAX_PARTITIONS_PER_TICK = 32;
+const PARTITION_WORK_BUDGET_MS = 30_000;
+const SWEEP_BATCH = 100;
+const GROUP_MEMBER_SCAN_BATCH = 500;
+const GROUP_MEMBER_MUTATION_BATCH = 50;
+const GROUP_GC_BATCH = 500;
+const ABANDONED_GROUP_DRAIN_GRACE_MS = 60 * 60 * 1000;
+const FINISHED_CONTROL_RECHECK_MS = 60_000;
 const STALL_FAILED_REASON = "Job stalled too many times";
+
+class OwnershipLostError extends Error {}
+
+type OwnershipRecord = {
+  w: string;
+  g: string;
+  x: number;
+};
+
+type PartitionClaim = {
+  ks: NuqFdbKeyspace;
+  phase: string;
+  partition: number;
+  generation: string;
+};
+
+type PartitionWork = {
+  ks: NuqFdbKeyspace;
+  phase: string;
+  partition: number;
+  run: (claim: PartitionClaim) => Promise<void>;
+};
 
 type SweepLagStats = {
   dueCount: number;
   processedCount: number;
   oldestOverdueAgeMs: number;
-  saturatedBucketCount: number;
+  saturatedBatchCount: number;
+  budgetExhausted: boolean;
   durationMs: number;
 };
 
@@ -82,105 +116,379 @@ function emptySweepLagStats(): SweepLagStats {
     dueCount: 0,
     processedCount: 0,
     oldestOverdueAgeMs: 0,
-    saturatedBucketCount: 0,
+    saturatedBatchCount: 0,
+    budgetExhausted: false,
     durationMs: 0,
   };
 }
 
-function addDueKeysToLagStats(
-  stats: SweepLagStats,
-  ks: NuqFdbKeyspace,
-  due: [unknown, unknown][],
-  now: number,
-): void {
-  stats.dueCount += due.length;
-  if (due.length >= SWEEP_BATCH) stats.saturatedBucketCount++;
-  for (const [key] of due) {
-    const dueAt = Number(ks.unpackId(key as Buffer, 1));
-    if (Number.isFinite(dueAt)) {
-      stats.oldestOverdueAgeMs = Math.max(
-        stats.oldestOverdueAgeMs,
-        now - dueAt,
-      );
-    }
-  }
-}
-
-function logSweepLag(
-  logger: Logger,
-  queue: NuQFdbQueue,
-  index: "lease" | "backlog_timeout" | "delay",
-  stats: SweepLagStats,
-): void {
-  if (stats.dueCount === 0 && stats.saturatedBucketCount === 0) return;
-  logger[stats.saturatedBucketCount > 0 ? "warn" : "debug"](
-    "NuQ FDB sweeper lag",
-    {
-      canonicalLog: "nuq-fdb/sweeper_lag",
-      queueName: queue.queueName,
-      index,
-      timeBuckets: TIME_BUCKETS,
-      sweepBatch: SWEEP_BATCH,
-      ...stats,
-    },
-  );
-}
-
-// One sweeper services all queues against the same FDB cluster. Each queue
-// gets its own pass; a leased singleton lock (held on the first queue's
-// keyspace) keeps multiple candidate processes from sweeping concurrently.
+// Maintenance is split into independently leased queue/index/bucket
+// partitions. Replicas race for a bounded number of partitions per tick, so
+// adding replicas adds throughput while a fencing generation prevents overlap.
 export class NuqFdbSweeper {
   private readonly sweeperId = randomUUID();
   private loop: NodeJS.Timeout | null = null;
   private running = false;
+  private partitionOffset = 0;
+  private readonly lockTtlMs: number;
+  private readonly maxPartitionsPerTick: number;
 
   constructor(
     public readonly queues: NuQFdbQueue[],
     public readonly externalSlots: NuqFdbExternalSlots[] = [],
-  ) {}
+    options: { lockTtlMs?: number; maxPartitionsPerTick?: number } = {},
+  ) {
+    this.lockTtlMs = options.lockTtlMs ?? DEFAULT_SWEEP_LOCK_TTL_MS;
+    this.maxPartitionsPerTick =
+      options.maxPartitionsPerTick ?? DEFAULT_MAX_PARTITIONS_PER_TICK;
+  }
 
   private get db() {
     return getNuqFdbDatabase();
   }
 
-  private get lockKs(): NuqFdbKeyspace {
-    return this.queues[0].ks;
-  }
-
-  public async tryAcquireLock(now: number = Date.now()): Promise<boolean> {
+  private async tryAcquirePartition(
+    ks: NuqFdbKeyspace,
+    phase: string,
+    partition: number,
+    now: number = Date.now(),
+  ): Promise<PartitionClaim | null> {
+    const generation = randomUUID();
     return await this.db.doTn(async tn => {
-      const rec = decodeJson<{ w: string; x: number }>(
-        await tn.get(this.lockKs.sweeperLock()),
+      // During rolling deployment, defer to the old all-or-nothing owner until
+      // its final lease expires; old and new protocols must not overlap.
+      const legacy = decodeJson<{ x: number }>(
+        await tn.get(this.queues[0].ks.legacySweeperLock()),
       );
-      if (rec && rec.x > now && rec.w !== this.sweeperId) return false;
+      if (legacy && legacy.x > now) return null;
+      const key = ks.sweeperPartition(phase, partition);
+      const current = decodeJson<OwnershipRecord>(await tn.get(key));
+      if (current && current.x > now && current.w !== this.sweeperId) {
+        return null;
+      }
       tn.set(
-        this.lockKs.sweeperLock(),
-        encodeJson({ w: this.sweeperId, x: now + SWEEP_LOCK_TTL_MS }),
+        key,
+        encodeJson({
+          w: this.sweeperId,
+          g: generation,
+          x: now + this.lockTtlMs,
+        } satisfies OwnershipRecord),
       );
-      return true;
+      return { ks, phase, partition, generation };
     });
   }
 
-  // Runs one full sweep over all queues. Exposed for tests; production uses
-  // start(), which wraps this in the singleton lock loop.
-  public async sweepOnce(logger: Logger = _logger): Promise<void> {
-    const now = Date.now();
+  private async renewClaim(claim: PartitionClaim): Promise<void> {
+    await this.db.doTn(async tn => {
+      const key = claim.ks.sweeperPartition(claim.phase, claim.partition);
+      const current = decodeJson<OwnershipRecord>(await tn.get(key));
+      const now = Date.now();
+      if (
+        !current ||
+        current.w !== this.sweeperId ||
+        current.g !== claim.generation ||
+        current.x <= now
+      ) {
+        throw new OwnershipLostError();
+      }
+      tn.set(key, encodeJson({ ...current, x: now + this.lockTtlMs }));
+    });
+  }
+
+  private async guardClaim(
+    tn: Transaction,
+    claim: PartitionClaim,
+  ): Promise<void> {
+    const current = decodeJson<OwnershipRecord>(
+      await tn.get(claim.ks.sweeperPartition(claim.phase, claim.partition)),
+    );
+    if (
+      !current ||
+      current.w !== this.sweeperId ||
+      current.g !== claim.generation ||
+      current.x <= Date.now()
+    ) {
+      throw new OwnershipLostError();
+    }
+  }
+
+  private guard(claim: PartitionClaim): ExternalSlotSweepGuard {
+    return async tn => await this.guardClaim(tn, claim);
+  }
+
+  private partitionWork(now: number, logger: Logger): PartitionWork[] {
+    const work: PartitionWork[] = [];
     for (const queue of this.queues) {
-      await queue.backfillMetricCounts(100, config.NUQ_FDB_METRICS_V2_ACTIVATE);
-      await this.sweepLeases(queue, now, logger);
-      await this.sweepBacklogTimeouts(queue, now, logger);
-      await this.sweepDelayed(queue, now, logger);
-      await this.sweepClaimMarkers(queue, now);
-      await this.sweepAbandonedIngests(queue, now);
-      await this.sweepGroupFinishTasks(queue, now, logger);
-      await this.sweepGroupCancelTasks(queue, now, logger);
-      await this.sweepTeamRaiseTasks(queue, now, logger);
-      await this.sweepKeyRaiseTasks(queue, now, logger);
-      await this.sweepJobExpiry(queue, now, logger);
-      await this.sweepGroupExpiry(queue, now, logger);
+      work.push({
+        ks: queue.ks,
+        phase: "metric-backfill",
+        partition: 0,
+        run: async claim => {
+          await this.renewClaim(claim);
+          await queue.backfillMetricCounts(
+            100,
+            config.NUQ_FDB_METRICS_V2_ACTIVATE,
+          );
+        },
+      });
+      for (let bucket = 0; bucket < TIME_BUCKETS; bucket++) {
+        work.push(
+          {
+            ks: queue.ks,
+            phase: "lease",
+            partition: bucket,
+            run: claim => this.sweepLeases(queue, bucket, now, logger, claim),
+          },
+          {
+            ks: queue.ks,
+            phase: "backlog-timeout",
+            partition: bucket,
+            run: claim =>
+              this.sweepBacklogTimeouts(queue, bucket, now, logger, claim),
+          },
+          {
+            ks: queue.ks,
+            phase: "delay",
+            partition: bucket,
+            run: claim => this.sweepDelayed(queue, bucket, now, logger, claim),
+          },
+          {
+            ks: queue.ks,
+            phase: "job-expiry",
+            partition: bucket,
+            run: claim => this.sweepJobExpiry(queue, bucket, now, claim),
+          },
+          {
+            ks: queue.ks,
+            phase: "group-finish",
+            partition: bucket,
+            run: claim =>
+              this.sweepGroupFinishTasks(
+                queue,
+                now,
+                claim,
+                queue.ks.taskGroupFinishRange(bucket),
+              ),
+          },
+          {
+            ks: queue.ks,
+            phase: "group-cancel",
+            partition: bucket,
+            run: claim =>
+              this.sweepGroupCancelTasks(
+                queue,
+                now,
+                claim,
+                queue.ks.taskGroupCancelRange(bucket),
+              ),
+          },
+          {
+            ks: queue.ks,
+            phase: "team-raise",
+            partition: bucket,
+            run: claim =>
+              this.sweepTeamRaiseTasks(
+                queue,
+                claim,
+                queue.ks.taskTeamRaiseRange(bucket),
+              ),
+          },
+          {
+            ks: queue.ks,
+            phase: "key-raise",
+            partition: bucket,
+            run: claim =>
+              this.sweepKeyRaiseTasks(
+                queue,
+                claim,
+                queue.ks.taskKeyRaiseRange(bucket),
+              ),
+          },
+          {
+            ks: queue.ks,
+            phase: "group-expiry",
+            partition: bucket,
+            run: claim =>
+              this.sweepGroupExpiry(
+                queue,
+                now,
+                claim,
+                queue.ks.groupExpiryScanRange(bucket, now),
+                false,
+              ),
+          },
+          {
+            ks: queue.ks,
+            phase: "team-ledger-gc",
+            partition: bucket,
+            run: claim => this.sweepLedgers(queue, "team", bucket, claim),
+          },
+          {
+            ks: queue.ks,
+            phase: "key-ledger-gc",
+            partition: bucket,
+            run: claim => this.sweepLedgers(queue, "key", bucket, claim),
+          },
+        );
+      }
+      work.push(
+        {
+          ks: queue.ks,
+          phase: "legacy-group-finish",
+          partition: 0,
+          run: claim =>
+            this.sweepGroupFinishTasks(
+              queue,
+              now,
+              claim,
+              queue.ks.legacyTaskGroupFinishRange(),
+            ),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-group-cancel",
+          partition: 0,
+          run: claim =>
+            this.sweepGroupCancelTasks(
+              queue,
+              now,
+              claim,
+              queue.ks.legacyTaskGroupCancelRange(),
+            ),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-team-raise",
+          partition: 0,
+          run: claim =>
+            this.sweepTeamRaiseTasks(
+              queue,
+              claim,
+              queue.ks.legacyTaskTeamRaiseRange(),
+            ),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-key-raise",
+          partition: 0,
+          run: claim =>
+            this.sweepKeyRaiseTasks(
+              queue,
+              claim,
+              queue.ks.legacyTaskKeyRaiseRange(),
+            ),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-group-expiry",
+          partition: 0,
+          run: claim =>
+            this.sweepGroupExpiry(
+              queue,
+              now,
+              claim,
+              queue.ks.legacyGroupExpiryScanRange(now),
+              true,
+            ),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-active-group-index",
+          partition: 0,
+          run: claim => this.indexLegacyActiveGroups(queue, claim),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-all-group-index",
+          partition: 0,
+          run: claim => this.indexLegacyGroups(queue, claim),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-team-ledger-index",
+          partition: 0,
+          run: claim => this.indexLegacyLedgers(queue, "team", claim),
+        },
+        {
+          ks: queue.ks,
+          phase: "legacy-key-ledger-index",
+          partition: 0,
+          run: claim => this.indexLegacyLedgers(queue, "key", claim),
+        },
+        {
+          ks: queue.ks,
+          phase: "claim-marker",
+          partition: 0,
+          run: claim => this.sweepClaimMarkers(queue, now, claim),
+        },
+        {
+          ks: queue.ks,
+          phase: "abandoned-ingest",
+          partition: 0,
+          run: claim => this.sweepAbandonedIngests(queue, now, claim),
+        },
+      );
     }
     for (const slots of this.externalSlots) {
-      await slots.sweepExpired(now, TIME_BUCKETS);
+      for (let bucket = 0; bucket < TIME_BUCKETS; bucket++) {
+        work.push({
+          ks: slots.ks,
+          phase: "external-expiry",
+          partition: bucket,
+          run: async claim => {
+            await this.renewClaim(claim);
+            await slots.sweepExpiredBucket(now, bucket, this.guard(claim));
+          },
+        });
+      }
+    }
+    return work;
+  }
+
+  // Exposed for real-FDB tests. Direct calls attempt every partition; the
+  // production loop caps claims so replicas naturally divide the work.
+  public async sweepOnce(
+    logger: Logger = _logger,
+    maxPartitions: number = Number.POSITIVE_INFINITY,
+  ): Promise<void> {
+    const now = Date.now();
+    const startedAt = Date.now();
+    const work = this.partitionWork(now, logger);
+    const offset = this.partitionOffset % Math.max(1, work.length);
+    const ordered = [...work.slice(offset), ...work.slice(0, offset)];
+    let acquired = 0;
+    let scanned = 0;
+    for (const item of ordered) {
+      if (
+        acquired >= maxPartitions ||
+        (Number.isFinite(maxPartitions) &&
+          Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS)
+      ) {
+        break;
+      }
+      scanned++;
+      this.partitionOffset = (offset + scanned) % work.length;
+      const claim = await this.tryAcquirePartition(
+        item.ks,
+        item.phase,
+        item.partition,
+      );
+      if (!claim) continue;
+      acquired++;
+      try {
+        await item.run(claim);
+      } catch (error) {
+        if (error instanceof OwnershipLostError) {
+          logger.info("NuQ FDB sweeper partition ownership lost", {
+            canonicalLog: "nuq-fdb/sweeper_ownership_lost",
+            queueName: item.ks.queueName,
+            phase: item.phase,
+            partition: item.partition,
+          });
+          continue;
+        }
+        throw error;
+      }
     }
   }
 
@@ -190,9 +498,7 @@ export class NuqFdbSweeper {
       if (this.running) return;
       this.running = true;
       try {
-        if (await this.tryAcquireLock()) {
-          await this.sweepOnce(logger);
-        }
+        await this.sweepOnce(logger, this.maxPartitionsPerTick);
       } catch (error) {
         logger.warn("NuQ FDB sweeper tick failed", {
           module: "nuq-fdb/sweeper",
@@ -211,47 +517,96 @@ export class NuqFdbSweeper {
     }
   }
 
-  // === Lease expiry: requeue stalled jobs, fail them after MAX_STALLS
+  private addLag(
+    stats: SweepLagStats,
+    ks: NuqFdbKeyspace,
+    due: [unknown, unknown][],
+    now: number,
+  ): void {
+    stats.dueCount += due.length;
+    if (due.length >= SWEEP_BATCH) stats.saturatedBatchCount++;
+    for (const [key] of due) {
+      const dueAt = Number(ks.unpackId(key as Buffer, 1));
+      if (Number.isFinite(dueAt)) {
+        stats.oldestOverdueAgeMs = Math.max(
+          stats.oldestOverdueAgeMs,
+          now - dueAt,
+        );
+      }
+    }
+  }
+
+  private logLag(
+    logger: Logger,
+    queue: NuQFdbQueue,
+    index: string,
+    stats: SweepLagStats,
+  ): void {
+    if (stats.dueCount === 0 && !stats.budgetExhausted) return;
+    logger[
+      stats.budgetExhausted || stats.saturatedBatchCount > 0 ? "warn" : "debug"
+    ]("NuQ FDB sweeper lag", {
+      canonicalLog: "nuq-fdb/sweeper_lag",
+      queueName: queue.queueName,
+      index,
+      partitioned: true,
+      timeBuckets: TIME_BUCKETS,
+      sweepBatch: SWEEP_BATCH,
+      ...stats,
+    });
+  }
+
+  private async dueBatch(
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
+    limit: number = SWEEP_BATCH,
+  ): Promise<[Buffer, Buffer][]> {
+    await this.renewClaim(claim);
+    return await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      return (await tn
+        .snapshot()
+        .getRangeAll(range.begin, range.end, { limit })) as [Buffer, Buffer][];
+    });
+  }
 
   private async sweepLeases(
     queue: NuQFdbQueue,
+    bucket: number,
     now: number,
     logger: Logger,
+    claim: PartitionClaim,
   ): Promise<void> {
     const startedAt = Date.now();
     const ks = queue.ks;
     const stats = emptySweepLagStats();
-    for (let b = 0; b < TIME_BUCKETS; b++) {
-      const r = ks.leaseScanRange(b, now);
-      const due = await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(r.begin, r.end, { limit: SWEEP_BATCH }),
-      );
-      addDueKeysToLagStats(stats, ks, due, now);
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(claim, ks.leaseScanRange(bucket, now));
+      this.addLag(stats, ks, due, now);
+      if (due.length === 0) break;
       for (const [key, value] of due) {
-        const id = ks.unpackId(key as Buffer);
-        const lease = decodeJson<{ l: string }>(value as Buffer);
+        await this.renewClaim(claim);
+        const id = ks.unpackId(key);
+        const lease = decodeJson<{ l: string }>(value);
         await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
           const txc = newTxContext();
           const st = decodeJson<JobStatusRecord>(
             await tn.get(ks.jobStatus(id)),
           );
-          // stale entries: job moved on (renewal, finish) or was reaped already
           if (!st || st.s !== "active" || st.l !== lease?.l) {
-            tn.clear(key as Buffer);
+            tn.clear(key);
             return;
           }
           if (st.e !== undefined && st.e > now) {
-            // renewed after our snapshot; the old index entry is what expired
-            tn.clear(key as Buffer);
+            tn.clear(key);
             return;
           }
           const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
-          tn.clear(key as Buffer);
+          tn.clear(key);
           if (!meta) return;
           const entry = entryFromMeta(id, meta);
-
           if (st.st < MAX_STALLS) {
-            // requeue directly to ready -- the job retains its slots
             pushReady(tn, ks, entry, txc);
             setStatusQueued(tn, ks, id, st.st + 1);
             await alignQueueMetricStatus(tn, ks, id);
@@ -307,32 +662,37 @@ export class NuqFdbSweeper {
         });
         stats.processedCount++;
       }
+      if (due.length < SWEEP_BATCH) break;
     }
+    stats.budgetExhausted = Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS;
     stats.durationMs = Date.now() - startedAt;
-    logSweepLag(logger, queue, "lease", stats);
+    this.logLag(logger, queue, "lease", stats);
   }
-
-  // === Backlog timeouts: silently drop pending jobs past their deadline
 
   private async sweepBacklogTimeouts(
     queue: NuQFdbQueue,
+    bucket: number,
     now: number,
     logger: Logger,
+    claim: PartitionClaim,
   ): Promise<void> {
     const startedAt = Date.now();
     const ks = queue.ks;
     const stats = emptySweepLagStats();
-    for (let b = 0; b < TIME_BUCKETS; b++) {
-      const r = ks.backlogTimeoutScanRange(b, now);
-      const due = await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(r.begin, r.end, { limit: SWEEP_BATCH }),
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(
+        claim,
+        ks.backlogTimeoutScanRange(bucket, now),
       );
-      addDueKeysToLagStats(stats, ks, due, now);
+      this.addLag(stats, ks, due, now);
+      if (due.length === 0) break;
       for (const [key] of due) {
-        const id = ks.unpackId(key as Buffer);
+        await this.renewClaim(claim);
+        const id = ks.unpackId(key);
         await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
           const txc = newTxContext();
-          tn.clear(key as Buffer);
+          tn.clear(key);
           const st = decodeJson<JobStatusRecord>(
             await tn.get(ks.jobStatus(id)),
           );
@@ -362,8 +722,9 @@ export class NuqFdbSweeper {
           if (meta.g && meta.f & F_GACC && queue.groupOps) {
             tn.clear(ks.groupJob(meta.g, id));
             tn.add(ks.groupRemaining(meta.g), MINUS_ONE);
-            if (meta.f & F_COUNTABLE)
+            if (meta.f & F_COUNTABLE) {
               bumpGroupStatusCount(tn, ks, meta.g, "pending", -1);
+            }
             tn.set(ks.taskGroupFinish(meta.g), EMPTY);
           }
           deleteJobRecords(tn, ks, id);
@@ -371,208 +732,290 @@ export class NuqFdbSweeper {
         });
         stats.processedCount++;
       }
+      if (due.length < SWEEP_BATCH) break;
     }
+    stats.budgetExhausted = Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS;
     stats.durationMs = Date.now() - startedAt;
-    logSweepLag(logger, queue, "backlog_timeout", stats);
+    this.logLag(logger, queue, "backlog_timeout", stats);
   }
-
-  // === Delayed (crawl delay) promotions
 
   private async sweepDelayed(
     queue: NuQFdbQueue,
+    bucket: number,
     now: number,
     logger: Logger,
+    claim: PartitionClaim,
   ): Promise<void> {
     const startedAt = Date.now();
     const ks = queue.ks;
     const stats = emptySweepLagStats();
-    for (let b = 0; b < TIME_BUCKETS; b++) {
-      const r = ks.delayedScanRange(b, now);
-      const due = await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(r.begin, r.end, { limit: SWEEP_BATCH }),
-      );
-      addDueKeysToLagStats(stats, ks, due, now);
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(claim, ks.delayedScanRange(bucket, now));
+      this.addLag(stats, ks, due, now);
+      if (due.length === 0) break;
       for (const [key, value] of due) {
-        const e = decodeJson<QueueEntry>(value as Buffer);
-        if (!e) continue;
+        const entry = decodeJson<QueueEntry>(value);
+        if (!entry) continue;
+        await this.renewClaim(claim);
         await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
           const txc = newTxContext();
           const st = decodeJson<JobStatusRecord>(
-            await tn.get(ks.jobStatus(e.i)),
+            await tn.get(ks.jobStatus(entry.i)),
           );
-          tn.clear(key as Buffer);
+          tn.clear(key);
           if (!st || st.s !== "pending" || st.loc?.k !== "dl") return;
-          // the job already holds its crawl slot; admit through the key gate
-          // and then the team gate
-          await admitThroughGates(tn, ks, e, txc);
-          await alignQueueMetricStatus(tn, ks, e.i);
+          await admitThroughGates(tn, ks, entry, txc);
+          await alignQueueMetricStatus(tn, ks, entry.i);
         });
         stats.processedCount++;
       }
+      if (due.length < SWEEP_BATCH) break;
     }
+    stats.budgetExhausted = Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS;
     stats.durationMs = Date.now() - startedAt;
-    logSweepLag(logger, queue, "delay", stats);
+    this.logLag(logger, queue, "delay", stats);
   }
-
-  // === Commit-unknown claim marker GC
 
   private async sweepClaimMarkers(
     queue: NuQFdbQueue,
     now: number,
+    claim: PartitionClaim,
   ): Promise<void> {
+    const startedAt = Date.now();
     const ks = queue.ks;
     const range = ks.claimExpiryScanRange(now);
-    const due = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(range.begin, range.end, {
-        limit: SWEEP_BATCH,
-      }),
-    );
-    if (due.length === 0) return;
-    await this.db.doTn(async tn => {
-      for (const [key] of due) {
-        const expiryKey = key as Buffer;
-        const op = ks.unpackId(expiryKey);
-        const expiresAt = Number(ks.unpackId(expiryKey, 1));
-        const marker = decodeJson<{ e: number }>(await tn.get(ks.claim(op)));
-        if (marker && marker.e === expiresAt && marker.e <= now) {
-          tn.clear(ks.claim(op));
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(claim, range);
+      if (due.length === 0) break;
+      await this.renewClaim(claim);
+      await this.db.doTn(async tn => {
+        await this.guardClaim(tn, claim);
+        for (const [key] of due) {
+          const op = ks.unpackId(key);
+          const expiresAt = Number(ks.unpackId(key, 1));
+          const marker = decodeJson<{ e: number }>(await tn.get(ks.claim(op)));
+          if (marker && marker.e === expiresAt && marker.e <= now) {
+            tn.clear(ks.claim(op));
+          }
+          // Always discard the observed expiry row. A mismatched/live marker
+          // has its own later durable row and must survive stale-row cleanup.
+          tn.clear(key);
         }
-        // Always discard the observed expiry row. A mismatched/live marker has
-        // its own later durable row and must survive this stale-row cleanup.
-        tn.clear(expiryKey);
-      }
-    });
+      });
+      if (due.length < SWEEP_BATCH) break;
+    }
   }
-
-  // === Abandoned resumable enqueues
 
   private async sweepAbandonedIngests(
     queue: NuQFdbQueue,
     now: number,
+    claim: PartitionClaim,
   ): Promise<void> {
+    const startedAt = Date.now();
     const ks = queue.ks;
     const range = ks.ingestExpiryScanRange(now);
-    const due = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(range.begin, range.end, { limit: 20 }),
-    );
-    for (const [expiryKey] of due) {
-      const op = ks.unpackId(expiryKey as Buffer);
-      await this.db.doTn(async tn => {
-        const meta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
-        if (!meta) {
-          tn.clear(expiryKey as Buffer);
-          return;
-        }
-        const jobsRange = ks.ingestJobRange(op);
-        const members = await tn.getRangeAll(jobsRange.begin, jobsRange.end, {
-          limit: SWEEP_BATCH,
-        });
-        for (const [memberKey] of members) {
-          const id = ks.unpackId(memberKey as Buffer);
-          const status = decodeJson<JobStatusRecord>(
-            await tn.get(ks.jobStatus(id)),
-          );
-          if (status?.s === "ingesting" && status.op === op) {
-            deleteJobRecords(tn, ks, id);
-            await alignQueueMetricStatus(tn, ks, id);
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(claim, range, 20);
+      if (due.length === 0) break;
+      let incomplete = false;
+      for (const [expiryKey] of due) {
+        await this.renewClaim(claim);
+        const op = ks.unpackId(expiryKey);
+        const finished = await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
+          const meta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+          if (!meta) {
+            tn.clear(expiryKey);
+            return true;
           }
-          tn.clear(memberKey as Buffer);
-        }
-        if (members.length >= SWEEP_BATCH) return;
+          const jobsRange = ks.ingestJobRange(op);
+          const members = await tn.getRangeAll(
+            jobsRange.begin,
+            jobsRange.end,
+            { limit: SWEEP_BATCH },
+          );
+          for (const [memberKey] of members) {
+            const id = ks.unpackId(memberKey as Buffer);
+            const status = decodeJson<JobStatusRecord>(
+              await tn.get(ks.jobStatus(id)),
+            );
+            if (status?.s === "ingesting" && status.op === op) {
+              deleteJobRecords(tn, ks, id);
+              await alignQueueMetricStatus(tn, ks, id);
+            }
+            tn.clear(memberKey as Buffer);
+          }
+          if (members.length >= SWEEP_BATCH) return false;
 
-        const groupsRange = ks.ingestGroupRange(op);
-        const groups = await tn.getRangeAll(
-          groupsRange.begin,
-          groupsRange.end,
-          { limit: SWEEP_BATCH },
-        );
-        for (const [groupKey] of groups) {
-          const gid = ks.unpackId(groupKey as Buffer);
-          tn.clear(groupKey as Buffer);
-          tn.add(ks.groupIngestCount(gid), MINUS_ONE);
-          tn.set(ks.taskGroupFinish(gid), EMPTY);
-        }
-        if (groups.length >= SWEEP_BATCH) return;
+          const groupsRange = ks.ingestGroupRange(op);
+          const groups = await tn.getRangeAll(
+            groupsRange.begin,
+            groupsRange.end,
+            { limit: SWEEP_BATCH },
+          );
+          for (const [groupKey] of groups) {
+            const gid = ks.unpackId(groupKey as Buffer);
+            tn.clear(groupKey as Buffer);
+            tn.add(ks.groupIngestCount(gid), MINUS_ONE);
+            tn.set(ks.taskGroupFinish(gid), EMPTY);
+          }
+          if (groups.length >= SWEEP_BATCH) return false;
 
-        if (meta.r > 0 && meta.o) {
-          tn.add(ks.teamIngestReserved(meta.o), encodeI64(-meta.r));
-        }
-        tn.clear(ks.ingest(op));
-        tn.clear(expiryKey as Buffer);
-      });
+          if (meta.r > 0 && meta.o) {
+            tn.add(ks.teamIngestReserved(meta.o), encodeI64(-meta.r));
+          }
+          tn.clear(ks.ingest(op));
+          tn.clear(expiryKey);
+          return true;
+        });
+        if (!finished) incomplete = true;
+        if (Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS) return;
+      }
+      if (!incomplete && due.length < 20) break;
     }
   }
 
-  // === Group finish detection (backstop for the inline path)
+  private async taskBatch(
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
+    limit: number,
+  ): Promise<[Buffer, Buffer][]> {
+    await this.renewClaim(claim);
+    return await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      const cursor = await tn
+        .snapshot()
+        .get(claim.ks.sweeperCursor(claim.phase, claim.partition));
+      let rows = (await tn
+        .snapshot()
+        .getRangeAll(cursor ? keyAfter(cursor) : range.begin, range.end, {
+          limit,
+        })) as [Buffer, Buffer][];
+      if (rows.length === 0 && cursor) {
+        tn.clear(claim.ks.sweeperCursor(claim.phase, claim.partition));
+        rows = (await tn
+          .snapshot()
+          .getRangeAll(range.begin, range.end, { limit })) as [
+          Buffer,
+          Buffer,
+        ][];
+      }
+      if (rows.length > 0) {
+        tn.set(
+          claim.ks.sweeperCursor(claim.phase, claim.partition),
+          rows[rows.length - 1][0],
+        );
+      }
+      return rows;
+    });
+  }
 
   private async sweepGroupFinishTasks(
     queue: NuQFdbQueue,
     now: number,
-    logger: Logger,
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
   ): Promise<void> {
     if (!queue.groupOps) return;
+    const startedAt = Date.now();
     const ks = queue.ks;
-    const r = ks.taskGroupFinishRange();
-    const tasks = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(r.begin, r.end, { limit: 200 }),
-    );
-    for (const [key] of tasks) {
-      const gid = ks.unpackId(key as Buffer);
-      await this.db.doTn(async tn => {
-        const txc = newTxContext();
-        // normal read so a concurrent finisher's decrement forces a retry --
-        // clearing the task may not race with the group draining to zero
-        const rem = decodeI64(await tn.get(ks.groupRemaining(gid)));
-        if (rem > 0) {
-          tn.clear(key as Buffer);
-          return;
-        }
-        await queue.groupOps!.tryCompleteGroup(tn, gid, now, txc);
-      });
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const tasks = await this.taskBatch(claim, range, SWEEP_BATCH);
+      if (tasks.length === 0) break;
+      for (const [key] of tasks) {
+        const gid = ks.unpackId(key);
+        await this.renewClaim(claim);
+        await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
+          const txc = newTxContext();
+          const rem = decodeI64(await tn.get(ks.groupRemaining(gid)));
+          if (rem > 0) {
+            tn.clear(key);
+            return;
+          }
+          await queue.groupOps!.tryCompleteGroup(tn, gid, now, txc);
+          tn.clear(key);
+        });
+      }
+      if (tasks.length < SWEEP_BATCH) break;
     }
   }
-
-  // === Lazy group cancellation cleanup
 
   private async sweepGroupCancelTasks(
     queue: NuQFdbQueue,
     now: number,
-    logger: Logger,
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
   ): Promise<void> {
     if (!queue.groupOps) return;
+    const startedAt = Date.now();
     const ks = queue.ks;
-    const r = ks.taskGroupCancelRange();
-    const tasks = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(r.begin, r.end, { limit: 20 }),
-    );
-    for (const [key] of tasks) {
-      const gid = ks.unpackId(key as Buffer);
-      let exhausted = false;
-      // The task value is a durable cursor. A concurrent cancelled-group
-      // enqueue resets it to EMPTY and conflicts with this normal read, so a
-      // newly inserted member can never be skipped behind the cursor.
-      for (let rounds = 0; rounds < 50 && !exhausted; rounds++) {
-        exhausted = await this.db.doTn(async tn => {
-          const cursor = await tn.get(key as Buffer);
-          if (!cursor) return true;
-          const jr = ks.groupJobRange(gid);
-          const rangeBegin = cursor.length > 0 ? keyAfter(cursor) : jr.begin;
-          const members = await tn
-            .snapshot()
-            .getRangeAll(rangeBegin, jr.end, { limit: 500 });
-          let cleaned = 0;
-          let lastExamined: Buffer | undefined;
-          for (const [mKey, mValue] of members) {
-            lastExamined = mKey as Buffer;
-            const gj = decodeJson<GroupJobIndexValue>(mValue as Buffer);
-            if (!gj || gj.s !== "pending") continue;
-            const id = ks.unpackId(mKey as Buffer);
-            const st = decodeJson<JobStatusRecord>(
-              await tn.get(ks.jobStatus(id)),
-            );
-            if (!st || st.s !== "pending" || !st.loc) continue;
-            const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
-            if (!meta) continue;
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const tasks = await this.taskBatch(claim, range, 20);
+      if (tasks.length === 0) break;
+      for (const [key] of tasks) {
+        await this.cleanCancelledGroup(
+          queue,
+          ks.unpackId(key),
+          now,
+          claim,
+          key,
+        );
+        if (Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS) break;
+      }
+      if (tasks.length < 20) break;
+    }
+  }
+
+  private async cleanCancelledGroup(
+    queue: NuQFdbQueue,
+    gid: string,
+    now: number,
+    claim: PartitionClaim,
+    observedTaskKey: Buffer,
+  ): Promise<void> {
+    const ks = queue.ks;
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      await this.renewClaim(claim);
+      const result = await this.db.doTn(async tn => {
+        await this.guardClaim(tn, claim);
+        const g = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
+        if (!g || (g.s !== "cancelled" && g.s !== "active")) {
+          tn.clear(ks.taskGroupCancel(gid));
+          tn.clear(observedTaskKey);
+          tn.clear(ks.groupCancelCursor(gid));
+          return { exhausted: true, progressed: false };
+        }
+        const jr = ks.groupJobRange(gid);
+        const cursor = await tn.get(ks.groupCancelCursor(gid));
+        const members = await tn
+          .snapshot()
+          .getRangeAll(cursor ? keyAfter(cursor) : jr.begin, jr.end, {
+            limit: GROUP_MEMBER_SCAN_BATCH,
+          });
+        let cleaned = 0;
+        let visited = 0;
+        let lastKey: Buffer | null = null;
+        for (const [rawKey, rawValue] of members) {
+          const memberKey = rawKey as Buffer;
+          lastKey = memberKey;
+          visited++;
+          const gj = decodeJson<GroupJobIndexValue>(rawValue as Buffer);
+          if (!gj || (gj.s !== "pending" && !g.z)) continue;
+          const id = ks.unpackId(memberKey);
+          const st = decodeJson<JobStatusRecord>(
+            await tn.get(ks.jobStatus(id)),
+          );
+          const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
+          if (!st || !meta) {
+            // Orphaned/stale index rows are removed so they cannot permanently
+            // hide real pending members later in the range.
+            tn.clear(memberKey);
+            continue;
+          }
+          if (st.s === "pending" && st.loc) {
             clearPendingPlacement(
               tn,
               ks,
@@ -587,124 +1030,188 @@ export class NuqFdbSweeper {
               tn.add(ks.groupCrawlActive(gid), MINUS_ONE);
             }
             if (st.loc.k === "tq" && meta.k && meta.f & F_KEY_GATED) {
-              tn.add(ks.keyActive(meta.k), MINUS_ONE);
-              tn.set(ks.taskKeyRaise(meta.k), EMPTY);
+              bumpKeyActive(tn, ks, meta.k, -1);
+              scheduleRaiseTask(tn, ks.taskKeyRaise(meta.k));
             }
-            tn.clear(mKey as Buffer);
+            tn.clear(memberKey);
             tn.add(ks.groupRemaining(gid), MINUS_ONE);
-            if (meta.f & F_COUNTABLE)
+            if (meta.f & F_COUNTABLE) {
               bumpGroupStatusCount(tn, ks, gid, "pending", -1);
+            }
             deleteJobRecords(tn, ks, id);
             await alignQueueMetricStatus(tn, ks, id);
             cleaned++;
-            if (cleaned >= SWEEP_BATCH) break;
+          } else if (g.z && (st.s === "queued" || st.s === "active")) {
+            tn.set(
+              ks.jobStatus(id),
+              encodeJson({
+                s: "cancelled",
+                st: st.st,
+              } satisfies JobStatusRecord),
+            );
+            await alignQueueMetricStatus(tn, ks, id);
+            if (st.s === "active" && st.e !== undefined) {
+              tn.clear(ks.lease(timeBucket(id), st.e, id));
+            }
+            await releaseSlotsAndPromote(
+              tn,
+              ks,
+              entryFromMeta(id, meta),
+              { team: true, key: true, crawl: true },
+              now,
+              newTxContext(),
+            );
+            tn.clear(memberKey);
+            tn.add(ks.groupRemaining(gid), MINUS_ONE);
+            if (meta.f & F_COUNTABLE) {
+              bumpGroupStatusCount(tn, ks, gid, st.s, -1);
+            }
+            tn.set(
+              ks.jobExpiry(
+                timeBucket(id),
+                now + COMPLETED_STANDALONE_RETENTION_MS,
+                id,
+              ),
+              EMPTY,
+            );
+            cleaned++;
+          } else if (gj.s !== st.s) {
+            setGroupJobIndex(tn, ks, gid, id, gj.m === 1, st.s);
           }
-          const done = members.length < 500 && cleaned < SWEEP_BATCH;
-          if (done) {
-            tn.clear(key as Buffer);
-            tn.set(ks.taskGroupFinish(gid), EMPTY);
-          } else if (lastExamined) {
-            tn.set(key as Buffer, lastExamined);
-          }
-          return done;
-        });
-      }
+          if (cleaned >= GROUP_MEMBER_MUTATION_BATCH) break;
+        }
+        const exhausted =
+          members.length < GROUP_MEMBER_SCAN_BATCH &&
+          visited === members.length;
+        if (exhausted) {
+          tn.clear(ks.groupCancelCursor(gid));
+          tn.clear(ks.taskGroupCancel(gid));
+          tn.clear(observedTaskKey);
+          tn.set(ks.taskGroupFinish(gid), EMPTY);
+        } else if (lastKey) {
+          tn.set(ks.groupCancelCursor(gid), lastKey);
+        }
+        return { exhausted, progressed: visited > 0 };
+      });
+      if (result.exhausted || !result.progressed) break;
     }
   }
 
-  // === Limit raises: drain newly-available slots
+  private sameTaskGeneration(
+    current: Buffer | undefined | null,
+    observed: Buffer,
+  ): boolean {
+    if (!current) return false;
+    // Pre-generation tasks used an empty value.
+    if (current.length === 0 || observed.length === 0) {
+      return current.length === observed.length;
+    }
+    const a = decodeJson<RaiseTask>(current);
+    const b = decodeJson<RaiseTask>(observed);
+    if (a?.g && b?.g) return a.g === b.g;
+    // Compatibility with task keys written before generations were added.
+    return current.equals(observed);
+  }
 
   private async sweepTeamRaiseTasks(
     queue: NuQFdbQueue,
-    now: number,
-    logger: Logger,
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
   ): Promise<void> {
+    const startedAt = Date.now();
     const ks = queue.ks;
-    const r = ks.taskTeamRaiseRange();
-    const tasks = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(r.begin, r.end, { limit: 50 }),
-    );
-    for (const [key] of tasks) {
-      const tid = ks.unpackId(key as Buffer);
-      await this.db.doTn(async tn => {
-        // Consume the generation in the same conflicting transaction as the
-        // drain so a concurrent raiser cannot have its signal cleared later.
-        if (!(await tn.get(key as Buffer))) return;
-        const txc = newTxContext();
-        const limitBuf = await tn.get(ks.teamLimit(tid));
-        const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
-        const active = decodeI64(await tn.get(ks.teamActive(tid)));
-        let free = Math.min(Math.max(0, limit - active), 32);
-        let promoted = 0;
-        while (free > 0) {
-          const e = await popTeamPending(tn, ks, tid);
-          if (!e) break;
-          await promoteEntryToReady(tn, ks, e, txc);
-          promoted++;
-          free--;
-        }
-        if (promoted > 0) bumpTeamActive(tn, ks, tid, promoted);
-        // done when no free slots remain or the pending queue is drained
-        if (free > 0 || limit - active <= 0) tn.clear(key as Buffer);
-      });
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const tasks = await this.taskBatch(claim, range, SWEEP_BATCH);
+      if (tasks.length === 0) break;
+      for (const [key, observed] of tasks) {
+        const tid = ks.unpackId(key);
+        await this.renewClaim(claim);
+        await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
+          const current = await tn.get(key);
+          if (!this.sameTaskGeneration(current, observed)) return;
+          const txc = newTxContext();
+          const limitBuf = await tn.get(ks.teamLimit(tid));
+          const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
+          const active = decodeI64(await tn.get(ks.teamActive(tid)));
+          let free = Math.min(Math.max(0, limit - active), 32);
+          let promoted = 0;
+          while (free > 0) {
+            const entry = await popTeamPending(tn, ks, tid);
+            if (!entry) break;
+            await promoteEntryToReady(tn, ks, entry, txc);
+            promoted++;
+            free--;
+          }
+          if (promoted > 0) bumpTeamActive(tn, ks, tid, promoted);
+          const pending = decodeI64(await tn.get(ks.teamPendingCount(tid)));
+          if (active + promoted >= limit || pending <= 0) tn.clear(key);
+        });
+      }
+      if (tasks.length < SWEEP_BATCH) break;
     }
   }
 
-  // Key raises admit key-pending heads through the team gate: each promoted
-  // job acquires a key slot here and a team slot (or a team-pending place)
-  // in admitThroughTeamGate.
   private async sweepKeyRaiseTasks(
     queue: NuQFdbQueue,
-    now: number,
-    logger: Logger,
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
   ): Promise<void> {
+    const startedAt = Date.now();
     const ks = queue.ks;
-    const r = ks.taskKeyRaiseRange();
-    const tasks = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(r.begin, r.end, { limit: 50 }),
-    );
-    for (const [key] of tasks) {
-      const kid = ks.unpackId(key as Buffer);
-      await this.db.doTn(async tn => {
-        if (!(await tn.get(key as Buffer))) return;
-        const txc = newTxContext();
-        const limitBuf = await tn.get(ks.keyLimit(kid));
-        const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
-        const active = decodeI64(await tn.get(ks.keyActive(kid)));
-        let free = Math.min(Math.max(0, limit - active), 32);
-        let promoted = 0;
-        while (free > 0) {
-          const e = await popKeyPending(tn, ks, kid);
-          if (!e) break;
-          await admitThroughTeamGate(tn, ks, e, txc);
-          promoted++;
-          free--;
-        }
-        if (promoted > 0) tn.add(ks.keyActive(kid), encodeI64(promoted));
-        // done when no free slots remain or the pending queue is drained
-        if (free > 0 || limit - active <= 0) tn.clear(key as Buffer);
-      });
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const tasks = await this.taskBatch(claim, range, SWEEP_BATCH);
+      if (tasks.length === 0) break;
+      for (const [key, observed] of tasks) {
+        const kid = ks.unpackId(key);
+        await this.renewClaim(claim);
+        await this.db.doTn(async tn => {
+          await this.guardClaim(tn, claim);
+          const current = await tn.get(key);
+          if (!this.sameTaskGeneration(current, observed)) return;
+          const txc = newTxContext();
+          const limitBuf = await tn.get(ks.keyLimit(kid));
+          const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
+          const active = decodeI64(await tn.get(ks.keyActive(kid)));
+          let free = Math.min(Math.max(0, limit - active), 32);
+          let promoted = 0;
+          while (free > 0) {
+            const entry = await popKeyPending(tn, ks, kid);
+            if (!entry) break;
+            await admitThroughTeamGate(tn, ks, entry, txc);
+            promoted++;
+            free--;
+          }
+          if (promoted > 0) bumpKeyActive(tn, ks, kid, promoted);
+          const pending = decodeI64(await tn.get(ks.keyPendingCount(kid)));
+          if (active + promoted >= limit || pending <= 0) tn.clear(key);
+        });
+      }
+      if (tasks.length < SWEEP_BATCH) break;
     }
   }
-
-  // === Record GC
 
   private async sweepJobExpiry(
     queue: NuQFdbQueue,
+    bucket: number,
     now: number,
-    logger: Logger,
+    claim: PartitionClaim,
   ): Promise<void> {
+    const startedAt = Date.now();
     const ks = queue.ks;
-    for (let b = 0; b < TIME_BUCKETS; b++) {
-      const r = ks.jobExpiryScanRange(b, now);
-      const due = await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(r.begin, r.end, { limit: SWEEP_BATCH * 2 }),
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(
+        claim,
+        ks.jobExpiryScanRange(bucket, now),
+        SWEEP_BATCH * 2,
       );
-      if (due.length === 0) continue;
+      if (due.length === 0) break;
+      await this.renewClaim(claim);
       await this.db.doTn(async tn => {
+        await this.guardClaim(tn, claim);
         for (const [key] of due) {
-          const id = ks.unpackId(key as Buffer);
-          tn.clear(key as Buffer);
+          const id = ks.unpackId(key);
+          tn.clear(key);
           const st = decodeJson<JobStatusRecord>(
             await tn.get(ks.jobStatus(id)),
           );
@@ -717,56 +1224,402 @@ export class NuqFdbSweeper {
           await alignQueueMetricStatus(tn, ks, id);
         }
       });
+      if (due.length < SWEEP_BATCH * 2) break;
     }
   }
 
   private async sweepGroupExpiry(
     queue: NuQFdbQueue,
     now: number,
-    logger: Logger,
+    claim: PartitionClaim,
+    range: { begin: Buffer; end: Buffer },
+    legacy: boolean,
   ): Promise<void> {
     if (!queue.groupOps) return;
+    const startedAt = Date.now();
     const ks = queue.ks;
-    const r = ks.groupExpiryScanRange(now);
-    const due = await this.db.doTn(async tn =>
-      tn.snapshot().getRangeAll(r.begin, r.end, { limit: 20 }),
-    );
-    for (const [key] of due) {
-      const gid = ks.unpackId(key as Buffer);
-      // delete member job records in batches, then the group's own keyspace
-      let drained = false;
-      for (let rounds = 0; rounds < 200 && !drained; rounds++) {
-        drained = await this.db.doTn(async tn => {
-          const jr = ks.groupJobRange(gid);
-          const members = await tn
-            .snapshot()
-            .getRangeAll(jr.begin, jr.end, { limit: 200 });
-          for (const [mKey] of members) {
-            const id = ks.unpackId(mKey as Buffer);
-            deleteJobRecords(tn, ks, id);
-            await alignQueueMetricStatus(tn, ks, id);
-            tn.clear(mKey as Buffer);
-          }
-          return members.length < 200;
-        });
-      }
-      if (!drained) continue;
-      await this.db.doTn(async tn => {
-        const g = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
-        // the crawl-finished job for this group lives in the finished queue
-        const fjobBuf = await tn.get(ks.groupFinishedJob(gid));
-        if (fjobBuf && queue.groupOps!.finishedKs) {
-          const fid = fjobBuf.toString("utf8");
-          const finishedKs = queue.groupOps!.finishedKs;
-          deleteJobRecords(tn, finishedKs, fid);
-          await alignQueueMetricStatus(tn, finishedKs, fid);
+    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+      const due = await this.dueBatch(claim, range, 20);
+      if (due.length === 0) break;
+      for (const [key] of due) {
+        const parts = ks.unpack(key);
+        const expiresAt = Number(parts[legacy ? 3 : 4]);
+        const gid = String(parts[legacy ? 4 : 5]);
+        const generation = String(parts[legacy ? 5 : 6] ?? "");
+        const action = await this.prepareGroupExpiry(
+          queue,
+          key,
+          gid,
+          expiresAt,
+          generation,
+          now,
+          claim,
+        );
+        if (action === "gc") {
+          await this.gcCompletedGroup(queue, key, gid, now, claim);
         }
-        const gr = ks.groupRange(gid);
-        tn.clearRange(gr.begin, gr.end);
-        if (g) tn.clear(ks.ongoingGroup(g.o, gid));
-        tn.clear(ks.taskGroupFinish(gid));
-        tn.clear(ks.taskGroupCancel(gid));
-        tn.clear(key as Buffer);
+      }
+      if (due.length < 20) break;
+    }
+  }
+
+  private async prepareGroupExpiry(
+    queue: NuQFdbQueue,
+    key: Buffer,
+    gid: string,
+    expiresAt: number,
+    generation: string,
+    now: number,
+    claim: PartitionClaim,
+  ): Promise<"gc" | "done"> {
+    const ks = queue.ks;
+    await this.renewClaim(claim);
+    return await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      const g = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
+      if (!g) {
+        tn.clear(key);
+        return "done";
+      }
+      const scheduledAt = g.s === "completed" ? g.x : g.a;
+      if (scheduledAt !== expiresAt || (g.eg ?? "") !== generation) {
+        tn.clear(key);
+        return "done";
+      }
+      if (g.s === "active") {
+        const nextAt = now + ABANDONED_GROUP_DRAIN_GRACE_MS;
+        const nextGeneration = randomUUID();
+        tn.set(
+          ks.groupMeta(gid),
+          encodeJson({
+            ...g,
+            s: "cancelled",
+            a: nextAt,
+            eg: nextGeneration,
+          } satisfies GroupMeta),
+        );
+        tn.clear(ks.ongoingGroup(g.o, gid));
+        tn.set(ks.taskGroupCancel(gid), EMPTY);
+        tn.set(ks.taskGroupFinish(gid), EMPTY);
+        tn.clear(key);
+        tn.set(ks.groupExpiry(nextAt, gid, nextGeneration), EMPTY);
+        return "done";
+      }
+      if (g.s === "cancelled") {
+        // Normal cancellation lets active work finish. At the bounded
+        // abandonment deadline, force tombstones so queued/active work cannot
+        // keep the group forever. Move the expiry row forward while the
+        // cursor-driven cancel task drains it, so one stuck group cannot hide
+        // later expiry rows in this ordered range.
+        const nextAt = now + FINISHED_CONTROL_RECHECK_MS;
+        const nextGeneration = randomUUID();
+        tn.set(
+          ks.groupMeta(gid),
+          encodeJson({
+            ...g,
+            z: true,
+            a: nextAt,
+            eg: nextGeneration,
+          } satisfies GroupMeta),
+        );
+        tn.set(ks.taskGroupCancel(gid), EMPTY);
+        tn.set(ks.taskGroupFinish(gid), EMPTY);
+        tn.clear(key);
+        tn.set(ks.groupExpiry(nextAt, gid, nextGeneration), EMPTY);
+        return "done";
+      }
+      return "gc";
+    });
+  }
+
+  private async gcCompletedGroup(
+    queue: NuQFdbQueue,
+    expiryKey: Buffer,
+    gid: string,
+    now: number,
+    claim: PartitionClaim,
+  ): Promise<void> {
+    const ks = queue.ks;
+    const finishedKs = queue.groupOps!.finishedKs;
+
+    // Never remove crawl-finished control work while it can still be consumed
+    // or is actively being processed. Move the group expiry generation
+    // forward and retry after a bounded interval instead.
+    if (finishedKs) {
+      await this.renewClaim(claim);
+      const deferred = await this.db.doTn(async tn => {
+        await this.guardClaim(tn, claim);
+        const fjobBuf = await tn.get(ks.groupFinishedJob(gid));
+        if (!fjobBuf) return false;
+        const fid = fjobBuf.toString("utf8");
+        const status = decodeJson<JobStatusRecord>(
+          await tn.get(finishedKs.jobStatus(fid)),
+        );
+        if (status?.s !== "queued" && status?.s !== "active") return false;
+        const g = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
+        if (!g || g.s !== "completed") return false;
+        const nextAt = now + FINISHED_CONTROL_RECHECK_MS;
+        const nextGeneration = randomUUID();
+        tn.set(
+          ks.groupMeta(gid),
+          encodeJson({ ...g, x: nextAt, eg: nextGeneration }),
+        );
+        tn.clear(expiryKey);
+        tn.set(ks.groupExpiry(nextAt, gid, nextGeneration), EMPTY);
+        return true;
+      });
+      if (deferred) return;
+    }
+
+    const gcStartedAt = Date.now();
+    while (true) {
+      await this.renewClaim(claim);
+      const result = await this.db.doTn(async tn => {
+        await this.guardClaim(tn, claim);
+        const jr = ks.groupJobRange(gid);
+        const cursor = await tn.get(ks.groupGcCursor(gid));
+        const members = await tn
+          .snapshot()
+          .getRangeAll(cursor ? keyAfter(cursor) : jr.begin, jr.end, {
+            limit: GROUP_GC_BATCH,
+          });
+        for (const [memberKey] of members) {
+          const id = ks.unpackId(memberKey as Buffer);
+          deleteJobRecords(tn, ks, id);
+          await alignQueueMetricStatus(tn, ks, id);
+          tn.clear(memberKey as Buffer);
+        }
+        const exhausted = members.length < GROUP_GC_BATCH;
+        if (exhausted) {
+          tn.clear(ks.groupGcCursor(gid));
+        } else {
+          tn.set(
+            ks.groupGcCursor(gid),
+            members[members.length - 1][0] as Buffer,
+          );
+        }
+        return { exhausted, count: members.length };
+      });
+      if (result.exhausted) break;
+      if (result.count === 0) return;
+      if (Date.now() - gcStartedAt >= PARTITION_WORK_BUDGET_MS) return;
+    }
+
+    await this.renewClaim(claim);
+    await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      const g = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
+      if (!g || g.s !== "completed") {
+        tn.clear(expiryKey);
+        return;
+      }
+      const fjobBuf = await tn.get(ks.groupFinishedJob(gid));
+      if (fjobBuf && finishedKs) {
+        const fid = fjobBuf.toString("utf8");
+        const status = decodeJson<JobStatusRecord>(
+          await tn.get(finishedKs.jobStatus(fid)),
+        );
+        if (status?.s === "queued" || status?.s === "active") return;
+        deleteJobRecords(tn, finishedKs, fid);
+        await alignQueueMetricStatus(tn, finishedKs, fid);
+      }
+      const groupRange = ks.groupRange(gid);
+      tn.clearRange(groupRange.begin, groupRange.end);
+      tn.clear(ks.ongoingGroup(g.o, gid));
+      tn.clear(ks.taskGroupFinish(gid));
+      tn.clear(ks.taskGroupCancel(gid));
+      tn.clear(expiryKey);
+    });
+  }
+
+  private async indexLegacyActiveGroups(
+    queue: NuQFdbQueue,
+    claim: PartitionClaim,
+  ): Promise<void> {
+    if (!queue.groupOps) return;
+    await this.renewClaim(claim);
+    const ks = queue.ks;
+    await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      const range = ks.ongoingGroupAllRange();
+      const cursorKey = ks.sweeperCursor(claim.phase, claim.partition);
+      const cursor = await tn.get(cursorKey);
+      if (cursor?.equals(range.end)) return;
+      const rows = await tn
+        .snapshot()
+        .getRangeAll(cursor ? keyAfter(cursor) : range.begin, range.end, {
+          limit: SWEEP_BATCH,
+        });
+      if (rows.length === 0) {
+        tn.set(cursorKey, range.end);
+        return;
+      }
+      const now = Date.now();
+      for (const [key] of rows) {
+        const gid = ks.unpackId(key as Buffer);
+        const group = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
+        if (!group || group.s !== "active") {
+          tn.clear(key as Buffer);
+          continue;
+        }
+        if (group.a !== undefined && group.eg) continue;
+        const naturalDeadline = group.c + ACTIVE_GROUP_MAX_AGE_MS;
+        const deadline = naturalDeadline <= now ? now - 1 : naturalDeadline;
+        const generation = randomUUID();
+        tn.set(
+          ks.groupMeta(gid),
+          encodeJson({ ...group, a: deadline, eg: generation }),
+        );
+        tn.set(ks.groupExpiry(deadline, gid, generation), EMPTY);
+      }
+      tn.set(cursorKey, rows[rows.length - 1][0] as Buffer);
+    });
+  }
+
+  private async indexLegacyGroups(
+    queue: NuQFdbQueue,
+    claim: PartitionClaim,
+  ): Promise<void> {
+    if (!queue.groupOps) return;
+    await this.renewClaim(claim);
+    const ks = queue.ks;
+    await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      const range = ks.groupAllRange();
+      const cursorKey = ks.sweeperCursor(claim.phase, claim.partition);
+      const cursor = await tn.get(cursorKey);
+      if (cursor?.equals(range.end)) return;
+      const rows = await tn
+        .snapshot()
+        .getRangeAll(cursor ? keyAfter(cursor) : range.begin, range.end, {
+          limit: SWEEP_BATCH * 2,
+        });
+      if (rows.length === 0) {
+        tn.set(cursorKey, range.end);
+        return;
+      }
+      const now = Date.now();
+      for (const [key] of rows) {
+        let parts: unknown[];
+        try {
+          // groupDone uses a raw versionstamp suffix and is intentionally not
+          // a complete tuple key.
+          parts = ks.unpack(key as Buffer);
+        } catch {
+          continue;
+        }
+        if (parts[4] !== "meta") continue;
+        const gid = String(parts[3]);
+        const group = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
+        if (!group || group.eg) continue;
+        let deadline: number | undefined;
+        if (group.s === "completed") {
+          deadline = group.x;
+        } else {
+          const naturalDeadline = group.c + ACTIVE_GROUP_MAX_AGE_MS;
+          deadline = naturalDeadline <= now ? now - 1 : naturalDeadline;
+        }
+        if (deadline === undefined) continue;
+        const generation = randomUUID();
+        tn.set(
+          ks.groupMeta(gid),
+          encodeJson({
+            ...group,
+            ...(group.s === "completed" ? { x: deadline } : { a: deadline }),
+            eg: generation,
+          }),
+        );
+        tn.set(ks.groupExpiry(deadline, gid, generation), EMPTY);
+      }
+      tn.set(cursorKey, rows[rows.length - 1][0] as Buffer);
+    });
+  }
+
+  private async indexLegacyLedgers(
+    queue: NuQFdbQueue,
+    kind: "team" | "key",
+    claim: PartitionClaim,
+  ): Promise<void> {
+    await this.renewClaim(claim);
+    const ks = queue.ks;
+    await this.db.doTn(async tn => {
+      await this.guardClaim(tn, claim);
+      const range = kind === "team" ? ks.teamRange() : ks.keyGateRange();
+      const cursorKey = ks.sweeperCursor(claim.phase, claim.partition);
+      const cursor = await tn.get(cursorKey);
+      if (cursor?.equals(range.end)) return;
+      const rows = await tn
+        .snapshot()
+        .getRangeAll(cursor ? keyAfter(cursor) : range.begin, range.end, {
+          limit: SWEEP_BATCH * 2,
+        });
+      if (rows.length === 0) {
+        tn.set(cursorKey, range.end);
+        return;
+      }
+      const ids = new Set<string>();
+      for (const [key] of rows) {
+        const parts = ks.unpack(key as Buffer);
+        if (typeof parts[3] === "string") ids.add(parts[3]);
+      }
+      for (const id of ids) {
+        if (kind === "team") {
+          // This range is also the aggregate-count index, so initialize it
+          // from the authoritative ledger under a normal read conflict.
+          const active = decodeI64(await tn.get(ks.teamActive(id)));
+          tn.set(ks.teamActiveIndex(id), encodeI64(active));
+          tn.set(ks.teamLedgerGcIndex(id), EMPTY);
+        } else {
+          tn.set(ks.keyLedgerIndex(id), EMPTY);
+        }
+      }
+      tn.set(cursorKey, rows[rows.length - 1][0] as Buffer);
+    });
+  }
+
+  private async sweepLedgers(
+    queue: NuQFdbQueue,
+    kind: "team" | "key",
+    bucket: number,
+    claim: PartitionClaim,
+  ): Promise<void> {
+    const ks = queue.ks;
+    const range =
+      kind === "team"
+        ? ks.teamLedgerGcIndexRange(bucket)
+        : ks.keyLedgerIndexRange(bucket);
+    // Persistent live-ledger markers are expected. Process one cursor page per
+    // tick so an exact full page cannot wrap and hot-loop over the same rows.
+    const rows = await this.taskBatch(claim, range, SWEEP_BATCH);
+    for (const [indexKey] of rows) {
+      const id = ks.unpackId(indexKey);
+      await this.renewClaim(claim);
+      await this.db.doTn(async tn => {
+        await this.guardClaim(tn, claim);
+        const active = decodeI64(
+          await tn.get(kind === "team" ? ks.teamActive(id) : ks.keyActive(id)),
+        );
+        const pending = decodeI64(
+          await tn.get(
+            kind === "team" ? ks.teamPendingCount(id) : ks.keyPendingCount(id),
+          ),
+        );
+        if (active > 0 || pending > 0) return;
+        // Delayed and crawl-pending work intentionally holds neither an
+        // active nor a pending slot at the inner gates. Keep the cold limit
+        // key so such latent work cannot wake up to Infinity; collect the
+        // zero/historical mutable ledger and its discovery markers.
+        if (kind === "team") {
+          tn.clear(ks.teamActive(id));
+          tn.clear(ks.teamPendingCount(id));
+          const shards = ks.teamShardCountRange(id);
+          tn.clearRange(shards.begin, shards.end);
+          tn.clear(ks.teamActiveIndex(id));
+        } else {
+          tn.clear(ks.keyActive(id));
+          tn.clear(ks.keyPendingCount(id));
+        }
+        tn.clear(indexKey);
       });
     }
   }

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -87,7 +87,26 @@ type PartitionClaim = {
   partition: number;
   generation: string;
   expiresAt: number;
+  lifecycleGeneration?: number;
 };
+
+type TickErrorDisposition = "transient" | "fatal";
+type TickErrorClassifier = (error: unknown) => TickErrorDisposition;
+
+// foundationdb@2 exposes native failures as FDBError instances whose stable
+// cross-package shape is Error + numeric code. Avoid importing the constructor
+// at runtime: doing so eagerly loads libfdb_c in processes that do not use FDB,
+// and instanceof would fail if more than one package copy were loaded.
+function defaultTickErrorClassifier(error: unknown): TickErrorDisposition {
+  if (
+    error instanceof Error &&
+    typeof (error as Error & { code?: unknown }).code === "number" &&
+    Number.isInteger((error as Error & { code: number }).code)
+  ) {
+    return "transient";
+  }
+  return "fatal";
+}
 
 type OverdueObservation = {
   queue: string;
@@ -155,20 +174,33 @@ export class NuqFdbSweeper {
   private readonly sweeperId = randomUUID();
   private loop: NodeJS.Timeout | null = null;
   private running = false;
+  private stopRequested = true;
+  private healthy = false;
+  private runGeneration = 0;
+  private donePromise: Promise<void> = Promise.resolve();
+  private resolveDone: (() => void) | null = null;
+  private rejectDone: ((error: unknown) => void) | null = null;
   private metricsEnabled = true;
   private partitionOffset = 0;
   private readonly overdueObservations = new Map<string, OverdueObservation>();
   private readonly lockTtlMs: number;
   private readonly maxPartitionsPerTick: number;
+  private readonly classifyTickError: TickErrorClassifier;
 
   constructor(
     public readonly queues: NuQFdbQueue[],
     public readonly externalSlots: NuqFdbExternalSlots[] = [],
-    options: { lockTtlMs?: number; maxPartitionsPerTick?: number } = {},
+    options: {
+      lockTtlMs?: number;
+      maxPartitionsPerTick?: number;
+      classifyTickError?: TickErrorClassifier;
+    } = {},
   ) {
     this.lockTtlMs = options.lockTtlMs ?? DEFAULT_SWEEP_LOCK_TTL_MS;
     this.maxPartitionsPerTick =
       options.maxPartitionsPerTick ?? DEFAULT_MAX_PARTITIONS_PER_TICK;
+    this.classifyTickError =
+      options.classifyTickError ?? defaultTickErrorClassifier;
   }
 
   private get db() {
@@ -180,6 +212,7 @@ export class NuqFdbSweeper {
     phase: string,
     partition: number,
     now: number = Date.now(),
+    lifecycleGeneration?: number,
   ): Promise<PartitionClaim | null> {
     const generation = randomUUID();
     const claim = await this.db.doTn(async tn => {
@@ -219,21 +252,42 @@ export class NuqFdbSweeper {
           x: expiresAt,
         } satisfies OwnershipRecord),
       );
-      return { ks, phase, partition, generation, expiresAt };
+      return {
+        ks,
+        phase,
+        partition,
+        generation,
+        expiresAt,
+        lifecycleGeneration,
+      };
     });
     // A new claim must be repopulated only by its own scan. A failed claim
     // means another replica owns the partition, so this process must not keep
-    // exporting an observation from an earlier generation.
-    this.clearOverdueObservation(ks, phase, partition);
+    // exporting an observation from an earlier generation. A detached pass is
+    // not allowed to clear observations belonging to a restarted lifecycle.
+    this.clearOverdueObservation(ks, phase, partition, lifecycleGeneration);
     return claim;
   }
 
+  private assertCurrentLifecycleClaim(claim: PartitionClaim): void {
+    if (
+      claim.lifecycleGeneration !== undefined &&
+      claim.lifecycleGeneration !== this.runGeneration
+    ) {
+      throw new OwnershipLostError();
+    }
+  }
+
   private async renewClaim(claim: PartitionClaim): Promise<void> {
+    this.assertCurrentLifecycleClaim(claim);
     const expiresAt = await this.db.doTn(async tn => {
+      this.assertCurrentLifecycleClaim(claim);
       const key = claim.ks.sweeperPartition(claim.phase, claim.partition);
       const current = decodeJson<OwnershipRecord>(await tn.get(key));
+      this.assertCurrentLifecycleClaim(claim);
       const legacyKey = this.queues[0].ks.legacySweeperLock();
       const legacy = decodeJson<LegacyOwnershipRecord>(await tn.get(legacyKey));
+      this.assertCurrentLifecycleClaim(claim);
       const now = Date.now();
       if (
         !current ||
@@ -259,6 +313,7 @@ export class NuqFdbSweeper {
       }
       return expiresAt;
     });
+    this.assertCurrentLifecycleClaim(claim);
     claim.expiresAt = expiresAt;
     const observation = this.overdueObservations.get(
       this.observationKey(claim.ks, claim.phase, claim.partition),
@@ -270,12 +325,15 @@ export class NuqFdbSweeper {
     tn: Transaction,
     claim: PartitionClaim,
   ): Promise<void> {
+    this.assertCurrentLifecycleClaim(claim);
     const current = decodeJson<OwnershipRecord>(
       await tn.get(claim.ks.sweeperPartition(claim.phase, claim.partition)),
     );
+    this.assertCurrentLifecycleClaim(claim);
     const legacy = decodeJson<LegacyOwnershipRecord>(
       await tn.get(this.queues[0].ks.legacySweeperLock()),
     );
+    this.assertCurrentLifecycleClaim(claim);
     if (
       !current ||
       current.w !== this.sweeperId ||
@@ -535,6 +593,7 @@ export class NuqFdbSweeper {
   public async sweepOnce(
     logger: Logger = _logger,
     maxPartitions: number = Number.POSITIVE_INFINITY,
+    lifecycleGeneration?: number,
   ): Promise<void> {
     const now = Date.now();
     const startedAt = Date.now();
@@ -545,6 +604,8 @@ export class NuqFdbSweeper {
     let scanned = 0;
     for (const item of ordered) {
       if (
+        (lifecycleGeneration !== undefined &&
+          lifecycleGeneration !== this.runGeneration) ||
         acquired >= maxPartitions ||
         (Number.isFinite(maxPartitions) &&
           Date.now() - startedAt >= PARTITION_WORK_BUDGET_MS)
@@ -557,14 +618,27 @@ export class NuqFdbSweeper {
         item.ks,
         item.phase,
         item.partition,
+        Date.now(),
+        lifecycleGeneration,
       );
+      if (
+        lifecycleGeneration !== undefined &&
+        lifecycleGeneration !== this.runGeneration
+      ) {
+        break;
+      }
       if (!claim) continue;
       acquired++;
       try {
         await item.run(claim);
       } catch (error) {
         if (error instanceof OwnershipLostError) {
-          this.clearOverdueObservation(item.ks, item.phase, item.partition);
+          this.clearOverdueObservation(
+            item.ks,
+            item.phase,
+            item.partition,
+            lifecycleGeneration,
+          );
           logger.info("NuQ FDB sweeper partition ownership lost", {
             canonicalLog: "nuq-fdb/sweeper_ownership_lost",
             queueName: item.ks.queueName,
@@ -579,31 +653,175 @@ export class NuqFdbSweeper {
   }
 
   public start(intervalMs: number = 1000, logger: Logger = _logger): void {
-    if (this.loop) return;
+    if (!this.stopRequested || this.loop || this.running) return;
+    const lifecycleGeneration = ++this.runGeneration;
+    this.stopRequested = false;
+    this.healthy = true;
     this.metricsEnabled = true;
-    this.loop = setInterval(async () => {
-      if (this.running) return;
-      this.running = true;
-      try {
-        await this.sweepOnce(logger, this.maxPartitionsPerTick);
-      } catch (error) {
-        logger.warn("NuQ FDB sweeper tick failed", {
-          module: "nuq-fdb/sweeper",
-          error,
-        });
-      } finally {
-        this.running = false;
+    this.donePromise = new Promise<void>((resolve, reject) => {
+      this.resolveDone = resolve;
+      this.rejectDone = reject;
+    });
+    // A lifecycle supervisor attaches immediately after start(), but retain a
+    // rejection handler here as well so a very short interval cannot create an
+    // unhandled rejection before the component is registered.
+    void this.donePromise.catch(() => undefined);
+    this.loop = setInterval(() => {
+      if (
+        lifecycleGeneration !== this.runGeneration ||
+        this.running ||
+        this.stopRequested
+      ) {
+        return;
       }
+      this.running = true;
+      void this.sweepOnce(
+        logger,
+        this.maxPartitionsPerTick,
+        lifecycleGeneration,
+      ).then(
+        () => this.completeTick(lifecycleGeneration),
+        error => this.rejectTick(lifecycleGeneration, error, logger),
+      );
     }, intervalMs);
   }
 
   public stop(): void {
+    const lifecycleGeneration = this.runGeneration;
+    this.stopRequested = true;
+    this.healthy = false;
     this.metricsEnabled = false;
     this.overdueObservations.clear();
     if (this.loop) {
       clearInterval(this.loop);
       this.loop = null;
     }
+    if (!this.running) this.finishLifecycle(lifecycleGeneration);
+  }
+
+  // Shutdown deadlines may not wait for a long FDB pass. Invalidate the run so
+  // a detached pass cannot mutate a restarted lifecycle when it later settles.
+  public forceStop(): void {
+    const resolve = this.resolveDone;
+    const hasActiveLifecycle =
+      resolve !== null ||
+      this.rejectDone !== null ||
+      this.loop !== null ||
+      this.running;
+    this.stopRequested = true;
+    this.healthy = false;
+    this.metricsEnabled = false;
+    this.overdueObservations.clear();
+    if (this.loop) clearInterval(this.loop);
+    this.loop = null;
+    this.running = false;
+    this.resolveDone = null;
+    this.rejectDone = null;
+    if (hasActiveLifecycle) this.runGeneration++;
+    resolve?.();
+  }
+
+  public get done(): Promise<void> {
+    return this.donePromise;
+  }
+
+  public isHealthy(): boolean {
+    return this.healthy && !this.stopRequested && this.loop !== null;
+  }
+
+  private completeTick(lifecycleGeneration: number): void {
+    if (lifecycleGeneration !== this.runGeneration) return;
+    this.running = false;
+    if (this.stopRequested) {
+      this.finishLifecycle(lifecycleGeneration);
+      return;
+    }
+    this.healthy = true;
+  }
+
+  private rejectTick(
+    lifecycleGeneration: number,
+    error: unknown,
+    logger: Logger,
+  ): void {
+    if (lifecycleGeneration !== this.runGeneration) return;
+    this.running = false;
+    if (this.stopRequested) {
+      this.finishLifecycle(lifecycleGeneration);
+      return;
+    }
+
+    let disposition: TickErrorDisposition;
+    try {
+      disposition = this.classifyTickError(error);
+    } catch (classifierError) {
+      const logging = this.tryLog(logger, "error", {
+        message: "NuQ FDB sweeper error classifier failed",
+        meta: {
+          module: "nuq-fdb/sweeper",
+          error: classifierError,
+          tickError: error,
+        },
+      });
+      this.failLifecycle(
+        lifecycleGeneration,
+        logging.ok ? classifierError : logging.error,
+      );
+      return;
+    }
+
+    if (disposition === "transient") {
+      this.healthy = false;
+      const logging = this.tryLog(logger, "warn", {
+        message: "NuQ FDB sweeper tick failed transiently; retrying",
+        meta: { module: "nuq-fdb/sweeper", error },
+      });
+      if (!logging.ok) {
+        this.failLifecycle(lifecycleGeneration, logging.error);
+      }
+      return;
+    }
+
+    const logging = this.tryLog(logger, "error", {
+      message: "NuQ FDB sweeper loop failed fatally",
+      meta: { module: "nuq-fdb/sweeper", error },
+    });
+    this.failLifecycle(lifecycleGeneration, logging.ok ? error : logging.error);
+  }
+
+  private tryLog(
+    logger: Logger,
+    level: "warn" | "error",
+    entry: { message: string; meta: Record<string, unknown> },
+  ): { ok: true } | { ok: false; error: unknown } {
+    try {
+      logger[level](entry.message, entry.meta);
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error };
+    }
+  }
+
+  private finishLifecycle(lifecycleGeneration: number): void {
+    if (lifecycleGeneration !== this.runGeneration) return;
+    const resolve = this.resolveDone;
+    this.resolveDone = null;
+    this.rejectDone = null;
+    resolve?.();
+  }
+
+  private failLifecycle(lifecycleGeneration: number, error: unknown): void {
+    if (lifecycleGeneration !== this.runGeneration) return;
+    const reject = this.rejectDone;
+    this.stopRequested = true;
+    this.healthy = false;
+    this.metricsEnabled = false;
+    this.overdueObservations.clear();
+    if (this.loop) clearInterval(this.loop);
+    this.loop = null;
+    this.resolveDone = null;
+    this.rejectDone = null;
+    reject?.(error);
   }
 
   private observationKey(
@@ -618,7 +836,14 @@ export class NuqFdbSweeper {
     ks: NuqFdbKeyspace,
     phase: string,
     partition: number,
+    lifecycleGeneration?: number,
   ): void {
+    if (
+      lifecycleGeneration !== undefined &&
+      lifecycleGeneration !== this.runGeneration
+    ) {
+      return;
+    }
     this.overdueObservations.delete(this.observationKey(ks, phase, partition));
   }
 
@@ -628,6 +853,12 @@ export class NuqFdbSweeper {
     due: readonly [unknown, unknown][],
     dueAt: (key: Buffer) => number,
   ): void {
+    if (
+      claim.lifecycleGeneration !== undefined &&
+      claim.lifecycleGeneration !== this.runGeneration
+    ) {
+      return;
+    }
     const key = this.observationKey(claim.ks, claim.phase, claim.partition);
     if (!this.metricsEnabled || due.length === 0) {
       this.overdueObservations.delete(key);
@@ -997,11 +1228,9 @@ export class NuqFdbSweeper {
             return true;
           }
           const jobsRange = ks.ingestJobRange(op);
-          const members = await tn.getRangeAll(
-            jobsRange.begin,
-            jobsRange.end,
-            { limit: SWEEP_BATCH },
-          );
+          const members = await tn.getRangeAll(jobsRange.begin, jobsRange.end, {
+            limit: SWEEP_BATCH,
+          });
           for (const [memberKey] of members) {
             const id = ks.unpackId(memberKey as Buffer);
             const status = decodeJson<JobStatusRecord>(

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -586,7 +586,19 @@ export class NuqFdbSweeper {
     const now = Date.now();
     const startedAt = Date.now();
     for (const queue of this.queues) {
+      if (
+        lifecycleGeneration !== undefined &&
+        lifecycleGeneration !== this.runGeneration
+      ) {
+        return;
+      }
       await queue.backfillMetricCounts(100, config.NUQ_FDB_METRICS_V2_ACTIVATE);
+      if (
+        lifecycleGeneration !== undefined &&
+        lifecycleGeneration !== this.runGeneration
+      ) {
+        return;
+      }
     }
     const work = this.partitionWork(now, logger);
     const offset = this.partitionOffset % Math.max(1, work.length);

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -71,6 +71,16 @@ type OwnershipRecord = {
   x: number;
 };
 
+type LegacyOwnershipRecord = {
+  w: string;
+  x: number;
+  p?: 2; // partitioned protocol marker; old binaries ignore this field
+};
+
+const PARTITIONED_LEGACY_OWNER = "partitioned-v2";
+const LEGACY_COMPAT_TTL_MS = 60_000;
+const LEGACY_COMPAT_RENEW_AHEAD_MS = 30_000;
+
 type PartitionClaim = {
   ks: NuqFdbKeyspace;
   phase: string;
@@ -157,10 +167,26 @@ export class NuqFdbSweeper {
     return await this.db.doTn(async tn => {
       // During rolling deployment, defer to the old all-or-nothing owner until
       // its final lease expires; old and new protocols must not overlap.
-      const legacy = decodeJson<{ x: number }>(
-        await tn.get(this.queues[0].ks.legacySweeperLock()),
-      );
-      if (legacy && legacy.x > now) return null;
+      const legacyKey = this.queues[0].ks.legacySweeperLock();
+      const legacy = decodeJson<LegacyOwnershipRecord>(await tn.get(legacyKey));
+      if (legacy && legacy.x > now && legacy.p !== 2) return null;
+      // A shared v2 marker blocks old singleton sweepers while allowing all
+      // partitioned replicas to claim disjoint work during rolling deploys.
+      // Renew it infrequently to avoid turning compatibility into a hot write.
+      if (
+        !legacy ||
+        legacy.p !== 2 ||
+        legacy.x <= now + LEGACY_COMPAT_RENEW_AHEAD_MS
+      ) {
+        tn.set(
+          legacyKey,
+          encodeJson({
+            w: PARTITIONED_LEGACY_OWNER,
+            p: 2,
+            x: now + LEGACY_COMPAT_TTL_MS,
+          } satisfies LegacyOwnershipRecord),
+        );
+      }
       const key = ks.sweeperPartition(phase, partition);
       const current = decodeJson<OwnershipRecord>(await tn.get(key));
       if (current && current.x > now && current.w !== this.sweeperId) {
@@ -182,16 +208,31 @@ export class NuqFdbSweeper {
     await this.db.doTn(async tn => {
       const key = claim.ks.sweeperPartition(claim.phase, claim.partition);
       const current = decodeJson<OwnershipRecord>(await tn.get(key));
+      const legacyKey = this.queues[0].ks.legacySweeperLock();
+      const legacy = decodeJson<LegacyOwnershipRecord>(await tn.get(legacyKey));
       const now = Date.now();
       if (
         !current ||
         current.w !== this.sweeperId ||
         current.g !== claim.generation ||
-        current.x <= now
+        current.x <= now ||
+        !legacy ||
+        legacy.p !== 2
       ) {
         throw new OwnershipLostError();
       }
-      tn.set(key, encodeJson({ ...current, x: now + this.lockTtlMs }));
+      const expiresAt = now + this.lockTtlMs;
+      tn.set(key, encodeJson({ ...current, x: expiresAt }));
+      if (legacy.x <= now + LEGACY_COMPAT_RENEW_AHEAD_MS) {
+        tn.set(
+          legacyKey,
+          encodeJson({
+            w: PARTITIONED_LEGACY_OWNER,
+            p: 2,
+            x: now + LEGACY_COMPAT_TTL_MS,
+          } satisfies LegacyOwnershipRecord),
+        );
+      }
     });
   }
 
@@ -202,11 +243,17 @@ export class NuqFdbSweeper {
     const current = decodeJson<OwnershipRecord>(
       await tn.get(claim.ks.sweeperPartition(claim.phase, claim.partition)),
     );
+    const legacy = decodeJson<LegacyOwnershipRecord>(
+      await tn.get(this.queues[0].ks.legacySweeperLock()),
+    );
     if (
       !current ||
       current.w !== this.sweeperId ||
       current.g !== claim.generation ||
-      current.x <= Date.now()
+      current.x <= Date.now() ||
+      !legacy ||
+      legacy.p !== 2 ||
+      legacy.x <= Date.now()
     ) {
       throw new OwnershipLostError();
     }

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -354,18 +354,6 @@ export class NuqFdbSweeper {
   private partitionWork(now: number, logger: Logger): PartitionWork[] {
     const work: PartitionWork[] = [];
     for (const queue of this.queues) {
-      work.push({
-        ks: queue.ks,
-        phase: "metric-backfill",
-        partition: 0,
-        run: async claim => {
-          await this.renewClaim(claim);
-          await queue.backfillMetricCounts(
-            100,
-            config.NUQ_FDB_METRICS_V2_ACTIVATE,
-          );
-        },
-      });
       for (let bucket = 0; bucket < TIME_BUCKETS; bucket++) {
         work.push(
           {
@@ -597,6 +585,9 @@ export class NuqFdbSweeper {
   ): Promise<void> {
     const now = Date.now();
     const startedAt = Date.now();
+    for (const queue of this.queues) {
+      await queue.backfillMetricCounts(100, config.NUQ_FDB_METRICS_V2_ACTIVATE);
+    }
     const work = this.partitionWork(now, logger);
     const offset = this.partitionOffset % Math.max(1, work.length);
     const ordered = [...work.slice(offset), ...work.slice(0, offset)];

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -86,6 +86,15 @@ type PartitionClaim = {
   phase: string;
   partition: number;
   generation: string;
+  expiresAt: number;
+};
+
+type OverdueObservation = {
+  queue: string;
+  index: string;
+  partition: number;
+  oldestDueAtMs: number;
+  ownershipExpiresAtMs: number;
 };
 
 type PartitionWork = {
@@ -106,6 +115,13 @@ type SweepLagStats = {
 
 function keyAfter(key: Buffer): Buffer {
   return Buffer.concat([key, Buffer.from([0])]);
+}
+
+function escapePrometheusLabel(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/"/g, '\\"');
 }
 
 function entryFromMeta(id: string, meta: JobMeta): QueueEntry {
@@ -139,7 +155,9 @@ export class NuqFdbSweeper {
   private readonly sweeperId = randomUUID();
   private loop: NodeJS.Timeout | null = null;
   private running = false;
+  private metricsEnabled = true;
   private partitionOffset = 0;
+  private readonly overdueObservations = new Map<string, OverdueObservation>();
   private readonly lockTtlMs: number;
   private readonly maxPartitionsPerTick: number;
 
@@ -164,7 +182,7 @@ export class NuqFdbSweeper {
     now: number = Date.now(),
   ): Promise<PartitionClaim | null> {
     const generation = randomUUID();
-    return await this.db.doTn(async tn => {
+    const claim = await this.db.doTn(async tn => {
       // During rolling deployment, defer to the old all-or-nothing owner until
       // its final lease expires; old and new protocols must not overlap.
       const legacyKey = this.queues[0].ks.legacySweeperLock();
@@ -192,20 +210,26 @@ export class NuqFdbSweeper {
       if (current && current.x > now && current.w !== this.sweeperId) {
         return null;
       }
+      const expiresAt = now + this.lockTtlMs;
       tn.set(
         key,
         encodeJson({
           w: this.sweeperId,
           g: generation,
-          x: now + this.lockTtlMs,
+          x: expiresAt,
         } satisfies OwnershipRecord),
       );
-      return { ks, phase, partition, generation };
+      return { ks, phase, partition, generation, expiresAt };
     });
+    // A new claim must be repopulated only by its own scan. A failed claim
+    // means another replica owns the partition, so this process must not keep
+    // exporting an observation from an earlier generation.
+    this.clearOverdueObservation(ks, phase, partition);
+    return claim;
   }
 
   private async renewClaim(claim: PartitionClaim): Promise<void> {
-    await this.db.doTn(async tn => {
+    const expiresAt = await this.db.doTn(async tn => {
       const key = claim.ks.sweeperPartition(claim.phase, claim.partition);
       const current = decodeJson<OwnershipRecord>(await tn.get(key));
       const legacyKey = this.queues[0].ks.legacySweeperLock();
@@ -233,7 +257,13 @@ export class NuqFdbSweeper {
           } satisfies LegacyOwnershipRecord),
         );
       }
+      return expiresAt;
     });
+    claim.expiresAt = expiresAt;
+    const observation = this.overdueObservations.get(
+      this.observationKey(claim.ks, claim.phase, claim.partition),
+    );
+    if (observation) observation.ownershipExpiresAtMs = expiresAt;
   }
 
   private async guardClaim(
@@ -484,7 +514,15 @@ export class NuqFdbSweeper {
           partition: bucket,
           run: async claim => {
             await this.renewClaim(claim);
-            await slots.sweepExpiredBucket(now, bucket, this.guard(claim));
+            await slots.sweepExpiredBucket(
+              now,
+              bucket,
+              this.guard(claim),
+              due =>
+                this.observeDue(claim, "external_expiry", due, key =>
+                  Number(claim.ks.unpack(key)[4]),
+                ),
+            );
           },
         });
       }
@@ -526,6 +564,7 @@ export class NuqFdbSweeper {
         await item.run(claim);
       } catch (error) {
         if (error instanceof OwnershipLostError) {
+          this.clearOverdueObservation(item.ks, item.phase, item.partition);
           logger.info("NuQ FDB sweeper partition ownership lost", {
             canonicalLog: "nuq-fdb/sweeper_ownership_lost",
             queueName: item.ks.queueName,
@@ -541,6 +580,7 @@ export class NuqFdbSweeper {
 
   public start(intervalMs: number = 1000, logger: Logger = _logger): void {
     if (this.loop) return;
+    this.metricsEnabled = true;
     this.loop = setInterval(async () => {
       if (this.running) return;
       this.running = true;
@@ -558,10 +598,85 @@ export class NuqFdbSweeper {
   }
 
   public stop(): void {
+    this.metricsEnabled = false;
+    this.overdueObservations.clear();
     if (this.loop) {
       clearInterval(this.loop);
       this.loop = null;
     }
+  }
+
+  private observationKey(
+    ks: NuqFdbKeyspace,
+    phase: string,
+    partition: number,
+  ): string {
+    return JSON.stringify([ks.queueName, phase, partition]);
+  }
+
+  private clearOverdueObservation(
+    ks: NuqFdbKeyspace,
+    phase: string,
+    partition: number,
+  ): void {
+    this.overdueObservations.delete(this.observationKey(ks, phase, partition));
+  }
+
+  private observeDue(
+    claim: PartitionClaim,
+    index: string,
+    due: readonly [unknown, unknown][],
+    dueAt: (key: Buffer) => number,
+  ): void {
+    const key = this.observationKey(claim.ks, claim.phase, claim.partition);
+    if (!this.metricsEnabled || due.length === 0) {
+      this.overdueObservations.delete(key);
+      return;
+    }
+    let oldestDueAtMs = Number.POSITIVE_INFINITY;
+    for (const [rawKey] of due) {
+      const value = dueAt(rawKey as Buffer);
+      if (Number.isFinite(value))
+        oldestDueAtMs = Math.min(oldestDueAtMs, value);
+    }
+    if (!Number.isFinite(oldestDueAtMs)) {
+      this.overdueObservations.delete(key);
+      return;
+    }
+    this.overdueObservations.set(key, {
+      queue: claim.ks.queueName,
+      index,
+      partition: claim.partition,
+      oldestDueAtMs,
+      ownershipExpiresAtMs: claim.expiresAt,
+    });
+  }
+
+  // Pure in-memory collector: scans populate observations while metrics
+  // collection performs no FoundationDB reads. Expired local claims are
+  // removed here so a stopped or partitioned pod cannot pin autoscaling.
+  public getMetrics(nowMs: number = Date.now()): string {
+    const rows: string[] = [];
+    const observations = [...this.overdueObservations.entries()].sort(
+      ([a], [b]) => a.localeCompare(b),
+    );
+    for (const [key, observation] of observations) {
+      if (!this.metricsEnabled || observation.ownershipExpiresAtMs <= nowMs) {
+        this.overdueObservations.delete(key);
+        continue;
+      }
+      const labels = `queue="${escapePrometheusLabel(observation.queue)}",index="${escapePrometheusLabel(observation.index)}",partition="${observation.partition}"`;
+      const seconds = Math.max(0, nowMs - observation.oldestDueAtMs) / 1000;
+      rows.push(
+        `firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds{${labels}} ${seconds}`,
+      );
+    }
+    return [
+      "# HELP firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds Age of the oldest overdue entry observed by an owned NuQ FDB sweeper partition",
+      "# TYPE firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds gauge",
+      ...rows,
+      "",
+    ].join("\n");
   }
 
   private addLag(
@@ -629,6 +744,7 @@ export class NuqFdbSweeper {
     const stats = emptySweepLagStats();
     while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
       const due = await this.dueBatch(claim, ks.leaseScanRange(bucket, now));
+      this.observeDue(claim, "lease", due, key => Number(ks.unpackId(key, 1)));
       this.addLag(stats, ks, due, now);
       if (due.length === 0) break;
       for (const [key, value] of due) {
@@ -731,6 +847,9 @@ export class NuqFdbSweeper {
         claim,
         ks.backlogTimeoutScanRange(bucket, now),
       );
+      this.observeDue(claim, "backlog_timeout", due, key =>
+        Number(ks.unpackId(key, 1)),
+      );
       this.addLag(stats, ks, due, now);
       if (due.length === 0) break;
       for (const [key] of due) {
@@ -798,6 +917,7 @@ export class NuqFdbSweeper {
     const stats = emptySweepLagStats();
     while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
       const due = await this.dueBatch(claim, ks.delayedScanRange(bucket, now));
+      this.observeDue(claim, "delay", due, key => Number(ks.unpackId(key, 1)));
       this.addLag(stats, ks, due, now);
       if (due.length === 0) break;
       for (const [key, value] of due) {
@@ -1252,6 +1372,9 @@ export class NuqFdbSweeper {
         ks.jobExpiryScanRange(bucket, now),
         SWEEP_BATCH * 2,
       );
+      this.observeDue(claim, "job_expiry", due, key =>
+        Number(ks.unpackId(key, 1)),
+      );
       if (due.length === 0) break;
       await this.renewClaim(claim);
       await this.db.doTn(async tn => {
@@ -1287,6 +1410,12 @@ export class NuqFdbSweeper {
     const ks = queue.ks;
     while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
       const due = await this.dueBatch(claim, range, 20);
+      this.observeDue(
+        claim,
+        legacy ? "legacy_group_expiry" : "group_expiry",
+        due,
+        key => Number(ks.unpack(key)[legacy ? 3 : 4]),
+      );
       if (due.length === 0) break;
       for (const [key] of due) {
         const parts = ks.unpack(key);

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -1185,6 +1185,9 @@ export class NuqFdbSweeper {
     const range = ks.claimExpiryScanRange(now);
     while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
       const due = await this.dueBatch(claim, range);
+      this.observeDue(claim, "claim_expiry", due, key =>
+        Number(ks.unpackId(key, 1)),
+      );
       if (due.length === 0) break;
       await this.renewClaim(claim);
       await this.db.doTn(async tn => {
@@ -1215,6 +1218,9 @@ export class NuqFdbSweeper {
     const range = ks.ingestExpiryScanRange(now);
     while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
       const due = await this.dueBatch(claim, range, 20);
+      this.observeDue(claim, "ingest_expiry", due, key =>
+        Number(ks.unpackId(key, 1)),
+      );
       if (due.length === 0) break;
       let incomplete = false;
       for (const [expiryKey] of due) {

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -2015,7 +2015,11 @@ export class NuqFdbSweeper {
             kind === "team" ? ks.teamPendingCount(id) : ks.keyPendingCount(id),
           ),
         );
-        if (active > 0 || pending > 0) return;
+        const reserved =
+          kind === "team"
+            ? decodeI64(await tn.get(ks.teamIngestReserved(id)))
+            : 0;
+        if (active > 0 || pending > 0 || reserved > 0) return;
         // Delayed and crawl-pending work intentionally holds neither an
         // active nor a pending slot at the inner gates. Keep the cold limit
         // key so such latent work cannot wake up to Infinity; collect the
@@ -2023,6 +2027,7 @@ export class NuqFdbSweeper {
         if (kind === "team") {
           tn.clear(ks.teamActive(id));
           tn.clear(ks.teamPendingCount(id));
+          tn.clear(ks.teamIngestReserved(id));
           const shards = ks.teamShardCountRange(id);
           tn.clearRange(shards.begin, shards.end);
           tn.clear(ks.teamActiveIndex(id));

--- a/apps/api/src/services/worker/nuq-worker-runtime.test.ts
+++ b/apps/api/src/services/worker/nuq-worker-runtime.test.ts
@@ -5,7 +5,10 @@ import {
   settleDrain,
   type RuntimeLogger,
 } from "./nuq-worker-runtime";
-import { startCrawlFinishedLoop } from "./nuq-fdb-worker-runtime";
+import {
+  isLegacyFdbWorkerLive,
+  startCrawlFinishedLoop,
+} from "./nuq-fdb-worker-runtime";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -267,6 +270,14 @@ describe("NuQ worker lease lifecycle", () => {
 });
 
 describe("NuQ FDB worker supervision", () => {
+  test("keeps transient sweeper readiness out of legacy liveness", () => {
+    const crawlFinishedLoop = { isHealthy: vi.fn(() => true) };
+
+    expect(isLegacyFdbWorkerLive(crawlFinishedLoop)).toBe(true);
+    expect(crawlFinishedLoop.isHealthy).toHaveBeenCalledOnce();
+    expect(isLegacyFdbWorkerLive(null)).toBe(false);
+  });
+
   test("keeps crawl-finished loop healthy through transient dequeue and finish failures", async () => {
     vi.useFakeTimers();
     const directFdbJob = job();


### PR DESCRIPTION
## Summary

- replace singleton sweeping with renewable generation-fenced, deterministically partitioned ownership
- paginate cancellation, expiry, delayed, claim, ingest, and ledger maintenance with persistent cursors
- make external-slot expiry, group raise tasks, lifecycle TTL, and ledger GC generation-safe
- preserve staged ingest reservations during team-ledger GC
- export ownership-scoped, scan-free overdue lag metrics
- expose supervised sweeper lifecycle with transient recovery, readiness health, bounded stop, and force-stop fencing

## Metrics

`firecrawl_nuq_fdb_sweeper_oldest_overdue_seconds{queue,index,partition}` is derived only from due rows already observed during owned partition scans:

- owned/clear partitions emit zero
- ownership loss or stop removes the series
- collection performs no FDB reads
- labels use bounded queue/index/partition values

## Lifecycle

- numeric/native FDB tick failures mark the sweeper unhealthy but retain the retry loop and pending `done` promise; a successful tick restores health
- fatal internal failures reject `done`
- graceful stop waits for in-flight work
- force-stop generation-fences detached work so it cannot restore health, metrics, or start later queue backfills
- legacy combined-worker liveness does not include transient sweeper health; #3981 maps it to `/ready` after introducing separate `/live` and `/ready`

## Validation

- focused lifecycle, metrics, and worker-runtime tests: 29/29 passed
- real-FDB lifecycle/scalability suite: 14/14 passed
- targeted 40k TTL test and adversarial expiry/ownership tests passed
- `pnpm exec tsc --noEmit`
- `pnpm knip`
- Prettier and `git diff --check`

## Review

Independent integrated review approved `ef8bb43dcaec2e8d047ebe4531cc578be98fc996`, including:

- force-stop/restart generation race across two queue backfills
- standalone legacy liveness behavior
- staged-ingest reservation preservation and ledger GC
- partition ownership, lag-series cleanup, malformed expiry safety, and rollout fencing

## Dependency

Draft/stacked on #3984 (`mogery/nuq-fdb-core-correctness`), which is itself stacked on #3980. Keep draft until dependencies merge, retarget sequentially, and final CI is green.
