### PR TITLE
fix(api): harden NuQ FDB migration routing

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -245,7 +245,7 @@ jobs:
           PORT: 3003
 
       - name: Run Docker Postgres
-        if: matrix.nuq == 'postgres'
+        if: matrix.nuq == 'postgres' || matrix.nuq == 'fdb'
         run: |
           docker build -t firecrawl/nuq-postgres:latest ./apps/nuq-postgres
           docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres --name postgres firecrawl/nuq-postgres:latest
@@ -582,8 +582,15 @@ jobs:
   nuq-fdb-core:
     name: NuQ FoundationDB core tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     env:
       FDB_VERSION: 7.3.63
+      NUQ_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      REDIS_URL: redis://localhost:6379
     steps:
       - uses: actions/checkout@v5
 
@@ -611,6 +618,15 @@ jobs:
           curl -fsSL -o /tmp/fdb-clients.deb \
             "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb"
           sudo dpkg -i /tmp/fdb-clients.deb
+
+      - name: Start NuQ Postgres
+        run: |
+          docker build -t firecrawl/nuq-postgres:latest ./apps/nuq-postgres
+          docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres --name postgres firecrawl/nuq-postgres:latest
+          for i in $(seq 1 30); do
+            if docker exec postgres pg_isready -U postgres 2>/dev/null; then break; fi
+            sleep 1
+          done
 
       - name: Start FoundationDB
         run: |

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -591,6 +591,8 @@ jobs:
       FDB_VERSION: 7.3.63
       NUQ_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
       REDIS_URL: redis://localhost:6379
+      REDIS_RATE_LIMIT_URL: redis://localhost:6379
+      REDIS_EVICT_URL: redis://localhost:6379
     steps:
       - uses: actions/checkout@v5
 
@@ -639,7 +641,12 @@ jobs:
           echo "docker:docker@127.0.0.1:4500" > /tmp/fdb.cluster
 
       - name: Run NuQ FDB core tests
-        run: npx vitest run src/__tests__/nuq-fdb --reporter=default
+        shell: bash
+        run: |
+          set -euo pipefail
+          for test in src/__tests__/nuq-fdb/*.test.ts; do
+            npx vitest run "$test" --reporter=default --maxWorkers=1 --no-file-parallelism
+          done
         working-directory: apps/api
         env:
           FDB_CLUSTER_FILE: /tmp/fdb.cluster

--- a/apps/api/NUQ_MIGRATION_GC_DEPLOYMENT.md
+++ b/apps/api/NUQ_MIGRATION_GC_DEPLOYMENT.md
@@ -1,0 +1,55 @@
+# NuQ migration GC deployment contract
+
+This repository builds the `nuq-reconciler-worker`; it does not own the production Helm release. The infrastructure change that deploys this image **must** supply the following HPA contract before any 45-day migration-retention cohort becomes due.
+
+## Required replica/HPA settings
+
+- `minReplicas: 2` (production must not remain at the current single replica).
+- `maxReplicas: 32`. GC has 32 globally leased FDB partitions per category, so replicas above 32 cannot add useful FDB concurrency.
+- Scale on `nuq_migration_gc_due_backlog` using an external/object metric target of **100 due items per replica**. The adapter must take the **maximum**, not sum, of this global gauge across worker pods.
+- Also scale on `nuq_migration_gc_oldest_overdue_seconds` with a target of **300 seconds**. Kubernetes chooses the largest replica recommendation from the backlog and age metrics.
+- Use a fast scale-up policy (no scale-up stabilization; at least 100% or 8 pods per minute) and a conservative scale-down window of at least 10 minutes.
+- Keep the reconciler's normal CPU/memory safeguards. Backlog-aware cadence does not skip normal concurrency reconciliation: every retry performs both bounded GC and the ordinary team pass.
+
+The first production deployment must raise the replica floor above one and verify the external metrics/HPA recommendations before the 45-day due cliff. Do not rely on retention alone to smooth that first cohort.
+
+## Metric contract
+
+All GC metrics are served by the `nuq-reconciler-worker` `/metrics` endpoint and have a bounded `category` label:
+
+- `terminal_pin`
+- `control_history`
+- `closed_generation`
+- `redis_cleanup`
+
+Capacity metrics:
+
+- `nuq_migration_gc_due_backlog{category}`: exact count currently due.
+- `nuq_migration_gc_oldest_overdue_seconds{category}`: exact oldest due age, or zero when idle.
+
+Operational counters:
+
+- `nuq_migration_gc_runs_total{category}`
+- `nuq_migration_gc_pages_total{category}`
+- `nuq_migration_gc_items_total{category,outcome}` (`processed`, `removed`, `retained`, `stale`)
+- `nuq_migration_gc_errors_total{category}`
+
+Alert on any sustained error increase, oldest overdue age above 15 minutes, or backlog growth while replicas are below 32. At 32 replicas, sustained growth is a page latency/storage dependency incident rather than an HPA problem.
+
+FDB counts are maintained transactionally in 32 sharded timestamp trees and oldest timestamps use one limit-1 read from each index partition; collection performs no global range scan. Redis uses native `ZCARD`/`ZCOUNT` and a limit-1 oldest-score read.
+
+## Runtime tuning
+
+Safe validated defaults:
+
+- `NUQ_MIGRATION_GC_PAGE_LIMIT=100`
+- `NUQ_MIGRATION_GC_MAX_PAGES=128`
+- `NUQ_MIGRATION_GC_WORK_BUDGET_MS=20000`
+- `NUQ_RECONCILER_BACKLOG_RETRY_MS=5000`
+- `NUQ_RECONCILER_IDLE_INTERVAL_MS=60000`
+
+A page never exceeds 100 items. The independent page and wall-clock caps bound shutdown and reserve time for normal reconciliation. Retained rows are rescheduled one hour into the future and therefore do not cause a hot retry loop.
+
+## Infrastructure refresh note
+
+The final infrastructure refresh for #195 must replace the fixed `nuqReconciler.replicas=1` setting with the HPA above (or an equivalent external-metrics implementation), with a production minimum of two and maximum of 32. This API repository intentionally does not add a Helm example because the chart is owned by the infrastructure repository.

--- a/apps/api/NUQ_MIGRATION_GC_DEPLOYMENT.md
+++ b/apps/api/NUQ_MIGRATION_GC_DEPLOYMENT.md
@@ -7,7 +7,7 @@ This repository builds the `nuq-reconciler-worker`; it does not own the producti
 - `minReplicas: 2` (production must not remain at the current single replica).
 - `maxReplicas: 32`. GC has 32 globally leased FDB partitions per category, so replicas above 32 cannot add useful FDB concurrency.
 - Scale on `nuq_migration_gc_due_backlog` using an external/object metric target of **100 due items per replica**. The adapter must take the **maximum**, not sum, of this global gauge across worker pods.
-- Also scale on `nuq_migration_gc_oldest_overdue_seconds` with a target of **300 seconds**. Kubernetes chooses the largest replica recommendation from the backlog and age metrics.
+- Also scale on `nuq_migration_gc_oldest_overdue_seconds` with a target of **300 seconds**. The adapter must use the **maximum oldest age across pods** (never a sum or average). Kubernetes chooses the largest replica recommendation from the backlog and age metrics.
 - Use a fast scale-up policy (no scale-up stabilization; at least 100% or 8 pods per minute) and a conservative scale-down window of at least 10 minutes.
 - Keep the reconciler's normal CPU/memory safeguards. Backlog-aware cadence does not skip normal concurrency reconciliation: every retry performs both bounded GC and the ordinary team pass.
 
@@ -33,8 +33,10 @@ Operational counters:
 - `nuq_migration_gc_pages_total{category}`
 - `nuq_migration_gc_items_total{category,outcome}` (`processed`, `removed`, `retained`, `stale`)
 - `nuq_migration_gc_errors_total{category}`
+- `nuq_migration_gc_run_duration_seconds`
+- `nuq_migration_gc_processed_items_per_second{category}`
 
-Alert on any sustained error increase, oldest overdue age above 15 minutes, or backlog growth while replicas are below 32. At 32 replicas, sustained growth is a page latency/storage dependency incident rather than an HPA problem.
+Alert on any sustained error increase, oldest overdue age above 15 minutes, or backlog growth while replicas are below 32. Add a distinct critical alert for sustained backlog growth when the HPA is already at `maxReplicas=32`; at that point this is a page-latency/storage-dependency incident, not an HPA problem.
 
 FDB counts are maintained transactionally in 32 sharded timestamp trees and oldest timestamps use one limit-1 read from each index partition; collection performs no global range scan. Redis uses native `ZCARD`/`ZCOUNT` and a limit-1 oldest-score read.
 
@@ -48,7 +50,11 @@ Safe validated defaults:
 - `NUQ_RECONCILER_BACKLOG_RETRY_MS=5000`
 - `NUQ_RECONCILER_IDLE_INTERVAL_MS=60000`
 
-A page never exceeds 100 items. The independent page and wall-clock caps bound shutdown and reserve time for normal reconciliation. Retained rows are rescheduled one hour into the future and therefore do not cause a hot retry loop.
+A page never exceeds 100 items. The independent page and wall-clock caps bound shutdown and reserve time for normal reconciliation. Every storage transaction and external authority probe also has a 10-second operation bound, and the wall budget aborts page work between individual items. Retained rows are rescheduled one hour into the future and therefore do not cause a hot retry loop.
+
+## Isolated page-loop capacity evidence
+
+The deterministic isolated-service benchmark in `nuq-router-gc.test.ts` uses a 10,000-item due cohort, a representative 20 ms storage-page latency, one replica, 100-item pages, and the production `maxPages=128` contract. Its acceptance target is **at least 2,000 items/second**, comfortably above the documented planning arrival target of **1,000 due items/second per replica** while still asserting that no page exceeds 100 items. Production capacity must additionally be verified from `nuq_migration_gc_processed_items_per_second` and run-duration histograms because PG/Redis/FDB latency, rather than scheduler overhead, is the expected limiter.
 
 ## Infrastructure refresh note
 

--- a/apps/api/knip.config.ts
+++ b/apps/api/knip.config.ts
@@ -19,7 +19,8 @@ const config: KnipConfig = {
     // the provider/verdict types are consumed by the core-lib branch.
     "src/lib/threat-protection/types.ts",
   ],
-  ignoreDependencies: ["undici-types", "stripe"],
+  // Referenced as an explicit compiler path in long-running worker scripts.
+  ignoreDependencies: ["undici-types", "stripe", "typescript-7"],
 };
 
 export default config;

--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -31,6 +31,7 @@ const RUN = randomUUID().slice(0, 8);
 const TEST_LEASE_MS = 1500;
 
 const createdQueueNames: string[] = [];
+const previousMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
 
 type Ctx = {
   queue: NuQFdbQueue;
@@ -150,14 +151,25 @@ function countsFromLedger(
 }
 
 describeIf("NuQ FDB core", () => {
+  beforeAll(() => {
+    // This suite explicitly activates and validates maintained generations.
+    // Keep the runtime sweeper in release-B mode so it does not correctly
+    // invalidate those generations as a disabled rollout would in production.
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
+  });
+
   afterAll(async () => {
-    const fdb = getFdb();
-    const db = getNuqFdbDatabase();
-    for (const name of createdQueueNames) {
-      const r = fdb.tuple.range(["nuq", name]);
-      await db.doTn(async tn =>
-        tn.clearRange(r.begin as Buffer, r.end as Buffer),
-      );
+    try {
+      const fdb = getFdb();
+      const db = getNuqFdbDatabase();
+      for (const name of createdQueueNames) {
+        const r = fdb.tuple.range(["nuq", name]);
+        await db.doTn(async tn =>
+          tn.clearRange(r.begin as Buffer, r.end as Buffer),
+        );
+      }
+    } finally {
+      config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
     }
   });
 

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -504,7 +504,16 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await forceSealCorruptResidueForStaleGenerationTest(teamId);
     await new Promise(resolve => setTimeout(resolve, 1_100));
     const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
-    await expect(sweeper.sweepOnce()).rejects.toMatchObject({
+    let staleError: unknown;
+    for (let attempt = 0; attempt < 10 && !staleError; attempt++) {
+      try {
+        await sweeper.sweepOnce();
+      } catch (error) {
+        staleError = error;
+      }
+      if (!staleError) await new Promise(resolve => setTimeout(resolve, 500));
+    }
+    expect(staleError).toMatchObject({
       code: "NUQ_MIGRATION_STALE_GENERATION",
     });
   });

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -14,6 +14,7 @@ import {
   getNuqFdbDatabase,
 } from "../../services/worker/nuq-fdb/client";
 import { READY_SHARDS } from "../../services/worker/nuq-fdb/keyspace";
+import { clearMigrationTestTeams } from "./migration-test-cleanup";
 
 const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 const run = randomUUID();
@@ -118,21 +119,7 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
         tn.clearRange(range.begin as Buffer, range.end as Buffer),
       );
     }
-    for (const teamId of teams) {
-      const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-      await db.doTn(async tn => {
-        const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
-        const rows = await tn
-          .snapshot()
-          .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
-        for (const [key, value] of rows) {
-          if (JSON.parse((value as Buffer).toString()).teamId === teamId) {
-            tn.clear(key as Buffer);
-          }
-        }
-        tn.clearRange(range.begin as Buffer, range.end as Buffer);
-      });
-    }
+    await clearMigrationTestTeams(teams);
   });
 
   test("unmanaged legacy teams remain compatible while managed missing pins fail closed", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -33,6 +33,11 @@ const finishedQueue = new NuQFdbQueue<any, any>(finishedQueueName, {
 });
 const groups = new NuQFdbJobGroup(queue.ks, queue.groupOps!);
 const slots = new NuqFdbExternalSlots(queue.ks);
+// A production replica retains one sweeper identity while its partition leases
+// are live. Reuse that identity here too: constructing a new replica per test
+// leaves the exact partition under the prior replica's 15-second lease and
+// makes bounded promotion checks depend on suite runtime.
+const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
 const teams = new Set<string>();
 
 const unlimited = {
@@ -279,7 +284,6 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
         residue: { control_groups: 1 },
       }),
     );
-    const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
     for (let attempt = 0; attempt < 20; attempt++) {
       if ((await groups.getGroup(groupId))?.status === "completed") break;
       await sweeper.sweepOnce();
@@ -519,7 +523,6 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     });
 
     await new Promise(resolve => setTimeout(resolve, 1_100));
-    const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
     let promotedResidue = await residue(teamId);
     for (
       let attempt = 0;
@@ -748,7 +751,6 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
 
     await forceSealCorruptResidueForStaleGenerationTest(teamId);
     await new Promise(resolve => setTimeout(resolve, 1_100));
-    const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
     let staleError: unknown;
     for (let attempt = 0; attempt < 10 && !staleError; attempt++) {
       try {

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { config } from "../../config";
 import {
   MIGRATION_RESIDUE_COUNTERS,
+  externalSlotMigrationObjectId,
   NuQFdbJobGroup,
   NuQFdbQueue,
   NuqFdbExternalSlots,
@@ -169,8 +170,9 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     });
 
     await slots.acquire(teamId, holderId, 120_000);
+    const externalObjectId = externalSlotMigrationObjectId(teamId, holderId);
     await expect(
-      store.inspectPin("external_holder", holderId),
+      store.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({
       admission: "legacy-backfill",
       lifecycle: "active",
@@ -178,7 +180,7 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     });
     await slots.release(teamId, holderId);
     await expect(
-      store.inspectPin("external_holder", holderId),
+      store.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({ lifecycle: "terminal" });
   });
 
@@ -326,17 +328,18 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
   test("external holders and group/crawl_finished controls are exact", async () => {
     const teamId = await managedTeam();
     const holderId = randomUUID();
+    const externalObjectId = externalSlotMigrationObjectId(teamId, holderId);
     await store.preparePinnedObject({
       teamId,
       kind: "external_holder",
-      objectId: holderId,
+      objectId: externalObjectId,
       admission: { type: "new-root" },
       requiredBackend: "fdb",
       residue: { intent_unresolved: 1 },
     });
     await slots.acquire(teamId, holderId, 60_000);
     await expect(
-      store.inspectPin("external_holder", holderId),
+      store.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({ lifecycle: "active" });
     expect(await residue(teamId)).toMatchObject({
       capacity_external_holders: 1,
@@ -454,7 +457,7 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await store.preparePinnedObject({
       teamId: externalTeam,
       kind: "external_holder",
-      objectId: holderId,
+      objectId: externalSlotMigrationObjectId(externalTeam, holderId),
       admission: { type: "new-root" },
       requiredBackend: "fdb",
       residue: { intent_unresolved: 1 },

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -6,6 +6,7 @@ import {
   NuQFdbQueue,
   NuqFdbExternalSlots,
   NuqFdbMigrationStore,
+  NuqFdbSweeper,
 } from "../../services/worker/nuq-fdb";
 import {
   getFdb,
@@ -118,9 +119,16 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
       unlimited,
     );
     expect(legacy.migrationGeneration).toBeUndefined();
+    await queue.beginMetricCounterBackfill();
+    while (!(await queue.backfillMetricCounts(100))) {
+      // bounded pages
+    }
+    const metricControl = await queue.getMetricCounterBackfillStatus();
+    expect(metricControl?.phase).toBe("ready");
     await db.doTn(async tn => {
       tn.clear(queue.ks.ownerLiveJob(legacyTeam, legacyId));
-      tn.clear(queue.ks.ownerLiveBackfillCursor());
+      tn.clear(queue.ks.ownerLiveBackfillCursor(metricControl!.generation));
+      tn.clear(queue.ks.ownerLiveBackfillReady(metricControl!.generation));
     });
     await expect(queue.hasReadyOrActiveJobForOwner(legacyTeam)).resolves.toBe(
       true,
@@ -131,6 +139,47 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await expect(
       queue.addJob(randomUUID(), {}, { ownerId: teamId }, unlimited),
     ).rejects.toMatchObject({ code: "NUQ_MIGRATION_PIN_NOT_FOUND" });
+  });
+
+  test("existing pre-protocol jobs and external holders adopt the source generation while draining", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    const id = randomUUID();
+    const holderId = randomUUID();
+    await queue.addJob(id, {}, { ownerId: teamId }, unlimited);
+    await slots.acquire(teamId, holderId, 60_000);
+    await store.initializeLegacyTeam(teamId, "fdb", randomUUID());
+    await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId: randomUUID(),
+    });
+
+    const active = await queue.getJobToProcess();
+    expect(active?.id).toBe(id);
+    await expect(store.inspectPin("scrape_job", id)).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      backend: "fdb",
+      generation: 1,
+      lifecycle: "active",
+    });
+    await queue.jobFinish(id, active!.lock!, {});
+    await expect(store.inspectPin("scrape_job", id)).resolves.toMatchObject({
+      lifecycle: "terminal",
+    });
+
+    await slots.acquire(teamId, holderId, 120_000);
+    await expect(
+      store.inspectPin("external_holder", holderId),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      lifecycle: "active",
+      residue: { capacity_external_holders: 1 },
+    });
+    await slots.release(teamId, holderId);
+    await expect(
+      store.inspectPin("external_holder", holderId),
+    ).resolves.toMatchObject({ lifecycle: "terminal" });
   });
 
   test("ready/active residue is exact and terminal drain remains allowed", async () => {
@@ -223,6 +272,57 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     ).toBe(true);
   });
 
+  test("crawl-pending and delayed residue transition atomically through sweeper promotion", async () => {
+    const teamId = await managedTeam();
+    const gid = randomUUID();
+    const firstId = randomUUID();
+    const delayedId = randomUUID();
+    await prepareGroup(teamId, gid);
+    await groups.addGroup(gid, teamId, undefined, {
+      maxConcurrency: 1,
+      delaySeconds: 1,
+    });
+    for (const id of [firstId, delayedId]) await prepareJob(teamId, id, gid);
+    await queue.addJobs(
+      [firstId, delayedId].map(id => ({
+        id,
+        data: { mode: "single_urls" },
+        options: { ownerId: teamId, groupId: gid },
+      })),
+      { teamLimit: 10, queueCap: 10 },
+    );
+    expect(await residue(teamId)).toMatchObject({
+      capacity_ready_active: 1,
+      capacity_crawl_pending: 1,
+      capacity_delayed: 0,
+    });
+
+    const first = await queue.getJobToProcess();
+    expect(first?.id).toBe(firstId);
+    await queue.jobFinish(firstId, first!.lock!, {});
+    expect(await residue(teamId)).toMatchObject({
+      capacity_ready_active: 0,
+      capacity_crawl_pending: 0,
+      capacity_delayed: 1,
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 1_100));
+    const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
+    await sweeper.sweepOnce();
+    expect(await residue(teamId)).toMatchObject({
+      capacity_ready_active: 1,
+      capacity_delayed: 0,
+    });
+    const delayed = await queue.getJobToProcess();
+    expect(delayed?.id).toBe(delayedId);
+    await queue.jobFinish(delayedId, delayed!.lock!, {});
+    const finished = await finishedQueue.getJobToProcess();
+    await finishedQueue.jobFinish(finished!.id, finished!.lock!, {});
+    expect(
+      Object.values(await residue(teamId)).every(value => value === 0),
+    ).toBe(true);
+  });
+
   test("external holders and group/crawl_finished controls are exact", async () => {
     const teamId = await managedTeam();
     const holderId = randomUUID();
@@ -280,6 +380,53 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     expect((await residue(teamId)).control_crawl_finished).toBe(0);
   });
 
+  test("a live enqueue transaction and final seal cannot both commit", async () => {
+    const teamId = await managedTeam();
+    const id = randomUUID();
+    await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: id,
+      admission: { type: "new-root" },
+      requiredBackend: "fdb",
+      residue: {},
+    });
+    const transition = await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId: randomUUID(),
+    });
+
+    const results = await Promise.allSettled([
+      queue.addJob(id, {}, { ownerId: teamId }, unlimited),
+      store.finalSeal({
+        teamId,
+        transitionOperationId: transition.transitionOperationId!,
+      }),
+    ]);
+    expect(
+      results.filter(result => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    if (results[0].status === "fulfilled") {
+      expect(results[1]).toMatchObject({
+        status: "rejected",
+        reason: { code: "NUQ_MIGRATION_RESIDUE_NOT_EMPTY" },
+      });
+      await queue.removeJob(id);
+      await expect(
+        store.finalSeal({
+          teamId,
+          transitionOperationId: transition.transitionOperationId!,
+        }),
+      ).resolves.toMatchObject({ activeBackend: "pg" });
+    } else {
+      expect(results[0].reason).toMatchObject({
+        code: "NUQ_MIGRATION_STALE_GENERATION",
+      });
+      expect(results[1]).toMatchObject({ status: "fulfilled" });
+    }
+  });
+
   test("sealed generations reject enqueue and active finish mutations", async () => {
     const enqueueTeam = await managedTeam();
     const enqueueId = randomUUID();
@@ -324,6 +471,37 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await groups.addGroup(gid, groupTeam);
     await forceSealCorruptResidueForStaleGenerationTest(groupTeam);
     await expect(groups.cancelGroup(gid)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_STALE_GENERATION",
+    });
+  });
+
+  test("sealed generations reject delayed sweeper promotion", async () => {
+    const teamId = await managedTeam();
+    const gid = randomUUID();
+    const firstId = randomUUID();
+    const delayedId = randomUUID();
+    await prepareGroup(teamId, gid);
+    await groups.addGroup(gid, teamId, undefined, {
+      maxConcurrency: 1,
+      delaySeconds: 1,
+    });
+    for (const id of [firstId, delayedId]) await prepareJob(teamId, id, gid);
+    await queue.addJobs(
+      [firstId, delayedId].map(id => ({
+        id,
+        data: { mode: "single_urls" },
+        options: { ownerId: teamId, groupId: gid },
+      })),
+      { teamLimit: 10, queueCap: 10 },
+    );
+    const first = await queue.getJobToProcess();
+    await queue.jobFinish(first!.id, first!.lock!, {});
+    expect((await residue(teamId)).capacity_delayed).toBe(1);
+
+    await forceSealCorruptResidueForStaleGenerationTest(teamId);
+    await new Promise(resolve => setTimeout(resolve, 1_100));
+    const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
+    await expect(sweeper.sweepOnce()).rejects.toMatchObject({
       code: "NUQ_MIGRATION_STALE_GENERATION",
     });
   });

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -13,6 +13,7 @@ import {
   getFdb,
   getNuqFdbDatabase,
 } from "../../services/worker/nuq-fdb/client";
+import { READY_SHARDS } from "../../services/worker/nuq-fdb/keyspace";
 
 const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 const run = randomUUID();
@@ -77,6 +78,16 @@ async function residue(teamId: string, generation = 1) {
   return (await store.inspectGeneration(teamId, generation)).residue;
 }
 
+async function takeFinishedForGroup(groupId: string) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const job = await finishedQueue.getJobToProcess();
+    if (!job) return null;
+    if (job.groupId === groupId) return job;
+    await finishedQueue.jobFinish(job.id, job.lock!, {});
+  }
+  return null;
+}
+
 async function forceSealCorruptResidueForStaleGenerationTest(teamId: string) {
   await db.doTn(async tn => {
     for (const counter of MIGRATION_RESIDUE_COUNTERS) {
@@ -104,9 +115,18 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     }
     for (const teamId of teams) {
       const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-      await db.doTn(async tn =>
-        tn.clearRange(range.begin as Buffer, range.end as Buffer),
-      );
+      await db.doTn(async tn => {
+        const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
+        const rows = await tn
+          .snapshot()
+          .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
+        for (const [key, value] of rows) {
+          if (JSON.parse((value as Buffer).toString()).teamId === teamId) {
+            tn.clear(key as Buffer);
+          }
+        }
+        tn.clearRange(range.begin as Buffer, range.end as Buffer);
+      });
     }
   });
 
@@ -120,6 +140,18 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
       unlimited,
     );
     expect(legacy.migrationGeneration).toBeUndefined();
+    let staleReady: [Buffer, Buffer] | undefined;
+    await db.doTn(async tn => {
+      for (let shard = 0; shard < READY_SHARDS && !staleReady; shard++) {
+        const range = queue.ks.readyShardRange(shard);
+        const rows = await tn.snapshot().getRangeAll(range.begin, range.end);
+        staleReady = rows.find(([, value]) => {
+          const entry = JSON.parse((value as Buffer).toString("utf8"));
+          return entry.i === legacyId;
+        }) as [Buffer, Buffer] | undefined;
+      }
+    });
+    expect(staleReady).toBeDefined();
     await queue.beginMetricCounterBackfill();
     while (!(await queue.backfillMetricCounts(100))) {
       // bounded pages
@@ -134,7 +166,30 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await expect(queue.hasReadyOrActiveJobForOwner(legacyTeam)).resolves.toBe(
       true,
     );
+    const wrongOwner = randomUUID();
+    await db.doTn(async tn => {
+      tn.set(queue.ks.ownerLiveJob(wrongOwner, legacyId), Buffer.alloc(0));
+    });
+    await expect(
+      queue.hasReadyOrActiveJobForOwner(wrongOwner),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_CORRUPT" });
+    await db.doTn(async tn => {
+      tn.clear(queue.ks.ownerLiveJob(wrongOwner, legacyId));
+    });
     await queue.removeJob(legacyId);
+    await db.doTn(async tn => {
+      tn.set(queue.ks.ownerLiveJob(legacyTeam, legacyId), Buffer.alloc(0));
+      tn.set(staleReady![0], staleReady![1]);
+    });
+    await expect(queue.hasReadyOrActiveJobForOwner(legacyTeam)).resolves.toBe(
+      false,
+    );
+    await expect(
+      db.doTn(async tn => tn.get(queue.ks.ownerLiveJob(legacyTeam, legacyId))),
+    ).resolves.toBeUndefined();
+    // The obsolete ready row is not routing authority once the generation-
+    // scoped owner index is READY; normal queue/sweeper reconciliation owns
+    // its bounded cleanup.
 
     const teamId = await managedTeam();
     await expect(
@@ -182,6 +237,86 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await expect(
       store.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({ lifecycle: "terminal" });
+  });
+
+  test("terminal cancelled-group pins repair a missing sweeper continuation", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    const groupId = randomUUID();
+    await groups.addGroup(groupId, teamId);
+    await groups.cancelGroup(groupId);
+    await db.doTn(async tn => {
+      // Simulate pre-hook cancellation clearing owner discovery.
+      tn.clear(queue.ks.ongoingGroup(teamId, groupId));
+    });
+    await queue.beginMetricCounterBackfill();
+    while (!(await queue.backfillMetricCounts(10))) {
+      // bounded pages
+    }
+    while (!(await groups.backfillLegacyOwnerIndex(2))) {
+      // bounded pages
+    }
+    await expect(groups.hasUnfinishedByOwner(teamId)).resolves.toBe(true);
+    await store.initializeLegacyTeam(teamId, "fdb", randomUUID());
+    await store.preparePinnedObject({
+      teamId,
+      kind: "group",
+      objectId: groupId,
+      admission: {
+        type: "legacy-backfill",
+        backend: "fdb",
+        generation: 1,
+        terminal: true,
+      },
+      requiredBackend: "fdb",
+      residue: {},
+    });
+
+    await expect(groups.adoptLegacyCancelledGroup(groupId)).resolves.toBe(true);
+    await expect(
+      store.inspectPin("sweeper_task", `group-cancel/${groupId}`),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      lifecycle: "active",
+      residue: { control_sweeper_tasks: 1 },
+    });
+  });
+
+  test("sealed cancelled-group tombstones fail with an explicit lost-continuation fence", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    const groupId = randomUUID();
+    await groups.addGroup(groupId, teamId);
+    await groups.cancelGroup(groupId);
+    await store.initializeLegacyTeam(teamId, "fdb", randomUUID());
+    await store.preparePinnedObject({
+      teamId,
+      kind: "group",
+      objectId: groupId,
+      admission: {
+        type: "legacy-backfill",
+        backend: "fdb",
+        generation: 1,
+        terminal: true,
+      },
+      requiredBackend: "fdb",
+      residue: {},
+    });
+    const transition = await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId: randomUUID(),
+    });
+    await store.finalSeal({
+      teamId,
+      transitionOperationId: transition.transitionOperationId!,
+    });
+
+    await expect(
+      groups.adoptLegacyCancelledGroup(groupId),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CANCELLED_GROUP_CONTINUATION_LOST",
+    });
   });
 
   test("ready/active residue is exact and terminal drain remains allowed", async () => {
@@ -318,7 +453,8 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     const delayed = await queue.getJobToProcess();
     expect(delayed?.id).toBe(delayedId);
     await queue.jobFinish(delayedId, delayed!.lock!, {});
-    const finished = await finishedQueue.getJobToProcess();
+    const finished = await takeFinishedForGroup(gid);
+    expect(finished?.groupId).toBe(gid);
     await finishedQueue.jobFinish(finished!.id, finished!.lock!, {});
     expect(
       Object.values(await residue(teamId)).every(value => value === 0),
@@ -371,8 +507,9 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     const afterChild = await residue(teamId);
     expect(afterChild.control_groups).toBe(0);
     expect(afterChild.control_crawl_finished).toBe(1);
-    const finished = await finishedQueue.getJobToProcess();
+    const finished = await takeFinishedForGroup(gid);
     expect(finished).toMatchObject({
+      groupId: gid,
       migrationBackend: "fdb",
       migrationGeneration: 1,
     });

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -148,6 +148,10 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
       capacity_ready_active: 1,
       intent_unresolved: 0,
     });
+    await expect(store.inspectPin("scrape_job", id)).resolves.toMatchObject({
+      lifecycle: "active",
+      residue: { capacity_ready_active: 1 },
+    });
 
     const transition = await store.beginTransition({
       teamId,
@@ -231,6 +235,9 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
       residue: { intent_unresolved: 1 },
     });
     await slots.acquire(teamId, holderId, 60_000);
+    await expect(
+      store.inspectPin("external_holder", holderId),
+    ).resolves.toMatchObject({ lifecycle: "active" });
     expect(await residue(teamId)).toMatchObject({
       capacity_external_holders: 1,
       intent_unresolved: 0,
@@ -244,6 +251,9 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     const child = randomUUID();
     await prepareGroup(teamId, gid);
     await groups.addGroup(gid, teamId);
+    await expect(store.inspectPin("group", gid)).resolves.toMatchObject({
+      lifecycle: "active",
+    });
     expect((await residue(teamId)).control_groups).toBe(1);
     await prepareJob(teamId, child, gid);
     await queue.addJob(
@@ -263,6 +273,9 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
       migrationBackend: "fdb",
       migrationGeneration: 1,
     });
+    await expect(
+      store.inspectPin("crawl_finished", finished!.id),
+    ).resolves.toMatchObject({ lifecycle: "active" });
     await finishedQueue.jobFinish(finished!.id, finished!.lock!, {});
     expect((await residue(teamId)).control_crawl_finished).toBe(0);
   });
@@ -325,5 +338,8 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
       control_groups: 0,
       control_sweeper_tasks: 1,
     });
+    await expect(
+      store.inspectPin("sweeper_task", `group-cancel/${gid}`),
+    ).resolves.toMatchObject({ lifecycle: "active" });
   });
 });

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -383,6 +383,31 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     expect((await residue(teamId)).control_crawl_finished).toBe(0);
   });
 
+  test("rejected enqueue compensation cannot race a successful runtime commit", async () => {
+    const teamId = await managedTeam();
+    const id = randomUUID();
+    await prepareJob(teamId, id);
+    const results = await Promise.allSettled([
+      queue.addJob(id, {}, { ownerId: teamId }, unlimited),
+      queue.compensateRejectedMigrationJobs(teamId, [id]),
+    ]);
+    const pin = await store.inspectPin("scrape_job", id);
+    const job = await queue.getJob(id);
+    if (job) {
+      expect(pin).toMatchObject({
+        lifecycle: "active",
+        residue: { capacity_ready_active: 1, intent_unresolved: 0 },
+      });
+      await queue.removeJob(id);
+    } else {
+      expect(pin).toMatchObject({
+        lifecycle: "terminal",
+        residue: { capacity_ready_active: 0, intent_unresolved: 0 },
+      });
+      expect(results[0]).toMatchObject({ status: "rejected" });
+    }
+  });
+
   test("a live enqueue transaction and final seal cannot both commit", async () => {
     const teamId = await managedTeam();
     const id = randomUUID();

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -1,0 +1,329 @@
+import { randomUUID } from "crypto";
+import { config } from "../../config";
+import {
+  MIGRATION_RESIDUE_COUNTERS,
+  NuQFdbJobGroup,
+  NuQFdbQueue,
+  NuqFdbExternalSlots,
+  NuqFdbMigrationStore,
+} from "../../services/worker/nuq-fdb";
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+
+const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
+const run = randomUUID();
+const store = new NuqFdbMigrationStore();
+const db = getNuqFdbDatabase();
+const fdb = getFdb();
+
+const queueName = `generation-hooks-${run}`;
+const finishedQueueName = `${queueName}-finished`;
+const queue = new NuQFdbQueue<any, any>(queueName, {
+  hasGroups: true,
+  finishedQueueName,
+});
+const finishedQueue = new NuQFdbQueue<any, any>(finishedQueueName, {
+  hasGroups: false,
+  migrationObjectKind: "crawl_finished",
+});
+const groups = new NuQFdbJobGroup(queue.ks, queue.groupOps!);
+const slots = new NuqFdbExternalSlots(queue.ks);
+const teams = new Set<string>();
+
+const unlimited = {
+  teamLimit: null,
+  queueCap: Number.MAX_SAFE_INTEGER,
+};
+
+async function managedTeam() {
+  const teamId = randomUUID();
+  teams.add(teamId);
+  await store.initializeLegacyTeam(teamId, "fdb", randomUUID());
+  return teamId;
+}
+
+async function prepareJob(teamId: string, id: string, groupId?: string) {
+  return await store.preparePinnedObject({
+    teamId,
+    kind: "scrape_job",
+    objectId: id,
+    admission: groupId
+      ? {
+          type: "pinned-continuation",
+          source: { kind: "group", objectId: groupId },
+        }
+      : { type: "new-root" },
+    requiredBackend: "fdb",
+    residue: { intent_unresolved: 1 },
+  });
+}
+
+async function prepareGroup(teamId: string, id: string) {
+  return await store.preparePinnedObject({
+    teamId,
+    kind: "group",
+    objectId: id,
+    admission: { type: "new-root" },
+    requiredBackend: "fdb",
+    residue: { intent_unresolved: 1 },
+  });
+}
+
+async function residue(teamId: string, generation = 1) {
+  return (await store.inspectGeneration(teamId, generation)).residue;
+}
+
+async function forceSealCorruptResidueForStaleGenerationTest(teamId: string) {
+  await db.doTn(async tn => {
+    for (const counter of MIGRATION_RESIDUE_COUNTERS) {
+      tn.clear(store.residueKey(teamId, 1, counter));
+    }
+  });
+  const transition = await store.beginTransition({
+    teamId,
+    targetBackend: "pg",
+    operationId: randomUUID(),
+  });
+  await store.finalSeal({
+    teamId,
+    transitionOperationId: transition.transitionOperationId!,
+  });
+}
+
+describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
+  afterAll(async () => {
+    for (const name of [queueName, finishedQueueName]) {
+      const range = fdb.tuple.range(["nuq", name]);
+      await db.doTn(async tn =>
+        tn.clearRange(range.begin as Buffer, range.end as Buffer),
+      );
+    }
+    for (const teamId of teams) {
+      const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+      await db.doTn(async tn =>
+        tn.clearRange(range.begin as Buffer, range.end as Buffer),
+      );
+    }
+  });
+
+  test("unmanaged legacy teams remain compatible while managed missing pins fail closed", async () => {
+    const legacyTeam = randomUUID();
+    const legacyId = randomUUID();
+    const legacy = await queue.addJob(
+      legacyId,
+      {},
+      { ownerId: legacyTeam },
+      unlimited,
+    );
+    expect(legacy.migrationGeneration).toBeUndefined();
+    await db.doTn(async tn => {
+      tn.clear(queue.ks.ownerLiveJob(legacyTeam, legacyId));
+      tn.clear(queue.ks.ownerLiveBackfillCursor());
+    });
+    await expect(queue.hasReadyOrActiveJobForOwner(legacyTeam)).resolves.toBe(
+      true,
+    );
+    await queue.removeJob(legacyId);
+
+    const teamId = await managedTeam();
+    await expect(
+      queue.addJob(randomUUID(), {}, { ownerId: teamId }, unlimited),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_PIN_NOT_FOUND" });
+  });
+
+  test("ready/active residue is exact and terminal drain remains allowed", async () => {
+    const teamId = await managedTeam();
+    const id = randomUUID();
+    await prepareJob(teamId, id);
+
+    const added = await queue.addJob(id, {}, { ownerId: teamId }, unlimited);
+    expect(added).toMatchObject({
+      migrationBackend: "fdb",
+      migrationGeneration: 1,
+      status: "queued",
+    });
+    expect(await residue(teamId)).toMatchObject({
+      capacity_ready_active: 1,
+      intent_unresolved: 0,
+    });
+
+    const transition = await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId: randomUUID(),
+    });
+    const active = await queue.getJobToProcess();
+    expect(active?.id).toBe(id);
+    expect(await queue.jobFinish(id, active!.lock!, {})).toBe(true);
+    expect(await residue(teamId)).toMatchObject({
+      capacity_ready_active: 0,
+    });
+    await expect(
+      store.finalSeal({
+        teamId,
+        transitionOperationId: transition.transitionOperationId!,
+      }),
+    ).resolves.toMatchObject({ activeBackend: "pg", activeGeneration: 2 });
+  });
+
+  test("team and key pending counters transition exactly through promotion", async () => {
+    const teamId = await managedTeam();
+    const blocker = randomUUID();
+    const teamPending = randomUUID();
+    const keyPending = randomUUID();
+    for (const id of [blocker, teamPending, keyPending]) {
+      await prepareJob(teamId, id);
+    }
+
+    await queue.addJob(
+      blocker,
+      {},
+      { ownerId: teamId },
+      {
+        teamLimit: 1,
+        queueCap: 10,
+        key: { id: "key-a", limit: 1 },
+      },
+    );
+    await queue.addJob(
+      teamPending,
+      {},
+      { ownerId: teamId },
+      {
+        teamLimit: 1,
+        queueCap: 10,
+        key: { id: "key-b", limit: 1 },
+      },
+    );
+    await queue.addJob(
+      keyPending,
+      {},
+      { ownerId: teamId },
+      {
+        teamLimit: 1,
+        queueCap: 10,
+        key: { id: "key-a", limit: 1 },
+      },
+    );
+    expect(await residue(teamId)).toMatchObject({
+      capacity_ready_active: 1,
+      capacity_team_pending: 1,
+      capacity_key_pending: 1,
+    });
+
+    await queue.removeJobs([blocker, teamPending, keyPending]);
+    expect(
+      Object.values(await residue(teamId)).every(value => value === 0),
+    ).toBe(true);
+  });
+
+  test("external holders and group/crawl_finished controls are exact", async () => {
+    const teamId = await managedTeam();
+    const holderId = randomUUID();
+    await store.preparePinnedObject({
+      teamId,
+      kind: "external_holder",
+      objectId: holderId,
+      admission: { type: "new-root" },
+      requiredBackend: "fdb",
+      residue: { intent_unresolved: 1 },
+    });
+    await slots.acquire(teamId, holderId, 60_000);
+    expect(await residue(teamId)).toMatchObject({
+      capacity_external_holders: 1,
+      intent_unresolved: 0,
+    });
+    await slots.acquire(teamId, holderId, 120_000);
+    expect((await residue(teamId)).capacity_external_holders).toBe(1);
+    await slots.release(teamId, holderId);
+    expect((await residue(teamId)).capacity_external_holders).toBe(0);
+
+    const gid = randomUUID();
+    const child = randomUUID();
+    await prepareGroup(teamId, gid);
+    await groups.addGroup(gid, teamId);
+    expect((await residue(teamId)).control_groups).toBe(1);
+    await prepareJob(teamId, child, gid);
+    await queue.addJob(
+      child,
+      { mode: "single_urls" },
+      { ownerId: teamId, groupId: gid },
+      unlimited,
+    );
+    const active = await queue.getJobToProcess();
+    await queue.jobFinish(child, active!.lock!, {});
+
+    const afterChild = await residue(teamId);
+    expect(afterChild.control_groups).toBe(0);
+    expect(afterChild.control_crawl_finished).toBe(1);
+    const finished = await finishedQueue.getJobToProcess();
+    expect(finished).toMatchObject({
+      migrationBackend: "fdb",
+      migrationGeneration: 1,
+    });
+    await finishedQueue.jobFinish(finished!.id, finished!.lock!, {});
+    expect((await residue(teamId)).control_crawl_finished).toBe(0);
+  });
+
+  test("sealed generations reject enqueue and active finish mutations", async () => {
+    const enqueueTeam = await managedTeam();
+    const enqueueId = randomUUID();
+    await prepareJob(enqueueTeam, enqueueId);
+    await forceSealCorruptResidueForStaleGenerationTest(enqueueTeam);
+    await expect(
+      queue.addJob(enqueueId, {}, { ownerId: enqueueTeam }, unlimited),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_STALE_GENERATION" });
+
+    const finishTeam = await managedTeam();
+    const finishId = randomUUID();
+    await prepareJob(finishTeam, finishId);
+    await queue.addJob(finishId, {}, { ownerId: finishTeam }, unlimited);
+    const active = await queue.getJobToProcess();
+    expect(active?.id).toBe(finishId);
+    await forceSealCorruptResidueForStaleGenerationTest(finishTeam);
+    await expect(
+      queue.jobFinish(finishId, active!.lock!, {}),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_STALE_GENERATION" });
+  });
+
+  test("sealed generations reject external renewal and group control", async () => {
+    const externalTeam = await managedTeam();
+    const holderId = randomUUID();
+    await store.preparePinnedObject({
+      teamId: externalTeam,
+      kind: "external_holder",
+      objectId: holderId,
+      admission: { type: "new-root" },
+      requiredBackend: "fdb",
+      residue: { intent_unresolved: 1 },
+    });
+    await slots.acquire(externalTeam, holderId, 60_000);
+    await forceSealCorruptResidueForStaleGenerationTest(externalTeam);
+    await expect(
+      slots.acquire(externalTeam, holderId, 60_000),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_STALE_GENERATION" });
+
+    const groupTeam = await managedTeam();
+    const gid = randomUUID();
+    await prepareGroup(groupTeam, gid);
+    await groups.addGroup(gid, groupTeam);
+    await forceSealCorruptResidueForStaleGenerationTest(groupTeam);
+    await expect(groups.cancelGroup(gid)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_STALE_GENERATION",
+    });
+  });
+
+  test("group cancellation hands control to a pinned sweeper task", async () => {
+    const teamId = await managedTeam();
+    const gid = randomUUID();
+    await prepareGroup(teamId, gid);
+    await groups.addGroup(gid, teamId);
+    await groups.cancelGroup(gid);
+    expect(await residue(teamId)).toMatchObject({
+      control_groups: 0,
+      control_sweeper_tasks: 1,
+    });
+  });
+});

--- a/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/generation-hooks.test.ts
@@ -197,6 +197,31 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     ).rejects.toMatchObject({ code: "NUQ_MIGRATION_PIN_NOT_FOUND" });
   });
 
+  test("group owner discovery rejects cross-tenant live index rows", async () => {
+    const owner = randomUUID();
+    const wrongOwner = randomUUID();
+    const groupId = randomUUID();
+    await groups.addGroup(groupId, owner);
+    await queue.beginMetricCounterBackfill();
+    while (!(await queue.backfillMetricCounts(100))) {
+      // bounded pages
+    }
+    while (!(await groups.backfillLegacyOwnerIndex(100))) {
+      // bounded pages
+    }
+    await db.doTn(async tn => {
+      tn.set(queue.ks.ongoingGroup(wrongOwner, groupId), Buffer.alloc(0));
+    });
+    await expect(groups.hasUnfinishedByOwner(wrongOwner)).rejects.toMatchObject(
+      {
+        code: "NUQ_MIGRATION_CORRUPT",
+      },
+    );
+    await db.doTn(async tn => {
+      tn.clear(queue.ks.ongoingGroup(wrongOwner, groupId));
+    });
+  });
+
   test("existing pre-protocol jobs and external holders adopt the source generation while draining", async () => {
     const teamId = randomUUID();
     teams.add(teamId);
@@ -237,6 +262,56 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
     await expect(
       store.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({ lifecycle: "terminal" });
+  });
+
+  test("cancelled completion retires a group pin adopted before its continuation", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    const groupId = randomUUID();
+    await groups.addGroup(groupId, teamId);
+    await groups.cancelGroup(groupId);
+    await store.initializeLegacyTeam(teamId, "fdb", randomUUID());
+    await db.doTn(async tn =>
+      store.reconcileManagedObjectInTxn(tn, {
+        teamId,
+        kind: "group",
+        objectId: groupId,
+        residue: { control_groups: 1 },
+      }),
+    );
+    const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
+    for (let attempt = 0; attempt < 20; attempt++) {
+      if ((await groups.getGroup(groupId))?.status === "completed") break;
+      await sweeper.sweepOnce();
+    }
+    await expect(groups.getGroup(groupId)).resolves.toMatchObject({
+      status: "completed",
+    });
+    await expect(store.inspectPin("group", groupId)).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { control_groups: 0 },
+    });
+  });
+
+  test("legacy cancelled-group adoption commits its sweeper continuation atomically", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    const groupId = randomUUID();
+    await groups.addGroup(groupId, teamId);
+    await groups.cancelGroup(groupId);
+    await store.initializeLegacyTeam(teamId, "fdb", randomUUID());
+
+    await expect(groups.adoptLegacyCancelledGroup(groupId)).resolves.toBe(true);
+    await expect(store.inspectPin("group", groupId)).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { control_groups: 0 },
+    });
+    await expect(
+      store.inspectPin("sweeper_task", `group-cancel/${groupId}`),
+    ).resolves.toMatchObject({
+      lifecycle: "active",
+      residue: { control_sweeper_tasks: 1 },
+    });
   });
 
   test("terminal cancelled-group pins repair a missing sweeper continuation", async () => {
@@ -445,8 +520,16 @@ describeIf("NuQ FDB transaction-scoped migration generation hooks", () => {
 
     await new Promise(resolve => setTimeout(resolve, 1_100));
     const sweeper = new NuqFdbSweeper([queue, finishedQueue], []);
-    await sweeper.sweepOnce();
-    expect(await residue(teamId)).toMatchObject({
+    let promotedResidue = await residue(teamId);
+    for (
+      let attempt = 0;
+      attempt < 20 && promotedResidue.capacity_delayed !== 0;
+      attempt++
+    ) {
+      await sweeper.sweepOnce();
+      promotedResidue = await residue(teamId);
+    }
+    expect(promotedResidue).toMatchObject({
       capacity_ready_active: 1,
       capacity_delayed: 0,
     });

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -37,21 +37,13 @@ import {
   externalSlotMigrationObjectId,
   externalSlotsFdb,
   getNuqFdbSweeper,
-  type MigrationObjectKind,
-  type MigrationObjectPin,
   NuqFdbPgJobRemovalConflictError,
   nuqFdbMigrationStore,
   pgJobRemovalsFdb,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
-import {
-  encodeI64,
-  TIME_BUCKETS,
-} from "../../services/worker/nuq-fdb/keyspace";
-import {
-  getFdb,
-  getNuqFdbDatabase,
-} from "../../services/worker/nuq-fdb/client";
+import { TIME_BUCKETS } from "../../services/worker/nuq-fdb/keyspace";
+import { getNuqFdbDatabase } from "../../services/worker/nuq-fdb/client";
 import {
   NuQGroupPublicationConflictError,
   NuQPublicationConflictError,
@@ -68,6 +60,7 @@ import {
   reserveExternalSlot,
   scrapeQueue as routedScrapeQueue,
 } from "../../services/worker/nuq-router";
+import { clearMigrationTestTeams } from "./migration-test-cleanup";
 
 const describeIf =
   config.FDB_CLUSTER_FILE && config.NUQ_DATABASE_URL ? describe : describe.skip;
@@ -87,79 +80,7 @@ async function makeMetricsReady(): Promise<void> {
 }
 
 async function clearMigrationTeam(teamId: string): Promise<void> {
-  const pins: MigrationObjectPin[] = [];
-  let cursor: { kind: MigrationObjectKind; objectId: string } | undefined;
-  do {
-    const page = await nuqFdbMigrationStore.inspectTeamPinsPage(teamId, {
-      limit: 1000,
-      cursor,
-    });
-    pins.push(...page.pins);
-    cursor = page.nextCursor;
-  } while (cursor);
-
-  const db = getNuqFdbDatabase();
-  const fdb = getFdb();
-  await db.doTn(async tn => {
-    for (const pin of pins) {
-      tn.clear(nuqFdbMigrationStore.objectKey(pin.kind, pin.objectId));
-    }
-    // Terminal pins intentionally leave only global routing tombstones, so
-    // test cleanup must find those outside the active-only team index.
-    const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
-    const rows = await tn
-      .snapshot()
-      .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
-    const objectIds = new Set<string>();
-    for (const [key, value] of rows) {
-      const pin = JSON.parse((value as Buffer).toString());
-      if (pin.teamId === teamId) {
-        objectIds.add(pin.objectId);
-        tn.clear(key as Buffer);
-      }
-    }
-    const gc = fdb.tuple.range(["nuq-migration", 1, "gc"]);
-    const gcRows = await tn
-      .snapshot()
-      .getRangeAll(gc.begin as Buffer, gc.end as Buffer);
-    const dueCounts = fdb.tuple.range(["nuq-migration", 1, "gc", "due-count"]);
-    tn.clearRange(dueCounts.begin as Buffer, dueCounts.end as Buffer);
-    for (const [key] of gcRows) {
-      const unpacked = fdb.tuple.unpack(key as Buffer);
-      const parts = unpacked.map(String);
-      if (parts.includes(teamId) || parts.some(part => objectIds.has(part))) {
-        tn.clear(key as Buffer);
-        continue;
-      }
-      const category = String(unpacked[3]);
-      const partition = Number(unpacked[4]);
-      const dueAt = Number(unpacked[5]);
-      if (
-        (category === "pin" ||
-          category === "control" ||
-          category === "generation") &&
-        Number.isSafeInteger(partition) &&
-        Number.isSafeInteger(dueAt)
-      ) {
-        let node = BigInt(dueAt) + 1n;
-        while (node <= 1n << 53n) {
-          tn.add(
-            nuqFdbMigrationStore.pack([
-              "gc",
-              "due-count",
-              category,
-              partition,
-              node.toString(),
-            ]),
-            encodeI64(1),
-          );
-          node += node & -node;
-        }
-      }
-    }
-    const team = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-    tn.clearRange(team.begin as Buffer, team.end as Buffer);
-  });
+  await clearMigrationTestTeams([teamId]);
 }
 
 describeIf("NuQ PG publication with durable FDB authority", () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -16,6 +16,8 @@ import {
   externalSlotMigrationObjectId,
   externalSlotsFdb,
   getNuqFdbSweeper,
+  type MigrationObjectKind,
+  type MigrationObjectPin,
   NuqFdbPgJobRemovalConflictError,
   nuqFdbMigrationStore,
   pgJobRemovalsFdb,
@@ -56,15 +58,36 @@ async function makeMetricsReady(): Promise<void> {
 }
 
 async function clearMigrationTeam(teamId: string): Promise<void> {
-  const pins = await nuqFdbMigrationStore.inspectTeamPins(teamId);
+  const pins: MigrationObjectPin[] = [];
+  let cursor: { kind: MigrationObjectKind; objectId: string } | undefined;
+  do {
+    const page = await nuqFdbMigrationStore.inspectTeamPinsPage(teamId, {
+      limit: 1000,
+      cursor,
+    });
+    pins.push(...page.pins);
+    cursor = page.nextCursor;
+  } while (cursor);
+
   const db = getNuqFdbDatabase();
   const fdb = getFdb();
   await db.doTn(async tn => {
     for (const pin of pins) {
       tn.clear(nuqFdbMigrationStore.objectKey(pin.kind, pin.objectId));
     }
-    const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-    tn.clearRange(range.begin as Buffer, range.end as Buffer);
+    // Terminal pins intentionally leave only global routing tombstones, so
+    // test cleanup must find those outside the active-only team index.
+    const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
+    const rows = await tn
+      .snapshot()
+      .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
+    for (const [key, value] of rows) {
+      if (JSON.parse((value as Buffer).toString()).teamId === teamId) {
+        tn.clear(key as Buffer);
+      }
+    }
+    const team = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+    tn.clearRange(team.begin as Buffer, team.end as Buffer);
   });
 }
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -13,19 +13,33 @@ import { getRedisConnection } from "../../services/queue-service";
 import { redisEvictConnection } from "../../services/redis";
 import {
   crawlFinishedQueueFdb,
+  externalSlotMigrationObjectId,
+  externalSlotsFdb,
+  getNuqFdbSweeper,
+  NuqFdbPgJobRemovalConflictError,
   nuqFdbMigrationStore,
+  pgJobRemovalsFdb,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
+import { TIME_BUCKETS } from "../../services/worker/nuq-fdb/keyspace";
 import {
   getFdb,
   getNuqFdbDatabase,
 } from "../../services/worker/nuq-fdb/client";
 import {
+  NuQGroupPublicationConflictError,
   NuQPublicationConflictError,
+  crawlGroup as crawlGroupPg,
   nuqShutdown,
   scrapeQueue as scrapeQueuePg,
 } from "../../services/worker/nuq";
-import { scrapeQueue as routedScrapeQueue } from "../../services/worker/nuq-router";
+import {
+  crawlGroup as routedCrawlGroup,
+  isFdbTeam,
+  mirrorExternalSlotAcquire,
+  mirrorExternalSlotRelease,
+  scrapeQueue as routedScrapeQueue,
+} from "../../services/worker/nuq-router";
 
 const describeIf =
   config.FDB_CLUSTER_FILE && config.NUQ_DATABASE_URL ? describe : describe.skip;
@@ -59,6 +73,10 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
   const jobId = randomUUID();
   const conflictTeamId = randomUUID();
   const conflictJobId = randomUUID();
+  const groupTeamId = randomUUID();
+  const ambiguousGroupTeamId = randomUUID();
+  const conflictGroupTeamId = randomUUID();
+  const externalTeamId = randomUUID();
 
   beforeAll(async () => {
     config.NUQ_BACKEND = "pg";
@@ -90,6 +108,10 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     await Promise.all([
       clearMigrationTeam(teamId),
       clearMigrationTeam(conflictTeamId),
+      clearMigrationTeam(groupTeamId),
+      clearMigrationTeam(ambiguousGroupTeamId),
+      clearMigrationTeam(conflictGroupTeamId),
+      clearMigrationTeam(externalTeamId),
     ]);
     config.NUQ_BACKEND = previousBackend;
     config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
@@ -186,10 +208,51 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       data: { url: "https://example.com/original" },
     });
 
-    await routedScrapeQueue.removeJob(jobId);
+    const concurrencyKey = `concurrency-limiter:${teamId}`;
+    const beginFailure = new Error("injected durable deletion failure");
+    const beginSpy = vi
+      .spyOn(pgJobRemovalsFdb, "begin")
+      .mockRejectedValueOnce(beginFailure);
+    await expect(routedScrapeQueue.removeJob(jobId)).rejects.toBe(beginFailure);
+    beginSpy.mockRestore();
+    await expect(scrapeQueuePg.getJob(jobId)).resolves.toMatchObject({
+      id: jobId,
+    });
+    await expect(pgJobRemovalsFdb.inspect(jobId)).resolves.toBeNull();
+
+    await getRedisConnection().del(concurrencyKey);
+    await getRedisConnection().set(concurrencyKey, "inject-zrem-failure");
+    await expect(routedScrapeQueue.removeJob(jobId)).rejects.toBeInstanceOf(
+      AggregateError,
+    );
     await expect(scrapeQueuePg.getJob(jobId)).resolves.toBeNull();
     await expect(
-      getRedisConnection().zscore(`concurrency-limiter:${teamId}`, jobId),
+      getRedisConnection().get(`nuq:pg_remove_residue:${jobId}`),
+    ).resolves.not.toBeNull();
+    await expect(pgJobRemovalsFdb.inspect(jobId)).resolves.toMatchObject({
+      id: jobId,
+      ownerId: teamId,
+    });
+    await expect(
+      nuqFdbMigrationStore.inspectPin("scrape_job", jobId),
+    ).resolves.toMatchObject({ lifecycle: "active" });
+
+    // Model Redis loss after PG DELETE. The FDB descriptor still fences a
+    // same-ID publisher and gives removal enough metadata to finish cleanup.
+    await getRedisConnection().del(
+      concurrencyKey,
+      `nuq:pg_remove_residue:${jobId}`,
+    );
+    await expect(_addScrapeJobToBullMQ(data, jobId)).rejects.toBeInstanceOf(
+      NuqFdbPgJobRemovalConflictError,
+    );
+    await expect(scrapeQueuePg.getJob(jobId)).resolves.toBeNull();
+    await routedScrapeQueue.removeJob(jobId);
+    await expect(
+      getRedisConnection().get(`nuq:pg_remove_residue:${jobId}`),
+    ).resolves.toBeNull();
+    await expect(
+      getRedisConnection().zscore(concurrencyKey, jobId),
     ).resolves.toBeNull();
     await expect(
       nuqFdbMigrationStore.inspectPin("scrape_job", jobId),
@@ -197,5 +260,167 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       lifecycle: "terminal",
       residue: { capacity_ready_active: 0, intent_unresolved: 0 },
     });
+    await expect(pgJobRemovalsFdb.inspect(jobId)).resolves.toBeNull();
+  });
+
+  test("PG group stable publication reconciles existing rows and compensates only proven absence", async () => {
+    await isFdbTeam(groupTeamId);
+    const groupId = randomUUID();
+    const first = await routedCrawlGroup.addGroup(
+      groupId,
+      groupTeamId,
+      120_000,
+    );
+    const replay = await routedCrawlGroup.addGroup(
+      groupId,
+      groupTeamId,
+      120_000,
+    );
+    expect(replay).toMatchObject({
+      id: groupId,
+      ownerId: groupTeamId,
+      ttl: 120_000,
+    });
+    expect(replay.createdAt).toEqual(first.createdAt);
+    await expect(
+      routedCrawlGroup.addGroup(groupId, groupTeamId, 120_001),
+    ).rejects.toBeInstanceOf(NuQGroupPublicationConflictError);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("group", groupId),
+    ).resolves.toMatchObject({ lifecycle: "active", backend: "pg" });
+
+    await isFdbTeam(ambiguousGroupTeamId);
+    const ambiguousId = randomUUID();
+    await nuqFdbMigrationStore.preparePinnedObject({
+      teamId: ambiguousGroupTeamId,
+      kind: "group",
+      objectId: ambiguousId,
+      admission: { type: "new-root" },
+      requiredBackend: "pg",
+      residue: { intent_unresolved: 1 },
+    });
+    const published = await crawlGroupPg.addGroup(
+      ambiguousId,
+      ambiguousGroupTeamId,
+      90_000,
+    );
+    const reconciled = await routedCrawlGroup.addGroup(
+      ambiguousId,
+      ambiguousGroupTeamId,
+      90_000,
+    );
+    expect(reconciled.createdAt).toEqual(published.createdAt);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("group", ambiguousId),
+    ).resolves.toMatchObject({
+      lifecycle: "active",
+      residue: { control_groups: 1, intent_unresolved: 0 },
+    });
+
+    await isFdbTeam(conflictGroupTeamId);
+    const absentId = randomUUID();
+    const injected = new Error("injected PG publication failure");
+    const addSpy = vi.spyOn(crawlGroupPg, "addGroup");
+    addSpy.mockRejectedValueOnce(injected);
+    await expect(
+      routedCrawlGroup.addGroup(absentId, conflictGroupTeamId, 30_000),
+    ).rejects.toBe(injected);
+    addSpy.mockRestore();
+    await expect(crawlGroupPg.getGroup(absentId)).resolves.toBeNull();
+    await expect(
+      nuqFdbMigrationStore.inspectPin("group", absentId),
+    ).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { control_groups: 0, intent_unresolved: 0 },
+    });
+
+    const incompatibleId = randomUUID();
+    await crawlGroupPg.addGroup(incompatibleId, randomUUID(), 30_000);
+    await expect(
+      routedCrawlGroup.addGroup(incompatibleId, conflictGroupTeamId, 30_000),
+    ).rejects.toBeInstanceOf(NuQGroupPublicationConflictError);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("group", incompatibleId),
+    ).resolves.toMatchObject({
+      lifecycle: "prepared",
+      residue: { intent_unresolved: 1 },
+    });
+  });
+
+  test("PG external holder expiry remains durable after Redis loss and ignores stale renewal generations", async () => {
+    await isFdbTeam(externalTeamId);
+    const concurrencyKey = `concurrency-limiter:${externalTeamId}`;
+    const failedHolder = randomUUID();
+    const zaddFailure = new Error("injected zadd failure");
+    const zaddSpy = vi
+      .spyOn(getRedisConnection(), "zadd")
+      .mockRejectedValueOnce(zaddFailure);
+    await expect(
+      mirrorExternalSlotAcquire(externalTeamId, failedHolder, -1),
+    ).rejects.toBe(zaddFailure);
+    zaddSpy.mockRestore();
+    await expect(
+      nuqFdbMigrationStore.inspectPin(
+        "external_holder",
+        externalSlotMigrationObjectId(externalTeamId, failedHolder),
+      ),
+    ).resolves.toMatchObject({
+      backend: "pg",
+      lifecycle: "active",
+      residue: { capacity_external_holders: 1 },
+    });
+    await getRedisConnection().del(concurrencyKey);
+    await getNuqFdbSweeper().sweepOnce();
+    await expect(
+      nuqFdbMigrationStore.inspectPin(
+        "external_holder",
+        externalSlotMigrationObjectId(externalTeamId, failedHolder),
+      ),
+    ).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { capacity_external_holders: 0 },
+    });
+
+    const expiredHolder = randomUUID();
+    await mirrorExternalSlotAcquire(externalTeamId, expiredHolder, -1);
+    const expiredObjectId = externalSlotMigrationObjectId(
+      externalTeamId,
+      expiredHolder,
+    );
+    await getRedisConnection().del(concurrencyKey);
+    await getNuqFdbSweeper().sweepOnce();
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", expiredObjectId),
+    ).resolves.toMatchObject({
+      backend: "pg",
+      lifecycle: "terminal",
+      residue: { capacity_external_holders: 0 },
+    });
+
+    const renewedHolder = randomUUID();
+    await mirrorExternalSlotAcquire(externalTeamId, renewedHolder, -1);
+    let stale: [Buffer, Buffer] | undefined;
+    for (let bucket = 0; bucket < TIME_BUCKETS && !stale; bucket++) {
+      const range = externalSlotsFdb.pgExpiryScanRange(bucket, Date.now());
+      const rows = await getNuqFdbDatabase().doTn(async tn =>
+        tn.snapshot().getRangeAll(range.begin, range.end),
+      );
+      stale = rows[0] as [Buffer, Buffer] | undefined;
+    }
+    expect(stale).toBeDefined();
+    await mirrorExternalSlotAcquire(externalTeamId, renewedHolder, 60_000);
+    await getRedisConnection().del(concurrencyKey);
+    await getNuqFdbDatabase().doTn(async tn => tn.set(stale![0], stale![1]));
+    await getNuqFdbSweeper().sweepOnce();
+    await expect(
+      nuqFdbMigrationStore.inspectPin(
+        "external_holder",
+        externalSlotMigrationObjectId(externalTeamId, renewedHolder),
+      ),
+    ).resolves.toMatchObject({
+      lifecycle: "active",
+      residue: { capacity_external_holders: 1 },
+    });
+    await mirrorExternalSlotRelease(externalTeamId, renewedHolder);
   });
 });

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -1,11 +1,22 @@
 import { randomUUID } from "crypto";
 import { vi } from "vitest";
 
+const isolation = vi.hoisted(() => ({
+  abTestJob: vi.fn(),
+  getCrawl: vi.fn(),
+}));
+
 vi.mock("../../controllers/auth", () => ({
   getACUCTeam: vi.fn(async () => ({ flags: { nuqFdb: false } })),
 }));
 vi.mock("../../lib/deployment", () => ({ isSelfHosted: vi.fn(() => false) }));
-vi.mock("../../services/ab-test", () => ({ abTestJob: vi.fn() }));
+// Queue publication depends on crawl/scraper helpers only for unrelated crawl
+// and A/B paths. Keep those boundaries out of this real PG + Redis + FDB suite;
+// in particular, core CI intentionally installs without native scraper builds.
+vi.mock("../../lib/crawl-redis", () => ({ getCrawl: isolation.getCrawl }));
+vi.mock("../../services/ab-test", () => ({
+  abTestJob: isolation.abTestJob,
+}));
 
 import { config } from "../../config";
 import {

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -11,6 +11,7 @@ import { config } from "../../config";
 import {
   finalizeConcurrencyLimitActiveJobRollback,
   getConcurrencyLimitActiveJobsCount,
+  recoverConcurrencyLimitRollbacks,
   removeConcurrencyLimitActiveJob,
   reserveConcurrencyLimitActiveJob,
   rollbackConcurrencyLimitActiveJob,
@@ -94,8 +95,21 @@ async function clearMigrationTeam(teamId: string): Promise<void> {
     const rows = await tn
       .snapshot()
       .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
+    const objectIds = new Set<string>();
     for (const [key, value] of rows) {
-      if (JSON.parse((value as Buffer).toString()).teamId === teamId) {
+      const pin = JSON.parse((value as Buffer).toString());
+      if (pin.teamId === teamId) {
+        objectIds.add(pin.objectId);
+        tn.clear(key as Buffer);
+      }
+    }
+    const gc = fdb.tuple.range(["nuq-migration", 1, "gc"]);
+    const gcRows = await tn
+      .snapshot()
+      .getRangeAll(gc.begin as Buffer, gc.end as Buffer);
+    for (const [key] of gcRows) {
+      const parts = fdb.tuple.unpack(key as Buffer).map(String);
+      if (parts.includes(teamId) || parts.some(part => objectIds.has(part))) {
         tn.clear(key as Buffer);
       }
     }
@@ -243,6 +257,67 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       ),
     ).resolves.toBe(false);
     await removeConcurrencyLimitActiveJob(capacityTeamId, replacementHolder);
+  });
+
+  test("bounded rollback recovery needs no holder retry and fences a replacement", async () => {
+    const abandoned = randomUUID();
+    const first = await reserveConcurrencyLimitActiveJob(
+      capacityTeamId,
+      abandoned,
+      3,
+      30_000,
+    );
+    expect(first.rollbackToken).toEqual(expect.any(String));
+    await expect(
+      rollbackConcurrencyLimitActiveJob(
+        capacityTeamId,
+        abandoned,
+        first.rollbackToken!,
+        30_000,
+      ),
+    ).resolves.toBe(true);
+    await expect(recoverConcurrencyLimitRollbacks(100)).resolves.toMatchObject({
+      finalized: expect.any(Number),
+    });
+    await expect(
+      getRedisConnection().get(
+        `concurrency-limiter:${capacityTeamId}:reservation:${abandoned}`,
+      ),
+    ).resolves.toBeNull();
+
+    const raced = randomUUID();
+    const racedReservation = await reserveConcurrencyLimitActiveJob(
+      capacityTeamId,
+      raced,
+      3,
+      30_000,
+    );
+    await rollbackConcurrencyLimitActiveJob(
+      capacityTeamId,
+      raced,
+      racedReservation.rollbackToken!,
+      30_000,
+    );
+    const redis = getRedisConnection();
+    await redis.zadd(
+      `concurrency-limiter:${capacityTeamId}`,
+      Date.now() + 30_000,
+      raced,
+    );
+    await redis.set(
+      `concurrency-limiter:${capacityTeamId}:reservation:${raced}`,
+      "held",
+      "PX",
+      30_000,
+    );
+    await recoverConcurrencyLimitRollbacks(100);
+    await expect(
+      redis.zscore(`concurrency-limiter:${capacityTeamId}`, raced),
+    ).resolves.not.toBeNull();
+    await expect(
+      redis.get(`concurrency-limiter:${capacityTeamId}:reservation:${raced}`),
+    ).resolves.toBe("held");
+    await removeConcurrencyLimitActiveJob(capacityTeamId, raced);
   });
 
   test("PG queue and external admissions share one atomic capacity ledger", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../services/ab-test", () => ({ abTestJob: vi.fn() }));
 import { config } from "../../config";
 import { _addScrapeJobToBullMQ } from "../../services/queue-jobs";
 import { getRedisConnection } from "../../services/queue-service";
+import { redisEvictConnection } from "../../services/redis";
 import {
   crawlFinishedQueueFdb,
   nuqFdbMigrationStore,
@@ -64,9 +65,11 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     await getRedisConnection().del(
       `concurrency-limiter:${teamId}`,
       `nuq:pg-reservation:team:${teamId}:${jobId}`,
+      `nuq:job_backend:${jobId}`,
       `concurrency-limiter:${conflictTeamId}`,
       `nuq:pg-reservation:team:${conflictTeamId}:${conflictJobId}`,
     );
+    await redisEvictConnection.del(`nuq:job_backend:${jobId}`);
   });
 
   afterAll(async () => {
@@ -77,9 +80,11 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     await getRedisConnection().del(
       `concurrency-limiter:${teamId}`,
       `nuq:pg-reservation:team:${teamId}:${jobId}`,
+      `nuq:job_backend:${jobId}`,
       `concurrency-limiter:${conflictTeamId}`,
       `nuq:pg-reservation:team:${conflictTeamId}:${conflictJobId}`,
     );
+    await redisEvictConnection.del(`nuq:job_backend:${jobId}`);
     await Promise.all([
       clearMigrationTeam(teamId),
       clearMigrationTeam(conflictTeamId),
@@ -149,6 +154,18 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     expect(
       await getRedisConnection().zscore(`concurrency-limiter:${teamId}`, jobId),
     ).not.toBeNull();
+
+    const markerKey = `nuq:job_backend:${jobId}`;
+    await redisEvictConnection.set(markerKey, "corrupt");
+    await expect(routedScrapeQueue.getJob(jobId)).resolves.toMatchObject({
+      id: jobId,
+    });
+    await expect(redisEvictConnection.get(markerKey)).resolves.toBe("pg");
+    await redisEvictConnection.del(markerKey);
+    await expect(routedScrapeQueue.getJob(jobId)).resolves.toMatchObject({
+      id: jobId,
+    });
+    await expect(redisEvictConnection.get(markerKey)).resolves.toBe("pg");
 
     await expect(
       _addScrapeJobToBullMQ(

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "crypto";
+import { vi } from "vitest";
+
+vi.mock("../../controllers/auth", () => ({
+  getACUCTeam: vi.fn(async () => ({ flags: { nuqFdb: false } })),
+}));
+vi.mock("../../lib/deployment", () => ({ isSelfHosted: vi.fn(() => false) }));
+vi.mock("../../services/ab-test", () => ({ abTestJob: vi.fn() }));
+
+import { config } from "../../config";
+import { _addScrapeJobToBullMQ } from "../../services/queue-jobs";
+import { getRedisConnection } from "../../services/queue-service";
+import {
+  crawlFinishedQueueFdb,
+  nuqFdbMigrationStore,
+  scrapeQueueFdb,
+} from "../../services/worker/nuq-fdb";
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+import {
+  NuQPublicationConflictError,
+  nuqShutdown,
+  scrapeQueue as scrapeQueuePg,
+} from "../../services/worker/nuq";
+import { scrapeQueue as routedScrapeQueue } from "../../services/worker/nuq-router";
+
+const describeIf =
+  config.FDB_CLUSTER_FILE && config.NUQ_DATABASE_URL ? describe : describe.skip;
+const previousBackend = config.NUQ_BACKEND;
+
+async function makeMetricsReady(): Promise<void> {
+  for (const queue of [scrapeQueueFdb, crawlFinishedQueueFdb]) {
+    await queue.beginMetricCounterBackfill();
+    while (!(await queue.backfillMetricCounts(100))) {
+      // bounded pages
+    }
+  }
+}
+
+async function clearMigrationTeam(teamId: string): Promise<void> {
+  const pins = await nuqFdbMigrationStore.inspectTeamPins(teamId);
+  const db = getNuqFdbDatabase();
+  const fdb = getFdb();
+  await db.doTn(async tn => {
+    for (const pin of pins) {
+      tn.clear(nuqFdbMigrationStore.objectKey(pin.kind, pin.objectId));
+    }
+    const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+    tn.clearRange(range.begin as Buffer, range.end as Buffer);
+  });
+}
+
+describeIf("NuQ PG publication with durable FDB authority", () => {
+  const teamId = randomUUID();
+  const jobId = randomUUID();
+  const conflictTeamId = randomUUID();
+  const conflictJobId = randomUUID();
+
+  beforeAll(async () => {
+    config.NUQ_BACKEND = "pg";
+    await makeMetricsReady();
+    await getRedisConnection().del(
+      `concurrency-limiter:${teamId}`,
+      `nuq:pg-reservation:team:${teamId}:${jobId}`,
+      `concurrency-limiter:${conflictTeamId}`,
+      `nuq:pg-reservation:team:${conflictTeamId}:${conflictJobId}`,
+    );
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      scrapeQueuePg.removeJob(jobId).catch(() => undefined),
+      scrapeQueuePg.removeJob(conflictJobId).catch(() => undefined),
+    ]);
+    await getRedisConnection().del(
+      `concurrency-limiter:${teamId}`,
+      `nuq:pg-reservation:team:${teamId}:${jobId}`,
+      `concurrency-limiter:${conflictTeamId}`,
+      `nuq:pg-reservation:team:${conflictTeamId}:${conflictJobId}`,
+    );
+    await Promise.all([
+      clearMigrationTeam(teamId),
+      clearMigrationTeam(conflictTeamId),
+    ]);
+    config.NUQ_BACKEND = previousBackend;
+    await nuqShutdown();
+  });
+
+  test("a pre-commit PG conflict rolls back owned Redis reservation and its prepared intent", async () => {
+    const original = {
+      mode: "single_urls",
+      url: "https://example.com/legacy-row",
+      team_id: conflictTeamId,
+    } as any;
+    await scrapeQueuePg.addJob(conflictJobId, original, {
+      ownerId: conflictTeamId,
+    });
+
+    await expect(
+      _addScrapeJobToBullMQ(
+        { ...original, url: "https://example.com/incompatible" },
+        conflictJobId,
+      ),
+    ).rejects.toBeInstanceOf(NuQPublicationConflictError);
+    await expect(
+      getRedisConnection().zscore(
+        `concurrency-limiter:${conflictTeamId}`,
+        conflictJobId,
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      nuqFdbMigrationStore.inspectPin("scrape_job", conflictJobId),
+    ).resolves.toMatchObject({
+      backend: "pg",
+      lifecycle: "terminal",
+      residue: { capacity_ready_active: 0, intent_unresolved: 0 },
+    });
+    await expect(scrapeQueuePg.getJob(conflictJobId)).resolves.toMatchObject({
+      data: { url: "https://example.com/legacy-row" },
+    });
+  });
+
+  test("stable publish, incompatible retry compensation, and removal preserve one durable generation", async () => {
+    const data = {
+      mode: "single_urls",
+      url: "https://example.com/original",
+      team_id: teamId,
+    } as any;
+
+    const first = await _addScrapeJobToBullMQ(data, jobId);
+    expect(first.id).toBe(jobId);
+    await expect(_addScrapeJobToBullMQ(data, jobId)).resolves.toMatchObject({
+      id: jobId,
+    });
+
+    const activePin = await nuqFdbMigrationStore.inspectPin(
+      "scrape_job",
+      jobId,
+    );
+    expect(activePin).toMatchObject({
+      teamId,
+      backend: "pg",
+      generation: 1,
+      lifecycle: "active",
+      residue: { capacity_ready_active: 1, intent_unresolved: 0 },
+    });
+    expect(
+      await getRedisConnection().zscore(`concurrency-limiter:${teamId}`, jobId),
+    ).not.toBeNull();
+
+    await expect(
+      _addScrapeJobToBullMQ(
+        { ...data, url: "https://example.com/conflict" },
+        jobId,
+      ),
+    ).rejects.toBeInstanceOf(NuQPublicationConflictError);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("scrape_job", jobId),
+    ).resolves.toMatchObject({
+      lifecycle: "active",
+      residue: { capacity_ready_active: 1 },
+    });
+    await expect(scrapeQueuePg.getJob(jobId)).resolves.toMatchObject({
+      data: { url: "https://example.com/original" },
+    });
+
+    await routedScrapeQueue.removeJob(jobId);
+    await expect(scrapeQueuePg.getJob(jobId)).resolves.toBeNull();
+    await expect(
+      getRedisConnection().zscore(`concurrency-limiter:${teamId}`, jobId),
+    ).resolves.toBeNull();
+    await expect(
+      nuqFdbMigrationStore.inspectPin("scrape_job", jobId),
+    ).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { capacity_ready_active: 0, intent_unresolved: 0 },
+    });
+  });
+});

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -30,6 +30,7 @@ import { scrapeQueue as routedScrapeQueue } from "../../services/worker/nuq-rout
 const describeIf =
   config.FDB_CLUSTER_FILE && config.NUQ_DATABASE_URL ? describe : describe.skip;
 const previousBackend = config.NUQ_BACKEND;
+const previousMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
 
 async function makeMetricsReady(): Promise<void> {
   for (const queue of [scrapeQueueFdb, crawlFinishedQueueFdb]) {
@@ -61,6 +62,7 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
 
   beforeAll(async () => {
     config.NUQ_BACKEND = "pg";
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
     await makeMetricsReady();
     await getRedisConnection().del(
       `concurrency-limiter:${teamId}`,
@@ -90,6 +92,7 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       clearMigrationTeam(conflictTeamId),
     ]);
     config.NUQ_BACKEND = previousBackend;
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
     await nuqShutdown();
   });
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -11,6 +11,7 @@ import { config } from "../../config";
 import {
   finalizeConcurrencyLimitActiveJobRollback,
   getConcurrencyLimitActiveJobsCount,
+  getConcurrencyRollbackCleanupBacklog,
   recoverConcurrencyLimitRollbacks,
   removeConcurrencyLimitActiveJob,
   reserveConcurrencyLimitActiveJob,
@@ -32,7 +33,10 @@ import {
   pgJobRemovalsFdb,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
-import { TIME_BUCKETS } from "../../services/worker/nuq-fdb/keyspace";
+import {
+  encodeI64,
+  TIME_BUCKETS,
+} from "../../services/worker/nuq-fdb/keyspace";
 import {
   getFdb,
   getNuqFdbDatabase,
@@ -107,10 +111,39 @@ async function clearMigrationTeam(teamId: string): Promise<void> {
     const gcRows = await tn
       .snapshot()
       .getRangeAll(gc.begin as Buffer, gc.end as Buffer);
+    const dueCounts = fdb.tuple.range(["nuq-migration", 1, "gc", "due-count"]);
+    tn.clearRange(dueCounts.begin as Buffer, dueCounts.end as Buffer);
     for (const [key] of gcRows) {
-      const parts = fdb.tuple.unpack(key as Buffer).map(String);
+      const unpacked = fdb.tuple.unpack(key as Buffer);
+      const parts = unpacked.map(String);
       if (parts.includes(teamId) || parts.some(part => objectIds.has(part))) {
         tn.clear(key as Buffer);
+        continue;
+      }
+      const category = String(unpacked[3]);
+      const partition = Number(unpacked[4]);
+      const dueAt = Number(unpacked[5]);
+      if (
+        (category === "pin" ||
+          category === "control" ||
+          category === "generation") &&
+        Number.isSafeInteger(partition) &&
+        Number.isSafeInteger(dueAt)
+      ) {
+        let node = BigInt(dueAt) + 1n;
+        while (node <= 1n << 53n) {
+          tn.add(
+            nuqFdbMigrationStore.pack([
+              "gc",
+              "due-count",
+              category,
+              partition,
+              node.toString(),
+            ]),
+            encodeI64(1),
+          );
+          node += node & -node;
+        }
       }
     }
     const team = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
@@ -581,6 +614,46 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       lifecycle: "prepared",
       residue: { intent_unresolved: 1 },
     });
+  });
+
+  test("sustained Redis rollback cleanup drains multiple bounded pages", async () => {
+    const redis = getRedisConnection();
+    const queue = "concurrency-rollback-cleanup:v1";
+    await redis.del(queue);
+    const now = Date.now();
+    const entries = Array.from({ length: 250 }, (_, index) => {
+      const teamId = `${externalTeamId}-cleanup-${index}`;
+      const id = `holder-${index}`;
+      const token = `token-${index}`;
+      return {
+        member: JSON.stringify({ v: 1, teamId, id, token }),
+        marker: `concurrency-limiter:${teamId}:reservation:${id}`,
+        token,
+      };
+    });
+    const publish = redis.pipeline();
+    for (const entry of entries) {
+      publish.set(entry.marker, `cleanup:${entry.token}`, "PX", 60_000);
+      publish.zadd(queue, now - 1, entry.member);
+    }
+    await publish.exec();
+
+    await expect(
+      getConcurrencyRollbackCleanupBacklog(now),
+    ).resolves.toMatchObject({ due: 250 });
+    const pageSizes: number[] = [];
+    while ((await getConcurrencyRollbackCleanupBacklog(now)).due > 0) {
+      const page = await recoverConcurrencyLimitRollbacks(100);
+      pageSizes.push(page.read);
+      expect(page.read).toBeLessThanOrEqual(100);
+    }
+    expect(pageSizes).toEqual([100, 100, 50]);
+    await expect(
+      getConcurrencyRollbackCleanupBacklog(now),
+    ).resolves.toMatchObject({ total: 0, due: 0, oldestDueAt: null });
+    expect(await redis.mget(...entries.map(entry => entry.marker))).toEqual(
+      Array.from({ length: entries.length }, () => null),
+    );
   });
 
   test("PG external holder expiry remains durable after Redis loss and ignores stale renewal generations", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -19,6 +19,7 @@ import { getRedisConnection } from "../../services/queue-service";
 import { redisEvictConnection } from "../../services/redis";
 import {
   crawlFinishedQueueFdb,
+  crawlGroupFdb,
   externalSlotMigrationObjectId,
   externalSlotsFdb,
   getNuqFdbSweeper,
@@ -46,6 +47,7 @@ import {
   isFdbTeam,
   mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  renewExternalSlot,
   scrapeQueue as routedScrapeQueue,
 } from "../../services/worker/nuq-router";
 
@@ -60,6 +62,9 @@ async function makeMetricsReady(): Promise<void> {
     while (!(await queue.backfillMetricCounts(100))) {
       // bounded pages
     }
+  }
+  while (!(await crawlGroupFdb.backfillLegacyOwnerIndex(100))) {
+    // bounded pages
   }
 }
 
@@ -456,9 +461,9 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     await isFdbTeam(externalTeamId);
     const concurrencyKey = `concurrency-limiter:${externalTeamId}`;
     const failedHolder = randomUUID();
-    const zaddFailure = new Error("injected zadd failure");
+    const zaddFailure = new Error("injected Redis publication failure");
     const zaddSpy = vi
-      .spyOn(getRedisConnection(), "zadd")
+      .spyOn(getRedisConnection(), "eval")
       .mockRejectedValueOnce(zaddFailure);
     await expect(
       mirrorExternalSlotAcquire(externalTeamId, failedHolder, -1),
@@ -503,7 +508,14 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     });
 
     const renewedHolder = randomUUID();
-    await mirrorExternalSlotAcquire(externalTeamId, renewedHolder, -1);
+    await mirrorExternalSlotAcquire(externalTeamId, renewedHolder, 60_000);
+    // Force the durable deadline due while the Redis holder remains live, then
+    // exercise the heartbeat renewal path that publishes a fresh generation.
+    await externalSlotsFdb.renewPg(
+      externalTeamId,
+      renewedHolder,
+      Date.now() - 1,
+    );
     let stale: [Buffer, Buffer] | undefined;
     for (let bucket = 0; bucket < TIME_BUCKETS && !stale; bucket++) {
       const range = externalSlotsFdb.pgExpiryScanRange(bucket, Date.now());
@@ -513,7 +525,9 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       stale = rows[0] as [Buffer, Buffer] | undefined;
     }
     expect(stale).toBeDefined();
-    await mirrorExternalSlotAcquire(externalTeamId, renewedHolder, 60_000);
+    await expect(
+      renewExternalSlot(externalTeamId, renewedHolder, 60_000),
+    ).resolves.toBe(true);
     await getRedisConnection().del(concurrencyKey);
     await getNuqFdbDatabase().doTn(async tn => tn.set(stale![0], stale![1]));
     await getNuqFdbSweeper().sweepOnce();

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -10,11 +10,12 @@ vi.mock("../../services/ab-test", () => ({ abTestJob: vi.fn() }));
 import { config } from "../../config";
 import {
   finalizeConcurrencyLimitActiveJobRollback,
+  getConcurrencyLimitActiveJobsCount,
   removeConcurrencyLimitActiveJob,
   reserveConcurrencyLimitActiveJob,
   rollbackConcurrencyLimitActiveJob,
 } from "../../lib/concurrency-redis";
-import { _addScrapeJobToBullMQ } from "../../services/queue-jobs";
+import { _addScrapeJobToBullMQ, addScrapeJob } from "../../services/queue-jobs";
 import { getRedisConnection } from "../../services/queue-service";
 import { redisEvictConnection } from "../../services/redis";
 import {
@@ -48,6 +49,7 @@ import {
   mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
   renewExternalSlot,
+  reserveExternalSlot,
   scrapeQueue as routedScrapeQueue,
 } from "../../services/worker/nuq-router";
 
@@ -225,7 +227,56 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       newlyAcquired: true,
       rollbackToken: expect.any(String),
     });
+    await expect(
+      reserveConcurrencyLimitActiveJob(
+        capacityTeamId,
+        replacementHolder,
+        3,
+        30_000,
+      ),
+    ).resolves.toMatchObject({ newlyAcquired: false });
+    await expect(
+      rollbackConcurrencyLimitActiveJob(
+        capacityTeamId,
+        replacementHolder,
+        reacquired.rollbackToken!,
+      ),
+    ).resolves.toBe(false);
     await removeConcurrencyLimitActiveJob(capacityTeamId, replacementHolder);
+  });
+
+  test("PG queue and external admissions share one atomic capacity ledger", async () => {
+    const capacityTeam = randomUUID();
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+    const holderId = randomUUID();
+    await makeMetricsReady();
+    await expect(isFdbTeam(capacityTeam)).resolves.toBe(false);
+    const data = (id: string) =>
+      ({
+        mode: "single_urls",
+        url: `https://example.com/${id}`,
+        team_id: capacityTeam,
+        scrapeOptions: { formats: [] },
+      }) as any;
+
+    const [first, second, external] = await Promise.all([
+      addScrapeJob(data(firstId), firstId),
+      addScrapeJob(data(secondId), secondId),
+      reserveExternalSlot(capacityTeam, holderId, 60_000, 2),
+    ]);
+    expect(await getConcurrencyLimitActiveJobsCount(capacityTeam)).toBe(2);
+    expect([first, second].filter(Boolean).length + Number(external)).toBe(2);
+
+    if (external) await mirrorExternalSlotRelease(capacityTeam, holderId);
+    await scrapeQueuePg.removeJobs([firstId, secondId]);
+    await getRedisConnection().del(
+      `concurrency-limiter:${capacityTeam}`,
+      `concurrency-limit-queue:${capacityTeam}`,
+      `cq-job:${firstId}`,
+      `cq-job:${secondId}`,
+    );
+    await clearMigrationTeam(capacityTeam);
   });
 
   test("a pre-commit PG conflict rolls back owned Redis reservation and its prepared intent", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-pg-integration.test.ts
@@ -8,6 +8,12 @@ vi.mock("../../lib/deployment", () => ({ isSelfHosted: vi.fn(() => false) }));
 vi.mock("../../services/ab-test", () => ({ abTestJob: vi.fn() }));
 
 import { config } from "../../config";
+import {
+  finalizeConcurrencyLimitActiveJobRollback,
+  removeConcurrencyLimitActiveJob,
+  reserveConcurrencyLimitActiveJob,
+  rollbackConcurrencyLimitActiveJob,
+} from "../../lib/concurrency-redis";
 import { _addScrapeJobToBullMQ } from "../../services/queue-jobs";
 import { getRedisConnection } from "../../services/queue-service";
 import { redisEvictConnection } from "../../services/redis";
@@ -100,6 +106,7 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
   const ambiguousGroupTeamId = randomUUID();
   const conflictGroupTeamId = randomUUID();
   const externalTeamId = randomUUID();
+  const capacityTeamId = randomUUID();
 
   beforeAll(async () => {
     config.NUQ_BACKEND = "pg";
@@ -111,6 +118,7 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       `nuq:job_backend:${jobId}`,
       `concurrency-limiter:${conflictTeamId}`,
       `nuq:pg-reservation:team:${conflictTeamId}:${conflictJobId}`,
+      `concurrency-limiter:${capacityTeamId}`,
     );
     await redisEvictConnection.del(`nuq:job_backend:${jobId}`);
   });
@@ -126,6 +134,7 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
       `nuq:job_backend:${jobId}`,
       `concurrency-limiter:${conflictTeamId}`,
       `nuq:pg-reservation:team:${conflictTeamId}:${conflictJobId}`,
+      `concurrency-limiter:${capacityTeamId}`,
     );
     await redisEvictConnection.del(`nuq:job_backend:${jobId}`);
     await Promise.all([
@@ -139,6 +148,79 @@ describeIf("NuQ PG publication with durable FDB authority", () => {
     config.NUQ_BACKEND = previousBackend;
     config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
     await nuqShutdown();
+  });
+
+  test("concurrent Redis holder reservations serialize at the team limit", async () => {
+    const holders = Array.from({ length: 32 }, () => randomUUID());
+    const results = await Promise.all(
+      holders.map(holder =>
+        reserveConcurrencyLimitActiveJob(capacityTeamId, holder, 3, 30_000),
+      ),
+    );
+    const admitted = holders.filter((_, index) => results[index].reserved);
+
+    expect(admitted).toHaveLength(3);
+    expect(results.filter(result => result.newlyAcquired)).toHaveLength(3);
+    await expect(
+      reserveConcurrencyLimitActiveJob(capacityTeamId, admitted[0], 3, 30_000),
+    ).resolves.toEqual({
+      reserved: true,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: null,
+    });
+
+    await Promise.all(
+      admitted.map(holder =>
+        removeConcurrencyLimitActiveJob(capacityTeamId, holder),
+      ),
+    );
+    const replacementHolder = randomUUID();
+    const replacement = await reserveConcurrencyLimitActiveJob(
+      capacityTeamId,
+      replacementHolder,
+      3,
+      30_000,
+    );
+    expect(replacement).toMatchObject({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: expect.any(String),
+    });
+    await expect(
+      rollbackConcurrencyLimitActiveJob(
+        capacityTeamId,
+        replacementHolder,
+        replacement.rollbackToken!,
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      reserveConcurrencyLimitActiveJob(
+        capacityTeamId,
+        replacementHolder,
+        3,
+        30_000,
+      ),
+    ).resolves.toMatchObject({ reserved: false });
+    await expect(
+      finalizeConcurrencyLimitActiveJobRollback(
+        capacityTeamId,
+        replacementHolder,
+        replacement.rollbackToken!,
+      ),
+    ).resolves.toBe(true);
+    const reacquired = await reserveConcurrencyLimitActiveJob(
+      capacityTeamId,
+      replacementHolder,
+      3,
+      30_000,
+    );
+    expect(reacquired).toMatchObject({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: expect.any(String),
+    });
+    await removeConcurrencyLimitActiveJob(capacityTeamId, replacementHolder);
   });
 
   test("a pre-commit PG conflict rolls back owned Redis reservation and its prepared intent", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -321,7 +321,7 @@ describeIf("NuQ durable migration router", () => {
       [],
     );
     let finished = await crawlFinishedQueueFdb.getJobToProcess();
-    for (let attempt = 0; attempt < 5 && !finished; attempt++) {
+    for (let attempt = 0; attempt < 20 && !finished; attempt++) {
       await sweeper.sweepOnce();
       finished = await crawlFinishedQueueFdb.getJobToProcess();
     }

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -75,56 +75,18 @@ import {
   crawlGroupFdb,
   externalSlotMigrationObjectId,
   externalSlotsFdb,
-  type MigrationObjectKind,
-  type MigrationObjectPin,
   NuqFdbSweeper,
   nuqFdbMigrationStore,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
-import {
-  getFdb,
-  getNuqFdbDatabase,
-} from "../../services/worker/nuq-fdb/client";
+import { getNuqFdbDatabase } from "../../services/worker/nuq-fdb/client";
 import { decodeJson, timeBucket } from "../../services/worker/nuq-fdb/keyspace";
+import { clearMigrationTestTeams } from "./migration-test-cleanup";
 
 const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 const teams = new Set<string>();
 const previousBackend = config.NUQ_BACKEND;
 const previousMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
-
-async function clearTeam(teamId: string): Promise<void> {
-  const pins: MigrationObjectPin[] = [];
-  let cursor: { kind: MigrationObjectKind; objectId: string } | undefined;
-  do {
-    const page = await nuqFdbMigrationStore.inspectTeamPinsPage(teamId, {
-      limit: 1000,
-      cursor,
-    });
-    pins.push(...page.pins);
-    cursor = page.nextCursor;
-  } while (cursor);
-
-  const fdb = getFdb();
-  const db = getNuqFdbDatabase();
-  await db.doTn(async tn => {
-    for (const pin of pins) {
-      tn.clear(nuqFdbMigrationStore.objectKey(pin.kind, pin.objectId));
-    }
-    // Terminal pins intentionally leave only global routing tombstones, so
-    // test cleanup must find those outside the active-only team index.
-    const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
-    const rows = await tn
-      .snapshot()
-      .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
-    for (const [key, value] of rows) {
-      if (JSON.parse((value as Buffer).toString()).teamId === teamId) {
-        tn.clear(key as Buffer);
-      }
-    }
-    const team = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-    tn.clearRange(team.begin as Buffer, team.end as Buffer);
-  });
-}
 
 async function makeMetricsReady(): Promise<void> {
   for (const queue of [scrapeQueueFdb, crawlFinishedQueueFdb]) {
@@ -198,7 +160,7 @@ describeIf("NuQ durable migration router", () => {
     controls.pgResidue = 0;
     config.NUQ_BACKEND = previousBackend;
     config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
-    for (const teamId of teams) await clearTeam(teamId);
+    await clearMigrationTestTeams(teams);
   });
 
   test("freezes authority initialization until both corrected-core counters are ready", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "crypto";
+import { vi } from "vitest";
+
+const controls = vi.hoisted(() => ({ fdbFlag: false, pgResidue: 0 }));
+
+vi.mock("../../controllers/auth", () => ({
+  getACUCTeam: vi.fn(async () => ({ flags: { nuqFdb: controls.fdbFlag } })),
+}));
+vi.mock("../../lib/deployment", () => ({ isSelfHosted: vi.fn(() => false) }));
+vi.mock("../../services/worker/nuq", () => {
+  const queue = {
+    getJob: vi.fn().mockResolvedValue(null),
+    getJobs: vi.fn().mockResolvedValue([]),
+    getJobsFromBacklog: vi.fn().mockResolvedValue([]),
+    getJobToProcess: vi.fn().mockResolvedValue(null),
+  };
+  return {
+    scrapeQueue: queue,
+    crawlFinishedQueue: queue,
+    crawlGroup: {
+      getGroup: vi.fn().mockResolvedValue(null),
+      getOngoingByOwner: vi.fn().mockResolvedValue([]),
+    },
+    getNuQPgOwnerLiveResidue: vi.fn(async () => ({
+      scrape: controls.pgResidue,
+      backlog: 0,
+      groups: 0,
+      crawlFinished: 0,
+      total: controls.pgResidue,
+    })),
+  };
+});
+vi.mock("../../lib/concurrency-redis", () => ({
+  getTeamQueueLimit: vi.fn().mockResolvedValue(100),
+  getConcurrencyLimitActiveJobsCount: vi.fn().mockResolvedValue(0),
+  pushConcurrencyLimitActiveJob: vi.fn(),
+  removeConcurrencyLimitActiveJob: vi.fn(),
+  constructConcurrencyLimitKey: vi.fn((teamId: string) => `limit:${teamId}`),
+}));
+
+import { config } from "../../config";
+import { isFdbTeam } from "../../services/worker/nuq-router";
+import {
+  crawlFinishedQueueFdb,
+  nuqFdbMigrationStore,
+  scrapeQueueFdb,
+} from "../../services/worker/nuq-fdb";
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+
+const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
+const teams = new Set<string>();
+const previousBackend = config.NUQ_BACKEND;
+
+async function clearTeam(teamId: string): Promise<void> {
+  const pins = await nuqFdbMigrationStore.inspectTeamPins(teamId);
+  const fdb = getFdb();
+  const db = getNuqFdbDatabase();
+  await db.doTn(async tn => {
+    for (const pin of pins) {
+      tn.clear(nuqFdbMigrationStore.objectKey(pin.kind, pin.objectId));
+    }
+    const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+    tn.clearRange(range.begin as Buffer, range.end as Buffer);
+  });
+}
+
+async function makeMetricsReady(): Promise<void> {
+  for (const queue of [scrapeQueueFdb, crawlFinishedQueueFdb]) {
+    await queue.beginMetricCounterBackfill();
+    while (!(await queue.backfillMetricCounts(100))) {
+      // bounded pages; queues are empty in this focused suite
+    }
+  }
+}
+
+describeIf("NuQ durable migration router", () => {
+  beforeAll(async () => {
+    config.NUQ_BACKEND = "pg";
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await Promise.all([
+      scrapeQueueFdb.invalidateMetricCounterGeneration(),
+      crawlFinishedQueueFdb.invalidateMetricCounterGeneration(),
+    ]);
+  });
+
+  afterAll(async () => {
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    config.NUQ_BACKEND = previousBackend;
+    for (const teamId of teams) await clearTeam(teamId);
+  });
+
+  test("freezes authority initialization until both corrected-core counters are ready", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_FDB_CORE_METRICS_NOT_READY",
+      retryable: true,
+    });
+    await expect(nuqFdbMigrationStore.inspectState(teamId)).resolves.toBeNull();
+
+    await makeMetricsReady();
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      activeBackend: "pg",
+      activeGeneration: 1,
+      phase: "PG_ONLY",
+    });
+  });
+
+  test("durable source residue blocks seal until the authoritative ledger drains", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 1;
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
+    controls.fdbFlag = true;
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+    });
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_RESIDUE_NOT_EMPTY",
+      retryable: true,
+    });
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "DRAINING_TO_FDB",
+      activeBackend: "pg",
+    });
+
+    controls.pgResidue = 0;
+    await expect(isFdbTeam(teamId)).resolves.toBe(true);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "FDB_ONLY",
+      activeBackend: "fdb",
+    });
+  });
+
+  test("pause/drain seals both directions and a flag flap burns its target generation", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
+    controls.fdbFlag = true;
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+      retryable: true,
+    });
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "DRAINING_TO_FDB",
+      targetGeneration: 2,
+    });
+
+    controls.fdbFlag = false;
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "PG_ONLY",
+      activeGeneration: 1,
+      maxGeneration: 2,
+    });
+
+    controls.fdbFlag = true;
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+    });
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "DRAINING_TO_FDB",
+      targetGeneration: 3,
+    });
+    await expect(isFdbTeam(teamId)).resolves.toBe(true);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "FDB_ONLY",
+      activeGeneration: 3,
+      maxGeneration: 3,
+    });
+
+    controls.fdbFlag = false;
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+    });
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      phase: "PG_ONLY",
+      activeGeneration: 4,
+      maxGeneration: 4,
+    });
+  });
+});

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -51,6 +51,8 @@ import {
   crawlGroupFdb,
   externalSlotMigrationObjectId,
   externalSlotsFdb,
+  type MigrationObjectKind,
+  type MigrationObjectPin,
   NuqFdbSweeper,
   nuqFdbMigrationStore,
   scrapeQueueFdb,
@@ -66,15 +68,36 @@ const previousBackend = config.NUQ_BACKEND;
 const previousMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
 
 async function clearTeam(teamId: string): Promise<void> {
-  const pins = await nuqFdbMigrationStore.inspectTeamPins(teamId);
+  const pins: MigrationObjectPin[] = [];
+  let cursor: { kind: MigrationObjectKind; objectId: string } | undefined;
+  do {
+    const page = await nuqFdbMigrationStore.inspectTeamPinsPage(teamId, {
+      limit: 1000,
+      cursor,
+    });
+    pins.push(...page.pins);
+    cursor = page.nextCursor;
+  } while (cursor);
+
   const fdb = getFdb();
   const db = getNuqFdbDatabase();
   await db.doTn(async tn => {
     for (const pin of pins) {
       tn.clear(nuqFdbMigrationStore.objectKey(pin.kind, pin.objectId));
     }
-    const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-    tn.clearRange(range.begin as Buffer, range.end as Buffer);
+    // Terminal pins intentionally leave only global routing tombstones, so
+    // test cleanup must find those outside the active-only team index.
+    const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
+    const rows = await tn
+      .snapshot()
+      .getRangeAll(objects.begin as Buffer, objects.end as Buffer);
+    for (const [key, value] of rows) {
+      if (JSON.parse((value as Buffer).toString()).teamId === teamId) {
+        tn.clear(key as Buffer);
+      }
+    }
+    const team = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+    tn.clearRange(team.begin as Buffer, team.end as Buffer);
   });
 }
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -85,6 +85,7 @@ import {
   getFdb,
   getNuqFdbDatabase,
 } from "../../services/worker/nuq-fdb/client";
+import { decodeJson, timeBucket } from "../../services/worker/nuq-fdb/keyspace";
 
 const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 const teams = new Set<string>();
@@ -134,6 +135,49 @@ async function makeMetricsReady(): Promise<void> {
   }
   while (!(await crawlGroupFdb.backfillLegacyOwnerIndex(100))) {
     // bounded pages
+  }
+}
+
+async function waitForGroupMaintenanceLeaseExpiry(
+  groupId: string,
+): Promise<void> {
+  const db = getNuqFdbDatabase();
+  const bucket = timeBucket(groupId);
+  const keys = [
+    scrapeQueueFdb.ks.sweeperPartition("group-cancel", bucket),
+    scrapeQueueFdb.ks.sweeperPartition("group-finish", bucket),
+  ];
+  let waitDeadline: number | null = null;
+
+  while (true) {
+    const expiresAt = await db.doTn(async tn =>
+      Promise.all(
+        keys.map(
+          async key =>
+            decodeJson<{ x: number }>(await tn.snapshot().get(key))?.x ?? 0,
+        ),
+      ),
+    );
+    const now = Date.now();
+    const latestActiveLease = Math.max(...expiresAt.filter(at => at > now), 0);
+    if (latestActiveLease === 0) return;
+
+    // A prior test process may have exited immediately after a full sweep,
+    // leaving these exact partitions fenced for the remainder of their
+    // protocol lease. Wait for that recorded deadline rather than racing it
+    // with a fixed number of rapid sweeps. A live owner renewing the lease is
+    // an isolation failure, not permission for this test to steal its claim.
+    waitDeadline ??= latestActiveLease + 1_000;
+    const deadline = waitDeadline;
+    if (latestActiveLease > deadline || now >= deadline) {
+      throw new Error("group maintenance partition lease remained active");
+    }
+    await new Promise(resolve =>
+      setTimeout(
+        resolve,
+        Math.min(latestActiveLease + 1 - now, deadline - now),
+      ),
+    );
   }
 }
 
@@ -378,6 +422,7 @@ describeIf("NuQ durable migration router", () => {
       [scrapeQueueFdb, crawlFinishedQueueFdb],
       [],
     );
+    await waitForGroupMaintenanceLeaseExpiry(groupId);
     let finished = await crawlFinishedQueueFdb.getJobToProcess();
     for (let attempt = 0; attempt < 20 && !finished; attempt++) {
       await sweeper.sweepOnce();

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -39,9 +39,17 @@ vi.mock("../../lib/concurrency-redis", () => ({
 }));
 
 import { config } from "../../config";
-import { isFdbTeam } from "../../services/worker/nuq-router";
+import { getRedisConnection } from "../../services/queue-service";
+import {
+  isFdbTeam,
+  mirrorExternalSlotAcquire,
+  mirrorExternalSlotRelease,
+  resolveJobBackend,
+} from "../../services/worker/nuq-router";
 import {
   crawlFinishedQueueFdb,
+  crawlGroupFdb,
+  externalSlotsFdb,
   nuqFdbMigrationStore,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
@@ -113,6 +121,159 @@ describeIf("NuQ durable migration router", () => {
       activeGeneration: 1,
       phase: "PG_ONLY",
     });
+  });
+
+  test("discovers and drains an uncounted pre-protocol FDB job without dual authority", async () => {
+    const teamId = randomUUID();
+    const jobId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await scrapeQueueFdb.addJob(
+      jobId,
+      {
+        mode: "single_urls",
+        url: "https://example.com/legacy-direct",
+        team_id: teamId,
+      } as any,
+      { ownerId: teamId, bypassGate: true },
+      { teamLimit: 1, queueCap: 10 },
+    );
+
+    // The owner index catches bypass jobs that intentionally hold no team slot.
+    await expect(isFdbTeam(teamId)).resolves.toBe(true);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      activeBackend: "fdb",
+      phase: "FDB_ONLY",
+    });
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+    });
+
+    const active = await scrapeQueueFdb.getJobToProcess();
+    expect(active?.id).toBe(jobId);
+    await scrapeQueueFdb.jobFinish(jobId, active!.lock!, {});
+    await scrapeQueueFdb.removeJob(jobId);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("scrape_job", jobId),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      lifecycle: "terminal",
+    });
+
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      activeBackend: "pg",
+      phase: "PG_ONLY",
+    });
+  });
+
+  test("a legacy FDB group pins descendants and crawl-finished control through drain", async () => {
+    const teamId = randomUUID();
+    const groupId = randomUUID();
+    const childId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await crawlGroupFdb.addGroup(groupId, teamId);
+
+    const data = {
+      mode: "single_urls",
+      team_id: teamId,
+      crawl_id: groupId,
+      url: "https://example.com/legacy-group",
+    } as any;
+    await expect(resolveJobBackend(data)).resolves.toBe("fdb");
+    await expect(
+      nuqFdbMigrationStore.inspectPin("group", groupId),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      backend: "fdb",
+      lifecycle: "prepared",
+    });
+    await nuqFdbMigrationStore.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: childId,
+      admission: {
+        type: "pinned-continuation",
+        source: { kind: "group", objectId: groupId },
+      },
+      requiredBackend: "fdb",
+      residue: { intent_unresolved: 1 },
+    });
+    await scrapeQueueFdb.addJob(
+      childId,
+      data,
+      { ownerId: teamId, groupId },
+      { teamLimit: null, queueCap: 10 },
+    );
+
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+    });
+    const child = await scrapeQueueFdb.getJobToProcess();
+    expect(child?.id).toBe(childId);
+    await scrapeQueueFdb.jobFinish(childId, child!.lock!, {});
+    const finished = await crawlFinishedQueueFdb.getJobToProcess();
+    expect(finished?.groupId).toBe(groupId);
+    await crawlFinishedQueueFdb.jobFinish(finished!.id, finished!.lock!, {});
+    await Promise.all([
+      scrapeQueueFdb.removeJob(childId),
+      crawlFinishedQueueFdb.removeJob(finished!.id),
+    ]);
+
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectState(teamId),
+    ).resolves.toMatchObject({
+      activeBackend: "pg",
+      phase: "PG_ONLY",
+    });
+    const db = getNuqFdbDatabase();
+    await db.doTn(async tn => {
+      const range = crawlGroupFdb.ks.groupRange(groupId);
+      tn.clearRange(range.begin, range.end);
+      tn.clear(crawlGroupFdb.ks.ongoingGroup(teamId, groupId));
+    });
+  });
+
+  test("legacy external holders detect dual presence and retain their FDB generation", async () => {
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await externalSlotsFdb.acquire(teamId, holderId, 60_000);
+    await getRedisConnection().zadd(
+      `limit:${teamId}`,
+      Date.now() + 60_000,
+      holderId,
+    );
+
+    await expect(
+      mirrorExternalSlotAcquire(teamId, holderId, 120_000),
+    ).rejects.toMatchObject({ code: "NUQ_ROUTER_BOTH_BACKENDS_PRESENT" });
+    await getRedisConnection().zrem(`limit:${teamId}`, holderId);
+
+    await mirrorExternalSlotAcquire(teamId, holderId, 120_000);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      backend: "fdb",
+      lifecycle: "active",
+      residue: { capacity_external_holders: 1 },
+    });
+    await mirrorExternalSlotRelease(teamId, holderId);
+    await expect(externalSlotsFdb.has(teamId, holderId)).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+    ).resolves.toMatchObject({ lifecycle: "terminal" });
   });
 
   test("durable source residue blocks seal until the authoritative ledger drains", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -51,6 +51,7 @@ import {
   crawlGroupFdb,
   externalSlotMigrationObjectId,
   externalSlotsFdb,
+  NuqFdbSweeper,
   nuqFdbMigrationStore,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
@@ -62,6 +63,7 @@ import {
 const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 const teams = new Set<string>();
 const previousBackend = config.NUQ_BACKEND;
+const previousMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
 
 async function clearTeam(teamId: string): Promise<void> {
   const pins = await nuqFdbMigrationStore.inspectTeamPins(teamId);
@@ -88,6 +90,7 @@ async function makeMetricsReady(): Promise<void> {
 describeIf("NuQ durable migration router", () => {
   beforeAll(async () => {
     config.NUQ_BACKEND = "pg";
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
     controls.fdbFlag = false;
     controls.pgResidue = 0;
     await Promise.all([
@@ -100,6 +103,7 @@ describeIf("NuQ durable migration router", () => {
     controls.fdbFlag = false;
     controls.pgResidue = 0;
     config.NUQ_BACKEND = previousBackend;
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
     for (const teamId of teams) await clearTeam(teamId);
   });
 
@@ -122,6 +126,24 @@ describeIf("NuQ durable migration router", () => {
       activeGeneration: 1,
       phase: "PG_ONLY",
     });
+  });
+
+  test("disabled activation invalidates prior READY generations before rollback writers", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = false;
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_FDB_CORE_METRICS_NOT_ACTIVATED",
+      retryable: true,
+    });
+    await expect(
+      scrapeQueueFdb.getMetricCounterBackfillStatus(),
+    ).resolves.toBeNull();
+    await expect(
+      crawlFinishedQueueFdb.getMetricCounterBackfillStatus(),
+    ).resolves.toBeNull();
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
+    await makeMetricsReady();
   });
 
   test("discovers and drains an uncounted pre-protocol FDB job without dual authority", async () => {
@@ -235,6 +257,41 @@ describeIf("NuQ durable migration router", () => {
       activeBackend: "pg",
       phase: "PG_ONLY",
     });
+    const db = getNuqFdbDatabase();
+    await db.doTn(async tn => {
+      const range = crawlGroupFdb.ks.groupRange(groupId);
+      tn.clearRange(range.begin, range.end);
+      tn.clear(crawlGroupFdb.ks.ongoingGroup(teamId, groupId));
+    });
+  });
+
+  test("cancelled legacy groups remain source residue until their sweeper control finishes", async () => {
+    const teamId = randomUUID();
+    const groupId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await crawlGroupFdb.addGroup(groupId, teamId);
+    await crawlGroupFdb.cancelGroup(groupId);
+
+    await expect(isFdbTeam(teamId)).resolves.toBe(true);
+    await expect(isFdbTeam(teamId)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+    });
+    const sweeper = new NuqFdbSweeper(
+      [scrapeQueueFdb, crawlFinishedQueueFdb],
+      [],
+    );
+    let finished = await crawlFinishedQueueFdb.getJobToProcess();
+    for (let attempt = 0; attempt < 5 && !finished; attempt++) {
+      await sweeper.sweepOnce();
+      finished = await crawlFinishedQueueFdb.getJobToProcess();
+    }
+    expect(finished?.groupId).toBe(groupId);
+    await crawlFinishedQueueFdb.jobFinish(finished!.id, finished!.lock!, {});
+    await crawlFinishedQueueFdb.removeJob(finished!.id);
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
     const db = getNuqFdbDatabase();
     await db.doTn(async tn => {
       const range = crawlGroupFdb.ks.groupRange(groupId);

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -41,6 +41,18 @@ vi.mock("../../lib/concurrency-redis", () => ({
   finalizeConcurrencyLimitActiveJobRollback: controls.redisFinalize,
   getTeamQueueLimit: vi.fn().mockResolvedValue(100),
   getConcurrencyLimitActiveJobsCount: vi.fn().mockResolvedValue(0),
+  getConcurrencyRollbackCleanupBacklog: vi.fn().mockResolvedValue({
+    total: 0,
+    due: 0,
+    oldestDueAt: null,
+    oldestOverdueMs: 0,
+  }),
+  recoverConcurrencyLimitRollbacks: vi.fn().mockResolvedValue({
+    read: 0,
+    finalized: 0,
+    fenced: 0,
+    hasMore: false,
+  }),
   pushConcurrencyLimitActiveJob: vi.fn(),
   removeConcurrencyLimitActiveJob: controls.redisRemove,
   renewConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(true),
@@ -442,6 +454,7 @@ describeIf("NuQ durable migration router", () => {
       teamId,
       holderId,
       "owned-attempt",
+      30_000,
     );
     expect(controls.redisFinalize).toHaveBeenCalledWith(
       teamId,
@@ -489,6 +502,7 @@ describeIf("NuQ durable migration router", () => {
       teamId,
       holderId,
       "stale-attempt",
+      30_000,
     );
     expect(controls.redisFinalize).not.toHaveBeenCalled();
     await expect(
@@ -554,6 +568,7 @@ describeIf("NuQ durable migration router", () => {
       teamId,
       holderId,
       "reopened-attempt",
+      30_000,
     );
     await expect(
       nuqFdbMigrationStore.inspectPin("external_holder", objectId),

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -49,6 +49,7 @@ import {
 import {
   crawlFinishedQueueFdb,
   crawlGroupFdb,
+  externalSlotMigrationObjectId,
   externalSlotsFdb,
   nuqFdbMigrationStore,
   scrapeQueueFdb,
@@ -261,8 +262,9 @@ describeIf("NuQ durable migration router", () => {
     await getRedisConnection().zrem(`limit:${teamId}`, holderId);
 
     await mirrorExternalSlotAcquire(teamId, holderId, 120_000);
+    const externalObjectId = externalSlotMigrationObjectId(teamId, holderId);
     await expect(
-      nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+      nuqFdbMigrationStore.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({
       admission: "legacy-backfill",
       backend: "fdb",
@@ -272,7 +274,7 @@ describeIf("NuQ durable migration router", () => {
     await mirrorExternalSlotRelease(teamId, holderId);
     await expect(externalSlotsFdb.has(teamId, holderId)).resolves.toBe(false);
     await expect(
-      nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+      nuqFdbMigrationStore.inspectPin("external_holder", externalObjectId),
     ).resolves.toMatchObject({ lifecycle: "terminal" });
   });
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -184,6 +184,52 @@ describeIf("NuQ durable migration router", () => {
     await makeMetricsReady();
   });
 
+  test("begin and final seal require both corrected-core generations in their own transactions", async () => {
+    const teamId = randomUUID();
+    teams.add(teamId);
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
+    await crawlFinishedQueueFdb.invalidateMetricCounterGeneration();
+    await expect(
+      nuqFdbMigrationStore.beginTransition({
+        teamId,
+        targetBackend: "fdb",
+        operationId: randomUUID(),
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_FDB_CORE_METRICS_NOT_READY",
+      retryable: true,
+    });
+
+    await makeMetricsReady();
+    const transition = await nuqFdbMigrationStore.beginTransition({
+      teamId,
+      targetBackend: "fdb",
+      operationId: randomUUID(),
+    });
+    await scrapeQueueFdb.invalidateMetricCounterGeneration();
+    await expect(
+      nuqFdbMigrationStore.finalSeal({
+        teamId,
+        transitionOperationId: transition.transitionOperationId!,
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_FDB_CORE_METRICS_NOT_READY",
+      retryable: true,
+    });
+
+    await makeMetricsReady();
+    await expect(
+      nuqFdbMigrationStore.finalSeal({
+        teamId,
+        transitionOperationId: transition.transitionOperationId!,
+      }),
+    ).resolves.toMatchObject({
+      activeBackend: "fdb",
+      phase: "FDB_ONLY",
+    });
+  });
+
   test("discovers and drains an uncounted pre-protocol FDB job without dual authority", async () => {
     const teamId = randomUUID();
     const jobId = randomUUID();

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -407,10 +407,7 @@ describeIf("NuQ durable migration router", () => {
         "external_holder",
         externalSlotMigrationObjectId(teamId, holderId),
       ),
-    ).resolves.toMatchObject({
-      lifecycle: "terminal",
-      residue: { capacity_external_holders: 0, intent_unresolved: 0 },
-    });
+    ).resolves.toBeNull();
   });
 
   test("stale PG durable-expiry failure cannot roll back a replacement holder", async () => {
@@ -450,10 +447,7 @@ describeIf("NuQ durable migration router", () => {
     expect(controls.redisFinalize).not.toHaveBeenCalled();
     await expect(
       nuqFdbMigrationStore.inspectPin("external_holder", objectId),
-    ).resolves.toMatchObject({
-      lifecycle: "prepared",
-      residue: { intent_unresolved: 1 },
-    });
+    ).resolves.toBeNull();
   });
 
   test("retry recovers an abandoned PG rollback tombstone", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from "crypto";
 import { vi } from "vitest";
 
-const controls = vi.hoisted(() => ({ fdbFlag: false, pgResidue: 0 }));
+const controls = vi.hoisted(() => ({
+  fdbFlag: false,
+  pgResidue: 0,
+  redisReserve: vi.fn(),
+  redisRemove: vi.fn(),
+  redisRollback: vi.fn(),
+  redisFinalize: vi.fn(),
+}));
 
 vi.mock("../../controllers/auth", () => ({
   getACUCTeam: vi.fn(async () => ({ flags: { nuqFdb: controls.fdbFlag } })),
@@ -31,10 +38,14 @@ vi.mock("../../services/worker/nuq", () => {
   };
 });
 vi.mock("../../lib/concurrency-redis", () => ({
+  finalizeConcurrencyLimitActiveJobRollback: controls.redisFinalize,
   getTeamQueueLimit: vi.fn().mockResolvedValue(100),
   getConcurrencyLimitActiveJobsCount: vi.fn().mockResolvedValue(0),
   pushConcurrencyLimitActiveJob: vi.fn(),
-  removeConcurrencyLimitActiveJob: vi.fn(),
+  removeConcurrencyLimitActiveJob: controls.redisRemove,
+  renewConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(true),
+  reserveConcurrencyLimitActiveJob: controls.redisReserve,
+  rollbackConcurrencyLimitActiveJob: controls.redisRollback,
   constructConcurrencyLimitKey: vi.fn((teamId: string) => `limit:${teamId}`),
 }));
 
@@ -44,6 +55,7 @@ import {
   isFdbTeam,
   mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
   resolveJobBackend,
 } from "../../services/worker/nuq-router";
 import {
@@ -320,6 +332,233 @@ describeIf("NuQ durable migration router", () => {
       const range = crawlGroupFdb.ks.groupRange(groupId);
       tn.clearRange(range.begin, range.end);
       tn.clear(crawlGroupFdb.ks.ongoingGroup(teamId, groupId));
+    });
+  });
+
+  test("denied PG reservations do not create a migration intent", async () => {
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    controls.redisReserve.mockResolvedValueOnce({
+      reserved: false,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: null,
+    });
+    await makeMetricsReady();
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
+    await expect(
+      reserveExternalSlot(teamId, holderId, 30_000, 1),
+    ).resolves.toBe(false);
+    await expect(
+      nuqFdbMigrationStore.inspectPin(
+        "external_holder",
+        externalSlotMigrationObjectId(teamId, holderId),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  test("failed PG activation removes a new Redis holder and retires its intent", async () => {
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    const activationError = new Error("activation unavailable");
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    controls.redisReserve.mockResolvedValueOnce({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: "owned-attempt",
+      cleanupToken: null,
+    });
+    controls.redisRollback.mockResolvedValueOnce(true);
+    controls.redisFinalize.mockResolvedValueOnce(true);
+    await makeMetricsReady();
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
+    const transition = vi
+      .spyOn(nuqFdbMigrationStore, "transitionObjectResidue")
+      .mockRejectedValueOnce(activationError);
+    try {
+      await expect(
+        reserveExternalSlot(teamId, holderId, 30_000, 1),
+      ).rejects.toBe(activationError);
+    } finally {
+      transition.mockRestore();
+    }
+    expect(controls.redisRollback).toHaveBeenCalledWith(
+      teamId,
+      holderId,
+      "owned-attempt",
+    );
+    expect(controls.redisFinalize).toHaveBeenCalledWith(
+      teamId,
+      holderId,
+      "owned-attempt",
+    );
+    await expect(
+      nuqFdbMigrationStore.inspectPin(
+        "external_holder",
+        externalSlotMigrationObjectId(teamId, holderId),
+      ),
+    ).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { capacity_external_holders: 0, intent_unresolved: 0 },
+    });
+  });
+
+  test("stale PG activation failure cannot roll back a replacement holder", async () => {
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    const objectId = externalSlotMigrationObjectId(teamId, holderId);
+    const activationError = new Error("activation unavailable");
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    controls.redisReserve.mockResolvedValueOnce({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: "stale-attempt",
+      cleanupToken: null,
+    });
+    controls.redisRollback.mockResolvedValueOnce(false);
+    controls.redisFinalize.mockClear();
+    await makeMetricsReady();
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+
+    const transition = vi
+      .spyOn(nuqFdbMigrationStore, "transitionObjectResidue")
+      .mockRejectedValueOnce(activationError);
+    try {
+      await expect(
+        reserveExternalSlot(teamId, holderId, 30_000, 1),
+      ).rejects.toBe(activationError);
+    } finally {
+      transition.mockRestore();
+    }
+    expect(controls.redisRollback).toHaveBeenCalledWith(
+      teamId,
+      holderId,
+      "stale-attempt",
+    );
+    expect(controls.redisFinalize).not.toHaveBeenCalled();
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", objectId),
+    ).resolves.toMatchObject({
+      lifecycle: "prepared",
+      residue: { intent_unresolved: 1 },
+    });
+  });
+
+  test("retry recovers an abandoned PG rollback tombstone", async () => {
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    const objectId = externalSlotMigrationObjectId(teamId, holderId);
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await makeMetricsReady();
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await nuqFdbMigrationStore.preparePinnedObject({
+      teamId,
+      kind: "external_holder",
+      objectId,
+      admission: { type: "new-root" },
+      requiredBackend: "pg",
+      residue: { intent_unresolved: 1 },
+    });
+    controls.redisRollback.mockClear();
+    controls.redisFinalize.mockClear();
+    controls.redisReserve.mockResolvedValueOnce({
+      reserved: false,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: "abandoned-attempt",
+    });
+    controls.redisFinalize.mockResolvedValueOnce(true);
+
+    await expect(
+      reserveExternalSlot(teamId, holderId, 30_000, 1),
+    ).resolves.toBe(false);
+    expect(controls.redisFinalize).toHaveBeenCalledWith(
+      teamId,
+      holderId,
+      "abandoned-attempt",
+    );
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", objectId),
+    ).resolves.toMatchObject({
+      lifecycle: "terminal",
+      residue: { intent_unresolved: 0 },
+    });
+
+    // A finalize commit-unknown retry must not reopen this terminal holder ID.
+    controls.redisReserve.mockResolvedValueOnce({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: "reopened-attempt",
+      cleanupToken: null,
+    });
+    controls.redisRollback.mockResolvedValueOnce(true);
+    controls.redisFinalize.mockResolvedValueOnce(true);
+    await expect(
+      reserveExternalSlot(teamId, holderId, 30_000, 1),
+    ).resolves.toBe(false);
+    expect(controls.redisRollback).toHaveBeenCalledWith(
+      teamId,
+      holderId,
+      "reopened-attempt",
+    );
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", objectId),
+    ).resolves.toMatchObject({ lifecycle: "terminal" });
+  });
+
+  test("failed PG renewal does not remove or terminalize an existing holder", async () => {
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    const objectId = externalSlotMigrationObjectId(teamId, holderId);
+    const activationError = new Error("activation unavailable");
+    teams.add(teamId);
+    controls.fdbFlag = false;
+    controls.pgResidue = 0;
+    await makeMetricsReady();
+    await expect(isFdbTeam(teamId)).resolves.toBe(false);
+    await nuqFdbMigrationStore.preparePinnedObject({
+      teamId,
+      kind: "external_holder",
+      objectId,
+      admission: { type: "new-root" },
+      requiredBackend: "pg",
+      residue: { intent_unresolved: 1 },
+    });
+    controls.redisReserve.mockResolvedValueOnce({
+      reserved: true,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: null,
+    });
+    controls.redisRollback.mockClear();
+
+    const transition = vi
+      .spyOn(nuqFdbMigrationStore, "transitionObjectResidue")
+      .mockRejectedValueOnce(activationError);
+    try {
+      await expect(
+        reserveExternalSlot(teamId, holderId, 30_000, 1),
+      ).rejects.toBe(activationError);
+    } finally {
+      transition.mockRestore();
+    }
+    expect(controls.redisRollback).not.toHaveBeenCalled();
+    await expect(
+      nuqFdbMigrationStore.inspectPin("external_holder", objectId),
+    ).resolves.toMatchObject({
+      lifecycle: "prepared",
+      residue: { intent_unresolved: 1 },
     });
   });
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-router.test.ts
@@ -120,6 +120,9 @@ async function makeMetricsReady(): Promise<void> {
       // bounded pages; queues are empty in this focused suite
     }
   }
+  while (!(await crawlGroupFdb.backfillLegacyOwnerIndex(100))) {
+    // bounded pages
+  }
 }
 
 describeIf("NuQ durable migration router", () => {
@@ -251,7 +254,7 @@ describeIf("NuQ durable migration router", () => {
     ).resolves.toMatchObject({
       admission: "legacy-backfill",
       backend: "fdb",
-      lifecycle: "prepared",
+      lifecycle: "active",
     });
     await nuqFdbMigrationStore.preparePinnedObject({
       teamId,
@@ -361,7 +364,7 @@ describeIf("NuQ durable migration router", () => {
     ).resolves.toBeNull();
   });
 
-  test("failed PG activation removes a new Redis holder and retires its intent", async () => {
+  test("failed PG durable-expiry publication removes a new Redis holder and retires its intent", async () => {
     const teamId = randomUUID();
     const holderId = randomUUID();
     const activationError = new Error("activation unavailable");
@@ -380,7 +383,7 @@ describeIf("NuQ durable migration router", () => {
     await expect(isFdbTeam(teamId)).resolves.toBe(false);
 
     const transition = vi
-      .spyOn(nuqFdbMigrationStore, "transitionObjectResidue")
+      .spyOn(externalSlotsFdb, "renewPg")
       .mockRejectedValueOnce(activationError);
     try {
       await expect(
@@ -410,7 +413,7 @@ describeIf("NuQ durable migration router", () => {
     });
   });
 
-  test("stale PG activation failure cannot roll back a replacement holder", async () => {
+  test("stale PG durable-expiry failure cannot roll back a replacement holder", async () => {
     const teamId = randomUUID();
     const holderId = randomUUID();
     const objectId = externalSlotMigrationObjectId(teamId, holderId);
@@ -430,7 +433,7 @@ describeIf("NuQ durable migration router", () => {
     await expect(isFdbTeam(teamId)).resolves.toBe(false);
 
     const transition = vi
-      .spyOn(nuqFdbMigrationStore, "transitionObjectResidue")
+      .spyOn(externalSlotsFdb, "renewPg")
       .mockRejectedValueOnce(activationError);
     try {
       await expect(
@@ -517,7 +520,7 @@ describeIf("NuQ durable migration router", () => {
     ).resolves.toMatchObject({ lifecycle: "terminal" });
   });
 
-  test("failed PG renewal does not remove or terminalize an existing holder", async () => {
+  test("failed PG durable-expiry renewal does not remove or terminalize an existing holder", async () => {
     const teamId = randomUUID();
     const holderId = randomUUID();
     const objectId = externalSlotMigrationObjectId(teamId, holderId);
@@ -544,7 +547,7 @@ describeIf("NuQ durable migration router", () => {
     controls.redisRollback.mockClear();
 
     const transition = vi
-      .spyOn(nuqFdbMigrationStore, "transitionObjectResidue")
+      .spyOn(externalSlotsFdb, "renewPg")
       .mockRejectedValueOnce(activationError);
     try {
       await expect(

--- a/apps/api/src/__tests__/nuq-fdb/migration-store-lazy.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store-lazy.test.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "child_process";
+
+test("migration control-plane exports do not eagerly load foundationdb", () => {
+  const script = `
+    const Module = require("module");
+    const originalLoad = Module._load;
+    Module._load = function (id, ...args) {
+      if (id === "foundationdb") throw new Error("eager native foundationdb import");
+      return originalLoad.call(this, id, ...args);
+    };
+    require("./src/services/worker/nuq-fdb/index.ts");
+    process.stdout.write("lazy-ok");
+  `;
+  const output = execFileSync(
+    process.execPath,
+    ["--require", "tsx/cjs", "-e", script],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, FDB_CLUSTER_FILE: "", NUQ_BACKEND: "pg" },
+      encoding: "utf8",
+    },
+  );
+  expect(output).toBe("lazy-ok");
+});

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -9,6 +9,7 @@ import {
   getFdb,
   getNuqFdbDatabase,
 } from "../../services/worker/nuq-fdb/client";
+import { reconcilePgResidueFence } from "../../services/worker/nuq-migration-control";
 
 // These tests intentionally exercise transaction conflicts and atomic ADDs on
 // a real FoundationDB cluster. They are skipped in ordinary PG-only runs.
@@ -104,6 +105,27 @@ describeIf("NuQ global FDB migration control plane", () => {
     await expect(store.resolveSteady(teamId, "fdb")).resolves.toMatchObject({
       status: "transition-required",
     });
+  });
+
+  test("initialize-if-absent replay returns current durable state after migration", async () => {
+    const teamId = team();
+    const initializeOperationId = randomUUID();
+    await store.initializeLegacyTeam(teamId, "pg", initializeOperationId);
+    const transitionOperationId = randomUUID();
+    await begin(teamId, transitionOperationId);
+    const sealed = await store.finalSeal({
+      teamId,
+      transitionOperationId,
+    });
+
+    await expect(
+      store.initializeLegacyTeam(teamId, "pg", initializeOperationId, {
+        ifAbsent: true,
+      }),
+    ).resolves.toEqual(sealed);
+    await expect(
+      store.initializeLegacyTeam(teamId, "pg", initializeOperationId),
+    ).resolves.toMatchObject({ revision: 1, activeBackend: "pg" });
   });
 
   test("revision CAS admits exactly one racing transition", async () => {
@@ -396,6 +418,202 @@ describeIf("NuQ global FDB migration control plane", () => {
     }
   });
 
+  test("pin revision CAS rejects delayed reorder but exact commit replay wins", async () => {
+    const teamId = team();
+    const objectId = object();
+    await initialize(teamId, "fdb");
+    const prepared = await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      admission: { type: "new-root" },
+    });
+    const firstOperationId = randomUUID();
+    const first = await store.transitionObjectResidue({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: firstOperationId,
+      fromLifecycle: "prepared",
+      toLifecycle: "prepared",
+      residue: { intent_unresolved: 1 },
+      expectedRevision: prepared.revision,
+    });
+    await expect(
+      store.transitionObjectResidue({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: firstOperationId,
+        fromLifecycle: "prepared",
+        toLifecycle: "prepared",
+        residue: { intent_unresolved: 1 },
+        expectedRevision: prepared.revision,
+      }),
+    ).resolves.toEqual(first);
+    const second = await store.transitionObjectResidue({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: randomUUID(),
+      fromLifecycle: "prepared",
+      toLifecycle: "prepared",
+      residue: {},
+      expectedRevision: first.revision,
+    });
+    const newest = await store.transitionObjectResidue({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: randomUUID(),
+      fromLifecycle: "prepared",
+      toLifecycle: "prepared",
+      residue: { intent_unresolved: 1 },
+      expectedRevision: second.revision,
+    });
+
+    await expect(
+      store.transitionObjectResidue({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+        toLifecycle: "prepared",
+        residue: {},
+        expectedRevision: second.revision,
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CAS_MISMATCH",
+      retryable: true,
+    });
+    await expect(store.inspectPin("scrape_job", objectId)).resolves.toEqual(
+      newest,
+    );
+  });
+
+  test("source residue A-B-A reorder rejects the delayed observation", async () => {
+    const teamId = team();
+    await initialize(teamId, "pg");
+    await reconcilePgResidueFence(store, {
+      teamId,
+      total: 1,
+      observationId: "A-initial",
+    });
+
+    const originalTransition = store.transitionObjectResidue.bind(store);
+    let releaseDelayed!: () => void;
+    const delayedGate = new Promise<void>(resolve => {
+      releaseDelayed = resolve;
+    });
+    let captured!: () => void;
+    const capturedInput = new Promise<void>(resolve => {
+      captured = resolve;
+    });
+    const transitionSpy = vi
+      .spyOn(store, "transitionObjectResidue")
+      .mockImplementationOnce(async input => {
+        captured();
+        await delayedGate;
+        return await originalTransition(input);
+      });
+    const delayed = reconcilePgResidueFence(store, {
+      teamId,
+      total: 0,
+      observationId: "B-delayed",
+    });
+    await capturedInput;
+    try {
+      await reconcilePgResidueFence(store, {
+        teamId,
+        total: 0,
+        observationId: "B-current",
+      });
+      const newest = await reconcilePgResidueFence(store, {
+        teamId,
+        total: 1,
+        observationId: "A-newest",
+      });
+      releaseDelayed();
+      await expect(delayed).rejects.toMatchObject({
+        code: "NUQ_MIGRATION_CAS_MISMATCH",
+      });
+      await expect(
+        store.inspectPin("cross_store_intent", newest.objectId),
+      ).resolves.toMatchObject({
+        revision: newest.revision,
+        residue: { intent_unresolved: 1 },
+      });
+    } finally {
+      releaseDelayed();
+      transitionSpy.mockRestore();
+      await getNuqFdbDatabase().doTn(async tn =>
+        tn.clear(
+          store.objectKey(
+            "cross_store_intent",
+            `pg-residue/${teamId}/generation/1`,
+          ),
+        ),
+      );
+    }
+  });
+
+  test("independent residue counters commit without cross-counter conflicts", async () => {
+    const teamId = team();
+    const firstObjectId = object();
+    const secondObjectId = object();
+    await initialize(teamId, "fdb");
+    await Promise.all([
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: firstObjectId,
+        admission: { type: "new-root" },
+      }),
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: secondObjectId,
+        admission: { type: "new-root" },
+      }),
+    ]);
+
+    const db = getNuqFdbDatabase();
+    const firstTn = db.rawCreateTransaction();
+    const secondTn = db.rawCreateTransaction();
+    try {
+      await Promise.all([
+        store.transitionObjectResidueInTxn(firstTn, {
+          teamId,
+          kind: "scrape_job",
+          objectId: firstObjectId,
+          operationId: randomUUID(),
+          fromLifecycle: "prepared",
+          toLifecycle: "active",
+          residue: { capacity_ready_active: 1 },
+          expectedRevision: 1,
+        }),
+        store.transitionObjectResidueInTxn(secondTn, {
+          teamId,
+          kind: "scrape_job",
+          objectId: secondObjectId,
+          operationId: randomUUID(),
+          fromLifecycle: "prepared",
+          toLifecycle: "active",
+          residue: { control_groups: 1 },
+          expectedRevision: 1,
+        }),
+      ]);
+      await Promise.all([firstTn.rawCommit(), secondTn.rawCommit()]);
+    } finally {
+      firstTn.rawCancel();
+      secondTn.rawCancel();
+    }
+    await expect(store.inspectGeneration(teamId, 1)).resolves.toMatchObject({
+      residue: { capacity_ready_active: 1, control_groups: 1 },
+    });
+  });
+
   test("transaction-scoped hooks compose accounting with caller mutations", async () => {
     const teamId = team();
     const objectId = object();
@@ -572,6 +790,59 @@ describeIf("NuQ global FDB migration control plane", () => {
     );
   });
 
+  test("terminal tombstones leave the paged team index bounded to active pins", async () => {
+    const teamId = team();
+    const objectIds = [object(), object(), object()];
+    await initialize(teamId, "fdb");
+    await Promise.all(
+      objectIds.map(objectId =>
+        store.preparePinnedObject({
+          teamId,
+          kind: "scrape_job",
+          objectId,
+          admission: { type: "new-root" },
+        }),
+      ),
+    );
+    const terminal = await store.completePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: objectIds[1],
+      operationId: randomUUID(),
+      fromLifecycle: "prepared",
+    });
+
+    const indexed: string[] = [];
+    let cursor: { kind: "scrape_job"; objectId: string } | undefined;
+    do {
+      const page = await store.inspectTeamPinsPage(teamId, {
+        limit: 1,
+        cursor,
+      });
+      indexed.push(...page.pins.map(pin => pin.objectId));
+      cursor = page.nextCursor as typeof cursor;
+    } while (cursor);
+    expect(indexed.sort()).toEqual(
+      objectIds.filter(objectId => objectId !== terminal.objectId).sort(),
+    );
+    await expect(
+      store.inspectPin("scrape_job", terminal.objectId),
+    ).resolves.toEqual(terminal);
+    await expect(
+      getNuqFdbDatabase().doTn(async tn =>
+        tn.get(
+          store.pack([
+            "team",
+            teamId,
+            "object",
+            "scrape_job",
+            terminal.objectId,
+          ]),
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   test("legacy object-operation rows replay once into the bounded pin token", async () => {
     const teamId = team();
     const objectId = object();
@@ -742,6 +1013,77 @@ describeIf("NuQ global FDB migration control plane", () => {
     } finally {
       doTn.mockRestore();
     }
+  });
+
+  test("counter-local deltas preserve underflow checks and final-seal corruption detection", async () => {
+    const teamId = team();
+    const objectId = object();
+    await initialize(teamId, "fdb");
+    const prepared = await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      admission: { type: "new-root" },
+    });
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.set(
+        store.residueKey(teamId, 1, "capacity_external_holders"),
+        Buffer.from([1]),
+      ),
+    );
+    const active = await store.transitionObjectResidue({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: randomUUID(),
+      fromLifecycle: "prepared",
+      toLifecycle: "active",
+      residue: { capacity_ready_active: 1 },
+      expectedRevision: prepared.revision,
+    });
+    await store.completePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: randomUUID(),
+      fromLifecycle: "active",
+    });
+    const transitionOperationId = randomUUID();
+    await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId: transitionOperationId,
+    });
+    await expect(
+      store.finalSeal({ teamId, transitionOperationId }),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_CORRUPT" });
+
+    const underflowTeam = team();
+    const underflowObject = object();
+    await initialize(underflowTeam, "fdb");
+    await store.preparePinnedObject({
+      teamId: underflowTeam,
+      kind: "scrape_job",
+      objectId: underflowObject,
+      admission: { type: "new-root" },
+      residue: { capacity_ready_active: 1 },
+    });
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.clear(store.residueKey(underflowTeam, 1, "capacity_ready_active")),
+    );
+    await expect(
+      store.completePinnedObject({
+        teamId: underflowTeam,
+        kind: "scrape_job",
+        objectId: underflowObject,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CORRUPT",
+      message: expect.stringContaining("negative or overflow"),
+    });
+    expect(active.residue.capacity_ready_active).toBe(1);
   });
 
   test("malformed state and counters fail with deterministic corruption errors", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../services/worker/nuq-fdb/client";
 import { encodeI64 } from "../../services/worker/nuq-fdb/keyspace";
 import { reconcilePgResidueFence } from "../../services/worker/nuq-migration-control";
+import { clearMigrationTestTeams } from "./migration-test-cleanup";
 
 // These tests intentionally exercise transaction conflicts and atomic ADDs on
 // a real FoundationDB cluster. They are skipped in ordinary PG-only runs.
@@ -19,7 +20,6 @@ const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 const RUN = randomUUID();
 const store = new NuqFdbMigrationStore();
 const teams = new Set<string>();
-const objects: Array<{ kind: "scrape_job" | "group"; id: string }> = [];
 
 function team(): string {
   const id = `${RUN}-${randomUUID()}`;
@@ -27,10 +27,8 @@ function team(): string {
   return id;
 }
 
-function object(kind: "scrape_job" | "group" = "scrape_job") {
-  const id = `${RUN}-${randomUUID()}`;
-  objects.push({ kind, id });
-  return id;
+function object(_kind: "scrape_job" | "group" = "scrape_job") {
+  return `${RUN}-${randomUUID()}`;
 }
 
 async function initialize(teamId: string, backend: "pg" | "fdb" = "pg") {
@@ -128,63 +126,7 @@ async function withGcPostCommitReplay<T>(body: () => Promise<T>): Promise<T> {
 
 describeIf("NuQ global FDB migration control plane", () => {
   afterAll(async () => {
-    const fdb = getFdb();
-    const db = getNuqFdbDatabase();
-    for (const teamId of teams) {
-      const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
-      await db.doTn(async tn =>
-        tn.clearRange(range.begin as Buffer, range.end as Buffer),
-      );
-    }
-    for (const item of objects) {
-      await db.doTn(async tn => tn.clear(store.objectKey(item.kind, item.id)));
-    }
-    // GC indexes are global by design; test identities are run-qualified.
-    const gcRange = fdb.tuple.range(["nuq-migration", 1, "gc"]);
-    const gcRows = await db.doTn(async tn =>
-      tn.snapshot().getRangeAll(gcRange.begin as Buffer, gcRange.end as Buffer),
-    );
-    await db.doTn(async tn => {
-      const dueCountRange = fdb.tuple.range([
-        "nuq-migration",
-        1,
-        "gc",
-        "due-count",
-      ]);
-      tn.clearRange(dueCountRange.begin as Buffer, dueCountRange.end as Buffer);
-      for (const [key] of gcRows) {
-        const parts = fdb.tuple.unpack(key as Buffer);
-        if (parts.some(part => String(part).includes(RUN))) {
-          tn.clear(key as Buffer);
-          continue;
-        }
-        const category = String(parts[3]);
-        const partition = Number(parts[4]);
-        const dueAt = Number(parts[5]);
-        if (
-          (category === "pin" ||
-            category === "control" ||
-            category === "generation") &&
-          Number.isSafeInteger(partition) &&
-          Number.isSafeInteger(dueAt)
-        ) {
-          let node = BigInt(dueAt) + 1n;
-          while (node <= 1n << 53n) {
-            tn.add(
-              store.pack([
-                "gc",
-                "due-count",
-                category,
-                partition,
-                node.toString(),
-              ]),
-              encodeI64(1),
-            );
-            node += node & -node;
-          }
-        }
-      }
-    });
+    await clearMigrationTestTeams(teams);
   });
 
   test("legacy teams require explicit authority and steady resolution is durable", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -1315,11 +1315,14 @@ describeIf("NuQ global FDB migration control plane", () => {
     }
   });
 
-  test("expired lease takeover fences an authority probe from every final mutation", async () => {
+  test("expired lease takeover wraps past 31 owners and fences the old authority probe", async () => {
     const base = 1_825_000_000_000;
     const due = base + 46 * 24 * 60 * 60 * 1000;
     const clock = vi.spyOn(Date, "now").mockReturnValue(base);
     try {
+      const baselineDue = (await store.inspectGcBacklog(due)).pin.due;
+      const baselineAfterExpiry = (await store.inspectGcBacklog(due + 31_000))
+        .pin.due;
       const teamId = team();
       const objectId = object();
       await initialize(teamId, "pg");
@@ -1335,6 +1338,22 @@ describeIf("NuQ global FDB migration control plane", () => {
         objectId,
         operationId: randomUUID(),
         fromLifecycle: "prepared",
+      });
+      const indexRows = await getNuqFdbDatabase().doTn(async tn =>
+        tn
+          .snapshot()
+          .getRangeAll(
+            store.pack(["gc", "pin"]),
+            store.pack(["gc", "pin", 32]),
+          ),
+      );
+      const indexParts = indexRows
+        .map(([key]) => getFdb().tuple.unpack(key as Buffer))
+        .find(parts => parts.some(part => String(part) === objectId));
+      expect(indexParts).toBeDefined();
+      const partition = Number(indexParts![4]);
+      await expect(store.inspectGcBacklog(due)).resolves.toMatchObject({
+        pin: { due: baselineDue + 1, oldestDueAt: expect.any(Number) },
       });
 
       let releaseProbe!: () => void;
@@ -1359,34 +1378,162 @@ describeIf("NuQ global FDB migration control plane", () => {
       };
 
       clock.mockReturnValue(due);
-      const expiredOwners = Promise.allSettled(
-        Array.from({ length: 32 }, () =>
-          store.sweepTerminalPins(authority, { limit: 1 }),
+      await getNuqFdbDatabase().doTn(async tn =>
+        tn.set(
+          store.pack(["gc", "cursor", "pin"]),
+          Buffer.from(JSON.stringify(partition)),
         ),
       );
+      const expiredOwner = store.sweepTerminalPins(authority, { limit: 1 });
       await probeStarted;
-      clock.mockReturnValue(due + 31_000);
-      await Promise.all(
-        Array.from({ length: 32 }, () =>
-          store.sweepTerminalPins(authority, { limit: 1 }),
-        ),
-      );
-      releaseProbe();
-      const expiredResults = await expiredOwners;
 
-      expect(
-        expiredResults.some(
-          result =>
-            result.status === "rejected" &&
-            result.reason?.code === "NUQ_MIGRATION_GC_LEASE_LOST",
-        ),
-      ).toBe(true);
+      // Keep every empty shard owned while the cursor starts immediately after
+      // the expired work shard. The takeover must inspect one bounded rotation,
+      // wrap, and claim the only eligible partition without advancing past it.
+      clock.mockReturnValue(due + 31_000);
+      const liveLeaseKeys = Array.from({ length: 32 }, (_, candidate) =>
+        candidate === partition
+          ? null
+          : store.pack(["gc", "lease", "pin", candidate]),
+      ).filter((key): key is Buffer => key !== null);
+      await getNuqFdbDatabase().doTn(async tn => {
+        tn.set(
+          store.pack(["gc", "cursor", "pin"]),
+          Buffer.from(JSON.stringify((partition + 1) % 32)),
+        );
+        for (let candidate = 0; candidate < 32; candidate++) {
+          if (candidate !== partition) {
+            tn.set(
+              store.pack(["gc", "lease", "pin", candidate]),
+              Buffer.from(
+                JSON.stringify({
+                  token: `simultaneous-owner-${candidate}`,
+                  expiresAt: due + 61_000,
+                }),
+              ),
+            );
+          }
+        }
+      });
+      const takeover = await store.sweepTerminalPins(authority, { limit: 1 });
+      releaseProbe();
+      const expiredResult = await Promise.allSettled([expiredOwner]);
+      await getNuqFdbDatabase().doTn(async tn => {
+        for (const key of liveLeaseKeys) tn.clear(key);
+      });
+
+      expect(takeover).toEqual({
+        partition,
+        read: 1,
+        removed: 1,
+        retained: 0,
+        stale: 0,
+        hasMore: true,
+      });
+      expect(expiredResult[0]).toMatchObject({
+        status: "rejected",
+        reason: { code: "NUQ_MIGRATION_GC_LEASE_LOST" },
+      });
       await expect(
         store.inspectPin("scrape_job", objectId),
       ).resolves.toBeNull();
-      await expect(store.inspectGcBacklog()).resolves.toMatchObject({
-        pin: { due: expect.any(Number) },
+      await expect(store.inspectGcBacklog(due + 31_000)).resolves.toMatchObject(
+        { pin: { due: baselineAfterExpiry } },
+      );
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("takeover accounting is exact for retained and stale terminal pins", async () => {
+    const base = 1_837_500_000_000;
+    const due = base + 46 * 24 * 60 * 60 * 1000;
+    const recheckMs = 60 * 60 * 1000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(base);
+    try {
+      const baselineDue = (await store.inspectGcBacklog(due)).pin.due;
+      const baselineAtRecheck = (await store.inspectGcBacklog(due + recheckMs))
+        .pin.due;
+      const teamId = team();
+      const objectId = object();
+      await initialize(teamId, "pg");
+      await store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        admission: { type: "new-root" },
       });
+      await store.completePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      });
+      const indexRows = await getNuqFdbDatabase().doTn(async tn =>
+        tn
+          .snapshot()
+          .getRangeAll(
+            store.pack(["gc", "pin"]),
+            store.pack(["gc", "pin", 32]),
+          ),
+      );
+      const indexParts = indexRows
+        .map(([key]) => getFdb().tuple.unpack(key as Buffer))
+        .find(parts => parts.some(part => String(part) === objectId));
+      const partition = Number(indexParts?.[4]);
+      expect(partition).toBeGreaterThanOrEqual(0);
+      const authority = {
+        pgObjectExists: vi.fn(async () => true),
+        fdbReferenceExistsInTxn: vi.fn(async () => false),
+      };
+
+      clock.mockReturnValue(due);
+      await getNuqFdbDatabase().doTn(async tn =>
+        tn.set(
+          store.pack(["gc", "cursor", "pin"]),
+          Buffer.from(JSON.stringify(partition)),
+        ),
+      );
+      await expect(
+        store.sweepTerminalPins(authority, { limit: 1, recheckMs }),
+      ).resolves.toEqual({
+        partition,
+        read: 1,
+        removed: 0,
+        retained: 1,
+        stale: 0,
+        hasMore: true,
+      });
+      await expect(store.inspectGcBacklog(due)).resolves.toMatchObject({
+        pin: { due: baselineDue },
+      });
+      await expect(
+        store.inspectGcBacklog(due + recheckMs),
+      ).resolves.toMatchObject({ pin: { due: baselineAtRecheck + 1 } });
+
+      await getNuqFdbDatabase().doTn(async tn => {
+        tn.clear(store.objectKey("scrape_job", objectId));
+        tn.set(
+          store.pack(["gc", "cursor", "pin"]),
+          Buffer.from(JSON.stringify(partition)),
+        );
+      });
+      clock.mockReturnValue(due + recheckMs);
+      await expect(
+        store.sweepTerminalPins(authority, { limit: 1 }),
+      ).resolves.toEqual({
+        partition,
+        read: 1,
+        removed: 0,
+        retained: 0,
+        stale: 1,
+        hasMore: true,
+      });
+      expect(authority.pgObjectExists).toHaveBeenCalledTimes(1);
+      await expect(
+        store.inspectGcBacklog(due + recheckMs),
+      ).resolves.toMatchObject({ pin: { due: baselineAtRecheck } });
     } finally {
       clock.mockRestore();
     }

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -289,6 +289,47 @@ describeIf("NuQ global FDB migration control plane", () => {
     });
   });
 
+  test("legacy objects require explicit backend and generation backfill", async () => {
+    const teamId = team();
+    const groupId = object("group");
+    const childId = object();
+    await initialize(teamId);
+    await begin(teamId);
+
+    await expect(
+      store.preparePinnedObject({
+        teamId,
+        kind: "group",
+        objectId: groupId,
+        admission: { type: "legacy-backfill", backend: "fdb", generation: 1 },
+      }),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_STALE_GENERATION" });
+
+    const group = await store.preparePinnedObject({
+      teamId,
+      kind: "group",
+      objectId: groupId,
+      admission: { type: "legacy-backfill", backend: "pg", generation: 1 },
+      residue: { control_groups: 1 },
+    });
+    expect(group).toMatchObject({
+      admission: "legacy-backfill",
+      backend: "pg",
+      generation: 1,
+    });
+    await expect(
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: childId,
+        admission: {
+          type: "pinned-continuation",
+          source: { kind: "group", objectId: groupId },
+        },
+      }),
+    ).resolves.toMatchObject({ backend: "pg", generation: 1 });
+  });
+
   test("a concurrent residue increment and final seal cannot both win", async () => {
     const teamId = team();
     const pinId = object();

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -62,6 +62,19 @@ describeIf("NuQ global FDB migration control plane", () => {
     for (const item of objects) {
       await db.doTn(async tn => tn.clear(store.objectKey(item.kind, item.id)));
     }
+    // GC indexes are global by design; test identities are run-qualified.
+    const gcRange = fdb.tuple.range(["nuq-migration", 1, "gc"]);
+    const gcRows = await db.doTn(async tn =>
+      tn.snapshot().getRangeAll(gcRange.begin as Buffer, gcRange.end as Buffer),
+    );
+    await db.doTn(async tn => {
+      for (const [key] of gcRows) {
+        const parts = fdb.tuple.unpack(key as Buffer);
+        if (parts.some(part => String(part).includes(RUN))) {
+          tn.clear(key as Buffer);
+        }
+      }
+    });
   });
 
   test("legacy teams require explicit authority and steady resolution is durable", async () => {
@@ -1121,6 +1134,200 @@ describeIf("NuQ global FDB migration control plane", () => {
       });
     } finally {
       doTn.mockRestore();
+    }
+  });
+
+  test("bounded terminal GC retains canonical rows and resumes its durable cursor", async () => {
+    const base = 1_800_000_000_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(base);
+    try {
+      const teamId = team();
+      await initialize(teamId, "fdb");
+      const ids = Array.from({ length: 150 }, () => object());
+      await store.preparePinnedObjects(
+        ids.map(objectId => ({
+          teamId,
+          kind: "scrape_job" as const,
+          objectId,
+          admission: { type: "new-root" as const },
+        })),
+      );
+      for (const objectId of ids) {
+        await store.completePinnedObject({
+          teamId,
+          kind: "scrape_job",
+          objectId,
+          operationId: randomUUID(),
+          fromLifecycle: "prepared",
+        });
+      }
+
+      const retainedId = ids[0];
+      const runtimeKey = store.pack(["test-runtime", retainedId]);
+      await getNuqFdbDatabase().doTn(async tn =>
+        tn.set(runtimeKey, Buffer.from("live")),
+      );
+      clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
+      const authority = {
+        pgObjectExists: vi.fn(async () => false),
+        fdbReferenceExistsInTxn: vi.fn(
+          async (
+            tn: import("foundationdb").Transaction,
+            pin: { objectId: string },
+          ) =>
+            Boolean(
+              pin.objectId === retainedId ? await tn.get(runtimeKey) : false,
+            ),
+        ),
+      };
+
+      const firstStore = new NuqFdbMigrationStore();
+      const first = await firstStore.sweepTerminalPins(authority, { limit: 7 });
+      const restartedStore = new NuqFdbMigrationStore();
+      const second = await restartedStore.sweepTerminalPins(authority, {
+        limit: 7,
+      });
+      expect(first?.read).toBeLessThanOrEqual(7);
+      expect(second?.read).toBeLessThanOrEqual(7);
+      expect(second?.partition).not.toBe(first?.partition);
+
+      for (let pass = 0; pass < 3; pass++) {
+        for (let partition = 0; partition < 32; partition++) {
+          const result = await restartedStore.sweepTerminalPins(authority);
+          expect(result?.read ?? 0).toBeLessThanOrEqual(100);
+        }
+      }
+      await expect(
+        store.inspectPin("scrape_job", retainedId),
+      ).resolves.toMatchObject({ lifecycle: "terminal" });
+      for (const objectId of ids.slice(1)) {
+        await expect(
+          store.inspectPin("scrape_job", objectId),
+        ).resolves.toBeNull();
+      }
+
+      await getNuqFdbDatabase().doTn(async tn => tn.clear(runtimeKey));
+      clock.mockReturnValue(
+        base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+      );
+      for (let partition = 0; partition < 32; partition++) {
+        await restartedStore.sweepTerminalPins(authority);
+      }
+      await expect(
+        store.inspectPin("scrape_job", retainedId),
+      ).resolves.toBeNull();
+      expect(authority.pgObjectExists).not.toHaveBeenCalled();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("PG canonical check is followed by FDB CAS and marker loss cannot authorize early GC", async () => {
+    const base = 1_850_000_000_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(base);
+    try {
+      const teamId = team();
+      const objectId = object();
+      await initialize(teamId, "pg");
+      await store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        admission: { type: "new-root" },
+      });
+      await store.completePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      });
+      let pgPresent = true;
+      const authority = {
+        pgObjectExists: vi.fn(async () => pgPresent),
+        fdbReferenceExistsInTxn: vi.fn(async () => false),
+      };
+      clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
+      for (let partition = 0; partition < 32; partition++) {
+        await store.sweepTerminalPins(authority);
+      }
+      await expect(
+        store.inspectPin("scrape_job", objectId),
+      ).resolves.toMatchObject({ lifecycle: "terminal" });
+      expect(authority.pgObjectExists).toHaveBeenCalled();
+      expect(authority.fdbReferenceExistsInTxn).toHaveBeenCalled();
+
+      // This models a lost Redis routing hint: it is not part of the authority
+      // contract. Only the bounded PG adapter becoming empty permits removal.
+      pgPresent = false;
+      clock.mockReturnValue(
+        base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+      );
+      for (let partition = 0; partition < 32; partition++) {
+        await store.sweepTerminalPins(authority);
+      }
+      await expect(
+        store.inspectPin("scrape_job", objectId),
+      ).resolves.toBeNull();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("sealed history waits for pins and GC removes controls before generations", async () => {
+    const base = 1_900_000_000_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(base);
+    try {
+      const teamId = team();
+      const pinId = object();
+      await initialize(teamId, "pg");
+      await store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: pinId,
+        admission: { type: "new-root" },
+      });
+      await store.completePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: pinId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      });
+      const transitionOperationId = randomUUID();
+      await begin(teamId, transitionOperationId);
+      await store.finalSeal({ teamId, transitionOperationId });
+      clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
+
+      for (let partition = 0; partition < 32; partition++) {
+        await store.sweepClosedGenerations();
+      }
+      await expect(
+        store.inspectGenerationIfPresent(teamId, 1),
+      ).resolves.not.toBeNull();
+
+      const authority = {
+        pgObjectExists: async () => false,
+        fdbReferenceExistsInTxn: async () => false,
+      };
+      for (let partition = 0; partition < 32; partition++) {
+        await store.sweepTerminalPins(authority);
+        await store.sweepControlHistory();
+      }
+      clock.mockReturnValue(
+        base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+      );
+      for (let partition = 0; partition < 32; partition++) {
+        await store.sweepClosedGenerations();
+      }
+      await expect(
+        store.inspectGenerationIfPresent(teamId, 1),
+      ).resolves.toBeNull();
+      await expect(
+        store.inspectGenerationIfPresent(teamId, 2),
+      ).resolves.toMatchObject({ generation: { status: "open" } });
+    } finally {
+      clock.mockRestore();
     }
   });
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -357,6 +357,115 @@ describeIf("NuQ global FDB migration control plane", () => {
     ).resolves.toMatchObject({ backend: "pg", generation: 1 });
   });
 
+  test("terminal legacy rows allocate bounded closed backend history without changing authority", async () => {
+    const teamId = team();
+    const objectId = object();
+    await initialize(teamId, "pg");
+    await expect(
+      store.ensureTerminalLegacyGeneration(teamId, "fdb"),
+    ).resolves.toBe(2);
+    await expect(
+      store.ensureTerminalLegacyGeneration(teamId, "fdb"),
+    ).resolves.toBe(2);
+    await expect(store.inspectState(teamId)).resolves.toMatchObject({
+      activeBackend: "pg",
+      activeGeneration: 1,
+      maxGeneration: 2,
+    });
+    await expect(store.inspectGeneration(teamId, 2)).resolves.toMatchObject({
+      generation: { backend: "fdb", status: "closed" },
+    });
+    await expect(
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        admission: {
+          type: "legacy-backfill",
+          backend: "fdb",
+          generation: 2,
+          terminal: true,
+        },
+        residue: {},
+      }),
+    ).resolves.toMatchObject({
+      backend: "fdb",
+      generation: 2,
+      lifecycle: "terminal",
+    });
+    await expect(
+      getNuqFdbDatabase().doTn(async tn =>
+        store.reconcileManagedObjectInTxn(tn, {
+          teamId,
+          kind: "scrape_job",
+          objectId,
+          residue: {},
+          terminal: true,
+        }),
+      ),
+    ).resolves.toMatchObject({ lifecycle: "terminal", generation: 2 });
+  });
+
+  test("runtime rows adopt legacy pins but existing new-root pins still require generations", async () => {
+    const teamId = team();
+    const newRootId = object();
+    const legacyId = object();
+    const implicitLegacyId = object();
+    await initialize(teamId, "fdb");
+    await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: newRootId,
+      admission: { type: "new-root" },
+      residue: { capacity_ready_active: 1 },
+    });
+    await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: legacyId,
+      admission: { type: "legacy-backfill", backend: "fdb", generation: 1 },
+      residue: { capacity_ready_active: 1 },
+    });
+
+    await expect(
+      getNuqFdbDatabase().doTn(async tn =>
+        store.reconcileManagedObjectInTxn(tn, {
+          teamId,
+          kind: "scrape_job",
+          objectId: newRootId,
+          residue: { capacity_ready_active: 1 },
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_RUNTIME_PIN_MISSING" });
+    await expect(
+      getNuqFdbDatabase().doTn(async tn =>
+        store.reconcileManagedObjectInTxn(tn, {
+          teamId,
+          kind: "scrape_job",
+          objectId: legacyId,
+          residue: { capacity_ready_active: 1 },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      lifecycle: "active",
+    });
+    await expect(
+      getNuqFdbDatabase().doTn(async tn =>
+        store.reconcileManagedObjectInTxn(tn, {
+          teamId,
+          kind: "scrape_job",
+          objectId: implicitLegacyId,
+          residue: { capacity_ready_active: 1 },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      admission: "legacy-backfill",
+      lifecycle: "active",
+      residue: { capacity_ready_active: 1 },
+    });
+  });
+
   test("a concurrent residue increment and final seal cannot both win", async () => {
     const teamId = team();
     const pinId = object();

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -50,6 +50,34 @@ async function begin(
   });
 }
 
+async function withGcPostCommitReplay<T>(body: () => Promise<T>): Promise<T> {
+  const db = getNuqFdbDatabase();
+  const originalDoTn = db.doTn.bind(db);
+  let replaying = false;
+  const outcomes = new Set(["removed", "stale", "retained"]);
+  const hook = vi
+    .spyOn(db, "doTn")
+    .mockImplementation(async (closure, opts) => {
+      const result = await originalDoTn(closure, opts);
+      if (!replaying && outcomes.has(String(result))) {
+        replaying = true;
+        try {
+          // Deterministically model doTn re-entering a closure after its first
+          // commit succeeded but the commit acknowledgement was lost.
+          await originalDoTn(closure, opts);
+        } finally {
+          replaying = false;
+        }
+      }
+      return result;
+    });
+  try {
+    return await body();
+  } finally {
+    hook.mockRestore();
+  }
+}
+
 describeIf("NuQ global FDB migration control plane", () => {
   afterAll(async () => {
     const fdb = getFdb();
@@ -1247,12 +1275,15 @@ describeIf("NuQ global FDB migration control plane", () => {
         true,
       );
 
-      for (let pass = 0; pass < 3; pass++) {
-        for (let partition = 0; partition < 32; partition++) {
-          const result = await restartedStore.sweepTerminalPins(authority);
-          expect(result?.read ?? 0).toBeLessThanOrEqual(100);
+      await withGcPostCommitReplay(async () => {
+        for (let pass = 0; pass < 3; pass++) {
+          for (let partition = 0; partition < 32; partition++) {
+            const result = await restartedStore.sweepTerminalPins(authority);
+            expect(result?.read ?? 0).toBeLessThanOrEqual(100);
+            await store.inspectGcBacklog();
+          }
         }
-      }
+      });
       await expect(
         store.inspectPin("scrape_job", retainedId),
       ).resolves.toMatchObject({ lifecycle: "terminal" });
@@ -1265,9 +1296,12 @@ describeIf("NuQ global FDB migration control plane", () => {
       clock.mockReturnValue(
         base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
       );
-      for (let partition = 0; partition < 32; partition++) {
-        await restartedStore.sweepTerminalPins(authority);
-      }
+      await withGcPostCommitReplay(async () => {
+        for (let partition = 0; partition < 32; partition++) {
+          await restartedStore.sweepTerminalPins(authority);
+          await store.inspectGcBacklog();
+        }
+      });
       await expect(
         store.inspectPin("scrape_job", retainedId),
       ).resolves.toBeNull();
@@ -1276,6 +1310,83 @@ describeIf("NuQ global FDB migration control plane", () => {
           ids.includes(pin.objectId),
         ),
       ).toBe(false);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("expired lease takeover fences an authority probe from every final mutation", async () => {
+    const base = 1_825_000_000_000;
+    const due = base + 46 * 24 * 60 * 60 * 1000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(base);
+    try {
+      const teamId = team();
+      const objectId = object();
+      await initialize(teamId, "pg");
+      await store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        admission: { type: "new-root" },
+      });
+      await store.completePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      });
+
+      let releaseProbe!: () => void;
+      const probeGate = new Promise<void>(resolve => {
+        releaseProbe = resolve;
+      });
+      let markProbeStarted!: () => void;
+      const probeStarted = new Promise<void>(resolve => {
+        markProbeStarted = resolve;
+      });
+      let calls = 0;
+      const authority = {
+        pgObjectExists: vi.fn(async () => {
+          calls++;
+          if (calls === 1) {
+            markProbeStarted();
+            await probeGate;
+          }
+          return false;
+        }),
+        fdbReferenceExistsInTxn: vi.fn(async () => false),
+      };
+
+      clock.mockReturnValue(due);
+      const expiredOwners = Promise.allSettled(
+        Array.from({ length: 32 }, () =>
+          store.sweepTerminalPins(authority, { limit: 1 }),
+        ),
+      );
+      await probeStarted;
+      clock.mockReturnValue(due + 31_000);
+      await Promise.all(
+        Array.from({ length: 32 }, () =>
+          store.sweepTerminalPins(authority, { limit: 1 }),
+        ),
+      );
+      releaseProbe();
+      const expiredResults = await expiredOwners;
+
+      expect(
+        expiredResults.some(
+          result =>
+            result.status === "rejected" &&
+            result.reason?.code === "NUQ_MIGRATION_GC_LEASE_LOST",
+        ),
+      ).toBe(true);
+      await expect(
+        store.inspectPin("scrape_job", objectId),
+      ).resolves.toBeNull();
+      await expect(store.inspectGcBacklog()).resolves.toMatchObject({
+        pin: { due: expect.any(Number) },
+      });
     } finally {
       clock.mockRestore();
     }
@@ -1378,16 +1489,36 @@ describeIf("NuQ global FDB migration control plane", () => {
       await store.finalSeal({ teamId, transitionOperationId });
       // Simulate a delayed writer restoring the target's now-stale closed
       // generation entry. The open generation/version CAS must make it a no-op.
-      await getNuqFdbDatabase().doTn(async tn =>
-        tn.set(targetGcEntry![0], targetGcEntry![1]),
-      );
+      await getNuqFdbDatabase().doTn(async tn => {
+        tn.set(targetGcEntry![0], targetGcEntry![1]);
+        const parts = fdb.tuple.unpack(targetGcEntry![0] as Buffer);
+        const partition = Number(parts[4]);
+        const dueAt = Number(parts[5]);
+        let node = BigInt(dueAt) + 1n;
+        while (node <= 1n << 53n) {
+          tn.add(
+            store.pack([
+              "gc",
+              "due-count",
+              "generation",
+              partition,
+              node.toString(),
+            ]),
+            encodeI64(1),
+          );
+          node += node & -node;
+        }
+      });
       clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
 
       let staleGenerationEntries = 0;
-      for (let partition = 0; partition < 32; partition++) {
-        staleGenerationEntries +=
-          (await store.sweepClosedGenerations())?.stale ?? 0;
-      }
+      await withGcPostCommitReplay(async () => {
+        for (let partition = 0; partition < 32; partition++) {
+          staleGenerationEntries +=
+            (await store.sweepClosedGenerations())?.stale ?? 0;
+          await store.inspectGcBacklog();
+        }
+      });
       expect(staleGenerationEntries).toBeGreaterThan(0);
       await expect(
         store.inspectGenerationIfPresent(teamId, 1),
@@ -1397,16 +1528,20 @@ describeIf("NuQ global FDB migration control plane", () => {
         pgObjectExists: async () => false,
         fdbReferenceExistsInTxn: async () => false,
       };
-      for (let partition = 0; partition < 32; partition++) {
-        await store.sweepTerminalPins(authority);
-        await store.sweepControlHistory();
-      }
-      clock.mockReturnValue(
-        base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
-      );
-      for (let partition = 0; partition < 32; partition++) {
-        await store.sweepClosedGenerations();
-      }
+      await withGcPostCommitReplay(async () => {
+        for (let partition = 0; partition < 32; partition++) {
+          await store.sweepTerminalPins(authority);
+          await store.sweepControlHistory();
+          await store.inspectGcBacklog();
+        }
+        clock.mockReturnValue(
+          base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,
+        );
+        for (let partition = 0; partition < 32; partition++) {
+          await store.sweepClosedGenerations();
+          await store.inspectGcBacklog();
+        }
+      });
       await expect(
         store.inspectGenerationIfPresent(teamId, 1),
       ).resolves.toBeNull();

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -437,7 +437,7 @@ describeIf("NuQ global FDB migration control plane", () => {
   test("pin preparation and residue transitions are exact-once across every counter class", async () => {
     const teamId = team();
     const objectId = object();
-    await initialize(teamId);
+    await initialize(teamId, "fdb");
     const initial = Object.fromEntries(
       MIGRATION_RESIDUE_COUNTERS.map(counter => [counter, 1]),
     );
@@ -489,6 +489,40 @@ describeIf("NuQ global FDB migration control plane", () => {
       activeResidue,
     );
 
+    // An untagged runtime mutation may commit between an operation's unknown
+    // outcome and its retry. It must retain the one bounded token and replay
+    // the historical operation result without restoring stale residue.
+    const reconciledResidue = {
+      capacity_ready_active: 1,
+      control_groups: 1,
+    };
+    await getNuqFdbDatabase().doTn(async tn => {
+      await store.reconcileManagedObjectInTxn(tn, {
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        recordPin: {
+          backend: active.backend,
+          generation: active.generation,
+        },
+        residue: reconciledResidue,
+      });
+    });
+    await expect(
+      store.transitionObjectResidue({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: transitionOperationId,
+        fromLifecycle: "prepared",
+        toLifecycle: "active",
+        residue: activeResidue,
+      }),
+    ).resolves.toEqual(active);
+    expect((await store.inspectGeneration(teamId, 1)).residue).toMatchObject(
+      reconciledResidue,
+    );
+
     const completionOperationId = randomUUID();
     const terminal = await store.completePinnedObject({
       teamId,
@@ -507,12 +541,114 @@ describeIf("NuQ global FDB migration control plane", () => {
       }),
     ).resolves.toEqual(terminal);
     expect(terminal.lifecycle).toBe("terminal");
+    expect(terminal.lastOperation).toMatchObject({
+      operationId: completionOperationId,
+      fromLifecycle: "active",
+      toLifecycle: "terminal",
+      resultRevision: terminal.revision,
+    });
+    const operationRange = getFdb().tuple.range([
+      "nuq-migration",
+      1,
+      "team",
+      teamId,
+      "object-operation",
+    ]);
+    await expect(
+      getNuqFdbDatabase().doTn(async tn =>
+        tn
+          .snapshot()
+          .getRangeAll(
+            operationRange.begin as Buffer,
+            operationRange.end as Buffer,
+          ),
+      ),
+    ).resolves.toHaveLength(0);
     expect(
       Object.values((await store.inspectGeneration(teamId, 1)).residue),
     ).toEqual(Array(MIGRATION_RESIDUE_COUNTERS.length).fill(0));
     await expect(store.inspectPin("scrape_job", objectId)).resolves.toEqual(
       terminal,
     );
+  });
+
+  test("legacy object-operation rows replay once into the bounded pin token", async () => {
+    const teamId = team();
+    const objectId = object();
+    await initialize(teamId, "fdb");
+    await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      admission: { type: "new-root" },
+      residue: { capacity_ready_active: 1 },
+    });
+    const operationId = randomUUID();
+    const active = await store.transitionObjectResidue({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId,
+      fromLifecycle: "prepared",
+      toLifecycle: "active",
+      residue: { capacity_ready_active: 1 },
+    });
+    const { lastOperation: _boundedToken, ...legacyResult } = active;
+    const legacyOperationKey = store.pack([
+      "team",
+      teamId,
+      "object-operation",
+      "scrape_job",
+      objectId,
+      operationId,
+    ]);
+    await getNuqFdbDatabase().doTn(async tn => {
+      const encoded = Buffer.from(JSON.stringify(legacyResult));
+      tn.set(store.objectKey("scrape_job", objectId), encoded);
+      tn.set(
+        store.pack(["team", teamId, "object", "scrape_job", objectId]),
+        encoded,
+      );
+      tn.set(
+        legacyOperationKey,
+        Buffer.from(
+          JSON.stringify({
+            schemaVersion: 1,
+            operationId,
+            teamId,
+            kind: "scrape_job",
+            objectId,
+            fromLifecycle: "prepared",
+            toLifecycle: "active",
+            residue: active.residue,
+            result: legacyResult,
+          }),
+        ),
+      );
+    });
+
+    await expect(
+      store.transitionObjectResidue({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId,
+        fromLifecycle: "prepared",
+        toLifecycle: "active",
+        residue: { capacity_ready_active: 1 },
+      }),
+    ).resolves.toEqual(legacyResult);
+    await expect(
+      store.inspectPin("scrape_job", objectId),
+    ).resolves.toMatchObject({
+      lastOperation: {
+        operationId,
+        resultRevision: legacyResult.revision,
+      },
+    });
+    await expect(
+      getNuqFdbDatabase().doTn(async tn => tn.get(legacyOperationKey)),
+    ).resolves.toBeUndefined();
   });
 
   test("stable transition operation ids replay after no-op, cancel, and final seal", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -1169,7 +1169,7 @@ describeIf("NuQ global FDB migration control plane", () => {
       );
       clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
       const authority = {
-        pgObjectExists: vi.fn(async () => false),
+        pgObjectExists: vi.fn(async (_pin: { objectId: string }) => false),
         fdbReferenceExistsInTxn: vi.fn(
           async (
             tn: import("foundationdb").Transaction,
@@ -1216,7 +1216,11 @@ describeIf("NuQ global FDB migration control plane", () => {
       await expect(
         store.inspectPin("scrape_job", retainedId),
       ).resolves.toBeNull();
-      expect(authority.pgObjectExists).not.toHaveBeenCalled();
+      expect(
+        authority.pgObjectExists.mock.calls.some(([pin]) =>
+          ids.includes(pin.objectId),
+        ),
+      ).toBe(false);
     } finally {
       clock.mockRestore();
     }
@@ -1296,12 +1300,40 @@ describeIf("NuQ global FDB migration control plane", () => {
       });
       const transitionOperationId = randomUUID();
       await begin(teamId, transitionOperationId);
+      const fdb = getFdb();
+      const generationGcRange = fdb.tuple.range([
+        "nuq-migration",
+        1,
+        "gc",
+        "generation",
+      ]);
+      const targetGcEntry = await getNuqFdbDatabase().doTn(async tn => {
+        const rows = await tn
+          .snapshot()
+          .getRangeAll(
+            generationGcRange.begin as Buffer,
+            generationGcRange.end as Buffer,
+          );
+        return rows.find(([key]) => {
+          const parts = fdb.tuple.unpack(key as Buffer).map(String);
+          return parts.includes(teamId) && parts.includes("2");
+        }) as [Buffer, Buffer] | undefined;
+      });
+      expect(targetGcEntry).toBeDefined();
       await store.finalSeal({ teamId, transitionOperationId });
+      // Simulate a delayed writer restoring the target's now-stale closed
+      // generation entry. The open generation/version CAS must make it a no-op.
+      await getNuqFdbDatabase().doTn(async tn =>
+        tn.set(targetGcEntry![0], targetGcEntry![1]),
+      );
       clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
 
+      let staleGenerationEntries = 0;
       for (let partition = 0; partition < 32; partition++) {
-        await store.sweepClosedGenerations();
+        staleGenerationEntries +=
+          (await store.sweepClosedGenerations())?.stale ?? 0;
       }
+      expect(staleGenerationEntries).toBeGreaterThan(0);
       await expect(
         store.inspectGenerationIfPresent(teamId, 1),
       ).resolves.not.toBeNull();

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -93,6 +93,11 @@ describeIf("NuQ global FDB migration control plane", () => {
     await expect(
       store.initializeLegacyTeam(teamId, "pg", operationId),
     ).resolves.toEqual(initialized);
+    await expect(
+      store.initializeLegacyTeam(teamId, "fdb", randomUUID(), {
+        ifAbsent: true,
+      }),
+    ).resolves.toEqual(initialized);
     await expect(store.resolveSteady(teamId, "pg")).resolves.toMatchObject({
       status: "steady",
     });

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -9,6 +9,7 @@ import {
   getFdb,
   getNuqFdbDatabase,
 } from "../../services/worker/nuq-fdb/client";
+import { encodeI64 } from "../../services/worker/nuq-fdb/keyspace";
 import { reconcilePgResidueFence } from "../../services/worker/nuq-migration-control";
 
 // These tests intentionally exercise transaction conflicts and atomic ADDs on
@@ -68,10 +69,43 @@ describeIf("NuQ global FDB migration control plane", () => {
       tn.snapshot().getRangeAll(gcRange.begin as Buffer, gcRange.end as Buffer),
     );
     await db.doTn(async tn => {
+      const dueCountRange = fdb.tuple.range([
+        "nuq-migration",
+        1,
+        "gc",
+        "due-count",
+      ]);
+      tn.clearRange(dueCountRange.begin as Buffer, dueCountRange.end as Buffer);
       for (const [key] of gcRows) {
         const parts = fdb.tuple.unpack(key as Buffer);
         if (parts.some(part => String(part).includes(RUN))) {
           tn.clear(key as Buffer);
+          continue;
+        }
+        const category = String(parts[3]);
+        const partition = Number(parts[4]);
+        const dueAt = Number(parts[5]);
+        if (
+          (category === "pin" ||
+            category === "control" ||
+            category === "generation") &&
+          Number.isSafeInteger(partition) &&
+          Number.isSafeInteger(dueAt)
+        ) {
+          let node = BigInt(dueAt) + 1n;
+          while (node <= 1n << 53n) {
+            tn.add(
+              store.pack([
+                "gc",
+                "due-count",
+                category,
+                partition,
+                node.toString(),
+              ]),
+              encodeI64(1),
+            );
+            node += node & -node;
+          }
         }
       }
     });
@@ -1141,6 +1175,9 @@ describeIf("NuQ global FDB migration control plane", () => {
     const base = 1_800_000_000_000;
     const clock = vi.spyOn(Date, "now").mockReturnValue(base);
     try {
+      clock.mockReturnValue(base + 46 * 24 * 60 * 60 * 1000);
+      const baselineDue = (await store.inspectGcBacklog()).pin.due;
+      clock.mockReturnValue(base);
       const teamId = team();
       await initialize(teamId, "fdb");
       const ids = Array.from({ length: 150 }, () => object());
@@ -1181,6 +1218,13 @@ describeIf("NuQ global FDB migration control plane", () => {
         ),
       };
 
+      await expect(store.inspectGcBacklog()).resolves.toMatchObject({
+        pin: {
+          due: baselineDue + 150,
+          oldestOverdueMs: expect.any(Number),
+        },
+      });
+
       const firstStore = new NuqFdbMigrationStore();
       const first = await firstStore.sweepTerminalPins(authority, { limit: 7 });
       const restartedStore = new NuqFdbMigrationStore();
@@ -1190,6 +1234,18 @@ describeIf("NuQ global FDB migration control plane", () => {
       expect(first?.read).toBeLessThanOrEqual(7);
       expect(second?.read).toBeLessThanOrEqual(7);
       expect(second?.partition).not.toBe(first?.partition);
+
+      const concurrentClaims = await Promise.all(
+        Array.from({ length: 32 }, () =>
+          restartedStore.sweepTerminalPins(authority, { limit: 1 }),
+        ),
+      );
+      expect(
+        new Set(concurrentClaims.map(result => result?.partition)).size,
+      ).toBe(32);
+      expect(concurrentClaims.every(result => (result?.read ?? 0) <= 1)).toBe(
+        true,
+      );
 
       for (let pass = 0; pass < 3; pass++) {
         for (let partition = 0; partition < 32; partition++) {
@@ -1205,7 +1261,6 @@ describeIf("NuQ global FDB migration control plane", () => {
           store.inspectPin("scrape_job", objectId),
         ).resolves.toBeNull();
       }
-
       await getNuqFdbDatabase().doTn(async tn => tn.clear(runtimeKey));
       clock.mockReturnValue(
         base + 46 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000,

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -1,0 +1,652 @@
+import { randomUUID } from "crypto";
+import { vi } from "vitest";
+import { config } from "../../config";
+import {
+  MIGRATION_RESIDUE_COUNTERS,
+  NuqFdbMigrationStore,
+} from "../../services/worker/nuq-fdb";
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+
+// These tests intentionally exercise transaction conflicts and atomic ADDs on
+// a real FoundationDB cluster. They are skipped in ordinary PG-only runs.
+const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
+
+const RUN = randomUUID();
+const store = new NuqFdbMigrationStore();
+const teams = new Set<string>();
+const objects: Array<{ kind: "scrape_job" | "group"; id: string }> = [];
+
+function team(): string {
+  const id = `${RUN}-${randomUUID()}`;
+  teams.add(id);
+  return id;
+}
+
+function object(kind: "scrape_job" | "group" = "scrape_job") {
+  const id = `${RUN}-${randomUUID()}`;
+  objects.push({ kind, id });
+  return id;
+}
+
+async function initialize(teamId: string, backend: "pg" | "fdb" = "pg") {
+  return await store.initializeLegacyTeam(teamId, backend, randomUUID());
+}
+
+async function begin(
+  teamId: string,
+  operationId = randomUUID(),
+  expectedRevision?: number,
+) {
+  return await store.beginTransition({
+    teamId,
+    targetBackend: "fdb",
+    operationId,
+    expectedRevision,
+  });
+}
+
+describeIf("NuQ global FDB migration control plane", () => {
+  afterAll(async () => {
+    const fdb = getFdb();
+    const db = getNuqFdbDatabase();
+    for (const teamId of teams) {
+      const range = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+      await db.doTn(async tn =>
+        tn.clearRange(range.begin as Buffer, range.end as Buffer),
+      );
+    }
+    for (const item of objects) {
+      await db.doTn(async tn => tn.clear(store.objectKey(item.kind, item.id)));
+    }
+  });
+
+  test("legacy teams require explicit authority and steady resolution is durable", async () => {
+    const teamId = team();
+
+    await expect(store.resolveSteady(teamId, "fdb")).resolves.toEqual({
+      status: "legacy-uninitialized",
+    });
+    await expect(
+      store.beginTransition({
+        teamId,
+        targetBackend: "fdb",
+        operationId: randomUUID(),
+      }),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_LEGACY_UNINITIALIZED" });
+
+    const operationId = randomUUID();
+    const initialized = await store.initializeLegacyTeam(
+      teamId,
+      "pg",
+      operationId,
+    );
+    expect(initialized).toMatchObject({
+      revision: 1,
+      maxGeneration: 1,
+      activeBackend: "pg",
+      activeGeneration: 1,
+      phase: "PG_ONLY",
+    });
+    await expect(
+      store.initializeLegacyTeam(teamId, "pg", operationId),
+    ).resolves.toEqual(initialized);
+    await expect(store.resolveSteady(teamId, "pg")).resolves.toMatchObject({
+      status: "steady",
+    });
+    await expect(store.resolveSteady(teamId, "fdb")).resolves.toMatchObject({
+      status: "transition-required",
+    });
+  });
+
+  test("revision CAS admits exactly one racing transition", async () => {
+    const teamId = team();
+    await initialize(teamId);
+
+    const results = await Promise.allSettled([
+      begin(teamId, randomUUID(), 1),
+      begin(teamId, randomUUID(), 1),
+    ]);
+    expect(
+      results.filter(result => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = results.find(result => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      reason: { code: "NUQ_MIGRATION_CAS_MISMATCH", retryable: true },
+    });
+    await expect(store.inspectState(teamId)).resolves.toMatchObject({
+      revision: 2,
+      maxGeneration: 2,
+      phase: "DRAINING_TO_FDB",
+    });
+  });
+
+  test("flag flaps burn target generations and never reuse them", async () => {
+    const teamId = team();
+    await initialize(teamId);
+
+    const firstOp = randomUUID();
+    const first = await begin(teamId, firstOp);
+    expect(first.targetGeneration).toBe(2);
+    const firstCancel = await store.cancelTransition({
+      teamId,
+      transitionOperationId: firstOp,
+      expectedRevision: first.revision,
+    });
+    await expect(
+      store.cancelTransition({ teamId, transitionOperationId: firstOp }),
+    ).resolves.toEqual(firstCancel);
+
+    const secondOp = randomUUID();
+    const second = await begin(teamId, secondOp);
+    expect(second.targetGeneration).toBe(3);
+    await store.cancelTransition({
+      teamId,
+      transitionOperationId: secondOp,
+    });
+
+    const third = await begin(teamId);
+    expect(third).toMatchObject({ maxGeneration: 4, targetGeneration: 4 });
+    await expect(store.inspectGeneration(teamId, 2)).resolves.toMatchObject({
+      generation: { status: "closed", backend: "fdb" },
+    });
+    await expect(store.inspectGeneration(teamId, 3)).resolves.toMatchObject({
+      generation: { status: "closed", backend: "fdb" },
+    });
+  });
+
+  test("FDB to PG transitions use the same closed-target seal protocol", async () => {
+    const teamId = team();
+    await initialize(teamId, "fdb");
+    const operationId = randomUUID();
+    const draining = await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId,
+      expectedRevision: 1,
+    });
+    expect(draining).toMatchObject({
+      phase: "DRAINING_TO_PG",
+      activeBackend: "fdb",
+      targetBackend: "pg",
+      targetGeneration: 2,
+    });
+    const sealed = await store.finalSeal({
+      teamId,
+      transitionOperationId: operationId,
+      expectedRevision: draining.revision,
+    });
+    expect(sealed).toMatchObject({
+      phase: "PG_ONLY",
+      activeBackend: "pg",
+      activeGeneration: 2,
+    });
+    await expect(store.inspectGeneration(teamId, 1)).resolves.toMatchObject({
+      generation: { backend: "fdb", status: "closed" },
+    });
+    await expect(store.inspectGeneration(teamId, 2)).resolves.toMatchObject({
+      generation: { backend: "pg", status: "open" },
+    });
+  });
+
+  test("new roots stop while draining, pinned continuations drain, and sealed generations reject stale work", async () => {
+    const teamId = team();
+    const rootId = object("group");
+    const childId = object();
+    const lateId = object();
+    const dormantId = object();
+    await initialize(teamId);
+    await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: dormantId,
+      admission: { type: "new-root" },
+    });
+    await store.preparePinnedObject({
+      teamId,
+      kind: "group",
+      objectId: rootId,
+      admission: { type: "new-root" },
+      residue: { control_groups: 1 },
+    });
+    const operationId = randomUUID();
+    const transition = await begin(teamId, operationId);
+
+    await expect(
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: lateId,
+        admission: { type: "new-root" },
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+      retryable: true,
+    });
+    await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: childId,
+      admission: {
+        type: "pinned-continuation",
+        source: { kind: "group", objectId: rootId },
+      },
+      residue: { capacity_ready_active: 1 },
+    });
+    await expect(
+      store.finalSeal({ teamId, transitionOperationId: operationId }),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_RESIDUE_NOT_EMPTY" });
+
+    await store.completePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId: childId,
+      operationId: randomUUID(),
+      fromLifecycle: "prepared",
+    });
+    await store.completePinnedObject({
+      teamId,
+      kind: "group",
+      objectId: rootId,
+      operationId: randomUUID(),
+      fromLifecycle: "prepared",
+    });
+    await store.finalSeal({
+      teamId,
+      transitionOperationId: operationId,
+      expectedRevision: transition.revision,
+    });
+
+    await expect(
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: object(),
+        admission: {
+          type: "pinned-continuation",
+          source: { kind: "group", objectId: rootId },
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_STALE_GENERATION",
+      retryable: true,
+    });
+    await expect(
+      store.transitionObjectResidue({
+        teamId,
+        kind: "scrape_job",
+        objectId: dormantId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+        toLifecycle: "active",
+        residue: { capacity_ready_active: 1 },
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_STALE_GENERATION",
+      retryable: true,
+    });
+  });
+
+  test("a concurrent residue increment and final seal cannot both win", async () => {
+    const teamId = team();
+    const pinId = object();
+    const sourceId = object("group");
+    await initialize(teamId);
+    await store.preparePinnedObject({
+      teamId,
+      kind: "group",
+      objectId: sourceId,
+      admission: { type: "new-root" },
+    });
+    const transitionOperationId = randomUUID();
+    await begin(teamId, transitionOperationId);
+
+    const [prepareResult, sealResult] = await Promise.allSettled([
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: pinId,
+        admission: {
+          type: "pinned-continuation",
+          source: { kind: "group", objectId: sourceId },
+        },
+        residue: { capacity_team_pending: 1 },
+      }),
+      store.finalSeal({ teamId, transitionOperationId }),
+    ]);
+
+    expect(
+      prepareResult.status === "fulfilled" && sealResult.status === "fulfilled",
+    ).toBe(false);
+    const source = await store.inspectGeneration(teamId, 1);
+    if (sealResult.status === "fulfilled") {
+      expect(prepareResult).toMatchObject({
+        status: "rejected",
+        reason: { code: "NUQ_MIGRATION_STALE_GENERATION" },
+      });
+      expect(source).toMatchObject({
+        generation: { status: "closed" },
+        residue: { capacity_team_pending: 0 },
+      });
+    } else {
+      expect(prepareResult.status).toBe("fulfilled");
+      expect(sealResult).toMatchObject({
+        reason: { code: "NUQ_MIGRATION_RESIDUE_NOT_EMPTY" },
+      });
+      expect(source).toMatchObject({
+        generation: { status: "draining" },
+        residue: { capacity_team_pending: 1 },
+      });
+      await store.completePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId: pinId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      });
+      await store.finalSeal({ teamId, transitionOperationId });
+    }
+  });
+
+  test("transaction-scoped hooks compose accounting with caller mutations", async () => {
+    const teamId = team();
+    const objectId = object();
+    const marker = store.pack(["team", teamId, "test-caller-mutation"]);
+    await initialize(teamId);
+
+    await getNuqFdbDatabase().doTn(async tn => {
+      await store.preparePinnedObjectInTxn(tn, {
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        admission: { type: "new-root" },
+        residue: { intent_unresolved: 1 },
+      });
+      tn.set(marker, Buffer.from("published"));
+    });
+    await expect(
+      getNuqFdbDatabase().doTn(async tn => (await tn.get(marker))?.toString()),
+    ).resolves.toBe("published");
+    expect((await store.inspectGeneration(teamId, 1)).residue).toMatchObject({
+      intent_unresolved: 1,
+    });
+
+    await getNuqFdbDatabase().doTn(async tn => {
+      await store.completePinnedObjectInTxn(tn, {
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      });
+      tn.clear(marker);
+    });
+    expect((await store.inspectGeneration(teamId, 1)).residue).toMatchObject({
+      intent_unresolved: 0,
+    });
+  });
+
+  test("pin preparation and residue transitions are exact-once across every counter class", async () => {
+    const teamId = team();
+    const objectId = object();
+    await initialize(teamId);
+    const initial = Object.fromEntries(
+      MIGRATION_RESIDUE_COUNTERS.map(counter => [counter, 1]),
+    );
+    const prepared = await store.preparePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      admission: { type: "new-root" },
+      residue: initial,
+    });
+    await expect(
+      store.preparePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        admission: { type: "new-root" },
+        residue: initial,
+      }),
+    ).resolves.toEqual(prepared);
+    expect((await store.inspectGeneration(teamId, 1)).residue).toEqual(initial);
+
+    const activeResidue = {
+      capacity_ready_active: 2,
+      control_groups: 1,
+      intent_unresolved: 3,
+    };
+    const transitionOperationId = randomUUID();
+    const active = await store.transitionObjectResidue({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: transitionOperationId,
+      fromLifecycle: "prepared",
+      toLifecycle: "active",
+      residue: activeResidue,
+    });
+    await expect(
+      store.transitionObjectResidue({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: transitionOperationId,
+        fromLifecycle: "prepared",
+        toLifecycle: "active",
+        residue: activeResidue,
+      }),
+    ).resolves.toEqual(active);
+    expect((await store.inspectGeneration(teamId, 1)).residue).toMatchObject(
+      activeResidue,
+    );
+
+    const completionOperationId = randomUUID();
+    const terminal = await store.completePinnedObject({
+      teamId,
+      kind: "scrape_job",
+      objectId,
+      operationId: completionOperationId,
+      fromLifecycle: "active",
+    });
+    await expect(
+      store.completePinnedObject({
+        teamId,
+        kind: "scrape_job",
+        objectId,
+        operationId: completionOperationId,
+        fromLifecycle: "active",
+      }),
+    ).resolves.toEqual(terminal);
+    expect(terminal.lifecycle).toBe("terminal");
+    expect(
+      Object.values((await store.inspectGeneration(teamId, 1)).residue),
+    ).toEqual(Array(MIGRATION_RESIDUE_COUNTERS.length).fill(0));
+    await expect(store.inspectPin("scrape_job", objectId)).resolves.toEqual(
+      terminal,
+    );
+  });
+
+  test("stable transition operation ids replay after no-op, cancel, and final seal", async () => {
+    const teamId = team();
+    await initialize(teamId);
+    const noOpOperationId = randomUUID();
+    const noOp = await store.beginTransition({
+      teamId,
+      targetBackend: "pg",
+      operationId: noOpOperationId,
+    });
+    const cancelledOperationId = randomUUID();
+    const begun = await begin(teamId, cancelledOperationId);
+    await expect(begin(teamId, cancelledOperationId)).resolves.toEqual(begun);
+    const cancelled = await store.cancelTransition({
+      teamId,
+      transitionOperationId: cancelledOperationId,
+    });
+    await expect(
+      store.cancelTransition({
+        teamId,
+        transitionOperationId: cancelledOperationId,
+      }),
+    ).resolves.toEqual(cancelled);
+    await expect(begin(teamId, cancelledOperationId)).resolves.toEqual(
+      cancelled,
+    );
+
+    const sealedOperationId = randomUUID();
+    const second = await begin(teamId, sealedOperationId);
+    await expect(begin(teamId, sealedOperationId)).resolves.toEqual(second);
+    const sealed = await store.finalSeal({
+      teamId,
+      transitionOperationId: sealedOperationId,
+    });
+    await expect(
+      store.finalSeal({
+        teamId,
+        transitionOperationId: sealedOperationId,
+      }),
+    ).resolves.toEqual(sealed);
+    await expect(begin(teamId, sealedOperationId)).resolves.toEqual(sealed);
+    await expect(
+      store.beginTransition({
+        teamId,
+        targetBackend: "pg",
+        operationId: noOpOperationId,
+      }),
+    ).resolves.toEqual(noOp);
+    await expect(store.inspectState(teamId)).resolves.toEqual(sealed);
+    await expect(
+      store.beginTransition({
+        teamId,
+        targetBackend: "pg",
+        operationId: sealedOperationId,
+      }),
+    ).rejects.toMatchObject({ code: "NUQ_MIGRATION_OPERATION_CONFLICT" });
+  });
+
+  test("ambiguous committed control operation reconciles by stable id", async () => {
+    const teamId = team();
+    await initialize(teamId);
+    const operationId = randomUUID();
+    const db = getNuqFdbDatabase();
+    const originalDoTn = db.doTn.bind(db);
+    let discardedCommittedResult = false;
+    const doTn = vi.spyOn(db, "doTn").mockImplementation(async (body, opts) => {
+      const result = await originalDoTn(body, opts);
+      if (!discardedCommittedResult) {
+        discardedCommittedResult = true;
+        const error = new Error("commit_unknown_result") as Error & {
+          code: number;
+        };
+        error.code = 1021;
+        throw error;
+      }
+      return result;
+    });
+    try {
+      await expect(begin(teamId, operationId)).rejects.toMatchObject({
+        code: 1021,
+      });
+      await expect(begin(teamId, operationId)).resolves.toMatchObject({
+        transitionOperationId: operationId,
+        targetGeneration: 2,
+      });
+      await expect(store.inspectState(teamId)).resolves.toMatchObject({
+        revision: 2,
+        maxGeneration: 2,
+      });
+    } finally {
+      doTn.mockRestore();
+    }
+  });
+
+  test("malformed state and counters fail with deterministic corruption errors", async () => {
+    const corruptStateTeam = team();
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.set(store.teamStateKey(corruptStateTeam), Buffer.from("not-json")),
+    );
+    await expect(store.inspectState(corruptStateTeam)).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CORRUPT",
+      message: expect.stringContaining("invalid JSON"),
+    });
+
+    const corruptCounterTeam = team();
+    await initialize(corruptCounterTeam);
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.set(
+        store.residueKey(corruptCounterTeam, 1, "capacity_external_holders"),
+        Buffer.from([1]),
+      ),
+    );
+    await expect(
+      store.inspectGeneration(corruptCounterTeam, 1),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CORRUPT",
+      message: expect.stringContaining("counter must be 8 bytes"),
+    });
+
+    const corruptOperationTeam = team();
+    await initialize(corruptOperationTeam);
+    const operationId = randomUUID();
+    await begin(corruptOperationTeam, operationId);
+    const operationKey = store.pack([
+      "team",
+      corruptOperationTeam,
+      "control-operation",
+      operationId,
+    ]);
+    await getNuqFdbDatabase().doTn(async tn => {
+      const raw = await tn.get(operationKey);
+      const operation = JSON.parse(raw!.toString("utf8"));
+      operation.backend = "pg";
+      tn.set(operationKey, Buffer.from(JSON.stringify(operation)));
+    });
+    await expect(
+      store.beginTransition({
+        teamId: corruptOperationTeam,
+        targetBackend: "fdb",
+        operationId,
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CORRUPT",
+      message: expect.stringContaining("operation/state mismatch"),
+    });
+
+    const corruptIndexTeam = team();
+    const corruptIndexObject = object();
+    await initialize(corruptIndexTeam);
+    await store.preparePinnedObject({
+      teamId: corruptIndexTeam,
+      kind: "scrape_job",
+      objectId: corruptIndexObject,
+      admission: { type: "new-root" },
+      residue: { capacity_ready_active: 1 },
+    });
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.set(
+        store.pack([
+          "team",
+          corruptIndexTeam,
+          "object",
+          "scrape_job",
+          corruptIndexObject,
+        ]),
+        Buffer.from("not-json"),
+      ),
+    );
+    await expect(
+      store.completePinnedObject({
+        teamId: corruptIndexTeam,
+        kind: "scrape_job",
+        objectId: corruptIndexObject,
+        operationId: randomUUID(),
+        fromLifecycle: "prepared",
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_CORRUPT",
+      message: expect.stringContaining("invalid JSON"),
+    });
+  });
+});

--- a/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-store.test.ts
@@ -50,6 +50,54 @@ async function begin(
   });
 }
 
+type GcClaim = { partition: number; token: string };
+type GcClaimTestStore = {
+  claimGcPartition(category: string): Promise<GcClaim | null>;
+  releaseGcPartition(
+    category: string,
+    partition: number,
+    token: string,
+  ): Promise<void>;
+};
+
+async function clearGcClaimState(category: string): Promise<void> {
+  const range = getFdb().tuple.range([
+    "nuq-migration",
+    1,
+    "gc",
+    "lease",
+    category,
+  ]);
+  await getNuqFdbDatabase().doTn(async tn => {
+    tn.clearRange(range.begin as Buffer, range.end as Buffer);
+    tn.clear(store.pack(["gc", "cursor", category]));
+  });
+}
+
+async function readGcClaimState(category: string): Promise<{
+  cursor: number;
+  leases: Array<{ partition: number; token: string; expiresAt: number }>;
+}> {
+  const fdb = getFdb();
+  const range = fdb.tuple.range(["nuq-migration", 1, "gc", "lease", category]);
+  return await getNuqFdbDatabase().doTn(async tn => {
+    const [cursorValue, rows] = await Promise.all([
+      tn.get(store.pack(["gc", "cursor", category])),
+      tn.getRangeAll(range.begin as Buffer, range.end as Buffer),
+    ]);
+    return {
+      cursor: Number(JSON.parse(cursorValue?.toString() ?? "0")),
+      leases: rows.map(([key, value]) => ({
+        partition: Number(fdb.tuple.unpack(key as Buffer)[5]),
+        ...(JSON.parse(value.toString()) as {
+          token: string;
+          expiresAt: number;
+        }),
+      })),
+    };
+  });
+}
+
 async function withGcPostCommitReplay<T>(body: () => Promise<T>): Promise<T> {
   const db = getNuqFdbDatabase();
   const originalDoTn = db.doTn.bind(db);
@@ -1196,6 +1244,207 @@ describeIf("NuQ global FDB migration control plane", () => {
       });
     } finally {
       doTn.mockRestore();
+    }
+  });
+
+  test("GC claims reconcile repeated commit-unknown closure replay", async () => {
+    const claimStore = store as unknown as GcClaimTestStore;
+    const db = getNuqFdbDatabase();
+    const originalDoTn = db.doTn.bind(db);
+    const base = 1_795_000_000_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(base);
+    const categories = {
+      replay: `claim-replay-${RUN}`,
+      expired: `claim-expired-${RUN}`,
+      replaced: `claim-replaced-${RUN}`,
+      duplicates: `claim-duplicates-${RUN}`,
+    };
+    try {
+      // One lost acknowledgement, followed by repeated callback re-entry, must
+      // return the original claim without consuming more cursor positions.
+      await clearGcClaimState(categories.replay);
+      await db.doTn(async tn =>
+        tn.set(
+          store.pack(["gc", "cursor", categories.replay]),
+          Buffer.from(JSON.stringify(7)),
+        ),
+      );
+      const replayed: GcClaim[] = [];
+      let replaying = false;
+      const replayHook = vi
+        .spyOn(db, "doTn")
+        .mockImplementation(async (closure, opts) => {
+          let result = await originalDoTn(closure, opts);
+          if (!replaying) {
+            replaying = true;
+            try {
+              replayed.push(result as GcClaim);
+              for (let attempt = 0; attempt < 3; attempt++) {
+                result = await originalDoTn(closure, opts);
+                replayed.push(result as GcClaim);
+              }
+            } finally {
+              replaying = false;
+            }
+          }
+          return result;
+        });
+      const claim = await claimStore.claimGcPartition(categories.replay);
+      replayHook.mockRestore();
+      expect(claim).not.toBeNull();
+      expect(replayed).toEqual(Array.from({ length: 4 }, () => claim));
+      await expect(readGcClaimState(categories.replay)).resolves.toEqual({
+        cursor: 8,
+        leases: [
+          {
+            partition: 7,
+            token: claim!.token,
+            expiresAt: base + 30_000,
+          },
+        ],
+      });
+      await claimStore.releaseGcPartition(
+        categories.replay,
+        claim!.partition,
+        claim!.token,
+      );
+      await expect(readGcClaimState(categories.replay)).resolves.toEqual({
+        cursor: 8,
+        leases: [],
+      });
+      const concurrent = await (
+        new NuqFdbMigrationStore() as unknown as GcClaimTestStore
+      ).claimGcPartition(categories.replay);
+      expect(concurrent?.partition).toBe(8);
+      await claimStore.releaseGcPartition(
+        categories.replay,
+        concurrent!.partition,
+        concurrent!.token,
+      );
+
+      // Crossing the local deadline during replay renews an unchanged token.
+      await clearGcClaimState(categories.expired);
+      const expiryHook = vi
+        .spyOn(db, "doTn")
+        .mockImplementation(async (closure, opts) => {
+          const result = await originalDoTn(closure, opts);
+          clock.mockReturnValue(base + 31_000);
+          const reconciled = await originalDoTn(closure, opts);
+          expect(reconciled).toEqual(result);
+          return result;
+        });
+      const expired = await claimStore.claimGcPartition(categories.expired);
+      expiryHook.mockRestore();
+      await expect(readGcClaimState(categories.expired)).resolves.toEqual({
+        cursor: 1,
+        leases: [
+          {
+            partition: 0,
+            token: expired!.token,
+            expiresAt: base + 61_000,
+          },
+        ],
+      });
+
+      // If another owner really replaced the key, replay cannot resurrect it;
+      // it claims the next fair partition and leaves exactly one own lease.
+      clock.mockReturnValue(base);
+      await clearGcClaimState(categories.replaced);
+      let replacementReplay: GcClaim | null = null;
+      const replacementHook = vi
+        .spyOn(db, "doTn")
+        .mockImplementation(async (closure, opts) => {
+          const result = (await originalDoTn(closure, opts)) as GcClaim;
+          await originalDoTn(async tn =>
+            tn.set(
+              store.pack([
+                "gc",
+                "lease",
+                categories.replaced,
+                result.partition,
+              ]),
+              Buffer.from(
+                JSON.stringify({
+                  token: "replacement-owner",
+                  expiresAt: base + 60_000,
+                }),
+              ),
+            ),
+          );
+          replacementReplay = (await originalDoTn(closure, opts)) as GcClaim;
+          return replacementReplay;
+        });
+      const replaced = await claimStore.claimGcPartition(categories.replaced);
+      replacementHook.mockRestore();
+      expect(replaced?.partition).toBe(1);
+      expect(replacementReplay).toEqual(replaced);
+      const replacementState = await readGcClaimState(categories.replaced);
+      expect(replacementState.cursor).toBe(2);
+      expect(
+        replacementState.leases.filter(item => item.token === replaced!.token),
+      ).toEqual([
+        {
+          partition: 1,
+          token: replaced!.token,
+          expiresAt: base + 30_000,
+        },
+      ]);
+      expect(replacementState.leases).toContainEqual({
+        partition: 0,
+        token: "replacement-owner",
+        expiresAt: base + 60_000,
+      });
+
+      // Repair old duplicate-token leases in the same bounded transaction. The
+      // cursor says partition 15 was the last committed claim, so it wins.
+      await clearGcClaimState(categories.duplicates);
+      let duplicateReplay: GcClaim | null = null;
+      const duplicateHook = vi
+        .spyOn(db, "doTn")
+        .mockImplementation(async (closure, opts) => {
+          const result = (await originalDoTn(closure, opts)) as GcClaim;
+          await originalDoTn(async tn => {
+            for (const partition of [12, 15]) {
+              tn.set(
+                store.pack(["gc", "lease", categories.duplicates, partition]),
+                Buffer.from(
+                  JSON.stringify({
+                    token: result.token,
+                    expiresAt: base + 30_000,
+                  }),
+                ),
+              );
+            }
+            tn.set(
+              store.pack(["gc", "cursor", categories.duplicates]),
+              Buffer.from(JSON.stringify(16)),
+            );
+          });
+          duplicateReplay = (await originalDoTn(closure, opts)) as GcClaim;
+          return duplicateReplay;
+        });
+      const duplicated = await claimStore.claimGcPartition(
+        categories.duplicates,
+      );
+      duplicateHook.mockRestore();
+      expect(duplicated?.partition).toBe(15);
+      expect(duplicateReplay).toEqual(duplicated);
+      await expect(readGcClaimState(categories.duplicates)).resolves.toEqual({
+        cursor: 16,
+        leases: [
+          {
+            partition: 15,
+            token: duplicated!.token,
+            expiresAt: base + 30_000,
+          },
+        ],
+      });
+    } finally {
+      vi.restoreAllMocks();
+      clock.mockRestore();
+      for (const category of Object.values(categories)) {
+        await clearGcClaimState(category);
+      }
     }
   });
 

--- a/apps/api/src/__tests__/nuq-fdb/migration-test-cleanup.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-test-cleanup.ts
@@ -9,14 +9,15 @@ import {
 } from "../../services/worker/nuq-fdb/migration-store";
 
 const GC_CATEGORIES = new Set(["pin", "control", "generation"]);
-const OBJECT_KINDS = new Set<MigrationObjectKind>([
+const OBJECT_KIND_VALUES = [
   "scrape_job",
   "group",
   "external_holder",
   "crawl_finished",
   "sweeper_task",
   "cross_store_intent",
-]);
+] as const satisfies readonly MigrationObjectKind[];
+const OBJECT_KINDS: ReadonlySet<string> = new Set(OBJECT_KIND_VALUES);
 const FENWICK_UPPER_BOUND = 1n << 53n;
 
 /**

--- a/apps/api/src/__tests__/nuq-fdb/migration-test-cleanup.ts
+++ b/apps/api/src/__tests__/nuq-fdb/migration-test-cleanup.ts
@@ -1,0 +1,128 @@
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+import { encodeI64 } from "../../services/worker/nuq-fdb/keyspace";
+import {
+  MIGRATION_GC_PARTITIONS,
+  type MigrationObjectKind,
+} from "../../services/worker/nuq-fdb/migration-store";
+
+const GC_CATEGORIES = new Set(["pin", "control", "generation"]);
+const OBJECT_KINDS = new Set<MigrationObjectKind>([
+  "scrape_job",
+  "group",
+  "external_holder",
+  "crawl_finished",
+  "sweeper_task",
+  "cross_store_intent",
+]);
+const FENWICK_UPPER_BOUND = 1n << 53n;
+
+/**
+ * Removes migration-store records owned by the specified test teams without
+ * disturbing records owned by concurrently running suites.
+ *
+ * Migration tombstones are absent from the active team-object index, and each
+ * terminal pin/control operation/generation has a global GC index entry plus
+ * partition-local Fenwick counters. Discovering and removing all of those
+ * records in one transaction keeps the production accounting invariant exact.
+ * GC cursors and leases are category/partition scheduler state, not team-owned;
+ * retaining them is the only safe choice because another team's sweep may own
+ * the same partition.
+ */
+export async function clearMigrationTestTeams(
+  teamIds: Iterable<string>,
+): Promise<void> {
+  const selectedTeams = new Set(teamIds);
+  if (selectedTeams.size === 0) return;
+
+  const fdb = getFdb();
+  const db = getNuqFdbDatabase();
+  const objects = fdb.tuple.range(["nuq-migration", 1, "object"]);
+  const gc = fdb.tuple.range(["nuq-migration", 1, "gc"]);
+
+  await db.doTn(async tn => {
+    // These are intentionally non-snapshot range reads. Concurrent migration
+    // writers must conflict and retry cleanup rather than adding an index after
+    // its canonical row was inspected.
+    const [objectRows, gcRows] = await Promise.all([
+      tn.getRangeAll(objects.begin as Buffer, objects.end as Buffer),
+      tn.getRangeAll(gc.begin as Buffer, gc.end as Buffer),
+    ]);
+    const selectedObjects = new Set<string>();
+
+    for (const [key, value] of objectRows) {
+      const pin = JSON.parse((value as Buffer).toString()) as {
+        teamId?: unknown;
+        kind?: unknown;
+        objectId?: unknown;
+      };
+      if (typeof pin.teamId !== "string" || !selectedTeams.has(pin.teamId)) {
+        continue;
+      }
+      const parts = fdb.tuple.unpack(key as Buffer);
+      const kind = String(parts[3]);
+      const objectId = String(parts[4]);
+      if (
+        parts.length !== 5 ||
+        !OBJECT_KINDS.has(kind) ||
+        pin.kind !== kind ||
+        pin.objectId !== objectId
+      ) {
+        throw new Error("invalid canonical pin in migration test cleanup");
+      }
+      selectedObjects.add(`${kind}\0${objectId}`);
+      tn.clear(key as Buffer);
+    }
+
+    for (const [key] of gcRows) {
+      const parts = fdb.tuple.unpack(key as Buffer);
+      const category = String(parts[3]);
+      if (!GC_CATEGORIES.has(category)) continue;
+
+      const owned =
+        category === "pin"
+          ? selectedObjects.has(`${String(parts[6])}\0${String(parts[7])}`)
+          : selectedTeams.has(String(parts[6]));
+      if (!owned) continue;
+
+      const partition = Number(parts[4]);
+      const dueAt = Number(parts[5]);
+      const expectedParts = category === "pin" ? 11 : 10;
+      if (
+        parts.length !== expectedParts ||
+        !Number.isSafeInteger(partition) ||
+        partition < 0 ||
+        partition >= MIGRATION_GC_PARTITIONS ||
+        !Number.isSafeInteger(dueAt) ||
+        dueAt < 0
+      ) {
+        throw new Error(`invalid ${category} GC index in test cleanup`);
+      }
+
+      tn.clear(key as Buffer);
+      let node = BigInt(dueAt) + 1n;
+      while (node <= FENWICK_UPPER_BOUND) {
+        tn.add(
+          fdb.tuple.pack([
+            "nuq-migration",
+            1,
+            "gc",
+            "due-count",
+            category,
+            partition,
+            node.toString(),
+          ]),
+          encodeI64(-1),
+        );
+        node += node & -node;
+      }
+    }
+
+    for (const teamId of selectedTeams) {
+      const team = fdb.tuple.range(["nuq-migration", 1, "team", teamId]);
+      tn.clearRange(team.begin as Buffer, team.end as Buffer);
+    }
+  });
+}

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -20,29 +20,14 @@ vi.mock("../../services/ab-test", () => ({
 vi.mock("../../lib/crawl-redis", () => ({
   getCrawl: vi.fn(),
 }));
-vi.mock("../../services/redlock", () => ({
-  redlock: {
-    using: vi.fn(
-      async (
-        _resources: string[],
-        _duration: number,
-        _options: object,
-        fn: (signal: { aborted: boolean; error?: Error }) => unknown,
-      ) => await fn({ aborted: false }),
-    ),
-  },
-}));
-
 import { config } from "../../config";
 import { redisEvictConnection } from "../../services/redis";
-import { getRedisConnection } from "../../services/queue-service";
 import {
   fdbQueueEnabled,
   isFdbTeam,
   resolveJobBackend,
   resolveNewGroupBackend,
   fdbEnqueueScrapeJobs,
-  getCombinedTeamActiveCount,
   scrapeQueue,
   crawlGroup,
   crawlFinishedQueue,
@@ -182,7 +167,6 @@ describeIf("NuQ router (forced FDB mode)", () => {
     const forcedBackend = config.NUQ_BACKEND;
     const redisGet = vi.spyOn(redisEvictConnection, "get");
     const redisSet = vi.spyOn(redisEvictConnection, "set");
-    config.NUQ_BACKEND = "pg";
     try {
       const teamId = randomUUID();
       const jobId = randomUUID();
@@ -210,6 +194,7 @@ describeIf("NuQ router (forced FDB mode)", () => {
       expect(jobs[0].backend).toBe("fdb");
       expect(backloggedCount).toBe(0);
 
+      config.NUQ_BACKEND = "pg";
       const wait = scrapeQueue.waitForJob(jobId, 15_000);
 
       await new Promise(resolve => setTimeout(resolve, 800));
@@ -230,15 +215,11 @@ describeIf("NuQ router (forced FDB mode)", () => {
     const forcedBackend = config.NUQ_BACKEND;
     const redisGet = vi.spyOn(redisEvictConnection, "get");
     const redisSet = vi.spyOn(redisEvictConnection, "set");
-    config.NUQ_BACKEND = "pg";
     try {
       const teamId = randomUUID();
       const jobId = randomUUID();
       redisGet.mockResolvedValue(null);
-      redisSet.mockImplementation(async key => {
-        if (key === `nuq:fdb_team:${teamId}`) return "OK" as any;
-        throw new Error("marker unavailable");
-      });
+      redisSet.mockRejectedValue(new Error("marker unavailable"));
 
       const { jobs } = await fdbEnqueueScrapeJobs(
         [
@@ -260,6 +241,7 @@ describeIf("NuQ router (forced FDB mode)", () => {
       // The returned backend survives queue-jobs and can route a wait without
       // consulting Redis. ID-only reads/removes recover from durable FDB state.
       expect(jobs[0].backend).toBe("fdb");
+      config.NUQ_BACKEND = "pg";
       expect((await scrapeQueue.getJob(jobId))?.id).toBe(jobId);
       const wait = waitForQueuedJob(jobs[0], 15_000, false);
       const taken = await scrapeQueueFdb.getJobToProcess();
@@ -269,6 +251,7 @@ describeIf("NuQ router (forced FDB mode)", () => {
       await scrapeQueue.removeJob(jobId);
 
       const cancelId = randomUUID();
+      config.NUQ_BACKEND = "fdb";
       await fdbEnqueueScrapeJobs(
         [
           {
@@ -285,6 +268,7 @@ describeIf("NuQ router (forced FDB mode)", () => {
         teamId,
       );
       // ID-only standalone cancellation also probes durable FDB state.
+      config.NUQ_BACKEND = "pg";
       await scrapeQueue.removeJob(cancelId);
       expect(await scrapeQueue.getJob(cancelId)).toBeNull();
     } finally {
@@ -356,110 +340,6 @@ describeIf("NuQ router (forced FDB mode)", () => {
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
     await scrapeQueueFdb.removeJob(directId);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
-  });
-
-  test("flag rollback keeps crawl jobs pinned to their durable FDB group", async () => {
-    const forcedBackend = config.NUQ_BACKEND;
-    const redisGet = vi.spyOn(redisEvictConnection, "get");
-    const redisStateGet = vi.spyOn(getRedisConnection(), "get");
-    const redisCount = vi.spyOn(getRedisConnection(), "zcount");
-    const teamId = randomUUID();
-    const groupId = randomUUID();
-    const holderId = randomUUID();
-    try {
-      await crawlGroup.addGroup(groupId, teamId, 60_000, { backend: "fdb" });
-      await mirrorExternalSlotAcquire(teamId, holderId, 60_000);
-      config.NUQ_BACKEND = "pg";
-      redisGet.mockResolvedValue(null);
-      redisStateGet.mockImplementation(async key =>
-        key === `nuq:fdb_team:${teamId}` ? "1" : null,
-      );
-      redisCount.mockResolvedValue(0);
-
-      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(1);
-      await mirrorExternalSlotRelease(teamId, holderId);
-      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
-      await expect(
-        resolveJobBackend({
-          mode: "single_urls",
-          url: "https://example.com",
-          team_id: teamId,
-          crawl_id: groupId,
-        } as any),
-      ).resolves.toBe("fdb");
-      await expect(crawlGroup.cancelGroup(groupId)).resolves.toBe(true);
-    } finally {
-      config.NUQ_BACKEND = forcedBackend;
-      redisGet.mockRestore();
-      redisStateGet.mockRestore();
-      redisCount.mockRestore();
-    }
-  });
-
-  test("forced-cloud external-only occupancy survives rollback", async () => {
-    const forcedBackend = config.NUQ_BACKEND;
-    const previousDbAuth = config.USE_DB_AUTHENTICATION;
-    const redisStateSet = vi
-      .spyOn(getRedisConnection(), "set")
-      .mockResolvedValue("OK");
-    const redisStateGet = vi.spyOn(getRedisConnection(), "get");
-    const redisCount = vi
-      .spyOn(getRedisConnection(), "zcount")
-      .mockResolvedValue(0);
-    const teamId = randomUUID();
-    const holderId = randomUUID();
-    try {
-      config.NUQ_BACKEND = "fdb";
-      config.USE_DB_AUTHENTICATION = true;
-      await mirrorExternalSlotAcquire(teamId, holderId, 60_000);
-      expect(redisStateSet).toHaveBeenCalledWith(`nuq:fdb_team:${teamId}`, "1");
-
-      config.NUQ_BACKEND = "pg";
-      config.USE_DB_AUTHENTICATION = false;
-      redisStateGet.mockImplementation(async key =>
-        key === `nuq:fdb_team:${teamId}` ? "1" : null,
-      );
-      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(1);
-      await mirrorExternalSlotRelease(teamId, holderId);
-      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
-    } finally {
-      config.NUQ_BACKEND = forcedBackend;
-      config.USE_DB_AUTHENTICATION = previousDbAuth;
-      redisStateSet.mockRestore();
-      redisStateGet.mockRestore();
-      redisCount.mockRestore();
-    }
-  });
-
-  test("pure PG teams avoid FDB outages while migrated teams fail closed", async () => {
-    const forcedBackend = config.NUQ_BACKEND;
-    const redisStateGet = vi
-      .spyOn(getRedisConnection(), "get")
-      .mockResolvedValue(null);
-    const redisCount = vi
-      .spyOn(getRedisConnection(), "zcount")
-      .mockResolvedValue(0);
-    const fdbCount = vi
-      .spyOn(scrapeQueueFdb, "getTeamActiveCount")
-      .mockRejectedValue(new Error("FDB unavailable"));
-    const teamId = randomUUID();
-    config.NUQ_BACKEND = "pg";
-    try {
-      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
-      expect(fdbCount).not.toHaveBeenCalled();
-
-      redisStateGet.mockImplementation(async key =>
-        key === `nuq:fdb_team:${teamId}` ? "1" : null,
-      );
-      await expect(getCombinedTeamActiveCount(teamId)).rejects.toThrow(
-        "FDB unavailable",
-      );
-    } finally {
-      config.NUQ_BACKEND = forcedBackend;
-      redisStateGet.mockRestore();
-      redisCount.mockRestore();
-      fdbCount.mockRestore();
-    }
   });
 
   test("optional router never attempts an FDB dequeue before PG fallback", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -1,19 +1,56 @@
 import { randomUUID } from "crypto";
 import { vi } from "vitest";
+
+// This suite only exercises the routed FDB implementation. Keeping the PG
+// queue mocked avoids pulling scraper engine build artifacts into the focused
+// FoundationDB CI job.
+vi.mock("../../services/worker/nuq", () => {
+  const queue = {
+    getJobToProcess: vi.fn().mockResolvedValue(null),
+  };
+  return {
+    scrapeQueue: queue,
+    crawlFinishedQueue: queue,
+    crawlGroup: {},
+  };
+});
+vi.mock("../../services/ab-test", () => ({
+  abTestJob: vi.fn(),
+}));
+vi.mock("../../lib/crawl-redis", () => ({
+  getCrawl: vi.fn(),
+}));
+vi.mock("../../services/redlock", () => ({
+  redlock: {
+    using: vi.fn(
+      async (
+        _resources: string[],
+        _duration: number,
+        _options: object,
+        fn: (signal: { aborted: boolean; error?: Error }) => unknown,
+      ) => await fn({ aborted: false }),
+    ),
+  },
+}));
+
 import { config } from "../../config";
 import { redisEvictConnection } from "../../services/redis";
+import { getRedisConnection } from "../../services/queue-service";
 import {
   fdbQueueEnabled,
   isFdbTeam,
   resolveJobBackend,
   resolveNewGroupBackend,
   fdbEnqueueScrapeJobs,
+  getCombinedTeamActiveCount,
   scrapeQueue,
   crawlGroup,
   crawlFinishedQueue,
   mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
 } from "../../services/worker/nuq-router";
+import { waitForJob as waitForQueuedJob } from "../../services/queue-jobs";
 import { scrapeQueueFdb } from "../../services/worker/nuq-fdb";
 import {
   getNuqFdbDatabase,
@@ -189,6 +226,255 @@ describeIf("NuQ router (forced FDB mode)", () => {
     }
   });
 
+  test("marker failure or expiry cannot hide standalone FDB jobs", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const redisGet = vi.spyOn(redisEvictConnection, "get");
+    const redisSet = vi.spyOn(redisEvictConnection, "set");
+    config.NUQ_BACKEND = "pg";
+    try {
+      const teamId = randomUUID();
+      const jobId = randomUUID();
+      redisGet.mockResolvedValue(null);
+      redisSet.mockImplementation(async key => {
+        if (key === `nuq:fdb_team:${teamId}`) return "OK" as any;
+        throw new Error("marker unavailable");
+      });
+
+      const { jobs } = await fdbEnqueueScrapeJobs(
+        [
+          {
+            jobId,
+            data: {
+              mode: "single_urls",
+              url: "https://example.com",
+              team_id: teamId,
+            } as any,
+            priority: 0,
+            listenable: true,
+            backlogTimeoutMs: 60_000,
+          },
+        ],
+        teamId,
+      );
+
+      // The returned backend survives queue-jobs and can route a wait without
+      // consulting Redis. ID-only reads/removes recover from durable FDB state.
+      expect(jobs[0].backend).toBe("fdb");
+      expect((await scrapeQueue.getJob(jobId))?.id).toBe(jobId);
+      const wait = waitForQueuedJob(jobs[0], 15_000, false);
+      const taken = await scrapeQueueFdb.getJobToProcess();
+      expect(taken?.id).toBe(jobId);
+      await scrapeQueueFdb.jobFinish(jobId, taken!.lock!, { ok: true });
+      await expect(wait).resolves.toEqual({ ok: true });
+      await scrapeQueue.removeJob(jobId);
+
+      const cancelId = randomUUID();
+      await fdbEnqueueScrapeJobs(
+        [
+          {
+            jobId: cancelId,
+            data: {
+              mode: "single_urls",
+              url: "https://example.com/cancel",
+              team_id: teamId,
+            } as any,
+            priority: 0,
+            backlogTimeoutMs: 60_000,
+          },
+        ],
+        teamId,
+      );
+      // ID-only standalone cancellation also probes durable FDB state.
+      await scrapeQueue.removeJob(cancelId);
+      expect(await scrapeQueue.getJob(cancelId)).toBeNull();
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      redisGet.mockRestore();
+      redisSet.mockRestore();
+    }
+  });
+
+  test("repeated enqueue reconciles a late commit by stable job id", async () => {
+    const teamId = randomUUID();
+    const jobId = randomUUID();
+    const input = {
+      id: jobId,
+      data: {
+        mode: "single_urls",
+        url: "https://example.com",
+        team_id: teamId,
+      } as any,
+      options: {
+        ownerId: teamId,
+        priority: 0,
+        bypassGate: true,
+      },
+    };
+
+    const first = await scrapeQueueFdb.addJobs([input], {
+      teamLimit: 1,
+      queueCap: 10,
+    });
+    const retried = await scrapeQueueFdb.addJobs([input], {
+      teamLimit: 1,
+      queueCap: 10,
+    });
+    expect(first[0].id).toBe(jobId);
+    expect(retried[0].id).toBe(jobId);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    await scrapeQueueFdb.removeJob(jobId);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("PG occupancy reduces FDB admission and direct jobs keep occupancy parity", async () => {
+    const teamId = randomUUID();
+    const blockedId = randomUUID();
+    const directId = randomUUID();
+    const data = {
+      mode: "single_urls",
+      url: "https://example.com",
+      team_id: teamId,
+    } as any;
+
+    const blocked = await scrapeQueueFdb.addJob(
+      blockedId,
+      data,
+      { ownerId: teamId, priority: 0 },
+      { teamLimit: 2, externalActive: 2, queueCap: 10 },
+    );
+    expect(blocked.status).toBe("backlog");
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    await scrapeQueueFdb.removeJob(blockedId);
+
+    const direct = await scrapeQueueFdb.addJob(
+      directId,
+      data,
+      { ownerId: teamId, priority: 0, bypassGate: true },
+      { teamLimit: 1, queueCap: 10 },
+    );
+    expect(direct.status).toBe("queued");
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    await scrapeQueueFdb.removeJob(directId);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("flag rollback keeps crawl jobs pinned to their durable FDB group", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const redisGet = vi.spyOn(redisEvictConnection, "get");
+    const redisStateGet = vi.spyOn(getRedisConnection(), "get");
+    const redisCount = vi.spyOn(getRedisConnection(), "zcount");
+    const teamId = randomUUID();
+    const groupId = randomUUID();
+    const holderId = randomUUID();
+    try {
+      await crawlGroup.addGroup(groupId, teamId, 60_000, { backend: "fdb" });
+      await mirrorExternalSlotAcquire(teamId, holderId, 60_000);
+      config.NUQ_BACKEND = "pg";
+      redisGet.mockResolvedValue(null);
+      redisStateGet.mockImplementation(async key =>
+        key === `nuq:fdb_team:${teamId}` ? "1" : null,
+      );
+      redisCount.mockResolvedValue(0);
+
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(1);
+      await mirrorExternalSlotRelease(teamId, holderId);
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
+      await expect(
+        resolveJobBackend({
+          mode: "single_urls",
+          url: "https://example.com",
+          team_id: teamId,
+          crawl_id: groupId,
+        } as any),
+      ).resolves.toBe("fdb");
+      await expect(crawlGroup.cancelGroup(groupId)).resolves.toBe(true);
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      redisGet.mockRestore();
+      redisStateGet.mockRestore();
+      redisCount.mockRestore();
+    }
+  });
+
+  test("forced-cloud external-only occupancy survives rollback", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const previousDbAuth = config.USE_DB_AUTHENTICATION;
+    const redisStateSet = vi
+      .spyOn(getRedisConnection(), "set")
+      .mockResolvedValue("OK");
+    const redisStateGet = vi.spyOn(getRedisConnection(), "get");
+    const redisCount = vi
+      .spyOn(getRedisConnection(), "zcount")
+      .mockResolvedValue(0);
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    try {
+      config.NUQ_BACKEND = "fdb";
+      config.USE_DB_AUTHENTICATION = true;
+      await mirrorExternalSlotAcquire(teamId, holderId, 60_000);
+      expect(redisStateSet).toHaveBeenCalledWith(`nuq:fdb_team:${teamId}`, "1");
+
+      config.NUQ_BACKEND = "pg";
+      config.USE_DB_AUTHENTICATION = false;
+      redisStateGet.mockImplementation(async key =>
+        key === `nuq:fdb_team:${teamId}` ? "1" : null,
+      );
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(1);
+      await mirrorExternalSlotRelease(teamId, holderId);
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      config.USE_DB_AUTHENTICATION = previousDbAuth;
+      redisStateSet.mockRestore();
+      redisStateGet.mockRestore();
+      redisCount.mockRestore();
+    }
+  });
+
+  test("pure PG teams avoid FDB outages while migrated teams fail closed", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const redisStateGet = vi
+      .spyOn(getRedisConnection(), "get")
+      .mockResolvedValue(null);
+    const redisCount = vi
+      .spyOn(getRedisConnection(), "zcount")
+      .mockResolvedValue(0);
+    const fdbCount = vi
+      .spyOn(scrapeQueueFdb, "getTeamActiveCount")
+      .mockRejectedValue(new Error("FDB unavailable"));
+    const teamId = randomUUID();
+    config.NUQ_BACKEND = "pg";
+    try {
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
+      expect(fdbCount).not.toHaveBeenCalled();
+
+      redisStateGet.mockImplementation(async key =>
+        key === `nuq:fdb_team:${teamId}` ? "1" : null,
+      );
+      await expect(getCombinedTeamActiveCount(teamId)).rejects.toThrow(
+        "FDB unavailable",
+      );
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      redisStateGet.mockRestore();
+      redisCount.mockRestore();
+      fdbCount.mockRestore();
+    }
+  });
+
+  test("optional router never attempts an FDB dequeue before PG fallback", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const fdbTake = vi.spyOn(scrapeQueueFdb, "getJobToProcess");
+    config.NUQ_BACKEND = "pg";
+    try {
+      await scrapeQueue.getJobToProcess().catch(() => null);
+      expect(fdbTake).not.toHaveBeenCalled();
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      fdbTake.mockRestore();
+    }
+  });
+
   test("routed group lifecycle incl. crawl_finished consumption and cancel", async () => {
     const teamId = randomUUID();
     const gid = randomUUID();
@@ -254,11 +540,19 @@ describeIf("NuQ router (forced FDB mode)", () => {
     const holder = randomUUID();
     await mirrorExternalSlotAcquire(teamId, holder, 30_000);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    await expect(
+      reserveExternalSlot(teamId, randomUUID(), 30_000, 1),
+    ).resolves.toBe(false);
     // re-acquire (heartbeat) must not double-count
     await mirrorExternalSlotAcquire(teamId, holder, 30_000);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
     await mirrorExternalSlotRelease(teamId, holder);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    const nextHolder = randomUUID();
+    await expect(
+      reserveExternalSlot(teamId, nextHolder, 30_000, 1),
+    ).resolves.toBe(true);
+    await mirrorExternalSlotRelease(teamId, nextHolder);
     // double release is a no-op
     await mirrorExternalSlotRelease(teamId, holder);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -313,38 +313,6 @@ describeIf("NuQ router (forced FDB mode)", () => {
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
   });
 
-  test("PG occupancy reduces FDB admission and direct jobs keep occupancy parity", async () => {
-    const teamId = randomUUID();
-    const blockedId = randomUUID();
-    const directId = randomUUID();
-    const data = {
-      mode: "single_urls",
-      url: "https://example.com",
-      team_id: teamId,
-    } as any;
-
-    const blocked = await scrapeQueueFdb.addJob(
-      blockedId,
-      data,
-      { ownerId: teamId, priority: 0 },
-      { teamLimit: 2, externalActive: 2, queueCap: 10 },
-    );
-    expect(blocked.status).toBe("backlog");
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
-    await scrapeQueueFdb.removeJob(blockedId);
-
-    const direct = await scrapeQueueFdb.addJob(
-      directId,
-      data,
-      { ownerId: teamId, priority: 0, bypassGate: true },
-      { teamLimit: 1, queueCap: 10 },
-    );
-    expect(direct.status).toBe("queued");
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
-    await scrapeQueueFdb.removeJob(directId);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
-  });
-
   test("optional router never attempts an FDB dequeue before PG fallback", async () => {
     const forcedBackend = config.NUQ_BACKEND;
     const fdbTake = vi.spyOn(scrapeQueueFdb, "getJobToProcess");

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -14,7 +14,8 @@ vi.mock("../../services/worker/nuq", () => {
   return {
     scrapeQueue: queue,
     crawlFinishedQueue: queue,
-    crawlGroup: {},
+    crawlGroup: { getGroup: vi.fn().mockResolvedValue(null) },
+    getNuQPgOwnerLiveResidue: vi.fn().mockResolvedValue({ total: 0 }),
   };
 });
 vi.mock("../../services/ab-test", () => ({
@@ -22,6 +23,17 @@ vi.mock("../../services/ab-test", () => ({
 }));
 vi.mock("../../lib/crawl-redis", () => ({
   getCrawl: vi.fn(),
+}));
+vi.mock("../../lib/concurrency-redis", () => ({
+  getTeamQueueLimit: vi.fn().mockResolvedValue(100),
+  getConcurrencyLimitActiveJobsCount: vi.fn().mockResolvedValue(0),
+  pushConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(undefined),
+  removeConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(undefined),
+  renewConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(false),
+  reserveConcurrencyLimitActiveJob: vi.fn(),
+  rollbackConcurrencyLimitActiveJob: vi.fn(),
+  finalizeConcurrencyLimitActiveJobRollback: vi.fn(),
+  constructConcurrencyLimitKey: (teamId: string) => `concurrency:${teamId}`,
 }));
 import { config } from "../../config";
 import { redisEvictConnection } from "../../services/redis";
@@ -42,6 +54,7 @@ import {
 import { waitForJob as waitForQueuedJob } from "../../services/queue-jobs";
 import {
   crawlFinishedQueueFdb,
+  crawlGroupFdb,
   scrapeQueueFdb,
 } from "../../services/worker/nuq-fdb";
 import {
@@ -57,16 +70,28 @@ const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
 
 const prevNuqBackend = config.NUQ_BACKEND;
 const prevDbAuth = config.USE_DB_AUTHENTICATION;
+const prevMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
 
 describeIf("NuQ router (forced FDB mode)", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     config.NUQ_BACKEND = "fdb";
     config.USE_DB_AUTHENTICATION = false; // self-hosted: unlimited concurrency
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
+    for (const queue of [scrapeQueueFdb, crawlFinishedQueueFdb]) {
+      await queue.beginMetricCounterBackfill();
+      while (!(await queue.backfillMetricCounts(100))) {
+        // bounded pages
+      }
+    }
+    while (!(await crawlGroupFdb.backfillLegacyOwnerIndex(100))) {
+      // bounded pages
+    }
   });
 
   afterAll(async () => {
     config.NUQ_BACKEND = prevNuqBackend;
     config.USE_DB_AUTHENTICATION = prevDbAuth;
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = prevMetricsActivation;
     // forced mode writes into the real "scrape"/"crawl_finished" queue
     // namespaces; wipe them so reruns and other suites start clean
     const fdb = getFdb();
@@ -259,6 +284,7 @@ describeIf("NuQ router (forced FDB mode)", () => {
       await scrapeQueue.removeJob(jobId);
 
       const cancelId = randomUUID();
+      const cancelTeamId = randomUUID();
       config.NUQ_BACKEND = "fdb";
       await fdbEnqueueScrapeJobs(
         [
@@ -267,13 +293,13 @@ describeIf("NuQ router (forced FDB mode)", () => {
             data: {
               mode: "single_urls",
               url: "https://example.com/cancel",
-              team_id: teamId,
+              team_id: cancelTeamId,
             } as any,
             priority: 0,
             backlogTimeoutMs: 60_000,
           },
         ],
-        teamId,
+        cancelTeamId,
       );
       // ID-only standalone cancellation also probes durable FDB state.
       config.NUQ_BACKEND = "pg";

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -27,6 +27,18 @@ vi.mock("../../lib/crawl-redis", () => ({
 vi.mock("../../lib/concurrency-redis", () => ({
   getTeamQueueLimit: vi.fn().mockResolvedValue(100),
   getConcurrencyLimitActiveJobsCount: vi.fn().mockResolvedValue(0),
+  getConcurrencyRollbackCleanupBacklog: vi.fn().mockResolvedValue({
+    total: 0,
+    due: 0,
+    oldestDueAt: null,
+    oldestOverdueMs: 0,
+  }),
+  recoverConcurrencyLimitRollbacks: vi.fn().mockResolvedValue({
+    read: 0,
+    finalized: 0,
+    fenced: 0,
+    hasMore: false,
+  }),
   pushConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(undefined),
   removeConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(undefined),
   renewConcurrencyLimitActiveJob: vi.fn().mockResolvedValue(false),

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -36,7 +36,10 @@ import {
   reserveExternalSlot,
 } from "../../services/worker/nuq-router";
 import { waitForJob as waitForQueuedJob } from "../../services/queue-jobs";
-import { scrapeQueueFdb } from "../../services/worker/nuq-fdb";
+import {
+  crawlFinishedQueueFdb,
+  scrapeQueueFdb,
+} from "../../services/worker/nuq-fdb";
 import {
   getNuqFdbDatabase,
   getFdb,
@@ -398,6 +401,12 @@ describeIf("NuQ router (forced FDB mode)", () => {
     const listing = await scrapeQueue.getCrawlJobsForListing(gid, 10, 0);
     expect(listing.map(j => j.id)).toEqual([jobId]);
 
+    // The emitted ungated crawl_finished job is visible to legacy authority
+    // recovery even though it does not touch team gate counters.
+    await expect(
+      crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
+    ).resolves.toBe(true);
+
     // the emitted crawl_finished job is consumable through the router
     let fin: any = null;
     for (let i = 0; i < 10 && !fin; i++) {
@@ -410,6 +419,9 @@ describeIf("NuQ router (forced FDB mode)", () => {
     expect(await crawlFinishedQueue.jobFinish(fin.id, fin.lock!, null)).toBe(
       true,
     );
+    await expect(
+      crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
+    ).resolves.toBe(false);
 
     // cancel on an already-completed group is a no-op
     expect(await crawlGroup.cancelGroup(gid)).toBe(false);

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -36,6 +36,7 @@ import {
   crawlFinishedQueue,
   mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  renewExternalSlot,
   reserveExternalSlot,
 } from "../../services/worker/nuq-router";
 import { waitForJob as waitForQueuedJob } from "../../services/queue-jobs";
@@ -47,6 +48,7 @@ import {
   getNuqFdbDatabase,
   getFdb,
 } from "../../services/worker/nuq-fdb/client";
+import { decodeI64 } from "../../services/worker/nuq-fdb/keyspace";
 
 // Exercises the dual-backend router in forced-FDB mode (NUQ_BACKEND=fdb,
 // self-hosted), which needs neither ACUC nor a PG nuq database: everything
@@ -417,5 +419,114 @@ describeIf("NuQ router (forced FDB mode)", () => {
     // double release is a no-op
     await mirrorExternalSlotRelease(teamId, holder);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("concurrent FDB external reservations cannot oversubscribe a team", async () => {
+    const teamId = randomUUID();
+    const holders = Array.from({ length: 32 }, () => randomUUID());
+    const results = await Promise.all(
+      holders.map(holder => reserveExternalSlot(teamId, holder, 30_000, 3)),
+    );
+    const admitted = holders.filter((_, index) => results[index]);
+
+    expect(admitted).toHaveLength(3);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(3);
+
+    await Promise.all(
+      admitted.map(holder => mirrorExternalSlotRelease(teamId, holder)),
+    );
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("existing FDB holder renewal does not overwrite a newer team limit", async () => {
+    const teamId = randomUUID();
+    const firstHolder = randomUUID();
+    const secondHolder = randomUUID();
+    await expect(
+      reserveExternalSlot(teamId, firstHolder, 30_000, 10),
+    ).resolves.toBe(true);
+    await expect(
+      reserveExternalSlot(teamId, secondHolder, 30_000, 2),
+    ).resolves.toBe(true);
+
+    const readStoredLimit = async () =>
+      await getNuqFdbDatabase().doTn(async tn =>
+        decodeI64(await tn.snapshot().get(scrapeQueueFdb.ks.teamLimit(teamId))),
+      );
+    await expect(readStoredLimit()).resolves.toBe(2);
+    await expect(renewExternalSlot(teamId, firstHolder, 30_000)).resolves.toBe(
+      true,
+    );
+    await expect(readStoredLimit()).resolves.toBe(2);
+
+    await Promise.all([
+      mirrorExternalSlotRelease(teamId, firstHolder),
+      mirrorExternalSlotRelease(teamId, secondHolder),
+    ]);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("FDB external reservation includes queue occupancy atomically", async () => {
+    const teamId = randomUUID();
+    const jobIds = [randomUUID(), randomUUID()];
+    await scrapeQueueFdb.addJobs(
+      jobIds.map(jobId => ({
+        id: jobId,
+        data: {
+          mode: "single_urls",
+          url: "https://example.com/capacity",
+          team_id: teamId,
+        } as any,
+        options: { ownerId: teamId },
+      })),
+      { teamLimit: 2, queueCap: 10 },
+    );
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(2);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        reserveExternalSlot(teamId, randomUUID(), 30_000, 2),
+      ),
+    );
+    expect(results).toEqual(Array(8).fill(false));
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(2);
+
+    await Promise.all(jobIds.map(jobId => scrapeQueueFdb.removeJob(jobId)));
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("denied external reservation lowers the FDB promotion gate", async () => {
+    const teamId = randomUUID();
+    const jobIds = [randomUUID(), randomUUID(), randomUUID()];
+    const jobs = await scrapeQueueFdb.addJobs(
+      jobIds.map(jobId => ({
+        id: jobId,
+        data: {
+          mode: "single_urls",
+          url: "https://example.com/lowered-capacity",
+          team_id: teamId,
+        } as any,
+        options: { ownerId: teamId },
+      })),
+      { teamLimit: 2, queueCap: 10 },
+    );
+    const active = jobs.filter(job => job.status !== "backlog");
+    expect(active).toHaveLength(2);
+    expect(await scrapeQueueFdb.getTeamPendingCount(teamId)).toBe(1);
+
+    await expect(
+      reserveExternalSlot(teamId, randomUUID(), 30_000, 1),
+    ).resolves.toBe(false);
+    await scrapeQueueFdb.removeJob(active[0].id);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    expect(await scrapeQueueFdb.getTeamPendingCount(teamId)).toBe(1);
+
+    await Promise.all(
+      jobIds
+        .filter(jobId => jobId !== active[0].id)
+        .map(jobId => scrapeQueueFdb.removeJob(jobId)),
+    );
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    expect(await scrapeQueueFdb.getTeamPendingCount(teamId)).toBe(0);
   });
 });

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -7,6 +7,9 @@ import { vi } from "vitest";
 vi.mock("../../services/worker/nuq", () => {
   const queue = {
     getJobToProcess: vi.fn().mockResolvedValue(null),
+    getJob: vi.fn().mockResolvedValue(null),
+    getJobs: vi.fn().mockResolvedValue([]),
+    getJobsFromBacklog: vi.fn().mockResolvedValue([]),
   };
   return {
     scrapeQueue: queue,
@@ -308,9 +311,7 @@ describeIf("NuQ router (forced FDB mode)", () => {
     });
     expect(first[0].id).toBe(jobId);
     expect(retried[0].id).toBe(jobId);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
     await scrapeQueueFdb.removeJob(jobId);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
   });
 
   test("optional router never attempts an FDB dequeue before PG fallback", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/stress.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/stress.test.ts
@@ -136,9 +136,22 @@ describeIf("NuQ FDB concurrency stress", () => {
   test("parallel enqueuers + workers with a crawl gate stay within both limits", async () => {
     const name = `t-${RUN}-stress2`;
     queueNames.push(name);
+    const PRODUCERS = 4;
+    let stagedProducers = 0;
+    let releaseProducers!: () => void;
+    const allProducersStaged = new Promise<void>(resolve => {
+      releaseProducers = resolve;
+    });
     const queue: NuQFdbQueue = new NuQFdbQueue(name, {
       hasGroups: true,
       finishedQueueName: `${name}-fin`,
+      testHooks: {
+        afterStageBatch: async () => {
+          stagedProducers++;
+          if (stagedProducers === PRODUCERS) releaseProducers();
+          await allProducersStaged;
+        },
+      },
     });
     queueNames.push(`${name}-fin`);
     const finishedQueue: NuQFdbQueue = new NuQFdbQueue(`${name}-fin`, {
@@ -156,8 +169,10 @@ describeIf("NuQ FDB concurrency stress", () => {
       maxConcurrency: CRAWL_LIMIT,
     });
 
-    // enqueue from 4 parallel producers while workers consume
-    const producers = Array.from({ length: 4 }, (_, p) =>
+    // Each real crawl producer is itself an unfinished group member until its
+    // children are published. Admit every synthetic producer before consumption
+    // so this models that lifetime while preserving concurrent publication.
+    const producers = Array.from({ length: PRODUCERS }, () =>
       queue.addJobs(
         Array.from({ length: JOBS / 4 }, () => ({
           id: randomUUID(),

--- a/apps/api/src/__tests__/nuq-postgres.test.ts
+++ b/apps/api/src/__tests__/nuq-postgres.test.ts
@@ -1,13 +1,21 @@
 import { randomUUID } from "crypto";
 import { Pool } from "pg";
 import { config } from "../config";
-import { nuqShutdown, scrapeQueue } from "../services/worker/nuq";
+import {
+  crawlFinishedQueue,
+  crawlGroup,
+  getNuQPgOwnerLiveResidue,
+  NuQPublicationConflictError,
+  nuqShutdown,
+  scrapeQueue,
+} from "../services/worker/nuq";
 
 const describeIf = config.NUQ_DATABASE_URL ? describe : describe.skip;
 
 describeIf("NuQ Postgres queue", () => {
   let cleanupPool: Pool;
   const ids: string[] = [];
+  const groupIds: string[] = [];
 
   beforeAll(() => {
     cleanupPool = new Pool({
@@ -26,7 +34,16 @@ describeIf("NuQ Postgres queue", () => {
       "DELETE FROM nuq.queue_scrape WHERE id = ANY($1::uuid[])",
       [ids],
     );
+    await cleanupPool.query(
+      "DELETE FROM nuq.queue_crawl_finished WHERE id = ANY($1::uuid[]) OR group_id = ANY($2::uuid[])",
+      [ids, groupIds],
+    );
+    await cleanupPool.query(
+      "DELETE FROM nuq.group_crawl WHERE id = ANY($1::uuid[])",
+      [groupIds],
+    );
     ids.length = 0;
+    groupIds.length = 0;
   });
 
   afterAll(async () => {
@@ -41,6 +58,91 @@ describeIf("NuQ Postgres queue", () => {
       team_id: randomUUID(),
     } as any;
   }
+
+  test("stable single publication is idempotent and rejects incompatible reuse", async () => {
+    const id = randomUUID();
+    const ownerId = randomUUID();
+    ids.push(id);
+    const data = {
+      mode: "single_urls",
+      url: "https://example.com/stable",
+      team_id: ownerId,
+      nested: { b: 2, a: 1 },
+      traceContext: { traceparent: "first" },
+      concurrencyLimited: true,
+      requestedAt: new Date("2026-01-02T03:04:05.000Z"),
+      omitted: undefined,
+    } as any;
+
+    const first = await scrapeQueue.addJob(id, data, {
+      priority: 7,
+      ownerId,
+    });
+    const replay = await scrapeQueue.addJob(
+      id,
+      {
+        ...data,
+        nested: { a: 1, b: 2 },
+        traceContext: { traceparent: "retry" },
+        concurrencyLimited: false,
+        requestedAt: "2026-01-02T03:04:05.000Z",
+      },
+      { priority: 7, ownerId },
+    );
+
+    expect(replay).toMatchObject({ id, status: first.status, priority: 7 });
+    await expect(
+      scrapeQueue.addJob(id, data, { priority: 8, ownerId }),
+    ).rejects.toBeInstanceOf(NuQPublicationConflictError);
+    expect(await scrapeQueue.getJobs([id])).toHaveLength(1);
+  });
+
+  test("UUID casing is canonicalized for stable publication", async () => {
+    const id = randomUUID();
+    const ownerId = randomUUID();
+    ids.push(id);
+    const data = { ...scrapeData(), marker: "uuid-casing" };
+
+    const first = await scrapeQueue.addJob(id.toUpperCase(), data, {
+      ownerId: ownerId.toUpperCase(),
+    });
+    const replay = await scrapeQueue.addJob(id, data, { ownerId });
+
+    expect(first.id).toBe(id);
+    expect(replay.id).toBe(id);
+    expect(await scrapeQueue.getJobs([id])).toHaveLength(1);
+  });
+
+  test(
+    "bulk publication replays compatible rows across chunk boundaries",
+    { timeout: 30_000 },
+    async () => {
+      const ownerId = randomUUID();
+      const jobs = Array.from({ length: 1001 }, (_, index) => ({
+        id: randomUUID(),
+        data: {
+          mode: "single_urls",
+          url: `https://example.com/${index}`,
+          team_id: ownerId,
+        } as any,
+        options: { priority: index % 5, ownerId },
+      }));
+      ids.push(...jobs.map(job => job.id));
+
+      // Simulate a prior bulk attempt that committed its first chunk only.
+      await scrapeQueue.addJobs(jobs.slice(0, 1000));
+      const published = await scrapeQueue.addJobs(jobs);
+      const replayed = await scrapeQueue.addJobs(jobs);
+
+      expect(published.map(job => job.id)).toEqual(jobs.map(job => job.id));
+      expect(replayed.map(job => job.id)).toEqual(jobs.map(job => job.id));
+      const count = await cleanupPool.query(
+        "SELECT count(*)::int AS count FROM nuq.queue_scrape WHERE id = ANY($1::uuid[])",
+        [ids],
+      );
+      expect(count.rows[0].count).toBe(jobs.length);
+    },
+  );
 
   test("single backlogged inserts report backlog status", async () => {
     const addJobId = randomUUID();
@@ -57,21 +159,108 @@ describeIf("NuQ Postgres queue", () => {
       status: "backlog",
     });
 
+    const addJobIfNotExistsData = scrapeData();
     await expect(
-      scrapeQueue.addJobIfNotExists(addJobIfNotExistsId, scrapeData(), {
-        backlogged: true,
-        backloggedTimesOutAt: new Date(Date.now() + 60_000),
-      }),
+      scrapeQueue.addJobIfNotExists(
+        addJobIfNotExistsId,
+        addJobIfNotExistsData,
+        {
+          backlogged: true,
+          backloggedTimesOutAt: new Date(Date.now() + 60_000),
+        },
+      ),
     ).resolves.toMatchObject({
       id: addJobIfNotExistsId,
       status: "backlog",
     });
 
+    const original = await scrapeQueue.getJobsFromBacklog([
+      addJobIfNotExistsId,
+    ]);
     await expect(
-      scrapeQueue.addJobIfNotExists(addJobIfNotExistsId, scrapeData(), {
-        backlogged: true,
-        backloggedTimesOutAt: new Date(Date.now() + 60_000),
-      }),
+      scrapeQueue.addJobIfNotExists(
+        addJobIfNotExistsId,
+        addJobIfNotExistsData,
+        {
+          backlogged: true,
+          backloggedTimesOutAt: new Date(Date.now() + 600_000),
+        },
+      ),
     ).resolves.toBeNull();
+    const replayed = await scrapeQueue.getJobsFromBacklog([
+      addJobIfNotExistsId,
+    ]);
+    expect(replayed[0].backloggedTimesOutAt?.valueOf()).toBe(
+      original[0].backloggedTimesOutAt?.valueOf(),
+    );
+  });
+
+  test("backlog publication replay recognizes an already-promoted stable id", async () => {
+    const id = randomUUID();
+    const ownerId = randomUUID();
+    const data = { ...scrapeData(), team_id: ownerId };
+    ids.push(id);
+    const backlogOptions = {
+      ownerId,
+      backlogged: true,
+      backloggedTimesOutAt: new Date(Date.now() + 60_000),
+    };
+    await scrapeQueue.addJob(id, data, backlogOptions);
+    await expect(
+      scrapeQueue.promoteJobFromBacklogOrAdd(id, data, { ownerId }),
+    ).resolves.toMatchObject({ id, status: "queued" });
+    await expect(
+      scrapeQueue.addJob(id, data, backlogOptions),
+    ).resolves.toMatchObject({ id, status: "queued" });
+  });
+
+  test("removal clears active and backlog tables", async () => {
+    const activeId = randomUUID();
+    const backlogId = randomUUID();
+    ids.push(activeId, backlogId);
+    await scrapeQueue.addJob(activeId, scrapeData(), {});
+    await scrapeQueue.addJob(backlogId, scrapeData(), {
+      backlogged: true,
+      backloggedTimesOutAt: new Date(Date.now() + 60_000),
+    });
+
+    await expect(scrapeQueue.removeJobs([activeId, backlogId])).resolves.toBe(
+      2,
+    );
+    const residue = await cleanupPool.query(
+      `SELECT
+         (SELECT count(*)::int FROM nuq.queue_scrape WHERE id = ANY($1::uuid[])) +
+         (SELECT count(*)::int FROM nuq.queue_scrape_backlog WHERE id = ANY($1::uuid[])) AS count`,
+      [[activeId, backlogId]],
+    );
+    expect(residue.rows[0].count).toBe(0);
+  });
+
+  test("owner residue includes all worker-visible PG control surfaces", async () => {
+    const ownerId = randomUUID();
+    const groupId = randomUUID();
+    const scrapeId = randomUUID();
+    const backlogId = randomUUID();
+    const finishedId = randomUUID();
+    ids.push(scrapeId, backlogId, finishedId);
+    groupIds.push(groupId);
+
+    await crawlGroup.addGroup(groupId, ownerId);
+    await scrapeQueue.addJob(scrapeId, scrapeData(), { ownerId, groupId });
+    await scrapeQueue.addJob(backlogId, scrapeData(), {
+      ownerId,
+      groupId,
+      backlogged: true,
+      backloggedTimesOutAt: new Date(Date.now() + 60_000),
+    });
+    await crawlFinishedQueue.addJob(finishedId, {}, { ownerId, groupId });
+
+    await expect(getNuQPgOwnerLiveResidue(ownerId)).resolves.toEqual({
+      scrape: 1,
+      backlog: 1,
+      groups: 1,
+      crawlFinished: 1,
+      total: 4,
+    });
   });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -207,6 +207,29 @@ const configSchema = z.object({
   NUQ_WORKER_COUNT: z.coerce.number().default(5),
   NUQ_PREFETCH_WORKER_PORT: z.coerce.number().default(3011).catch(3011), // todo: investigate why .catch is needed
   NUQ_RECONCILER_WORKER_PORT: z.coerce.number().default(3012).catch(3012),
+  // Migration GC runs on the reconciler. Every storage page remains <=100;
+  // these two independent bounds prevent shutdown or normal reconciliation
+  // from being held by an arbitrarily large retained-history cliff.
+  NUQ_MIGRATION_GC_PAGE_LIMIT: emptyStringAsDefault(
+    z.coerce.number().int().min(1).max(100).default(100),
+  ),
+  NUQ_MIGRATION_GC_MAX_PAGES: emptyStringAsDefault(
+    z.coerce.number().int().min(1).max(1024).default(128),
+  ),
+  NUQ_MIGRATION_GC_WORK_BUDGET_MS: emptyStringAsDefault(
+    z.coerce.number().int().min(100).max(55_000).default(20_000),
+  ),
+  NUQ_RECONCILER_IDLE_INTERVAL_MS: emptyStringAsDefault(
+    z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(10 * 60_000)
+      .default(60_000),
+  ),
+  NUQ_RECONCILER_BACKLOG_RETRY_MS: emptyStringAsDefault(
+    z.coerce.number().int().min(1_000).max(60_000).default(5_000),
+  ),
   CCLOG_WORKER_PORT: z.coerce.number().default(3013).catch(3013),
   EXTRACT_WORKER_PORT: z.coerce.number().default(3004),
   NUQ_WAIT_MODE: z.string().optional(),

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -192,7 +192,7 @@ export async function scrapeController(
       req.acuc?.concurrency || 1,
       aborter.signal,
       timeout ?? 60_000,
-      async limited => {
+      async (limited, protectionSignal) => {
         const jobPriority = await getJobPriority({
           team_id: req.auth.team_id,
           basePriority: 10,
@@ -243,7 +243,7 @@ export async function scrapeController(
           },
         };
 
-        const doc = await processJobInternal(job);
+        const doc = await processJobInternal(job, protectionSignal);
         return doc ?? null;
       },
     );

--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -18,9 +18,8 @@ import {
   clearBrowserSessionPromptFlag,
 } from "../../lib/browser-sessions";
 import {
-  getCombinedTeamActiveCount,
-  mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
 } from "../../services/worker/nuq-router";
 import { RequestWithAuth } from "./types";
 import { billTeam } from "../../services/billing/credit_billing";
@@ -257,10 +256,14 @@ export async function browserCreateController(
 
   // 0b. Enforce concurrency limit (shared pool with scrape/crawl/interact)
   const concurrencyLimit = req.acuc?.concurrency ?? 2;
-  const activeCount = await getCombinedTeamActiveCount(req.auth.team_id);
-  if (activeCount >= concurrencyLimit) {
+  const reserved = await reserveExternalSlot(
+    req.auth.team_id,
+    sessionId,
+    ttl * 1000 + 60_000,
+    concurrencyLimit,
+  );
+  if (!reserved) {
     logger.warn("Concurrency limit reached for browser session", {
-      activeCount,
       limit: concurrencyLimit,
     });
     return res.status(429).json({
@@ -303,6 +306,9 @@ export async function browserCreateController(
     } catch (err) {
       // 409 means the profile is locked by another writer — don't retry
       if (err instanceof BrowserServiceError && err.status === 409) {
+        await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+          () => {},
+        );
         logger.warn("Profile is locked", {
           profileName: profile?.name,
           error: err,
@@ -327,6 +333,9 @@ export async function browserCreateController(
   }
 
   if (!svcResponse) {
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     logger.error("Failed to create browser session after all retries", {
       error: lastCreateError,
       attempts: MAX_CREATE_RETRIES,
@@ -374,6 +383,9 @@ export async function browserCreateController(
       "DELETE",
       `/browsers/${svcResponse.sessionId}`,
     ).catch(() => {});
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     return res.status(500).json({
       success: false,
       error: "Failed to persist browser session.",
@@ -382,12 +394,6 @@ export async function browserCreateController(
 
   // Invalidate cached count so next check reflects the new session
   invalidateActiveBrowserSessionCount(req.auth.team_id).catch(() => {});
-
-  // Register in the shared concurrency limiter so this session counts
-  // against the team's concurrent job limit while it's active.
-  mirrorExternalSlotAcquire(req.auth.team_id, sessionId, ttl * 1000).catch(
-    () => {},
-  );
 
   logger.info("Browser session created", {
     sessionId,

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -459,7 +459,7 @@ export async function parseController(
           concurrency,
           aborter.signal,
           timeout ?? 60_000,
-          async limited => {
+          async (limited, protectionSignal) => {
             const jobPriority = await getJobPriority({
               team_id: req.auth.team_id,
               basePriority: 10,
@@ -530,7 +530,7 @@ export async function parseController(
                   },
                 };
 
-                const result = await processJobInternal(job);
+                const result = await processJobInternal(job, protectionSignal);
 
                 setSpanAttributes(waitSpan, {
                   "wait.success": true,

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -19,9 +19,8 @@ import {
 } from "../../lib/browser-sessions";
 import {} from "../../lib/concurrency-limit";
 import {
-  getCombinedTeamActiveCount,
-  mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
 } from "../../services/worker/nuq-router";
 import {
   browserServiceRequest,
@@ -595,8 +594,13 @@ async function createSessionForScrape(
 
   // Active session limit — uses the same concurrency pool as scrape/crawl
   const concurrencyLimit = req.acuc?.concurrency ?? 2;
-  const activeCount = await getCombinedTeamActiveCount(req.auth.team_id);
-  if (activeCount >= concurrencyLimit) {
+  const reserved = await reserveExternalSlot(
+    req.auth.team_id,
+    sessionId,
+    ttl * 1000 + 60_000,
+    concurrencyLimit,
+  );
+  if (!reserved) {
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
     return {
       status: 429,
@@ -644,6 +648,9 @@ async function createSessionForScrape(
       break;
     } catch (err) {
       if (err instanceof BrowserServiceError && err.status === 409) {
+        await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+          () => {},
+        );
         adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(
           () => {},
         );
@@ -670,6 +677,9 @@ async function createSessionForScrape(
   }
 
   if (!svcResponse) {
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
     logger.error("Failed to create browser session after all retries", {
       error: lastCreateError,
@@ -772,6 +782,9 @@ async function createSessionForScrape(
       );
     }
   } catch (err) {
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
     logger.error("Failed to initialize scrape browser session context", {
       error: err,
@@ -823,12 +836,6 @@ async function createSessionForScrape(
 
     invalidateActiveBrowserSessionCount(req.auth.team_id).catch(() => {});
 
-    // Register in the shared concurrency limiter so this session counts
-    // against the team's concurrent job limit while it's active.
-    mirrorExternalSlotAcquire(req.auth.team_id, sessionId, ttl * 1000).catch(
-      () => {},
-    );
-
     return { session };
   } catch (err) {
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
@@ -839,6 +846,9 @@ async function createSessionForScrape(
       "DELETE",
       `/browsers/${svcResponse.sessionId}`,
     ).catch(() => {});
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     return {
       status: 500,
       body: { success: false, error: "Failed to persist browser session." },

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -275,7 +275,7 @@ export async function scrapeController(
           concurrency,
           aborter.signal,
           timeout ?? 60_000,
-          async limited => {
+          async (limited, protectionSignal) => {
             const jobPriority = await getJobPriority({
               team_id: req.auth.team_id,
               basePriority: 10,
@@ -345,7 +345,7 @@ export async function scrapeController(
                   },
                 };
 
-                const result = await processJobInternal(job);
+                const result = await processJobInternal(job, protectionSignal);
 
                 setSpanAttributes(waitSpan, {
                   "wait.success": true,

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -8,7 +8,6 @@ import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
 import {
   getCombinedTeamActiveCount,
   syncFdbLimitToPgOccupancy,
-  withTeamMigrationAdmission,
 } from "../services/worker/nuq-router";
 export { QueueFullError } from "./queue-full-error";
 export {
@@ -34,6 +33,17 @@ const constructJobKey = (jobId: string) => "cq-job:" + jobId;
 
 const constructCrawlKey = (crawl_id: string) =>
   "crawl-concurrency-limiter:" + crawl_id;
+
+function assertRedisPipelineSucceeded(
+  results: [Error | null, unknown][] | null,
+  operation: string,
+): void {
+  const errors =
+    results
+      ?.map(([error]) => error)
+      .filter((error): error is Error => error instanceof Error) ?? [];
+  if (errors.length > 0) throw new AggregateError(errors, operation);
+}
 
 export async function cleanOldConcurrencyLimitEntries(
   team_id: string,
@@ -72,7 +82,10 @@ export async function removeConcurrencyLimitedJobs(
     for (const id of chunk) {
       pipeline.del(constructJobKey(id));
     }
-    await pipeline.exec();
+    assertRedisPipelineSucceeded(
+      await pipeline.exec(),
+      "Failed to remove concurrency-limited jobs",
+    );
   }
 }
 
@@ -132,7 +145,10 @@ export async function pushConcurrencyLimitedJobs(
 
   pipeline.zadd(queueKey, ...zaddArgs);
   pipeline.sadd("concurrency-limit-queues", queueKey);
-  await pipeline.exec();
+  assertRedisPipelineSucceeded(
+    await pipeline.exec(),
+    "Failed to publish concurrency-limited jobs",
+  );
 }
 
 export async function getConcurrencyLimitedJobs(team_id: string) {
@@ -201,10 +217,18 @@ export async function removeCrawlConcurrencyLimitActiveJob(
  * @param teamId
  * @returns A job that can be run, or null if there are no more jobs to run.
  */
-export async function getNextConcurrentJob(teamId: string): Promise<{
+type ClaimedConcurrentJob = {
   job: ConcurrencyLimitedJob;
   timeout: number;
-} | null> {
+  score: number;
+  token: string;
+};
+
+const constructClaimKey = (jobId: string) => `cq-claim:${jobId}`;
+
+export async function getNextConcurrentJob(
+  teamId: string,
+): Promise<ClaimedConcurrentJob | null> {
   const crawlCache = new Map<string, StoredCrawl>();
   const queueKey = constructQueueKey(teamId);
   const redis = getRedisConnection();
@@ -213,30 +237,67 @@ export async function getNextConcurrentJob(teamId: string): Promise<{
   // Jobs we popped but can't run due to crawl concurrency limits.
   // We'll re-add them at the end so other callers can try them later.
   const crawlBlocked: { member: string; score: number; jobData: string }[] = [];
+  let interruptedClaim: { member: string; score: number } | null = null;
 
   try {
     while (true) {
-      // ZPOPMIN atomically removes and returns the lowest-scored member.
-      // No two workers can ever get the same entry.
-      const result = await redis.zpopmin(queueKey);
+      // Atomically pop and publish a reconciler-visible ownership token.
+      const token = crypto.randomUUID();
+      const result = (await redis.eval(
+        `local item = redis.call('ZPOPMIN', KEYS[1], 1)
+         if #item == 0 then return item end
+         redis.call('SET', 'cq-claim:' .. item[1], ARGV[1], 'PX', ARGV[2])
+         return item`,
+        1,
+        queueKey,
+        JSON.stringify({ teamId, token }),
+        5 * 60 * 1000,
+      )) as string[];
       if (!result || result.length === 0) return null;
 
       const [member, scoreStr] = result as [string, string];
       const score = parseFloat(scoreStr);
+      interruptedClaim = { member, score };
 
       // Expired entry - discard
       if (score < now) {
-        await redis.del(constructJobKey(member));
+        await redis.del(constructJobKey(member), constructClaimKey(member));
+        interruptedClaim = null;
         continue;
       }
 
       const jobData = await redis.get(constructJobKey(member));
       if (jobData === null) {
         // Job key TTL expired - orphaned sorted set entry, already removed by zpopmin
+        await redis.del(constructClaimKey(member));
+        interruptedClaim = null;
         continue;
       }
 
-      const job: ConcurrencyLimitedJob = JSON.parse(jobData);
+      let job: ConcurrencyLimitedJob;
+      try {
+        job = JSON.parse(jobData);
+      } catch (error) {
+        logger.error("Discarding corrupt concurrency queue payload", {
+          teamId,
+          jobId: member,
+          error,
+        });
+        await redis.del(constructJobKey(member), constructClaimKey(member));
+        interruptedClaim = null;
+        continue;
+      }
+      if (job.id !== member || job.data?.team_id !== teamId) {
+        logger.error("Discarding mismatched concurrency queue payload", {
+          teamId,
+          member,
+          payloadJobId: job.id,
+          payloadTeamId: job.data?.team_id,
+        });
+        await redis.del(constructJobKey(member), constructClaimKey(member));
+        interruptedClaim = null;
+        continue;
+      }
 
       // Check crawl concurrency limit
       if (job.data.crawl_id) {
@@ -262,30 +323,92 @@ export async function getNextConcurrentJob(teamId: string): Promise<{
           if (currentActiveConcurrency >= maxCrawlConcurrency) {
             // Crawl is at its limit - hold this job aside to re-add later
             crawlBlocked.push({ member, score, jobData });
+            interruptedClaim = null;
             continue;
           }
         }
       }
 
-      // We got a valid, eligible job
-      await redis.del(constructJobKey(member));
-      logger.debug("Removed job from concurrency limit queue", {
+      // Keep cq-job until the caller has durably promoted or discarded the
+      // claim. If anything after this destructive ZPOPMIN throws, the caller
+      // can restore the original score without reconstructing payload/TTL.
+      logger.debug("Claimed job from concurrency limit queue", {
         teamId,
         jobId: job.id,
         zeroDataRetention: job.data?.zeroDataRetention,
       });
-      return { job, timeout: Infinity };
+      interruptedClaim = null;
+      return { job, timeout: Infinity, score, token };
     }
   } finally {
-    // Re-add crawl-blocked jobs so they can be picked up later
-    if (crawlBlocked.length > 0) {
+    // Re-add crawl-blocked jobs and a pop interrupted by any downstream
+    // exception so ZPOPMIN is never a destructive failure boundary.
+    const toRestore = interruptedClaim
+      ? [...crawlBlocked, { ...interruptedClaim, jobData: "" }]
+      : crawlBlocked;
+    if (toRestore.length > 0) {
       const zaddArgs: (string | number)[] = [];
-      for (const { member, score } of crawlBlocked) {
+      for (const { member, score } of toRestore) {
         zaddArgs.push(score, member);
       }
-      await redis.zadd(queueKey, ...zaddArgs);
+      const pipeline = redis.pipeline();
+      pipeline.zadd(queueKey, ...zaddArgs);
+      for (const { member } of toRestore) {
+        pipeline.del(constructClaimKey(member));
+      }
+      assertRedisPipelineSucceeded(
+        await pipeline.exec(),
+        "Failed to restore interrupted concurrency claims",
+      );
     }
   }
+}
+
+export async function acknowledgeConcurrentJob(
+  claimed: ClaimedConcurrentJob,
+): Promise<void> {
+  await getRedisConnection().eval(
+    `local raw = redis.call('GET', KEYS[2])
+     if raw then
+       local claim = cjson.decode(raw)
+       if claim.token ~= ARGV[1] then return 0 end
+     end
+     redis.call('DEL', KEYS[1], KEYS[2])
+     return 1`,
+    2,
+    constructJobKey(claimed.job.id),
+    constructClaimKey(claimed.job.id),
+    claimed.token,
+  );
+}
+
+export async function restoreConcurrentJob(
+  teamId: string,
+  claimed: ClaimedConcurrentJob,
+): Promise<void> {
+  const redis = getRedisConnection();
+  if (claimed.score <= Date.now()) {
+    await acknowledgeConcurrentJob(claimed);
+    return;
+  }
+  await redis.eval(
+    `local raw = redis.call('GET', KEYS[3])
+     if raw then
+       local claim = cjson.decode(raw)
+       if claim.token ~= ARGV[3] then return 0 end
+     end
+     redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])
+     redis.call('SADD', KEYS[2], KEYS[1])
+     redis.call('DEL', KEYS[3])
+     return 1`,
+    3,
+    constructQueueKey(teamId),
+    "concurrency-limit-queues",
+    constructClaimKey(claimed.job.id),
+    claimed.score,
+    claimed.job.id,
+    claimed.token,
+  );
 }
 
 /**
@@ -294,124 +417,144 @@ export async function getNextConcurrentJob(teamId: string): Promise<{
  * @param job The BullMQ job that is done.
  */
 export async function concurrentJobDone(job: NuQJob<any>) {
-  if (job.id && job.data && job.data.team_id) {
-    await withTeamMigrationAdmission(job.data.team_id, async () => {
-      await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
-      await getRedisConnection().zrem(
-        constructQueueKey(job.data.team_id),
-        job.id,
+  if (!job.id || !job.data?.team_id) return;
+
+  const teamId = job.data.team_id;
+  await removeConcurrencyLimitActiveJob(teamId, job.id);
+  await getRedisConnection().zrem(constructQueueKey(teamId), job.id);
+  await getRedisConnection().del(
+    constructJobKey(job.id),
+    constructClaimKey(job.id),
+  );
+  await cleanOldConcurrencyLimitEntries(teamId);
+  await cleanOldConcurrencyLimitedJobs(teamId);
+
+  if (job.data.crawl_id) {
+    await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
+    await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
+  }
+
+  const maxTeamConcurrency =
+    (
+      await getACUCTeam(
+        teamId,
+        false,
+        true,
+        job.data.is_extract ? RateLimiterMode.Extract : RateLimiterMode.Crawl,
+      )
+    )?.concurrency ?? 2;
+  await syncFdbLimitToPgOccupancy(teamId);
+
+  const releaseClaimReservations = async (claimed: ClaimedConcurrentJob) => {
+    const cleanup: Promise<unknown>[] = [
+      removeConcurrencyLimitActiveJob(teamId, claimed.job.id),
+    ];
+    if (claimed.job.data.crawl_id) {
+      cleanup.push(
+        removeCrawlConcurrencyLimitActiveJob(
+          claimed.job.data.crawl_id,
+          claimed.job.id,
+        ),
       );
-      await getRedisConnection().del(constructJobKey(job.id));
-      await cleanOldConcurrencyLimitEntries(job.data.team_id);
-      await cleanOldConcurrencyLimitedJobs(job.data.team_id);
+    }
+    const results = await Promise.allSettled(cleanup);
+    await syncFdbLimitToPgOccupancy(teamId);
+    const failed = results.filter(result => result.status === "rejected");
+    if (failed.length > 0) {
+      throw new AggregateError(
+        failed.map(result => (result as PromiseRejectedResult).reason),
+        "Failed to release claimed concurrency reservations",
+      );
+    }
+  };
 
-      if (job.data.crawl_id) {
-        await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
-        await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
-      }
+  let staleSkipped = 0;
+  while (staleSkipped < 100) {
+    if ((await getCombinedTeamActiveCount(teamId)) >= maxTeamConcurrency) break;
+    const claimed = await getNextConcurrentJob(teamId);
+    if (claimed === null) break;
 
-      const maxTeamConcurrency =
-        (
-          await getACUCTeam(
-            job.data.team_id,
-            false,
-            true,
-            job.data.is_extract
-              ? RateLimiterMode.Extract
-              : RateLimiterMode.Crawl,
-          )
-        )?.concurrency ?? 2;
+    try {
+      await pushConcurrencyLimitActiveJob(teamId, claimed.job.id, 60 * 1000);
+      await syncFdbLimitToPgOccupancy(teamId);
 
-      // Releasing a legacy PG slot can raise the effective FDB limit and wake
-      // pending FDB work. Do this before deciding whether PG may promote.
-      await syncFdbLimitToPgOccupancy(job.data.team_id);
-
-      let staleSkipped = 0;
-      while (staleSkipped < 100) {
-        const currentActiveConcurrency = await getCombinedTeamActiveCount(
-          job.data.team_id,
-        );
-
-        if (currentActiveConcurrency >= maxTeamConcurrency) break;
-
-        const nextJob = await getNextConcurrentJob(job.data.team_id);
-        if (nextJob === null) break;
-
-        await pushConcurrencyLimitActiveJob(
-          job.data.team_id,
-          nextJob.job.id,
+      if (claimed.job.data.crawl_id) {
+        // Reserve crawl capacity before making the PG row worker-visible.
+        await pushCrawlConcurrencyLimitActiveJob(
+          claimed.job.data.crawl_id,
+          claimed.job.id,
           60 * 1000,
         );
-        await syncFdbLimitToPgOccupancy(job.data.team_id);
-
-        if (nextJob.job.data.crawl_id) {
-          await pushCrawlConcurrencyLimitActiveJob(
-            nextJob.job.data.crawl_id,
-            nextJob.job.id,
-            60 * 1000,
+        const sc = await getCrawl(claimed.job.data.crawl_id);
+        if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
+          await new Promise(resolve =>
+            setTimeout(resolve, sc.crawlerOptions.delay * 1000),
           );
-
-          const sc = await getCrawl(nextJob.job.data.crawl_id);
-          if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
-            await new Promise(resolve =>
-              setTimeout(resolve, sc.crawlerOptions.delay * 1000),
-            );
-          }
-        }
-
-        abTestJob(nextJob.job.data);
-
-        const promotedSuccessfully =
-          (await scrapeQueue.promoteJobFromBacklogOrAdd(
-            nextJob.job.id,
-            nextJob.job.data,
-            {
-              priority: nextJob.job.priority,
-              listenable: nextJob.job.listenable,
-              ownerId: nextJob.job.data.team_id ?? undefined,
-              groupId: nextJob.job.data.crawl_id ?? undefined,
-            },
-          )) !== null;
-
-        if (promotedSuccessfully) {
-          logger.debug("Successfully promoted concurrent queued job", {
-            teamId: job.data.team_id,
-            jobId: nextJob.job.id,
-            zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-          });
-          break;
-        } else {
-          logger.warn(
-            "Was unable to promote concurrent queued job as it already exists in the database",
-            {
-              teamId: job.data.team_id,
-              jobId: nextJob.job.id,
-              zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-            },
-          );
-          await removeConcurrencyLimitActiveJob(
-            job.data.team_id,
-            nextJob.job.id,
-          );
-          await syncFdbLimitToPgOccupancy(job.data.team_id);
-          if (nextJob.job.data.crawl_id) {
-            await removeCrawlConcurrencyLimitActiveJob(
-              nextJob.job.data.crawl_id,
-              nextJob.job.id,
-            );
-          }
-          staleSkipped++;
         }
       }
 
-      if (staleSkipped >= 100) {
-        logger.warn(
-          "Skipped 100 stale entries in concurrency queue without a successful promotion",
-          {
-            teamId: job.data.team_id,
-          },
+      abTestJob(claimed.job.data);
+      const promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
+        claimed.job.id,
+        claimed.job.data,
+        {
+          priority: claimed.job.priority,
+          listenable: claimed.job.listenable,
+          ownerId: claimed.job.data.team_id ?? undefined,
+          groupId: claimed.job.data.crawl_id ?? undefined,
+        },
+      );
+
+      if (promoted !== null) {
+        await acknowledgeConcurrentJob(claimed);
+        logger.debug("Successfully promoted concurrent queued job", {
+          teamId,
+          jobId: claimed.job.id,
+          zeroDataRetention: claimed.job.data?.zeroDataRetention,
+        });
+        break;
+      }
+
+      await releaseClaimReservations(claimed);
+      await acknowledgeConcurrentJob(claimed);
+      staleSkipped++;
+    } catch (error) {
+      // Reconcile a possible PG commit before undoing reservations. If the
+      // probe itself is unavailable, leave the payload and reservations for
+      // the periodic reconciler rather than guessing after an ambiguous write.
+      let materialized: NuQJob<any> | null;
+      try {
+        materialized = await scrapeQueue.getJob(claimed.job.id);
+      } catch {
+        throw error;
+      }
+      if (materialized) {
+        await acknowledgeConcurrentJob(claimed);
+        throw error;
+      }
+
+      const cleanup = await Promise.allSettled([
+        releaseClaimReservations(claimed),
+        restoreConcurrentJob(teamId, claimed),
+      ]);
+      const cleanupFailures = cleanup.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (cleanupFailures.length > 0) {
+        throw new AggregateError(
+          [error, ...cleanupFailures.map(result => result.reason)],
+          "Concurrent promotion and claim restoration both failed",
         );
       }
-    });
+      throw error;
+    }
+  }
+
+  if (staleSkipped >= 100) {
+    logger.warn(
+      "Skipped 100 stale entries in concurrency queue without a successful promotion",
+      { teamId },
+    );
   }
 }

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -5,6 +5,11 @@ import { getCrawl, StoredCrawl } from "./crawl-redis";
 import { logger } from "./logger";
 import { abTestJob } from "../services/ab-test";
 import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
+import {
+  getCombinedTeamActiveCount,
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "../services/worker/nuq-router";
 export { QueueFullError } from "./queue-full-error";
 export {
   getTeamQueueLimit,
@@ -290,110 +295,123 @@ export async function getNextConcurrentJob(teamId: string): Promise<{
  */
 export async function concurrentJobDone(job: NuQJob<any>) {
   if (job.id && job.data && job.data.team_id) {
-    await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
-    await getRedisConnection().zrem(
-      constructQueueKey(job.data.team_id),
-      job.id,
-    );
-    await getRedisConnection().del(constructJobKey(job.id));
-    await cleanOldConcurrencyLimitEntries(job.data.team_id);
-    await cleanOldConcurrencyLimitedJobs(job.data.team_id);
-
-    if (job.data.crawl_id) {
-      await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
-      await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
-    }
-
-    const maxTeamConcurrency =
-      (
-        await getACUCTeam(
-          job.data.team_id,
-          false,
-          true,
-          job.data.is_extract ? RateLimiterMode.Extract : RateLimiterMode.Crawl,
-        )
-      )?.concurrency ?? 2;
-
-    let staleSkipped = 0;
-    while (staleSkipped < 100) {
-      const currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(job.data.team_id)
-      ).length;
-
-      if (currentActiveConcurrency >= maxTeamConcurrency) break;
-
-      const nextJob = await getNextConcurrentJob(job.data.team_id);
-      if (nextJob === null) break;
-
-      await pushConcurrencyLimitActiveJob(
-        job.data.team_id,
-        nextJob.job.id,
-        60 * 1000,
+    await withTeamMigrationAdmission(job.data.team_id, async () => {
+      await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
+      await getRedisConnection().zrem(
+        constructQueueKey(job.data.team_id),
+        job.id,
       );
+      await getRedisConnection().del(constructJobKey(job.id));
+      await cleanOldConcurrencyLimitEntries(job.data.team_id);
+      await cleanOldConcurrencyLimitedJobs(job.data.team_id);
 
-      if (nextJob.job.data.crawl_id) {
-        await pushCrawlConcurrencyLimitActiveJob(
-          nextJob.job.data.crawl_id,
+      if (job.data.crawl_id) {
+        await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
+        await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
+      }
+
+      const maxTeamConcurrency =
+        (
+          await getACUCTeam(
+            job.data.team_id,
+            false,
+            true,
+            job.data.is_extract
+              ? RateLimiterMode.Extract
+              : RateLimiterMode.Crawl,
+          )
+        )?.concurrency ?? 2;
+
+      // Releasing a legacy PG slot can raise the effective FDB limit and wake
+      // pending FDB work. Do this before deciding whether PG may promote.
+      await syncFdbLimitToPgOccupancy(job.data.team_id);
+
+      let staleSkipped = 0;
+      while (staleSkipped < 100) {
+        const currentActiveConcurrency = await getCombinedTeamActiveCount(
+          job.data.team_id,
+        );
+
+        if (currentActiveConcurrency >= maxTeamConcurrency) break;
+
+        const nextJob = await getNextConcurrentJob(job.data.team_id);
+        if (nextJob === null) break;
+
+        await pushConcurrencyLimitActiveJob(
+          job.data.team_id,
           nextJob.job.id,
           60 * 1000,
         );
+        await syncFdbLimitToPgOccupancy(job.data.team_id);
 
-        const sc = await getCrawl(nextJob.job.data.crawl_id);
-        if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
-          await new Promise(resolve =>
-            setTimeout(resolve, sc.crawlerOptions.delay * 1000),
+        if (nextJob.job.data.crawl_id) {
+          await pushCrawlConcurrencyLimitActiveJob(
+            nextJob.job.data.crawl_id,
+            nextJob.job.id,
+            60 * 1000,
           );
+
+          const sc = await getCrawl(nextJob.job.data.crawl_id);
+          if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
+            await new Promise(resolve =>
+              setTimeout(resolve, sc.crawlerOptions.delay * 1000),
+            );
+          }
         }
-      }
 
-      abTestJob(nextJob.job.data);
+        abTestJob(nextJob.job.data);
 
-      const promotedSuccessfully =
-        (await scrapeQueue.promoteJobFromBacklogOrAdd(
-          nextJob.job.id,
-          nextJob.job.data,
-          {
-            priority: nextJob.job.priority,
-            listenable: nextJob.job.listenable,
-            ownerId: nextJob.job.data.team_id ?? undefined,
-            groupId: nextJob.job.data.crawl_id ?? undefined,
-          },
-        )) !== null;
+        const promotedSuccessfully =
+          (await scrapeQueue.promoteJobFromBacklogOrAdd(
+            nextJob.job.id,
+            nextJob.job.data,
+            {
+              priority: nextJob.job.priority,
+              listenable: nextJob.job.listenable,
+              ownerId: nextJob.job.data.team_id ?? undefined,
+              groupId: nextJob.job.data.crawl_id ?? undefined,
+            },
+          )) !== null;
 
-      if (promotedSuccessfully) {
-        logger.debug("Successfully promoted concurrent queued job", {
-          teamId: job.data.team_id,
-          jobId: nextJob.job.id,
-          zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-        });
-        break;
-      } else {
-        logger.warn(
-          "Was unable to promote concurrent queued job as it already exists in the database",
-          {
+        if (promotedSuccessfully) {
+          logger.debug("Successfully promoted concurrent queued job", {
             teamId: job.data.team_id,
             jobId: nextJob.job.id,
             zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-          },
-        );
-        await removeConcurrencyLimitActiveJob(job.data.team_id, nextJob.job.id);
-        if (nextJob.job.data.crawl_id) {
-          await removeCrawlConcurrencyLimitActiveJob(
-            nextJob.job.data.crawl_id,
+          });
+          break;
+        } else {
+          logger.warn(
+            "Was unable to promote concurrent queued job as it already exists in the database",
+            {
+              teamId: job.data.team_id,
+              jobId: nextJob.job.id,
+              zeroDataRetention: nextJob.job.data?.zeroDataRetention,
+            },
+          );
+          await removeConcurrencyLimitActiveJob(
+            job.data.team_id,
             nextJob.job.id,
           );
+          await syncFdbLimitToPgOccupancy(job.data.team_id);
+          if (nextJob.job.data.crawl_id) {
+            await removeCrawlConcurrencyLimitActiveJob(
+              nextJob.job.data.crawl_id,
+              nextJob.job.id,
+            );
+          }
+          staleSkipped++;
         }
-        staleSkipped++;
       }
-    }
 
-    if (staleSkipped >= 100) {
-      logger.warn(
-        "Skipped 100 stale entries in concurrency queue without a successful promotion",
-        {
-          teamId: job.data.team_id,
-        },
-      );
-    }
+      if (staleSkipped >= 100) {
+        logger.warn(
+          "Skipped 100 stale entries in concurrency queue without a successful promotion",
+          {
+            teamId: job.data.team_id,
+          },
+        );
+      }
+    });
   }
 }

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -5,10 +5,7 @@ import { getCrawl, StoredCrawl } from "./crawl-redis";
 import { logger } from "./logger";
 import { abTestJob } from "../services/ab-test";
 import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
-import {
-  getCombinedTeamActiveCount,
-  syncFdbLimitToPgOccupancy,
-} from "../services/worker/nuq-router";
+import { syncFdbLimitToPgOccupancy } from "../services/worker/nuq-router";
 export { QueueFullError } from "./queue-full-error";
 export {
   getTeamQueueLimit,
@@ -21,8 +18,8 @@ import {
   getTeamQueueLimit,
   MAX_BACKLOG_TIMEOUT_MS,
   constructConcurrencyLimitKey,
-  pushConcurrencyLimitActiveJob,
   removeConcurrencyLimitActiveJob,
+  reserveConcurrencyLimitActiveJob,
 } from "./concurrency-redis";
 
 const constructKey = constructConcurrencyLimitKey;
@@ -470,12 +467,21 @@ export async function concurrentJobDone(job: NuQJob<any>) {
 
   let staleSkipped = 0;
   while (staleSkipped < 100) {
-    if ((await getCombinedTeamActiveCount(teamId)) >= maxTeamConcurrency) break;
     const claimed = await getNextConcurrentJob(teamId);
     if (claimed === null) break;
 
     try {
-      await pushConcurrencyLimitActiveJob(teamId, claimed.job.id, 60 * 1000);
+      const reservation = await reserveConcurrencyLimitActiveJob(
+        teamId,
+        claimed.job.id,
+        maxTeamConcurrency,
+        60 * 1000,
+      );
+      if (!reservation.reserved) {
+        await restoreConcurrentJob(teamId, claimed);
+        break;
+      }
+
       await syncFdbLimitToPgOccupancy(teamId);
 
       if (claimed.job.data.crawl_id) {

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -6,10 +6,14 @@ import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
 import {
   getCombinedTeamActiveCount,
   syncFdbLimitToPgOccupancy,
-  withTeamMigrationAdmission,
 } from "../services/worker/nuq-router";
+import {
+  completeNuQPgPublication,
+  type NuQPgPublication,
+} from "../services/worker/nuq-pg-publication";
 import { RateLimiterMode, type ScrapeJobData } from "../types";
 import {
+  acknowledgeConcurrentJob,
   getConcurrencyLimitActiveJobs,
   getNextConcurrentJob,
   MAX_BACKLOG_TIMEOUT_MS,
@@ -18,6 +22,7 @@ import {
   pushCrawlConcurrencyLimitActiveJob,
   removeConcurrencyLimitActiveJob,
   removeCrawlConcurrencyLimitActiveJob,
+  restoreConcurrentJob,
 } from "./concurrency-limit";
 import { getCrawl } from "./crawl-redis";
 import { logger as _logger } from "./logger";
@@ -36,6 +41,18 @@ interface ReconcileResult {
 
 function isExtractJob(data: ScrapeJobData): boolean {
   return "is_extract" in data && !!data.is_extract;
+}
+
+function publicationForBacklogJob(
+  ownerId: string,
+  job: NuQJob<ScrapeJobData>,
+): NuQPgPublication {
+  return {
+    id: job.id,
+    ownerId,
+    groupId: job.data.crawl_id,
+    placement: "backlog",
+  };
 }
 
 function getBacklogJobTimeout(jobData: ScrapeJobData): number {
@@ -76,14 +93,6 @@ async function reservePgActiveSlot(
   }
 }
 
-async function releasePgActiveSlot(
-  ownerId: string,
-  jobId: string,
-): Promise<void> {
-  await removeConcurrencyLimitActiveJob(ownerId, jobId);
-  await syncFdbLimitToPgOccupancy(ownerId);
-}
-
 async function rollbackPgReservations(
   ownerId: string,
   jobId: string,
@@ -95,8 +104,20 @@ async function rollbackPgReservations(
   if (crawlId) {
     removals.push(removeCrawlConcurrencyLimitActiveJob(crawlId, jobId));
   }
-  await Promise.allSettled(removals);
-  await syncFdbLimitToPgOccupancy(ownerId);
+  const results = await Promise.allSettled(removals);
+  const failures = results
+    .filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    )
+    .map(result => result.reason);
+  try {
+    await syncFdbLimitToPgOccupancy(ownerId);
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Failed to roll back PG reservations");
+  }
 }
 
 async function getQueuedJobIDs(teamId: string): Promise<Set<string>> {
@@ -118,7 +139,49 @@ async function getQueuedJobIDs(teamId: string): Promise<Set<string>> {
     }
   } while (cursor !== "0");
 
+  // A ZSET member without cq-job payload cannot be promoted and is not a
+  // published backlog entry. Treat it as drift so the PG row repairs Redis.
+  const ids = [...queuedJobIDs];
+  for (let offset = 0; offset < ids.length; offset += 1000) {
+    const batch = ids.slice(offset, offset + 1000);
+    const payloads = await getRedisConnection().mget(
+      ...batch.map(id => `cq-job:${id}`),
+    );
+    payloads.forEach((payload, index) => {
+      const id = batch[index];
+      if (payload === null) {
+        queuedJobIDs.delete(id);
+        return;
+      }
+      try {
+        if (JSON.parse(payload)?.id !== id) queuedJobIDs.delete(id);
+      } catch {
+        queuedJobIDs.delete(id);
+      }
+    });
+  }
   return queuedJobIDs;
+}
+
+async function includeClaimedJobIDs(
+  ownerId: string,
+  ids: string[],
+  published: Set<string>,
+): Promise<void> {
+  for (let offset = 0; offset < ids.length; offset += 1000) {
+    const batch = ids.slice(offset, offset + 1000);
+    const claims = await getRedisConnection().mget(
+      ...batch.map(id => `cq-claim:${id}`),
+    );
+    claims.forEach((raw, index) => {
+      if (!raw) return;
+      try {
+        if (JSON.parse(raw)?.teamId === ownerId) published.add(batch[index]);
+      } catch {
+        // Corrupt/expired claims are repaired through the ordinary DB path.
+      }
+    });
+  }
 }
 
 async function reconcileTeam(
@@ -133,11 +196,22 @@ async function reconcileTeam(
   }
 
   const queuedJobIDs = await getQueuedJobIDs(ownerId);
-  const missingJobIDs = [...backloggedJobIDs].filter(x => !queuedJobIDs.has(x));
+  await includeClaimedJobIDs(ownerId, [...backloggedJobIDs], queuedJobIDs);
+  const healthyJobIDs = [...backloggedJobIDs].filter(id =>
+    queuedJobIDs.has(id),
+  );
+  await completeNuQPgPublication(
+    healthyJobIDs.map(id => ({
+      id,
+      ownerId,
+      placement: "backlog" as const,
+    })),
+  );
+  const missingJobIDs = [...backloggedJobIDs].filter(
+    id => !queuedJobIDs.has(id),
+  );
 
-  if (missingJobIDs.length === 0) {
-    return null;
-  }
+  if (missingJobIDs.length === 0) return null;
 
   const jobsToRecover = await scrapeQueue.getJobsFromBacklog(
     missingJobIDs,
@@ -198,15 +272,27 @@ async function reconcileTeam(
 
   for (const job of jobsToQueue) {
     await requeueJob(ownerId, job);
+    await completeNuQPgPublication([publicationForBacklogJob(ownerId, job)]);
     jobsRequeued++;
   }
 
   for (const job of jobsToStart) {
-    // Reserve the shared ledger before making the PG row runnable. If the
-    // promotion loses a race, roll the reservation back.
     await reservePgActiveSlot(ownerId, job.id);
+    let crawlReserved = false;
     let promoted: NuQJob<ScrapeJobData> | null;
     try {
+      if (job.data.crawl_id) {
+        const sc = await getCrawl(job.data.crawl_id);
+        if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
+          // Crawl reservation must precede worker-visible PG promotion.
+          await pushCrawlConcurrencyLimitActiveJob(
+            job.data.crawl_id,
+            job.id,
+            60 * 1000,
+          );
+          crawlReserved = true;
+        }
+      }
       promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
         job.id,
         job.data,
@@ -218,29 +304,36 @@ async function reconcileTeam(
         },
       );
     } catch (error) {
-      await releasePgActiveSlot(ownerId, job.id);
+      let materialized: NuQJob<ScrapeJobData> | null;
+      try {
+        materialized = await scrapeQueue.getJob(job.id, teamLogger);
+      } catch {
+        throw error;
+      }
+      if (!materialized) {
+        await rollbackPgReservations(
+          ownerId,
+          job.id,
+          crawlReserved ? job.data.crawl_id : undefined,
+        );
+      }
       throw error;
     }
 
     if (promoted !== null) {
-      if (job.data.crawl_id) {
-        const sc = await getCrawl(job.data.crawl_id);
-        if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
-          await pushCrawlConcurrencyLimitActiveJob(
-            job.data.crawl_id,
-            job.id,
-            60 * 1000,
-          );
-        }
-      }
-
+      await completeNuQPgPublication([publicationForBacklogJob(ownerId, job)]);
       jobsStarted++;
     } else {
-      await releasePgActiveSlot(ownerId, job.id);
+      await rollbackPgReservations(
+        ownerId,
+        job.id,
+        crawlReserved ? job.data.crawl_id : undefined,
+      );
       teamLogger.warn("Job promotion failed, re-queuing job", {
         jobId: job.id,
       });
       await requeueJob(ownerId, job);
+      await completeNuQPgPublication([publicationForBacklogJob(ownerId, job)]);
       jobsRequeued++;
     }
   }
@@ -300,16 +393,7 @@ async function drainQueue(
     const typeCount = isExtract ? extractCount : crawlCount;
 
     if (typeCount >= typeLimit) {
-      await pushConcurrencyLimitedJob(
-        ownerId,
-        {
-          id: nextJob.job.id,
-          data: nextJob.job.data,
-          priority: nextJob.job.priority,
-          listenable: nextJob.job.listenable,
-        },
-        nextJob.timeout === Infinity ? MAX_BACKLOG_TIMEOUT_MS : nextJob.timeout,
-      );
+      await restoreConcurrentJob(ownerId, nextJob);
       typeBlocked++;
       continue;
     }
@@ -337,20 +421,39 @@ async function drainQueue(
         },
       );
     } catch (error) {
-      await rollbackPgReservations(
-        ownerId,
-        nextJob.job.id,
-        crawlReserved ? nextJob.job.data.crawl_id : undefined,
-      ).catch(cleanupError =>
-        teamLogger.error("Failed to roll back PG promotion reservations", {
-          jobId: nextJob.job.id,
-          cleanupError,
-        }),
+      let materialized: NuQJob<ScrapeJobData> | null;
+      try {
+        materialized = await scrapeQueue.getJob(nextJob.job.id, teamLogger);
+      } catch {
+        throw error;
+      }
+      if (materialized) {
+        await acknowledgeConcurrentJob(nextJob);
+        throw error;
+      }
+      const cleanup = await Promise.allSettled([
+        rollbackPgReservations(
+          ownerId,
+          nextJob.job.id,
+          crawlReserved ? nextJob.job.data.crawl_id : undefined,
+        ),
+        restoreConcurrentJob(ownerId, nextJob),
+      ]);
+      const failures = cleanup.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
       );
+      if (failures.length > 0) {
+        throw new AggregateError(
+          [error, ...failures.map(result => result.reason)],
+          "PG queue drain and claim restoration both failed",
+        );
+      }
       throw error;
     }
 
     if (promoted !== null) {
+      await acknowledgeConcurrentJob(nextJob);
       if (isExtract) extractCount++;
       else crawlCount++;
       jobsPromoted++;
@@ -358,8 +461,9 @@ async function drainQueue(
       await rollbackPgReservations(
         ownerId,
         nextJob.job.id,
-        nextJob.job.data.crawl_id,
+        crawlReserved ? nextJob.job.data.crawl_id : undefined,
       );
+      await acknowledgeConcurrentJob(nextJob);
       staleSkipped++;
     }
   }
@@ -409,23 +513,21 @@ export async function reconcileConcurrencyQueue(
     const teamLogger = logger.child({ teamId: ownerId });
 
     try {
-      await withTeamMigrationAdmission(ownerId, async () => {
-        const teamResult = await reconcileTeam(ownerId, teamLogger);
-        if (teamResult !== null) {
-          result.teamsWithDrift++;
-          result.jobsStarted += teamResult.jobsStarted;
-          result.jobsRequeued += teamResult.jobsRequeued;
-        }
+      const teamResult = await reconcileTeam(ownerId, teamLogger);
+      if (teamResult !== null) {
+        result.teamsWithDrift++;
+        result.jobsStarted += teamResult.jobsStarted;
+        result.jobsRequeued += teamResult.jobsRequeued;
+      }
 
-        const drainResult = await drainQueue(ownerId, teamLogger);
-        if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
-          result.jobsStarted += drainResult.jobsPromoted;
-          teamLogger.info("Queue drain promoted jobs", {
-            jobsPromoted: drainResult.jobsPromoted,
-            staleSkipped: drainResult.staleSkipped,
-          });
-        }
-      });
+      const drainResult = await drainQueue(ownerId, teamLogger);
+      if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
+        result.jobsStarted += drainResult.jobsPromoted;
+        teamLogger.info("Queue drain promoted jobs", {
+          jobsPromoted: drainResult.jobsPromoted,
+          staleSkipped: drainResult.staleSkipped,
+        });
+      }
     } catch (error) {
       teamLogger.error("Failed to reconcile team, skipping", { error });
     }

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -45,7 +45,7 @@ function isExtractJob(data: ScrapeJobData): boolean {
 
 function publicationForBacklogJob(
   ownerId: string,
-  job: NuQJob<ScrapeJobData>,
+  job: Pick<NuQJob<ScrapeJobData>, "id" | "data">,
 ): NuQPgPublication {
   return {
     id: job.id,
@@ -321,7 +321,10 @@ async function reconcileTeam(
     }
 
     if (promoted !== null) {
-      await completeNuQPgPublication([publicationForBacklogJob(ownerId, job)]);
+      await completeNuQPgPublication(
+        [publicationForBacklogJob(ownerId, job)],
+        "promoted",
+      );
       jobsStarted++;
     } else {
       await rollbackPgReservations(
@@ -453,6 +456,10 @@ async function drainQueue(
     }
 
     if (promoted !== null) {
+      await completeNuQPgPublication(
+        [publicationForBacklogJob(ownerId, nextJob.job)],
+        "promoted",
+      );
       await acknowledgeConcurrentJob(nextJob);
       if (isExtract) extractCount++;
       else crawlCount++;

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -3,6 +3,11 @@ import { validate as isUUID } from "uuid";
 import { getACUCTeam } from "../controllers/auth";
 import { getRedisConnection } from "../services/queue-service";
 import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
+import {
+  getCombinedTeamActiveCount,
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "../services/worker/nuq-router";
 import { RateLimiterMode, type ScrapeJobData } from "../types";
 import {
   getConcurrencyLimitActiveJobs,
@@ -56,6 +61,42 @@ async function requeueJob(
     },
     getBacklogJobTimeout(job.data),
   );
+}
+
+async function reservePgActiveSlot(
+  ownerId: string,
+  jobId: string,
+): Promise<void> {
+  await pushConcurrencyLimitActiveJob(ownerId, jobId, 60 * 1000);
+  try {
+    await syncFdbLimitToPgOccupancy(ownerId);
+  } catch (error) {
+    await removeConcurrencyLimitActiveJob(ownerId, jobId);
+    throw error;
+  }
+}
+
+async function releasePgActiveSlot(
+  ownerId: string,
+  jobId: string,
+): Promise<void> {
+  await removeConcurrencyLimitActiveJob(ownerId, jobId);
+  await syncFdbLimitToPgOccupancy(ownerId);
+}
+
+async function rollbackPgReservations(
+  ownerId: string,
+  jobId: string,
+  crawlId?: string,
+): Promise<void> {
+  const removals: Promise<unknown>[] = [
+    removeConcurrencyLimitActiveJob(ownerId, jobId),
+  ];
+  if (crawlId) {
+    removals.push(removeCrawlConcurrencyLimitActiveJob(crawlId, jobId));
+  }
+  await Promise.allSettled(removals);
+  await syncFdbLimitToPgOccupancy(ownerId);
 }
 
 async function getQueuedJobIDs(teamId: string): Promise<Set<string>> {
@@ -125,6 +166,15 @@ async function reconcileTeam(
       activeCrawlCount++;
     }
   }
+  // FDB jobs are not represented in the PG job rows used for type splitting.
+  // Count them against either PG admission class so drift recovery cannot
+  // reopen a second ledger's worth of slots during migration.
+  const fdbActiveCount = Math.max(
+    0,
+    (await getCombinedTeamActiveCount(ownerId)) - activeJobs.length,
+  );
+  activeCrawlCount += fdbActiveCount;
+  activeExtractCount += fdbActiveCount;
 
   const jobsToStart: typeof jobsToRecover = [];
   const jobsToQueue: typeof jobsToRecover = [];
@@ -152,20 +202,27 @@ async function reconcileTeam(
   }
 
   for (const job of jobsToStart) {
-    const promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
-      job.id,
-      job.data,
-      {
-        priority: job.priority,
-        listenable: job.listenChannelId !== undefined,
-        ownerId: job.data.team_id ?? undefined,
-        groupId: job.data.crawl_id ?? undefined,
-      },
-    );
+    // Reserve the shared ledger before making the PG row runnable. If the
+    // promotion loses a race, roll the reservation back.
+    await reservePgActiveSlot(ownerId, job.id);
+    let promoted: NuQJob<ScrapeJobData> | null;
+    try {
+      promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
+        job.id,
+        job.data,
+        {
+          priority: job.priority,
+          listenable: job.listenChannelId !== undefined,
+          ownerId: job.data.team_id ?? undefined,
+          groupId: job.data.crawl_id ?? undefined,
+        },
+      );
+    } catch (error) {
+      await releasePgActiveSlot(ownerId, job.id);
+      throw error;
+    }
 
     if (promoted !== null) {
-      await pushConcurrencyLimitActiveJob(ownerId, job.id, 60 * 1000);
-
       if (job.data.crawl_id) {
         const sc = await getCrawl(job.data.crawl_id);
         if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
@@ -179,6 +236,7 @@ async function reconcileTeam(
 
       jobsStarted++;
     } else {
+      await releasePgActiveSlot(ownerId, job.id);
       teamLogger.warn("Job promotion failed, re-queuing job", {
         jobId: job.id,
       });
@@ -216,6 +274,12 @@ async function drainQueue(
     if (isExtractJob(aj.data)) extractCount++;
     else crawlCount++;
   }
+  const fdbActiveCount = Math.max(
+    0,
+    (await getCombinedTeamActiveCount(ownerId)) - activeJobs.length,
+  );
+  crawlCount += fdbActiveCount;
+  extractCount += fdbActiveCount;
 
   let jobsPromoted = 0;
   let staleSkipped = 0;
@@ -250,38 +314,52 @@ async function drainQueue(
       continue;
     }
 
-    await pushConcurrencyLimitActiveJob(ownerId, nextJob.job.id, 60 * 1000);
-    if (nextJob.job.data.crawl_id) {
-      await pushCrawlConcurrencyLimitActiveJob(
-        nextJob.job.data.crawl_id,
+    await reservePgActiveSlot(ownerId, nextJob.job.id);
+    let crawlReserved = false;
+    let promoted: NuQJob<ScrapeJobData> | null;
+    try {
+      if (nextJob.job.data.crawl_id) {
+        await pushCrawlConcurrencyLimitActiveJob(
+          nextJob.job.data.crawl_id,
+          nextJob.job.id,
+          60 * 1000,
+        );
+        crawlReserved = true;
+      }
+      promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
         nextJob.job.id,
-        60 * 1000,
+        nextJob.job.data,
+        {
+          priority: nextJob.job.priority,
+          listenable: nextJob.job.listenable,
+          ownerId: nextJob.job.data.team_id ?? undefined,
+          groupId: nextJob.job.data.crawl_id ?? undefined,
+        },
       );
+    } catch (error) {
+      await rollbackPgReservations(
+        ownerId,
+        nextJob.job.id,
+        crawlReserved ? nextJob.job.data.crawl_id : undefined,
+      ).catch(cleanupError =>
+        teamLogger.error("Failed to roll back PG promotion reservations", {
+          jobId: nextJob.job.id,
+          cleanupError,
+        }),
+      );
+      throw error;
     }
-
-    const promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
-      nextJob.job.id,
-      nextJob.job.data,
-      {
-        priority: nextJob.job.priority,
-        listenable: nextJob.job.listenable,
-        ownerId: nextJob.job.data.team_id ?? undefined,
-        groupId: nextJob.job.data.crawl_id ?? undefined,
-      },
-    );
 
     if (promoted !== null) {
       if (isExtract) extractCount++;
       else crawlCount++;
       jobsPromoted++;
     } else {
-      await removeConcurrencyLimitActiveJob(ownerId, nextJob.job.id);
-      if (nextJob.job.data.crawl_id) {
-        await removeCrawlConcurrencyLimitActiveJob(
-          nextJob.job.data.crawl_id,
-          nextJob.job.id,
-        );
-      }
+      await rollbackPgReservations(
+        ownerId,
+        nextJob.job.id,
+        nextJob.job.data.crawl_id,
+      );
       staleSkipped++;
     }
   }
@@ -331,21 +409,23 @@ export async function reconcileConcurrencyQueue(
     const teamLogger = logger.child({ teamId: ownerId });
 
     try {
-      const teamResult = await reconcileTeam(ownerId, teamLogger);
-      if (teamResult !== null) {
-        result.teamsWithDrift++;
-        result.jobsStarted += teamResult.jobsStarted;
-        result.jobsRequeued += teamResult.jobsRequeued;
-      }
+      await withTeamMigrationAdmission(ownerId, async () => {
+        const teamResult = await reconcileTeam(ownerId, teamLogger);
+        if (teamResult !== null) {
+          result.teamsWithDrift++;
+          result.jobsStarted += teamResult.jobsStarted;
+          result.jobsRequeued += teamResult.jobsRequeued;
+        }
 
-      const drainResult = await drainQueue(ownerId, teamLogger);
-      if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
-        result.jobsStarted += drainResult.jobsPromoted;
-        teamLogger.info("Queue drain promoted jobs", {
-          jobsPromoted: drainResult.jobsPromoted,
-          staleSkipped: drainResult.staleSkipped,
-        });
-      }
+        const drainResult = await drainQueue(ownerId, teamLogger);
+        if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
+          result.jobsStarted += drainResult.jobsPromoted;
+          teamLogger.info("Queue drain promoted jobs", {
+            jobsPromoted: drainResult.jobsPromoted,
+            staleSkipped: drainResult.staleSkipped,
+          });
+        }
+      });
     } catch (error) {
       teamLogger.error("Failed to reconcile team, skipping", { error });
     }

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -7,6 +7,7 @@ import {
   getCombinedTeamActiveCount,
   sweepNuQMigrationGc,
   syncFdbLimitToPgOccupancy,
+  type NuQMigrationGcSweepStats,
 } from "../services/worker/nuq-router";
 import {
   completeNuQPgPublication,
@@ -26,12 +27,12 @@ import {
   restoreConcurrentJob,
 } from "./concurrency-limit";
 import { getCrawl } from "./crawl-redis";
-import { recoverConcurrencyLimitRollbacks } from "./concurrency-redis";
 import { logger as _logger } from "./logger";
 
 interface ReconcileOptions {
   teamId?: string;
   logger?: Logger;
+  signal?: AbortSignal;
 }
 
 interface ReconcileResult {
@@ -39,6 +40,7 @@ interface ReconcileResult {
   teamsWithDrift: number;
   jobsRequeued: number;
   jobsStarted: number;
+  migrationGc: NuQMigrationGcSweepStats;
 }
 
 function isExtractJob(data: ScrapeJobData): boolean {
@@ -511,17 +513,18 @@ export async function reconcileConcurrencyQueue(
     ownerIds = [...new Set([...backlogOwners, ...queueOwners])];
   }
 
-  await recoverConcurrencyLimitRollbacks();
-  await sweepNuQMigrationGc();
+  const migrationGc = await sweepNuQMigrationGc({ signal: options.signal });
 
   const result: ReconcileResult = {
     teamsScanned: ownerIds.length,
     teamsWithDrift: 0,
     jobsRequeued: 0,
     jobsStarted: 0,
+    migrationGc,
   };
 
   for (const ownerId of ownerIds) {
+    if (options.signal?.aborted) break;
     const teamLogger = logger.child({ teamId: ownerId });
 
     try {

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -5,6 +5,7 @@ import { getRedisConnection } from "../services/queue-service";
 import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
 import {
   getCombinedTeamActiveCount,
+  sweepNuQMigrationGc,
   syncFdbLimitToPgOccupancy,
 } from "../services/worker/nuq-router";
 import {
@@ -25,6 +26,7 @@ import {
   restoreConcurrentJob,
 } from "./concurrency-limit";
 import { getCrawl } from "./crawl-redis";
+import { recoverConcurrencyLimitRollbacks } from "./concurrency-redis";
 import { logger as _logger } from "./logger";
 
 interface ReconcileOptions {
@@ -508,6 +510,9 @@ export async function reconcileConcurrencyQueue(
       .filter(id => id.length > 0 && isUUID(id));
     ownerIds = [...new Set([...backlogOwners, ...queueOwners])];
   }
+
+  await recoverConcurrencyLimitRollbacks();
+  await sweepNuQMigrationGc();
 
   const result: ReconcileResult = {
     teamsScanned: ownerIds.length,

--- a/apps/api/src/lib/concurrency-redis.test.ts
+++ b/apps/api/src/lib/concurrency-redis.test.ts
@@ -1,22 +1,29 @@
 import { vi } from "vitest";
 
-const evalMock = vi.hoisted(() => vi.fn());
+const redisMocks = vi.hoisted(() => ({
+  eval: vi.fn(),
+  zrangebyscore: vi.fn(),
+  zrem: vi.fn(),
+}));
+const evalMock = redisMocks.eval;
 
 vi.mock("../services/queue-service", () => ({
-  getRedisConnection: () => ({ eval: evalMock }),
+  getRedisConnection: () => redisMocks,
 }));
 
 import {
+  CONCURRENCY_ROLLBACK_MARKER_TTL_MS,
   finalizeConcurrencyLimitActiveJobRollback,
   getConcurrencyLimitActiveJobsCount,
   pushConcurrencyLimitActiveJob,
+  recoverConcurrencyLimitRollbacks,
   renewConcurrencyLimitActiveJob,
   reserveConcurrencyLimitActiveJob,
   rollbackConcurrencyLimitActiveJob,
 } from "./concurrency-redis";
 
 describe("PG concurrency slot reservation", () => {
-  beforeEach(() => evalMock.mockReset());
+  beforeEach(() => vi.clearAllMocks());
 
   test("uses one Redis script for capacity check and insertion", async () => {
     evalMock.mockResolvedValue([1, 1]);
@@ -113,12 +120,21 @@ describe("PG concurrency slot reservation", () => {
     ).resolves.toBe(false);
     expect(evalMock.mock.calls[0]).toEqual([
       expect.stringContaining("GET"),
-      2,
+      3,
       "concurrency-limiter:team",
       "concurrency-limiter:team:reservation:holder",
+      "concurrency-rollback-cleanup:v1",
       "holder",
       "stale-token",
+      JSON.stringify({
+        v: 1,
+        teamId: "team",
+        id: "holder",
+        token: "stale-token",
+      }),
+      CONCURRENCY_ROLLBACK_MARKER_TTL_MS,
     ]);
+    expect(evalMock.mock.calls[0][0]).not.toContain("PERSIST");
   });
 
   test("finalizes the cleanup tombstone by ownership token", async () => {
@@ -133,10 +149,76 @@ describe("PG concurrency slot reservation", () => {
     ).resolves.toBe(true);
     expect(evalMock.mock.calls[0]).toEqual([
       expect.stringContaining("cleanup:"),
-      1,
+      2,
       "concurrency-limiter:team:reservation:holder",
+      "concurrency-rollback-cleanup:v1",
       "owned-token",
+      JSON.stringify({
+        v: 1,
+        teamId: "team",
+        id: "holder",
+        token: "owned-token",
+      }),
     ]);
+  });
+
+  test("recovers abandoned rollback without a same-holder retry", async () => {
+    const member = JSON.stringify({
+      v: 1,
+      teamId: "team",
+      id: "holder",
+      token: "abandoned",
+    });
+    redisMocks.zrangebyscore.mockResolvedValue([member]);
+    evalMock.mockResolvedValue(1);
+
+    await expect(recoverConcurrencyLimitRollbacks(10)).resolves.toEqual({
+      read: 1,
+      finalized: 1,
+      fenced: 0,
+    });
+    expect(redisMocks.zrangebyscore).toHaveBeenCalledWith(
+      "concurrency-rollback-cleanup:v1",
+      "-inf",
+      expect.any(Number),
+      "LIMIT",
+      0,
+      10,
+    );
+    expect(evalMock.mock.calls[0]).toEqual([
+      expect.stringContaining("Never delete it"),
+      2,
+      "concurrency-limiter:team:reservation:holder",
+      "concurrency-rollback-cleanup:v1",
+      "abandoned",
+      member,
+    ]);
+  });
+
+  test("renewal/reacquire fencing and marker loss only retire the old index", async () => {
+    const replacement = JSON.stringify({
+      v: 1,
+      teamId: "team",
+      id: "replacement",
+      token: "old",
+    });
+    const lost = JSON.stringify({
+      v: 1,
+      teamId: "team",
+      id: "lost",
+      token: "lost",
+    });
+    redisMocks.zrangebyscore.mockResolvedValue([replacement, lost]);
+    evalMock.mockResolvedValue(0);
+
+    await expect(recoverConcurrencyLimitRollbacks(2)).resolves.toEqual({
+      read: 2,
+      finalized: 0,
+      fenced: 2,
+    });
+    const script = evalMock.mock.calls[0][0] as string;
+    expect(script).toContain("marker == 'cleanup:'");
+    expect(script).not.toContain("ZREM', KEYS[1]");
   });
 
   test("uses Redis time for legacy reads, writes, and renewals", async () => {

--- a/apps/api/src/lib/concurrency-redis.test.ts
+++ b/apps/api/src/lib/concurrency-redis.test.ts
@@ -4,6 +4,8 @@ const redisMocks = vi.hoisted(() => ({
   eval: vi.fn(),
   zrangebyscore: vi.fn(),
   zrem: vi.fn(),
+  zcard: vi.fn(),
+  zcount: vi.fn(),
 }));
 const evalMock = redisMocks.eval;
 
@@ -15,6 +17,7 @@ import {
   CONCURRENCY_ROLLBACK_MARKER_TTL_MS,
   finalizeConcurrencyLimitActiveJobRollback,
   getConcurrencyLimitActiveJobsCount,
+  getConcurrencyRollbackCleanupBacklog,
   pushConcurrencyLimitActiveJob,
   recoverConcurrencyLimitRollbacks,
   renewConcurrencyLimitActiveJob,
@@ -176,6 +179,7 @@ describe("PG concurrency slot reservation", () => {
       read: 1,
       finalized: 1,
       fenced: 0,
+      hasMore: false,
     });
     expect(redisMocks.zrangebyscore).toHaveBeenCalledWith(
       "concurrency-rollback-cleanup:v1",
@@ -215,10 +219,36 @@ describe("PG concurrency slot reservation", () => {
       read: 2,
       finalized: 0,
       fenced: 2,
+      hasMore: true,
     });
     const script = evalMock.mock.calls[0][0] as string;
     expect(script).toContain("marker == 'cleanup:'");
     expect(script).not.toContain("ZREM', KEYS[1]");
+  });
+
+  test("reports exact bounded cleanup backlog and oldest overdue age", async () => {
+    evalMock.mockResolvedValue([7, 3, "900"]);
+
+    await expect(getConcurrencyRollbackCleanupBacklog(1_000)).resolves.toEqual({
+      total: 7,
+      due: 3,
+      oldestDueAt: 900,
+      oldestOverdueMs: 100,
+    });
+    expect(evalMock).toHaveBeenCalledWith(
+      expect.stringMatching(/ZCARD[\s\S]*ZCOUNT[\s\S]*ZRANGEBYSCORE/),
+      1,
+      "concurrency-rollback-cleanup:v1",
+      1_000,
+    );
+    expect(evalMock.mock.calls[0][0]).toContain("'LIMIT', 0, 1");
+  });
+
+  test("fails closed on corrupt cleanup accounting", async () => {
+    evalMock.mockResolvedValue([1, 2, ""]);
+    await expect(getConcurrencyRollbackCleanupBacklog(1_000)).rejects.toThrow(
+      "Corrupt Redis rollback cleanup accounting",
+    );
   });
 
   test("uses Redis time for legacy reads, writes, and renewals", async () => {

--- a/apps/api/src/lib/concurrency-redis.test.ts
+++ b/apps/api/src/lib/concurrency-redis.test.ts
@@ -1,0 +1,158 @@
+import { vi } from "vitest";
+
+const evalMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/queue-service", () => ({
+  getRedisConnection: () => ({ eval: evalMock }),
+}));
+
+import {
+  finalizeConcurrencyLimitActiveJobRollback,
+  getConcurrencyLimitActiveJobsCount,
+  pushConcurrencyLimitActiveJob,
+  renewConcurrencyLimitActiveJob,
+  reserveConcurrencyLimitActiveJob,
+  rollbackConcurrencyLimitActiveJob,
+} from "./concurrency-redis";
+
+describe("PG concurrency slot reservation", () => {
+  beforeEach(() => evalMock.mockReset());
+
+  test("uses one Redis script for capacity check and insertion", async () => {
+    evalMock.mockResolvedValue([1, 1]);
+
+    await expect(
+      reserveConcurrencyLimitActiveJob("team", "holder", 3, 30_000),
+    ).resolves.toMatchObject({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: expect.any(String),
+      cleanupToken: null,
+    });
+
+    expect(evalMock).toHaveBeenCalledTimes(1);
+    const [
+      script,
+      keyCount,
+      key,
+      reservationKey,
+      holder,
+      limit,
+      ttl,
+      operationToken,
+    ] = evalMock.mock.calls[0];
+    expect(script).toContain("ZREMRANGEBYSCORE");
+    expect(script).toContain("ZCARD");
+    expect(script).toContain("ZADD");
+    expect(script).toContain("cleanup:");
+    expect(keyCount).toBe(2);
+    expect(key).toBe("concurrency-limiter:team");
+    expect(reservationKey).toBe("concurrency-limiter:team:reservation:holder");
+    expect([holder, limit, ttl]).toEqual(["holder", 3, 30_000]);
+    expect(operationToken).toEqual(expect.any(String));
+  });
+
+  test("preserves denied and idempotent-renewal outcomes", async () => {
+    evalMock.mockResolvedValueOnce([0, 0]).mockResolvedValueOnce([1, 0]);
+
+    await expect(
+      reserveConcurrencyLimitActiveJob("team", "new", 1, 30_000),
+    ).resolves.toEqual({
+      reserved: false,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: null,
+    });
+    await expect(
+      reserveConcurrencyLimitActiveJob("team", "existing", 1, 30_000),
+    ).resolves.toEqual({
+      reserved: true,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: null,
+    });
+  });
+
+  test("retries an ambiguous reservation reply without losing ownership", async () => {
+    evalMock
+      .mockRejectedValueOnce(new Error("connection lost after write"))
+      .mockResolvedValueOnce([1, 1]);
+
+    await expect(
+      reserveConcurrencyLimitActiveJob("team", "holder", 1, 30_000),
+    ).resolves.toMatchObject({
+      reserved: true,
+      newlyAcquired: true,
+      rollbackToken: expect.any(String),
+      cleanupToken: null,
+    });
+    expect(evalMock).toHaveBeenCalledTimes(2);
+    expect(evalMock.mock.calls[1].slice(1)).toEqual(
+      evalMock.mock.calls[0].slice(1),
+    );
+  });
+
+  test("surfaces an abandoned cleanup tombstone for recovery", async () => {
+    evalMock.mockResolvedValueOnce([2, "abandoned-token"]);
+
+    await expect(
+      reserveConcurrencyLimitActiveJob("team", "holder", 1, 30_000),
+    ).resolves.toEqual({
+      reserved: false,
+      newlyAcquired: false,
+      rollbackToken: null,
+      cleanupToken: "abandoned-token",
+    });
+  });
+
+  test("guarded rollback refuses to delete a replacement owner", async () => {
+    evalMock.mockResolvedValueOnce(0);
+
+    await expect(
+      rollbackConcurrencyLimitActiveJob("team", "holder", "stale-token"),
+    ).resolves.toBe(false);
+    expect(evalMock.mock.calls[0]).toEqual([
+      expect.stringContaining("GET"),
+      2,
+      "concurrency-limiter:team",
+      "concurrency-limiter:team:reservation:holder",
+      "holder",
+      "stale-token",
+    ]);
+  });
+
+  test("finalizes the cleanup tombstone by ownership token", async () => {
+    evalMock.mockResolvedValueOnce(1);
+
+    await expect(
+      finalizeConcurrencyLimitActiveJobRollback(
+        "team",
+        "holder",
+        "owned-token",
+      ),
+    ).resolves.toBe(true);
+    expect(evalMock.mock.calls[0]).toEqual([
+      expect.stringContaining("cleanup:"),
+      1,
+      "concurrency-limiter:team:reservation:holder",
+      "owned-token",
+    ]);
+  });
+
+  test("uses Redis time for legacy reads, writes, and renewals", async () => {
+    evalMock
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1);
+
+    await expect(getConcurrencyLimitActiveJobsCount("team")).resolves.toBe(2);
+    await pushConcurrencyLimitActiveJob("team", "holder", 30_000);
+    await expect(
+      renewConcurrencyLimitActiveJob("team", "holder", 30_000),
+    ).resolves.toBe(true);
+
+    expect(evalMock.mock.calls[0][0]).toContain("redis.call('TIME')");
+    expect(evalMock.mock.calls[1][0]).toContain("redis.call('TIME')");
+    expect(evalMock.mock.calls[2][0]).toContain("redis.call('TIME')");
+  });
+});

--- a/apps/api/src/lib/concurrency-redis.ts
+++ b/apps/api/src/lib/concurrency-redis.ts
@@ -264,9 +264,74 @@ return marker == 'cleanup:' .. ARGV[1] and 1 or 0
 
 /** Drains one bounded due page. It never scans Redis keyspace and exact-token
  * fencing prevents a delayed cleanup from deleting a replacement holder. */
+export type ConcurrencyRollbackCleanupBacklog = {
+  total: number;
+  due: number;
+  oldestDueAt: number | null;
+  oldestOverdueMs: number;
+};
+
+const observeConcurrencyRollbackBacklogScript = `
+local total = redis.call('ZCARD', KEYS[1])
+local due = redis.call('ZCOUNT', KEYS[1], '-inf', ARGV[1])
+local oldest = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'WITHSCORES', 'LIMIT', 0, 1)
+return {total, due, oldest[2] or ''}
+`;
+
+/** Exact bounded queue observability. One atomic script uses native ZCARD and
+ * ZCOUNT plus one limit-1 ordered read; it never scans the Redis keyspace. */
+export async function getConcurrencyRollbackCleanupBacklog(
+  now = Date.now(),
+): Promise<ConcurrencyRollbackCleanupBacklog> {
+  if (!Number.isSafeInteger(now) || now < 0) {
+    throw new TypeError("rollback observation time must be nonnegative");
+  }
+  const result = (await getRedisConnection().eval(
+    observeConcurrencyRollbackBacklogScript,
+    1,
+    CONCURRENCY_ROLLBACK_QUEUE,
+    now,
+  )) as [number, number, string];
+  if (!Array.isArray(result) || result.length !== 3) {
+    throw new Error("Corrupt Redis rollback cleanup accounting");
+  }
+  const [total, due, oldestScore] = result;
+  if (
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    !Number.isSafeInteger(due) ||
+    due < 0 ||
+    due > total ||
+    typeof oldestScore !== "string"
+  ) {
+    throw new Error("Corrupt Redis rollback cleanup accounting");
+  }
+  const oldestDueAt = oldestScore === "" ? null : Number(oldestScore);
+  if (
+    (due === 0) !== (oldestDueAt === null) ||
+    (oldestDueAt !== null &&
+      (!Number.isSafeInteger(oldestDueAt) ||
+        oldestDueAt < 0 ||
+        oldestDueAt > now))
+  ) {
+    throw new Error("Corrupt Redis rollback cleanup oldest score");
+  }
+  return {
+    total,
+    due,
+    oldestDueAt,
+    oldestOverdueMs: oldestDueAt === null ? 0 : Math.max(0, now - oldestDueAt),
+  };
+}
+
 export async function recoverConcurrencyLimitRollbacks(
   limit = CONCURRENCY_ROLLBACK_BATCH,
-): Promise<{ read: number; finalized: number; fenced: number }> {
+): Promise<{
+  read: number;
+  finalized: number;
+  fenced: number;
+  hasMore: boolean;
+}> {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
     throw new TypeError("rollback recovery limit must be between 1 and 1000");
   }
@@ -318,7 +383,12 @@ export async function recoverConcurrencyLimitRollbacks(
     if (removed === 1) finalized++;
     else fenced++;
   }
-  return { read: members.length, finalized, fenced };
+  return {
+    read: members.length,
+    finalized,
+    fenced,
+    hasMore: members.length === limit,
+  };
 }
 
 const renewConcurrencySlotScript = `

--- a/apps/api/src/lib/concurrency-redis.ts
+++ b/apps/api/src/lib/concurrency-redis.ts
@@ -58,6 +58,9 @@ if redis.call('ZSCORE', KEYS[1], ARGV[1]) then
     redis.call('PEXPIRE', KEYS[2], ARGV[3])
     return {1, 1}
   end
+  -- A distinct retry/renewal now owns the stable holder. Fence any older
+  -- insertion token without granting this renewal destructive rollback rights.
+  redis.call('SET', KEYS[2], 'held', 'PX', ARGV[3])
   return {1, 0}
 end
 
@@ -149,7 +152,7 @@ export async function pushConcurrencyLimitActiveJob(
 const removeConcurrencySlotScript = `
 if redis.call('ZREM', KEYS[1], ARGV[1]) == 0 then return 0 end
 local marker = redis.call('GET', KEYS[2])
-if marker and string.sub(marker, 1, 6) == 'owner:' then
+if marker and string.sub(marker, 1, 8) ~= 'cleanup:' then
   redis.call('DEL', KEYS[2])
 end
 return 1
@@ -220,6 +223,8 @@ local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
 redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now_ms)
 if not redis.call('ZSCORE', KEYS[1], ARGV[1]) then return 0 end
 redis.call('ZADD', KEYS[1], 'XX', now_ms + tonumber(ARGV[2]), ARGV[1])
+-- Heartbeat renewal fences a delayed rollback from the original insertion.
+redis.call('SET', KEYS[2], 'held', 'PX', ARGV[2])
 return 1
 `;
 
@@ -231,8 +236,9 @@ export async function renewConcurrencyLimitActiveJob(
   return (
     (await getRedisConnection().eval(
       renewConcurrencySlotScript,
-      1,
+      2,
       constructConcurrencyLimitKey(teamId),
+      constructConcurrencyReservationKey(teamId, id),
       id,
       timeout,
     )) === 1

--- a/apps/api/src/lib/concurrency-redis.ts
+++ b/apps/api/src/lib/concurrency-redis.ts
@@ -17,6 +17,20 @@ export function getTeamQueueLimit(concurrencyLimit: number): number {
 // unrecoverable anyway — its StoredCrawl in Redis (24h TTL) is gone.
 export const MAX_BACKLOG_TIMEOUT_MS = 172800000; // 48h
 
+const CONCURRENCY_ROLLBACK_QUEUE = "concurrency-rollback-cleanup:v1";
+// Deliberately longer than every normal holder lease. The durable FDB holder
+// deadline remains the recovery authority if Redis itself is lost.
+export const CONCURRENCY_ROLLBACK_MARKER_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const CONCURRENCY_ROLLBACK_BATCH = 100;
+
+function concurrencyRollbackQueueMember(
+  teamId: string,
+  id: string,
+  token: string,
+): string {
+  return JSON.stringify({ v: 1, teamId, id, token });
+}
+
 export const constructConcurrencyLimitKey = (team_id: string) =>
   "concurrency-limiter:" + team_id;
 
@@ -174,8 +188,10 @@ export async function removeConcurrencyLimitActiveJob(
 const rollbackConcurrencySlotScript = `
 if redis.call('GET', KEYS[2]) ~= 'owner:' .. ARGV[2] then return 0 end
 redis.call('ZREM', KEYS[1], ARGV[1])
-redis.call('SET', KEYS[2], 'cleanup:' .. ARGV[2])
-redis.call('PERSIST', KEYS[2])
+local t = redis.call('TIME')
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('SET', KEYS[2], 'cleanup:' .. ARGV[2], 'PX', ARGV[4])
+redis.call('ZADD', KEYS[3], now_ms, ARGV[3])
 return 1
 `;
 
@@ -183,15 +199,23 @@ export async function rollbackConcurrencyLimitActiveJob(
   teamId: string,
   id: string,
   rollbackToken: string,
+  holderTtlMs = 0,
 ): Promise<boolean> {
+  const markerTtlMs = Math.max(
+    CONCURRENCY_ROLLBACK_MARKER_TTL_MS,
+    holderTtlMs + 24 * 60 * 60 * 1000,
+  );
   return (
     (await getRedisConnection().eval(
       rollbackConcurrencySlotScript,
-      2,
+      3,
       constructConcurrencyLimitKey(teamId),
       constructConcurrencyReservationKey(teamId, id),
+      CONCURRENCY_ROLLBACK_QUEUE,
       id,
       rollbackToken,
+      concurrencyRollbackQueueMember(teamId, id, rollbackToken),
+      markerTtlMs,
     )) === 1
   );
 }
@@ -199,6 +223,7 @@ export async function rollbackConcurrencyLimitActiveJob(
 const finalizeConcurrencyRollbackScript = `
 if redis.call('GET', KEYS[1]) ~= 'cleanup:' .. ARGV[1] then return 0 end
 redis.call('DEL', KEYS[1])
+redis.call('ZREM', KEYS[2], ARGV[2])
 return 1
 `;
 
@@ -210,11 +235,90 @@ export async function finalizeConcurrencyLimitActiveJobRollback(
   return (
     (await getRedisConnection().eval(
       finalizeConcurrencyRollbackScript,
-      1,
+      2,
       constructConcurrencyReservationKey(teamId, id),
+      CONCURRENCY_ROLLBACK_QUEUE,
       rollbackToken,
+      concurrencyRollbackQueueMember(teamId, id, rollbackToken),
     )) === 1
   );
+}
+
+type ConcurrencyRollbackQueueEntry = {
+  v: 1;
+  teamId: string;
+  id: string;
+  token: string;
+};
+
+const recoverConcurrencyRollbackScript = `
+local marker = redis.call('GET', KEYS[1])
+if marker == 'cleanup:' .. ARGV[1] then
+  redis.call('DEL', KEYS[1])
+end
+-- A renewal/reacquire may have replaced the marker. Never delete it, but this
+-- exact old queue item is complete either way.
+redis.call('ZREM', KEYS[2], ARGV[2])
+return marker == 'cleanup:' .. ARGV[1] and 1 or 0
+`;
+
+/** Drains one bounded due page. It never scans Redis keyspace and exact-token
+ * fencing prevents a delayed cleanup from deleting a replacement holder. */
+export async function recoverConcurrencyLimitRollbacks(
+  limit = CONCURRENCY_ROLLBACK_BATCH,
+): Promise<{ read: number; finalized: number; fenced: number }> {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) {
+    throw new TypeError("rollback recovery limit must be between 1 and 1000");
+  }
+  const redis = getRedisConnection();
+  const now = Date.now();
+  const members = await redis.zrangebyscore(
+    CONCURRENCY_ROLLBACK_QUEUE,
+    "-inf",
+    now,
+    "LIMIT",
+    0,
+    limit,
+  );
+  let finalized = 0;
+  let fenced = 0;
+  for (const member of members) {
+    let entry: ConcurrencyRollbackQueueEntry | null = null;
+    try {
+      const decoded = JSON.parse(
+        member,
+      ) as Partial<ConcurrencyRollbackQueueEntry>;
+      if (
+        decoded.v === 1 &&
+        typeof decoded.teamId === "string" &&
+        decoded.teamId.length > 0 &&
+        typeof decoded.id === "string" &&
+        decoded.id.length > 0 &&
+        typeof decoded.token === "string" &&
+        decoded.token.length > 0
+      ) {
+        entry = decoded as ConcurrencyRollbackQueueEntry;
+      }
+    } catch {
+      // Corrupt queue entries carry no authority.
+    }
+    if (!entry) {
+      await redis.zrem(CONCURRENCY_ROLLBACK_QUEUE, member);
+      fenced++;
+      continue;
+    }
+    const removed = await redis.eval(
+      recoverConcurrencyRollbackScript,
+      2,
+      constructConcurrencyReservationKey(entry.teamId, entry.id),
+      CONCURRENCY_ROLLBACK_QUEUE,
+      entry.token,
+      member,
+    );
+    if (removed === 1) finalized++;
+    else fenced++;
+  }
+  return { read: members.length, finalized, fenced };
 }
 
 const renewConcurrencySlotScript = `

--- a/apps/api/src/lib/concurrency-redis.ts
+++ b/apps/api/src/lib/concurrency-redis.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { getRedisConnection } from "../services/queue-service";
 
 // Redis primitives of the concurrency limiter, split out of
@@ -19,32 +20,221 @@ export const MAX_BACKLOG_TIMEOUT_MS = 172800000; // 48h
 export const constructConcurrencyLimitKey = (team_id: string) =>
   "concurrency-limiter:" + team_id;
 
+const constructConcurrencyReservationKey = (teamId: string, id: string) =>
+  `${constructConcurrencyLimitKey(teamId)}:reservation:${id}`;
+
+const countConcurrencySlotsScript = `
+local t = redis.call('TIME')
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now_ms)
+return redis.call('ZCARD', KEYS[1])
+`;
+
 export async function getConcurrencyLimitActiveJobsCount(
   team_id: string,
 ): Promise<number> {
-  return await getRedisConnection().zcount(
+  return (await getRedisConnection().eval(
+    countConcurrencySlotsScript,
+    1,
     constructConcurrencyLimitKey(team_id),
-    Date.now(),
-    Infinity,
-  );
+  )) as number;
 }
+
+type ConcurrencySlotReservation = {
+  reserved: boolean;
+  newlyAcquired: boolean;
+  rollbackToken: string | null;
+  cleanupToken: string | null;
+};
+
+const reserveConcurrencySlotScript = `
+local t = redis.call('TIME')
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now_ms)
+
+if redis.call('ZSCORE', KEYS[1], ARGV[1]) then
+  redis.call('ZADD', KEYS[1], 'XX', now_ms + tonumber(ARGV[3]), ARGV[1])
+  if redis.call('GET', KEYS[2]) == 'owner:' .. ARGV[4] then
+    redis.call('PEXPIRE', KEYS[2], ARGV[3])
+    return {1, 1}
+  end
+  return {1, 0}
+end
+
+local marker = redis.call('GET', KEYS[2])
+if marker then
+  if string.sub(marker, 1, 8) == 'cleanup:' then
+    return {2, string.sub(marker, 9)}
+  end
+  return {0, 0}
+end
+if redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[2]) then
+  return {0, 0}
+end
+
+redis.call('ZADD', KEYS[1], 'NX', now_ms + tonumber(ARGV[3]), ARGV[1])
+redis.call('SET', KEYS[2], 'owner:' .. ARGV[4], 'PX', ARGV[3])
+return {1, 1}
+`;
+
+// The PG capacity ledger is a Redis ZSET. Admission and insertion must remain
+// one server-side operation: browser/session requests may arrive concurrently.
+export async function reserveConcurrencyLimitActiveJob(
+  team_id: string,
+  id: string,
+  limit: number,
+  timeout: number,
+): Promise<ConcurrencySlotReservation> {
+  const redis = getRedisConnection();
+  const operationToken = randomUUID();
+  let result: [number, number | string] | null = null;
+  let firstError: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      result = (await redis.eval(
+        reserveConcurrencySlotScript,
+        2,
+        constructConcurrencyLimitKey(team_id),
+        constructConcurrencyReservationKey(team_id, id),
+        id,
+        limit,
+        timeout,
+        operationToken,
+      )) as [number, number | string];
+      break;
+    } catch (error) {
+      if (attempt === 1) {
+        throw new AggregateError(
+          firstError === undefined ? [error] : [firstError, error],
+          "Redis concurrency reservation failed after idempotent retry",
+        );
+      }
+      firstError = error;
+    }
+  }
+  const [status, detail] = result!;
+  const newlyAcquired = status === 1 && detail === 1;
+  return {
+    reserved: status === 1,
+    newlyAcquired,
+    rollbackToken: newlyAcquired ? operationToken : null,
+    cleanupToken: status === 2 ? String(detail) : null,
+  };
+}
+
+const pushConcurrencySlotScript = `
+local marker = redis.call('GET', KEYS[2])
+if marker and string.sub(marker, 1, 8) == 'cleanup:' then return 0 end
+local t = redis.call('TIME')
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('DEL', KEYS[2])
+return redis.call('ZADD', KEYS[1], now_ms + tonumber(ARGV[2]), ARGV[1])
+`;
 
 export async function pushConcurrencyLimitActiveJob(
   team_id: string,
   id: string,
   timeout: number,
-  now: number = Date.now(),
 ) {
-  await getRedisConnection().zadd(
+  await getRedisConnection().eval(
+    pushConcurrencySlotScript,
+    2,
     constructConcurrencyLimitKey(team_id),
-    now + timeout,
+    constructConcurrencyReservationKey(team_id, id),
     id,
+    timeout,
   );
 }
+
+const removeConcurrencySlotScript = `
+if redis.call('ZREM', KEYS[1], ARGV[1]) == 0 then return 0 end
+local marker = redis.call('GET', KEYS[2])
+if marker and string.sub(marker, 1, 6) == 'owner:' then
+  redis.call('DEL', KEYS[2])
+end
+return 1
+`;
 
 export async function removeConcurrencyLimitActiveJob(
   team_id: string,
   id: string,
 ) {
-  await getRedisConnection().zrem(constructConcurrencyLimitKey(team_id), id);
+  await getRedisConnection().eval(
+    removeConcurrencySlotScript,
+    2,
+    constructConcurrencyLimitKey(team_id),
+    constructConcurrencyReservationKey(team_id, id),
+    id,
+  );
+}
+
+const rollbackConcurrencySlotScript = `
+if redis.call('GET', KEYS[2]) ~= 'owner:' .. ARGV[2] then return 0 end
+redis.call('ZREM', KEYS[1], ARGV[1])
+redis.call('SET', KEYS[2], 'cleanup:' .. ARGV[2])
+redis.call('PERSIST', KEYS[2])
+return 1
+`;
+
+export async function rollbackConcurrencyLimitActiveJob(
+  teamId: string,
+  id: string,
+  rollbackToken: string,
+): Promise<boolean> {
+  return (
+    (await getRedisConnection().eval(
+      rollbackConcurrencySlotScript,
+      2,
+      constructConcurrencyLimitKey(teamId),
+      constructConcurrencyReservationKey(teamId, id),
+      id,
+      rollbackToken,
+    )) === 1
+  );
+}
+
+const finalizeConcurrencyRollbackScript = `
+if redis.call('GET', KEYS[1]) ~= 'cleanup:' .. ARGV[1] then return 0 end
+redis.call('DEL', KEYS[1])
+return 1
+`;
+
+export async function finalizeConcurrencyLimitActiveJobRollback(
+  teamId: string,
+  id: string,
+  rollbackToken: string,
+): Promise<boolean> {
+  return (
+    (await getRedisConnection().eval(
+      finalizeConcurrencyRollbackScript,
+      1,
+      constructConcurrencyReservationKey(teamId, id),
+      rollbackToken,
+    )) === 1
+  );
+}
+
+const renewConcurrencySlotScript = `
+local t = redis.call('TIME')
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now_ms)
+if not redis.call('ZSCORE', KEYS[1], ARGV[1]) then return 0 end
+redis.call('ZADD', KEYS[1], 'XX', now_ms + tonumber(ARGV[2]), ARGV[1])
+return 1
+`;
+
+export async function renewConcurrencyLimitActiveJob(
+  teamId: string,
+  id: string,
+  timeout: number,
+): Promise<boolean> {
+  return (
+    (await getRedisConnection().eval(
+      renewConcurrencySlotScript,
+      1,
+      constructConcurrencyLimitKey(teamId),
+      id,
+      timeout,
+    )) === 1
+  );
 }

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -9,9 +9,11 @@ configDotenv();
 export async function startWebScraperPipeline({
   job,
   costTracking,
+  signal,
 }: {
   job: NuQJob<ScrapeJobSingleUrls>;
   costTracking: CostTracking;
+  signal?: AbortSignal;
 }) {
   return await runWebScraper({
     url: job.data.url,
@@ -29,6 +31,16 @@ export async function startWebScraperPipeline({
       crawlId: job.data.crawl_id,
       teamId: job.data.team_id,
       ...job.data.internalOptions,
+      externalAbort: signal
+        ? {
+            signal,
+            tier: "external",
+            throwable: () =>
+              signal.reason instanceof Error
+                ? signal.reason
+                : new Error("Scrape work aborted"),
+          }
+        : job.data.internalOptions?.externalAbort,
     },
     team_id: job.data.team_id,
     bull_job_id: job.id,

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -996,6 +996,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
             engineResult,
           );
         } catch (error) {
+          if (error instanceof AbortManagerThrownError) throw error;
           meta.logger.warn(
             "Failed to run postprocessor " + postprocessor.name,
             {
@@ -1056,8 +1057,10 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
           : warning;
     }
 
+    meta.abort.throwIfAborted();
     // NOTE: for sitemap, we don't need all the transformers, need to skip unused ones
     document = await executeTransformers(meta, document);
+    meta.abort.throwIfAborted();
 
     // Set final span attributes
     setSpanAttributes(span, {
@@ -1209,7 +1212,10 @@ export async function scrapeURL(
               throw new CrawlDenialError("URL blocked by robots.txt");
             }
           } catch (error) {
-            if (error instanceof CrawlDenialError) {
+            if (
+              error instanceof CrawlDenialError ||
+              error instanceof AbortManagerThrownError
+            ) {
               throw error;
             }
             meta.logger.debug("Failed to fetch robots.txt, allowing scrape", {

--- a/apps/api/src/scraper/scrapeURL/lib/abortManager.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/abortManager.test.ts
@@ -1,0 +1,23 @@
+import { AbortManager, AbortManagerThrownError } from "./abortManager";
+
+describe("AbortManager", () => {
+  test("maps an already-aborted external ownership signal immediately", () => {
+    const controller = new AbortController();
+    const ownershipLost = new Error("ownership lost");
+    controller.abort(ownershipLost);
+    const manager = new AbortManager({
+      signal: controller.signal,
+      tier: "external",
+      throwable: () => ownershipLost,
+    });
+
+    const signal = manager.asSignal();
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBeInstanceOf(AbortManagerThrownError);
+    expect(signal.reason).toMatchObject({
+      tier: "external",
+      inner: ownershipLost,
+    });
+    manager.dispose();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/lib/abortManager.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/abortManager.ts
@@ -46,6 +46,7 @@ export class AbortManager {
 
     abort.signal.addEventListener("abort", handler);
     this.listeners.push({ signal: abort.signal, handler });
+    if (abort.signal.aborted) handler();
   }
 
   add(...instances: (AbortInstance | undefined | null)[]) {

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -42,6 +42,7 @@ import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
 import { getRedisConnection } from "./queue-service";
 import {
   completePreparedNuQPgPublication,
+  completePreparedNuQPgPublicationSubset,
   prepareNuQPgPublication,
   type NuQPgPublication,
 } from "./worker/nuq-pg-publication";
@@ -308,8 +309,18 @@ async function _addScrapeJobToConcurrencyQueue(
       throw error;
     }
     try {
-      if (inserted) {
+      let materialized = inserted;
+      if (!materialized) {
+        const [active, backlog] = await Promise.all([
+          scrapeQueue.getJob(jobId),
+          scrapeQueue.getJobsFromBacklog([jobId]),
+        ]);
+        materialized = active !== null || backlog.length > 0;
+      }
+      if (materialized) {
         await compensateAmbiguousBacklogRedisPublication([publication]);
+      } else {
+        await completePreparedNuQPgPublication(prepared, "compensated");
       }
     } catch (cleanupError) {
       throw new AggregateError(
@@ -404,12 +415,25 @@ async function _addScrapeJobsToConcurrencyQueue(
       throw error;
     }
     try {
+      const ids = publications.map(publication => publication.id);
+      const [active, backlog] = await Promise.all([
+        scrapeQueue.getJobs(ids),
+        scrapeQueue.getJobsFromBacklog(ids),
+      ]);
+      for (const job of [...active, ...backlog]) insertedIds.add(job.id);
       const insertedPublications = publications.filter(publication =>
         insertedIds.has(publication.id.toLowerCase()),
       );
       if (insertedPublications.length > 0) {
         await compensateAmbiguousBacklogRedisPublication(insertedPublications);
       }
+      await completePreparedNuQPgPublicationSubset(
+        prepared,
+        publications.filter(
+          publication => !insertedIds.has(publication.id.toLowerCase()),
+        ),
+        "compensated",
+      );
     } catch (cleanupError) {
       throw new AggregateError(
         [error, cleanupError],
@@ -584,9 +608,13 @@ async function _addScrapeJobsToBullMQ(
     );
     try {
       await rollbackActiveReservations(safeToRelease);
-      if (materialized.size === 0) {
-        await completePreparedNuQPgPublication(prepared, "compensated");
-      }
+      await completePreparedNuQPgPublicationSubset(
+        prepared,
+        publications.filter(
+          publication => !materialized.has(publication.id.toLowerCase()),
+        ),
+        "compensated",
+      );
     } catch (cleanupError) {
       throw new AggregateError(
         [error, cleanupError],

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -9,6 +9,9 @@ import {
   pushConcurrencyLimitedJob,
   pushConcurrencyLimitedJobs,
   pushCrawlConcurrencyLimitActiveJob,
+  removeConcurrencyLimitActiveJob,
+  removeConcurrencyLimitedJobs,
+  removeCrawlConcurrencyLimitActiveJob,
   QueueFullError,
 } from "../lib/concurrency-limit";
 import { logger as _logger } from "../lib/logger";
@@ -22,7 +25,7 @@ import { Logger } from "winston";
 import { ScrapeJobTimeoutError, TransportableError } from "../lib/error";
 import { deserializeTransportableError } from "../lib/error-serde";
 import { abTestJob } from "./ab-test";
-import { NuQJob, scrapeQueue } from "./worker/nuq";
+import { NuQJob, NuQPublicationConflictError, scrapeQueue } from "./worker/nuq";
 import {
   fdbEnqueueScrapeJobs,
   getCombinedTeamActiveCount,
@@ -40,6 +43,11 @@ import {
 import { serializeTraceContext } from "../lib/otel-tracer";
 import { isSelfHosted } from "../lib/deployment";
 import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
+import {
+  completePreparedNuQPgPublication,
+  prepareNuQPgPublication,
+  type NuQPgPublication,
+} from "./worker/nuq-pg-publication";
 
 // Queue-wait deadline for a backlogged job (how long its owner still cares about the result)
 function backlogTimeoutMs(data: ScrapeJobData): number {
@@ -64,92 +72,223 @@ function isCrawlOrBatchScrape(options: {
   return !!options.crawlerOptions || !!options.crawl_id;
 }
 
+function pgPublication(
+  jobId: string,
+  data: ScrapeJobData,
+  placement: "active" | "backlog",
+): NuQPgPublication {
+  return {
+    id: jobId,
+    ownerId: data.team_id,
+    groupId: data.crawl_id,
+    placement,
+  };
+}
+
+async function compensateAmbiguousBacklogRedisPublication(
+  publications: readonly NuQPgPublication[],
+): Promise<void> {
+  const byOwner = new Map<string, string[]>();
+  for (const publication of publications) {
+    const ids = byOwner.get(publication.ownerId) ?? [];
+    ids.push(publication.id);
+    byOwner.set(publication.ownerId, ids);
+  }
+  // PG is authoritative once inserted. Normalize an ambiguous Redis outcome
+  // to DB-only and leave the prepared generation intent unresolved; the
+  // reconciler republishes cq-job + ZSET and then completes the intent.
+  for (const [ownerId, ids] of byOwner) {
+    await removeConcurrencyLimitedJobs(ownerId, ids);
+  }
+}
+
+async function rollbackActiveReservations(
+  jobs: readonly { jobId: string; data: ScrapeJobData }[],
+): Promise<void> {
+  const cleanup: Promise<unknown>[] = [];
+  for (const job of jobs) {
+    cleanup.push(removeConcurrencyLimitActiveJob(job.data.team_id, job.jobId));
+    if (job.data.crawl_id) {
+      cleanup.push(
+        removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.jobId),
+      );
+    }
+  }
+  const results = await Promise.allSettled(cleanup);
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map(failure => failure.reason),
+      "Failed to roll back PG queue reservations",
+    );
+  }
+}
+
 async function _addScrapeJobToConcurrencyQueue(
-  webScraperOptions: any,
+  webScraperOptions: ScrapeJobData,
   jobId: string,
   priority: number = 0,
   listenable: boolean = false,
 ) {
-  await scrapeQueue.addJob(
-    jobId,
-    {
-      ...webScraperOptions,
-      concurrencyLimited: true,
-    },
-    {
-      priority,
-      listenable,
-      ownerId: webScraperOptions.team_id ?? undefined,
-      groupId: webScraperOptions.crawl_id ?? undefined,
-      backlogged: true,
-      backloggedTimesOutAt: new Date(
-        Date.now() + backlogTimeoutMs(webScraperOptions),
-      ),
-    },
-  );
+  const publication = pgPublication(jobId, webScraperOptions, "backlog");
+  const prepared = await prepareNuQPgPublication([publication]);
+  let inserted = false;
+  try {
+    const result = await scrapeQueue.addJobWithPublicationState(
+      jobId,
+      {
+        ...webScraperOptions,
+        concurrencyLimited: true,
+      },
+      {
+        priority,
+        listenable,
+        ownerId: webScraperOptions.team_id ?? undefined,
+        groupId: webScraperOptions.crawl_id ?? undefined,
+        backlogged: true,
+        backloggedTimesOutAt: new Date(
+          Date.now() + backlogTimeoutMs(webScraperOptions),
+        ),
+      },
+    );
+    inserted = result.inserted;
+    if (result.job.status !== "backlog") {
+      await completePreparedNuQPgPublication(prepared);
+      return;
+    }
+    const authoritativeTimeout = result.job.backloggedTimesOutAt
+      ? Math.max(1, result.job.backloggedTimesOutAt.valueOf() - Date.now())
+      : backlogTimeoutMs(webScraperOptions);
 
-  await pushConcurrencyLimitedJob(
-    webScraperOptions.team_id,
-    {
-      id: jobId,
-      data: webScraperOptions,
-      priority,
-      listenable,
-    },
-    backlogTimeoutMs(webScraperOptions),
-  );
+    await pushConcurrencyLimitedJob(
+      webScraperOptions.team_id,
+      {
+        id: jobId,
+        data: webScraperOptions,
+        priority,
+        listenable,
+      },
+      authoritativeTimeout,
+    );
+  } catch (error) {
+    if (error instanceof NuQPublicationConflictError) {
+      await completePreparedNuQPgPublication(prepared, "compensated");
+      throw error;
+    }
+    try {
+      if (inserted) {
+        await compensateAmbiguousBacklogRedisPublication([publication]);
+      }
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "PG backlog publication and compensation both failed",
+      );
+    }
+    throw error;
+  }
+  await completePreparedNuQPgPublication(prepared);
 }
 
 async function _addScrapeJobsToConcurrencyQueue(
   jobs: {
-    data: any;
+    data: ScrapeJobData;
     jobId: string;
     priority: number;
     listenable?: boolean;
   }[],
 ) {
-  await scrapeQueue.addJobs(
-    jobs.map(job => ({
-      id: job.jobId,
-      data: job.data,
-      options: {
-        priority: job.priority,
-        listenable: job.listenable ?? false,
-        ownerId: job.data.team_id ?? undefined,
-        groupId: job.data.crawl_id ?? undefined,
-        backlogged: true,
-        backloggedTimesOutAt: new Date(Date.now() + backlogTimeoutMs(job.data)),
-      },
-    })),
+  const publications = jobs.map(job =>
+    pgPublication(job.jobId, job.data, "backlog"),
   );
-
-  const jobsByTeam = new Map<
-    string,
-    {
-      job: { id: string; data: any; priority: number; listenable: boolean };
-      timeout: number;
-    }[]
-  >();
-
-  for (const job of jobs) {
-    const teamId = job.data.team_id as string;
-    if (!jobsByTeam.has(teamId)) {
-      jobsByTeam.set(teamId, []);
-    }
-    jobsByTeam.get(teamId)!.push({
-      job: {
+  const prepared = await prepareNuQPgPublication(publications);
+  let insertedIds = new Set<string>();
+  try {
+    const publicationResult = await scrapeQueue.addJobsWithPublicationState(
+      jobs.map(job => ({
         id: job.jobId,
         data: job.data,
-        priority: job.priority,
-        listenable: job.listenable ?? false,
-      },
-      timeout: backlogTimeoutMs(job.data),
-    });
-  }
+        options: {
+          priority: job.priority,
+          listenable: job.listenable ?? false,
+          ownerId: job.data.team_id ?? undefined,
+          groupId: job.data.crawl_id ?? undefined,
+          backlogged: true,
+          backloggedTimesOutAt: new Date(
+            Date.now() + backlogTimeoutMs(job.data),
+          ),
+        },
+      })),
+    );
+    insertedIds = publicationResult.insertedIds;
+    const publishedById = new Map(
+      publicationResult.jobs.map(job => [job.id, job]),
+    );
 
-  for (const [teamId, teamJobs] of jobsByTeam) {
-    await pushConcurrencyLimitedJobs(teamId, teamJobs);
+    const jobsByTeam = new Map<
+      string,
+      {
+        job: {
+          id: string;
+          data: ScrapeJobData;
+          priority: number;
+          listenable: boolean;
+        };
+        timeout: number;
+      }[]
+    >();
+
+    for (const job of jobs) {
+      if (publishedById.get(job.jobId.toLowerCase())?.status !== "backlog") {
+        continue;
+      }
+      const teamJobs = jobsByTeam.get(job.data.team_id) ?? [];
+      teamJobs.push({
+        job: {
+          id: job.jobId,
+          data: job.data,
+          priority: job.priority,
+          listenable: job.listenable ?? false,
+        },
+        timeout: publishedById.get(job.jobId.toLowerCase())
+          ?.backloggedTimesOutAt
+          ? Math.max(
+              1,
+              publishedById
+                .get(job.jobId.toLowerCase())!
+                .backloggedTimesOutAt!.valueOf() - Date.now(),
+            )
+          : backlogTimeoutMs(job.data),
+      });
+      jobsByTeam.set(job.data.team_id, teamJobs);
+    }
+
+    for (const [teamId, teamJobs] of jobsByTeam) {
+      await pushConcurrencyLimitedJobs(teamId, teamJobs);
+    }
+  } catch (error) {
+    if (error instanceof NuQPublicationConflictError) {
+      await completePreparedNuQPgPublication(prepared, "compensated");
+      throw error;
+    }
+    try {
+      const insertedPublications = publications.filter(publication =>
+        insertedIds.has(publication.id.toLowerCase()),
+      );
+      if (insertedPublications.length > 0) {
+        await compensateAmbiguousBacklogRedisPublication(insertedPublications);
+      }
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "Bulk PG backlog publication and compensation both failed",
+      );
+    }
+    throw error;
   }
+  await completePreparedNuQPgPublication(prepared);
 }
 
 export async function _addScrapeJobToBullMQ(
@@ -203,12 +342,15 @@ async function _addScrapeJobToBullMQPg(
     abTestJob(webScraperOptions);
   }
 
-  if (webScraperOptions && webScraperOptions.team_id) {
+  const publication = pgPublication(jobId, webScraperOptions, "active");
+  const prepared = await prepareNuQPgPublication([publication]);
+  const reserved = [{ jobId, data: webScraperOptions }];
+  try {
     await pushConcurrencyLimitActiveJob(
       webScraperOptions.team_id,
       jobId,
       60 * 1000,
-    ); // 60s default timeout
+    );
 
     if (webScraperOptions.crawl_id) {
       const sc = await getCrawl(webScraperOptions.crawl_id);
@@ -220,35 +362,73 @@ async function _addScrapeJobToBullMQPg(
         );
       }
     }
-  }
 
-  return await scrapeQueue.addJob(jobId, webScraperOptions, {
-    priority,
-    listenable,
-    ownerId: webScraperOptions.team_id ?? undefined,
-    groupId: webScraperOptions.crawl_id ?? undefined,
-  });
+    const job = await scrapeQueue.addJob(jobId, webScraperOptions, {
+      priority,
+      listenable,
+      ownerId: webScraperOptions.team_id ?? undefined,
+      groupId: webScraperOptions.crawl_id ?? undefined,
+    });
+    if (job.status === "completed" || job.status === "failed") {
+      await rollbackActiveReservations(reserved);
+    }
+    await completePreparedNuQPgPublication(prepared);
+    return job;
+  } catch (error) {
+    if (error instanceof NuQPublicationConflictError) {
+      await rollbackActiveReservations(reserved);
+      await completePreparedNuQPgPublication(prepared, "compensated");
+      throw error;
+    }
+    // Once PG has succeeded, a generation-complete failure must remain
+    // unresolved and published for reconciliation; do not tear it down.
+    let existing: NuQJob<ScrapeJobData> | null;
+    try {
+      existing = await scrapeQueue.getJob(jobId);
+    } catch {
+      // Probe unavailable: preserve reservations for a possibly committed row.
+      throw error;
+    }
+    if (!existing) {
+      try {
+        await rollbackActiveReservations(reserved);
+        await completePreparedNuQPgPublication(prepared, "compensated");
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "PG active publication and reservation rollback both failed",
+        );
+      }
+    }
+    throw error;
+  }
 }
 
 async function _addScrapeJobsToBullMQ(
   jobs: {
-    data: any;
+    data: ScrapeJobData;
     jobId: string;
     priority: number;
     listenable?: boolean;
   }[],
 ): Promise<NuQJob<ScrapeJobData>[]> {
   for (const job of jobs) {
-    if (job.data.mode === "single_urls") {
-      abTestJob(job.data);
-    }
+    if (job.data.mode === "single_urls") abTestJob(job.data);
+  }
 
-    if (job.data && job.data.team_id) {
+  const publications = jobs.map(job =>
+    pgPublication(job.jobId, job.data, "active"),
+  );
+  const prepared = await prepareNuQPgPublication(publications);
+  const reserved: { jobId: string; data: ScrapeJobData }[] = [];
+  try {
+    for (const job of jobs) {
       await pushConcurrencyLimitActiveJob(
         job.data.team_id,
         job.jobId,
         60 * 1000,
-      ); // 60s default timeout
+      );
+      reserved.push({ jobId: job.jobId, data: job.data });
 
       if (job.data.crawl_id) {
         const sc = await getCrawl(job.data.crawl_id);
@@ -261,20 +441,59 @@ async function _addScrapeJobsToBullMQ(
         }
       }
     }
-  }
 
-  return await scrapeQueue.addJobs(
-    jobs.map(job => ({
-      id: job.jobId,
-      data: job.data,
-      options: {
-        priority: job.priority,
-        listenable: job.listenable ?? false,
-        ownerId: job.data.team_id ?? undefined,
-        groupId: job.data.crawl_id ?? undefined,
-      },
-    })),
-  );
+    const result = await scrapeQueue.addJobs(
+      jobs.map(job => ({
+        id: job.jobId,
+        data: job.data,
+        options: {
+          priority: job.priority,
+          listenable: job.listenable ?? false,
+          ownerId: job.data.team_id ?? undefined,
+          groupId: job.data.crawl_id ?? undefined,
+        },
+      })),
+    );
+    const terminalIds = new Set(
+      result
+        .filter(job => job.status === "completed" || job.status === "failed")
+        .map(job => job.id),
+    );
+    await rollbackActiveReservations(
+      reserved.filter(job => terminalIds.has(job.jobId.toLowerCase())),
+    );
+    await completePreparedNuQPgPublication(prepared);
+    return result;
+  } catch (error) {
+    if (error instanceof NuQPublicationConflictError) {
+      await rollbackActiveReservations(reserved);
+      await completePreparedNuQPgPublication(prepared, "compensated");
+      throw error;
+    }
+    let existingJobs: NuQJob<ScrapeJobData>[];
+    try {
+      existingJobs = await scrapeQueue.getJobs(jobs.map(job => job.jobId));
+    } catch {
+      // Probe unavailable: preserve reservations for possibly committed rows.
+      throw error;
+    }
+    const materialized = new Set(existingJobs.map(job => job.id));
+    const safeToRelease = reserved.filter(
+      job => !materialized.has(job.jobId.toLowerCase()),
+    );
+    try {
+      await rollbackActiveReservations(safeToRelease);
+      if (materialized.size === 0) {
+        await completePreparedNuQPgPublication(prepared, "compensated");
+      }
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "Bulk PG active publication and reservation rollback both failed",
+      );
+    }
+    throw error;
+  }
 }
 
 async function addScrapeJobFdb(

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -455,8 +455,8 @@ export async function _addScrapeJobToBullMQ(
   return await withTeamMigrationAdmission(
     webScraperOptions.team_id,
     async () => {
-      // Direct adds bypass admission but occupy/release a team slot on both
-      // backends.
+      // Direct/kickoff adds bypass the queue gate. The FDB core deliberately
+      // gives bypass jobs no slot; the PG path retains its legacy reservation.
       if ((await resolveJobBackend(webScraperOptions)) === "fdb") {
         if (webScraperOptions.mode === "single_urls") {
           abTestJob(webScraperOptions);

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -5,13 +5,9 @@ import {
   getCrawlConcurrencyLimitActiveJobs,
   getTeamQueueLimit,
   MAX_BACKLOG_TIMEOUT_MS,
-  pushConcurrencyLimitActiveJob,
   pushConcurrencyLimitedJob,
   pushConcurrencyLimitedJobs,
-  pushCrawlConcurrencyLimitActiveJob,
-  removeConcurrencyLimitActiveJob,
   removeConcurrencyLimitedJobs,
-  removeCrawlConcurrencyLimitActiveJob,
   QueueFullError,
 } from "../lib/concurrency-limit";
 import { logger as _logger } from "../lib/logger";
@@ -43,6 +39,7 @@ import {
 import { serializeTraceContext } from "../lib/otel-tracer";
 import { isSelfHosted } from "../lib/deployment";
 import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
+import { getRedisConnection } from "./queue-service";
 import {
   completePreparedNuQPgPublication,
   prepareNuQPgPublication,
@@ -102,27 +99,160 @@ async function compensateAmbiguousBacklogRedisPublication(
   }
 }
 
-async function rollbackActiveReservations(
-  jobs: readonly { jobId: string; data: ScrapeJobData }[],
-): Promise<void> {
-  const cleanup: Promise<unknown>[] = [];
-  for (const job of jobs) {
-    cleanup.push(removeConcurrencyLimitActiveJob(job.data.team_id, job.jobId));
-    if (job.data.crawl_id) {
-      cleanup.push(
-        removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.jobId),
-      );
-    }
+type ReservationOwnership = {
+  zsetKey: string;
+  markerKey: string;
+  jobId: string;
+  token: string;
+  previousScore: string | null;
+  reservedScore: string;
+};
+
+type ActiveReservation = {
+  jobId: string;
+  data: ScrapeJobData;
+  ownerships: ReservationOwnership[];
+};
+
+async function acquireActiveReservation(
+  zsetKey: string,
+  markerKey: string,
+  jobId: string,
+): Promise<ReservationOwnership | null> {
+  const token = crypto.randomUUID();
+  const now = Date.now();
+  const reservedScore = String(now + 60 * 1000);
+  const result = (await getRedisConnection().eval(
+    `local current = redis.call('ZSCORE', KEYS[1], ARGV[1])
+     if redis.call('EXISTS', KEYS[2]) == 1 then
+       return {2, current or '', ''}
+     end
+     if current and tonumber(current) > tonumber(ARGV[2]) then
+       return {0, current, ''}
+     end
+     redis.call('ZADD', KEYS[1], ARGV[3], ARGV[1])
+     redis.call('SET', KEYS[2], cjson.encode({token=ARGV[4], previous=current or '', reserved=ARGV[3]}), 'PX', ARGV[5])
+     return {1, current or '', ARGV[3]}`,
+    2,
+    zsetKey,
+    markerKey,
+    jobId,
+    now,
+    reservedScore,
+    token,
+    2 * 60 * 1000,
+  )) as [number, string, string];
+  const status = Number(result[0]);
+  if (status === 2) {
+    throw new Error(`PG active reservation is already pending for ${jobId}`);
   }
-  const results = await Promise.allSettled(cleanup);
+  if (status !== 1) return null;
+  return {
+    zsetKey,
+    markerKey,
+    jobId,
+    token,
+    previousScore: result[1] || null,
+    reservedScore: result[2],
+  };
+}
+
+async function rollbackReservationOwnership(
+  ownership: ReservationOwnership,
+): Promise<void> {
+  await getRedisConnection().eval(
+    `local raw = redis.call('GET', KEYS[2])
+     if not raw then return 0 end
+     local marker = cjson.decode(raw)
+     if marker.token ~= ARGV[2] then return 0 end
+     local current = redis.call('ZSCORE', KEYS[1], ARGV[1])
+     if current and current == ARGV[3] then
+       if ARGV[4] == '' then
+         redis.call('ZREM', KEYS[1], ARGV[1])
+       else
+         redis.call('ZADD', KEYS[1], ARGV[4], ARGV[1])
+       end
+     end
+     redis.call('DEL', KEYS[2])
+     return 1`,
+    2,
+    ownership.zsetKey,
+    ownership.markerKey,
+    ownership.jobId,
+    ownership.token,
+    ownership.reservedScore,
+    ownership.previousScore ?? "",
+  );
+}
+
+async function rollbackActiveReservations(
+  reservations: readonly ActiveReservation[],
+): Promise<void> {
+  const results = await Promise.allSettled(
+    reservations.flatMap(reservation =>
+      reservation.ownerships.map(rollbackReservationOwnership),
+    ),
+  );
   const failures = results.filter(
     (result): result is PromiseRejectedResult => result.status === "rejected",
   );
   if (failures.length > 0) {
     throw new AggregateError(
       failures.map(failure => failure.reason),
-      "Failed to roll back PG queue reservations",
+      "Failed to restore PG queue reservations",
     );
+  }
+}
+
+async function commitActiveReservations(
+  reservations: readonly ActiveReservation[],
+): Promise<void> {
+  const redis = getRedisConnection();
+  await Promise.all(
+    reservations.flatMap(reservation =>
+      reservation.ownerships.map(ownership =>
+        redis.eval(
+          `local raw = redis.call('GET', KEYS[1])
+           if not raw then return 0 end
+           local marker = cjson.decode(raw)
+           if marker.token == ARGV[1] then return redis.call('DEL', KEYS[1]) end
+           return 0`,
+          1,
+          ownership.markerKey,
+          ownership.token,
+        ),
+      ),
+    ),
+  );
+}
+
+async function reserveActiveJob(
+  jobId: string,
+  data: ScrapeJobData,
+): Promise<ActiveReservation> {
+  const reservation: ActiveReservation = { jobId, data, ownerships: [] };
+  try {
+    const teamOwnership = await acquireActiveReservation(
+      `concurrency-limiter:${data.team_id}`,
+      `nuq:pg-reservation:team:${data.team_id}:${jobId}`,
+      jobId,
+    );
+    if (teamOwnership) reservation.ownerships.push(teamOwnership);
+    if (data.crawl_id) {
+      const sc = await getCrawl(data.crawl_id);
+      if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
+        const crawlOwnership = await acquireActiveReservation(
+          `crawl-concurrency-limiter:${data.crawl_id}`,
+          `nuq:pg-reservation:crawl:${data.crawl_id}:${jobId}`,
+          jobId,
+        );
+        if (crawlOwnership) reservation.ownerships.push(crawlOwnership);
+      }
+    }
+    return reservation;
+  } catch (error) {
+    await rollbackActiveReservations([reservation]);
+    throw error;
   }
 }
 
@@ -344,24 +474,9 @@ async function _addScrapeJobToBullMQPg(
 
   const publication = pgPublication(jobId, webScraperOptions, "active");
   const prepared = await prepareNuQPgPublication([publication]);
-  const reserved = [{ jobId, data: webScraperOptions }];
+  const reserved: ActiveReservation[] = [];
   try {
-    await pushConcurrencyLimitActiveJob(
-      webScraperOptions.team_id,
-      jobId,
-      60 * 1000,
-    );
-
-    if (webScraperOptions.crawl_id) {
-      const sc = await getCrawl(webScraperOptions.crawl_id);
-      if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
-        await pushCrawlConcurrencyLimitActiveJob(
-          webScraperOptions.crawl_id,
-          jobId,
-          60 * 1000,
-        );
-      }
-    }
+    reserved.push(await reserveActiveJob(jobId, webScraperOptions));
 
     const job = await scrapeQueue.addJob(jobId, webScraperOptions, {
       priority,
@@ -373,6 +488,7 @@ async function _addScrapeJobToBullMQPg(
       await rollbackActiveReservations(reserved);
     }
     await completePreparedNuQPgPublication(prepared);
+    await commitActiveReservations(reserved);
     return job;
   } catch (error) {
     if (error instanceof NuQPublicationConflictError) {
@@ -420,26 +536,10 @@ async function _addScrapeJobsToBullMQ(
     pgPublication(job.jobId, job.data, "active"),
   );
   const prepared = await prepareNuQPgPublication(publications);
-  const reserved: { jobId: string; data: ScrapeJobData }[] = [];
+  const reserved: ActiveReservation[] = [];
   try {
     for (const job of jobs) {
-      await pushConcurrencyLimitActiveJob(
-        job.data.team_id,
-        job.jobId,
-        60 * 1000,
-      );
-      reserved.push({ jobId: job.jobId, data: job.data });
-
-      if (job.data.crawl_id) {
-        const sc = await getCrawl(job.data.crawl_id);
-        if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
-          await pushCrawlConcurrencyLimitActiveJob(
-            job.data.crawl_id,
-            job.jobId,
-            60 * 1000,
-          );
-        }
-      }
+      reserved.push(await reserveActiveJob(job.jobId, job.data));
     }
 
     const result = await scrapeQueue.addJobs(
@@ -463,6 +563,7 @@ async function _addScrapeJobsToBullMQ(
       reserved.filter(job => terminalIds.has(job.jobId.toLowerCase())),
     );
     await completePreparedNuQPgPublication(prepared);
+    await commitActiveReservations(reserved);
     return result;
   } catch (error) {
     if (error instanceof NuQPublicationConflictError) {

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -2,8 +2,6 @@ import { v7 as uuidv7 } from "uuid";
 import { NotificationType, RateLimiterMode, ScrapeJobData } from "../types";
 import {
   cleanOldConcurrencyLimitEntries,
-  getConcurrencyLimitActiveJobs,
-  getConcurrencyQueueJobsCount,
   getCrawlConcurrencyLimitActiveJobs,
   getTeamQueueLimit,
   MAX_BACKLOG_TIMEOUT_MS,
@@ -27,8 +25,12 @@ import { abTestJob } from "./ab-test";
 import { NuQJob, scrapeQueue } from "./worker/nuq";
 import {
   fdbEnqueueScrapeJobs,
+  getCombinedTeamActiveCount,
+  getCombinedTeamPendingCount,
   resolveJobBackend,
+  withTeamMigrationAdmission,
   scrapeQueue as routedScrapeQueue,
+  type QueueBackend,
 } from "./worker/nuq-router";
 import {
   nuqFdbHealthCheck,
@@ -156,32 +158,38 @@ export async function _addScrapeJobToBullMQ(
   priority: number = 0,
   listenable: boolean = false,
 ): Promise<NuQJob<ScrapeJobData>> {
-  // direct adds bypass the gates; on the FDB backend that's a slotless enqueue
-  if ((await resolveJobBackend(webScraperOptions)) === "fdb") {
-    if (webScraperOptions.mode === "single_urls") {
-      abTestJob(webScraperOptions);
-    }
-    const { jobs } = await fdbEnqueueScrapeJobs(
-      [
-        {
-          jobId,
-          data: webScraperOptions,
-          priority,
-          listenable,
-          backlogTimeoutMs: backlogTimeoutMs(webScraperOptions),
-        },
-      ],
-      webScraperOptions.team_id,
-      { bypassGate: true },
-    );
-    return jobs[0];
-  }
+  return await withTeamMigrationAdmission(
+    webScraperOptions.team_id,
+    async () => {
+      // Direct adds bypass admission but occupy/release a team slot on both
+      // backends.
+      if ((await resolveJobBackend(webScraperOptions)) === "fdb") {
+        if (webScraperOptions.mode === "single_urls") {
+          abTestJob(webScraperOptions);
+        }
+        const { jobs } = await fdbEnqueueScrapeJobs(
+          [
+            {
+              jobId,
+              data: webScraperOptions,
+              priority,
+              listenable,
+              backlogTimeoutMs: backlogTimeoutMs(webScraperOptions),
+            },
+          ],
+          webScraperOptions.team_id,
+          { bypassGate: true },
+        );
+        return jobs[0];
+      }
 
-  return _addScrapeJobToBullMQPg(
-    webScraperOptions,
-    jobId,
-    priority,
-    listenable,
+      return _addScrapeJobToBullMQPg(
+        webScraperOptions,
+        jobId,
+        priority,
+        listenable,
+      );
+    },
   );
 }
 
@@ -411,16 +419,16 @@ async function addScrapeJobRaw(
     if (concurrencyLimited === null) {
       const now = Date.now();
       await cleanOldConcurrencyLimitEntries(webScraperOptions.team_id, now);
-      currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(webScraperOptions.team_id, now)
-      ).length;
+      currentActiveConcurrency = await getCombinedTeamActiveCount(
+        webScraperOptions.team_id,
+      );
       concurrencyLimited =
         currentActiveConcurrency >= maxConcurrency ? "yes" : "no";
     }
   }
 
   if (concurrencyLimited === "yes" || concurrencyLimited === "yes-crawl") {
-    const concurrencyQueueJobs = await getConcurrencyQueueJobsCount(
+    const concurrencyQueueJobs = await getCombinedTeamPendingCount(
       webScraperOptions.team_id,
     );
 
@@ -432,9 +440,9 @@ async function addScrapeJobRaw(
     if (currentActiveConcurrency === null) {
       const now = Date.now();
       await cleanOldConcurrencyLimitEntries(webScraperOptions.team_id, now);
-      currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(webScraperOptions.team_id, now)
-      ).length;
+      currentActiveConcurrency = await getCombinedTeamActiveCount(
+        webScraperOptions.team_id,
+      );
     }
 
     _logger.info("Adding scrape job to concurrency queue", {
@@ -511,13 +519,38 @@ export async function addScrapeJob(
     traceContext,
   };
 
-  return await addScrapeJobRaw(
-    optionsWithTrace,
-    jobId,
-    priority,
-    directToBullMQ,
-    listenable,
+  return await withTeamMigrationAdmission(
+    optionsWithTrace.team_id,
+    async () =>
+      await addScrapeJobRaw(
+        optionsWithTrace,
+        jobId,
+        priority,
+        directToBullMQ,
+        listenable,
+      ),
   );
+}
+
+async function preflightPgPartition(
+  teamId: string,
+  jobs: { data: ScrapeJobData }[],
+): Promise<void> {
+  if (jobs.length === 0 || isSelfHosted()) return;
+  const maxConcurrency =
+    (await getACUCTeam(teamId, false, true, RateLimiterMode.Scrape))
+      ?.concurrency ?? 2;
+  const active = await getCombinedTeamActiveCount(teamId);
+  const newlyPending = Math.max(
+    0,
+    jobs.length - Math.max(0, maxConcurrency - active),
+  );
+  if (newlyPending === 0) return;
+  const pending = await getCombinedTeamPendingCount(teamId);
+  const queueLimit = getTeamQueueLimit(maxConcurrency);
+  if (pending + newlyPending > queueLimit) {
+    throw new QueueFullError(pending, queueLimit);
+  }
 }
 
 export async function addScrapeJobs(
@@ -551,261 +584,268 @@ export async function addScrapeJobs(
   }
 
   for (const [teamId, allTeamJobs] of jobsByTeam) {
-    // jobs can split across backends mid-migration (old crawls drain on PG
-    // while the team's new crawls run on FDB); partition by job backend
-    const backendByJob = new Map<string, "pg" | "fdb">();
-    const backendByCrawl = new Map<string, "pg" | "fdb">();
-    for (const job of allTeamJobs) {
-      const crawlId = job.data.crawl_id;
-      if (crawlId && backendByCrawl.has(crawlId)) {
-        backendByJob.set(job.jobId, backendByCrawl.get(crawlId)!);
-        continue;
+    await withTeamMigrationAdmission(teamId, async () => {
+      // jobs can split across backends mid-migration (old crawls drain on PG
+      // while the team's new crawls run on FDB); partition by job backend
+      const backendByJob = new Map<string, "pg" | "fdb">();
+      const backendByCrawl = new Map<string, "pg" | "fdb">();
+      for (const job of allTeamJobs) {
+        const crawlId = job.data.crawl_id;
+        if (crawlId && backendByCrawl.has(crawlId)) {
+          backendByJob.set(job.jobId, backendByCrawl.get(crawlId)!);
+          continue;
+        }
+        const backend = await resolveJobBackend(job.data);
+        backendByJob.set(job.jobId, backend);
+        if (crawlId) backendByCrawl.set(crawlId, backend);
       }
-      const backend = await resolveJobBackend(job.data);
-      backendByJob.set(job.jobId, backend);
-      if (crawlId) backendByCrawl.set(crawlId, backend);
-    }
 
-    const fdbJobs = allTeamJobs.filter(
-      j => backendByJob.get(j.jobId) === "fdb",
-    );
-    if (fdbJobs.length > 0) {
-      const { backloggedCount, teamLimit } = await fdbEnqueueScrapeJobs(
-        fdbJobs.map(job => ({
-          jobId: job.jobId,
-          data: { ...job.data, traceContext },
-          priority: job.priority,
-          listenable: job.listenable,
-          backlogTimeoutMs: backlogTimeoutMs(job.data),
-        })),
-        teamId,
+      const fdbJobs = allTeamJobs.filter(
+        j => backendByJob.get(j.jobId) === "fdb",
       );
-      if (backloggedCount > 0) {
-        await maybeSendConcurrencyNotificationFdb(
+      const pgJobs = allTeamJobs.filter(
+        j => backendByJob.get(j.jobId) === "pg",
+      );
+      // Deterministic combined-cap failures must happen before either ledger
+      // commits. Stable ids then make transient second-ledger failures safe to
+      // retry without duplicating the already-committed partition.
+      await preflightPgPartition(teamId, pgJobs);
+      if (fdbJobs.length > 0) {
+        const { backloggedCount, teamLimit } = await fdbEnqueueScrapeJobs(
+          fdbJobs.map(job => ({
+            jobId: job.jobId,
+            data: { ...job.data, traceContext },
+            priority: job.priority,
+            listenable: job.listenable,
+            backlogTimeoutMs: backlogTimeoutMs(job.data),
+          })),
           teamId,
-          teamLimit,
-          isCrawlOrBatchScrape(fdbJobs[0].data),
+          // Reserve the worst-case future PG backlog before FDB commits. This
+          // makes deterministic combined-cap failure happen before either
+          // partition is visible; the exact PG planner may consume less.
+          { reservedExternalPending: pgJobs.length },
         );
+        if (backloggedCount > 0) {
+          await maybeSendConcurrencyNotificationFdb(
+            teamId,
+            teamLimit,
+            isCrawlOrBatchScrape(fdbJobs[0].data),
+          );
+        }
       }
-    }
 
-    const teamJobs = allTeamJobs.filter(
-      j => backendByJob.get(j.jobId) === "pg",
-    );
-    if (teamJobs.length === 0) continue;
-    // == Buckets for jobs ==
-    let jobsForcedToCQ: {
-      data: ScrapeJobData;
-      jobId: string;
-      priority: number;
-      listenable?: boolean;
-    }[] = [];
-
-    let jobsPotentiallyInCQ: {
-      data: ScrapeJobData;
-      jobId: string;
-      priority: number;
-      listenable?: boolean;
-    }[] = [];
-
-    // == Select jobs by crawl ID ==
-    const jobsByCrawlID = new Map<
-      string,
-      {
+      const teamJobs = pgJobs;
+      if (teamJobs.length === 0) return;
+      // == Buckets for jobs ==
+      let jobsForcedToCQ: {
         data: ScrapeJobData;
         jobId: string;
         priority: number;
         listenable?: boolean;
-      }[]
-    >();
+      }[] = [];
 
-    const jobsWithoutCrawlID: {
-      data: ScrapeJobData;
-      jobId: string;
-      priority: number;
-      listenable?: boolean;
-    }[] = [];
-    const crawlConcurrencyLimits: {
-      crawlId: string;
-      maxCrawlConcurrency: number;
-      currentCrawlConcurrency: number;
-      jobsCount: number;
-    }[] = [];
+      let jobsPotentiallyInCQ: {
+        data: ScrapeJobData;
+        jobId: string;
+        priority: number;
+        listenable?: boolean;
+      }[] = [];
 
-    for (const job of teamJobs) {
-      if (job.data.crawl_id) {
-        if (!jobsByCrawlID.has(job.data.crawl_id)) {
-          jobsByCrawlID.set(job.data.crawl_id, []);
+      // == Select jobs by crawl ID ==
+      const jobsByCrawlID = new Map<
+        string,
+        {
+          data: ScrapeJobData;
+          jobId: string;
+          priority: number;
+          listenable?: boolean;
+        }[]
+      >();
+
+      const jobsWithoutCrawlID: {
+        data: ScrapeJobData;
+        jobId: string;
+        priority: number;
+        listenable?: boolean;
+      }[] = [];
+      const crawlConcurrencyLimits: {
+        crawlId: string;
+        maxCrawlConcurrency: number;
+        currentCrawlConcurrency: number;
+        jobsCount: number;
+      }[] = [];
+
+      for (const job of teamJobs) {
+        if (job.data.crawl_id) {
+          if (!jobsByCrawlID.has(job.data.crawl_id)) {
+            jobsByCrawlID.set(job.data.crawl_id, []);
+          }
+          jobsByCrawlID.get(job.data.crawl_id)!.push(job);
+        } else {
+          jobsWithoutCrawlID.push(job);
         }
-        jobsByCrawlID.get(job.data.crawl_id)!.push(job);
-      } else {
-        jobsWithoutCrawlID.push(job);
       }
-    }
 
-    // == Select jobs by crawl ID ==
-    for (const [crawlID, crawlJobs] of jobsByCrawlID) {
-      const crawl = await getCrawl(crawlID);
-      const concurrencyLimit = !crawl
-        ? null
-        : crawl.crawlerOptions?.delay === undefined &&
-            crawl.maxConcurrency === undefined
+      // == Select jobs by crawl ID ==
+      for (const [crawlID, crawlJobs] of jobsByCrawlID) {
+        const crawl = await getCrawl(crawlID);
+        const concurrencyLimit = !crawl
           ? null
-          : (crawl.maxConcurrency ?? 1);
+          : crawl.crawlerOptions?.delay === undefined &&
+              crawl.maxConcurrency === undefined
+            ? null
+            : (crawl.maxConcurrency ?? 1);
 
-      if (concurrencyLimit === null) {
-        // All jobs may be in the CQ depending on the global team concurrency limit
-        jobsPotentiallyInCQ.push(...crawlJobs);
+        if (concurrencyLimit === null) {
+          // All jobs may be in the CQ depending on the global team concurrency limit
+          jobsPotentiallyInCQ.push(...crawlJobs);
+        } else {
+          const currentCrawlConcurrency = (
+            await getCrawlConcurrencyLimitActiveJobs(crawlID)
+          ).length;
+          const freeSlots = Math.max(
+            concurrencyLimit - currentCrawlConcurrency,
+            0,
+          );
+          const crawlLimitedJobs = crawlJobs.slice(freeSlots);
+
+          // The first n jobs may be in the CQ depending on the global team concurrency limit
+          jobsPotentiallyInCQ.push(...crawlJobs.slice(0, freeSlots));
+
+          // Every job after that must be in the CQ, as the crawl concurrency limit has been reached
+          jobsForcedToCQ.push(...crawlLimitedJobs);
+
+          if (crawlLimitedJobs.length > 0) {
+            crawlConcurrencyLimits.push({
+              crawlId: crawlID,
+              maxCrawlConcurrency: concurrencyLimit,
+              currentCrawlConcurrency,
+              jobsCount: crawlLimitedJobs.length,
+            });
+          }
+        }
+      }
+
+      // All jobs without a crawl ID may be in the CQ depending on the global team concurrency limit
+      jobsPotentiallyInCQ.push(...jobsWithoutCrawlID);
+
+      // Bypass concurrency limits for self-hosted deployments
+      let addToBull: typeof jobsPotentiallyInCQ;
+      let addToCQ: typeof jobsPotentiallyInCQ;
+      let maxConcurrency = 0;
+      let currentActiveConcurrency: number | null = null;
+      let countCanBeDirectlyAdded = 0;
+
+      if (isSelfHosted()) {
+        // For self-hosted, add all jobs directly to BullMQ
+        addToBull = jobsPotentiallyInCQ;
+        addToCQ = jobsForcedToCQ;
       } else {
-        const currentCrawlConcurrency = (
-          await getCrawlConcurrencyLimitActiveJobs(crawlID)
-        ).length;
-        const freeSlots = Math.max(
-          concurrencyLimit - currentCrawlConcurrency,
+        const now = Date.now();
+        maxConcurrency =
+          (await getACUCTeam(teamId, false, true, RateLimiterMode.Scrape))
+            ?.concurrency ?? 2;
+        await cleanOldConcurrencyLimitEntries(teamId, now);
+
+        currentActiveConcurrency = await getCombinedTeamActiveCount(teamId);
+
+        countCanBeDirectlyAdded = Math.max(
+          maxConcurrency - currentActiveConcurrency,
           0,
         );
-        const crawlLimitedJobs = crawlJobs.slice(freeSlots);
 
-        // The first n jobs may be in the CQ depending on the global team concurrency limit
-        jobsPotentiallyInCQ.push(...crawlJobs.slice(0, freeSlots));
+        addToBull = jobsPotentiallyInCQ.slice(0, countCanBeDirectlyAdded);
+        addToCQ = jobsPotentiallyInCQ
+          .slice(countCanBeDirectlyAdded)
+          .concat(jobsForcedToCQ);
 
-        // Every job after that must be in the CQ, as the crawl concurrency limit has been reached
-        jobsForcedToCQ.push(...crawlLimitedJobs);
-
-        if (crawlLimitedJobs.length > 0) {
-          crawlConcurrencyLimits.push({
-            crawlId: crawlID,
-            maxCrawlConcurrency: concurrencyLimit,
-            currentCrawlConcurrency,
-            jobsCount: crawlLimitedJobs.length,
-          });
+        if (addToCQ.length > 0) {
+          const currentQueueSize = await getCombinedTeamPendingCount(teamId);
+          const queueLimit = getTeamQueueLimit(maxConcurrency);
+          if (currentQueueSize + addToCQ.length > queueLimit) {
+            throw new QueueFullError(currentQueueSize, queueLimit);
+          }
         }
       }
-    }
-
-    // All jobs without a crawl ID may be in the CQ depending on the global team concurrency limit
-    jobsPotentiallyInCQ.push(...jobsWithoutCrawlID);
-
-    // Bypass concurrency limits for self-hosted deployments
-    let addToBull: typeof jobsPotentiallyInCQ;
-    let addToCQ: typeof jobsPotentiallyInCQ;
-    let maxConcurrency = 0;
-    let currentActiveConcurrency: number | null = null;
-    let countCanBeDirectlyAdded = 0;
-
-    if (isSelfHosted()) {
-      // For self-hosted, add all jobs directly to BullMQ
-      addToBull = jobsPotentiallyInCQ;
-      addToCQ = jobsForcedToCQ;
-    } else {
-      const now = Date.now();
-      maxConcurrency =
-        (await getACUCTeam(teamId, false, true, RateLimiterMode.Scrape))
-          ?.concurrency ?? 2;
-      await cleanOldConcurrencyLimitEntries(teamId, now);
-
-      currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(teamId, now)
-      ).length;
-
-      countCanBeDirectlyAdded = Math.max(
-        maxConcurrency - currentActiveConcurrency,
-        0,
-      );
-
-      addToBull = jobsPotentiallyInCQ.slice(0, countCanBeDirectlyAdded);
-      addToCQ = jobsPotentiallyInCQ
-        .slice(countCanBeDirectlyAdded)
-        .concat(jobsForcedToCQ);
 
       if (addToCQ.length > 0) {
-        const currentQueueSize = await getConcurrencyQueueJobsCount(teamId);
-        const queueLimit = getTeamQueueLimit(maxConcurrency);
-        if (currentQueueSize + addToCQ.length > queueLimit) {
-          throw new QueueFullError(currentQueueSize, queueLimit);
+        const crawlConcurrencyLimitedJobs = crawlConcurrencyLimits.reduce(
+          (sum, x) => sum + x.jobsCount,
+          0,
+        );
+        const teamConcurrencyLimitedJobs = Math.max(
+          addToCQ.length - crawlConcurrencyLimitedJobs,
+          0,
+        );
+
+        if (currentActiveConcurrency === null) {
+          const now = Date.now();
+          await cleanOldConcurrencyLimitEntries(teamId, now);
+          currentActiveConcurrency = await getCombinedTeamActiveCount(teamId);
+        }
+
+        _logger.info("Adding scrape jobs to concurrency queue", {
+          teamId,
+          concurrencyLimitReason:
+            teamConcurrencyLimitedJobs > 0 && crawlConcurrencyLimitedJobs > 0
+              ? "team-and-crawl"
+              : crawlConcurrencyLimitedJobs > 0
+                ? "crawl"
+                : "team",
+          maxConcurrency,
+          currentConcurrency: currentActiveConcurrency,
+          jobsCount: addToCQ.length,
+          teamConcurrencyLimitedJobs,
+          crawlConcurrencyLimitedJobs,
+          crawlConcurrencyLimits,
+        });
+      }
+
+      // equals 2x the max concurrency (only check for non-self-hosted)
+      if (
+        !isSelfHosted() &&
+        jobsPotentiallyInCQ.length - countCanBeDirectlyAdded > maxConcurrency
+      ) {
+        // logger.info(`Concurrency limited 2x (multiple) - Concurrency queue jobs: ${addToCQ.length} Max concurrency: ${maxConcurrency} Team ID: ${jobs[0].data.team_id}`);
+        // Only send notification if it's not a crawl or batch scrape
+        if (!isCrawlOrBatchScrape(jobs[0].data)) {
+          const shouldSendNotification =
+            await shouldSendConcurrencyLimitNotification(jobs[0].data.team_id);
+          if (shouldSendNotification) {
+            sendNotificationWithCustomDays(
+              jobs[0].data.team_id,
+              NotificationType.CONCURRENCY_LIMIT_REACHED,
+              15,
+              false,
+              true,
+            ).catch(error => {
+              _logger.error(
+                "Error sending notification (concurrency limit reached)",
+                { error },
+              );
+            });
+          }
         }
       }
-    }
 
-    if (addToCQ.length > 0) {
-      const crawlConcurrencyLimitedJobs = crawlConcurrencyLimits.reduce(
-        (sum, x) => sum + x.jobsCount,
-        0,
-      );
-      const teamConcurrencyLimitedJobs = Math.max(
-        addToCQ.length - crawlConcurrencyLimitedJobs,
-        0,
+      await _addScrapeJobsToConcurrencyQueue(
+        addToCQ.map(job => ({
+          jobId: job.jobId,
+          data: { ...job.data, traceContext },
+          priority: job.priority,
+          listenable: job.listenable,
+        })),
       );
 
-      if (currentActiveConcurrency === null) {
-        const now = Date.now();
-        await cleanOldConcurrencyLimitEntries(teamId, now);
-        currentActiveConcurrency = (
-          await getConcurrencyLimitActiveJobs(teamId, now)
-        ).length;
-      }
-
-      _logger.info("Adding scrape jobs to concurrency queue", {
-        teamId,
-        concurrencyLimitReason:
-          teamConcurrencyLimitedJobs > 0 && crawlConcurrencyLimitedJobs > 0
-            ? "team-and-crawl"
-            : crawlConcurrencyLimitedJobs > 0
-              ? "crawl"
-              : "team",
-        maxConcurrency,
-        currentConcurrency: currentActiveConcurrency,
-        jobsCount: addToCQ.length,
-        teamConcurrencyLimitedJobs,
-        crawlConcurrencyLimitedJobs,
-        crawlConcurrencyLimits,
-      });
-    }
-
-    // equals 2x the max concurrency (only check for non-self-hosted)
-    if (
-      !isSelfHosted() &&
-      jobsPotentiallyInCQ.length - countCanBeDirectlyAdded > maxConcurrency
-    ) {
-      // logger.info(`Concurrency limited 2x (multiple) - Concurrency queue jobs: ${addToCQ.length} Max concurrency: ${maxConcurrency} Team ID: ${jobs[0].data.team_id}`);
-      // Only send notification if it's not a crawl or batch scrape
-      if (!isCrawlOrBatchScrape(jobs[0].data)) {
-        const shouldSendNotification =
-          await shouldSendConcurrencyLimitNotification(jobs[0].data.team_id);
-        if (shouldSendNotification) {
-          sendNotificationWithCustomDays(
-            jobs[0].data.team_id,
-            NotificationType.CONCURRENCY_LIMIT_REACHED,
-            15,
-            false,
-            true,
-          ).catch(error => {
-            _logger.error(
-              "Error sending notification (concurrency limit reached)",
-              { error },
-            );
-          });
-        }
-      }
-    }
-
-    await _addScrapeJobsToConcurrencyQueue(
-      addToCQ.map(job => ({
-        jobId: job.jobId,
-        data: { ...job.data, traceContext },
-        priority: job.priority,
-        listenable: job.listenable,
-      })),
-    );
-
-    await _addScrapeJobsToBullMQ(
-      addToBull.map(job => ({
-        jobId: job.jobId,
-        data: { ...job.data, traceContext },
-        priority: job.priority,
-        listenable: job.listenable,
-      })),
-    );
+      await _addScrapeJobsToBullMQ(
+        addToBull.map(job => ({
+          jobId: job.jobId,
+          data: { ...job.data, traceContext },
+          priority: job.priority,
+          listenable: job.listenable,
+        })),
+      );
+    });
   }
 }
 
@@ -816,6 +856,11 @@ export async function waitForJob(
   logger: Logger = _logger,
 ): Promise<Document> {
   const jobId = typeof job == "string" ? job : job.id;
+  const backend =
+    typeof job === "string"
+      ? undefined
+      : ((job as NuQJob<ScrapeJobData> & { backend?: QueueBackend }).backend ??
+        undefined);
   const isConcurrencyLimited = !!(typeof job === "string");
 
   let timeoutHandle: NodeJS.Timeout | null = null;
@@ -827,6 +872,7 @@ export async function waitForJob(
           jobId,
           timeout !== null ? timeout + 100 : null,
           logger,
+          backend,
         ),
         timeout !== null
           ? new Promise<Document>((_resolve, reject) => {

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -116,10 +116,13 @@ type ActiveReservation = {
   ownerships: ReservationOwnership[];
 };
 
+class PgCapacityReservationDeniedError extends Error {}
+
 async function acquireActiveReservation(
   zsetKey: string,
   markerKey: string,
   jobId: string,
+  limit: number | null,
 ): Promise<ReservationOwnership | null> {
   const token = crypto.randomUUID();
   const now = Date.now();
@@ -132,6 +135,9 @@ async function acquireActiveReservation(
      if current and tonumber(current) > tonumber(ARGV[2]) then
        return {0, current, ''}
      end
+     if not current and tonumber(ARGV[6]) >= 0 and redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[6]) then
+       return {3, '', ''}
+     end
      redis.call('ZADD', KEYS[1], ARGV[3], ARGV[1])
      redis.call('SET', KEYS[2], cjson.encode({token=ARGV[4], previous=current or '', reserved=ARGV[3]}), 'PX', ARGV[5])
      return {1, current or '', ARGV[3]}`,
@@ -143,8 +149,10 @@ async function acquireActiveReservation(
     reservedScore,
     token,
     2 * 60 * 1000,
+    limit ?? -1,
   )) as [number, string, string];
   const status = Number(result[0]);
+  if (status === 3) throw new PgCapacityReservationDeniedError();
   if (status === 2) {
     throw new Error(`PG active reservation is already pending for ${jobId}`);
   }
@@ -231,6 +239,7 @@ async function commitActiveReservations(
 async function reserveActiveJob(
   jobId: string,
   data: ScrapeJobData,
+  teamLimit: number | null,
 ): Promise<ActiveReservation> {
   const reservation: ActiveReservation = { jobId, data, ownerships: [] };
   try {
@@ -238,6 +247,7 @@ async function reserveActiveJob(
       `concurrency-limiter:${data.team_id}`,
       `nuq:pg-reservation:team:${data.team_id}:${jobId}`,
       jobId,
+      teamLimit,
     );
     if (teamOwnership) reservation.ownerships.push(teamOwnership);
     if (data.crawl_id) {
@@ -247,6 +257,7 @@ async function reserveActiveJob(
           `crawl-concurrency-limiter:${data.crawl_id}`,
           `nuq:pg-reservation:crawl:${data.crawl_id}:${jobId}`,
           jobId,
+          sc.maxConcurrency ?? 1,
         );
         if (crawlOwnership) reservation.ownerships.push(crawlOwnership);
       }
@@ -492,6 +503,7 @@ async function _addScrapeJobToBullMQPg(
   jobId: string,
   priority: number = 0,
   listenable: boolean = false,
+  teamLimit: number | null = null,
 ): Promise<NuQJob<ScrapeJobData>> {
   if (webScraperOptions.mode === "single_urls") {
     abTestJob(webScraperOptions);
@@ -501,7 +513,7 @@ async function _addScrapeJobToBullMQPg(
   const prepared = await prepareNuQPgPublication([publication]);
   const reserved: ActiveReservation[] = [];
   try {
-    reserved.push(await reserveActiveJob(jobId, webScraperOptions));
+    reserved.push(await reserveActiveJob(jobId, webScraperOptions, teamLimit));
 
     const job = await scrapeQueue.addJob(jobId, webScraperOptions, {
       priority,
@@ -516,6 +528,12 @@ async function _addScrapeJobToBullMQPg(
     await commitActiveReservations(reserved);
     return job;
   } catch (error) {
+    if (error instanceof PgCapacityReservationDeniedError) {
+      await rollbackActiveReservations(reserved);
+      // Preserve the prepared generation intent: the caller republishes the
+      // same stable id into the PG backlog after losing atomic admission.
+      throw error;
+    }
     if (error instanceof NuQPublicationConflictError) {
       await rollbackActiveReservations(reserved);
       await completePreparedNuQPgPublication(prepared, "compensated");
@@ -552,6 +570,7 @@ async function _addScrapeJobsToBullMQ(
     priority: number;
     listenable?: boolean;
   }[],
+  teamLimit: number | null = null,
 ): Promise<NuQJob<ScrapeJobData>[]> {
   for (const job of jobs) {
     if (job.data.mode === "single_urls") abTestJob(job.data);
@@ -564,7 +583,7 @@ async function _addScrapeJobsToBullMQ(
   const reserved: ActiveReservation[] = [];
   try {
     for (const job of jobs) {
-      reserved.push(await reserveActiveJob(job.jobId, job.data));
+      reserved.push(await reserveActiveJob(job.jobId, job.data, teamLimit));
     }
 
     const result = await scrapeQueue.addJobs(
@@ -591,6 +610,12 @@ async function _addScrapeJobsToBullMQ(
     await commitActiveReservations(reserved);
     return result;
   } catch (error) {
+    if (error instanceof PgCapacityReservationDeniedError) {
+      await rollbackActiveReservations(reserved);
+      // Preserve prepared intents for atomic fallback of the whole candidate
+      // partition into backlog placement.
+      throw error;
+    }
     if (error instanceof NuQPublicationConflictError) {
       await rollbackActiveReservations(reserved);
       await completePreparedNuQPgPublication(prepared, "compensated");
@@ -845,12 +870,30 @@ async function addScrapeJobRaw(
     );
     return null;
   } else {
-    return await _addScrapeJobToBullMQPg(
-      webScraperOptions,
-      jobId,
-      priority,
-      listenable,
-    );
+    try {
+      return await _addScrapeJobToBullMQPg(
+        webScraperOptions,
+        jobId,
+        priority,
+        listenable,
+        !isSelfHosted() && !directToBullMQ ? maxConcurrency : null,
+      );
+    } catch (error) {
+      if (!(error instanceof PgCapacityReservationDeniedError)) throw error;
+      const pending = await getCombinedTeamPendingCount(
+        webScraperOptions.team_id,
+      );
+      const queueLimit = getTeamQueueLimit(maxConcurrency);
+      if (pending >= queueLimit) throw new QueueFullError(pending, queueLimit);
+      webScraperOptions.concurrencyLimited = true;
+      await _addScrapeJobToConcurrencyQueue(
+        webScraperOptions,
+        jobId,
+        priority,
+        listenable,
+      );
+      return null;
+    }
   }
 }
 
@@ -1185,14 +1228,26 @@ export async function addScrapeJobs(
         })),
       );
 
-      await _addScrapeJobsToBullMQ(
-        addToBull.map(job => ({
-          jobId: job.jobId,
-          data: { ...job.data, traceContext },
-          priority: job.priority,
-          listenable: job.listenable,
-        })),
-      );
+      const activeCandidates = addToBull.map(job => ({
+        jobId: job.jobId,
+        data: { ...job.data, traceContext },
+        priority: job.priority,
+        listenable: job.listenable,
+      }));
+      try {
+        await _addScrapeJobsToBullMQ(
+          activeCandidates,
+          isSelfHosted() ? null : maxConcurrency,
+        );
+      } catch (error) {
+        if (!(error instanceof PgCapacityReservationDeniedError)) throw error;
+        const pending = await getCombinedTeamPendingCount(teamId);
+        const queueLimit = getTeamQueueLimit(maxConcurrency);
+        if (pending + activeCandidates.length > queueLimit) {
+          throw new QueueFullError(pending, queueLimit);
+        }
+        await _addScrapeJobsToConcurrencyQueue(activeCandidates);
+      }
     });
   }
 }

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -40,6 +40,7 @@ import { serializeTraceContext } from "../lib/otel-tracer";
 import { isSelfHosted } from "../lib/deployment";
 import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
 import { getRedisConnection } from "./queue-service";
+import { NuQRouterBothBackendsError } from "./worker/nuq-migration-control";
 import {
   completePreparedNuQPgPublication,
   completePreparedNuQPgPublicationSubset,
@@ -954,9 +955,12 @@ export async function addScrapeJobs(
       const pgJobs = allTeamJobs.filter(
         j => backendByJob.get(j.jobId) === "pg",
       );
-      // Deterministic combined-cap failures must happen before either ledger
-      // commits. Stable ids then make transient second-ledger failures safe to
-      // retry without duplicating the already-committed partition.
+      // Pause/drain never publishes one batch into both ledgers. Mixed pins
+      // indicate corrupt or incompletely migrated source state and must fail
+      // before either backend commits.
+      if (fdbJobs.length > 0 && pgJobs.length > 0) {
+        throw new NuQRouterBothBackendsError("team_batch", teamId);
+      }
       await preflightPgPartition(teamId, pgJobs);
       if (fdbJobs.length > 0) {
         const { backloggedCount, teamLimit } = await fdbEnqueueScrapeJobs(
@@ -968,10 +972,6 @@ export async function addScrapeJobs(
             backlogTimeoutMs: backlogTimeoutMs(job.data),
           })),
           teamId,
-          // Reserve the worst-case future PG backlog before FDB commits. This
-          // makes deterministic combined-cap failure happen before either
-          // partition is visible; the exact PG planner may consume less.
-          { reservedExternalPending: pgJobs.length },
         );
         if (backloggedCount > 0) {
           await maybeSendConcurrencyNotificationFdb(

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import "./worker/nuq-router";
 import { config } from "../config";
 import "./sentry";
 import { setSentryServiceTag } from "./sentry";

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -29,7 +29,11 @@ import {
   runtimeMigrationPin,
   stampMigrationPin,
 } from "./ops";
-import { MigrationStoreError, nuqFdbMigrationStore } from "./migration-store";
+import {
+  MigrationCorruptionError,
+  MigrationStoreError,
+  nuqFdbMigrationStore,
+} from "./migration-store";
 
 export type NuQFdbGroupStatus = "active" | "completed" | "cancelled";
 
@@ -240,6 +244,25 @@ export class NuqFdbGroupOps {
       tn.set(this.ks.groupFinishedJob(gid), Buffer.from(fid, "utf8"));
     }
     if (gMeta.s === "cancelled") {
+      // A router from an earlier rollout may have adopted the group before
+      // publishing its continuation in a second transaction. Retire any such
+      // live group pin in this completion transaction so the race cannot leave
+      // permanent source residue.
+      const groupPin = await nuqFdbMigrationStore.inspectPinInTxn(
+        tn,
+        "group",
+        gid,
+      );
+      if (groupPin && groupPin.lifecycle !== "terminal") {
+        await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+          teamId: gMeta.o,
+          kind: "group",
+          objectId: gid,
+          recordPin: runtimeMigrationPin(gMeta),
+          residue: {},
+          terminal: true,
+        });
+      }
       await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
         teamId: gMeta.o,
         kind: "sweeper_task",
@@ -415,7 +438,15 @@ export class NuQFdbJobGroup {
         const group = decodeJson<GroupMeta>(
           await tn.get(this.ks.groupMeta(gid)),
         );
-        if (group?.s === "active" || group?.s === "cancelled") return true;
+        if (group?.s === "active" || group?.s === "cancelled") {
+          if (group.o !== owner) {
+            throw new MigrationCorruptionError(
+              `group owner index ${owner}/${gid}`,
+              "live group owner mismatch",
+            );
+          }
+          return true;
+        }
         tn.clear(key as Buffer);
       }
       const control = decodeJson<{ generation: string; phase: string }>(
@@ -461,14 +492,22 @@ export class NuQFdbJobGroup {
     if (owner === null) return [];
     return await this.db.doTn(async tn => {
       const r = this.ks.ongoingGroupRange(owner);
-      const rows = await tn.snapshot().getRangeAll(r.begin, r.end);
+      const rows = await tn.getRangeAll(r.begin, r.end);
       const out: NuQFdbJobGroupInstance[] = [];
       for (const [key] of rows) {
         const gid = this.ks.unpackId(key as Buffer);
-        const g = decodeJson<GroupMeta>(
-          await tn.snapshot().get(this.ks.groupMeta(gid)),
-        );
-        if (g && g.s === "active") out.push(this.toInstance(gid, g));
+        const g = decodeJson<GroupMeta>(await tn.get(this.ks.groupMeta(gid)));
+        if (g && (g.s === "active" || g.s === "cancelled")) {
+          if (g.o !== owner) {
+            throw new MigrationCorruptionError(
+              `group owner index ${owner}/${gid}`,
+              "live group owner mismatch",
+            );
+          }
+          if (g.s === "active") out.push(this.toInstance(gid, g));
+        } else if (!g || g.s === "completed") {
+          tn.clear(key as Buffer);
+        }
       }
       return out;
     });
@@ -488,6 +527,8 @@ export class NuQFdbJobGroup {
           kind: "group",
           objectId: id,
           residue: { control_groups: 1 },
+          terminal: true,
+          cancelledGroupContinuation: true,
           activateNonterminal: false,
         }));
       if (!groupPin) throw new Error(`Legacy group ${id} was not adopted`);
@@ -547,12 +588,32 @@ export class NuQFdbJobGroup {
         return taskPin !== null;
       }
 
-      await prepareGroupSweepTaskInTxn(tn, id, group);
+      const taskPin = await nuqFdbMigrationStore.inspectPinInTxn(
+        tn,
+        "sweeper_task",
+        groupSweepTaskId(id),
+      );
+      if (!taskPin) {
+        throw new MigrationCorruptionError(
+          `cancelled group ${id}`,
+          "legacy adoption committed without its sweeper continuation",
+        );
+      }
+      await nuqFdbMigrationStore.validatePinnedObjectInTxn(tn, {
+        teamId: group.o,
+        kind: "sweeper_task",
+        objectId: groupSweepTaskId(id),
+        backend: groupPin.backend,
+        generation: groupPin.generation,
+      });
       await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
         teamId: group.o,
         kind: "group",
         objectId: id,
-        recordPin: runtimeMigrationPin(group),
+        recordPin: {
+          backend: groupPin.backend,
+          generation: groupPin.generation,
+        },
         residue: {},
         terminal: true,
       });

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -25,7 +25,11 @@ import {
   setGroupJobIndex,
   bumpGroupStatusCount,
   alignQueueMetricStatus,
+  reconcileJobMigrationInTxn,
+  runtimeMigrationPin,
+  stampMigrationPin,
 } from "./ops";
+import { nuqFdbMigrationStore } from "./migration-store";
 
 export type NuQFdbGroupStatus = "active" | "completed" | "cancelled";
 
@@ -38,6 +42,8 @@ export type NuQFdbJobGroupInstance = {
   expiresAt?: Date;
   maxConcurrency?: number;
   delaySeconds?: number;
+  migrationBackend?: "pg" | "fdb";
+  migrationGeneration?: number;
 };
 
 const DEFAULT_GROUP_TTL_MS = 86400000;
@@ -45,6 +51,35 @@ const DEFAULT_GROUP_TTL_MS = 86400000;
 // never reaches normal completion must not live forever. This deadline is
 // independent of the post-completion retention TTL.
 export const ACTIVE_GROUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function groupSweepTaskId(gid: string): string {
+  return `group-cancel/${gid}`;
+}
+
+export async function prepareGroupSweepTaskInTxn(
+  tn: Transaction,
+  gid: string,
+  group: GroupMeta,
+): Promise<import("./migration-store").MigrationObjectPin | null> {
+  const groupPin = await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+    teamId: group.o,
+    kind: "group",
+    objectId: gid,
+    recordPin: runtimeMigrationPin(group),
+  });
+  if (!groupPin) return null;
+  return await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
+    teamId: group.o,
+    kind: "sweeper_task",
+    objectId: groupSweepTaskId(gid),
+    admission: {
+      type: "pinned-continuation",
+      source: { kind: "group", objectId: gid },
+    },
+    requiredBackend: "fdb",
+    residue: { control_sweeper_tasks: 1 },
+  });
+}
 
 export class NuqFdbGroupOps {
   constructor(
@@ -115,6 +150,20 @@ export class NuqFdbGroupOps {
       tn.clear(this.ks.taskGroupFinish(gid));
       return false;
     }
+    const continuationPin =
+      gMeta.s === "cancelled"
+        ? await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+            teamId: gMeta.o,
+            kind: "sweeper_task",
+            objectId: groupSweepTaskId(gid),
+            recordPin: runtimeMigrationPin(gMeta),
+          })
+        : await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+            teamId: gMeta.o,
+            kind: "group",
+            objectId: gid,
+            recordPin: runtimeMigrationPin(gMeta),
+          });
     const expiresAt = now + gMeta.t;
     const expiryGeneration = randomUUID();
     const updated: GroupMeta = {
@@ -133,22 +182,66 @@ export class NuqFdbGroupOps {
 
     if (this.finishedKs) {
       const fid = randomUUID();
-      const meta: JobMeta = { c: now, p: 0, o: gMeta.o, g: gid, f: 0, dc: 1 };
+      const finishedPin = continuationPin
+        ? await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
+            teamId: gMeta.o,
+            kind: "crawl_finished",
+            objectId: fid,
+            admission: {
+              type: "pinned-continuation",
+              source: {
+                kind: gMeta.s === "cancelled" ? "sweeper_task" : "group",
+                objectId: gMeta.s === "cancelled" ? groupSweepTaskId(gid) : gid,
+              },
+            },
+            requiredBackend: "fdb",
+            residue: { control_crawl_finished: 1 },
+          })
+        : null;
+      const meta: JobMeta = stampMigrationPin(
+        { c: now, p: 0, o: gMeta.o, g: gid, f: 0, dc: 1 },
+        finishedPin,
+      );
       tn.set(this.finishedKs.jobMeta(fid), encodeJson(meta));
       tn.set(this.finishedKs.jobData(fid, 0), encodeJson({}));
-      const entry: QueueEntry = {
-        i: fid,
-        o: gMeta.o,
-        g: gid,
-        p: 0,
-        f: 0,
-        c: now,
-      };
+      const entry: QueueEntry = stampMigrationPin(
+        {
+          i: fid,
+          o: gMeta.o,
+          g: gid,
+          p: 0,
+          f: 0,
+          c: now,
+        },
+        finishedPin,
+      );
       pushReady(tn, this.finishedKs, entry, txc);
+      await reconcileJobMigrationInTxn(tn, this.finishedKs, entry, {
+        control_crawl_finished: 1,
+      });
       setStatusQueued(tn, this.finishedKs, fid);
       await alignQueueMetricStatus(tn, this.finishedKs, fid);
       // pointer for group TTL cleanup to find the finished job's records
       tn.set(this.ks.groupFinishedJob(gid), Buffer.from(fid, "utf8"));
+    }
+    if (gMeta.s === "cancelled") {
+      await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+        teamId: gMeta.o,
+        kind: "sweeper_task",
+        objectId: groupSweepTaskId(gid),
+        recordPin: runtimeMigrationPin(gMeta),
+        residue: {},
+        terminal: true,
+      });
+    } else {
+      await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+        teamId: gMeta.o,
+        kind: "group",
+        objectId: gid,
+        recordPin: runtimeMigrationPin(gMeta),
+        residue: {},
+        terminal: true,
+      });
     }
     return true;
   }
@@ -174,6 +267,8 @@ export class NuQFdbJobGroup {
       expiresAt: g.x !== undefined ? new Date(g.x) : undefined,
       maxConcurrency: g.m,
       delaySeconds: g.d,
+      migrationBackend: g.mb,
+      migrationGeneration: g.mg,
     };
   }
 
@@ -189,20 +284,38 @@ export class NuQFdbJobGroup {
     return await this.db.doTn(async tn => {
       const existingBuf = await tn.get(this.ks.groupMeta(id));
       const existing = decodeJson<GroupMeta>(existingBuf);
-      if (existing) return this.toInstance(id, existing);
+      if (existing) {
+        await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+          teamId: owner,
+          kind: "group",
+          objectId: id,
+          recordPin: runtimeMigrationPin(existing),
+        });
+        return this.toInstance(id, existing);
+      }
       const now = Date.now();
       const abandonmentDeadline = now + ACTIVE_GROUP_MAX_AGE_MS;
       const expiryGeneration = randomUUID();
-      const g: GroupMeta = {
-        o: owner,
-        c: now,
-        t: ttl ?? DEFAULT_GROUP_TTL_MS,
-        s: "active",
-        m: opts?.maxConcurrency,
-        d: opts?.delaySeconds,
-        a: abandonmentDeadline,
-        eg: expiryGeneration,
-      };
+      const pin = await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+        teamId: owner,
+        kind: "group",
+        objectId: id,
+        allowMissingRecordPin: true,
+        residue: { control_groups: 1 },
+      });
+      const g: GroupMeta = stampMigrationPin(
+        {
+          o: owner,
+          c: now,
+          t: ttl ?? DEFAULT_GROUP_TTL_MS,
+          s: "active",
+          m: opts?.maxConcurrency,
+          d: opts?.delaySeconds,
+          a: abandonmentDeadline,
+          eg: expiryGeneration,
+        },
+        pin,
+      );
       tn.set(this.ks.groupMeta(id), encodeJson(g));
       tn.set(
         this.ks.groupExpiry(abandonmentDeadline, id, expiryGeneration),
@@ -253,6 +366,15 @@ export class NuQFdbJobGroup {
     return await this.db.doTn(async tn => {
       const g = decodeJson<GroupMeta>(await tn.get(this.ks.groupMeta(id)));
       if (!g || g.s !== "active") return false;
+      await prepareGroupSweepTaskInTxn(tn, id, g);
+      await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+        teamId: g.o,
+        kind: "group",
+        objectId: id,
+        recordPin: runtimeMigrationPin(g),
+        residue: {},
+        terminal: true,
+      });
       tn.set(
         this.ks.groupMeta(id),
         encodeJson({ ...g, s: "cancelled" } satisfies GroupMeta),

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -346,6 +346,23 @@ export class NuQFdbJobGroup {
     });
   }
 
+  public async hasUnfinishedByOwner(ownerId: string): Promise<boolean> {
+    const owner = normalizeOwnerId(ownerId);
+    if (owner === null) return false;
+    return await this.db.doTn(async tn => {
+      const range = this.ks.ongoingGroupRange(owner);
+      const rows = await tn.getRangeAll(range.begin, range.end);
+      for (const [key] of rows) {
+        const gid = this.ks.unpackId(key as Buffer);
+        const group = decodeJson<GroupMeta>(
+          await tn.get(this.ks.groupMeta(gid)),
+        );
+        if (group?.s === "active" || group?.s === "cancelled") return true;
+      }
+      return false;
+    });
+  }
+
   public async getOngoingByOwner(
     ownerId: string,
     logger: Logger = _logger,
@@ -390,7 +407,8 @@ export class NuQFdbJobGroup {
         encodeJson({ ...g, s: "cancelled" } satisfies GroupMeta),
       );
       tn.set(this.ks.taskGroupCancel(id), EMPTY);
-      tn.clear(this.ks.ongoingGroup(g.o, id));
+      // Retain the owner index until completion so migration discovery can
+      // fence the cancelled group's still-pending sweeper/control work.
       return true;
     });
   }

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -29,7 +29,7 @@ import {
   runtimeMigrationPin,
   stampMigrationPin,
 } from "./ops";
-import { nuqFdbMigrationStore } from "./migration-store";
+import { MigrationStoreError, nuqFdbMigrationStore } from "./migration-store";
 
 export type NuQFdbGroupStatus = "active" | "completed" | "cancelled";
 
@@ -51,6 +51,8 @@ const DEFAULT_GROUP_TTL_MS = 86400000;
 // never reaches normal completion must not live forever. This deadline is
 // independent of the post-completion retention TTL.
 export const ACTIVE_GROUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const LEGACY_GROUP_OWNER_INDEX_PHASE =
+  "migration-legacy-group-owner-index-v1";
 
 export function groupSweepTaskId(gid: string): string {
   return `group-cancel/${gid}`;
@@ -66,6 +68,7 @@ export async function prepareGroupSweepTaskInTxn(
     kind: "group",
     objectId: gid,
     recordPin: runtimeMigrationPin(group),
+    legacyResidue: { control_groups: 1 },
   });
   if (!groupPin) return null;
   const taskPin = await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
@@ -167,12 +170,14 @@ export class NuqFdbGroupOps {
             kind: "sweeper_task",
             objectId: groupSweepTaskId(gid),
             recordPin: runtimeMigrationPin(gMeta),
+            legacyResidue: { control_sweeper_tasks: 1 },
           })
         : await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
             teamId: gMeta.o,
             kind: "group",
             objectId: gid,
             recordPin: runtimeMigrationPin(gMeta),
+            legacyResidue: { control_groups: 1 },
           });
     const expiresAt = now + gMeta.t;
     const expiryGeneration = randomUUID();
@@ -300,6 +305,7 @@ export class NuQFdbJobGroup {
           kind: "group",
           objectId: id,
           recordPin: runtimeMigrationPin(existing),
+          legacyResidue: { control_groups: 1 },
         });
         return this.toInstance(id, existing);
       }
@@ -346,6 +352,58 @@ export class NuQFdbJobGroup {
     });
   }
 
+  /** Advances the bounded deployment backfill that restores owner rows cleared
+   * by pre-hook cancellation code. Migration discovery fails closed until the
+   * global scan reaches its durable completion cursor. */
+  public async backfillLegacyOwnerIndex(batchSize = 500): Promise<boolean> {
+    const pageSize = Math.max(1, batchSize);
+    return await this.db.doTn(async tn => {
+      const control = decodeJson<{ generation: string; phase: string }>(
+        await tn.get(this.ks.metricControl()),
+      );
+      if (!control?.generation || control.phase !== "ready") {
+        throw new MigrationStoreError(
+          "NUQ_FDB_GROUP_OWNER_INDEX_NOT_READY",
+          "group owner backfill requires a ready metric generation",
+          true,
+        );
+      }
+      const range = this.ks.groupAllRange();
+      const cursorKey = this.ks.sweeperCursor(
+        `${LEGACY_GROUP_OWNER_INDEX_PHASE}/${control.generation}`,
+        0,
+      );
+      const cursor = await tn.get(cursorKey);
+      if (cursor?.equals(range.end)) return true;
+      const begin = cursor
+        ? Buffer.concat([cursor as Buffer, Buffer.from([0])])
+        : range.begin;
+      const rows = await tn.getRangeAll(begin, range.end, { limit: pageSize });
+      for (const [key, value] of rows) {
+        let parts: unknown[];
+        try {
+          // groupDone carries a raw versionstamp suffix, not a complete tuple.
+          parts = this.ks.unpack(key as Buffer);
+        } catch {
+          continue;
+        }
+        if (parts[parts.length - 1] !== "meta") continue;
+        const group = decodeJson<GroupMeta>(value as Buffer);
+        if (!group || (group.s !== "active" && group.s !== "cancelled")) {
+          continue;
+        }
+        const gid = String(parts[parts.length - 2]);
+        tn.set(this.ks.ongoingGroup(group.o, gid), encodeJson({ c: group.c }));
+      }
+      if (rows.length < pageSize) {
+        tn.set(cursorKey, range.end);
+        return true;
+      }
+      tn.set(cursorKey, rows[rows.length - 1][0] as Buffer);
+      return false;
+    });
+  }
+
   public async hasUnfinishedByOwner(ownerId: string): Promise<boolean> {
     const owner = normalizeOwnerId(ownerId);
     if (owner === null) return false;
@@ -358,8 +416,40 @@ export class NuQFdbJobGroup {
           await tn.get(this.ks.groupMeta(gid)),
         );
         if (group?.s === "active" || group?.s === "cancelled") return true;
+        tn.clear(key as Buffer);
+      }
+      const control = decodeJson<{ generation: string; phase: string }>(
+        await tn.get(this.ks.metricControl()),
+      );
+      const all = this.ks.groupAllRange();
+      const cursor = control?.generation
+        ? await tn.get(
+            this.ks.sweeperCursor(
+              `${LEGACY_GROUP_OWNER_INDEX_PHASE}/${control.generation}`,
+              0,
+            ),
+          )
+        : null;
+      if (control?.phase !== "ready" || !cursor?.equals(all.end)) {
+        throw new MigrationStoreError(
+          "NUQ_FDB_GROUP_OWNER_INDEX_NOT_READY",
+          "legacy group owner index backfill is not complete",
+          true,
+        );
       }
       return false;
+    });
+  }
+
+  /** Restores the owner-discovery row cleared by pre-hook cancellation code. */
+  public async restoreLegacyCancelledGroupOwnerIndex(
+    id: string,
+  ): Promise<boolean> {
+    return await this.db.doTn(async tn => {
+      const group = decodeJson<GroupMeta>(await tn.get(this.ks.groupMeta(id)));
+      if (!group || group.s !== "cancelled") return false;
+      tn.set(this.ks.ongoingGroup(group.o, id), encodeJson({ c: group.c }));
+      return true;
     });
   }
 
@@ -381,6 +471,100 @@ export class NuQFdbJobGroup {
         if (g && g.s === "active") out.push(this.toInstance(gid, g));
       }
       return out;
+    });
+  }
+
+  /** Adopts cancellation work written before migration hooks. The legacy
+   * group pin becomes terminal only after an active sweeper continuation is
+   * established in the same transaction. */
+  public async adoptLegacyCancelledGroup(id: string): Promise<boolean> {
+    return await this.db.doTn(async tn => {
+      const group = decodeJson<GroupMeta>(await tn.get(this.ks.groupMeta(id)));
+      if (!group || group.s !== "cancelled") return false;
+      const groupPin =
+        (await nuqFdbMigrationStore.inspectPinInTxn(tn, "group", id)) ??
+        (await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+          teamId: group.o,
+          kind: "group",
+          objectId: id,
+          residue: { control_groups: 1 },
+          activateNonterminal: false,
+        }));
+      if (!groupPin) throw new Error(`Legacy group ${id} was not adopted`);
+      if (groupPin.lifecycle === "terminal") {
+        // Older rollout code could terminalize a cancelled group without first
+        // creating its continuation. Repair that state as an explicit legacy
+        // task in the same generation while it remains drainable.
+        let taskPin = await nuqFdbMigrationStore.inspectPinInTxn(
+          tn,
+          "sweeper_task",
+          groupSweepTaskId(id),
+        );
+        if (!taskPin) {
+          try {
+            taskPin = await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
+              teamId: group.o,
+              kind: "sweeper_task",
+              objectId: groupSweepTaskId(id),
+              admission: {
+                type: "legacy-backfill",
+                backend: groupPin.backend,
+                generation: groupPin.generation,
+              },
+              requiredBackend: "fdb",
+              residue: { control_sweeper_tasks: 1 },
+            });
+          } catch (error) {
+            if (
+              error instanceof MigrationStoreError &&
+              error.code === "NUQ_MIGRATION_STALE_GENERATION"
+            ) {
+              throw new MigrationStoreError(
+                "NUQ_MIGRATION_CANCELLED_GROUP_CONTINUATION_LOST",
+                `cancelled group ${id} was sealed before its sweeper continuation was recorded`,
+              );
+            }
+            throw error;
+          }
+          taskPin = await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+            teamId: group.o,
+            kind: "sweeper_task",
+            objectId: groupSweepTaskId(id),
+            recordPin: taskPin,
+            residue: { control_sweeper_tasks: 1 },
+          });
+        } else {
+          await nuqFdbMigrationStore.validatePinnedObjectInTxn(tn, {
+            teamId: group.o,
+            kind: "sweeper_task",
+            objectId: groupSweepTaskId(id),
+            backend: groupPin.backend,
+            generation: groupPin.generation,
+          });
+        }
+        tn.set(this.ks.taskGroupCancel(id), EMPTY);
+        tn.set(this.ks.taskGroupFinish(id), EMPTY);
+        return taskPin !== null;
+      }
+
+      await prepareGroupSweepTaskInTxn(tn, id, group);
+      await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+        teamId: group.o,
+        kind: "group",
+        objectId: id,
+        recordPin: runtimeMigrationPin(group),
+        residue: {},
+        terminal: true,
+      });
+      // Backfill the shared generation onto GroupMeta so later sweeper-task
+      // validation does not depend on the legacy missing-pin exception.
+      tn.set(
+        this.ks.groupMeta(id),
+        encodeJson(stampMigrationPin(group, groupPin)),
+      );
+      tn.set(this.ks.taskGroupCancel(id), EMPTY);
+      tn.set(this.ks.taskGroupFinish(id), EMPTY);
+      return true;
     });
   }
 

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -68,7 +68,7 @@ export async function prepareGroupSweepTaskInTxn(
     recordPin: runtimeMigrationPin(group),
   });
   if (!groupPin) return null;
-  return await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
+  const taskPin = await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
     teamId: group.o,
     kind: "sweeper_task",
     objectId: groupSweepTaskId(gid),
@@ -77,6 +77,16 @@ export async function prepareGroupSweepTaskInTxn(
       source: { kind: "group", objectId: gid },
     },
     requiredBackend: "fdb",
+    residue: { control_sweeper_tasks: 1 },
+  });
+  return await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+    teamId: group.o,
+    kind: "sweeper_task",
+    objectId: groupSweepTaskId(gid),
+    recordPin: {
+      backend: taskPin.backend,
+      generation: taskPin.generation,
+    },
     residue: { control_sweeper_tasks: 1 },
   });
 }

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -8,7 +8,9 @@ import {
 import { NuQFdbJobGroup } from "./groups";
 import { NuqFdbSweeper } from "./sweeper";
 import { NuqFdbExternalSlots } from "./slots";
+import { NuqFdbPgJobRemovals } from "./pg-removals";
 import { isFdbConfigured, nuqFdbHealthCheck, withFdbTimeout } from "./client";
+import { nuqFdbMigrationStore } from "./migration-store";
 
 export {
   NuQFdbQueue,
@@ -26,6 +28,11 @@ export { NuQFdbJobGroup } from "./groups";
 export type { NuQFdbJobGroupInstance, NuQFdbGroupStatus } from "./groups";
 export { NuqFdbSweeper } from "./sweeper";
 export { NuqFdbExternalSlots, externalSlotMigrationObjectId } from "./slots";
+export {
+  NuqFdbPgJobRemovals,
+  NuqFdbPgJobRemovalConflictError,
+} from "./pg-removals";
+export type { DurablePgJobRemoval } from "./pg-removals";
 export { isFdbConfigured, nuqFdbHealthCheck, withFdbTimeout } from "./client";
 export {
   MIGRATION_RESIDUE_COUNTERS,
@@ -80,6 +87,7 @@ export const crawlGroupFdb = new NuQFdbJobGroup(
 );
 
 export const externalSlotsFdb = new NuqFdbExternalSlots(scrapeQueueFdb.ks);
+export const pgJobRemovalsFdb = new NuqFdbPgJobRemovals(nuqFdbMigrationStore);
 
 export async function nuqFdbGetMetrics(): Promise<string> {
   const readiness = `# HELP firecrawl_nuq_fdb_metrics_ready Whether maintained FDB queue metrics are fully initialized

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -62,6 +62,7 @@ export type {
   MigrationResidue,
   MigrationResidueCounter,
   MigrationSteadyResolution,
+  MigrationTeamPinsPage,
   MigrationTeamState,
   PreparePinnedObjectInput,
   ReconcileManagedObjectInput,

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -25,7 +25,7 @@ export type {
 export { NuQFdbJobGroup } from "./groups";
 export type { NuQFdbJobGroupInstance, NuQFdbGroupStatus } from "./groups";
 export { NuqFdbSweeper } from "./sweeper";
-export { NuqFdbExternalSlots } from "./slots";
+export { NuqFdbExternalSlots, externalSlotMigrationObjectId } from "./slots";
 export { isFdbConfigured, nuqFdbHealthCheck, withFdbTimeout } from "./client";
 export {
   MIGRATION_RESIDUE_COUNTERS,

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -1,3 +1,4 @@
+import { config } from "../../../config";
 import type { ScrapeJobData } from "../../../types";
 import {
   NuQFdbQueue,
@@ -100,6 +101,9 @@ export async function nuqFdbGetMetrics(): Promise<string> {
 # TYPE firecrawl_nuq_fdb_pending_jobs gauge
 firecrawl_nuq_fdb_pending_jobs ${workerLoad}
 `;
+  if (!config.NUQ_FDB_METRICS_V2_ACTIVATE) {
+    return `${readiness}firecrawl_nuq_fdb_metrics_ready 0\n`;
+  }
   try {
     const [scrapeQueueMetrics, crawlFinishedQueueMetrics, workerLoad] =
       await Promise.all([

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -37,6 +37,8 @@ export {
 export type { DurablePgJobRemoval } from "./pg-removals";
 export { isFdbConfigured, nuqFdbHealthCheck, withFdbTimeout } from "./client";
 export {
+  MIGRATION_GC_PAGE_LIMIT,
+  MIGRATION_GC_PARTITIONS,
   MIGRATION_RESIDUE_COUNTERS,
   MigrationCasError,
   MigrationCorruptionError,
@@ -52,6 +54,10 @@ export {
 export type {
   CompletePinnedObjectInput,
   MigrationBackend,
+  MigrationGcAuthority,
+  MigrationGcBacklog,
+  MigrationGcCategory,
+  MigrationGcSweepResult,
   MigrationGeneration,
   MigrationGenerationStatus,
   MigrationObjectKind,

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -46,6 +46,7 @@ export type {
   MigrationGeneration,
   MigrationGenerationStatus,
   MigrationObjectKind,
+  MigrationObjectLastOperation,
   MigrationObjectLifecycle,
   MigrationObjectPin,
   MigrationRecordPin,

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -27,6 +27,36 @@ export type { NuQFdbJobGroupInstance, NuQFdbGroupStatus } from "./groups";
 export { NuqFdbSweeper } from "./sweeper";
 export { NuqFdbExternalSlots } from "./slots";
 export { isFdbConfigured, nuqFdbHealthCheck, withFdbTimeout } from "./client";
+export {
+  MIGRATION_RESIDUE_COUNTERS,
+  MigrationCasError,
+  MigrationCorruptionError,
+  MigrationInProgressError,
+  MigrationLegacyStateError,
+  MigrationOperationConflictError,
+  MigrationResidueNotEmptyError,
+  MigrationStaleGenerationError,
+  MigrationStoreError,
+  NuqFdbMigrationStore,
+  nuqFdbMigrationStore,
+} from "./migration-store";
+export type {
+  CompletePinnedObjectInput,
+  MigrationBackend,
+  MigrationGeneration,
+  MigrationGenerationStatus,
+  MigrationObjectKind,
+  MigrationObjectLifecycle,
+  MigrationObjectPin,
+  MigrationPhase,
+  MigrationPinAdmission,
+  MigrationResidue,
+  MigrationResidueCounter,
+  MigrationSteadyResolution,
+  MigrationTeamState,
+  PreparePinnedObjectInput,
+  TransitionObjectResidueInput,
+} from "./migration-store";
 
 export const scrapeQueueFdb = new NuQFdbQueue<ScrapeJobData, any>("scrape", {
   hasGroups: true,

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -22,6 +22,7 @@ export type {
   NuQFdbJob,
   NuQFdbJobOptions,
   NuQFdbGate,
+  NuQFdbLegacyJobDescriptor,
   NuQJobStatusCompat,
 } from "./queue";
 export { NuQFdbJobGroup } from "./groups";

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -48,6 +48,7 @@ export type {
   MigrationObjectKind,
   MigrationObjectLifecycle,
   MigrationObjectPin,
+  MigrationRecordPin,
   MigrationPhase,
   MigrationPinAdmission,
   MigrationResidue,
@@ -55,6 +56,7 @@ export type {
   MigrationSteadyResolution,
   MigrationTeamState,
   PreparePinnedObjectInput,
+  ReconcileManagedObjectInput,
   TransitionObjectResidueInput,
 } from "./migration-store";
 
@@ -67,6 +69,7 @@ export const crawlFinishedQueueFdb = new NuQFdbQueue<any, any>(
   "crawl_finished",
   {
     hasGroups: false,
+    migrationObjectKind: "crawl_finished",
   },
 );
 

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -226,8 +226,11 @@ export class NuqFdbKeyspace {
   ownerLiveJobRange(ownerId: string) {
     return this.packRange(["oj", ownerId]);
   }
-  ownerLiveBackfillCursor(): Buffer {
-    return this.pack(["ojctl", "cursor"]);
+  ownerLiveBackfillCursor(metricGeneration: string): Buffer {
+    return this.pack(["ojctl", metricGeneration, "cursor"]);
+  }
+  ownerLiveBackfillReady(metricGeneration: string): Buffer {
+    return this.pack(["ojctl", metricGeneration, "ready"]);
   }
 
   // === Resumable enqueue / commit-unknown claim records

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -1,5 +1,6 @@
 import { config } from "../../../config";
 import { getFdb } from "./client";
+import type { MigrationBackend, MigrationObjectKind } from "./migration-store";
 
 export { normalizeOwnerId } from "../../../lib/owner-id";
 
@@ -52,7 +53,12 @@ export type PendingLoc =
   | { k: "gq"; p: number; c: number } // crawl-pending: priority, createdAtMs
   | { k: "dl"; at: number }; // delay index: notBeforeMs
 
-export type JobMeta = {
+export type MigrationRuntimePin = {
+  mb?: MigrationBackend; // durable migration backend (paired with mg)
+  mg?: number; // never-reused team generation (paired with mb)
+};
+
+export type JobMeta = MigrationRuntimePin & {
   c: number; // createdAt ms
   p: number; // priority
   o: string; // ownerId (normalized uuid)
@@ -90,7 +96,7 @@ export type ClaimRecord = {
 };
 
 // Entry stored in ready shards, pending queues and the delay index.
-export type QueueEntry = {
+export type QueueEntry = MigrationRuntimePin & {
   i: string; // jobId
   o: string; // ownerId
   g?: string; // groupId
@@ -101,7 +107,7 @@ export type QueueEntry = {
   to?: number; // backlog timesOutAt ms
 };
 
-export type GroupMeta = {
+export type GroupMeta = MigrationRuntimePin & {
   o: string; // ownerId
   c: number; // createdAt ms
   t: number; // ttl ms
@@ -168,7 +174,10 @@ export function teamPendingShard(jobId: string): number {
 }
 
 export class NuqFdbKeyspace {
-  constructor(public readonly queueName: string) {}
+  constructor(
+    public readonly queueName: string,
+    public readonly migrationObjectKind: MigrationObjectKind = "scrape_job",
+  ) {}
 
   pack(parts: any[]): Buffer {
     return getFdb().tuple.pack(["nuq", this.queueName, ...parts]) as Buffer;
@@ -210,6 +219,15 @@ export class NuqFdbKeyspace {
   }
   jobRange(id: string) {
     return this.packRange(["j", id]);
+  }
+  ownerLiveJob(ownerId: string, id: string): Buffer {
+    return this.pack(["oj", ownerId, id]);
+  }
+  ownerLiveJobRange(ownerId: string) {
+    return this.packRange(["oj", ownerId]);
+  }
+  ownerLiveBackfillCursor(): Buffer {
+    return this.pack(["ojctl", "cursor"]);
   }
 
   // === Resumable enqueue / commit-unknown claim records

--- a/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { config } from "../../../config";
 import {
   encodeI64,
   encodeJson,
@@ -34,6 +35,8 @@ nuq_fdb_queue_crawl_finished_job_count{status="failed"} 1
 nuq_fdb_queue_crawl_finished_job_count{status="backlog"} 0
 `;
 
+const previousActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
+
 const CONTROL: NuqFdbMetricControl = {
   format: 3,
   generation: "generation",
@@ -42,6 +45,7 @@ const CONTROL: NuqFdbMetricControl = {
 };
 
 afterEach(() => {
+  config.NUQ_FDB_METRICS_V2_ACTIVATE = previousActivation;
   vi.restoreAllMocks();
 });
 
@@ -129,6 +133,7 @@ describe("NuQ FDB metrics", () => {
   });
 
   test("exported collector composes READY fixed families", async () => {
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
     vi.spyOn(scrapeQueueFdb, "getMetrics").mockResolvedValue(SCRAPE_METRICS);
     vi.spyOn(crawlFinishedQueueFdb, "getMetrics").mockResolvedValue(
       CRAWL_FINISHED_METRICS,
@@ -140,7 +145,16 @@ describe("NuQ FDB metrics", () => {
     );
   });
 
+  test("deactivated rollout exports ready=0 even if an old generation remains READY", async () => {
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = false;
+    vi.spyOn(scrapeQueueFdb, "getMetrics");
+    const output = await nuqFdbGetMetrics();
+    expect(output).toBe(`${READINESS}firecrawl_nuq_fdb_metrics_ready 0\n`);
+    expect(scrapeQueueFdb.getMetrics).not.toHaveBeenCalled();
+  });
+
   test("release A exposes only readiness while fixed counters build", async () => {
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
     vi.spyOn(scrapeQueueFdb, "getMetrics").mockRejectedValue(
       new NuqFdbMetricsInitializingError("initializing"),
     );

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -2799,30 +2799,34 @@ export class NuqFdbMigrationStore {
 
   private async claimGcPartition(
     category: string,
-    now: number,
   ): Promise<{ partition: number; token: string } | null> {
-    for (let attempt = 0; attempt < MIGRATION_GC_PARTITIONS; attempt++) {
-      const token = randomUUID();
-      const claim = await this.db.doTn(async tn => {
-        this.configureGcTransaction(tn);
-        const cursorKey = this.gcCursorKey(category);
-        const cursor = Number(
-          parseJson(await tn.get(cursorKey), `GC ${category} cursor`) ?? 0,
+    const token = randomUUID();
+    return await this.db.doTn(async tn => {
+      this.configureGcTransaction(tn);
+      // This closure may start or retry long after the sweep's index cutoff was
+      // captured. Lease eligibility must use the current attempt's wall clock,
+      // not that stale cutoff, or delayed claimants can skip an expired shard
+      // and advance the cursor past it.
+      const leaseNow = Date.now();
+      const cursorKey = this.gcCursorKey(category);
+      const cursor = Number(
+        parseJson(await tn.get(cursorKey), `GC ${category} cursor`) ?? 0,
+      );
+      if (!isNonnegativeInteger(cursor) || cursor >= MIGRATION_GC_PARTITIONS) {
+        throw new MigrationCorruptionError(
+          `GC ${category} cursor`,
+          "invalid partition",
         );
-        if (
-          !isNonnegativeInteger(cursor) ||
-          cursor >= MIGRATION_GC_PARTITIONS
-        ) {
-          throw new MigrationCorruptionError(
-            `GC ${category} cursor`,
-            "invalid partition",
-          );
-        }
-        const partition = cursor;
-        tn.set(
-          cursorKey,
-          encodeJson((partition + 1) % MIGRATION_GC_PARTITIONS),
-        );
+      }
+
+      // Select and advance in one transaction. Advancing once per unavailable
+      // partition let racing callers consume a complete cursor rotation while
+      // old owners were still finishing empty shards, so an expired owner with
+      // real work could be skipped indefinitely. A successful claim is now the
+      // only operation that advances the cursor; the lease reads also conflict
+      // with concurrent claims and releases.
+      for (let offset = 0; offset < MIGRATION_GC_PARTITIONS; offset++) {
+        const partition = (cursor + offset) % MIGRATION_GC_PARTITIONS;
         const leaseKey = this.gcLeaseKey(category, partition);
         const lease = parseJson(
           await tn.get(leaseKey),
@@ -2839,16 +2843,19 @@ export class NuqFdbMigrationStore {
             "invalid lease fields",
           );
         }
-        if (lease && (lease.expiresAt as number) > now) return null;
+        if (lease && (lease.expiresAt as number) > leaseNow) continue;
         tn.set(
           leaseKey,
-          encodeJson({ token, expiresAt: now + MIGRATION_GC_LEASE_MS }),
+          encodeJson({ token, expiresAt: leaseNow + MIGRATION_GC_LEASE_MS }),
+        );
+        tn.set(
+          cursorKey,
+          encodeJson((partition + 1) % MIGRATION_GC_PARTITIONS),
         );
         return { partition, token };
-      });
-      if (claim) return claim;
-    }
-    return null;
+      }
+      return null;
+    });
   }
 
   private async assertGcLeaseInTxn(
@@ -2946,7 +2953,7 @@ export class NuqFdbMigrationStore {
         "GC recheck must be a positive safe integer",
       );
     }
-    const claim = await this.claimGcPartition("pin", now);
+    const claim = await this.claimGcPartition("pin");
     if (!claim) return null;
     const result: MigrationGcSweepResult = {
       partition: claim.partition,
@@ -3189,7 +3196,7 @@ export class NuqFdbMigrationStore {
         "GC recheck must be a positive safe integer",
       );
     }
-    const claim = await this.claimGcPartition("control", now);
+    const claim = await this.claimGcPartition("control");
     if (!claim) return null;
     const result: MigrationGcSweepResult = {
       partition: claim.partition,
@@ -3356,7 +3363,7 @@ export class NuqFdbMigrationStore {
         "GC recheck must be a positive safe integer",
       );
     }
-    const claim = await this.claimGcPartition("generation", now);
+    const claim = await this.claimGcPartition("generation");
     if (!claim) return null;
     const result: MigrationGcSweepResult = {
       partition: claim.partition,

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -117,6 +117,14 @@ export type TransitionObjectResidueInput = {
   fromLifecycle: MigrationObjectLifecycle;
   toLifecycle: MigrationObjectLifecycle;
   residue: Partial<MigrationResidue>;
+  /** Compared with the pin revision before mutation. Exact replay of the
+   * current lastOperation wins before this check for commit-unknown recovery. */
+  expectedRevision?: number;
+};
+
+export type MigrationTeamPinsPage = {
+  pins: MigrationObjectPin[];
+  nextCursor?: { kind: MigrationObjectKind; objectId: string };
 };
 
 export type CompletePinnedObjectInput = {
@@ -788,8 +796,7 @@ export class NuqFdbMigrationStore {
     from: MigrationResidue,
     to: MigrationResidue,
   ): Promise<void> {
-    const current = await this.readResidue(tn, teamId, generation);
-    for (const counter of MIGRATION_RESIDUE_COUNTERS) {
+    const changes = MIGRATION_RESIDUE_COUNTERS.flatMap(counter => {
       const delta = to[counter] - from[counter];
       if (!Number.isSafeInteger(delta)) {
         throw new MigrationStoreError(
@@ -797,15 +804,27 @@ export class NuqFdbMigrationStore {
           `counter delta for ${counter} is not a safe integer`,
         );
       }
-      if (!isNonnegativeInteger(current[counter] + delta)) {
+      return delta === 0 ? [] : [{ counter, delta }];
+    });
+    const current = await Promise.all(
+      changes.map(({ counter }) =>
+        tn.get(this.residueKey(teamId, generation, counter)),
+      ),
+    );
+    for (let index = 0; index < changes.length; index++) {
+      const { counter, delta } = changes[index];
+      const key = this.residueKey(teamId, generation, counter);
+      const value = decodeCounter(
+        current[index],
+        `team ${teamId} generation ${generation} residue ${counter}`,
+      );
+      if (!isNonnegativeInteger(value + delta)) {
         throw new MigrationCorruptionError(
           `team ${teamId} generation ${generation} residue ${counter}`,
           "pin delta would make counter negative or overflow",
         );
       }
-      if (delta !== 0) {
-        tn.add(this.residueKey(teamId, generation, counter), encodeI64(delta));
-      }
+      tn.add(key, encodeI64(delta));
     }
   }
 
@@ -879,8 +898,29 @@ export class NuqFdbMigrationStore {
     }));
   }
 
-  public async inspectTeamPins(teamId: string): Promise<MigrationObjectPin[]> {
+  public async inspectTeamPinsPage(
+    teamId: string,
+    options: {
+      limit: number;
+      cursor?: { kind: MigrationObjectKind; objectId: string };
+    },
+  ): Promise<MigrationTeamPinsPage> {
     assertNonempty(teamId, "teamId");
+    if (!isPositiveInteger(options.limit) || options.limit > 1000) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "pin page limit must be between 1 and 1000",
+      );
+    }
+    if (options.cursor) {
+      assertNonempty(options.cursor.objectId, "cursor.objectId");
+      if (!OBJECT_KINDS.includes(options.cursor.kind)) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_INVALID_ARGUMENT",
+          "cursor.kind is invalid",
+        );
+      }
+    }
     return await this.db.doTn(async tn => {
       const range = getFdb().tuple.range([
         "nuq-migration",
@@ -889,22 +929,65 @@ export class NuqFdbMigrationStore {
         teamId,
         "object",
       ]);
+      const begin = options.cursor
+        ? Buffer.concat([
+            this.teamObjectKey(
+              teamId,
+              options.cursor.kind,
+              options.cursor.objectId,
+            ),
+            Buffer.from([0]),
+          ])
+        : (range.begin as Buffer);
       const rows = await tn
         .snapshot()
-        .getRangeAll(range.begin as Buffer, range.end as Buffer);
-      return rows.map(([, value]) => {
+        .getRangeAll(begin, range.end as Buffer, { limit: options.limit });
+      const indexed: MigrationObjectPin[] = [];
+      for (const [key, value] of rows) {
         const pin = validatePin(
-          parseJson(value as Buffer, `team ${teamId} object index`),
-          `team ${teamId} object index`,
+          parseJson(value as Buffer, `team ${teamId} active object index`),
+          `team ${teamId} active object index`,
         );
-        if (pin.teamId !== teamId) {
+        if (
+          pin.teamId !== teamId ||
+          !(key as Buffer).equals(
+            this.teamObjectKey(teamId, pin.kind, pin.objectId),
+          )
+        ) {
           throw new MigrationCorruptionError(
-            `team ${teamId} object index`,
-            "team id mismatch",
+            `team ${teamId} active object index`,
+            "identity mismatch",
           );
         }
-        return pin;
-      });
+        if (pin.lifecycle === "terminal") {
+          const globalRaw = await tn.get(
+            this.objectKey(pin.kind, pin.objectId),
+          );
+          const global = globalRaw
+            ? validatePin(
+                parseJson(globalRaw, `object ${pin.kind}/${pin.objectId}`),
+                `object ${pin.kind}/${pin.objectId}`,
+              )
+            : null;
+          if (!global || JSON.stringify(global) !== JSON.stringify(pin)) {
+            throw new MigrationCorruptionError(
+              `team ${teamId} active object index`,
+              "terminal tombstone mismatch",
+            );
+          }
+          // Compact indexes written by the prototype before this became an
+          // active-only index. The global tombstone remains routing authority.
+          tn.clear(key as Buffer);
+        }
+        indexed.push(pin);
+      }
+      const last = indexed.at(-1);
+      return {
+        pins: indexed.filter(pin => pin.lifecycle !== "terminal"),
+        ...(rows.length === options.limit && last
+          ? { nextCursor: { kind: last.kind, objectId: last.objectId } }
+          : {}),
+      };
     });
   }
 
@@ -931,6 +1014,41 @@ export class NuqFdbMigrationStore {
       throw new MigrationCorruptionError(record, "identity mismatch");
     }
     return pin;
+  }
+
+  private async validateTeamPinIndex(
+    tn: Transaction,
+    pin: MigrationObjectPin,
+    record: string,
+  ): Promise<void> {
+    const indexedRaw = await tn.get(
+      this.teamObjectKey(pin.teamId, pin.kind, pin.objectId),
+    );
+    if (pin.lifecycle === "terminal") {
+      if (indexedRaw) {
+        const indexed = validatePin(
+          parseJson(indexedRaw, `${record} team index`),
+          `${record} team index`,
+        );
+        if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
+          throw new MigrationCorruptionError(record, "team pin index mismatch");
+        }
+        // Upgrade old terminal index entries in-place while preserving the
+        // global tombstone used for deterministic routing.
+        tn.clear(this.teamObjectKey(pin.teamId, pin.kind, pin.objectId));
+      }
+      return;
+    }
+    if (!indexedRaw) {
+      throw new MigrationCorruptionError(record, "missing team pin index");
+    }
+    const indexed = validatePin(
+      parseJson(indexedRaw, `${record} team index`),
+      `${record} team index`,
+    );
+    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
+      throw new MigrationCorruptionError(record, "team pin index mismatch");
+    }
   }
 
   public async validatePinnedObjectInTxn(
@@ -966,17 +1084,7 @@ export class NuqFdbMigrationStore {
         pin.generation,
       );
     }
-    const indexedRaw = await tn.get(this.teamObjectKey(teamId, kind, objectId));
-    if (!indexedRaw) {
-      throw new MigrationCorruptionError(record, "missing team pin index");
-    }
-    const indexed = validatePin(
-      parseJson(indexedRaw, `${record} team index`),
-      `${record} team index`,
-    );
-    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
-      throw new MigrationCorruptionError(record, "team pin index mismatch");
-    }
+    await this.validateTeamPinIndex(tn, pin, record);
     const generation = await this.requireGeneration(tn, teamId, pin.generation);
     if (
       generation.backend !== pin.backend ||
@@ -1078,24 +1186,6 @@ export class NuqFdbMigrationStore {
         pin.generation,
       );
     }
-    const rawIndex = await tn.get(this.teamObjectKey(teamId, kind, objectId));
-    if (!rawIndex) {
-      throw new MigrationCorruptionError(
-        `object ${kind}/${objectId}`,
-        "missing team pin index",
-      );
-    }
-    const indexed = validatePin(
-      parseJson(rawIndex, `object ${kind}/${objectId} team index`),
-      `object ${kind}/${objectId} team index`,
-    );
-    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
-      throw new MigrationCorruptionError(
-        `object ${kind}/${objectId}`,
-        "team pin index mismatch",
-      );
-    }
-
     const residue = normalizeResidue(input.residue);
     const terminal = input.terminal === true;
     const targetLifecycle: MigrationObjectLifecycle = terminal
@@ -1104,6 +1194,7 @@ export class NuqFdbMigrationStore {
         ? pin.lifecycle
         : "active";
     if (pin.lifecycle === "terminal") {
+      await this.validateTeamPinIndex(tn, pin, `object ${kind}/${objectId}`);
       if (!terminal || Object.values(residue).some(value => value !== 0)) {
         throw new MigrationStoreError(
           "NUQ_MIGRATION_LIFECYCLE_MISMATCH",
@@ -1112,6 +1203,7 @@ export class NuqFdbMigrationStore {
       }
       return pin;
     }
+    await this.validateTeamPinIndex(tn, pin, `object ${kind}/${objectId}`);
     if (
       pin.lifecycle === targetLifecycle &&
       residueEqual(pin.residue, residue)
@@ -1140,7 +1232,11 @@ export class NuqFdbMigrationStore {
     };
     const encoded = encodeJson(next);
     tn.set(this.objectKey(kind, objectId), encoded);
-    tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
+    if (next.lifecycle === "terminal") {
+      tn.clear(this.teamObjectKey(teamId, kind, objectId));
+    } else {
+      tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
+    }
     return next;
   }
 
@@ -1208,6 +1304,17 @@ export class NuqFdbMigrationStore {
         }
         if (op.kind !== "initialize" || op.backend !== backend) {
           throw new MigrationOperationConflictError(operationId);
+        }
+        if (options?.ifAbsent) {
+          const current = await this.readState(tn, teamId);
+          if (!current) {
+            throw new MigrationCorruptionError(
+              `control operation ${operationId}`,
+              "initialize operation exists without team state",
+            );
+          }
+          await this.validateTopology(tn, current);
+          return current;
         }
         return op.state;
       }
@@ -1525,16 +1632,7 @@ export class NuqFdbMigrationStore {
       ) {
         throw new MigrationOperationConflictError(`${kind}/${objectId}`);
       }
-      if (!rawIndex) {
-        throw new MigrationCorruptionError(record, "missing team pin index");
-      }
-      const indexed = validatePin(
-        parseJson(rawIndex, `${record} team index`),
-        `${record} team index`,
-      );
-      if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
-        throw new MigrationCorruptionError(record, "team pin index mismatch");
-      }
+      await this.validateTeamPinIndex(tn, pin, record);
       return pin;
     }
     if (rawIndex) {
@@ -1597,29 +1695,7 @@ export class NuqFdbMigrationStore {
           sourcePin.generation,
         );
       }
-      const sourceIndexRaw = await tn.get(
-        this.teamObjectKey(
-          teamId,
-          admission.source.kind,
-          admission.source.objectId,
-        ),
-      );
-      if (!sourceIndexRaw) {
-        throw new MigrationCorruptionError(
-          sourceRecord,
-          "missing team pin index",
-        );
-      }
-      const sourceIndexed = validatePin(
-        parseJson(sourceIndexRaw, `${sourceRecord} team index`),
-        `${sourceRecord} team index`,
-      );
-      if (JSON.stringify(sourceIndexed) !== JSON.stringify(sourcePin)) {
-        throw new MigrationCorruptionError(
-          sourceRecord,
-          "team pin index mismatch",
-        );
-      }
+      await this.validateTeamPinIndex(tn, sourcePin, sourceRecord);
       backend = sourcePin.backend;
       generationNumber = sourcePin.generation;
     }
@@ -1689,7 +1765,7 @@ export class NuqFdbMigrationStore {
     );
     const encoded = encodeJson(pin);
     tn.set(key, encoded);
-    tn.set(indexKey, encoded);
+    if (!terminalLegacyBackfill) tn.set(indexKey, encoded);
     return pin;
   }
 
@@ -1705,11 +1781,27 @@ export class NuqFdbMigrationStore {
     tn: Transaction,
     input: TransitionObjectResidueInput,
   ): Promise<MigrationObjectPin> {
-    const { teamId, kind, objectId, operationId, fromLifecycle, toLifecycle } =
-      input;
+    const {
+      teamId,
+      kind,
+      objectId,
+      operationId,
+      fromLifecycle,
+      toLifecycle,
+      expectedRevision,
+    } = input;
     assertNonempty(teamId, "teamId");
     assertNonempty(objectId, "objectId");
     assertNonempty(operationId, "operationId");
+    if (
+      expectedRevision !== undefined &&
+      !isPositiveInteger(expectedRevision)
+    ) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "expectedRevision must be a positive safe integer",
+      );
+    }
     const residue = normalizeResidue(input.residue);
     const key = this.objectKey(kind, objectId);
     const record = `object ${kind}/${objectId}`;
@@ -1736,19 +1828,7 @@ export class NuqFdbMigrationStore {
       ) {
         throw new MigrationOperationConflictError(operationId);
       }
-      const replayIndexRaw = await tn.get(
-        this.teamObjectKey(teamId, kind, objectId),
-      );
-      if (!replayIndexRaw) {
-        throw new MigrationCorruptionError(record, "missing team pin index");
-      }
-      const replayIndex = validatePin(
-        parseJson(replayIndexRaw, `${record} team index`),
-        `${record} team index`,
-      );
-      if (JSON.stringify(replayIndex) !== JSON.stringify(pin)) {
-        throw new MigrationCorruptionError(record, "team pin index mismatch");
-      }
+      await this.validateTeamPinIndex(tn, pin, record);
       return {
         ...pin,
         lifecycle: pin.lastOperation.toLifecycle,
@@ -1800,19 +1880,7 @@ export class NuqFdbMigrationStore {
           "legacy operation does not describe this pin revision history",
         );
       }
-      const legacyIndexRaw = await tn.get(
-        this.teamObjectKey(teamId, kind, objectId),
-      );
-      if (!legacyIndexRaw) {
-        throw new MigrationCorruptionError(record, "missing team pin index");
-      }
-      const legacyIndex = validatePin(
-        parseJson(legacyIndexRaw, `${record} team index`),
-        `${record} team index`,
-      );
-      if (JSON.stringify(legacyIndex) !== JSON.stringify(pin)) {
-        throw new MigrationCorruptionError(record, "team pin index mismatch");
-      }
+      await this.validateTeamPinIndex(tn, pin, record);
       if (!pin.lastOperation) {
         const migratedPin: MigrationObjectPin = {
           ...pin,
@@ -1827,10 +1895,15 @@ export class NuqFdbMigrationStore {
         };
         const migratedEncoded = encodeJson(migratedPin);
         tn.set(key, migratedEncoded);
-        tn.set(this.teamObjectKey(teamId, kind, objectId), migratedEncoded);
+        if (migratedPin.lifecycle !== "terminal") {
+          tn.set(this.teamObjectKey(teamId, kind, objectId), migratedEncoded);
+        }
         tn.clear(legacyOperationKey);
       }
       return legacyOperation.result;
+    }
+    if (expectedRevision !== undefined && pin.revision !== expectedRevision) {
+      throw new MigrationCasError(expectedRevision, pin.revision);
     }
     if (pin.lifecycle !== fromLifecycle) {
       throw new MigrationStoreError(
@@ -1858,17 +1931,7 @@ export class NuqFdbMigrationStore {
         pin.generation,
       );
     }
-    const rawIndex = await tn.get(this.teamObjectKey(teamId, kind, objectId));
-    if (!rawIndex) {
-      throw new MigrationCorruptionError(record, "missing team pin index");
-    }
-    const indexed = validatePin(
-      parseJson(rawIndex, `${record} team index`),
-      `${record} team index`,
-    );
-    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
-      throw new MigrationCorruptionError(record, "team pin index mismatch");
-    }
+    await this.validateTeamPinIndex(tn, pin, record);
     await this.applyResidueDelta(
       tn,
       teamId,
@@ -1896,7 +1959,11 @@ export class NuqFdbMigrationStore {
     };
     const encoded = encodeJson(next);
     tn.set(key, encoded);
-    tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
+    if (next.lifecycle === "terminal") {
+      tn.clear(this.teamObjectKey(teamId, kind, objectId));
+    } else {
+      tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
+    }
     return next;
   }
 

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -65,7 +65,8 @@ export type MigrationObjectPin = {
   backend: MigrationBackend;
   generation: number;
   lifecycle: MigrationObjectLifecycle;
-  admission: "new-root" | "pinned-continuation";
+  revision: number;
+  admission: "new-root" | "pinned-continuation" | "legacy-backfill";
   sourceKind?: MigrationObjectKind;
   sourceObjectId?: string;
   initialResidue: MigrationResidue;
@@ -77,6 +78,14 @@ export type MigrationPinAdmission =
   | {
       type: "pinned-continuation";
       source: { kind: MigrationObjectKind; objectId: string };
+    }
+  | {
+      // Explicit interpretation for an object known to predate control-plane
+      // initialization. Never infer this from Redis or today's rollout flag.
+      type: "legacy-backfill";
+      backend: MigrationBackend;
+      generation: number;
+      terminal?: boolean;
     };
 
 export type PreparePinnedObjectInput = {
@@ -84,6 +93,7 @@ export type PreparePinnedObjectInput = {
   kind: MigrationObjectKind;
   objectId: string;
   admission: MigrationPinAdmission;
+  requiredBackend?: MigrationBackend;
   residue?: Partial<MigrationResidue>;
 };
 
@@ -384,12 +394,15 @@ function validatePin(value: unknown, record: string): MigrationObjectPin {
     !BACKENDS.includes(pin.backend as MigrationBackend) ||
     !isPositiveInteger(pin.generation) ||
     !OBJECT_LIFECYCLES.includes(pin.lifecycle as MigrationObjectLifecycle) ||
-    (pin.admission !== "new-root" && pin.admission !== "pinned-continuation")
+    !isPositiveInteger(pin.revision) ||
+    (pin.admission !== "new-root" &&
+      pin.admission !== "pinned-continuation" &&
+      pin.admission !== "legacy-backfill")
   ) {
     throw new MigrationCorruptionError(record, "invalid object pin fields");
   }
   if (
-    (pin.admission === "new-root" &&
+    ((pin.admission === "new-root" || pin.admission === "legacy-backfill") &&
       (pin.sourceKind !== undefined || pin.sourceObjectId !== undefined)) ||
     (pin.admission === "pinned-continuation" &&
       (!OBJECT_KINDS.includes(pin.sourceKind as MigrationObjectKind) ||
@@ -778,6 +791,35 @@ export class NuqFdbMigrationStore {
       generation: await this.requireGeneration(tn, teamId, generation),
       residue: await this.readResidue(tn, teamId, generation),
     }));
+  }
+
+  public async inspectTeamPins(teamId: string): Promise<MigrationObjectPin[]> {
+    assertNonempty(teamId, "teamId");
+    return await this.db.doTn(async tn => {
+      const range = getFdb().tuple.range([
+        "nuq-migration",
+        1,
+        "team",
+        teamId,
+        "object",
+      ]);
+      const rows = await tn
+        .snapshot()
+        .getRangeAll(range.begin as Buffer, range.end as Buffer);
+      return rows.map(([, value]) => {
+        const pin = validatePin(
+          parseJson(value as Buffer, `team ${teamId} object index`),
+          `team ${teamId} object index`,
+        );
+        if (pin.teamId !== teamId) {
+          throw new MigrationCorruptionError(
+            `team ${teamId} object index`,
+            "team id mismatch",
+          );
+        }
+        return pin;
+      });
+    });
   }
 
   public async inspectPin(
@@ -1175,9 +1217,19 @@ export class NuqFdbMigrationStore {
   public async preparePinnedObject(
     input: PreparePinnedObjectInput,
   ): Promise<MigrationObjectPin> {
-    return await this.db.doTn(async tn =>
-      this.preparePinnedObjectInTxn(tn, input),
-    );
+    return (await this.preparePinnedObjects([input]))[0];
+  }
+
+  public async preparePinnedObjects(
+    inputs: readonly PreparePinnedObjectInput[],
+  ): Promise<MigrationObjectPin[]> {
+    return await this.db.doTn(async tn => {
+      const pins: MigrationObjectPin[] = [];
+      for (const input of inputs) {
+        pins.push(await this.preparePinnedObjectInTxn(tn, input));
+      }
+      return pins;
+    });
   }
 
   // Transaction-scoped hook for queue/group/slot/sweeper code. The caller can
@@ -1189,7 +1241,7 @@ export class NuqFdbMigrationStore {
     tn: Transaction,
     input: PreparePinnedObjectInput,
   ): Promise<MigrationObjectPin> {
-    const { teamId, kind, objectId, admission } = input;
+    const { teamId, kind, objectId, admission, requiredBackend } = input;
     assertNonempty(teamId, "teamId");
     assertNonempty(objectId, "objectId");
     const initialResidue = normalizeResidue(input.residue);
@@ -1200,17 +1252,21 @@ export class NuqFdbMigrationStore {
     if (rawPin) {
       const record = `object ${kind}/${objectId}`;
       const pin = validatePin(parseJson(rawPin, record), record);
-      const expectedAdmission =
-        admission.type === "new-root" ? "new-root" : "pinned-continuation";
+      const expectedAdmission = admission.type;
       if (
         pin.teamId !== teamId ||
         pin.kind !== kind ||
         pin.objectId !== objectId ||
         pin.admission !== expectedAdmission ||
         !residueEqual(pin.initialResidue, initialResidue) ||
+        (requiredBackend !== undefined && pin.backend !== requiredBackend) ||
         (admission.type === "pinned-continuation" &&
           (pin.sourceKind !== admission.source.kind ||
-            pin.sourceObjectId !== admission.source.objectId))
+            pin.sourceObjectId !== admission.source.objectId)) ||
+        (admission.type === "legacy-backfill" &&
+          (pin.backend !== admission.backend ||
+            pin.generation !== admission.generation ||
+            (pin.lifecycle === "terminal") !== (admission.terminal === true)))
       ) {
         throw new MigrationOperationConflictError(`${kind}/${objectId}`);
       }
@@ -1242,6 +1298,20 @@ export class NuqFdbMigrationStore {
       }
       backend = state.activeBackend;
       generationNumber = state.activeGeneration;
+    } else if (admission.type === "legacy-backfill") {
+      backend = admission.backend;
+      generationNumber = admission.generation;
+      if (
+        admission.terminal !== true &&
+        (state.activeBackend !== backend ||
+          state.activeGeneration !== generationNumber)
+      ) {
+        throw new MigrationStaleGenerationError(
+          teamId,
+          backend,
+          generationNumber,
+        );
+      }
     } else {
       assertNonempty(admission.source.objectId, "admission.source.objectId");
       const sourceRecord = `source object ${admission.source.kind}/${admission.source.objectId}`;
@@ -1298,16 +1368,35 @@ export class NuqFdbMigrationStore {
       backend = sourcePin.backend;
       generationNumber = sourcePin.generation;
     }
+    if (requiredBackend !== undefined && backend !== requiredBackend) {
+      throw new MigrationStaleGenerationError(
+        teamId,
+        requiredBackend,
+        generationNumber,
+      );
+    }
     const generation = await this.requireGeneration(
       tn,
       teamId,
       generationNumber,
     );
+    const terminalLegacyBackfill =
+      admission.type === "legacy-backfill" && admission.terminal === true;
+    if (
+      terminalLegacyBackfill &&
+      Object.values(initialResidue).some(value => value !== 0)
+    ) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "terminal legacy backfill cannot carry residue",
+      );
+    }
     const allowed =
       generation.backend === backend &&
-      (admission.type === "new-root"
-        ? generation.status === "open"
-        : generation.status === "open" || generation.status === "draining");
+      (terminalLegacyBackfill ||
+        (admission.type === "new-root"
+          ? generation.status === "open"
+          : generation.status === "open" || generation.status === "draining"));
     if (!allowed) {
       throw new MigrationStaleGenerationError(
         teamId,
@@ -1322,9 +1411,9 @@ export class NuqFdbMigrationStore {
       objectId,
       backend,
       generation: generationNumber,
-      lifecycle: "prepared",
-      admission:
-        admission.type === "new-root" ? "new-root" : "pinned-continuation",
+      lifecycle: terminalLegacyBackfill ? "terminal" : "prepared",
+      revision: 1,
+      admission: admission.type,
       sourceKind:
         admission.type === "pinned-continuation"
           ? admission.source.kind
@@ -1453,9 +1542,14 @@ export class NuqFdbMigrationStore {
       pin.residue,
       residue,
     );
+    const revision = pin.revision + 1;
+    if (!Number.isSafeInteger(revision)) {
+      throw new MigrationCorruptionError(record, "pin revision exhausted");
+    }
     const next: MigrationObjectPin = {
       ...pin,
       lifecycle: toLifecycle,
+      revision,
       residue,
     };
     const encoded = encodeJson(next);

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import type { Transaction } from "foundationdb";
 import { getFdb, getNuqFdbDatabase } from "./client";
 import { encodeI64 } from "./keyspace";
@@ -42,6 +43,11 @@ export type MigrationGeneration = {
   backend: MigrationBackend;
   generation: number;
   status: MigrationGenerationStatus;
+  /** Present on generations created by the bounded-GC protocol. Older
+   * generations deliberately remain ineligible until explicitly backfilled. */
+  gcIndexed?: true;
+  terminalAt?: number;
+  terminalVersion?: number;
 };
 
 export type MigrationTeamState = {
@@ -83,6 +89,37 @@ export type MigrationObjectPin = {
   /** Single bounded commit-unknown reconciliation token. A later mutation
    * supersedes it; no per-transition ledger rows are accumulated. */
   lastOperation?: MigrationObjectLastOperation;
+  /** Immutable identity of the terminal incarnation. It fences delayed GC
+   * entries from a newer/replaced record with the same object id. */
+  terminalAt?: number;
+  terminalVersion?: number;
+};
+
+export const MIGRATION_GC_PARTITIONS = 32;
+export const MIGRATION_GC_PAGE_LIMIT = 100;
+// Longer than the 30-day Redis routing hint TTL, so a tombstone can never be
+// collected while a surviving hint is still expected to route callers.
+export const MIGRATION_GC_MIN_RETENTION_MS = 45 * 24 * 60 * 60 * 1000;
+export const MIGRATION_GC_RECHECK_MS = 60 * 60 * 1000;
+
+export type MigrationGcAuthority = {
+  /** Must use only bounded point reads. This is run before the FDB CAS for PG
+   * objects, and must return true whenever the canonical PG object may live. */
+  pgObjectExists(pin: MigrationObjectPin): Promise<boolean>;
+  /** Conflict-safe FDB point reads for runtime rows, task rows, durable PG
+   * holder intents and deletion intents. */
+  fdbReferenceExistsInTxn(
+    tn: Transaction,
+    pin: MigrationObjectPin,
+  ): Promise<boolean>;
+};
+
+export type MigrationGcSweepResult = {
+  partition: number;
+  read: number;
+  removed: number;
+  retained: number;
+  stale: number;
 };
 
 export type MigrationPinAdmission =
@@ -287,6 +324,15 @@ function isNonnegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
+function migrationGcPartition(identity: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < identity.length; index++) {
+    hash ^= identity.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) % MIGRATION_GC_PARTITIONS;
+}
+
 function encodeJson(value: unknown): Buffer {
   return Buffer.from(JSON.stringify(value), "utf8");
 }
@@ -416,7 +462,15 @@ function validateGeneration(
     !isPositiveInteger(generation.generation) ||
     !GENERATION_STATUSES.includes(
       generation.status as MigrationGenerationStatus,
-    )
+    ) ||
+    (generation.gcIndexed !== undefined && generation.gcIndexed !== true) ||
+    (generation.terminalAt !== undefined &&
+      !isNonnegativeInteger(generation.terminalAt)) ||
+    (generation.terminalVersion !== undefined &&
+      !isPositiveInteger(generation.terminalVersion)) ||
+    (generation.terminalAt === undefined) !==
+      (generation.terminalVersion === undefined) ||
+    (generation.status !== "closed" && generation.terminalAt !== undefined)
   ) {
     throw new MigrationCorruptionError(record, "invalid generation fields");
   }
@@ -452,6 +506,16 @@ function validatePin(value: unknown, record: string): MigrationObjectPin {
         pin.sourceObjectId.length === 0))
   ) {
     throw new MigrationCorruptionError(record, "invalid source pin fields");
+  }
+  if (
+    (pin.terminalAt !== undefined && !isNonnegativeInteger(pin.terminalAt)) ||
+    (pin.terminalVersion !== undefined &&
+      !isPositiveInteger(pin.terminalVersion)) ||
+    (pin.terminalAt === undefined) !== (pin.terminalVersion === undefined) ||
+    (pin.lifecycle !== "terminal" && pin.terminalAt !== undefined) ||
+    (pin.terminalVersion !== undefined && pin.terminalVersion !== pin.revision)
+  ) {
+    throw new MigrationCorruptionError(record, "invalid terminal GC fields");
   }
   const initialResidue = validateStoredResidue(
     pin.initialResidue,
@@ -561,6 +625,8 @@ type ControlOperation = {
   backend: MigrationBackend;
   outcome: "completed" | "pending" | "cancelled";
   state: MigrationTeamState;
+  terminalAt?: number;
+  terminalVersion?: number;
 };
 
 // Read-only compatibility with operation rows produced by the prototype before
@@ -593,7 +659,12 @@ function validateControlOperation(
     !BACKENDS.includes(op.backend as MigrationBackend) ||
     (op.outcome !== "completed" &&
       op.outcome !== "pending" &&
-      op.outcome !== "cancelled")
+      op.outcome !== "cancelled") ||
+    (op.terminalAt !== undefined && !isNonnegativeInteger(op.terminalAt)) ||
+    (op.terminalVersion !== undefined &&
+      !isPositiveInteger(op.terminalVersion)) ||
+    (op.terminalAt === undefined) !== (op.terminalVersion === undefined) ||
+    (op.outcome === "pending" && op.terminalAt !== undefined)
   ) {
     throw new MigrationCorruptionError(
       record,
@@ -730,8 +801,131 @@ export class NuqFdbMigrationStore {
     return this.pack(["team", teamId, "object", kind, objectId]);
   }
 
+  private generationObjectKey(pin: MigrationObjectPin): Buffer {
+    return this.pack([
+      "team",
+      pin.teamId,
+      "generation-object",
+      pin.generation,
+      pin.kind,
+      pin.objectId,
+    ]);
+  }
+
+  private generationObjectRange(teamId: string, generation: number) {
+    return getFdb().tuple.range([
+      "nuq-migration",
+      1,
+      "team",
+      teamId,
+      "generation-object",
+      generation,
+    ]);
+  }
+
+  private terminalPinGcKey(
+    pin: MigrationObjectPin,
+    dueAt: number = pin.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS,
+  ): Buffer {
+    return this.pack([
+      "gc",
+      "pin",
+      migrationGcPartition(`${pin.kind}/${pin.objectId}`),
+      dueAt,
+      pin.kind,
+      pin.objectId,
+      pin.generation,
+      pin.terminalVersion!,
+      pin.terminalAt!,
+    ]);
+  }
+
+  private terminalPinGcRange(partition: number, through: number) {
+    return {
+      begin: this.pack(["gc", "pin", partition]),
+      end: this.pack(["gc", "pin", partition, through]),
+    };
+  }
+
+  private gcCursorKey(category: string): Buffer {
+    return this.pack(["gc", "cursor", category]);
+  }
+
+  private gcLeaseKey(category: string, partition: number): Buffer {
+    return this.pack(["gc", "lease", category, partition]);
+  }
+
   private controlOperationKey(teamId: string, operationId: string): Buffer {
     return this.pack(["team", teamId, "control-operation", operationId]);
+  }
+
+  private controlGenerationRefKey(
+    teamId: string,
+    generation: number,
+    operationId: string,
+  ): Buffer {
+    return this.pack([
+      "team",
+      teamId,
+      "generation-control",
+      generation,
+      operationId,
+    ]);
+  }
+
+  private controlGenerationRefRange(teamId: string, generation: number) {
+    return getFdb().tuple.range([
+      "nuq-migration",
+      1,
+      "team",
+      teamId,
+      "generation-control",
+      generation,
+    ]);
+  }
+
+  private controlGcKey(
+    teamId: string,
+    operation: ControlOperation,
+    dueAt = operation.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS,
+  ): Buffer {
+    return this.pack([
+      "gc",
+      "control",
+      migrationGcPartition(`${teamId}/${operation.operationId}`),
+      dueAt,
+      teamId,
+      operation.operationId,
+      operation.terminalVersion!,
+      operation.terminalAt!,
+    ]);
+  }
+
+  private generationGcKey(
+    generation: MigrationGeneration,
+    dueAt = generation.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS,
+  ): Buffer {
+    return this.pack([
+      "gc",
+      "generation",
+      migrationGcPartition(`${generation.teamId}/${generation.generation}`),
+      dueAt,
+      generation.teamId,
+      generation.generation,
+      generation.terminalVersion!,
+      generation.terminalAt!,
+    ]);
+  }
+
+  private gcRange(
+    category: "control" | "generation",
+    partition: number,
+    through: number,
+  ) {
+    return {
+      begin: this.pack(["gc", category, partition]),
+      end: this.pack(["gc", category, partition, through]),
+    };
   }
 
   private legacyObjectOperationKey(
@@ -748,6 +942,98 @@ export class NuqFdbMigrationStore {
       objectId,
       operationId,
     ]);
+  }
+
+  private writeGenerationInTxn(
+    tn: Transaction,
+    previous: MigrationGeneration | null,
+    generation: MigrationGeneration,
+  ): void {
+    tn.set(
+      this.generationKey(generation.teamId, generation.generation),
+      encodeJson(generation),
+    );
+    if (generation.status === "closed" && generation.terminalAt !== undefined) {
+      tn.set(this.generationGcKey(generation), Buffer.alloc(0));
+    }
+    if (
+      previous?.status === "closed" &&
+      previous.terminalAt !== undefined &&
+      (generation.status !== "closed" ||
+        previous.terminalAt !== generation.terminalAt ||
+        previous.terminalVersion !== generation.terminalVersion)
+    ) {
+      tn.clear(this.generationGcKey(previous));
+    }
+  }
+
+  private controlReferencedGenerations(operation: ControlOperation): number[] {
+    return [
+      operation.state.activeGeneration,
+      ...(operation.state.targetGeneration === undefined
+        ? []
+        : [operation.state.targetGeneration]),
+    ];
+  }
+
+  private writeControlOperationInTxn(
+    tn: Transaction,
+    teamId: string,
+    previous: ControlOperation | null,
+    operation: ControlOperation,
+  ): void {
+    if (previous) {
+      for (const generation of this.controlReferencedGenerations(previous)) {
+        tn.clear(
+          this.controlGenerationRefKey(
+            teamId,
+            generation,
+            previous.operationId,
+          ),
+        );
+      }
+      if (previous.terminalAt !== undefined) {
+        tn.clear(this.controlGcKey(teamId, previous));
+      }
+    }
+    tn.set(
+      this.controlOperationKey(teamId, operation.operationId),
+      encodeJson(operation),
+    );
+    for (const generation of this.controlReferencedGenerations(operation)) {
+      tn.set(
+        this.controlGenerationRefKey(teamId, generation, operation.operationId),
+        Buffer.alloc(0),
+      );
+    }
+    if (operation.terminalAt !== undefined) {
+      tn.set(this.controlGcKey(teamId, operation), Buffer.alloc(0));
+    }
+  }
+
+  private writePinInTxn(
+    tn: Transaction,
+    previous: MigrationObjectPin | null,
+    pin: MigrationObjectPin,
+  ): void {
+    const encoded = encodeJson(pin);
+    tn.set(this.objectKey(pin.kind, pin.objectId), encoded);
+    tn.set(this.generationObjectKey(pin), Buffer.alloc(0));
+    if (pin.lifecycle === "terminal") {
+      tn.clear(this.teamObjectKey(pin.teamId, pin.kind, pin.objectId));
+      tn.set(this.terminalPinGcKey(pin), Buffer.alloc(0));
+    } else {
+      tn.set(this.teamObjectKey(pin.teamId, pin.kind, pin.objectId), encoded);
+    }
+    if (
+      previous?.lifecycle === "terminal" &&
+      previous.terminalAt !== undefined &&
+      (previous.terminalAt !== pin.terminalAt ||
+        previous.terminalVersion !== pin.terminalVersion ||
+        previous.generation !== pin.generation)
+    ) {
+      tn.clear(this.terminalPinGcKey(previous));
+    }
   }
 
   private async readState(
@@ -906,6 +1192,31 @@ export class NuqFdbMigrationStore {
       const state = await this.readState(tn, teamId);
       if (state) await this.validateTopology(tn, state);
       return state;
+    });
+  }
+
+  public async inspectGenerationIfPresent(
+    teamId: string,
+    generation: number,
+  ): Promise<{
+    generation: MigrationGeneration;
+    residue: MigrationResidue;
+  } | null> {
+    assertNonempty(teamId, "teamId");
+    if (!isPositiveInteger(generation)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "generation must be a positive safe integer",
+      );
+    }
+    return await this.db.doTn(async tn => {
+      const record = await this.readGeneration(tn, teamId, generation);
+      return record
+        ? {
+            generation: record,
+            residue: await this.readResidue(tn, teamId, generation),
+          }
+        : null;
     });
   }
 
@@ -1332,14 +1643,11 @@ export class NuqFdbMigrationStore {
       lifecycle: targetLifecycle,
       revision,
       residue,
+      ...(targetLifecycle === "terminal"
+        ? { terminalAt: Date.now(), terminalVersion: revision }
+        : {}),
     };
-    const encoded = encodeJson(next);
-    tn.set(this.objectKey(kind, objectId), encoded);
-    if (next.lifecycle === "terminal") {
-      tn.clear(this.teamObjectKey(teamId, kind, objectId));
-    } else {
-      tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
-    }
+    this.writePinInTxn(tn, pin, next);
     return next;
   }
 
@@ -1449,6 +1757,7 @@ export class NuqFdbMigrationStore {
         backend,
         generation: 1,
         status: "open",
+        gcIndexed: true,
       };
       const op: ControlOperation = {
         schemaVersion: 1,
@@ -1457,10 +1766,12 @@ export class NuqFdbMigrationStore {
         backend,
         outcome: "completed",
         state,
+        terminalAt: Date.now(),
+        terminalVersion: state.revision,
       };
       tn.set(this.teamStateKey(teamId), encodeJson(state));
-      tn.set(this.generationKey(teamId, 1), encodeJson(generation));
-      tn.set(opKey, encodeJson(op));
+      this.writeGenerationInTxn(tn, null, generation);
+      this.writeControlOperationInTxn(tn, teamId, null, op);
       return state;
     });
   }
@@ -1473,8 +1784,8 @@ export class NuqFdbMigrationStore {
     const { teamId } = state;
     if (state.activeBackend === backend) return state.activeGeneration;
     for (let candidate = state.maxGeneration; candidate >= 1; candidate--) {
-      const generation = await this.requireGeneration(tn, teamId, candidate);
-      if (generation.backend === backend) return candidate;
+      const generation = await this.readGeneration(tn, teamId, candidate);
+      if (generation?.backend === backend) return candidate;
     }
     if (state.phase !== "PG_ONLY" && state.phase !== "FDB_ONLY") {
       throw new MigrationInProgressError(teamId);
@@ -1498,16 +1809,16 @@ export class NuqFdbMigrationStore {
       backend,
       generation: generationNumber,
       status: "closed",
+      gcIndexed: true,
+      terminalAt: Date.now(),
+      terminalVersion: nextRevision(state),
     };
     const next: MigrationTeamState = {
       ...state,
       revision: nextRevision(state),
       maxGeneration: generationNumber,
     };
-    tn.set(
-      this.generationKey(teamId, generationNumber),
-      encodeJson(generation),
-    );
+    this.writeGenerationInTxn(tn, null, generation);
     tn.set(this.teamStateKey(teamId), encodeJson(next));
     return generationNumber;
   }
@@ -1577,8 +1888,10 @@ export class NuqFdbMigrationStore {
           backend: targetBackend,
           outcome: "completed",
           state,
+          terminalAt: Date.now(),
+          terminalVersion: state.revision,
         };
-        tn.set(opKey, encodeJson(op));
+        this.writeControlOperationInTxn(tn, teamId, null, op);
         return state;
       }
 
@@ -1610,6 +1923,7 @@ export class NuqFdbMigrationStore {
         ...source,
         status: "draining",
       };
+      const transitionRevision = nextRevision(state);
       const target: MigrationGeneration = {
         schemaVersion: 1,
         teamId,
@@ -1618,10 +1932,13 @@ export class NuqFdbMigrationStore {
         // A target remains closed until the source reaches exact zero. If the
         // transition is cancelled this generation stays closed forever.
         status: "closed",
+        gcIndexed: true,
+        terminalAt: Date.now(),
+        terminalVersion: transitionRevision,
       };
       const next: MigrationTeamState = {
         ...state,
-        revision: nextRevision(state),
+        revision: transitionRevision,
         maxGeneration: targetGeneration,
         phase: drainingPhase(targetBackend),
         targetBackend,
@@ -1636,13 +1953,10 @@ export class NuqFdbMigrationStore {
         outcome: "pending",
         state: next,
       };
-      tn.set(
-        this.generationKey(teamId, source.generation),
-        encodeJson(drainingSource),
-      );
-      tn.set(this.generationKey(teamId, targetGeneration), encodeJson(target));
+      this.writeGenerationInTxn(tn, source, drainingSource);
+      this.writeGenerationInTxn(tn, null, target);
       tn.set(this.teamStateKey(teamId), encodeJson(next));
-      tn.set(opKey, encodeJson(op));
+      this.writeControlOperationInTxn(tn, teamId, null, op);
       return next;
     });
   }
@@ -1722,7 +2036,12 @@ export class NuqFdbMigrationStore {
           "transition generations cannot be cancelled",
         );
       }
-      const reopened: MigrationGeneration = { ...source, status: "open" };
+      const reopened: MigrationGeneration = {
+        ...source,
+        status: "open",
+        terminalAt: undefined,
+        terminalVersion: undefined,
+      };
       const next: MigrationTeamState = {
         schemaVersion: 1,
         teamId,
@@ -1736,13 +2055,12 @@ export class NuqFdbMigrationStore {
         ...op,
         outcome: "cancelled",
         state: next,
+        terminalAt: Date.now(),
+        terminalVersion: next.revision,
       };
-      tn.set(
-        this.generationKey(teamId, source.generation),
-        encodeJson(reopened),
-      );
+      this.writeGenerationInTxn(tn, source, reopened);
       tn.set(this.teamStateKey(teamId), encodeJson(next));
-      tn.set(opKey, encodeJson(cancelledOp));
+      this.writeControlOperationInTxn(tn, teamId, op, cancelledOp);
       return next;
     });
   }
@@ -1926,6 +2244,9 @@ export class NuqFdbMigrationStore {
           : undefined,
       initialResidue,
       residue: initialResidue,
+      ...(terminalLegacyBackfill
+        ? { terminalAt: Date.now(), terminalVersion: 1 }
+        : {}),
     };
     await this.applyResidueDelta(
       tn,
@@ -1934,9 +2255,7 @@ export class NuqFdbMigrationStore {
       normalizeResidue(undefined),
       initialResidue,
     );
-    const encoded = encodeJson(pin);
-    tn.set(key, encoded);
-    if (!terminalLegacyBackfill) tn.set(indexKey, encoded);
+    this.writePinInTxn(tn, null, pin);
     return pin;
   }
 
@@ -2064,11 +2383,7 @@ export class NuqFdbMigrationStore {
             resultRevision: legacyOperation.result.revision,
           },
         };
-        const migratedEncoded = encodeJson(migratedPin);
-        tn.set(key, migratedEncoded);
-        if (migratedPin.lifecycle !== "terminal") {
-          tn.set(this.teamObjectKey(teamId, kind, objectId), migratedEncoded);
-        }
+        this.writePinInTxn(tn, pin, migratedPin);
         tn.clear(legacyOperationKey);
       }
       return legacyOperation.result;
@@ -2119,6 +2434,9 @@ export class NuqFdbMigrationStore {
       lifecycle: toLifecycle,
       revision,
       residue,
+      ...(toLifecycle === "terminal"
+        ? { terminalAt: Date.now(), terminalVersion: revision }
+        : {}),
       lastOperation: {
         schemaVersion: 1,
         operationId,
@@ -2128,13 +2446,7 @@ export class NuqFdbMigrationStore {
         resultRevision: revision,
       },
     };
-    const encoded = encodeJson(next);
-    tn.set(key, encoded);
-    if (next.lifecycle === "terminal") {
-      tn.clear(this.teamObjectKey(teamId, kind, objectId));
-    } else {
-      tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
-    }
+    this.writePinInTxn(tn, pin, next);
     return next;
   }
 
@@ -2157,6 +2469,365 @@ export class NuqFdbMigrationStore {
       toLifecycle: "terminal",
       residue: {},
     });
+  }
+
+  private async claimGcPartition(
+    category: string,
+    now: number,
+  ): Promise<{ partition: number; token: string } | null> {
+    for (let attempt = 0; attempt < MIGRATION_GC_PARTITIONS; attempt++) {
+      const token = randomUUID();
+      const claim = await this.db.doTn(async tn => {
+        const cursorKey = this.gcCursorKey(category);
+        const cursor = Number(
+          parseJson(await tn.get(cursorKey), `GC ${category} cursor`) ?? 0,
+        );
+        if (!isNonnegativeInteger(cursor)) {
+          throw new MigrationCorruptionError(
+            `GC ${category} cursor`,
+            "invalid partition",
+          );
+        }
+        const partition = cursor % MIGRATION_GC_PARTITIONS;
+        tn.set(
+          cursorKey,
+          encodeJson((partition + 1) % MIGRATION_GC_PARTITIONS),
+        );
+        const leaseKey = this.gcLeaseKey(category, partition);
+        const lease = parseJson(
+          await tn.get(leaseKey),
+          `GC ${category} lease`,
+        ) as { token?: unknown; expiresAt?: unknown } | null;
+        if (
+          lease &&
+          typeof lease.token === "string" &&
+          isNonnegativeInteger(lease.expiresAt) &&
+          lease.expiresAt > now
+        ) {
+          return null;
+        }
+        tn.set(leaseKey, encodeJson({ token, expiresAt: now + 5 * 60 * 1000 }));
+        return { partition, token };
+      });
+      if (claim) return claim;
+    }
+    return null;
+  }
+
+  private async releaseGcPartition(
+    category: string,
+    partition: number,
+    token: string,
+  ): Promise<void> {
+    await this.db.doTn(async tn => {
+      const key = this.gcLeaseKey(category, partition);
+      const lease = parseJson(await tn.get(key), `GC ${category} lease`) as {
+        token?: unknown;
+      } | null;
+      if (lease?.token === token) tn.clear(key);
+    });
+  }
+
+  /**
+   * Process one durably selected shard and at most one bounded page. PG is
+   * probed first; deletion then re-reads the pin and every FDB canonical key in
+   * one conflict-safe transaction. A missing Redis hint is intentionally not
+   * an input to this decision.
+   */
+  public async sweepTerminalPins(
+    authority: MigrationGcAuthority,
+    options: {
+      now?: number;
+      limit?: number;
+      recheckMs?: number;
+    } = {},
+  ): Promise<MigrationGcSweepResult | null> {
+    const now = options.now ?? Date.now();
+    const limit = options.limit ?? MIGRATION_GC_PAGE_LIMIT;
+    const recheckMs = options.recheckMs ?? MIGRATION_GC_RECHECK_MS;
+    if (!isPositiveInteger(limit) || limit > MIGRATION_GC_PAGE_LIMIT) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        `GC page limit must be between 1 and ${MIGRATION_GC_PAGE_LIMIT}`,
+      );
+    }
+    if (!isPositiveInteger(recheckMs)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "GC recheck must be a positive safe integer",
+      );
+    }
+    const claim = await this.claimGcPartition("pin", now);
+    if (!claim) return null;
+    const result: MigrationGcSweepResult = {
+      partition: claim.partition,
+      read: 0,
+      removed: 0,
+      retained: 0,
+      stale: 0,
+    };
+    try {
+      const range = this.terminalPinGcRange(claim.partition, now + 1);
+      const rows = (await this.db.doTn(async tn =>
+        tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
+      )) as [Buffer, Buffer][];
+      result.read = rows.length;
+      for (const [indexKey] of rows) {
+        const parts = getFdb().tuple.unpack(indexKey);
+        const kind = String(parts[6]) as MigrationObjectKind;
+        const objectId = String(parts[7]);
+        const generation = Number(parts[8]);
+        const terminalVersion = Number(parts[9]);
+        const terminalAt = Number(parts[10]);
+        if (
+          !OBJECT_KINDS.includes(kind) ||
+          !isPositiveInteger(generation) ||
+          !isPositiveInteger(terminalVersion) ||
+          !isNonnegativeInteger(terminalAt)
+        ) {
+          throw new MigrationCorruptionError(
+            "terminal pin GC index",
+            "invalid identity",
+          );
+        }
+        const observed = await this.inspectPin(kind, objectId);
+        const matches =
+          observed?.lifecycle === "terminal" &&
+          observed.generation === generation &&
+          observed.terminalVersion === terminalVersion &&
+          observed.terminalAt === terminalAt;
+        if (!matches) {
+          await this.db.doTn(async tn => tn.clear(indexKey));
+          result.stale++;
+          continue;
+        }
+
+        const pgExists =
+          observed.backend === "pg"
+            ? await authority.pgObjectExists(observed)
+            : false;
+        const outcome = await this.db.doTn(async tn => {
+          const current = await this.inspectPinInTxn(tn, kind, objectId);
+          if (
+            !current ||
+            current.lifecycle !== "terminal" ||
+            current.generation !== generation ||
+            current.terminalVersion !== terminalVersion ||
+            current.terminalAt !== terminalAt
+          ) {
+            tn.clear(indexKey);
+            return "stale" as const;
+          }
+          const teamIndex = await tn.get(
+            this.teamObjectKey(current.teamId, current.kind, current.objectId),
+          );
+          const hasFdbReference = await authority.fdbReferenceExistsInTxn(
+            tn,
+            current,
+          );
+          if (
+            pgExists ||
+            hasFdbReference ||
+            teamIndex ||
+            Object.values(current.residue).some(value => value !== 0)
+          ) {
+            tn.clear(indexKey);
+            tn.set(
+              this.terminalPinGcKey(current, now + recheckMs),
+              Buffer.alloc(0),
+            );
+            return "retained" as const;
+          }
+          tn.clear(this.objectKey(kind, objectId));
+          tn.clear(this.generationObjectKey(current));
+          tn.clear(indexKey);
+          return "removed" as const;
+        });
+        result[outcome]++;
+      }
+      return result;
+    } finally {
+      await this.releaseGcPartition("pin", claim.partition, claim.token);
+    }
+  }
+
+  public async sweepControlHistory(
+    options: { now?: number; limit?: number } = {},
+  ): Promise<MigrationGcSweepResult | null> {
+    const now = options.now ?? Date.now();
+    const limit = options.limit ?? MIGRATION_GC_PAGE_LIMIT;
+    if (!isPositiveInteger(limit) || limit > MIGRATION_GC_PAGE_LIMIT) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        `GC page limit must be between 1 and ${MIGRATION_GC_PAGE_LIMIT}`,
+      );
+    }
+    const claim = await this.claimGcPartition("control", now);
+    if (!claim) return null;
+    const result: MigrationGcSweepResult = {
+      partition: claim.partition,
+      read: 0,
+      removed: 0,
+      retained: 0,
+      stale: 0,
+    };
+    try {
+      const range = this.gcRange("control", claim.partition, now + 1);
+      const rows = (await this.db.doTn(async tn =>
+        tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
+      )) as [Buffer, Buffer][];
+      result.read = rows.length;
+      for (const [indexKey] of rows) {
+        const parts = getFdb().tuple.unpack(indexKey);
+        const teamId = String(parts[6]);
+        const operationId = String(parts[7]);
+        const version = Number(parts[8]);
+        const terminalAt = Number(parts[9]);
+        const outcome = await this.db.doTn(async tn => {
+          const raw = await tn.get(
+            this.controlOperationKey(teamId, operationId),
+          );
+          if (!raw) {
+            tn.clear(indexKey);
+            return "stale" as const;
+          }
+          const operation = validateControlOperation(
+            parseJson(raw, `control operation ${operationId}`),
+            `control operation ${operationId}`,
+          );
+          if (
+            operation.terminalVersion !== version ||
+            operation.terminalAt !== terminalAt ||
+            operation.outcome === "pending"
+          ) {
+            tn.clear(indexKey);
+            return "stale" as const;
+          }
+          const state = await this.readState(tn, teamId);
+          if (state?.transitionOperationId === operationId) {
+            return "retained" as const;
+          }
+          tn.clear(this.controlOperationKey(teamId, operationId));
+          for (const generation of this.controlReferencedGenerations(
+            operation,
+          )) {
+            tn.clear(
+              this.controlGenerationRefKey(teamId, generation, operationId),
+            );
+          }
+          tn.clear(indexKey);
+          return "removed" as const;
+        });
+        result[outcome]++;
+      }
+      return result;
+    } finally {
+      await this.releaseGcPartition("control", claim.partition, claim.token);
+    }
+  }
+
+  public async sweepClosedGenerations(
+    options: { now?: number; limit?: number; recheckMs?: number } = {},
+  ): Promise<MigrationGcSweepResult | null> {
+    const now = options.now ?? Date.now();
+    const limit = options.limit ?? MIGRATION_GC_PAGE_LIMIT;
+    const recheckMs = options.recheckMs ?? MIGRATION_GC_RECHECK_MS;
+    if (!isPositiveInteger(limit) || limit > MIGRATION_GC_PAGE_LIMIT) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        `GC page limit must be between 1 and ${MIGRATION_GC_PAGE_LIMIT}`,
+      );
+    }
+    const claim = await this.claimGcPartition("generation", now);
+    if (!claim) return null;
+    const result: MigrationGcSweepResult = {
+      partition: claim.partition,
+      read: 0,
+      removed: 0,
+      retained: 0,
+      stale: 0,
+    };
+    try {
+      const range = this.gcRange("generation", claim.partition, now + 1);
+      const rows = (await this.db.doTn(async tn =>
+        tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
+      )) as [Buffer, Buffer][];
+      result.read = rows.length;
+      for (const [indexKey] of rows) {
+        const parts = getFdb().tuple.unpack(indexKey);
+        const teamId = String(parts[6]);
+        const generationNumber = Number(parts[7]);
+        const version = Number(parts[8]);
+        const terminalAt = Number(parts[9]);
+        const outcome = await this.db.doTn(async tn => {
+          const generation = await this.readGeneration(
+            tn,
+            teamId,
+            generationNumber,
+          );
+          if (
+            !generation ||
+            generation.status !== "closed" ||
+            generation.gcIndexed !== true ||
+            generation.terminalVersion !== version ||
+            generation.terminalAt !== terminalAt
+          ) {
+            tn.clear(indexKey);
+            return "stale" as const;
+          }
+          const state = await this.readState(tn, teamId);
+          const residue = await this.readResidue(tn, teamId, generationNumber);
+          const objectRange = this.generationObjectRange(
+            teamId,
+            generationNumber,
+          );
+          const controlRange = this.controlGenerationRefRange(
+            teamId,
+            generationNumber,
+          );
+          const [objects, controls] = await Promise.all([
+            tn.getRangeAll(
+              objectRange.begin as Buffer,
+              objectRange.end as Buffer,
+              {
+                limit: 1,
+              },
+            ),
+            tn.getRangeAll(
+              controlRange.begin as Buffer,
+              controlRange.end as Buffer,
+              {
+                limit: 1,
+              },
+            ),
+          ]);
+          if (
+            state?.activeGeneration === generationNumber ||
+            state?.targetGeneration === generationNumber ||
+            Object.values(residue).some(value => value !== 0) ||
+            objects.length > 0 ||
+            controls.length > 0
+          ) {
+            tn.clear(indexKey);
+            tn.set(
+              this.generationGcKey(generation, now + recheckMs),
+              Buffer.alloc(0),
+            );
+            return "retained" as const;
+          }
+          tn.clear(this.generationKey(teamId, generationNumber));
+          for (const counter of MIGRATION_RESIDUE_COUNTERS) {
+            tn.clear(this.residueKey(teamId, generationNumber, counter));
+          }
+          tn.clear(indexKey);
+          return "removed" as const;
+        });
+        result[outcome]++;
+      }
+      return result;
+    } finally {
+      await this.releaseGcPartition("generation", claim.partition, claim.token);
+    }
   }
 
   public async finalSeal(input: {
@@ -2252,11 +2923,6 @@ export class NuqFdbMigrationStore {
           "closed target has residue",
         );
       }
-      const closedSource: MigrationGeneration = {
-        ...source,
-        status: "closed",
-      };
-      const openTarget: MigrationGeneration = { ...target, status: "open" };
       const next: MigrationTeamState = {
         schemaVersion: 1,
         teamId,
@@ -2266,21 +2932,30 @@ export class NuqFdbMigrationStore {
         activeGeneration: target.generation,
         phase: stablePhase(target.backend),
       };
+      const closedSource: MigrationGeneration = {
+        ...source,
+        status: "closed",
+        ...(source.gcIndexed
+          ? { terminalAt: Date.now(), terminalVersion: next.revision }
+          : {}),
+      };
+      const openTarget: MigrationGeneration = {
+        ...target,
+        status: "open",
+        terminalAt: undefined,
+        terminalVersion: undefined,
+      };
       const completedOp: ControlOperation = {
         ...op,
         outcome: "completed",
         state: next,
+        terminalAt: Date.now(),
+        terminalVersion: next.revision,
       };
-      tn.set(
-        this.generationKey(teamId, source.generation),
-        encodeJson(closedSource),
-      );
-      tn.set(
-        this.generationKey(teamId, target.generation),
-        encodeJson(openTarget),
-      );
+      this.writeGenerationInTxn(tn, source, closedSource);
+      this.writeGenerationInTxn(tn, target, openTarget);
       tn.set(this.teamStateKey(teamId), encodeJson(next));
-      tn.set(opKey, encodeJson(completedOp));
+      this.writeControlOperationInTxn(tn, teamId, op, completedOp);
       return next;
     });
   }

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -1,0 +1,1626 @@
+import type { Transaction } from "foundationdb";
+import { getFdb, getNuqFdbDatabase } from "./client";
+import { encodeI64 } from "./keyspace";
+
+export type MigrationBackend = "pg" | "fdb";
+export type MigrationPhase =
+  | "PG_ONLY"
+  | "DRAINING_TO_FDB"
+  | "FDB_ONLY"
+  | "DRAINING_TO_PG"
+  | "ERROR";
+export type MigrationGenerationStatus = "open" | "draining" | "closed";
+export type MigrationObjectKind =
+  | "scrape_job"
+  | "group"
+  | "external_holder"
+  | "crawl_finished"
+  | "sweeper_task"
+  | "cross_store_intent";
+export type MigrationObjectLifecycle = "prepared" | "active" | "terminal";
+
+export const MIGRATION_RESIDUE_COUNTERS = [
+  "capacity_team_pending",
+  "capacity_key_pending",
+  "capacity_crawl_pending",
+  "capacity_delayed",
+  "capacity_ready_active",
+  "capacity_external_holders",
+  "control_groups",
+  "control_crawl_finished",
+  "control_sweeper_tasks",
+  "intent_unresolved",
+] as const;
+
+export type MigrationResidueCounter =
+  (typeof MIGRATION_RESIDUE_COUNTERS)[number];
+export type MigrationResidue = Record<MigrationResidueCounter, number>;
+
+export type MigrationGeneration = {
+  schemaVersion: 1;
+  teamId: string;
+  backend: MigrationBackend;
+  generation: number;
+  status: MigrationGenerationStatus;
+};
+
+export type MigrationTeamState = {
+  schemaVersion: 1;
+  teamId: string;
+  revision: number;
+  maxGeneration: number;
+  activeBackend: MigrationBackend;
+  activeGeneration: number;
+  phase: MigrationPhase;
+  targetBackend?: MigrationBackend;
+  targetGeneration?: number;
+  transitionOperationId?: string;
+};
+
+export type MigrationObjectPin = {
+  schemaVersion: 1;
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  backend: MigrationBackend;
+  generation: number;
+  lifecycle: MigrationObjectLifecycle;
+  admission: "new-root" | "pinned-continuation";
+  sourceKind?: MigrationObjectKind;
+  sourceObjectId?: string;
+  initialResidue: MigrationResidue;
+  residue: MigrationResidue;
+};
+
+export type MigrationPinAdmission =
+  | { type: "new-root" }
+  | {
+      type: "pinned-continuation";
+      source: { kind: MigrationObjectKind; objectId: string };
+    };
+
+export type PreparePinnedObjectInput = {
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  admission: MigrationPinAdmission;
+  residue?: Partial<MigrationResidue>;
+};
+
+export type TransitionObjectResidueInput = {
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  operationId: string;
+  fromLifecycle: MigrationObjectLifecycle;
+  toLifecycle: MigrationObjectLifecycle;
+  residue: Partial<MigrationResidue>;
+};
+
+export type CompletePinnedObjectInput = {
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  operationId: string;
+  fromLifecycle: "prepared" | "active";
+};
+
+export type MigrationSteadyResolution =
+  | { status: "legacy-uninitialized" }
+  | { status: "steady"; state: MigrationTeamState }
+  | { status: "transition-required"; state: MigrationTeamState }
+  | { status: "transitioning"; state: MigrationTeamState }
+  | { status: "cancel-required"; state: MigrationTeamState };
+
+export class MigrationStoreError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly retryable = false,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = this.constructor.name;
+  }
+}
+
+export class MigrationCorruptionError extends MigrationStoreError {
+  constructor(record: string, detail: string) {
+    super("NUQ_MIGRATION_CORRUPT", `${record}: ${detail}`);
+  }
+}
+
+export class MigrationCasError extends MigrationStoreError {
+  constructor(expected: number, actual: number) {
+    super(
+      "NUQ_MIGRATION_CAS_MISMATCH",
+      `expected revision ${expected}, found ${actual}`,
+      true,
+    );
+  }
+}
+
+export class MigrationInProgressError extends MigrationStoreError {
+  constructor(teamId: string) {
+    super(
+      "NUQ_MIGRATION_IN_PROGRESS",
+      `new root admission is closed for team ${teamId}`,
+      true,
+    );
+  }
+}
+
+export class MigrationStaleGenerationError extends MigrationStoreError {
+  constructor(teamId: string, backend: MigrationBackend, generation: number) {
+    super(
+      "NUQ_MIGRATION_STALE_GENERATION",
+      `generation ${backend}/${generation} is not open or draining for team ${teamId}`,
+      true,
+    );
+  }
+}
+
+export class MigrationResidueNotEmptyError extends MigrationStoreError {
+  constructor(teamId: string, generation: number, residue: MigrationResidue) {
+    const nonzero = Object.entries(residue)
+      .filter(([, value]) => value !== 0)
+      .map(([name, value]) => `${name}=${value}`)
+      .join(",");
+    super(
+      "NUQ_MIGRATION_RESIDUE_NOT_EMPTY",
+      `team ${teamId} generation ${generation} has residue ${nonzero}`,
+      true,
+    );
+  }
+}
+
+export class MigrationLegacyStateError extends MigrationStoreError {
+  constructor(teamId: string) {
+    super(
+      "NUQ_MIGRATION_LEGACY_UNINITIALIZED",
+      `team ${teamId} must be explicitly initialized with its legacy backend`,
+    );
+  }
+}
+
+export class MigrationOperationConflictError extends MigrationStoreError {
+  constructor(operationId: string) {
+    super(
+      "NUQ_MIGRATION_OPERATION_CONFLICT",
+      `operation ${operationId} was already used with different input`,
+    );
+  }
+}
+
+const BACKENDS: readonly MigrationBackend[] = ["pg", "fdb"];
+const PHASES: readonly MigrationPhase[] = [
+  "PG_ONLY",
+  "DRAINING_TO_FDB",
+  "FDB_ONLY",
+  "DRAINING_TO_PG",
+  "ERROR",
+];
+const GENERATION_STATUSES: readonly MigrationGenerationStatus[] = [
+  "open",
+  "draining",
+  "closed",
+];
+const OBJECT_KINDS: readonly MigrationObjectKind[] = [
+  "scrape_job",
+  "group",
+  "external_holder",
+  "crawl_finished",
+  "sweeper_task",
+  "cross_store_intent",
+];
+const OBJECT_LIFECYCLES: readonly MigrationObjectLifecycle[] = [
+  "prepared",
+  "active",
+  "terminal",
+];
+
+function assertNonempty(value: string, name: string): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new MigrationStoreError(
+      "NUQ_MIGRATION_INVALID_ARGUMENT",
+      `${name} must be non-empty`,
+    );
+  }
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function encodeJson(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(value), "utf8");
+}
+
+function parseJson(value: Buffer | undefined | null, record: string): unknown {
+  if (!value) return null;
+  try {
+    return JSON.parse(value.toString("utf8"));
+  } catch {
+    throw new MigrationCorruptionError(record, "invalid JSON");
+  }
+}
+
+function normalizeResidue(
+  input: Partial<MigrationResidue> | undefined,
+  record = "residue input",
+): MigrationResidue {
+  const source = input ?? {};
+  for (const key of Object.keys(source)) {
+    if (!(MIGRATION_RESIDUE_COUNTERS as readonly string[]).includes(key)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        `${record} contains unknown counter ${key}`,
+      );
+    }
+  }
+  return Object.fromEntries(
+    MIGRATION_RESIDUE_COUNTERS.map(counter => {
+      const value = source[counter] ?? 0;
+      if (!isNonnegativeInteger(value)) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_INVALID_ARGUMENT",
+          `${record}.${counter} must be a nonnegative safe integer`,
+        );
+      }
+      return [counter, value];
+    }),
+  ) as MigrationResidue;
+}
+
+function validateStoredResidue(
+  value: unknown,
+  record: string,
+): MigrationResidue {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new MigrationCorruptionError(record, "invalid residue");
+  }
+  const keys = Object.keys(value);
+  if (
+    keys.length !== MIGRATION_RESIDUE_COUNTERS.length ||
+    keys.some(
+      key => !(MIGRATION_RESIDUE_COUNTERS as readonly string[]).includes(key),
+    )
+  ) {
+    throw new MigrationCorruptionError(record, "invalid residue counters");
+  }
+  const residue = value as Record<string, unknown>;
+  for (const counter of MIGRATION_RESIDUE_COUNTERS) {
+    if (!isNonnegativeInteger(residue[counter])) {
+      throw new MigrationCorruptionError(record, `invalid counter ${counter}`);
+    }
+  }
+  return residue as MigrationResidue;
+}
+
+function validateTeamState(value: unknown, record: string): MigrationTeamState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new MigrationCorruptionError(record, "invalid team state");
+  }
+  const state = value as Record<string, unknown>;
+  if (
+    state.schemaVersion !== 1 ||
+    typeof state.teamId !== "string" ||
+    !isPositiveInteger(state.revision) ||
+    !isPositiveInteger(state.maxGeneration) ||
+    !BACKENDS.includes(state.activeBackend as MigrationBackend) ||
+    !isPositiveInteger(state.activeGeneration) ||
+    state.activeGeneration > state.maxGeneration ||
+    !PHASES.includes(state.phase as MigrationPhase)
+  ) {
+    throw new MigrationCorruptionError(record, "invalid team state fields");
+  }
+  const transitioning =
+    state.phase === "DRAINING_TO_FDB" || state.phase === "DRAINING_TO_PG";
+  if (transitioning) {
+    if (
+      !BACKENDS.includes(state.targetBackend as MigrationBackend) ||
+      !isPositiveInteger(state.targetGeneration) ||
+      typeof state.transitionOperationId !== "string" ||
+      state.transitionOperationId.length === 0 ||
+      state.targetBackend === state.activeBackend ||
+      state.targetGeneration !== state.maxGeneration ||
+      state.targetGeneration <= state.activeGeneration
+    ) {
+      throw new MigrationCorruptionError(record, "invalid transition fields");
+    }
+  } else if (
+    state.targetBackend !== undefined ||
+    state.targetGeneration !== undefined ||
+    state.transitionOperationId !== undefined
+  ) {
+    throw new MigrationCorruptionError(record, "unexpected transition fields");
+  }
+  if (
+    (state.phase === "PG_ONLY" && state.activeBackend !== "pg") ||
+    (state.phase === "FDB_ONLY" && state.activeBackend !== "fdb") ||
+    (state.phase === "DRAINING_TO_FDB" && state.targetBackend !== "fdb") ||
+    (state.phase === "DRAINING_TO_PG" && state.targetBackend !== "pg")
+  ) {
+    throw new MigrationCorruptionError(record, "phase/backend mismatch");
+  }
+  return state as MigrationTeamState;
+}
+
+function validateGeneration(
+  value: unknown,
+  record: string,
+): MigrationGeneration {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new MigrationCorruptionError(record, "invalid generation");
+  }
+  const generation = value as Record<string, unknown>;
+  if (
+    generation.schemaVersion !== 1 ||
+    typeof generation.teamId !== "string" ||
+    !BACKENDS.includes(generation.backend as MigrationBackend) ||
+    !isPositiveInteger(generation.generation) ||
+    !GENERATION_STATUSES.includes(
+      generation.status as MigrationGenerationStatus,
+    )
+  ) {
+    throw new MigrationCorruptionError(record, "invalid generation fields");
+  }
+  return generation as MigrationGeneration;
+}
+
+function validatePin(value: unknown, record: string): MigrationObjectPin {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new MigrationCorruptionError(record, "invalid object pin");
+  }
+  const pin = value as Record<string, unknown>;
+  if (
+    pin.schemaVersion !== 1 ||
+    typeof pin.teamId !== "string" ||
+    !OBJECT_KINDS.includes(pin.kind as MigrationObjectKind) ||
+    typeof pin.objectId !== "string" ||
+    !BACKENDS.includes(pin.backend as MigrationBackend) ||
+    !isPositiveInteger(pin.generation) ||
+    !OBJECT_LIFECYCLES.includes(pin.lifecycle as MigrationObjectLifecycle) ||
+    (pin.admission !== "new-root" && pin.admission !== "pinned-continuation")
+  ) {
+    throw new MigrationCorruptionError(record, "invalid object pin fields");
+  }
+  if (
+    (pin.admission === "new-root" &&
+      (pin.sourceKind !== undefined || pin.sourceObjectId !== undefined)) ||
+    (pin.admission === "pinned-continuation" &&
+      (!OBJECT_KINDS.includes(pin.sourceKind as MigrationObjectKind) ||
+        typeof pin.sourceObjectId !== "string" ||
+        pin.sourceObjectId.length === 0))
+  ) {
+    throw new MigrationCorruptionError(record, "invalid source pin fields");
+  }
+  const initialResidue = validateStoredResidue(
+    pin.initialResidue,
+    `${record}.initialResidue`,
+  );
+  const residue = validateStoredResidue(pin.residue, `${record}.residue`);
+  return { ...(pin as MigrationObjectPin), initialResidue, residue };
+}
+
+function decodeCounter(
+  value: Buffer | undefined | null,
+  record: string,
+): number {
+  if (!value) return 0;
+  if (value.length !== 8) {
+    throw new MigrationCorruptionError(record, "counter must be 8 bytes");
+  }
+  const decoded = Number(value.readBigInt64LE());
+  if (!isNonnegativeInteger(decoded)) {
+    throw new MigrationCorruptionError(
+      record,
+      "counter must be a nonnegative safe integer",
+    );
+  }
+  return decoded;
+}
+
+function stablePhase(backend: MigrationBackend): MigrationPhase {
+  return backend === "pg" ? "PG_ONLY" : "FDB_ONLY";
+}
+
+function drainingPhase(target: MigrationBackend): MigrationPhase {
+  return target === "pg" ? "DRAINING_TO_PG" : "DRAINING_TO_FDB";
+}
+
+function nextRevision(state: MigrationTeamState): number {
+  const revision = state.revision + 1;
+  if (!Number.isSafeInteger(revision)) {
+    throw new MigrationCorruptionError(
+      `team ${state.teamId}`,
+      "revision exhausted safe integer range",
+    );
+  }
+  return revision;
+}
+
+function residueEqual(a: MigrationResidue, b: MigrationResidue): boolean {
+  return MIGRATION_RESIDUE_COUNTERS.every(counter => a[counter] === b[counter]);
+}
+
+type ControlOperation = {
+  schemaVersion: 1;
+  kind: "initialize" | "begin";
+  operationId: string;
+  backend: MigrationBackend;
+  outcome: "completed" | "pending" | "cancelled";
+  state: MigrationTeamState;
+};
+
+type ObjectOperation = {
+  schemaVersion: 1;
+  operationId: string;
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  fromLifecycle: MigrationObjectLifecycle;
+  toLifecycle: MigrationObjectLifecycle;
+  residue: MigrationResidue;
+  result: MigrationObjectPin;
+};
+
+function validateControlOperation(
+  value: unknown,
+  record: string,
+): ControlOperation {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new MigrationCorruptionError(record, "invalid control operation");
+  }
+  const op = value as Record<string, unknown>;
+  if (
+    op.schemaVersion !== 1 ||
+    (op.kind !== "initialize" && op.kind !== "begin") ||
+    typeof op.operationId !== "string" ||
+    !BACKENDS.includes(op.backend as MigrationBackend) ||
+    (op.outcome !== "completed" &&
+      op.outcome !== "pending" &&
+      op.outcome !== "cancelled")
+  ) {
+    throw new MigrationCorruptionError(
+      record,
+      "invalid control operation fields",
+    );
+  }
+  const decoded = {
+    ...(op as ControlOperation),
+    state: validateTeamState(op.state, `${record}.state`),
+  };
+  const steady =
+    decoded.state.phase === "PG_ONLY" || decoded.state.phase === "FDB_ONLY";
+  if (
+    (decoded.kind === "initialize" &&
+      (decoded.outcome !== "completed" ||
+        !steady ||
+        decoded.state.activeBackend !== decoded.backend)) ||
+    (decoded.kind === "begin" &&
+      decoded.outcome === "pending" &&
+      (decoded.state.transitionOperationId !== decoded.operationId ||
+        decoded.state.targetBackend !== decoded.backend)) ||
+    (decoded.kind === "begin" &&
+      decoded.outcome === "completed" &&
+      (!steady || decoded.state.activeBackend !== decoded.backend)) ||
+    (decoded.kind === "begin" &&
+      decoded.outcome === "cancelled" &&
+      (!steady || decoded.state.activeBackend === decoded.backend))
+  ) {
+    throw new MigrationCorruptionError(record, "operation/state mismatch");
+  }
+  return decoded;
+}
+
+function validateObjectOperation(
+  value: unknown,
+  record: string,
+): ObjectOperation {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new MigrationCorruptionError(record, "invalid object operation");
+  }
+  const op = value as Record<string, unknown>;
+  if (
+    op.schemaVersion !== 1 ||
+    typeof op.operationId !== "string" ||
+    typeof op.teamId !== "string" ||
+    !OBJECT_KINDS.includes(op.kind as MigrationObjectKind) ||
+    typeof op.objectId !== "string" ||
+    !OBJECT_LIFECYCLES.includes(op.fromLifecycle as MigrationObjectLifecycle) ||
+    !OBJECT_LIFECYCLES.includes(op.toLifecycle as MigrationObjectLifecycle)
+  ) {
+    throw new MigrationCorruptionError(
+      record,
+      "invalid object operation fields",
+    );
+  }
+  const decoded = {
+    ...(op as ObjectOperation),
+    residue: validateStoredResidue(op.residue, `${record}.residue`),
+    result: validatePin(op.result, `${record}.result`),
+  };
+  if (
+    decoded.result.teamId !== decoded.teamId ||
+    decoded.result.kind !== decoded.kind ||
+    decoded.result.objectId !== decoded.objectId ||
+    decoded.result.lifecycle !== decoded.toLifecycle ||
+    !residueEqual(decoded.result.residue, decoded.residue)
+  ) {
+    throw new MigrationCorruptionError(record, "operation/result mismatch");
+  }
+  return decoded;
+}
+
+export class NuqFdbMigrationStore {
+  private get db() {
+    return getNuqFdbDatabase();
+  }
+
+  // This prefix is deliberately global and disjoint from every queue's
+  // ("nuq", queueName) subspace.
+  public pack(parts: any[]): Buffer {
+    return getFdb().tuple.pack(["nuq-migration", 1, ...parts]) as Buffer;
+  }
+
+  public teamStateKey(teamId: string): Buffer {
+    return this.pack(["team", teamId, "state"]);
+  }
+
+  public generationKey(teamId: string, generation: number): Buffer {
+    return this.pack(["team", teamId, "generation", generation]);
+  }
+
+  public residueKey(
+    teamId: string,
+    generation: number,
+    counter: MigrationResidueCounter,
+  ): Buffer {
+    return this.pack(["team", teamId, "residue", generation, counter]);
+  }
+
+  public objectKey(kind: MigrationObjectKind, objectId: string): Buffer {
+    return this.pack(["object", kind, objectId]);
+  }
+
+  private teamObjectKey(
+    teamId: string,
+    kind: MigrationObjectKind,
+    objectId: string,
+  ): Buffer {
+    return this.pack(["team", teamId, "object", kind, objectId]);
+  }
+
+  private controlOperationKey(teamId: string, operationId: string): Buffer {
+    return this.pack(["team", teamId, "control-operation", operationId]);
+  }
+
+  private objectOperationKey(
+    teamId: string,
+    kind: MigrationObjectKind,
+    objectId: string,
+    operationId: string,
+  ): Buffer {
+    return this.pack([
+      "team",
+      teamId,
+      "object-operation",
+      kind,
+      objectId,
+      operationId,
+    ]);
+  }
+
+  private async readState(
+    tn: Transaction,
+    teamId: string,
+  ): Promise<MigrationTeamState | null> {
+    const value = await tn.get(this.teamStateKey(teamId));
+    if (!value) return null;
+    const state = validateTeamState(
+      value && parseJson(value, `team ${teamId}`),
+      `team ${teamId}`,
+    );
+    if (state.teamId !== teamId) {
+      throw new MigrationCorruptionError(`team ${teamId}`, "team id mismatch");
+    }
+    return state;
+  }
+
+  private async readGeneration(
+    tn: Transaction,
+    teamId: string,
+    generation: number,
+  ): Promise<MigrationGeneration | null> {
+    const record = `team ${teamId} generation ${generation}`;
+    const value = await tn.get(this.generationKey(teamId, generation));
+    if (!value) return null;
+    const decoded = validateGeneration(parseJson(value, record), record);
+    if (decoded.teamId !== teamId || decoded.generation !== generation) {
+      throw new MigrationCorruptionError(record, "identity mismatch");
+    }
+    return decoded;
+  }
+
+  private async requireGeneration(
+    tn: Transaction,
+    teamId: string,
+    generation: number,
+  ): Promise<MigrationGeneration> {
+    const value = await this.readGeneration(tn, teamId, generation);
+    if (!value) {
+      throw new MigrationCorruptionError(
+        `team ${teamId} generation ${generation}`,
+        "missing generation record",
+      );
+    }
+    return value;
+  }
+
+  private async readResidue(
+    tn: Transaction,
+    teamId: string,
+    generation: number,
+  ): Promise<MigrationResidue> {
+    const values = await Promise.all(
+      MIGRATION_RESIDUE_COUNTERS.map(counter =>
+        tn.get(this.residueKey(teamId, generation, counter)),
+      ),
+    );
+    return Object.fromEntries(
+      MIGRATION_RESIDUE_COUNTERS.map((counter, index) => [
+        counter,
+        decodeCounter(
+          values[index],
+          `team ${teamId} generation ${generation} residue ${counter}`,
+        ),
+      ]),
+    ) as MigrationResidue;
+  }
+
+  private async applyResidueDelta(
+    tn: Transaction,
+    teamId: string,
+    generation: number,
+    from: MigrationResidue,
+    to: MigrationResidue,
+  ): Promise<void> {
+    const current = await this.readResidue(tn, teamId, generation);
+    for (const counter of MIGRATION_RESIDUE_COUNTERS) {
+      const delta = to[counter] - from[counter];
+      if (!Number.isSafeInteger(delta)) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_INVALID_ARGUMENT",
+          `counter delta for ${counter} is not a safe integer`,
+        );
+      }
+      if (!isNonnegativeInteger(current[counter] + delta)) {
+        throw new MigrationCorruptionError(
+          `team ${teamId} generation ${generation} residue ${counter}`,
+          "pin delta would make counter negative or overflow",
+        );
+      }
+      if (delta !== 0) {
+        tn.add(this.residueKey(teamId, generation, counter), encodeI64(delta));
+      }
+    }
+  }
+
+  private async validateTopology(
+    tn: Transaction,
+    state: MigrationTeamState,
+  ): Promise<void> {
+    if (state.phase === "ERROR") return;
+    const source = await this.requireGeneration(
+      tn,
+      state.teamId,
+      state.activeGeneration,
+    );
+    if (source.backend !== state.activeBackend) {
+      throw new MigrationCorruptionError(
+        `team ${state.teamId}`,
+        "active generation backend mismatch",
+      );
+    }
+    if (state.phase === "PG_ONLY" || state.phase === "FDB_ONLY") {
+      if (source.status !== "open") {
+        throw new MigrationCorruptionError(
+          `team ${state.teamId}`,
+          "steady generation is not open",
+        );
+      }
+      return;
+    }
+    const target = await this.requireGeneration(
+      tn,
+      state.teamId,
+      state.targetGeneration!,
+    );
+    if (
+      source.status !== "draining" ||
+      target.status !== "closed" ||
+      target.backend !== state.targetBackend
+    ) {
+      throw new MigrationCorruptionError(
+        `team ${state.teamId}`,
+        "transition generation topology mismatch",
+      );
+    }
+  }
+
+  public async inspectState(
+    teamId: string,
+  ): Promise<MigrationTeamState | null> {
+    assertNonempty(teamId, "teamId");
+    return await this.db.doTn(async tn => {
+      const state = await this.readState(tn, teamId);
+      if (state) await this.validateTopology(tn, state);
+      return state;
+    });
+  }
+
+  public async inspectGeneration(
+    teamId: string,
+    generation: number,
+  ): Promise<{ generation: MigrationGeneration; residue: MigrationResidue }> {
+    assertNonempty(teamId, "teamId");
+    if (!isPositiveInteger(generation)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "generation must be a positive safe integer",
+      );
+    }
+    return await this.db.doTn(async tn => ({
+      generation: await this.requireGeneration(tn, teamId, generation),
+      residue: await this.readResidue(tn, teamId, generation),
+    }));
+  }
+
+  public async inspectPin(
+    kind: MigrationObjectKind,
+    objectId: string,
+  ): Promise<MigrationObjectPin | null> {
+    assertNonempty(objectId, "objectId");
+    return await this.db.doTn(async tn =>
+      this.inspectPinInTxn(tn, kind, objectId),
+    );
+  }
+
+  public async inspectPinInTxn(
+    tn: Transaction,
+    kind: MigrationObjectKind,
+    objectId: string,
+  ): Promise<MigrationObjectPin | null> {
+    const record = `object ${kind}/${objectId}`;
+    const value = await tn.get(this.objectKey(kind, objectId));
+    if (!value) return null;
+    const pin = validatePin(parseJson(value, record), record);
+    if (pin.kind !== kind || pin.objectId !== objectId) {
+      throw new MigrationCorruptionError(record, "identity mismatch");
+    }
+    return pin;
+  }
+
+  public async validatePinnedObjectInTxn(
+    tn: Transaction,
+    input: {
+      teamId: string;
+      kind: MigrationObjectKind;
+      objectId: string;
+      backend?: MigrationBackend;
+      generation?: number;
+    },
+  ): Promise<MigrationObjectPin> {
+    const { teamId, kind, objectId } = input;
+    const record = `object ${kind}/${objectId}`;
+    const pin = await this.inspectPinInTxn(tn, kind, objectId);
+    if (!pin) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_PIN_NOT_FOUND",
+        `${kind}/${objectId} has no durable pin`,
+      );
+    }
+    if (
+      pin.teamId !== teamId ||
+      (input.backend !== undefined && pin.backend !== input.backend) ||
+      (input.generation !== undefined && pin.generation !== input.generation)
+    ) {
+      throw new MigrationCorruptionError(record, "pin expectation mismatch");
+    }
+    if (pin.lifecycle === "terminal") {
+      throw new MigrationStaleGenerationError(
+        teamId,
+        pin.backend,
+        pin.generation,
+      );
+    }
+    const indexedRaw = await tn.get(this.teamObjectKey(teamId, kind, objectId));
+    if (!indexedRaw) {
+      throw new MigrationCorruptionError(record, "missing team pin index");
+    }
+    const indexed = validatePin(
+      parseJson(indexedRaw, `${record} team index`),
+      `${record} team index`,
+    );
+    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
+      throw new MigrationCorruptionError(record, "team pin index mismatch");
+    }
+    const generation = await this.requireGeneration(tn, teamId, pin.generation);
+    if (
+      generation.backend !== pin.backend ||
+      (generation.status !== "open" && generation.status !== "draining")
+    ) {
+      throw new MigrationStaleGenerationError(
+        teamId,
+        pin.backend,
+        pin.generation,
+      );
+    }
+    return pin;
+  }
+
+  public async resolveSteady(
+    teamId: string,
+    desiredBackend: MigrationBackend,
+  ): Promise<MigrationSteadyResolution> {
+    assertNonempty(teamId, "teamId");
+    return await this.db.doTn(async tn => {
+      const state = await this.readState(tn, teamId);
+      if (!state) return { status: "legacy-uninitialized" } as const;
+      await this.validateTopology(tn, state);
+      if (state.phase === "ERROR") {
+        throw new MigrationCorruptionError(
+          `team ${teamId}`,
+          "team is in ERROR phase",
+        );
+      }
+      if (state.phase === "PG_ONLY" || state.phase === "FDB_ONLY") {
+        return state.activeBackend === desiredBackend
+          ? ({ status: "steady", state } as const)
+          : ({ status: "transition-required", state } as const);
+      }
+      return state.targetBackend === desiredBackend
+        ? ({ status: "transitioning", state } as const)
+        : ({ status: "cancel-required", state } as const);
+    });
+  }
+
+  // Legacy state is never guessed from Redis or today's flag. A caller must
+  // explicitly name the authoritative backend once.
+  public async initializeLegacyTeam(
+    teamId: string,
+    backend: MigrationBackend,
+    operationId: string,
+  ): Promise<MigrationTeamState> {
+    assertNonempty(teamId, "teamId");
+    assertNonempty(operationId, "operationId");
+    return await this.db.doTn(async tn => {
+      const opKey = this.controlOperationKey(teamId, operationId);
+      const rawOp = await tn.get(opKey);
+      if (rawOp) {
+        const op = validateControlOperation(
+          parseJson(rawOp, `control operation ${operationId}`),
+          `control operation ${operationId}`,
+        );
+        if (op.operationId !== operationId || op.state.teamId !== teamId) {
+          throw new MigrationCorruptionError(
+            `control operation ${operationId}`,
+            "identity mismatch",
+          );
+        }
+        if (op.kind !== "initialize" || op.backend !== backend) {
+          throw new MigrationOperationConflictError(operationId);
+        }
+        return op.state;
+      }
+      if (await this.readState(tn, teamId)) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_ALREADY_INITIALIZED",
+          `team ${teamId} is already initialized`,
+        );
+      }
+      const state: MigrationTeamState = {
+        schemaVersion: 1,
+        teamId,
+        revision: 1,
+        maxGeneration: 1,
+        activeBackend: backend,
+        activeGeneration: 1,
+        phase: stablePhase(backend),
+      };
+      const generation: MigrationGeneration = {
+        schemaVersion: 1,
+        teamId,
+        backend,
+        generation: 1,
+        status: "open",
+      };
+      const op: ControlOperation = {
+        schemaVersion: 1,
+        kind: "initialize",
+        operationId,
+        backend,
+        outcome: "completed",
+        state,
+      };
+      tn.set(this.teamStateKey(teamId), encodeJson(state));
+      tn.set(this.generationKey(teamId, 1), encodeJson(generation));
+      tn.set(opKey, encodeJson(op));
+      return state;
+    });
+  }
+
+  public async beginTransition(input: {
+    teamId: string;
+    targetBackend: MigrationBackend;
+    operationId: string;
+    expectedRevision?: number;
+  }): Promise<MigrationTeamState> {
+    const { teamId, targetBackend, operationId, expectedRevision } = input;
+    assertNonempty(teamId, "teamId");
+    assertNonempty(operationId, "operationId");
+    return await this.db.doTn(async tn => {
+      const opKey = this.controlOperationKey(teamId, operationId);
+      const rawOp = await tn.get(opKey);
+      if (rawOp) {
+        const op = validateControlOperation(
+          parseJson(rawOp, `control operation ${operationId}`),
+          `control operation ${operationId}`,
+        );
+        if (op.operationId !== operationId || op.state.teamId !== teamId) {
+          throw new MigrationCorruptionError(
+            `control operation ${operationId}`,
+            "identity mismatch",
+          );
+        }
+        if (op.kind !== "begin" || op.backend !== targetBackend) {
+          throw new MigrationOperationConflictError(operationId);
+        }
+        return op.state;
+      }
+      const state = await this.readState(tn, teamId);
+      if (!state) throw new MigrationLegacyStateError(teamId);
+      if (
+        expectedRevision !== undefined &&
+        state.revision !== expectedRevision
+      ) {
+        throw new MigrationCasError(expectedRevision, state.revision);
+      }
+      if (state.phase !== "PG_ONLY" && state.phase !== "FDB_ONLY") {
+        throw new MigrationInProgressError(teamId);
+      }
+      await this.validateTopology(tn, state);
+      if (state.activeBackend === targetBackend) {
+        const op: ControlOperation = {
+          schemaVersion: 1,
+          kind: "begin",
+          operationId,
+          backend: targetBackend,
+          outcome: "completed",
+          state,
+        };
+        tn.set(opKey, encodeJson(op));
+        return state;
+      }
+
+      const source = await this.requireGeneration(
+        tn,
+        teamId,
+        state.activeGeneration,
+      );
+      if (source.status !== "open" || source.backend !== state.activeBackend) {
+        throw new MigrationCorruptionError(
+          `team ${teamId} generation ${source.generation}`,
+          "active generation is not open",
+        );
+      }
+      const targetGeneration = state.maxGeneration + 1;
+      if (!Number.isSafeInteger(targetGeneration)) {
+        throw new MigrationCorruptionError(
+          `team ${teamId}`,
+          "generation exhausted safe integer range",
+        );
+      }
+      if (await this.readGeneration(tn, teamId, targetGeneration)) {
+        throw new MigrationCorruptionError(
+          `team ${teamId} generation ${targetGeneration}`,
+          "generation was previously allocated beyond maxGeneration",
+        );
+      }
+      const drainingSource: MigrationGeneration = {
+        ...source,
+        status: "draining",
+      };
+      const target: MigrationGeneration = {
+        schemaVersion: 1,
+        teamId,
+        backend: targetBackend,
+        generation: targetGeneration,
+        // A target remains closed until the source reaches exact zero. If the
+        // transition is cancelled this generation stays closed forever.
+        status: "closed",
+      };
+      const next: MigrationTeamState = {
+        ...state,
+        revision: nextRevision(state),
+        maxGeneration: targetGeneration,
+        phase: drainingPhase(targetBackend),
+        targetBackend,
+        targetGeneration,
+        transitionOperationId: operationId,
+      };
+      const op: ControlOperation = {
+        schemaVersion: 1,
+        kind: "begin",
+        operationId,
+        backend: targetBackend,
+        outcome: "pending",
+        state: next,
+      };
+      tn.set(
+        this.generationKey(teamId, source.generation),
+        encodeJson(drainingSource),
+      );
+      tn.set(this.generationKey(teamId, targetGeneration), encodeJson(target));
+      tn.set(this.teamStateKey(teamId), encodeJson(next));
+      tn.set(opKey, encodeJson(op));
+      return next;
+    });
+  }
+
+  public async cancelTransition(input: {
+    teamId: string;
+    transitionOperationId: string;
+    expectedRevision?: number;
+  }): Promise<MigrationTeamState> {
+    const { teamId, transitionOperationId, expectedRevision } = input;
+    assertNonempty(teamId, "teamId");
+    assertNonempty(transitionOperationId, "transitionOperationId");
+    return await this.db.doTn(async tn => {
+      const opKey = this.controlOperationKey(teamId, transitionOperationId);
+      const rawOp = await tn.get(opKey);
+      if (!rawOp) {
+        throw new MigrationOperationConflictError(transitionOperationId);
+      }
+      const op = validateControlOperation(
+        parseJson(rawOp, `control operation ${transitionOperationId}`),
+        `control operation ${transitionOperationId}`,
+      );
+      if (
+        op.operationId !== transitionOperationId ||
+        op.state.teamId !== teamId
+      ) {
+        throw new MigrationCorruptionError(
+          `control operation ${transitionOperationId}`,
+          "identity mismatch",
+        );
+      }
+      if (op.kind !== "begin") {
+        throw new MigrationOperationConflictError(transitionOperationId);
+      }
+      if (op.outcome === "cancelled") return op.state;
+      if (op.outcome === "completed") {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_ALREADY_SEALED",
+          `transition ${transitionOperationId} is already sealed`,
+        );
+      }
+      const state = await this.readState(tn, teamId);
+      if (!state) throw new MigrationLegacyStateError(teamId);
+      if (
+        expectedRevision !== undefined &&
+        state.revision !== expectedRevision
+      ) {
+        throw new MigrationCasError(expectedRevision, state.revision);
+      }
+      if (state.transitionOperationId !== transitionOperationId) {
+        throw new MigrationOperationConflictError(transitionOperationId);
+      }
+      const source = await this.requireGeneration(
+        tn,
+        teamId,
+        state.activeGeneration,
+      );
+      const target = await this.requireGeneration(
+        tn,
+        teamId,
+        state.targetGeneration!,
+      );
+      const targetResidue = await this.readResidue(
+        tn,
+        teamId,
+        target.generation,
+      );
+      if (
+        source.status !== "draining" ||
+        source.backend !== state.activeBackend ||
+        target.status !== "closed" ||
+        target.backend !== state.targetBackend ||
+        Object.values(targetResidue).some(value => value !== 0)
+      ) {
+        throw new MigrationCorruptionError(
+          `team ${teamId}`,
+          "transition generations cannot be cancelled",
+        );
+      }
+      const reopened: MigrationGeneration = { ...source, status: "open" };
+      const next: MigrationTeamState = {
+        schemaVersion: 1,
+        teamId,
+        revision: nextRevision(state),
+        maxGeneration: state.maxGeneration,
+        activeBackend: state.activeBackend,
+        activeGeneration: state.activeGeneration,
+        phase: stablePhase(state.activeBackend),
+      };
+      const cancelledOp: ControlOperation = {
+        ...op,
+        outcome: "cancelled",
+        state: next,
+      };
+      tn.set(
+        this.generationKey(teamId, source.generation),
+        encodeJson(reopened),
+      );
+      tn.set(this.teamStateKey(teamId), encodeJson(next));
+      tn.set(opKey, encodeJson(cancelledOp));
+      return next;
+    });
+  }
+
+  public async preparePinnedObject(
+    input: PreparePinnedObjectInput,
+  ): Promise<MigrationObjectPin> {
+    return await this.db.doTn(async tn =>
+      this.preparePinnedObjectInTxn(tn, input),
+    );
+  }
+
+  // Transaction-scoped hook for queue/group/slot/sweeper code. The caller can
+  // validate and account for a generation in the same FDB transaction as the
+  // mutation that creates residue. An existing object ID is an idempotent
+  // replay and may already be active/terminal, so the composing mutation must
+  // also reconcile by its stable object ID rather than blindly recreate work.
+  public async preparePinnedObjectInTxn(
+    tn: Transaction,
+    input: PreparePinnedObjectInput,
+  ): Promise<MigrationObjectPin> {
+    const { teamId, kind, objectId, admission } = input;
+    assertNonempty(teamId, "teamId");
+    assertNonempty(objectId, "objectId");
+    const initialResidue = normalizeResidue(input.residue);
+    const key = this.objectKey(kind, objectId);
+    const indexKey = this.teamObjectKey(teamId, kind, objectId);
+    const rawPin = await tn.get(key);
+    const rawIndex = await tn.get(indexKey);
+    if (rawPin) {
+      const record = `object ${kind}/${objectId}`;
+      const pin = validatePin(parseJson(rawPin, record), record);
+      const expectedAdmission =
+        admission.type === "new-root" ? "new-root" : "pinned-continuation";
+      if (
+        pin.teamId !== teamId ||
+        pin.kind !== kind ||
+        pin.objectId !== objectId ||
+        pin.admission !== expectedAdmission ||
+        !residueEqual(pin.initialResidue, initialResidue) ||
+        (admission.type === "pinned-continuation" &&
+          (pin.sourceKind !== admission.source.kind ||
+            pin.sourceObjectId !== admission.source.objectId))
+      ) {
+        throw new MigrationOperationConflictError(`${kind}/${objectId}`);
+      }
+      if (!rawIndex) {
+        throw new MigrationCorruptionError(record, "missing team pin index");
+      }
+      const indexed = validatePin(
+        parseJson(rawIndex, `${record} team index`),
+        `${record} team index`,
+      );
+      if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
+        throw new MigrationCorruptionError(record, "team pin index mismatch");
+      }
+      return pin;
+    }
+    if (rawIndex) {
+      throw new MigrationCorruptionError(
+        `object ${kind}/${objectId}`,
+        "orphaned team pin index",
+      );
+    }
+    const state = await this.readState(tn, teamId);
+    if (!state) throw new MigrationLegacyStateError(teamId);
+    let backend: MigrationBackend;
+    let generationNumber: number;
+    if (admission.type === "new-root") {
+      if (state.phase !== "PG_ONLY" && state.phase !== "FDB_ONLY") {
+        throw new MigrationInProgressError(teamId);
+      }
+      backend = state.activeBackend;
+      generationNumber = state.activeGeneration;
+    } else {
+      assertNonempty(admission.source.objectId, "admission.source.objectId");
+      const sourceRecord = `source object ${admission.source.kind}/${admission.source.objectId}`;
+      const sourceRaw = await tn.get(
+        this.objectKey(admission.source.kind, admission.source.objectId),
+      );
+      if (!sourceRaw) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_SOURCE_PIN_NOT_FOUND",
+          `${admission.source.kind}/${admission.source.objectId} has no durable source pin`,
+        );
+      }
+      const sourcePin = validatePin(
+        parseJson(sourceRaw, sourceRecord),
+        sourceRecord,
+      );
+      if (
+        sourcePin.teamId !== teamId ||
+        sourcePin.kind !== admission.source.kind ||
+        sourcePin.objectId !== admission.source.objectId
+      ) {
+        throw new MigrationCorruptionError(sourceRecord, "identity mismatch");
+      }
+      if (sourcePin.lifecycle === "terminal") {
+        throw new MigrationStaleGenerationError(
+          teamId,
+          sourcePin.backend,
+          sourcePin.generation,
+        );
+      }
+      const sourceIndexRaw = await tn.get(
+        this.teamObjectKey(
+          teamId,
+          admission.source.kind,
+          admission.source.objectId,
+        ),
+      );
+      if (!sourceIndexRaw) {
+        throw new MigrationCorruptionError(
+          sourceRecord,
+          "missing team pin index",
+        );
+      }
+      const sourceIndexed = validatePin(
+        parseJson(sourceIndexRaw, `${sourceRecord} team index`),
+        `${sourceRecord} team index`,
+      );
+      if (JSON.stringify(sourceIndexed) !== JSON.stringify(sourcePin)) {
+        throw new MigrationCorruptionError(
+          sourceRecord,
+          "team pin index mismatch",
+        );
+      }
+      backend = sourcePin.backend;
+      generationNumber = sourcePin.generation;
+    }
+    const generation = await this.requireGeneration(
+      tn,
+      teamId,
+      generationNumber,
+    );
+    const allowed =
+      generation.backend === backend &&
+      (admission.type === "new-root"
+        ? generation.status === "open"
+        : generation.status === "open" || generation.status === "draining");
+    if (!allowed) {
+      throw new MigrationStaleGenerationError(
+        teamId,
+        backend,
+        generationNumber,
+      );
+    }
+    const pin: MigrationObjectPin = {
+      schemaVersion: 1,
+      teamId,
+      kind,
+      objectId,
+      backend,
+      generation: generationNumber,
+      lifecycle: "prepared",
+      admission:
+        admission.type === "new-root" ? "new-root" : "pinned-continuation",
+      sourceKind:
+        admission.type === "pinned-continuation"
+          ? admission.source.kind
+          : undefined,
+      sourceObjectId:
+        admission.type === "pinned-continuation"
+          ? admission.source.objectId
+          : undefined,
+      initialResidue,
+      residue: initialResidue,
+    };
+    await this.applyResidueDelta(
+      tn,
+      teamId,
+      generationNumber,
+      normalizeResidue(undefined),
+      initialResidue,
+    );
+    const encoded = encodeJson(pin);
+    tn.set(key, encoded);
+    tn.set(indexKey, encoded);
+    return pin;
+  }
+
+  public async transitionObjectResidue(
+    input: TransitionObjectResidueInput,
+  ): Promise<MigrationObjectPin> {
+    return await this.db.doTn(async tn =>
+      this.transitionObjectResidueInTxn(tn, input),
+    );
+  }
+
+  public async transitionObjectResidueInTxn(
+    tn: Transaction,
+    input: TransitionObjectResidueInput,
+  ): Promise<MigrationObjectPin> {
+    const { teamId, kind, objectId, operationId, fromLifecycle, toLifecycle } =
+      input;
+    assertNonempty(teamId, "teamId");
+    assertNonempty(objectId, "objectId");
+    assertNonempty(operationId, "operationId");
+    const residue = normalizeResidue(input.residue);
+    const operationKey = this.objectOperationKey(
+      teamId,
+      kind,
+      objectId,
+      operationId,
+    );
+    const rawOperation = await tn.get(operationKey);
+    if (rawOperation) {
+      const op = validateObjectOperation(
+        parseJson(rawOperation, `object operation ${operationId}`),
+        `object operation ${operationId}`,
+      );
+      if (
+        op.operationId !== operationId ||
+        op.teamId !== teamId ||
+        op.kind !== kind ||
+        op.objectId !== objectId ||
+        op.fromLifecycle !== fromLifecycle ||
+        op.toLifecycle !== toLifecycle ||
+        !residueEqual(op.residue, residue)
+      ) {
+        throw new MigrationOperationConflictError(operationId);
+      }
+      return op.result;
+    }
+    const key = this.objectKey(kind, objectId);
+    const record = `object ${kind}/${objectId}`;
+    const rawPin = await tn.get(key);
+    if (!rawPin) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_PIN_NOT_FOUND",
+        `${kind}/${objectId} has no durable pin`,
+      );
+    }
+    const pin = validatePin(parseJson(rawPin, record), record);
+    if (
+      pin.teamId !== teamId ||
+      pin.kind !== kind ||
+      pin.objectId !== objectId
+    ) {
+      throw new MigrationCorruptionError(record, "identity mismatch");
+    }
+    if (pin.lifecycle !== fromLifecycle) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_LIFECYCLE_MISMATCH",
+        `${kind}/${objectId} expected ${fromLifecycle}, found ${pin.lifecycle}`,
+      );
+    }
+    if (pin.lifecycle === "terminal" && toLifecycle !== "terminal") {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_LIFECYCLE_MISMATCH",
+        `${kind}/${objectId} tombstone cannot be reopened`,
+      );
+    }
+    const generation = await this.requireGeneration(tn, teamId, pin.generation);
+    if (generation.backend !== pin.backend) {
+      throw new MigrationCorruptionError(
+        record,
+        "pin backend does not match generation",
+      );
+    }
+    if (generation.status === "closed") {
+      throw new MigrationStaleGenerationError(
+        teamId,
+        pin.backend,
+        pin.generation,
+      );
+    }
+    const rawIndex = await tn.get(this.teamObjectKey(teamId, kind, objectId));
+    if (!rawIndex) {
+      throw new MigrationCorruptionError(record, "missing team pin index");
+    }
+    const indexed = validatePin(
+      parseJson(rawIndex, `${record} team index`),
+      `${record} team index`,
+    );
+    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
+      throw new MigrationCorruptionError(record, "team pin index mismatch");
+    }
+    await this.applyResidueDelta(
+      tn,
+      teamId,
+      pin.generation,
+      pin.residue,
+      residue,
+    );
+    const next: MigrationObjectPin = {
+      ...pin,
+      lifecycle: toLifecycle,
+      residue,
+    };
+    const encoded = encodeJson(next);
+    tn.set(key, encoded);
+    tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
+    const op: ObjectOperation = {
+      schemaVersion: 1,
+      operationId,
+      teamId,
+      kind,
+      objectId,
+      fromLifecycle,
+      toLifecycle,
+      residue,
+      result: next,
+    };
+    tn.set(operationKey, encodeJson(op));
+    return next;
+  }
+
+  public async completePinnedObject(
+    input: CompletePinnedObjectInput,
+  ): Promise<MigrationObjectPin> {
+    return await this.transitionObjectResidue({
+      ...input,
+      toLifecycle: "terminal",
+      residue: {},
+    });
+  }
+
+  public async completePinnedObjectInTxn(
+    tn: Transaction,
+    input: CompletePinnedObjectInput,
+  ): Promise<MigrationObjectPin> {
+    return await this.transitionObjectResidueInTxn(tn, {
+      ...input,
+      toLifecycle: "terminal",
+      residue: {},
+    });
+  }
+
+  public async finalSeal(input: {
+    teamId: string;
+    transitionOperationId: string;
+    expectedRevision?: number;
+  }): Promise<MigrationTeamState> {
+    const { teamId, transitionOperationId, expectedRevision } = input;
+    assertNonempty(teamId, "teamId");
+    assertNonempty(transitionOperationId, "transitionOperationId");
+    return await this.db.doTn(async tn => {
+      const opKey = this.controlOperationKey(teamId, transitionOperationId);
+      const rawOp = await tn.get(opKey);
+      if (!rawOp) {
+        throw new MigrationOperationConflictError(transitionOperationId);
+      }
+      const op = validateControlOperation(
+        parseJson(rawOp, `control operation ${transitionOperationId}`),
+        `control operation ${transitionOperationId}`,
+      );
+      if (
+        op.operationId !== transitionOperationId ||
+        op.state.teamId !== teamId
+      ) {
+        throw new MigrationCorruptionError(
+          `control operation ${transitionOperationId}`,
+          "identity mismatch",
+        );
+      }
+      if (op.kind !== "begin") {
+        throw new MigrationOperationConflictError(transitionOperationId);
+      }
+      if (op.outcome === "completed") return op.state;
+      if (op.outcome === "cancelled") {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_TRANSITION_CANCELLED",
+          `transition ${transitionOperationId} was cancelled`,
+        );
+      }
+      const state = await this.readState(tn, teamId);
+      if (!state) throw new MigrationLegacyStateError(teamId);
+      if (
+        expectedRevision !== undefined &&
+        state.revision !== expectedRevision
+      ) {
+        throw new MigrationCasError(expectedRevision, state.revision);
+      }
+      if (state.transitionOperationId !== transitionOperationId) {
+        throw new MigrationOperationConflictError(transitionOperationId);
+      }
+      const source = await this.requireGeneration(
+        tn,
+        teamId,
+        state.activeGeneration,
+      );
+      const target = await this.requireGeneration(
+        tn,
+        teamId,
+        state.targetGeneration!,
+      );
+      if (
+        source.status !== "draining" ||
+        source.backend !== state.activeBackend ||
+        target.status !== "closed" ||
+        target.backend !== state.targetBackend
+      ) {
+        throw new MigrationCorruptionError(
+          `team ${teamId}`,
+          "transition generation state mismatch",
+        );
+      }
+      const sourceResidue = await this.readResidue(
+        tn,
+        teamId,
+        source.generation,
+      );
+      if (Object.values(sourceResidue).some(value => value !== 0)) {
+        throw new MigrationResidueNotEmptyError(
+          teamId,
+          source.generation,
+          sourceResidue,
+        );
+      }
+      const targetResidue = await this.readResidue(
+        tn,
+        teamId,
+        target.generation,
+      );
+      if (Object.values(targetResidue).some(value => value !== 0)) {
+        throw new MigrationCorruptionError(
+          `team ${teamId} generation ${target.generation}`,
+          "closed target has residue",
+        );
+      }
+      const closedSource: MigrationGeneration = {
+        ...source,
+        status: "closed",
+      };
+      const openTarget: MigrationGeneration = { ...target, status: "open" };
+      const next: MigrationTeamState = {
+        schemaVersion: 1,
+        teamId,
+        revision: nextRevision(state),
+        maxGeneration: state.maxGeneration,
+        activeBackend: target.backend,
+        activeGeneration: target.generation,
+        phase: stablePhase(target.backend),
+      };
+      const completedOp: ControlOperation = {
+        ...op,
+        outcome: "completed",
+        state: next,
+      };
+      tn.set(
+        this.generationKey(teamId, source.generation),
+        encodeJson(closedSource),
+      );
+      tn.set(
+        this.generationKey(teamId, target.generation),
+        encodeJson(openTarget),
+      );
+      tn.set(this.teamStateKey(teamId), encodeJson(next));
+      tn.set(opKey, encodeJson(completedOp));
+      return next;
+    });
+  }
+}
+
+export const nuqFdbMigrationStore = new NuqFdbMigrationStore();

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -995,8 +995,10 @@ export class NuqFdbMigrationStore {
    * Composes migration accounting with a queue/group/slot mutation. Teams that
    * have never entered the migration control plane remain untouched. Once a
    * team state exists, the durable object pin and the pin copied onto an
-   * existing runtime record are mandatory. Reading the generation and residue
-   * keys here gives finalSeal a conflict with every residue increase.
+   * existing runtime record are mandatory. Explicit legacy-backfill pins are
+   * the sole exception for records written before runtime pins existed.
+   * Reading the generation and residue keys here gives finalSeal a conflict
+   * with every residue increase.
    */
   public async reconcileManagedObjectInTxn(
     tn: Transaction,
@@ -1016,17 +1018,41 @@ export class NuqFdbMigrationStore {
       return null;
     }
     await this.validateTopology(tn, state);
-    if (!input.recordPin && !input.allowMissingRecordPin) {
+    let pin = await this.inspectPinInTxn(tn, kind, objectId);
+    let adoptedLegacyRecord = false;
+    if (!pin) {
+      // Callers set allowMissingRecordPin only while creating a new runtime
+      // record, which must already have a router-prepared intent. Mutations of
+      // an existing pre-protocol record may adopt the active source generation
+      // explicitly; this cannot reopen new-root admission while draining.
+      if (input.recordPin || input.allowMissingRecordPin) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_PIN_NOT_FOUND",
+          `${kind}/${objectId} has no durable pin`,
+        );
+      }
+      pin = await this.preparePinnedObjectInTxn(tn, {
+        teamId,
+        kind,
+        objectId,
+        admission: {
+          type: "legacy-backfill",
+          backend: "fdb",
+          generation: state.activeGeneration,
+        },
+        requiredBackend: "fdb",
+        residue: input.residue,
+      });
+      adoptedLegacyRecord = true;
+    }
+    if (
+      !input.recordPin &&
+      !input.allowMissingRecordPin &&
+      pin.admission !== "legacy-backfill"
+    ) {
       throw new MigrationStoreError(
         "NUQ_MIGRATION_RUNTIME_PIN_MISSING",
         `${kind}/${objectId} is missing its runtime generation pin`,
-      );
-    }
-    const pin = await this.inspectPinInTxn(tn, kind, objectId);
-    if (!pin) {
-      throw new MigrationStoreError(
-        "NUQ_MIGRATION_PIN_NOT_FOUND",
-        `${kind}/${objectId} has no durable pin`,
       );
     }
     if (
@@ -1074,7 +1100,7 @@ export class NuqFdbMigrationStore {
     const terminal = input.terminal === true;
     const targetLifecycle: MigrationObjectLifecycle = terminal
       ? "terminal"
-      : input.activateNonterminal === false
+      : input.activateNonterminal === false && !adoptedLegacyRecord
         ? pin.lifecycle
         : "active";
     if (pin.lifecycle === "terminal") {

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -1126,6 +1126,8 @@ export class NuqFdbMigrationStore {
       return null;
     }
     await this.validateTopology(tn, state);
+    const residue = normalizeResidue(input.residue);
+    const terminal = input.terminal === true;
     let pin = await this.inspectPinInTxn(tn, kind, objectId);
     let adoptedLegacyRecord = false;
     if (!pin) {
@@ -1139,6 +1141,9 @@ export class NuqFdbMigrationStore {
           `${kind}/${objectId} has no durable pin`,
         );
       }
+      const generation = terminal
+        ? await this.ensureTerminalLegacyGenerationInTxn(tn, state, "fdb")
+        : state.activeGeneration;
       pin = await this.preparePinnedObjectInTxn(tn, {
         teamId,
         kind,
@@ -1146,10 +1151,11 @@ export class NuqFdbMigrationStore {
         admission: {
           type: "legacy-backfill",
           backend: "fdb",
-          generation: state.activeGeneration,
+          generation,
+          terminal,
         },
         requiredBackend: "fdb",
-        residue: input.residue,
+        residue,
       });
       adoptedLegacyRecord = true;
     }
@@ -1176,9 +1182,15 @@ export class NuqFdbMigrationStore {
       );
     }
     const generation = await this.requireGeneration(tn, teamId, pin.generation);
+    const terminalIdempotent =
+      pin.lifecycle === "terminal" &&
+      terminal &&
+      Object.values(residue).every(value => value === 0);
     if (
       generation.backend !== pin.backend ||
-      (generation.status !== "open" && generation.status !== "draining")
+      (generation.status !== "open" &&
+        generation.status !== "draining" &&
+        !terminalIdempotent)
     ) {
       throw new MigrationStaleGenerationError(
         teamId,
@@ -1186,8 +1198,6 @@ export class NuqFdbMigrationStore {
         pin.generation,
       );
     }
-    const residue = normalizeResidue(input.residue);
-    const terminal = input.terminal === true;
     const targetLifecycle: MigrationObjectLifecycle = terminal
       ? "terminal"
       : input.activateNonterminal === false && !adoptedLegacyRecord
@@ -1242,12 +1252,15 @@ export class NuqFdbMigrationStore {
 
   public async validateManagedObjectInTxn(
     tn: Transaction,
-    input: Omit<ReconcileManagedObjectInput, "residue" | "terminal">,
+    input: Omit<ReconcileManagedObjectInput, "residue" | "terminal"> & {
+      legacyResidue?: Partial<MigrationResidue>;
+    },
   ): Promise<MigrationObjectPin | null> {
     const pin = await this.inspectPinInTxn(tn, input.kind, input.objectId);
+    const { legacyResidue, ...reconcileInput } = input;
     return await this.reconcileManagedObjectInTxn(tn, {
-      ...input,
-      residue: pin?.residue ?? {},
+      ...reconcileInput,
+      residue: pin?.residue ?? legacyResidue ?? {},
       activateNonterminal: false,
     });
   }
@@ -1355,6 +1368,69 @@ export class NuqFdbMigrationStore {
       tn.set(this.generationKey(teamId, 1), encodeJson(generation));
       tn.set(opKey, encodeJson(op));
       return state;
+    });
+  }
+
+  private async ensureTerminalLegacyGenerationInTxn(
+    tn: Transaction,
+    state: MigrationTeamState,
+    backend: MigrationBackend,
+  ): Promise<number> {
+    const { teamId } = state;
+    if (state.activeBackend === backend) return state.activeGeneration;
+    for (let candidate = state.maxGeneration; candidate >= 1; candidate--) {
+      const generation = await this.requireGeneration(tn, teamId, candidate);
+      if (generation.backend === backend) return candidate;
+    }
+    if (state.phase !== "PG_ONLY" && state.phase !== "FDB_ONLY") {
+      throw new MigrationInProgressError(teamId);
+    }
+    const generationNumber = state.maxGeneration + 1;
+    if (!Number.isSafeInteger(generationNumber)) {
+      throw new MigrationCorruptionError(
+        `team ${teamId}`,
+        "generation exhausted safe integer range",
+      );
+    }
+    if (await this.readGeneration(tn, teamId, generationNumber)) {
+      throw new MigrationCorruptionError(
+        `team ${teamId} generation ${generationNumber}`,
+        "generation was previously allocated beyond maxGeneration",
+      );
+    }
+    const generation: MigrationGeneration = {
+      schemaVersion: 1,
+      teamId,
+      backend,
+      generation: generationNumber,
+      status: "closed",
+    };
+    const next: MigrationTeamState = {
+      ...state,
+      revision: nextRevision(state),
+      maxGeneration: generationNumber,
+    };
+    tn.set(
+      this.generationKey(teamId, generationNumber),
+      encodeJson(generation),
+    );
+    tn.set(this.teamStateKey(teamId), encodeJson(next));
+    return generationNumber;
+  }
+
+  /** Allocates at most one closed historical generation for terminal runtime
+   * records discovered after authority initialization. It never changes the
+   * active backend and is idempotent across commit-unknown retries. */
+  public async ensureTerminalLegacyGeneration(
+    teamId: string,
+    backend: MigrationBackend,
+  ): Promise<number> {
+    assertNonempty(teamId, "teamId");
+    return await this.db.doTn(async tn => {
+      const state = await this.readState(tn, teamId);
+      if (!state) throw new MigrationLegacyStateError(teamId);
+      await this.validateTopology(tn, state);
+      return await this.ensureTerminalLegacyGenerationInTxn(tn, state, backend);
     });
   }
 

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "crypto";
-import type { Transaction } from "foundationdb";
+import type {
+  Transaction,
+  TransactionOptionCode as FdbTransactionOptionCode,
+} from "foundationdb";
 import { getFdb, getNuqFdbDatabase } from "./client";
 import { encodeI64 } from "./keyspace";
 
@@ -101,11 +104,44 @@ export const MIGRATION_GC_PAGE_LIMIT = 100;
 // collected while a surviving hint is still expected to route callers.
 export const MIGRATION_GC_MIN_RETENTION_MS = 45 * 24 * 60 * 60 * 1000;
 export const MIGRATION_GC_RECHECK_MS = 60 * 60 * 1000;
+const MIGRATION_GC_LEASE_MS = 30_000;
+const MIGRATION_GC_TRANSACTION_TIMEOUT_MS = 10_000;
+const TransactionOptionCode = {
+  Timeout: 500 as FdbTransactionOptionCode,
+};
+
+async function withGcDeadline<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal?.aborted) throw signal.reason ?? new Error("GC aborted");
+  let timer: NodeJS.Timeout | undefined;
+  let abort: (() => void) | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("GC authority operation timed out")),
+      MIGRATION_GC_TRANSACTION_TIMEOUT_MS,
+    );
+    if (signal) {
+      abort = () => reject(signal.reason ?? new Error("GC aborted"));
+      signal.addEventListener("abort", abort, { once: true });
+    }
+  });
+  try {
+    return await Promise.race([operation, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (signal && abort) signal.removeEventListener("abort", abort);
+  }
+}
 
 export type MigrationGcAuthority = {
   /** Must use only bounded point reads. This is run before the FDB CAS for PG
    * objects, and must return true whenever the canonical PG object may live. */
-  pgObjectExists(pin: MigrationObjectPin): Promise<boolean>;
+  pgObjectExists(
+    pin: MigrationObjectPin,
+    signal?: AbortSignal,
+  ): Promise<boolean>;
   /** Conflict-safe FDB point reads for runtime rows, task rows, durable PG
    * holder intents and deletion intents. */
   fdbReferenceExistsInTxn(
@@ -897,26 +933,35 @@ export class NuqFdbMigrationStore {
     }
   }
 
-  private setGcIndexInTxn(
+  private async setGcIndexInTxn(
     tn: Transaction,
     category: MigrationGcCategory,
     partition: number,
     dueAt: number,
     key: Buffer,
-  ): void {
+  ): Promise<boolean> {
+    // This must be a normal read. Besides making the counter conditional, its
+    // conflict range makes a commit-unknown closure replay and overlapping GC
+    // workers converge on exactly one increment.
+    if ((await tn.get(key)) !== undefined) return false;
     tn.set(key, Buffer.alloc(0));
     this.mutateGcDueCountInTxn(tn, category, partition, dueAt, 1);
+    return true;
   }
 
-  private clearGcIndexInTxn(
+  private async clearGcIndexInTxn(
     tn: Transaction,
     category: MigrationGcCategory,
     partition: number,
     dueAt: number,
     key: Buffer,
-  ): void {
+  ): Promise<boolean> {
+    // Never decrement from a scan result alone: it may have been consumed by a
+    // committed transaction whose result was lost, or by an expired owner.
+    if ((await tn.get(key)) === undefined) return false;
     tn.clear(key);
     this.mutateGcDueCountInTxn(tn, category, partition, dueAt, -1);
+    return true;
   }
 
   private controlOperationKey(teamId: string, operationId: string): Buffer {
@@ -1024,11 +1069,11 @@ export class NuqFdbMigrationStore {
     ]);
   }
 
-  private writeGenerationInTxn(
+  private async writeGenerationInTxn(
     tn: Transaction,
     previous: MigrationGeneration | null,
     generation: MigrationGeneration,
-  ): void {
+  ): Promise<void> {
     tn.set(
       this.generationKey(generation.teamId, generation.generation),
       encodeJson(generation),
@@ -1047,7 +1092,7 @@ export class NuqFdbMigrationStore {
     );
     if (previousIndexed && !sameIndex) {
       const dueAt = previous.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
-      this.clearGcIndexInTxn(
+      await this.clearGcIndexInTxn(
         tn,
         "generation",
         partition,
@@ -1057,7 +1102,7 @@ export class NuqFdbMigrationStore {
     }
     if (nextIndexed && !sameIndex) {
       const dueAt = generation.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
-      this.setGcIndexInTxn(
+      await this.setGcIndexInTxn(
         tn,
         "generation",
         partition,
@@ -1076,12 +1121,12 @@ export class NuqFdbMigrationStore {
     ];
   }
 
-  private writeControlOperationInTxn(
+  private async writeControlOperationInTxn(
     tn: Transaction,
     teamId: string,
     previous: ControlOperation | null,
     operation: ControlOperation,
-  ): void {
+  ): Promise<void> {
     const previousIndexed = previous?.terminalAt !== undefined;
     const nextIndexed = operation.terminalAt !== undefined;
     const sameIndex =
@@ -1104,7 +1149,7 @@ export class NuqFdbMigrationStore {
       }
       if (previousIndexed && !sameIndex) {
         const dueAt = previous.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
-        this.clearGcIndexInTxn(
+        await this.clearGcIndexInTxn(
           tn,
           "control",
           partition,
@@ -1125,7 +1170,7 @@ export class NuqFdbMigrationStore {
     }
     if (nextIndexed && !sameIndex) {
       const dueAt = operation.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
-      this.setGcIndexInTxn(
+      await this.setGcIndexInTxn(
         tn,
         "control",
         partition,
@@ -1135,11 +1180,11 @@ export class NuqFdbMigrationStore {
     }
   }
 
-  private writePinInTxn(
+  private async writePinInTxn(
     tn: Transaction,
     previous: MigrationObjectPin | null,
     pin: MigrationObjectPin,
-  ): void {
+  ): Promise<void> {
     const encoded = encodeJson(pin);
     tn.set(this.objectKey(pin.kind, pin.objectId), encoded);
     tn.set(this.generationObjectKey(pin), Buffer.alloc(0));
@@ -1161,7 +1206,7 @@ export class NuqFdbMigrationStore {
     }
     if (previousIndexed && !sameIndex) {
       const dueAt = previous.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
-      this.clearGcIndexInTxn(
+      await this.clearGcIndexInTxn(
         tn,
         "pin",
         partition,
@@ -1171,7 +1216,7 @@ export class NuqFdbMigrationStore {
     }
     if (nextIndexed && !sameIndex) {
       const dueAt = pin.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
-      this.setGcIndexInTxn(
+      await this.setGcIndexInTxn(
         tn,
         "pin",
         partition,
@@ -1792,7 +1837,7 @@ export class NuqFdbMigrationStore {
         ? { terminalAt: Date.now(), terminalVersion: revision }
         : {}),
     };
-    this.writePinInTxn(tn, pin, next);
+    await this.writePinInTxn(tn, pin, next);
     return next;
   }
 
@@ -1915,8 +1960,8 @@ export class NuqFdbMigrationStore {
         terminalVersion: state.revision,
       };
       tn.set(this.teamStateKey(teamId), encodeJson(state));
-      this.writeGenerationInTxn(tn, null, generation);
-      this.writeControlOperationInTxn(tn, teamId, null, op);
+      await this.writeGenerationInTxn(tn, null, generation);
+      await this.writeControlOperationInTxn(tn, teamId, null, op);
       return state;
     });
   }
@@ -1963,7 +2008,7 @@ export class NuqFdbMigrationStore {
       revision: nextRevision(state),
       maxGeneration: generationNumber,
     };
-    this.writeGenerationInTxn(tn, null, generation);
+    await this.writeGenerationInTxn(tn, null, generation);
     tn.set(this.teamStateKey(teamId), encodeJson(next));
     return generationNumber;
   }
@@ -2036,7 +2081,7 @@ export class NuqFdbMigrationStore {
           terminalAt: Date.now(),
           terminalVersion: state.revision,
         };
-        this.writeControlOperationInTxn(tn, teamId, null, op);
+        await this.writeControlOperationInTxn(tn, teamId, null, op);
         return state;
       }
 
@@ -2098,10 +2143,10 @@ export class NuqFdbMigrationStore {
         outcome: "pending",
         state: next,
       };
-      this.writeGenerationInTxn(tn, source, drainingSource);
-      this.writeGenerationInTxn(tn, null, target);
+      await this.writeGenerationInTxn(tn, source, drainingSource);
+      await this.writeGenerationInTxn(tn, null, target);
       tn.set(this.teamStateKey(teamId), encodeJson(next));
-      this.writeControlOperationInTxn(tn, teamId, null, op);
+      await this.writeControlOperationInTxn(tn, teamId, null, op);
       return next;
     });
   }
@@ -2203,9 +2248,9 @@ export class NuqFdbMigrationStore {
         terminalAt: Date.now(),
         terminalVersion: next.revision,
       };
-      this.writeGenerationInTxn(tn, source, reopened);
+      await this.writeGenerationInTxn(tn, source, reopened);
       tn.set(this.teamStateKey(teamId), encodeJson(next));
-      this.writeControlOperationInTxn(tn, teamId, op, cancelledOp);
+      await this.writeControlOperationInTxn(tn, teamId, op, cancelledOp);
       return next;
     });
   }
@@ -2400,7 +2445,7 @@ export class NuqFdbMigrationStore {
       normalizeResidue(undefined),
       initialResidue,
     );
-    this.writePinInTxn(tn, null, pin);
+    await this.writePinInTxn(tn, null, pin);
     return pin;
   }
 
@@ -2528,7 +2573,7 @@ export class NuqFdbMigrationStore {
             resultRevision: legacyOperation.result.revision,
           },
         };
-        this.writePinInTxn(tn, pin, migratedPin);
+        await this.writePinInTxn(tn, pin, migratedPin);
         tn.clear(legacyOperationKey);
       }
       return legacyOperation.result;
@@ -2591,7 +2636,7 @@ export class NuqFdbMigrationStore {
         resultRevision: revision,
       },
     };
-    this.writePinInTxn(tn, pin, next);
+    await this.writePinInTxn(tn, pin, next);
     return next;
   }
 
@@ -2660,6 +2705,7 @@ export class NuqFdbMigrationStore {
    * and oldest timestamps use one limit-1 read from each of 32 partitions. */
   public async inspectGcBacklog(
     now = Date.now(),
+    signal?: AbortSignal,
   ): Promise<Record<MigrationGcCategory, MigrationGcBacklog>> {
     if (!isNonnegativeInteger(now)) {
       throw new MigrationStoreError(
@@ -2667,8 +2713,11 @@ export class NuqFdbMigrationStore {
         "GC observation time must be a nonnegative safe integer",
       );
     }
+    if (signal?.aborted) throw signal.reason ?? new Error("GC aborted");
     const categories: MigrationGcCategory[] = ["pin", "control", "generation"];
     return await this.db.doTn(async tn => {
+      this.configureGcTransaction(tn);
+      if (signal?.aborted) throw signal.reason ?? new Error("GC aborted");
       const snapshots = await Promise.all(
         categories.map(async category => {
           const partitions = await Promise.all(
@@ -2741,6 +2790,13 @@ export class NuqFdbMigrationStore {
     });
   }
 
+  private configureGcTransaction(tn: Transaction): void {
+    tn.setOption(
+      TransactionOptionCode.Timeout,
+      MIGRATION_GC_TRANSACTION_TIMEOUT_MS,
+    );
+  }
+
   private async claimGcPartition(
     category: string,
     now: number,
@@ -2748,6 +2804,7 @@ export class NuqFdbMigrationStore {
     for (let attempt = 0; attempt < MIGRATION_GC_PARTITIONS; attempt++) {
       const token = randomUUID();
       const claim = await this.db.doTn(async tn => {
+        this.configureGcTransaction(tn);
         const cursorKey = this.gcCursorKey(category);
         const cursor = Number(
           parseJson(await tn.get(cursorKey), `GC ${category} cursor`) ?? 0,
@@ -2783,12 +2840,65 @@ export class NuqFdbMigrationStore {
           );
         }
         if (lease && (lease.expiresAt as number) > now) return null;
-        tn.set(leaseKey, encodeJson({ token, expiresAt: now + 5 * 60 * 1000 }));
+        tn.set(
+          leaseKey,
+          encodeJson({ token, expiresAt: now + MIGRATION_GC_LEASE_MS }),
+        );
         return { partition, token };
       });
       if (claim) return claim;
     }
     return null;
+  }
+
+  private async assertGcLeaseInTxn(
+    tn: Transaction,
+    category: string,
+    partition: number,
+    token: string,
+    now: number,
+  ): Promise<void> {
+    const lease = parseJson(
+      await tn.get(this.gcLeaseKey(category, partition)),
+      `GC ${category} lease`,
+    ) as { token?: unknown; expiresAt?: unknown } | null;
+    if (
+      lease?.token !== token ||
+      !isNonnegativeInteger(lease.expiresAt) ||
+      (lease.expiresAt as number) <= now
+    ) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_GC_LEASE_LOST",
+        `GC ${category} partition ${partition} lease lost`,
+      );
+    }
+  }
+
+  private async renewGcPartition(
+    category: string,
+    partition: number,
+    token: string,
+    now: number,
+  ): Promise<boolean> {
+    return await this.db.doTn(async tn => {
+      this.configureGcTransaction(tn);
+      try {
+        await this.assertGcLeaseInTxn(tn, category, partition, token, now);
+      } catch (error) {
+        if (
+          error instanceof MigrationStoreError &&
+          error.code === "NUQ_MIGRATION_GC_LEASE_LOST"
+        ) {
+          return false;
+        }
+        throw error;
+      }
+      tn.set(
+        this.gcLeaseKey(category, partition),
+        encodeJson({ token, expiresAt: now + MIGRATION_GC_LEASE_MS }),
+      );
+      return true;
+    });
   }
 
   private async releaseGcPartition(
@@ -2797,6 +2907,7 @@ export class NuqFdbMigrationStore {
     token: string,
   ): Promise<void> {
     await this.db.doTn(async tn => {
+      this.configureGcTransaction(tn);
       const key = this.gcLeaseKey(category, partition);
       const lease = parseJson(await tn.get(key), `GC ${category} lease`) as {
         token?: unknown;
@@ -2847,12 +2958,33 @@ export class NuqFdbMigrationStore {
     };
     try {
       const range = this.terminalPinGcRange(claim.partition, now + 1);
-      const rows = (await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
-      )) as [Buffer, Buffer][];
+      const rows = (await this.db.doTn(async tn => {
+        this.configureGcTransaction(tn);
+        await this.assertGcLeaseInTxn(
+          tn,
+          "pin",
+          claim.partition,
+          claim.token,
+          Date.now(),
+        );
+        return await tn.snapshot().getRangeAll(range.begin, range.end, {
+          limit,
+        });
+      })) as [Buffer, Buffer][];
       result.hasMore = rows.length === limit;
       for (const [indexKey] of rows) {
         if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
+        if (
+          !(await this.renewGcPartition(
+            "pin",
+            claim.partition,
+            claim.token,
+            Date.now(),
+          ))
+        ) {
           result.hasMore = true;
           break;
         }
@@ -2884,6 +3016,14 @@ export class NuqFdbMigrationStore {
           observed.terminalAt === terminalAt;
         if (!matches) {
           const cleared = await this.db.doTn(async tn => {
+            this.configureGcTransaction(tn);
+            await this.assertGcLeaseInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              claim.token,
+              Date.now(),
+            );
             const current = await this.inspectPinInTxn(tn, kind, objectId);
             if (
               current?.lifecycle === "terminal" &&
@@ -2895,8 +3035,13 @@ export class NuqFdbMigrationStore {
             }
             // The canonical read conflicts with a concurrent replacement before
             // this index/accounting pair is cleared.
-            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
-            return true;
+            return await this.clearGcIndexInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
           });
           if (cleared) result.stale++;
           else result.retained++;
@@ -2905,9 +3050,24 @@ export class NuqFdbMigrationStore {
 
         const pgExists =
           observed.backend === "pg"
-            ? await authority.pgObjectExists(observed)
+            ? await withGcDeadline(
+                authority.pgObjectExists(observed, options.signal),
+                options.signal,
+              )
             : false;
+        if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
         const outcome = await this.db.doTn(async tn => {
+          this.configureGcTransaction(tn);
+          await this.assertGcLeaseInTxn(
+            tn,
+            "pin",
+            claim.partition,
+            claim.token,
+            Date.now(),
+          );
           const current = await this.inspectPinInTxn(tn, kind, objectId);
           if (
             !current ||
@@ -2916,7 +3076,13 @@ export class NuqFdbMigrationStore {
             current.terminalVersion !== terminalVersion ||
             current.terminalAt !== terminalAt
           ) {
-            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
+            await this.clearGcIndexInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
             return "stale" as const;
           }
           const teamIndex = await tn.get(
@@ -2942,8 +3108,14 @@ export class NuqFdbMigrationStore {
             teamIndex ||
             Object.values(current.residue).some(value => value !== 0)
           ) {
-            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
-            this.setGcIndexInTxn(
+            await this.clearGcIndexInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
+            await this.setGcIndexInTxn(
               tn,
               "pin",
               claim.partition,
@@ -2959,8 +3131,14 @@ export class NuqFdbMigrationStore {
             tn.clear(operationKey as Buffer);
           }
           if (operationRows.length === MIGRATION_GC_PAGE_LIMIT) {
-            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
-            this.setGcIndexInTxn(
+            await this.clearGcIndexInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
+            await this.setGcIndexInTxn(
               tn,
               "pin",
               claim.partition,
@@ -2971,7 +3149,13 @@ export class NuqFdbMigrationStore {
           }
           tn.clear(this.objectKey(kind, objectId));
           tn.clear(this.generationObjectKey(current));
-          this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
+          await this.clearGcIndexInTxn(
+            tn,
+            "pin",
+            claim.partition,
+            dueAt,
+            indexKey,
+          );
           return "removed" as const;
         });
         result[outcome]++;
@@ -3017,12 +3201,33 @@ export class NuqFdbMigrationStore {
     };
     try {
       const range = this.gcRange("control", claim.partition, now + 1);
-      const rows = (await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
-      )) as [Buffer, Buffer][];
+      const rows = (await this.db.doTn(async tn => {
+        this.configureGcTransaction(tn);
+        await this.assertGcLeaseInTxn(
+          tn,
+          "control",
+          claim.partition,
+          claim.token,
+          Date.now(),
+        );
+        return await tn.snapshot().getRangeAll(range.begin, range.end, {
+          limit,
+        });
+      })) as [Buffer, Buffer][];
       result.hasMore = rows.length === limit;
       for (const [indexKey] of rows) {
         if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
+        if (
+          !(await this.renewGcPartition(
+            "control",
+            claim.partition,
+            claim.token,
+            Date.now(),
+          ))
+        ) {
           result.hasMore = true;
           break;
         }
@@ -3046,11 +3251,19 @@ export class NuqFdbMigrationStore {
           );
         }
         const outcome = await this.db.doTn(async tn => {
+          this.configureGcTransaction(tn);
+          await this.assertGcLeaseInTxn(
+            tn,
+            "control",
+            claim.partition,
+            claim.token,
+            Date.now(),
+          );
           const raw = await tn.get(
             this.controlOperationKey(teamId, operationId),
           );
           if (!raw) {
-            this.clearGcIndexInTxn(
+            await this.clearGcIndexInTxn(
               tn,
               "control",
               claim.partition,
@@ -3068,7 +3281,7 @@ export class NuqFdbMigrationStore {
             operation.terminalAt !== terminalAt ||
             operation.outcome === "pending"
           ) {
-            this.clearGcIndexInTxn(
+            await this.clearGcIndexInTxn(
               tn,
               "control",
               claim.partition,
@@ -3079,14 +3292,14 @@ export class NuqFdbMigrationStore {
           }
           const state = await this.readState(tn, teamId);
           if (state?.transitionOperationId === operationId) {
-            this.clearGcIndexInTxn(
+            await this.clearGcIndexInTxn(
               tn,
               "control",
               claim.partition,
               dueAt,
               indexKey,
             );
-            this.setGcIndexInTxn(
+            await this.setGcIndexInTxn(
               tn,
               "control",
               claim.partition,
@@ -3103,7 +3316,7 @@ export class NuqFdbMigrationStore {
               this.controlGenerationRefKey(teamId, generation, operationId),
             );
           }
-          this.clearGcIndexInTxn(
+          await this.clearGcIndexInTxn(
             tn,
             "control",
             claim.partition,
@@ -3155,12 +3368,33 @@ export class NuqFdbMigrationStore {
     };
     try {
       const range = this.gcRange("generation", claim.partition, now + 1);
-      const rows = (await this.db.doTn(async tn =>
-        tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
-      )) as [Buffer, Buffer][];
+      const rows = (await this.db.doTn(async tn => {
+        this.configureGcTransaction(tn);
+        await this.assertGcLeaseInTxn(
+          tn,
+          "generation",
+          claim.partition,
+          claim.token,
+          Date.now(),
+        );
+        return await tn.snapshot().getRangeAll(range.begin, range.end, {
+          limit,
+        });
+      })) as [Buffer, Buffer][];
       result.hasMore = rows.length === limit;
       for (const [indexKey] of rows) {
         if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
+        if (
+          !(await this.renewGcPartition(
+            "generation",
+            claim.partition,
+            claim.token,
+            Date.now(),
+          ))
+        ) {
           result.hasMore = true;
           break;
         }
@@ -3184,6 +3418,14 @@ export class NuqFdbMigrationStore {
           );
         }
         const outcome = await this.db.doTn(async tn => {
+          this.configureGcTransaction(tn);
+          await this.assertGcLeaseInTxn(
+            tn,
+            "generation",
+            claim.partition,
+            claim.token,
+            Date.now(),
+          );
           const generation = await this.readGeneration(
             tn,
             teamId,
@@ -3196,7 +3438,7 @@ export class NuqFdbMigrationStore {
             generation.terminalVersion !== version ||
             generation.terminalAt !== terminalAt
           ) {
-            this.clearGcIndexInTxn(
+            await this.clearGcIndexInTxn(
               tn,
               "generation",
               claim.partition,
@@ -3238,14 +3480,14 @@ export class NuqFdbMigrationStore {
             objects.length > 0 ||
             controls.length > 0
           ) {
-            this.clearGcIndexInTxn(
+            await this.clearGcIndexInTxn(
               tn,
               "generation",
               claim.partition,
               dueAt,
               indexKey,
             );
-            this.setGcIndexInTxn(
+            await this.setGcIndexInTxn(
               tn,
               "generation",
               claim.partition,
@@ -3258,7 +3500,7 @@ export class NuqFdbMigrationStore {
           for (const counter of MIGRATION_RESIDUE_COUNTERS) {
             tn.clear(this.residueKey(teamId, generationNumber, counter));
           }
-          this.clearGcIndexInTxn(
+          await this.clearGcIndexInTxn(
             tn,
             "generation",
             claim.partition,
@@ -3397,10 +3639,10 @@ export class NuqFdbMigrationStore {
         terminalAt: Date.now(),
         terminalVersion: next.revision,
       };
-      this.writeGenerationInTxn(tn, source, closedSource);
-      this.writeGenerationInTxn(tn, target, openTarget);
+      await this.writeGenerationInTxn(tn, source, closedSource);
+      await this.writeGenerationInTxn(tn, target, openTarget);
       tn.set(this.teamStateKey(teamId), encodeJson(next));
-      this.writeControlOperationInTxn(tn, teamId, op, completedOp);
+      await this.writeControlOperationInTxn(tn, teamId, op, completedOp);
       return next;
     });
   }

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -57,6 +57,15 @@ export type MigrationTeamState = {
   transitionOperationId?: string;
 };
 
+export type MigrationObjectLastOperation = {
+  schemaVersion: 1;
+  operationId: string;
+  fromLifecycle: MigrationObjectLifecycle;
+  toLifecycle: MigrationObjectLifecycle;
+  residue: MigrationResidue;
+  resultRevision: number;
+};
+
 export type MigrationObjectPin = {
   schemaVersion: 1;
   teamId: string;
@@ -71,6 +80,9 @@ export type MigrationObjectPin = {
   sourceObjectId?: string;
   initialResidue: MigrationResidue;
   residue: MigrationResidue;
+  /** Single bounded commit-unknown reconciliation token. A later mutation
+   * supersedes it; no per-transition ledger rows are accumulated. */
+  lastOperation?: MigrationObjectLastOperation;
 };
 
 export type MigrationPinAdmission =
@@ -433,7 +445,59 @@ function validatePin(value: unknown, record: string): MigrationObjectPin {
     `${record}.initialResidue`,
   );
   const residue = validateStoredResidue(pin.residue, `${record}.residue`);
-  return { ...(pin as MigrationObjectPin), initialResidue, residue };
+  let lastOperation: MigrationObjectLastOperation | undefined;
+  if (pin.lastOperation !== undefined) {
+    if (
+      !pin.lastOperation ||
+      typeof pin.lastOperation !== "object" ||
+      Array.isArray(pin.lastOperation)
+    ) {
+      throw new MigrationCorruptionError(record, "invalid last operation");
+    }
+    const operation = pin.lastOperation as Record<string, unknown>;
+    if (
+      operation.schemaVersion !== 1 ||
+      typeof operation.operationId !== "string" ||
+      operation.operationId.length === 0 ||
+      !OBJECT_LIFECYCLES.includes(
+        operation.fromLifecycle as MigrationObjectLifecycle,
+      ) ||
+      !OBJECT_LIFECYCLES.includes(
+        operation.toLifecycle as MigrationObjectLifecycle,
+      ) ||
+      !isPositiveInteger(operation.resultRevision)
+    ) {
+      throw new MigrationCorruptionError(
+        record,
+        "invalid last operation fields",
+      );
+    }
+    const operationResidue = validateStoredResidue(
+      operation.residue,
+      `${record}.lastOperation.residue`,
+    );
+    if (
+      operation.resultRevision > (pin.revision as number) ||
+      (operation.resultRevision === pin.revision &&
+        (operation.toLifecycle !== pin.lifecycle ||
+          !residueEqual(operationResidue, residue)))
+    ) {
+      throw new MigrationCorruptionError(
+        record,
+        "last operation does not describe this pin revision history",
+      );
+    }
+    lastOperation = {
+      ...(operation as MigrationObjectLastOperation),
+      residue: operationResidue,
+    };
+  }
+  return {
+    ...(pin as MigrationObjectPin),
+    initialResidue,
+    residue,
+    ...(lastOperation ? { lastOperation } : {}),
+  };
 }
 
 function decodeCounter(
@@ -486,7 +550,10 @@ type ControlOperation = {
   state: MigrationTeamState;
 };
 
-type ObjectOperation = {
+// Read-only compatibility with operation rows produced by the prototype before
+// pins carried their one bounded reconciliation token. New code never creates
+// these rows and migrates one into the pin when it is replayed safely.
+type LegacyObjectOperation = {
   schemaVersion: 1;
   operationId: string;
   teamId: string;
@@ -547,10 +614,10 @@ function validateControlOperation(
   return decoded;
 }
 
-function validateObjectOperation(
+function validateLegacyObjectOperation(
   value: unknown,
   record: string,
-): ObjectOperation {
+): LegacyObjectOperation {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new MigrationCorruptionError(record, "invalid object operation");
   }
@@ -570,7 +637,7 @@ function validateObjectOperation(
     );
   }
   const decoded = {
-    ...(op as ObjectOperation),
+    ...(op as LegacyObjectOperation),
     residue: validateStoredResidue(op.residue, `${record}.residue`),
     result: validatePin(op.result, `${record}.result`),
   };
@@ -629,7 +696,7 @@ export class NuqFdbMigrationStore {
     return this.pack(["team", teamId, "control-operation", operationId]);
   }
 
-  private objectOperationKey(
+  private legacyObjectOperationKey(
     teamId: string,
     kind: MigrationObjectKind,
     objectId: string,
@@ -1605,31 +1672,6 @@ export class NuqFdbMigrationStore {
     assertNonempty(objectId, "objectId");
     assertNonempty(operationId, "operationId");
     const residue = normalizeResidue(input.residue);
-    const operationKey = this.objectOperationKey(
-      teamId,
-      kind,
-      objectId,
-      operationId,
-    );
-    const rawOperation = await tn.get(operationKey);
-    if (rawOperation) {
-      const op = validateObjectOperation(
-        parseJson(rawOperation, `object operation ${operationId}`),
-        `object operation ${operationId}`,
-      );
-      if (
-        op.operationId !== operationId ||
-        op.teamId !== teamId ||
-        op.kind !== kind ||
-        op.objectId !== objectId ||
-        op.fromLifecycle !== fromLifecycle ||
-        op.toLifecycle !== toLifecycle ||
-        !residueEqual(op.residue, residue)
-      ) {
-        throw new MigrationOperationConflictError(operationId);
-      }
-      return op.result;
-    }
     const key = this.objectKey(kind, objectId);
     const record = `object ${kind}/${objectId}`;
     const rawPin = await tn.get(key);
@@ -1646,6 +1688,110 @@ export class NuqFdbMigrationStore {
       pin.objectId !== objectId
     ) {
       throw new MigrationCorruptionError(record, "identity mismatch");
+    }
+    if (pin.lastOperation?.operationId === operationId) {
+      if (
+        pin.lastOperation.fromLifecycle !== fromLifecycle ||
+        pin.lastOperation.toLifecycle !== toLifecycle ||
+        !residueEqual(pin.lastOperation.residue, residue)
+      ) {
+        throw new MigrationOperationConflictError(operationId);
+      }
+      const replayIndexRaw = await tn.get(
+        this.teamObjectKey(teamId, kind, objectId),
+      );
+      if (!replayIndexRaw) {
+        throw new MigrationCorruptionError(record, "missing team pin index");
+      }
+      const replayIndex = validatePin(
+        parseJson(replayIndexRaw, `${record} team index`),
+        `${record} team index`,
+      );
+      if (JSON.stringify(replayIndex) !== JSON.stringify(pin)) {
+        throw new MigrationCorruptionError(record, "team pin index mismatch");
+      }
+      return {
+        ...pin,
+        lifecycle: pin.lastOperation.toLifecycle,
+        revision: pin.lastOperation.resultRevision,
+        residue: pin.lastOperation.residue,
+      };
+    }
+
+    const legacyOperationKey = this.legacyObjectOperationKey(
+      teamId,
+      kind,
+      objectId,
+      operationId,
+    );
+    const legacyOperationRaw = await tn.get(legacyOperationKey);
+    if (legacyOperationRaw) {
+      const legacyOperation = validateLegacyObjectOperation(
+        parseJson(legacyOperationRaw, `legacy object operation ${operationId}`),
+        `legacy object operation ${operationId}`,
+      );
+      if (
+        legacyOperation.operationId !== operationId ||
+        legacyOperation.teamId !== teamId ||
+        legacyOperation.kind !== kind ||
+        legacyOperation.objectId !== objectId ||
+        legacyOperation.fromLifecycle !== fromLifecycle ||
+        legacyOperation.toLifecycle !== toLifecycle ||
+        !residueEqual(legacyOperation.residue, residue)
+      ) {
+        throw new MigrationOperationConflictError(operationId);
+      }
+      if (
+        legacyOperation.result.backend !== pin.backend ||
+        legacyOperation.result.generation !== pin.generation ||
+        legacyOperation.result.admission !== pin.admission ||
+        legacyOperation.result.sourceKind !== pin.sourceKind ||
+        legacyOperation.result.sourceObjectId !== pin.sourceObjectId ||
+        !residueEqual(
+          legacyOperation.result.initialResidue,
+          pin.initialResidue,
+        ) ||
+        legacyOperation.result.revision > pin.revision ||
+        (legacyOperation.result.revision === pin.revision &&
+          (legacyOperation.result.lifecycle !== pin.lifecycle ||
+            !residueEqual(legacyOperation.result.residue, pin.residue)))
+      ) {
+        throw new MigrationCorruptionError(
+          record,
+          "legacy operation does not describe this pin revision history",
+        );
+      }
+      const legacyIndexRaw = await tn.get(
+        this.teamObjectKey(teamId, kind, objectId),
+      );
+      if (!legacyIndexRaw) {
+        throw new MigrationCorruptionError(record, "missing team pin index");
+      }
+      const legacyIndex = validatePin(
+        parseJson(legacyIndexRaw, `${record} team index`),
+        `${record} team index`,
+      );
+      if (JSON.stringify(legacyIndex) !== JSON.stringify(pin)) {
+        throw new MigrationCorruptionError(record, "team pin index mismatch");
+      }
+      if (!pin.lastOperation) {
+        const migratedPin: MigrationObjectPin = {
+          ...pin,
+          lastOperation: {
+            schemaVersion: 1,
+            operationId,
+            fromLifecycle,
+            toLifecycle,
+            residue,
+            resultRevision: legacyOperation.result.revision,
+          },
+        };
+        const migratedEncoded = encodeJson(migratedPin);
+        tn.set(key, migratedEncoded);
+        tn.set(this.teamObjectKey(teamId, kind, objectId), migratedEncoded);
+        tn.clear(legacyOperationKey);
+      }
+      return legacyOperation.result;
     }
     if (pin.lifecycle !== fromLifecycle) {
       throw new MigrationStoreError(
@@ -1700,22 +1846,18 @@ export class NuqFdbMigrationStore {
       lifecycle: toLifecycle,
       revision,
       residue,
+      lastOperation: {
+        schemaVersion: 1,
+        operationId,
+        fromLifecycle,
+        toLifecycle,
+        residue,
+        resultRevision: revision,
+      },
     };
     const encoded = encodeJson(next);
     tn.set(key, encoded);
     tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
-    const op: ObjectOperation = {
-      schemaVersion: 1,
-      operationId,
-      teamId,
-      kind,
-      objectId,
-      fromLifecycle,
-      toLifecycle,
-      residue,
-      result: next,
-    };
-    tn.set(operationKey, encodeJson(op));
     return next;
   }
 

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -114,12 +114,21 @@ export type MigrationGcAuthority = {
   ): Promise<boolean>;
 };
 
+export type MigrationGcCategory = "pin" | "control" | "generation";
+
+export type MigrationGcBacklog = {
+  due: number;
+  oldestDueAt: number | null;
+  oldestOverdueMs: number;
+};
+
 export type MigrationGcSweepResult = {
   partition: number;
   read: number;
   removed: number;
   retained: number;
   stale: number;
+  hasMore: boolean;
 };
 
 export type MigrationPinAdmission =
@@ -855,6 +864,61 @@ export class NuqFdbMigrationStore {
     return this.pack(["gc", "lease", category, partition]);
   }
 
+  // A Fenwick tree over the safe-integer timestamp domain makes exact due
+  // counts a bounded set of point reads. Each GC index mutation updates at
+  // most 53 partition-local counters in the same transaction; collection never
+  // scans a global index or an unbounded due range.
+  private gcDueCountKey(
+    category: MigrationGcCategory,
+    partition: number,
+    node: bigint,
+  ): Buffer {
+    return this.pack(["gc", "due-count", category, partition, node.toString()]);
+  }
+
+  private mutateGcDueCountInTxn(
+    tn: Transaction,
+    category: MigrationGcCategory,
+    partition: number,
+    dueAt: number,
+    delta: 1 | -1,
+  ): void {
+    if (!isNonnegativeInteger(dueAt)) {
+      throw new MigrationCorruptionError(
+        `GC ${category} index`,
+        "invalid due timestamp",
+      );
+    }
+    const upper = 1n << 53n;
+    let node = BigInt(dueAt) + 1n;
+    while (node <= upper) {
+      tn.add(this.gcDueCountKey(category, partition, node), encodeI64(delta));
+      node += node & -node;
+    }
+  }
+
+  private setGcIndexInTxn(
+    tn: Transaction,
+    category: MigrationGcCategory,
+    partition: number,
+    dueAt: number,
+    key: Buffer,
+  ): void {
+    tn.set(key, Buffer.alloc(0));
+    this.mutateGcDueCountInTxn(tn, category, partition, dueAt, 1);
+  }
+
+  private clearGcIndexInTxn(
+    tn: Transaction,
+    category: MigrationGcCategory,
+    partition: number,
+    dueAt: number,
+    key: Buffer,
+  ): void {
+    tn.clear(key);
+    this.mutateGcDueCountInTxn(tn, category, partition, dueAt, -1);
+  }
+
   private controlOperationKey(teamId: string, operationId: string): Buffer {
     return this.pack(["team", teamId, "control-operation", operationId]);
   }
@@ -969,17 +1033,37 @@ export class NuqFdbMigrationStore {
       this.generationKey(generation.teamId, generation.generation),
       encodeJson(generation),
     );
-    if (generation.status === "closed" && generation.terminalAt !== undefined) {
-      tn.set(this.generationGcKey(generation), Buffer.alloc(0));
+    const previousIndexed =
+      previous?.status === "closed" && previous.terminalAt !== undefined;
+    const nextIndexed =
+      generation.status === "closed" && generation.terminalAt !== undefined;
+    const sameIndex =
+      previousIndexed &&
+      nextIndexed &&
+      previous.terminalAt === generation.terminalAt &&
+      previous.terminalVersion === generation.terminalVersion;
+    const partition = migrationGcPartition(
+      `${generation.teamId}/${generation.generation}`,
+    );
+    if (previousIndexed && !sameIndex) {
+      const dueAt = previous.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
+      this.clearGcIndexInTxn(
+        tn,
+        "generation",
+        partition,
+        dueAt,
+        this.generationGcKey(previous),
+      );
     }
-    if (
-      previous?.status === "closed" &&
-      previous.terminalAt !== undefined &&
-      (generation.status !== "closed" ||
-        previous.terminalAt !== generation.terminalAt ||
-        previous.terminalVersion !== generation.terminalVersion)
-    ) {
-      tn.clear(this.generationGcKey(previous));
+    if (nextIndexed && !sameIndex) {
+      const dueAt = generation.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
+      this.setGcIndexInTxn(
+        tn,
+        "generation",
+        partition,
+        dueAt,
+        this.generationGcKey(generation),
+      );
     }
   }
 
@@ -998,6 +1082,16 @@ export class NuqFdbMigrationStore {
     previous: ControlOperation | null,
     operation: ControlOperation,
   ): void {
+    const previousIndexed = previous?.terminalAt !== undefined;
+    const nextIndexed = operation.terminalAt !== undefined;
+    const sameIndex =
+      previousIndexed &&
+      nextIndexed &&
+      previous.terminalAt === operation.terminalAt &&
+      previous.terminalVersion === operation.terminalVersion;
+    const partition = migrationGcPartition(
+      `${teamId}/${operation.operationId}`,
+    );
     if (previous) {
       for (const generation of this.controlReferencedGenerations(previous)) {
         tn.clear(
@@ -1008,8 +1102,15 @@ export class NuqFdbMigrationStore {
           ),
         );
       }
-      if (previous.terminalAt !== undefined) {
-        tn.clear(this.controlGcKey(teamId, previous));
+      if (previousIndexed && !sameIndex) {
+        const dueAt = previous.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
+        this.clearGcIndexInTxn(
+          tn,
+          "control",
+          partition,
+          dueAt,
+          this.controlGcKey(teamId, previous),
+        );
       }
     }
     tn.set(
@@ -1022,8 +1123,15 @@ export class NuqFdbMigrationStore {
         Buffer.alloc(0),
       );
     }
-    if (operation.terminalAt !== undefined) {
-      tn.set(this.controlGcKey(teamId, operation), Buffer.alloc(0));
+    if (nextIndexed && !sameIndex) {
+      const dueAt = operation.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
+      this.setGcIndexInTxn(
+        tn,
+        "control",
+        partition,
+        dueAt,
+        this.controlGcKey(teamId, operation),
+      );
     }
   }
 
@@ -1035,20 +1143,41 @@ export class NuqFdbMigrationStore {
     const encoded = encodeJson(pin);
     tn.set(this.objectKey(pin.kind, pin.objectId), encoded);
     tn.set(this.generationObjectKey(pin), Buffer.alloc(0));
+    const previousIndexed =
+      previous?.lifecycle === "terminal" && previous.terminalAt !== undefined;
+    const nextIndexed =
+      pin.lifecycle === "terminal" && pin.terminalAt !== undefined;
+    const sameIndex =
+      previousIndexed &&
+      nextIndexed &&
+      previous.terminalAt === pin.terminalAt &&
+      previous.terminalVersion === pin.terminalVersion &&
+      previous.generation === pin.generation;
+    const partition = migrationGcPartition(`${pin.kind}/${pin.objectId}`);
     if (pin.lifecycle === "terminal") {
       tn.clear(this.teamObjectKey(pin.teamId, pin.kind, pin.objectId));
-      tn.set(this.terminalPinGcKey(pin), Buffer.alloc(0));
     } else {
       tn.set(this.teamObjectKey(pin.teamId, pin.kind, pin.objectId), encoded);
     }
-    if (
-      previous?.lifecycle === "terminal" &&
-      previous.terminalAt !== undefined &&
-      (previous.terminalAt !== pin.terminalAt ||
-        previous.terminalVersion !== pin.terminalVersion ||
-        previous.generation !== pin.generation)
-    ) {
-      tn.clear(this.terminalPinGcKey(previous));
+    if (previousIndexed && !sameIndex) {
+      const dueAt = previous.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
+      this.clearGcIndexInTxn(
+        tn,
+        "pin",
+        partition,
+        dueAt,
+        this.terminalPinGcKey(previous),
+      );
+    }
+    if (nextIndexed && !sameIndex) {
+      const dueAt = pin.terminalAt! + MIGRATION_GC_MIN_RETENTION_MS;
+      this.setGcIndexInTxn(
+        tn,
+        "pin",
+        partition,
+        dueAt,
+        this.terminalPinGcKey(pin),
+      );
     }
   }
 
@@ -2487,6 +2616,131 @@ export class NuqFdbMigrationStore {
     });
   }
 
+  private gcCategoryRange(
+    category: MigrationGcCategory,
+    partition: number,
+    through: number,
+  ) {
+    return category === "pin"
+      ? this.terminalPinGcRange(partition, through)
+      : this.gcRange(category, partition, through);
+  }
+
+  private async readGcDueCountInTxn(
+    tn: Transaction,
+    category: MigrationGcCategory,
+    partition: number,
+    through: number,
+  ): Promise<number> {
+    let node = BigInt(through) + 1n;
+    const keys: Buffer[] = [];
+    while (node > 0n) {
+      keys.push(this.gcDueCountKey(category, partition, node));
+      node -= node & -node;
+    }
+    const values = await Promise.all(keys.map(key => tn.snapshot().get(key)));
+    let total = 0;
+    for (let index = 0; index < values.length; index++) {
+      const value = decodeCounter(
+        values[index],
+        `GC ${category} due counter partition ${partition} node ${keys[index].toString("hex")}`,
+      );
+      total += value;
+      if (!Number.isSafeInteger(total)) {
+        throw new MigrationCorruptionError(
+          `GC ${category} due counter partition ${partition}`,
+          "count exceeds safe integer range",
+        );
+      }
+    }
+    return total;
+  }
+
+  /** Exact, bounded GC observability: counts use Fenwick point reads
+   * and oldest timestamps use one limit-1 read from each of 32 partitions. */
+  public async inspectGcBacklog(
+    now = Date.now(),
+  ): Promise<Record<MigrationGcCategory, MigrationGcBacklog>> {
+    if (!isNonnegativeInteger(now)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "GC observation time must be a nonnegative safe integer",
+      );
+    }
+    const categories: MigrationGcCategory[] = ["pin", "control", "generation"];
+    return await this.db.doTn(async tn => {
+      const snapshots = await Promise.all(
+        categories.map(async category => {
+          const partitions = await Promise.all(
+            Array.from(
+              { length: MIGRATION_GC_PARTITIONS },
+              async (_, partition) => {
+                const range = this.gcCategoryRange(
+                  category,
+                  partition,
+                  now + 1,
+                );
+                const [due, oldest] = await Promise.all([
+                  this.readGcDueCountInTxn(tn, category, partition, now),
+                  tn
+                    .snapshot()
+                    .getRangeAll(range.begin, range.end, { limit: 1 }),
+                ]);
+                const oldestDueAt = oldest[0]
+                  ? Number(getFdb().tuple.unpack(oldest[0][0] as Buffer)[5])
+                  : null;
+                if (
+                  oldestDueAt !== null &&
+                  !isNonnegativeInteger(oldestDueAt)
+                ) {
+                  throw new MigrationCorruptionError(
+                    `GC ${category} index partition ${partition}`,
+                    "invalid due timestamp",
+                  );
+                }
+                return { due, oldestDueAt };
+              },
+            ),
+          );
+          const due = partitions.reduce((sum, item) => sum + item.due, 0);
+          if (!Number.isSafeInteger(due)) {
+            throw new MigrationCorruptionError(
+              `GC ${category} due counters`,
+              "count exceeds safe integer range",
+            );
+          }
+          const oldestDueAt = partitions.reduce<number | null>(
+            (oldest, item) =>
+              item.oldestDueAt !== null &&
+              (oldest === null || item.oldestDueAt < oldest)
+                ? item.oldestDueAt
+                : oldest,
+            null,
+          );
+          if ((due === 0) !== (oldestDueAt === null)) {
+            throw new MigrationCorruptionError(
+              `GC ${category} accounting`,
+              `due count ${due} disagrees with due index`,
+            );
+          }
+          return [
+            category,
+            {
+              due,
+              oldestDueAt,
+              oldestOverdueMs:
+                oldestDueAt === null ? 0 : Math.max(0, now - oldestDueAt),
+            },
+          ] as const;
+        }),
+      );
+      return Object.fromEntries(snapshots) as Record<
+        MigrationGcCategory,
+        MigrationGcBacklog
+      >;
+    });
+  }
+
   private async claimGcPartition(
     category: string,
     now: number,
@@ -2498,13 +2752,16 @@ export class NuqFdbMigrationStore {
         const cursor = Number(
           parseJson(await tn.get(cursorKey), `GC ${category} cursor`) ?? 0,
         );
-        if (!isNonnegativeInteger(cursor)) {
+        if (
+          !isNonnegativeInteger(cursor) ||
+          cursor >= MIGRATION_GC_PARTITIONS
+        ) {
           throw new MigrationCorruptionError(
             `GC ${category} cursor`,
             "invalid partition",
           );
         }
-        const partition = cursor % MIGRATION_GC_PARTITIONS;
+        const partition = cursor;
         tn.set(
           cursorKey,
           encodeJson((partition + 1) % MIGRATION_GC_PARTITIONS),
@@ -2516,12 +2773,16 @@ export class NuqFdbMigrationStore {
         ) as { token?: unknown; expiresAt?: unknown } | null;
         if (
           lease &&
-          typeof lease.token === "string" &&
-          isNonnegativeInteger(lease.expiresAt) &&
-          lease.expiresAt > now
+          (typeof lease.token !== "string" ||
+            lease.token.length === 0 ||
+            !isNonnegativeInteger(lease.expiresAt))
         ) {
-          return null;
+          throw new MigrationCorruptionError(
+            `GC ${category} lease`,
+            "invalid lease fields",
+          );
         }
+        if (lease && (lease.expiresAt as number) > now) return null;
         tn.set(leaseKey, encodeJson({ token, expiresAt: now + 5 * 60 * 1000 }));
         return { partition, token };
       });
@@ -2556,6 +2817,7 @@ export class NuqFdbMigrationStore {
       now?: number;
       limit?: number;
       recheckMs?: number;
+      signal?: AbortSignal;
     } = {},
   ): Promise<MigrationGcSweepResult | null> {
     const now = options.now ?? Date.now();
@@ -2581,21 +2843,29 @@ export class NuqFdbMigrationStore {
       removed: 0,
       retained: 0,
       stale: 0,
+      hasMore: false,
     };
     try {
       const range = this.terminalPinGcRange(claim.partition, now + 1);
       const rows = (await this.db.doTn(async tn =>
         tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
       )) as [Buffer, Buffer][];
-      result.read = rows.length;
+      result.hasMore = rows.length === limit;
       for (const [indexKey] of rows) {
+        if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
+        result.read++;
         const parts = getFdb().tuple.unpack(indexKey);
+        const dueAt = Number(parts[5]);
         const kind = String(parts[6]) as MigrationObjectKind;
         const objectId = String(parts[7]);
         const generation = Number(parts[8]);
         const terminalVersion = Number(parts[9]);
         const terminalAt = Number(parts[10]);
         if (
+          !isNonnegativeInteger(dueAt) ||
           !OBJECT_KINDS.includes(kind) ||
           !isPositiveInteger(generation) ||
           !isPositiveInteger(terminalVersion) ||
@@ -2613,8 +2883,23 @@ export class NuqFdbMigrationStore {
           observed.terminalVersion === terminalVersion &&
           observed.terminalAt === terminalAt;
         if (!matches) {
-          await this.db.doTn(async tn => tn.clear(indexKey));
-          result.stale++;
+          const cleared = await this.db.doTn(async tn => {
+            const current = await this.inspectPinInTxn(tn, kind, objectId);
+            if (
+              current?.lifecycle === "terminal" &&
+              current.generation === generation &&
+              current.terminalVersion === terminalVersion &&
+              current.terminalAt === terminalAt
+            ) {
+              return false;
+            }
+            // The canonical read conflicts with a concurrent replacement before
+            // this index/accounting pair is cleared.
+            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
+            return true;
+          });
+          if (cleared) result.stale++;
+          else result.retained++;
           continue;
         }
 
@@ -2631,7 +2916,7 @@ export class NuqFdbMigrationStore {
             current.terminalVersion !== terminalVersion ||
             current.terminalAt !== terminalAt
           ) {
-            tn.clear(indexKey);
+            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
             return "stale" as const;
           }
           const teamIndex = await tn.get(
@@ -2657,10 +2942,13 @@ export class NuqFdbMigrationStore {
             teamIndex ||
             Object.values(current.residue).some(value => value !== 0)
           ) {
-            tn.clear(indexKey);
-            tn.set(
+            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
+            this.setGcIndexInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              now + recheckMs,
               this.terminalPinGcKey(current, now + recheckMs),
-              Buffer.alloc(0),
             );
             return "retained" as const;
           }
@@ -2671,16 +2959,19 @@ export class NuqFdbMigrationStore {
             tn.clear(operationKey as Buffer);
           }
           if (operationRows.length === MIGRATION_GC_PAGE_LIMIT) {
-            tn.clear(indexKey);
-            tn.set(
+            this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
+            this.setGcIndexInTxn(
+              tn,
+              "pin",
+              claim.partition,
+              now + recheckMs,
               this.terminalPinGcKey(current, now + recheckMs),
-              Buffer.alloc(0),
             );
             return "retained" as const;
           }
           tn.clear(this.objectKey(kind, objectId));
           tn.clear(this.generationObjectKey(current));
-          tn.clear(indexKey);
+          this.clearGcIndexInTxn(tn, "pin", claim.partition, dueAt, indexKey);
           return "removed" as const;
         });
         result[outcome]++;
@@ -2692,14 +2983,26 @@ export class NuqFdbMigrationStore {
   }
 
   public async sweepControlHistory(
-    options: { now?: number; limit?: number } = {},
+    options: {
+      now?: number;
+      limit?: number;
+      recheckMs?: number;
+      signal?: AbortSignal;
+    } = {},
   ): Promise<MigrationGcSweepResult | null> {
     const now = options.now ?? Date.now();
     const limit = options.limit ?? MIGRATION_GC_PAGE_LIMIT;
+    const recheckMs = options.recheckMs ?? MIGRATION_GC_RECHECK_MS;
     if (!isPositiveInteger(limit) || limit > MIGRATION_GC_PAGE_LIMIT) {
       throw new MigrationStoreError(
         "NUQ_MIGRATION_INVALID_ARGUMENT",
         `GC page limit must be between 1 and ${MIGRATION_GC_PAGE_LIMIT}`,
+      );
+    }
+    if (!isPositiveInteger(recheckMs)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "GC recheck must be a positive safe integer",
       );
     }
     const claim = await this.claimGcPartition("control", now);
@@ -2710,25 +3013,50 @@ export class NuqFdbMigrationStore {
       removed: 0,
       retained: 0,
       stale: 0,
+      hasMore: false,
     };
     try {
       const range = this.gcRange("control", claim.partition, now + 1);
       const rows = (await this.db.doTn(async tn =>
         tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
       )) as [Buffer, Buffer][];
-      result.read = rows.length;
+      result.hasMore = rows.length === limit;
       for (const [indexKey] of rows) {
+        if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
+        result.read++;
         const parts = getFdb().tuple.unpack(indexKey);
+        const dueAt = Number(parts[5]);
         const teamId = String(parts[6]);
         const operationId = String(parts[7]);
         const version = Number(parts[8]);
         const terminalAt = Number(parts[9]);
+        if (
+          !isNonnegativeInteger(dueAt) ||
+          teamId.length === 0 ||
+          operationId.length === 0 ||
+          !isPositiveInteger(version) ||
+          !isNonnegativeInteger(terminalAt)
+        ) {
+          throw new MigrationCorruptionError(
+            "control history GC index",
+            "invalid identity",
+          );
+        }
         const outcome = await this.db.doTn(async tn => {
           const raw = await tn.get(
             this.controlOperationKey(teamId, operationId),
           );
           if (!raw) {
-            tn.clear(indexKey);
+            this.clearGcIndexInTxn(
+              tn,
+              "control",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
             return "stale" as const;
           }
           const operation = validateControlOperation(
@@ -2740,11 +3068,31 @@ export class NuqFdbMigrationStore {
             operation.terminalAt !== terminalAt ||
             operation.outcome === "pending"
           ) {
-            tn.clear(indexKey);
+            this.clearGcIndexInTxn(
+              tn,
+              "control",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
             return "stale" as const;
           }
           const state = await this.readState(tn, teamId);
           if (state?.transitionOperationId === operationId) {
+            this.clearGcIndexInTxn(
+              tn,
+              "control",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
+            this.setGcIndexInTxn(
+              tn,
+              "control",
+              claim.partition,
+              now + recheckMs,
+              this.controlGcKey(teamId, operation, now + recheckMs),
+            );
             return "retained" as const;
           }
           tn.clear(this.controlOperationKey(teamId, operationId));
@@ -2755,7 +3103,13 @@ export class NuqFdbMigrationStore {
               this.controlGenerationRefKey(teamId, generation, operationId),
             );
           }
-          tn.clear(indexKey);
+          this.clearGcIndexInTxn(
+            tn,
+            "control",
+            claim.partition,
+            dueAt,
+            indexKey,
+          );
           return "removed" as const;
         });
         result[outcome]++;
@@ -2767,7 +3121,12 @@ export class NuqFdbMigrationStore {
   }
 
   public async sweepClosedGenerations(
-    options: { now?: number; limit?: number; recheckMs?: number } = {},
+    options: {
+      now?: number;
+      limit?: number;
+      recheckMs?: number;
+      signal?: AbortSignal;
+    } = {},
   ): Promise<MigrationGcSweepResult | null> {
     const now = options.now ?? Date.now();
     const limit = options.limit ?? MIGRATION_GC_PAGE_LIMIT;
@@ -2778,6 +3137,12 @@ export class NuqFdbMigrationStore {
         `GC page limit must be between 1 and ${MIGRATION_GC_PAGE_LIMIT}`,
       );
     }
+    if (!isPositiveInteger(recheckMs)) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_INVALID_ARGUMENT",
+        "GC recheck must be a positive safe integer",
+      );
+    }
     const claim = await this.claimGcPartition("generation", now);
     if (!claim) return null;
     const result: MigrationGcSweepResult = {
@@ -2786,19 +3151,38 @@ export class NuqFdbMigrationStore {
       removed: 0,
       retained: 0,
       stale: 0,
+      hasMore: false,
     };
     try {
       const range = this.gcRange("generation", claim.partition, now + 1);
       const rows = (await this.db.doTn(async tn =>
         tn.snapshot().getRangeAll(range.begin, range.end, { limit }),
       )) as [Buffer, Buffer][];
-      result.read = rows.length;
+      result.hasMore = rows.length === limit;
       for (const [indexKey] of rows) {
+        if (options.signal?.aborted) {
+          result.hasMore = true;
+          break;
+        }
+        result.read++;
         const parts = getFdb().tuple.unpack(indexKey);
+        const dueAt = Number(parts[5]);
         const teamId = String(parts[6]);
         const generationNumber = Number(parts[7]);
         const version = Number(parts[8]);
         const terminalAt = Number(parts[9]);
+        if (
+          !isNonnegativeInteger(dueAt) ||
+          teamId.length === 0 ||
+          !isPositiveInteger(generationNumber) ||
+          !isPositiveInteger(version) ||
+          !isNonnegativeInteger(terminalAt)
+        ) {
+          throw new MigrationCorruptionError(
+            "closed generation GC index",
+            "invalid identity",
+          );
+        }
         const outcome = await this.db.doTn(async tn => {
           const generation = await this.readGeneration(
             tn,
@@ -2812,7 +3196,13 @@ export class NuqFdbMigrationStore {
             generation.terminalVersion !== version ||
             generation.terminalAt !== terminalAt
           ) {
-            tn.clear(indexKey);
+            this.clearGcIndexInTxn(
+              tn,
+              "generation",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
             return "stale" as const;
           }
           const state = await this.readState(tn, teamId);
@@ -2848,10 +3238,19 @@ export class NuqFdbMigrationStore {
             objects.length > 0 ||
             controls.length > 0
           ) {
-            tn.clear(indexKey);
-            tn.set(
+            this.clearGcIndexInTxn(
+              tn,
+              "generation",
+              claim.partition,
+              dueAt,
+              indexKey,
+            );
+            this.setGcIndexInTxn(
+              tn,
+              "generation",
+              claim.partition,
+              now + recheckMs,
               this.generationGcKey(generation, now + recheckMs),
-              Buffer.alloc(0),
             );
             return "retained" as const;
           }
@@ -2859,7 +3258,13 @@ export class NuqFdbMigrationStore {
           for (const counter of MIGRATION_RESIDUE_COUNTERS) {
             tn.clear(this.residueKey(teamId, generationNumber, counter));
           }
-          tn.clear(indexKey);
+          this.clearGcIndexInTxn(
+            tn,
+            "generation",
+            claim.partition,
+            dueAt,
+            indexKey,
+          );
           return "removed" as const;
         });
         result[outcome]++;

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -150,6 +150,9 @@ export type ReconcileManagedObjectInput = {
   allowMissingRecordPin?: boolean;
   residue: Partial<MigrationResidue>;
   terminal?: boolean;
+  /** Legacy cancelled groups must adopt their sweeper continuation in the
+   * same transaction before the group itself becomes terminal. */
+  cancelledGroupContinuation?: boolean;
   /** Validation-only callers suppress the prepared->active transition. */
   activateNonterminal?: boolean;
 };
@@ -664,6 +667,8 @@ function validateLegacyObjectOperation(
 }
 
 export class NuqFdbMigrationStore {
+  constructor(private readonly requireCoreReadiness = false) {}
+
   private get db() {
     return getNuqFdbDatabase();
   }
@@ -672,6 +677,29 @@ export class NuqFdbMigrationStore {
   // ("nuq", queueName) subspace.
   public pack(parts: any[]): Buffer {
     return getFdb().tuple.pack(["nuq-migration", 1, ...parts]) as Buffer;
+  }
+
+  public coreReadinessKey(queueName: "scrape" | "crawl_finished"): Buffer {
+    return this.pack(["core-readiness", queueName]);
+  }
+
+  private async assertCoreReadinessInTxn(tn: Transaction): Promise<void> {
+    if (!this.requireCoreReadiness) return;
+    for (const queueName of ["scrape", "crawl_finished"] as const) {
+      const raw = await tn.get(this.coreReadinessKey(queueName));
+      const readiness = raw
+        ? (parseJson(raw, `${queueName} core readiness`) as {
+            phase?: unknown;
+          })
+        : null;
+      if (readiness?.phase !== "ready") {
+        throw new MigrationStoreError(
+          "NUQ_FDB_CORE_METRICS_NOT_READY",
+          `${queueName} corrected-core generation is not ready`,
+          true,
+        );
+      }
+    }
   }
 
   public teamStateKey(teamId: string): Buffer {
@@ -1130,6 +1158,71 @@ export class NuqFdbMigrationStore {
     const terminal = input.terminal === true;
     let pin = await this.inspectPinInTxn(tn, kind, objectId);
     let adoptedLegacyRecord = false;
+    if (
+      !pin &&
+      kind === "group" &&
+      terminal &&
+      input.cancelledGroupContinuation === true &&
+      !input.recordPin &&
+      !input.allowMissingRecordPin
+    ) {
+      // A cancelled legacy group is not terminal migration residue until its
+      // sweeper continuation has completed. Adopt both controls atomically so
+      // a crash cannot strand an active group pin without discoverable work.
+      pin = await this.preparePinnedObjectInTxn(tn, {
+        teamId,
+        kind,
+        objectId,
+        admission: {
+          type: "legacy-backfill",
+          backend: "fdb",
+          generation: state.activeGeneration,
+        },
+        requiredBackend: "fdb",
+        residue,
+      });
+      pin = (await this.reconcileManagedObjectInTxn(tn, {
+        teamId,
+        kind,
+        objectId,
+        recordPin: { backend: pin.backend, generation: pin.generation },
+        residue,
+      }))!;
+      const taskObjectId = `group-cancel/${objectId}`;
+      await this.preparePinnedObjectInTxn(tn, {
+        teamId,
+        kind: "sweeper_task",
+        objectId: taskObjectId,
+        admission: {
+          type: "pinned-continuation",
+          source: { kind: "group", objectId },
+        },
+        requiredBackend: "fdb",
+        residue: { control_sweeper_tasks: 1 },
+      });
+      const taskPin = await this.inspectPinInTxn(
+        tn,
+        "sweeper_task",
+        taskObjectId,
+      );
+      if (!taskPin) {
+        throw new MigrationCorruptionError(
+          `object sweeper_task/${taskObjectId}`,
+          "prepared continuation disappeared in its transaction",
+        );
+      }
+      await this.reconcileManagedObjectInTxn(tn, {
+        teamId,
+        kind: "sweeper_task",
+        objectId: taskObjectId,
+        recordPin: {
+          backend: taskPin.backend,
+          generation: taskPin.generation,
+        },
+        residue: { control_sweeper_tasks: 1 },
+      });
+      return pin;
+    }
     if (!pin) {
       // Callers set allowMissingRecordPin only while creating a new runtime
       // record, which must already have a router-prepared intent. Mutations of
@@ -1302,6 +1395,7 @@ export class NuqFdbMigrationStore {
     assertNonempty(teamId, "teamId");
     assertNonempty(operationId, "operationId");
     return await this.db.doTn(async tn => {
+      await this.assertCoreReadinessInTxn(tn);
       const opKey = this.controlOperationKey(teamId, operationId);
       const rawOp = await tn.get(opKey);
       if (rawOp) {
@@ -1444,6 +1538,7 @@ export class NuqFdbMigrationStore {
     assertNonempty(teamId, "teamId");
     assertNonempty(operationId, "operationId");
     return await this.db.doTn(async tn => {
+      await this.assertCoreReadinessInTxn(tn);
       const opKey = this.controlOperationKey(teamId, operationId);
       const rawOp = await tn.get(opKey);
       if (rawOp) {
@@ -2073,6 +2168,7 @@ export class NuqFdbMigrationStore {
     assertNonempty(teamId, "teamId");
     assertNonempty(transitionOperationId, "transitionOperationId");
     return await this.db.doTn(async tn => {
+      await this.assertCoreReadinessInTxn(tn);
       const opKey = this.controlOperationKey(teamId, transitionOperationId);
       const rawOp = await tn.get(opKey);
       if (!rawOp) {
@@ -2190,4 +2286,4 @@ export class NuqFdbMigrationStore {
   }
 }
 
-export const nuqFdbMigrationStore = new NuqFdbMigrationStore();
+export const nuqFdbMigrationStore = new NuqFdbMigrationStore(true);

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -115,6 +115,23 @@ export type CompletePinnedObjectInput = {
   fromLifecycle: "prepared" | "active";
 };
 
+export type MigrationRecordPin = {
+  backend: MigrationBackend;
+  generation: number;
+};
+
+export type ReconcileManagedObjectInput = {
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  /** Pin copied onto the runtime record. It may be omitted only while creating
+   * that record; existing managed records must always carry it. */
+  recordPin?: MigrationRecordPin;
+  allowMissingRecordPin?: boolean;
+  residue: Partial<MigrationResidue>;
+  terminal?: boolean;
+};
+
 export type MigrationSteadyResolution =
   | { status: "legacy-uninitialized" }
   | { status: "steady"; state: MigrationTeamState }
@@ -903,6 +920,134 @@ export class NuqFdbMigrationStore {
       );
     }
     return pin;
+  }
+
+  /**
+   * Composes migration accounting with a queue/group/slot mutation. Teams that
+   * have never entered the migration control plane remain untouched. Once a
+   * team state exists, the durable object pin and the pin copied onto an
+   * existing runtime record are mandatory. Reading the generation and residue
+   * keys here gives finalSeal a conflict with every residue increase.
+   */
+  public async reconcileManagedObjectInTxn(
+    tn: Transaction,
+    input: ReconcileManagedObjectInput,
+  ): Promise<MigrationObjectPin | null> {
+    const { teamId, kind, objectId } = input;
+    assertNonempty(teamId, "teamId");
+    assertNonempty(objectId, "objectId");
+    const state = await this.readState(tn, teamId);
+    if (!state) {
+      if (input.recordPin) {
+        throw new MigrationCorruptionError(
+          `object ${kind}/${objectId}`,
+          "runtime generation pin exists without team migration state",
+        );
+      }
+      return null;
+    }
+    await this.validateTopology(tn, state);
+    if (!input.recordPin && !input.allowMissingRecordPin) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_RUNTIME_PIN_MISSING",
+        `${kind}/${objectId} is missing its runtime generation pin`,
+      );
+    }
+    const pin = await this.inspectPinInTxn(tn, kind, objectId);
+    if (!pin) {
+      throw new MigrationStoreError(
+        "NUQ_MIGRATION_PIN_NOT_FOUND",
+        `${kind}/${objectId} has no durable pin`,
+      );
+    }
+    if (
+      pin.teamId !== teamId ||
+      pin.backend !== "fdb" ||
+      (input.recordPin !== undefined &&
+        (input.recordPin.backend !== pin.backend ||
+          input.recordPin.generation !== pin.generation))
+    ) {
+      throw new MigrationCorruptionError(
+        `object ${kind}/${objectId}`,
+        "runtime and durable pin mismatch",
+      );
+    }
+    const generation = await this.requireGeneration(tn, teamId, pin.generation);
+    if (
+      generation.backend !== pin.backend ||
+      (generation.status !== "open" && generation.status !== "draining")
+    ) {
+      throw new MigrationStaleGenerationError(
+        teamId,
+        pin.backend,
+        pin.generation,
+      );
+    }
+    const rawIndex = await tn.get(this.teamObjectKey(teamId, kind, objectId));
+    if (!rawIndex) {
+      throw new MigrationCorruptionError(
+        `object ${kind}/${objectId}`,
+        "missing team pin index",
+      );
+    }
+    const indexed = validatePin(
+      parseJson(rawIndex, `object ${kind}/${objectId} team index`),
+      `object ${kind}/${objectId} team index`,
+    );
+    if (JSON.stringify(indexed) !== JSON.stringify(pin)) {
+      throw new MigrationCorruptionError(
+        `object ${kind}/${objectId}`,
+        "team pin index mismatch",
+      );
+    }
+
+    const residue = normalizeResidue(input.residue);
+    const terminal = input.terminal === true;
+    if (pin.lifecycle === "terminal") {
+      if (!terminal || Object.values(residue).some(value => value !== 0)) {
+        throw new MigrationStoreError(
+          "NUQ_MIGRATION_LIFECYCLE_MISMATCH",
+          `${kind}/${objectId} tombstone cannot be reopened`,
+        );
+      }
+      return pin;
+    }
+    if (!terminal && residueEqual(pin.residue, residue)) return pin;
+    await this.applyResidueDelta(
+      tn,
+      teamId,
+      pin.generation,
+      pin.residue,
+      residue,
+    );
+    const revision = pin.revision + 1;
+    if (!Number.isSafeInteger(revision)) {
+      throw new MigrationCorruptionError(
+        `object ${kind}/${objectId}`,
+        "pin revision exhausted",
+      );
+    }
+    const next: MigrationObjectPin = {
+      ...pin,
+      lifecycle: terminal ? "terminal" : pin.lifecycle,
+      revision,
+      residue,
+    };
+    const encoded = encodeJson(next);
+    tn.set(this.objectKey(kind, objectId), encoded);
+    tn.set(this.teamObjectKey(teamId, kind, objectId), encoded);
+    return next;
+  }
+
+  public async validateManagedObjectInTxn(
+    tn: Transaction,
+    input: Omit<ReconcileManagedObjectInput, "residue" | "terminal">,
+  ): Promise<MigrationObjectPin | null> {
+    const pin = await this.inspectPinInTxn(tn, input.kind, input.objectId);
+    return await this.reconcileManagedObjectInTxn(tn, {
+      ...input,
+      residue: pin?.residue ?? {},
+    });
   }
 
   public async resolveSteady(

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -142,6 +142,8 @@ export type ReconcileManagedObjectInput = {
   allowMissingRecordPin?: boolean;
   residue: Partial<MigrationResidue>;
   terminal?: boolean;
+  /** Validation-only callers suppress the prepared->active transition. */
+  activateNonterminal?: boolean;
 };
 
 export type MigrationSteadyResolution =
@@ -1070,6 +1072,11 @@ export class NuqFdbMigrationStore {
 
     const residue = normalizeResidue(input.residue);
     const terminal = input.terminal === true;
+    const targetLifecycle: MigrationObjectLifecycle = terminal
+      ? "terminal"
+      : input.activateNonterminal === false
+        ? pin.lifecycle
+        : "active";
     if (pin.lifecycle === "terminal") {
       if (!terminal || Object.values(residue).some(value => value !== 0)) {
         throw new MigrationStoreError(
@@ -1079,7 +1086,12 @@ export class NuqFdbMigrationStore {
       }
       return pin;
     }
-    if (!terminal && residueEqual(pin.residue, residue)) return pin;
+    if (
+      pin.lifecycle === targetLifecycle &&
+      residueEqual(pin.residue, residue)
+    ) {
+      return pin;
+    }
     await this.applyResidueDelta(
       tn,
       teamId,
@@ -1096,7 +1108,7 @@ export class NuqFdbMigrationStore {
     }
     const next: MigrationObjectPin = {
       ...pin,
-      lifecycle: terminal ? "terminal" : pin.lifecycle,
+      lifecycle: targetLifecycle,
       revision,
       residue,
     };
@@ -1114,6 +1126,7 @@ export class NuqFdbMigrationStore {
     return await this.reconcileManagedObjectInTxn(tn, {
       ...input,
       residue: pin?.residue ?? {},
+      activateNonterminal: false,
     });
   }
 

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -944,6 +944,22 @@ export class NuqFdbMigrationStore {
     ]);
   }
 
+  private legacyObjectOperationRange(
+    teamId: string,
+    kind: MigrationObjectKind,
+    objectId: string,
+  ) {
+    return getFdb().tuple.range([
+      "nuq-migration",
+      1,
+      "team",
+      teamId,
+      "object-operation",
+      kind,
+      objectId,
+    ]);
+  }
+
   private writeGenerationInTxn(
     tn: Transaction,
     previous: MigrationGeneration | null,
@@ -2625,12 +2641,36 @@ export class NuqFdbMigrationStore {
             tn,
             current,
           );
+          const operationRange = this.legacyObjectOperationRange(
+            current.teamId,
+            current.kind,
+            current.objectId,
+          );
+          const operationRows = await tn.getRangeAll(
+            operationRange.begin as Buffer,
+            operationRange.end as Buffer,
+            { limit: MIGRATION_GC_PAGE_LIMIT },
+          );
           if (
             pgExists ||
             hasFdbReference ||
             teamIndex ||
             Object.values(current.residue).some(value => value !== 0)
           ) {
+            tn.clear(indexKey);
+            tn.set(
+              this.terminalPinGcKey(current, now + recheckMs),
+              Buffer.alloc(0),
+            );
+            return "retained" as const;
+          }
+          // Prototype operation ledgers are boundedly compacted only after the
+          // pin's full retention window. Delete the pin in the same commit only
+          // when no operation token remains to reference it.
+          for (const [operationKey] of operationRows) {
+            tn.clear(operationKey as Buffer);
+          }
+          if (operationRows.length === MIGRATION_GC_PAGE_LIMIT) {
             tn.clear(indexKey);
             tn.set(
               this.terminalPinGcKey(current, now + recheckMs),

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -937,6 +937,7 @@ export class NuqFdbMigrationStore {
     teamId: string,
     backend: MigrationBackend,
     operationId: string,
+    options?: { ifAbsent?: boolean },
   ): Promise<MigrationTeamState> {
     assertNonempty(teamId, "teamId");
     assertNonempty(operationId, "operationId");
@@ -959,7 +960,10 @@ export class NuqFdbMigrationStore {
         }
         return op.state;
       }
-      if (await this.readState(tn, teamId)) {
+      const existing = await this.readState(tn, teamId);
+      if (existing) {
+        await this.validateTopology(tn, existing);
+        if (options?.ifAbsent) return existing;
         throw new MigrationStoreError(
           "NUQ_MIGRATION_ALREADY_INITIALIZED",
           `team ${teamId} is already initialized`,

--- a/apps/api/src/services/worker/nuq-fdb/migration-store.ts
+++ b/apps/api/src/services/worker/nuq-fdb/migration-store.ts
@@ -2819,42 +2819,84 @@ export class NuqFdbMigrationStore {
         );
       }
 
-      // Select and advance in one transaction. Advancing once per unavailable
-      // partition let racing callers consume a complete cursor rotation while
-      // old owners were still finishing empty shards, so an expired owner with
-      // real work could be skipped indefinitely. A successful claim is now the
-      // only operation that advances the cursor; the lease reads also conflict
-      // with concurrent claims and releases.
+      // Read one complete, bounded rotation before choosing. Besides preserving
+      // the conflict reads used by ordinary claims, this lets a doTn closure
+      // replay after commit_unknown_result find the lease committed by its
+      // first attempt instead of treating it as busy and advancing again.
+      const leases: Array<{
+        partition: number;
+        key: Buffer;
+        lease: { token: string; expiresAt: number } | null;
+      }> = [];
       for (let offset = 0; offset < MIGRATION_GC_PARTITIONS; offset++) {
         const partition = (cursor + offset) % MIGRATION_GC_PARTITIONS;
-        const leaseKey = this.gcLeaseKey(category, partition);
-        const lease = parseJson(
-          await tn.get(leaseKey),
-          `GC ${category} lease`,
-        ) as { token?: unknown; expiresAt?: unknown } | null;
+        const key = this.gcLeaseKey(category, partition);
+        const value = parseJson(await tn.get(key), `GC ${category} lease`) as {
+          token?: unknown;
+          expiresAt?: unknown;
+        } | null;
         if (
-          lease &&
-          (typeof lease.token !== "string" ||
-            lease.token.length === 0 ||
-            !isNonnegativeInteger(lease.expiresAt))
+          value &&
+          (typeof value.token !== "string" ||
+            value.token.length === 0 ||
+            !isNonnegativeInteger(value.expiresAt))
         ) {
           throw new MigrationCorruptionError(
             `GC ${category} lease`,
             "invalid lease fields",
           );
         }
-        if (lease && (lease.expiresAt as number) > leaseNow) continue;
+        leases.push({
+          partition,
+          key,
+          lease: value
+            ? {
+                token: value.token as string,
+                expiresAt: value.expiresAt as number,
+              }
+            : null,
+        });
+      }
+
+      const ownLeases = leases.filter(item => item.lease?.token === token);
+      if (ownLeases.length > 0) {
+        // A successful claim leaves the cursor immediately after its partition.
+        // Prefer that lease when repairing duplicates left by older buggy
+        // commit-unknown replays; otherwise cursor order is deterministic.
+        const committedPartition =
+          (cursor + MIGRATION_GC_PARTITIONS - 1) % MIGRATION_GC_PARTITIONS;
+        const keeper =
+          ownLeases.find(item => item.partition === committedPartition) ??
+          ownLeases[0];
+        for (const duplicate of ownLeases) {
+          if (duplicate.partition !== keeper.partition) tn.clear(duplicate.key);
+        }
+        // The same invocation may replay after its local lease deadline. The
+        // key still names it, so no replacement won that partition and renewal
+        // is safe. Deliberately do not move the already-committed cursor.
         tn.set(
-          leaseKey,
+          keeper.key,
           encodeJson({ token, expiresAt: leaseNow + MIGRATION_GC_LEASE_MS }),
         );
-        tn.set(
-          cursorKey,
-          encodeJson((partition + 1) % MIGRATION_GC_PARTITIONS),
-        );
-        return { partition, token };
+        return { partition: keeper.partition, token };
       }
-      return null;
+
+      // Advancing once per unavailable partition let racing callers consume a
+      // complete cursor rotation while old owners were still finishing empty
+      // shards. Only a successful new claim advances the cursor.
+      const available = leases.find(
+        item => !item.lease || item.lease.expiresAt <= leaseNow,
+      );
+      if (!available) return null;
+      tn.set(
+        available.key,
+        encodeJson({ token, expiresAt: leaseNow + MIGRATION_GC_LEASE_MS }),
+      );
+      tn.set(
+        cursorKey,
+        encodeJson((available.partition + 1) % MIGRATION_GC_PARTITIONS),
+      );
+      return { partition: available.partition, token };
     });
   }
 

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -139,6 +139,29 @@ export function setTeamActive(
   tn.set(ks.teamLedgerGcIndex(teamId), EMPTY);
 }
 
+// Keep the release/promotion gate synchronized with the limit observed by any
+// authoritative admission path, not only queue ingestion. Returns the current
+// active count from the same conflictful transaction.
+export async function synchronizeTeamLimitInTxn(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  teamId: string,
+  limit: number,
+): Promise<number> {
+  const storedBuf = await tn.get(ks.teamLimit(teamId));
+  const stored = storedBuf ? decodeI64(storedBuf) : null;
+  if (stored !== limit) {
+    tn.set(ks.teamLimit(teamId), encodeI64(limit));
+    // Also indexes teams whose configured limit is zero.
+    tn.add(ks.teamActiveIndex(teamId), encodeI64(0));
+    tn.set(ks.teamLedgerGcIndex(teamId), EMPTY);
+    if (stored !== null && limit > stored) {
+      scheduleRaiseTask(tn, ks.taskTeamRaise(teamId));
+    }
+  }
+  return decodeI64(await tn.get(ks.teamActive(teamId)));
+}
+
 export function bumpKeyActive(
   tn: Transaction,
   ks: NuqFdbKeyspace,

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -76,6 +76,8 @@ export async function reconcileJobMigrationInTxn(
   residue: Partial<MigrationResidue>,
   options?: { allowMissingRecordPin?: boolean; terminal?: boolean },
 ): Promise<MigrationObjectPin | null> {
+  // Ownerless operational jobs have no team migration authority or capacity.
+  if (!entry.o) return null;
   const effectiveResidue =
     ks.migrationObjectKind === "crawl_finished" && !options?.terminal
       ? ({ control_crawl_finished: 1 } as const)
@@ -100,6 +102,7 @@ export async function validateJobMigrationInTxn(
   entry: QueueEntry,
   options?: { allowMissingRecordPin?: boolean },
 ): Promise<MigrationObjectPin | null> {
+  if (!entry.o) return null;
   return await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
     teamId: entry.o,
     kind: ks.migrationObjectKind,

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -26,7 +26,14 @@ import {
   NuqFdbMetricStatus,
   fnv1a,
   RaiseTask,
+  MigrationRuntimePin,
 } from "./keyspace";
+import {
+  MigrationCorruptionError,
+  MigrationObjectPin,
+  MigrationResidue,
+  nuqFdbMigrationStore,
+} from "./migration-store";
 
 export const ONE = encodeI64(1);
 export const MINUS_ONE = encodeI64(-1);
@@ -36,6 +43,71 @@ export const LEASE_MS = 90_000;
 export const MAX_STALLS = 9;
 export const COMPLETED_STANDALONE_RETENTION_MS = 60 * 60 * 1000;
 export const FAILED_STANDALONE_RETENTION_MS = 6 * 60 * 60 * 1000;
+
+export function runtimeMigrationPin(
+  record: MigrationRuntimePin,
+): { backend: "pg" | "fdb"; generation: number } | undefined {
+  if (record.mb === undefined && record.mg === undefined) return undefined;
+  if (
+    (record.mb !== "pg" && record.mb !== "fdb") ||
+    !Number.isSafeInteger(record.mg) ||
+    record.mg! <= 0
+  ) {
+    throw new MigrationCorruptionError(
+      "NuQ runtime record",
+      "migration backend and generation must be a valid pair",
+    );
+  }
+  return { backend: record.mb, generation: record.mg! };
+}
+
+export function stampMigrationPin<T extends object>(
+  record: T,
+  pin: MigrationObjectPin | null,
+): T & MigrationRuntimePin {
+  if (!pin) return record;
+  return { ...record, mb: pin.backend, mg: pin.generation };
+}
+
+export async function reconcileJobMigrationInTxn(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  entry: QueueEntry,
+  residue: Partial<MigrationResidue>,
+  options?: { allowMissingRecordPin?: boolean; terminal?: boolean },
+): Promise<MigrationObjectPin | null> {
+  const effectiveResidue =
+    ks.migrationObjectKind === "crawl_finished" && !options?.terminal
+      ? ({ control_crawl_finished: 1 } as const)
+      : residue;
+  const pin = await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+    teamId: entry.o,
+    kind: ks.migrationObjectKind,
+    objectId: entry.i,
+    recordPin: runtimeMigrationPin(entry),
+    allowMissingRecordPin: options?.allowMissingRecordPin,
+    residue: effectiveResidue,
+    terminal: options?.terminal,
+  });
+  if (options?.terminal) tn.clear(ks.ownerLiveJob(entry.o, entry.i));
+  else tn.set(ks.ownerLiveJob(entry.o, entry.i), EMPTY);
+  return pin;
+}
+
+export async function validateJobMigrationInTxn(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  entry: QueueEntry,
+  options?: { allowMissingRecordPin?: boolean },
+): Promise<MigrationObjectPin | null> {
+  return await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+    teamId: entry.o,
+    kind: ks.migrationObjectKind,
+    objectId: entry.i,
+    recordPin: runtimeMigrationPin(entry),
+    allowMissingRecordPin: options?.allowMissingRecordPin,
+  });
+}
 
 export function bumpTeamActive(
   tn: Transaction,
@@ -262,6 +334,9 @@ export async function promoteEntryToReady(
   pushReady(tn, ks, e, txc);
   setStatusQueued(tn, ks, e.i);
   await alignQueueMetricStatus(tn, ks, e.i);
+  await reconcileJobMigrationInTxn(tn, ks, e, {
+    capacity_ready_active: 1,
+  });
   if (e.g && e.f & F_COUNTABLE) {
     tn.add(ks.groupStatusCount(e.g, "pending"), MINUS_ONE);
     tn.add(ks.groupStatusCount(e.g, "queued"), ONE);
@@ -491,6 +566,9 @@ export async function releaseSlotsAndPromote(
         } else {
           const loc = appendTeamPending(tn, ks, keyHead);
           setStatusPending(tn, ks, keyHead.i, loc);
+          await reconcileJobMigrationInTxn(tn, ks, keyHead, {
+            capacity_team_pending: 1,
+          });
           await alignQueueMetricStatus(tn, ks, keyHead.i);
         }
       }
@@ -522,6 +600,9 @@ export async function releaseSlotsAndPromote(
       const notBefore = now + crawlDelaySeconds * 1000;
       tn.set(ks.delayed(timeBucket(j2.i), notBefore, j2.i), encodeJson(j2));
       setStatusPending(tn, ks, j2.i, { k: "dl", at: notBefore });
+      await reconcileJobMigrationInTxn(tn, ks, j2, {
+        capacity_delayed: 1,
+      });
       await alignQueueMetricStatus(tn, ks, j2.i);
     } else {
       // key gate for the crawl-promoted job
@@ -547,6 +628,9 @@ export async function releaseSlotsAndPromote(
         // waits in the key gate; keeps the crawl slot
         const loc = appendKeyPending(tn, ks, j2);
         setStatusPending(tn, ks, j2.i, loc);
+        await reconcileJobMigrationInTxn(tn, ks, j2, {
+          capacity_key_pending: 1,
+        });
         await alignQueueMetricStatus(tn, ks, j2.i);
       } else if (teamSlotFree()) {
         // the freed team slot goes directly to the crawl-promoted job
@@ -560,6 +644,9 @@ export async function releaseSlotsAndPromote(
         // waits in the team gate; keeps the crawl + key slots
         const loc = appendTeamPending(tn, ks, j2);
         setStatusPending(tn, ks, j2.i, loc);
+        await reconcileJobMigrationInTxn(tn, ks, j2, {
+          capacity_team_pending: 1,
+        });
         await alignQueueMetricStatus(tn, ks, j2.i);
       }
     }
@@ -599,6 +686,9 @@ export async function admitThroughTeamGate(
   } else {
     const loc = appendTeamPending(tn, ks, e);
     setStatusPending(tn, ks, e.i, loc);
+    await reconcileJobMigrationInTxn(tn, ks, e, {
+      capacity_team_pending: 1,
+    });
     await alignQueueMetricStatus(tn, ks, e.i);
   }
 }
@@ -618,6 +708,9 @@ export async function admitThroughGates(
     if (kActive >= kLimit) {
       const loc = appendKeyPending(tn, ks, e);
       setStatusPending(tn, ks, e.i, loc);
+      await reconcileJobMigrationInTxn(tn, ks, e, {
+        capacity_key_pending: 1,
+      });
       await alignQueueMetricStatus(tn, ks, e.i);
       return;
     }

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -100,7 +100,10 @@ export async function validateJobMigrationInTxn(
   tn: Transaction,
   ks: NuqFdbKeyspace,
   entry: QueueEntry,
-  options?: { allowMissingRecordPin?: boolean },
+  options?: {
+    allowMissingRecordPin?: boolean;
+    legacyResidue?: Partial<MigrationResidue>;
+  },
 ): Promise<MigrationObjectPin | null> {
   if (!entry.o) return null;
   return await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
@@ -109,6 +112,11 @@ export async function validateJobMigrationInTxn(
     objectId: entry.i,
     recordPin: runtimeMigrationPin(entry),
     allowMissingRecordPin: options?.allowMissingRecordPin,
+    legacyResidue:
+      options?.legacyResidue ??
+      (ks.migrationObjectKind === "crawl_finished"
+        ? { control_crawl_finished: 1 }
+        : { capacity_ready_active: 1 }),
   });
 }
 

--- a/apps/api/src/services/worker/nuq-fdb/pg-removals.ts
+++ b/apps/api/src/services/worker/nuq-fdb/pg-removals.ts
@@ -1,0 +1,140 @@
+import { getFdb, getNuqFdbDatabase } from "./client";
+import { decodeJson, encodeJson } from "./keyspace";
+import { NuqFdbMigrationStore } from "./migration-store";
+
+export type DurablePgJobRemoval = {
+  schemaVersion: 1;
+  id: string;
+  ownerId?: string;
+  groupId?: string;
+};
+
+export class NuqFdbPgJobRemovalConflictError extends Error {
+  constructor(jobId: string, reason: string) {
+    super(`PG job removal conflict for ${jobId}: ${reason}`);
+    this.name = "NuqFdbPgJobRemovalConflictError";
+  }
+}
+
+function validateDescriptor(
+  value: DurablePgJobRemoval | null,
+  jobId: string,
+): DurablePgJobRemoval | null {
+  if (value === null) return null;
+  if (
+    value.schemaVersion !== 1 ||
+    value.id !== jobId ||
+    (value.ownerId !== undefined && typeof value.ownerId !== "string") ||
+    (value.groupId !== undefined && typeof value.groupId !== "string")
+  ) {
+    throw new NuqFdbPgJobRemovalConflictError(jobId, "descriptor is corrupt");
+  }
+  return value;
+}
+
+// Durable cross-store deletion intent. The PG advisory lock serializes this
+// record with publication, while FDB keeps enough routing metadata to finish
+// Redis cleanup after the PG row has disappeared.
+export class NuqFdbPgJobRemovals {
+  constructor(private readonly migrationStore: NuqFdbMigrationStore) {}
+
+  private key(jobId: string): Buffer {
+    return getFdb().tuple.pack([
+      "nuq-migration",
+      1,
+      "pg-job-removal",
+      jobId.toLowerCase(),
+    ]) as Buffer;
+  }
+
+  public async inspect(jobId: string): Promise<DurablePgJobRemoval | null> {
+    const stableId = jobId.toLowerCase();
+    return await getNuqFdbDatabase().doTn(async tn =>
+      validateDescriptor(
+        decodeJson<DurablePgJobRemoval>(await tn.get(this.key(stableId))),
+        stableId,
+      ),
+    );
+  }
+
+  public async begin(descriptor: DurablePgJobRemoval): Promise<void> {
+    const stableId = descriptor.id.toLowerCase();
+    const stableDescriptor = { ...descriptor, id: stableId };
+    await getNuqFdbDatabase().doTn(async tn => {
+      const key = this.key(stableId);
+      const existing = validateDescriptor(
+        decodeJson<DurablePgJobRemoval>(await tn.get(key)),
+        stableId,
+      );
+      if (existing) {
+        if (JSON.stringify(existing) !== JSON.stringify(stableDescriptor)) {
+          throw new NuqFdbPgJobRemovalConflictError(
+            stableId,
+            "descriptor differs",
+          );
+        }
+        return;
+      }
+      const pin = await this.migrationStore.inspectPinInTxn(
+        tn,
+        "scrape_job",
+        stableId,
+      );
+      if (!pin || pin.backend !== "pg" || pin.lifecycle === "terminal") {
+        throw new NuqFdbPgJobRemovalConflictError(
+          stableId,
+          "live PG migration pin is missing",
+        );
+      }
+      tn.set(key, encodeJson(stableDescriptor));
+    });
+  }
+
+  // Called while PG holds the stable-ID advisory lock. A deletion intent that
+  // committed before this lock was acquired fences publication; rechecking the
+  // pin also catches publishers prepared before deletion terminalized it.
+  public async assertPublishable(jobIds: readonly string[]): Promise<void> {
+    await getNuqFdbDatabase().doTn(async tn => {
+      for (const jobId of jobIds) {
+        const stableId = jobId.toLowerCase();
+        if (await tn.get(this.key(stableId))) {
+          throw new NuqFdbPgJobRemovalConflictError(
+            stableId,
+            "deletion is in progress",
+          );
+        }
+        const pin = await this.migrationStore.inspectPinInTxn(
+          tn,
+          "scrape_job",
+          stableId,
+        );
+        // Legacy/direct PG callers have no migration pin and remain valid.
+        if (!pin) continue;
+        if (pin.backend !== "pg" || pin.lifecycle === "terminal") {
+          throw new NuqFdbPgJobRemovalConflictError(
+            stableId,
+            "migration pin is not publishable",
+          );
+        }
+      }
+    });
+  }
+
+  public async complete(jobId: string): Promise<void> {
+    const stableId = jobId.toLowerCase();
+    await getNuqFdbDatabase().doTn(async tn => {
+      const pin = await this.migrationStore.inspectPinInTxn(
+        tn,
+        "scrape_job",
+        stableId,
+      );
+      if (!pin || pin.lifecycle !== "terminal") {
+        throw new NuqFdbPgJobRemovalConflictError(
+          stableId,
+          "cannot clear intent without a terminal pin",
+        );
+      }
+      tn.clear(this.key(stableId));
+    });
+  }
+}

--- a/apps/api/src/services/worker/nuq-fdb/pg-removals.ts
+++ b/apps/api/src/services/worker/nuq-fdb/pg-removals.ts
@@ -1,3 +1,4 @@
+import type { Transaction } from "foundationdb";
 import { getFdb, getNuqFdbDatabase } from "./client";
 import { decodeJson, encodeJson } from "./keyspace";
 import { NuqFdbMigrationStore } from "./migration-store";
@@ -55,6 +56,10 @@ export class NuqFdbPgJobRemovals {
         stableId,
       ),
     );
+  }
+
+  public async hasInTxn(tn: Transaction, jobId: string): Promise<boolean> {
+    return Boolean(await tn.get(this.key(jobId.toLowerCase())));
   }
 
   public async begin(descriptor: DurablePgJobRemoval): Promise<void> {

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -65,7 +65,16 @@ import {
   bumpKeyActive,
   scheduleRaiseTask,
   GroupJobIndexValue,
+  reconcileJobMigrationInTxn,
+  validateJobMigrationInTxn,
+  stampMigrationPin,
 } from "./ops";
+import { MigrationStoreError, nuqFdbMigrationStore } from "./migration-store";
+import type {
+  MigrationBackend,
+  MigrationObjectKind,
+  MigrationResidue,
+} from "./migration-store";
 import { NuqFdbGroupOps } from "./groups";
 
 // FDB's stable transaction option code for TIMEOUT. Keep this local so merely
@@ -123,6 +132,8 @@ export type NuQFdbJob<Data = any, ReturnValue = any> = {
   leaseExpiresAt?: Date;
   ownerId?: string;
   groupId?: string;
+  migrationBackend?: MigrationBackend;
+  migrationGeneration?: number;
 };
 
 export type NuQFdbJobOptions = {
@@ -226,6 +237,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       // lease duration override, used by tests
       leaseMs?: number;
       // Deterministic fault/race injection for the FDB integration tests.
+      migrationObjectKind?: MigrationObjectKind;
       testHooks?: {
         afterManifest?: () => Promise<void>;
         afterStageBatch?: (batch: number) => Promise<void>;
@@ -235,12 +247,15 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       };
     },
   ) {
-    this.ks = new NuqFdbKeyspace(queueName);
+    this.ks = new NuqFdbKeyspace(
+      queueName,
+      options.migrationObjectKind ?? "scrape_job",
+    );
     this.groupOps = options.hasGroups
       ? new NuqFdbGroupOps(
           this.ks,
           options.finishedQueueName
-            ? new NuqFdbKeyspace(options.finishedQueueName)
+            ? new NuqFdbKeyspace(options.finishedQueueName, "crawl_finished")
             : null,
         )
       : null;
@@ -631,6 +646,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         }
       }
       if (fresh.length === 0) return;
+      for (const { job, plan } of fresh) {
+        await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+          teamId: plan.o,
+          kind: ks.migrationObjectKind,
+          objectId: job.id,
+          allowMissingRecordPin: true,
+        });
+      }
 
       const gated = fresh.filter(
         ({ plan }) => opMeta.l !== null && !plan.b,
@@ -816,7 +839,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         if (groupAccounted) flags |= F_GACC;
 
         const timesOutAt = gated ? j.options.timesOutAt?.getTime() : undefined;
-        const entry: QueueEntry = {
+        let entry: QueueEntry = {
           i: j.id,
           o: ownerId ?? "",
           g: gid,
@@ -826,28 +849,38 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           c: now,
           to: timesOutAt,
         };
+        const migrationPin = await validateJobMigrationInTxn(tn, ks, entry, {
+          allowMissingRecordPin: true,
+        });
+        entry = stampMigrationPin(entry, migrationPin);
 
-        const meta: JobMeta = {
-          c: now,
-          p: entry.p,
-          o: entry.o,
-          g: gid,
-          k: entry.k,
-          f: flags,
-          to: timesOutAt,
-          dc: j.dataChunks.length,
-        };
+        const meta: JobMeta = stampMigrationPin(
+          {
+            c: now,
+            p: entry.p,
+            o: entry.o,
+            g: gid,
+            k: entry.k,
+            f: flags,
+            to: timesOutAt,
+            dc: j.dataChunks.length,
+          },
+          migrationPin,
+        );
         tn.set(ks.jobMeta(j.id), encodeJson(meta));
 
         let placedStatus: NuqFdbJobStatus;
+        let migrationResidue: Partial<MigrationResidue>;
         if (!gated) {
           pushReady(tn, ks, entry, txc);
           setStatusQueued(tn, ks, j.id);
           placedStatus = "queued";
+          migrationResidue = { capacity_ready_active: 1 };
         } else if (crawlGated && crawlFree.get(gid!)! <= 0) {
           const loc = appendCrawlPending(tn, ks, entry);
           setStatusPending(tn, ks, j.id, loc);
           placedStatus = "pending";
+          migrationResidue = { capacity_crawl_pending: 1 };
         } else if (keyGated && keyFree <= 0) {
           // holds the crawl slot (if any) while waiting in the key gate
           if (crawlGated) {
@@ -857,6 +890,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           const loc = appendKeyPending(tn, ks, entry);
           setStatusPending(tn, ks, j.id, loc);
           placedStatus = "pending";
+          migrationResidue = { capacity_key_pending: 1 };
         } else {
           if (crawlGated) {
             crawlFree.set(gid!, crawlFree.get(gid!)! - 1);
@@ -872,13 +906,16 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
             pushReady(tn, ks, entry, txc);
             setStatusQueued(tn, ks, j.id);
             placedStatus = "queued";
+            migrationResidue = { capacity_ready_active: 1 };
           } else {
             const loc = appendTeamPending(tn, ks, entry);
             setStatusPending(tn, ks, j.id, loc);
             placedStatus = "pending";
+            migrationResidue = { capacity_team_pending: 1 };
           }
         }
 
+        await reconcileJobMigrationInTxn(tn, ks, entry, migrationResidue);
         await alignQueueMetricStatus(tn, ks, j.id);
         if (groupAccounted && gid) {
           tn.add(ks.groupRemaining(gid), ONE);
@@ -936,6 +973,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
             await tn.get(ks.jobStatus(id)),
           );
           if (status?.s === "ingesting" && status.op === op) {
+            await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+              teamId: opMeta.o,
+              kind: ks.migrationObjectKind,
+              objectId: id,
+              allowMissingRecordPin: true,
+              residue: {},
+              terminal: true,
+            });
             deleteJobRecords(tn, ks, id);
             await alignQueueMetricStatus(tn, ks, id);
           }
@@ -1182,6 +1227,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         return "dropped";
       }
 
+      await validateJobMigrationInTxn(tn, ks, e);
+
       if (e.g && this.options.hasGroups) {
         const gMeta = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(e.g)));
         if (gMeta && gMeta.s === "cancelled") {
@@ -1198,6 +1245,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
               tn.set(ks.taskGroupFinish(e.g), EMPTY);
             }
           }
+          await reconcileJobMigrationInTxn(tn, ks, e, {}, { terminal: true });
           deleteJobRecords(tn, ks, e.i);
           await alignQueueMetricStatus(tn, ks, e.i);
           await releaseSlotsAndPromote(
@@ -1255,6 +1303,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         leaseExpiresAt: new Date(exp),
         ownerId: meta.o || undefined,
         groupId: meta.g,
+        migrationBackend: meta.mb,
+        migrationGeneration: meta.mg,
       };
     };
     let result = await this.db.doTn(claimTransaction);
@@ -1336,6 +1386,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       leaseExpiresAt: new Date(claim.e),
       ownerId: meta.o || undefined,
       groupId: meta.g,
+      migrationBackend: meta.mb,
+      migrationGeneration: meta.mg,
     };
   }
 
@@ -1357,6 +1409,20 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       // reap. The status' lock/expiry, not worker-local memory, is authoritative.
       const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));
       if (!st || st.s !== "active" || st.l !== lock) return false;
+      const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
+      if (!meta) return false;
+      await validateJobMigrationInTxn(tn, ks, {
+        i: id,
+        o: meta.o,
+        g: meta.g,
+        k: meta.k,
+        p: meta.p,
+        f: meta.f,
+        c: meta.c,
+        to: meta.to,
+        mb: meta.mb,
+        mg: meta.mg,
+      });
       if (st.e !== undefined) {
         tn.clear(ks.lease(timeBucket(id), st.e, id));
       }
@@ -1494,7 +1560,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         f: meta.f,
         c: meta.c,
         to: meta.to,
+        mb: meta.mb,
+        mg: meta.mg,
       };
+      await reconcileJobMigrationInTxn(tn, ks, entry, {}, { terminal: true });
       await releaseSlotsAndPromote(
         tn,
         ks,
@@ -1576,6 +1645,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       lock: st.s === "active" ? st.l : undefined,
       ownerId: meta.o || undefined,
       groupId: meta.g,
+      migrationBackend: meta.mb,
+      migrationGeneration: meta.mg,
     };
   }
 
@@ -1665,9 +1736,13 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         f: meta.f,
         c: meta.c,
         to: meta.to,
+        mb: meta.mb,
+        mg: meta.mg,
       };
       const countable = !!(meta.f & F_COUNTABLE);
       const accounted = !!(meta.f & F_GACC) && !!meta.g && !!this.groupOps;
+
+      await reconcileJobMigrationInTxn(tn, ks, entry, {}, { terminal: true });
 
       if (st.s === "pending") {
         clearPendingPlacement(
@@ -1932,43 +2007,67 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   // === Introspection used by status/admin endpoints
 
-  // Recovery-only probe for ungated queues (notably crawl_finished). The
-  // migration integration replaces this legacy scan with owner-generation
-  // indexes before enabling cutover.
+  // Maintained transactionally with every live/terminal job transition. A
+  // bounded, durable backfill makes the index rollout-safe for jobs written by
+  // older binaries; callers retry rather than falsely declaring PG authority
+  // while that backfill is incomplete.
   public async hasReadyOrActiveJobForOwner(ownerId: string): Promise<boolean> {
     const owner = normalizeOwnerId(ownerId);
     if (owner === null) return false;
-    return await this.db.doTn(async tn => {
-      const snapshot = tn.snapshot();
-      const ready = await Promise.all(
-        Array.from({ length: READY_SHARDS }, (_, shard) => {
-          const range = this.ks.readyShardRange(shard);
-          return snapshot.getRangeAll(range.begin, range.end);
-        }),
-      );
-      if (
-        ready.some(rows =>
-          rows.some(
-            ([, value]) => decodeJson<QueueEntry>(value as Buffer)?.o === owner,
-          ),
-        )
-      ) {
-        return true;
-      }
-      const leaseRange = this.ks.leaseRange();
-      const leases = await snapshot.getRangeAll(
-        leaseRange.begin,
-        leaseRange.end,
-      );
-      for (const [key] of leases) {
-        const id = this.ks.unpackId(key as Buffer);
-        const meta = decodeJson<JobMeta>(
-          await snapshot.get(this.ks.jobMeta(id)),
+    const batchSize = 500;
+    const maxBatchesPerCall = 10;
+    for (let batch = 0; batch < maxBatchesPerCall; batch++) {
+      const result = await this.db.doTn(async tn => {
+        const ownerRange = this.ks.ownerLiveJobRange(owner);
+        const indexed = await tn
+          .snapshot()
+          .getRangeAll(ownerRange.begin, ownerRange.end, { limit: 1 });
+        if (indexed.length > 0) return { found: true, ready: true };
+        const jobs = this.ks.jobRootRange();
+        const cursor = await tn.get(this.ks.ownerLiveBackfillCursor());
+        const begin: Buffer | FdbKeySelector = cursor
+          ? { key: cursor, orEqual: true, offset: 1, _isKeySelector: true }
+          : jobs.begin;
+        const rows = await tn
+          .snapshot()
+          .getRangeAll(begin as any, jobs.end, { limit: batchSize });
+        let found = false;
+        for (const [rawKey, rawValue] of rows) {
+          const parts = this.ks.unpack(rawKey as Buffer);
+          if (parts[4] !== "m") continue;
+          const id = String(parts[3]);
+          const meta = decodeJson<JobMeta>(rawValue as Buffer);
+          if (!meta) continue;
+          // Normal status read conflicts with terminalization while this page
+          // publishes its index rows.
+          const status = decodeJson<JobStatusRecord>(
+            await tn.get(this.ks.jobStatus(id)),
+          );
+          if (status?.s !== "queued" && status?.s !== "active") continue;
+          tn.set(this.ks.ownerLiveJob(meta.o, id), EMPTY);
+          if (meta.o === owner) found = true;
+        }
+        if (rows.length < batchSize) {
+          // Do not persist a permanent "complete" marker: during a rolling
+          // deployment an older writer can still publish an unindexed job.
+          // A later negative lookup safely repeats this bounded scan.
+          tn.clear(this.ks.ownerLiveBackfillCursor());
+          return { found, ready: true };
+        }
+        tn.set(
+          this.ks.ownerLiveBackfillCursor(),
+          rows[rows.length - 1][0] as Buffer,
         );
-        if (meta?.o === owner) return true;
-      }
-      return false;
-    });
+        return { found, ready: false };
+      });
+      if (result.found) return true;
+      if (result.ready) return false;
+    }
+    throw new MigrationStoreError(
+      "NUQ_FDB_OWNER_INDEX_INITIALIZING",
+      `owner live-job index for ${this.queueName} is still backfilling`,
+      true,
+    );
   }
 
   public async getTeamActiveCount(teamId: string): Promise<number> {

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -61,6 +61,7 @@ import {
   setGroupJobIndex,
   bumpGroupStatusCount,
   bumpTeamActive,
+  synchronizeTeamLimitInTxn,
   alignQueueMetricStatus,
   bumpKeyActive,
   scheduleRaiseTask,
@@ -758,21 +759,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
       let free = Infinity;
       if (gate.teamLimit !== null && ownerId !== null) {
-        const storedBuf = await tn.get(ks.teamLimit(ownerId));
-        const stored = storedBuf ? decodeI64(storedBuf) : null;
-        if (stored !== gate.teamLimit) {
-          tn.set(ks.teamLimit(ownerId), encodeI64(gate.teamLimit));
-          // Also indexes teams whose configured limit is zero.
-          tn.add(ks.teamActiveIndex(ownerId), encodeI64(0));
-          tn.set(ks.teamLedgerGcIndex(ownerId), EMPTY);
-          if (stored !== null && gate.teamLimit > stored) {
-            scheduleRaiseTask(tn, ks.taskTeamRaise(ownerId));
-          }
-        }
-
         // Strict for every limit, including >=256. The ingest reservation
         // bounds queue admission; this conflicting read bounds active slots.
-        const active = decodeI64(await tn.get(ks.teamActive(ownerId)));
+        const active = await synchronizeTeamLimitInTxn(
+          tn,
+          ks,
+          ownerId,
+          gate.teamLimit,
+        );
         free = Math.max(0, gate.teamLimit - active);
       }
 

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -70,7 +70,11 @@ import {
   validateJobMigrationInTxn,
   stampMigrationPin,
 } from "./ops";
-import { MigrationStoreError, nuqFdbMigrationStore } from "./migration-store";
+import {
+  MigrationCorruptionError,
+  MigrationStoreError,
+  nuqFdbMigrationStore,
+} from "./migration-store";
 import type {
   MigrationBackend,
   MigrationObjectKind,
@@ -135,6 +139,12 @@ export type NuQFdbJob<Data = any, ReturnValue = any> = {
   groupId?: string;
   migrationBackend?: MigrationBackend;
   migrationGeneration?: number;
+};
+
+export type NuQFdbLegacyJobDescriptor = {
+  teamId: string;
+  terminal: boolean;
+  residue: Partial<MigrationResidue>;
 };
 
 export type NuQFdbJobOptions = {
@@ -1662,6 +1672,70 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     });
   }
 
+  /** Explicit adoption descriptor for runtime rows written before generation
+   * hooks. It conservatively accounts one live object in its exact placement
+   * class; terminal records adopt a zero-residue tombstone. */
+  public async inspectLegacyMigrationObject(
+    id: string,
+  ): Promise<NuQFdbLegacyJobDescriptor | null> {
+    return await this.db.doTn(async tn => {
+      const snapshot = tn.snapshot();
+      const [meta, status] = await Promise.all([
+        snapshot
+          .get(this.ks.jobMeta(id))
+          .then(value => decodeJson<JobMeta>(value)),
+        snapshot
+          .get(this.ks.jobStatus(id))
+          .then(value => decodeJson<JobStatusRecord>(value)),
+      ]);
+      if (!meta || !status || !meta.o) return null;
+      if (
+        status.s === "completed" ||
+        status.s === "failed" ||
+        status.s === "cancelled"
+      ) {
+        return { teamId: meta.o, terminal: true, residue: {} };
+      }
+      if (this.ks.migrationObjectKind === "crawl_finished") {
+        return {
+          teamId: meta.o,
+          terminal: false,
+          residue: { control_crawl_finished: 1 },
+        };
+      }
+      if (status.s === "queued" || status.s === "active") {
+        return {
+          teamId: meta.o,
+          terminal: false,
+          residue: { capacity_ready_active: 1 },
+        };
+      }
+      if (status.s === "pending") {
+        const counter =
+          status.loc?.k === "kq"
+            ? "capacity_key_pending"
+            : status.loc?.k === "gq"
+              ? "capacity_crawl_pending"
+              : status.loc?.k === "dl"
+                ? "capacity_delayed"
+                : "capacity_team_pending";
+        return {
+          teamId: meta.o,
+          terminal: false,
+          residue: { [counter]: 1 },
+        };
+      }
+      // In-progress ingest manifests have no published JobMeta and normally
+      // return above. If a legacy partial row does carry metadata, keep seal
+      // conservative until its cleanup reconciles it.
+      return {
+        teamId: meta.o,
+        terminal: false,
+        residue: { capacity_ready_active: 1 },
+      };
+    });
+  }
+
   public async getJobs(
     ids: string[],
     logger: Logger = _logger,
@@ -2056,12 +2130,43 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           );
         }
         const ownerRange = this.ks.ownerLiveJobRange(owner);
-        // Normal range reads conflict with a concurrent indexed publication.
+        // Normal range reads conflict with concurrent publication. Validate
+        // each index row against authoritative status/meta so mixed-version
+        // terminalization cannot leave sticky residue, and fail closed if an
+        // index ever points across tenant ownership.
         const indexed = await tn.getRangeAll(ownerRange.begin, ownerRange.end, {
-          limit: 1,
+          limit: 100,
         });
-        if (indexed.length > 0) return { found: true, ready: true };
+        for (const [key] of indexed) {
+          const id = this.ks.unpackId(key as Buffer);
+          const [status, meta] = await Promise.all([
+            tn
+              .get(this.ks.jobStatus(id))
+              .then(value => decodeJson<JobStatusRecord>(value)),
+            tn
+              .get(this.ks.jobMeta(id))
+              .then(value => decodeJson<JobMeta>(value)),
+          ]);
+          if (status?.s === "queued" || status?.s === "active") {
+            if (meta?.o !== owner) {
+              throw new MigrationCorruptionError(
+                `owner index ${owner}/${id}`,
+                "live job owner mismatch",
+              );
+            }
+            return { found: true, ready: true };
+          }
+          tn.clear(key as Buffer);
+        }
         if (await tn.get(this.ks.ownerLiveBackfillReady(control.generation))) {
+          if (indexed.length === 100) {
+            // Commit this bounded stale-row cleanup, then retry before making a
+            // negative authority decision; a live row may follow this page.
+            return { found: false, ready: false };
+          }
+          // READY makes the maintained owner index authoritative. Obsolete
+          // ready-shard entries are ignored here and cleaned by queue/sweeper
+          // reconciliation; they cannot pin a team without a live status row.
           return { found: false, ready: true };
         }
         const jobs = this.ks.jobRootRange();

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -2277,6 +2277,18 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     );
   }
 
+  private syncCoreReadinessInTxn(
+    tn: Transaction,
+    control: NuqFdbMetricControl | null,
+  ): void {
+    if (this.queueName !== "scrape" && this.queueName !== "crawl_finished") {
+      return;
+    }
+    const key = nuqFdbMigrationStore.coreReadinessKey(this.queueName);
+    if (control) tn.set(key, encodeJson(control));
+    else tn.clear(key);
+  }
+
   private decodeMetricControl(
     value: Buffer | undefined | null,
   ): NuqFdbMetricControl | null {
@@ -2306,8 +2318,12 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const current = this.decodeMetricControl(
         await tn.get(this.ks.metricControl()),
       );
-      if (current) return current;
+      if (current) {
+        this.syncCoreReadinessInTxn(tn, current);
+        return current;
+      }
       tn.set(this.ks.metricControl(), encodeJson(requested));
+      this.syncCoreReadinessInTxn(tn, requested);
       return requested;
     });
   }
@@ -2329,7 +2345,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const control = this.decodeMetricControl(
         await tn.get(this.ks.metricControl()),
       );
-      if (!control) return true;
+      if (!control) {
+        this.syncCoreReadinessInTxn(tn, null);
+        return true;
+      }
       if (
         expectedGeneration !== undefined &&
         control.generation !== expectedGeneration
@@ -2337,6 +2356,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         return false;
       }
       tn.clear(this.ks.metricControl());
+      this.syncCoreReadinessInTxn(tn, null);
       return true;
     });
   }
@@ -2355,7 +2375,11 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const control = this.decodeMetricControl(
         await tn.get(this.ks.metricControl()),
       );
-      if (!control) return false;
+      if (!control) {
+        this.syncCoreReadinessInTxn(tn, null);
+        return false;
+      }
+      this.syncCoreReadinessInTxn(tn, control);
       if (control.phase === "ready") return true;
 
       if (control.phase === "backfill-jobs") {
@@ -2381,10 +2405,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         }
         if (rows.length < pageSize) {
           tn.clear(this.ks.metricJobsCursor(control.generation));
-          tn.set(
-            this.ks.metricControl(),
-            encodeJson({ ...control, phase: "backfill-ledger" }),
-          );
+          const next = { ...control, phase: "backfill-ledger" } as const;
+          tn.set(this.ks.metricControl(), encodeJson(next));
+          this.syncCoreReadinessInTxn(tn, next);
         } else {
           tn.set(
             this.ks.metricJobsCursor(control.generation),
@@ -2413,10 +2436,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       }
       if (rows.length < pageSize) {
         tn.clear(this.ks.metricLedgerCursor(control.generation));
-        tn.set(
-          this.ks.metricControl(),
-          encodeJson({ ...control, phase: "ready" }),
-        );
+        const next = { ...control, phase: "ready" } as const;
+        tn.set(this.ks.metricControl(), encodeJson(next));
+        this.syncCoreReadinessInTxn(tn, next);
         return true;
       }
       tn.set(

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -2008,6 +2008,37 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       );
   }
 
+  // Atomically reconcile a router-prepared intent after enqueue rejected
+  // before creating runtime records. Reading the job status in the same FDB
+  // transaction makes this conflict with a concurrent successful enqueue.
+  public async compensateRejectedMigrationJobs(
+    teamId: string,
+    ids: readonly string[],
+  ): Promise<void> {
+    if (ids.length === 0) return;
+    const ks = this.ks;
+    await this.db.doTn(async tn => {
+      for (const id of ids) {
+        if (await tn.get(ks.jobStatus(id))) continue;
+        const pin = await nuqFdbMigrationStore.inspectPinInTxn(
+          tn,
+          ks.migrationObjectKind,
+          id,
+        );
+        if (!pin || pin.teamId !== teamId || pin.lifecycle !== "prepared") {
+          continue;
+        }
+        await nuqFdbMigrationStore.completePinnedObjectInTxn(tn, {
+          teamId,
+          kind: ks.migrationObjectKind,
+          objectId: id,
+          operationId: `nuq-router/v1/fdb-enqueue-rejected/${id}`,
+          fromLifecycle: "prepared",
+        });
+      }
+    });
+  }
+
   // === Introspection used by status/admin endpoints
 
   // Maintained transactionally with every live/terminal job transition. The

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -647,6 +647,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       }
       if (fresh.length === 0) return;
       for (const { job, plan } of fresh) {
+        if (!plan.o) continue;
         await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
           teamId: plan.o,
           kind: ks.migrationObjectKind,
@@ -973,14 +974,16 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
             await tn.get(ks.jobStatus(id)),
           );
           if (status?.s === "ingesting" && status.op === op) {
-            await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
-              teamId: opMeta.o,
-              kind: ks.migrationObjectKind,
-              objectId: id,
-              allowMissingRecordPin: true,
-              residue: {},
-              terminal: true,
-            });
+            if (opMeta.o) {
+              await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+                teamId: opMeta.o,
+                kind: ks.migrationObjectKind,
+                objectId: id,
+                allowMissingRecordPin: true,
+                residue: {},
+                terminal: true,
+              });
+            }
             deleteJobRecords(tn, ks, id);
             await alignQueueMetricStatus(tn, ks, id);
           }
@@ -2007,10 +2010,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   // === Introspection used by status/admin endpoints
 
-  // Maintained transactionally with every live/terminal job transition. A
-  // bounded, durable backfill makes the index rollout-safe for jobs written by
-  // older binaries; callers retry rather than falsely declaring PG authority
-  // while that backfill is incomplete.
+  // Maintained transactionally with every live/terminal job transition. The
+  // backfill marker is scoped to the corrected-core metric generation, so a
+  // rollback invalidation forces the next deployment to rescan legacy writers.
   public async hasReadyOrActiveJobForOwner(ownerId: string): Promise<boolean> {
     const owner = normalizeOwnerId(ownerId);
     if (owner === null) return false;
@@ -2018,19 +2020,37 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const maxBatchesPerCall = 10;
     for (let batch = 0; batch < maxBatchesPerCall; batch++) {
       const result = await this.db.doTn(async tn => {
+        const control = this.decodeMetricControl(
+          await tn.get(this.ks.metricControl()),
+        );
+        if (!control || control.phase !== "ready") {
+          throw new MigrationStoreError(
+            "NUQ_FDB_OWNER_INDEX_NOT_READY",
+            `owner live-job index for ${this.queueName} requires ready metric counters`,
+            true,
+          );
+        }
         const ownerRange = this.ks.ownerLiveJobRange(owner);
-        const indexed = await tn
-          .snapshot()
-          .getRangeAll(ownerRange.begin, ownerRange.end, { limit: 1 });
+        // Normal range reads conflict with a concurrent indexed publication.
+        const indexed = await tn.getRangeAll(ownerRange.begin, ownerRange.end, {
+          limit: 1,
+        });
         if (indexed.length > 0) return { found: true, ready: true };
+        if (await tn.get(this.ks.ownerLiveBackfillReady(control.generation))) {
+          return { found: false, ready: true };
+        }
         const jobs = this.ks.jobRootRange();
-        const cursor = await tn.get(this.ks.ownerLiveBackfillCursor());
+        const cursor = await tn.get(
+          this.ks.ownerLiveBackfillCursor(control.generation),
+        );
         const begin: Buffer | FdbKeySelector = cursor
           ? { key: cursor, orEqual: true, offset: 1, _isKeySelector: true }
           : jobs.begin;
-        const rows = await tn
-          .snapshot()
-          .getRangeAll(begin as any, jobs.end, { limit: batchSize });
+        // A normal scan conflicts with publication by a mixed-version writer
+        // before this generation's completion marker commits.
+        const rows = await tn.getRangeAll(begin as any, jobs.end, {
+          limit: batchSize,
+        });
         let found = false;
         for (const [rawKey, rawValue] of rows) {
           const parts = this.ks.unpack(rawKey as Buffer);
@@ -2048,14 +2068,12 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           if (meta.o === owner) found = true;
         }
         if (rows.length < batchSize) {
-          // Do not persist a permanent "complete" marker: during a rolling
-          // deployment an older writer can still publish an unindexed job.
-          // A later negative lookup safely repeats this bounded scan.
-          tn.clear(this.ks.ownerLiveBackfillCursor());
+          tn.clear(this.ks.ownerLiveBackfillCursor(control.generation));
+          tn.set(this.ks.ownerLiveBackfillReady(control.generation), EMPTY);
           return { found, ready: true };
         }
         tn.set(
-          this.ks.ownerLiveBackfillCursor(),
+          this.ks.ownerLiveBackfillCursor(control.generation),
           rows[rows.length - 1][0] as Buffer,
         );
         return { found, ready: false };

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -1932,6 +1932,45 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   // === Introspection used by status/admin endpoints
 
+  // Recovery-only probe for ungated queues (notably crawl_finished). The
+  // migration integration replaces this legacy scan with owner-generation
+  // indexes before enabling cutover.
+  public async hasReadyOrActiveJobForOwner(ownerId: string): Promise<boolean> {
+    const owner = normalizeOwnerId(ownerId);
+    if (owner === null) return false;
+    return await this.db.doTn(async tn => {
+      const snapshot = tn.snapshot();
+      const ready = await Promise.all(
+        Array.from({ length: READY_SHARDS }, (_, shard) => {
+          const range = this.ks.readyShardRange(shard);
+          return snapshot.getRangeAll(range.begin, range.end);
+        }),
+      );
+      if (
+        ready.some(rows =>
+          rows.some(
+            ([, value]) => decodeJson<QueueEntry>(value as Buffer)?.o === owner,
+          ),
+        )
+      ) {
+        return true;
+      }
+      const leaseRange = this.ks.leaseRange();
+      const leases = await snapshot.getRangeAll(
+        leaseRange.begin,
+        leaseRange.end,
+      );
+      for (const [key] of leases) {
+        const id = this.ks.unpackId(key as Buffer);
+        const meta = decodeJson<JobMeta>(
+          await snapshot.get(this.ks.jobMeta(id)),
+        );
+        if (meta?.o === owner) return true;
+      }
+      return false;
+    });
+  }
+
   public async getTeamActiveCount(teamId: string): Promise<number> {
     const owner = normalizeOwnerId(teamId);
     if (owner === null) return 0;

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -32,6 +32,13 @@ export type ExternalSlotRecord = {
   mg?: number; // never-reused migration generation
 };
 
+type PgExternalSlotExpiryRecord = {
+  e: number;
+  g: string;
+  t: string;
+  h: string;
+};
+
 export type ExternalSlotSweepGuard = (tn: Transaction) => Promise<void>;
 export type ExternalSlotSweepObserver = (
   due: readonly [Buffer, Buffer][],
@@ -78,10 +85,38 @@ export class NuqFdbExternalSlots {
     return this.ks.pack(["xsexp", bucket, expMs, holderId]);
   }
 
+  private pgExpiryRecordKey(teamId: string, holderId: string): Buffer {
+    return this.ks.pack(["pgxs", teamId, holderId]);
+  }
+
+  private pgExpiryKey(
+    bucket: number,
+    expMs: number,
+    teamId: string,
+    holderId: string,
+    generation: string,
+  ): Buffer {
+    return this.ks.pack([
+      "pgxsexp",
+      bucket,
+      expMs,
+      teamId,
+      holderId,
+      generation,
+    ]);
+  }
+
   public expiryScanRange(bucket: number, untilMs: number) {
     return {
       begin: this.ks.pack(["xsexp", bucket]),
       end: this.ks.pack(["xsexp", bucket, untilMs]),
+    };
+  }
+
+  public pgExpiryScanRange(bucket: number, untilMs: number) {
+    return {
+      begin: this.ks.pack(["pgxsexp", bucket]),
+      end: this.ks.pack(["pgxsexp", bucket, untilMs]),
     };
   }
 
@@ -158,6 +193,112 @@ export class NuqFdbExternalSlots {
         ),
         Buffer.alloc(0),
       );
+    });
+  }
+
+  // PG holders live in Redis, but their migration residue cannot depend on a
+  // volatile Redis TTL. Publish the exact renewal generation into FDB and
+  // activate the pin atomically with that expiry record.
+  public async renewPg(
+    teamId: string,
+    holderId: string,
+    expiresAt: number,
+  ): Promise<void> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return;
+    if (!Number.isSafeInteger(expiresAt)) {
+      throw new TypeError("external holder expiry must be a safe integer");
+    }
+    const generation = randomUUID();
+    const objectId = externalSlotMigrationObjectId(owner, holderId);
+    await this.db.doTn(async tn => {
+      const pin = await nuqFdbMigrationStore.validatePinnedObjectInTxn(tn, {
+        teamId: owner,
+        kind: "external_holder",
+        objectId,
+        backend: "pg",
+      });
+      const prior = decodeJson<PgExternalSlotExpiryRecord>(
+        await tn.get(this.pgExpiryRecordKey(owner, holderId)),
+      );
+      if (prior) {
+        tn.clear(
+          this.pgExpiryKey(
+            timeBucket(`${owner}/${holderId}`),
+            prior.e,
+            owner,
+            holderId,
+            prior.g,
+          ),
+        );
+      }
+      if (pin.lifecycle === "prepared") {
+        await nuqFdbMigrationStore.transitionObjectResidueInTxn(tn, {
+          teamId: owner,
+          kind: "external_holder",
+          objectId,
+          operationId: `nuq-router/v1/external-holder-active/${objectId}`,
+          fromLifecycle: "prepared",
+          toLifecycle: "active",
+          residue: { capacity_external_holders: 1 },
+        });
+      }
+      const record: PgExternalSlotExpiryRecord = {
+        e: expiresAt,
+        g: generation,
+        t: owner,
+        h: holderId,
+      };
+      tn.set(this.pgExpiryRecordKey(owner, holderId), encodeJson(record));
+      tn.set(
+        this.pgExpiryKey(
+          timeBucket(`${owner}/${holderId}`),
+          expiresAt,
+          owner,
+          holderId,
+          generation,
+        ),
+        Buffer.alloc(0),
+      );
+    });
+  }
+
+  public async releasePg(teamId: string, holderId: string): Promise<void> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return;
+    const objectId = externalSlotMigrationObjectId(owner, holderId);
+    await this.db.doTn(async tn => {
+      const prior = decodeJson<PgExternalSlotExpiryRecord>(
+        await tn.get(this.pgExpiryRecordKey(owner, holderId)),
+      );
+      if (prior) {
+        tn.clear(
+          this.pgExpiryKey(
+            timeBucket(`${owner}/${holderId}`),
+            prior.e,
+            owner,
+            holderId,
+            prior.g,
+          ),
+        );
+        tn.clear(this.pgExpiryRecordKey(owner, holderId));
+      }
+      const pin = await nuqFdbMigrationStore.inspectPinInTxn(
+        tn,
+        "external_holder",
+        objectId,
+      );
+      if (!pin || pin.lifecycle === "terminal") return;
+      if (pin.teamId !== owner || pin.backend !== "pg") {
+        throw new Error(`PG external holder pin mismatch for ${objectId}`);
+      }
+      await nuqFdbMigrationStore.completePinnedObjectInTxn(tn, {
+        teamId: owner,
+        kind: "external_holder",
+        objectId,
+        operationId: `nuq-router/v1/external-holder-terminal/${objectId}`,
+        fromLifecycle: pin.lifecycle,
+      });
     });
   }
 
@@ -278,9 +419,86 @@ export class NuqFdbExternalSlots {
     return processed;
   }
 
+  public async sweepExpiredPgBucket(
+    now: number,
+    bucket: number,
+    guard?: ExternalSlotSweepGuard,
+    observeDue?: ExternalSlotSweepObserver,
+  ): Promise<number> {
+    const startedAt = Date.now();
+    let processed = 0;
+    while (Date.now() - startedAt < EXTERNAL_SWEEP_BUDGET_MS) {
+      const range = this.pgExpiryScanRange(bucket, now);
+      const due = (await this.db.doTn(async tn => {
+        if (guard) await guard(tn);
+        return await tn.snapshot().getRangeAll(range.begin, range.end, {
+          limit: EXTERNAL_SWEEP_BATCH,
+        });
+      })) as [Buffer, Buffer][];
+      observeDue?.(due);
+      if (due.length === 0) break;
+      for (const [key] of due) {
+        const parts = this.ks.unpack(key);
+        const expiresAt = Number(parts[4]);
+        const owner = String(parts[5]);
+        const holderId = String(parts[6]);
+        const generation = String(parts[7]);
+        await this.db.doTn(async tn => {
+          if (guard) await guard(tn);
+          const recordKey = this.pgExpiryRecordKey(owner, holderId);
+          const current = decodeJson<PgExternalSlotExpiryRecord>(
+            await tn.get(recordKey),
+          );
+          if (
+            !current ||
+            current.e !== expiresAt ||
+            current.g !== generation ||
+            current.t !== owner ||
+            current.h !== holderId ||
+            current.e > now
+          ) {
+            tn.clear(key);
+            return;
+          }
+          const objectId = externalSlotMigrationObjectId(owner, holderId);
+          const pin = await nuqFdbMigrationStore.inspectPinInTxn(
+            tn,
+            "external_holder",
+            objectId,
+          );
+          if (!pin) {
+            throw new Error(`Missing PG external holder pin ${objectId}`);
+          }
+          if (pin.teamId !== owner || pin.backend !== "pg") {
+            throw new Error(`PG external holder pin mismatch for ${objectId}`);
+          }
+          if (pin.lifecycle === "active") {
+            await nuqFdbMigrationStore.completePinnedObjectInTxn(tn, {
+              teamId: owner,
+              kind: "external_holder",
+              objectId,
+              operationId: `nuq-router/v1/external-holder-expiry/${generation}`,
+              fromLifecycle: "active",
+            });
+          } else if (pin.lifecycle !== "terminal") {
+            throw new Error(
+              `PG external holder expiry found ${pin.lifecycle} pin ${objectId}`,
+            );
+          }
+          tn.clear(recordKey);
+          tn.clear(key);
+        });
+        processed++;
+      }
+      if (due.length < EXTERNAL_SWEEP_BATCH) break;
+    }
+    return processed;
+  }
+
   public async sweepExpired(now: number, buckets: number): Promise<void> {
     for (let bucket = 0; bucket < buckets; bucket++) {
       await this.sweepExpiredBucket(now, bucket);
+      await this.sweepExpiredPgBucket(now, bucket);
     }
   }
 }

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -77,6 +77,14 @@ export class NuqFdbExternalSlots {
     };
   }
 
+  public async has(teamId: string, holderId: string): Promise<boolean> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return false;
+    return await this.db.doTn(async tn =>
+      Boolean(await tn.snapshot().get(this.key(owner, holderId))),
+    );
+  }
+
   // Acquires (or renews) an external slot. Unconditional: never blocks on the
   // team limit; the caller's own gate (Lua semaphore, session limits) decides
   // admission. Re-acquiring an existing holder just extends its expiry.
@@ -95,11 +103,12 @@ export class NuqFdbExternalSlots {
         await tn.get(this.key(owner, holderId)),
       );
       const existingPin = existing
-        ? await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+        ? await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
             teamId: owner,
             kind: "external_holder",
             objectId: holderId,
             recordPin: runtimeMigrationPin(existing),
+            residue: { capacity_external_holders: 1 },
           })
         : null;
       if (existing) {

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -40,6 +40,14 @@ export type ExternalSlotSweepObserver = (
 const EXTERNAL_SWEEP_BATCH = 100;
 const EXTERNAL_SWEEP_BUDGET_MS = 5_000;
 
+// Holder IDs are tenant-local; migration pins live in a global object keyspace.
+export function externalSlotMigrationObjectId(
+  teamId: string,
+  holderId: string,
+): string {
+  return `${teamId}/${holderId}`;
+}
+
 export class NuqFdbExternalSlots {
   constructor(public readonly ks: NuqFdbKeyspace) {}
 
@@ -106,7 +114,7 @@ export class NuqFdbExternalSlots {
         ? await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
             teamId: owner,
             kind: "external_holder",
-            objectId: holderId,
+            objectId: externalSlotMigrationObjectId(owner, holderId),
             recordPin: runtimeMigrationPin(existing),
             residue: { capacity_external_holders: 1 },
           })
@@ -131,7 +139,7 @@ export class NuqFdbExternalSlots {
         : await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
             teamId: owner,
             kind: "external_holder",
-            objectId: holderId,
+            objectId: externalSlotMigrationObjectId(owner, holderId),
             allowMissingRecordPin: true,
             residue: { capacity_external_holders: 1 },
           });
@@ -174,7 +182,7 @@ export class NuqFdbExternalSlots {
     await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
       teamId: owner,
       kind: "external_holder",
-      objectId: holderId,
+      objectId: externalSlotMigrationObjectId(owner, holderId),
       recordPin: runtimeMigrationPin(existing),
       residue: {},
       terminal: true,

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -15,6 +15,7 @@ import {
   newTxContext,
   releaseSlotsAndPromote,
   runtimeMigrationPin,
+  synchronizeTeamLimitInTxn,
   stampMigrationPin,
 } from "./ops";
 import { nuqFdbMigrationStore } from "./migration-store";
@@ -128,70 +129,111 @@ export class NuqFdbExternalSlots {
     );
   }
 
-  // Acquires (or renews) an external slot. Unconditional: never blocks on the
-  // team limit; the caller's own gate (Lua semaphore, session limits) decides
-  // admission. Re-acquiring an existing holder just extends its expiry.
+  private async acquireInTxn(
+    tn: Transaction,
+    owner: string,
+    holderId: string,
+    ttlMs: number,
+    limit: number | null,
+    prepareMigrationPin: boolean,
+    requireExisting: boolean,
+  ): Promise<boolean> {
+    const existing = decodeJson<ExternalSlotRecord>(
+      await tn.get(this.key(owner, holderId)),
+    );
+
+    if (!existing && requireExisting) return false;
+
+    // A non-snapshot read conflicts with every queue/external active-count
+    // mutation. The capacity check and holder insertion therefore serialize in
+    // FDB instead of relying on a process lock or a second Redis ledger. A
+    // capacity-aware reservation carries the caller's current configured limit;
+    // renew-only heartbeats pass no limit and therefore cannot overwrite it.
+    const active =
+      limit !== null
+        ? await synchronizeTeamLimitInTxn(tn, this.ks, owner, limit)
+        : null;
+    if (!existing && limit !== null && active !== null && active >= limit) {
+      return false;
+    }
+
+    const objectId = externalSlotMigrationObjectId(owner, holderId);
+    if (!existing && prepareMigrationPin) {
+      await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
+        teamId: owner,
+        kind: "external_holder",
+        objectId,
+        admission: { type: "new-root" },
+        requiredBackend: "fdb",
+        residue: { capacity_external_holders: 1 },
+      });
+    }
+
+    const pin = await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+      teamId: owner,
+      kind: "external_holder",
+      objectId,
+      ...(existing
+        ? { recordPin: runtimeMigrationPin(existing) }
+        : { allowMissingRecordPin: true }),
+      residue: { capacity_external_holders: 1 },
+    });
+
+    if (existing) {
+      tn.clear(
+        existing.g
+          ? this.expiryKey(
+              timeBucket(`${owner}/${holderId}`),
+              existing.e,
+              owner,
+              holderId,
+              existing.g,
+            )
+          : this.legacyExpiryKey(timeBucket(holderId), existing.e, holderId),
+      );
+    } else {
+      bumpTeamActive(tn, this.ks, owner, 1);
+    }
+
+    const exp = Date.now() + ttlMs;
+    const generation = randomUUID();
+    const record = stampMigrationPin(
+      { e: exp, g: generation } satisfies ExternalSlotRecord,
+      pin,
+    );
+    tn.set(this.key(owner, holderId), encodeJson(record));
+    tn.set(
+      this.expiryKey(
+        timeBucket(`${owner}/${holderId}`),
+        exp,
+        owner,
+        holderId,
+        generation,
+      ),
+      Buffer.alloc(0),
+    );
+    return true;
+  }
+
+  // Acquires (or renews) an external slot unconditionally. Router-owned new
+  // holders prepare their migration pin in this same transaction.
   public async acquire(
     teamId: string,
     holderId: string,
     ttlMs: number,
+    options?: { prepareMigrationPin?: boolean },
   ): Promise<void> {
     const owner = normalizeOwnerId(teamId);
     if (owner === null) return;
-    const now = Date.now();
-    const exp = now + ttlMs;
-    const generation = randomUUID();
     await this.db.doTn(async tn => {
-      const existing = decodeJson<ExternalSlotRecord>(
-        await tn.get(this.key(owner, holderId)),
-      );
-      const existingPin = existing
-        ? await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
-            teamId: owner,
-            kind: "external_holder",
-            objectId: externalSlotMigrationObjectId(owner, holderId),
-            recordPin: runtimeMigrationPin(existing),
-            residue: { capacity_external_holders: 1 },
-          })
-        : null;
-      if (existing) {
-        tn.clear(
-          existing.g
-            ? this.expiryKey(
-                timeBucket(`${owner}/${holderId}`),
-                existing.e,
-                owner,
-                holderId,
-                existing.g,
-              )
-            : this.legacyExpiryKey(timeBucket(holderId), existing.e, holderId),
-        );
-      } else {
-        bumpTeamActive(tn, this.ks, owner, 1);
-      }
-      const pin = existing
-        ? existingPin
-        : await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
-            teamId: owner,
-            kind: "external_holder",
-            objectId: externalSlotMigrationObjectId(owner, holderId),
-            allowMissingRecordPin: true,
-            residue: { capacity_external_holders: 1 },
-          });
-      const record = stampMigrationPin(
-        { e: exp, g: generation } satisfies ExternalSlotRecord,
-        pin,
-      );
-      tn.set(this.key(owner, holderId), encodeJson(record));
-      tn.set(
-        this.expiryKey(
-          timeBucket(`${owner}/${holderId}`),
-          exp,
-          owner,
-          holderId,
-          generation,
-        ),
-        Buffer.alloc(0),
+      await this.acquireInTxn(
+        tn,
+        owner,
+        holderId,
+        ttlMs,
+        null,
+        options?.prepareMigrationPin === true,
+        false,
       );
     });
   }
@@ -300,6 +342,44 @@ export class NuqFdbExternalSlots {
         fromLifecycle: pin.lifecycle,
       });
     });
+  }
+
+  // Atomically checks authoritative team occupancy and inserts the holder.
+  // Re-acquiring an existing holder only renews it and never double-counts.
+  public async reserve(
+    teamId: string,
+    holderId: string,
+    ttlMs: number,
+    limit: number,
+    options?: { prepareMigrationPin?: boolean },
+  ): Promise<boolean> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return false;
+    return await this.db.doTn(async tn =>
+      this.acquireInTxn(
+        tn,
+        owner,
+        holderId,
+        ttlMs,
+        limit,
+        options?.prepareMigrationPin === true,
+        false,
+      ),
+    );
+  }
+
+  // Renews an existing holder without changing the configured team limit or
+  // resurrecting a holder that expiry cleanup has already released.
+  public async renew(
+    teamId: string,
+    holderId: string,
+    ttlMs: number,
+  ): Promise<boolean> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return false;
+    return await this.db.doTn(async tn =>
+      this.acquireInTxn(tn, owner, holderId, ttlMs, null, false, true),
+    );
   }
 
   // Releases the slot, handing it to a pending job when one exists.

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -245,6 +245,7 @@ export class NuqFdbExternalSlots {
     teamId: string,
     holderId: string,
     expiresAt: number,
+    options?: { prepareMigrationPin?: boolean },
   ): Promise<void> {
     const owner = normalizeOwnerId(teamId);
     if (owner === null) return;
@@ -254,12 +255,28 @@ export class NuqFdbExternalSlots {
     const generation = randomUUID();
     const objectId = externalSlotMigrationObjectId(owner, holderId);
     await this.db.doTn(async tn => {
-      const pin = await nuqFdbMigrationStore.validatePinnedObjectInTxn(tn, {
-        teamId: owner,
-        kind: "external_holder",
+      let pin = await nuqFdbMigrationStore.inspectPinInTxn(
+        tn,
+        "external_holder",
         objectId,
-        backend: "pg",
-      });
+      );
+      if (!pin && options?.prepareMigrationPin) {
+        pin = await nuqFdbMigrationStore.preparePinnedObjectInTxn(tn, {
+          teamId: owner,
+          kind: "external_holder",
+          objectId,
+          admission: { type: "new-root" },
+          requiredBackend: "pg",
+          residue: { intent_unresolved: 1 },
+        });
+      } else {
+        pin = await nuqFdbMigrationStore.validatePinnedObjectInTxn(tn, {
+          teamId: owner,
+          kind: "external_holder",
+          objectId,
+          backend: "pg",
+        });
+      }
       const prior = decodeJson<PgExternalSlotExpiryRecord>(
         await tn.get(this.pgExpiryRecordKey(owner, holderId)),
       );

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -10,7 +10,14 @@ import {
   F_GATED,
   normalizeOwnerId,
 } from "./keyspace";
-import { bumpTeamActive, newTxContext, releaseSlotsAndPromote } from "./ops";
+import {
+  bumpTeamActive,
+  newTxContext,
+  releaseSlotsAndPromote,
+  runtimeMigrationPin,
+  stampMigrationPin,
+} from "./ops";
+import { nuqFdbMigrationStore } from "./migration-store";
 
 // External slots: capacity consumed by things that are not queue jobs (sync
 // scrapes via the team semaphore, browser sessions). They unconditionally bump
@@ -18,9 +25,11 @@ import { bumpTeamActive, newTxContext, releaseSlotsAndPromote } from "./ops";
 // behavior where sync holders were mirrored into the same ZSET -- and hand
 // their slot through the normal promotion chain on release.
 
-type ExternalSlotRecord = {
+export type ExternalSlotRecord = {
   e: number; // expiry ms
   g?: string; // renewal generation (absent on pre-generation records)
+  mb?: "pg" | "fdb"; // migration backend pin
+  mg?: number; // never-reused migration generation
 };
 
 export type ExternalSlotSweepGuard = (tn: Transaction) => Promise<void>;
@@ -85,6 +94,14 @@ export class NuqFdbExternalSlots {
       const existing = decodeJson<ExternalSlotRecord>(
         await tn.get(this.key(owner, holderId)),
       );
+      const existingPin = existing
+        ? await nuqFdbMigrationStore.validateManagedObjectInTxn(tn, {
+            teamId: owner,
+            kind: "external_holder",
+            objectId: holderId,
+            recordPin: runtimeMigrationPin(existing),
+          })
+        : null;
       if (existing) {
         tn.clear(
           existing.g
@@ -100,10 +117,20 @@ export class NuqFdbExternalSlots {
       } else {
         bumpTeamActive(tn, this.ks, owner, 1);
       }
-      tn.set(
-        this.key(owner, holderId),
-        encodeJson({ e: exp, g: generation } satisfies ExternalSlotRecord),
+      const pin = existing
+        ? existingPin
+        : await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+            teamId: owner,
+            kind: "external_holder",
+            objectId: holderId,
+            allowMissingRecordPin: true,
+            residue: { capacity_external_holders: 1 },
+          });
+      const record = stampMigrationPin(
+        { e: exp, g: generation } satisfies ExternalSlotRecord,
+        pin,
       );
+      tn.set(this.key(owner, holderId), encodeJson(record));
       tn.set(
         this.expiryKey(
           timeBucket(`${owner}/${holderId}`),
@@ -135,6 +162,14 @@ export class NuqFdbExternalSlots {
       await tn.get(this.key(owner, holderId)),
     );
     if (!existing) return false;
+    await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+      teamId: owner,
+      kind: "external_holder",
+      objectId: holderId,
+      recordPin: runtimeMigrationPin(existing),
+      residue: {},
+      terminal: true,
+    });
     tn.clear(this.key(owner, holderId));
     tn.clear(
       existing.g

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -129,6 +129,22 @@ export class NuqFdbExternalSlots {
     );
   }
 
+  /** Conflict-safe point reads used by migration tombstone GC. The durable PG
+   * expiry intent remains authoritative when Redis has been flushed. */
+  public async hasMigrationReferenceInTxn(
+    tn: Transaction,
+    teamId: string,
+    holderId: string,
+  ): Promise<boolean> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return false;
+    const [fdb, pg] = await Promise.all([
+      tn.get(this.key(owner, holderId)),
+      tn.get(this.pgExpiryRecordKey(owner, holderId)),
+    ]);
+    return Boolean(fdb || pg);
+  }
+
   private async acquireInTxn(
     tn: Transaction,
     owner: string,

--- a/apps/api/src/services/worker/nuq-fdb/sweeper-lifecycle.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "winston";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { config } from "../../../config";
 import type { NuqFdbKeyspace } from "./keyspace";
 import type { NuQFdbQueue } from "./queue";
 import { NuqFdbSweeper } from "./sweeper";
@@ -9,6 +10,7 @@ const logger = {
   warn: vi.fn(),
   error: vi.fn(),
 } as unknown as Logger;
+const previousMetricsActivation = config.NUQ_FDB_METRICS_V2_ACTIVATE;
 
 function deferred() {
   let resolve!: () => void;
@@ -55,9 +57,13 @@ describe("NuqFdbSweeper lifecycle", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // Lifecycle backfill tests model the activated release-B sweeper. Disabled
+    // rollout behavior is covered separately by the metric invalidation tests.
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = true;
   });
 
   afterEach(() => {
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = previousMetricsActivation;
     vi.useRealTimers();
   });
 
@@ -229,6 +235,21 @@ describe("NuqFdbSweeper lifecycle", () => {
     expect(sweepOnce).toHaveBeenCalledTimes(2);
     sweeper.stop();
     await expect(restartedDone).resolves.toBeUndefined();
+  });
+
+  it("invalidates queue metric generations while release-B activation is disabled", async () => {
+    config.NUQ_FDB_METRICS_V2_ACTIVATE = false;
+    const queue = {
+      ks: { queueName: "disabled" },
+      invalidateMetricCounterGeneration: vi.fn().mockResolvedValue(true),
+      backfillMetricCounts: vi.fn(),
+    } as unknown as NuQFdbQueue;
+    const sweeper = new NuqFdbSweeper([queue]);
+
+    await sweeper.sweepOnce(logger, 0);
+
+    expect(queue.invalidateMetricCounterGeneration).toHaveBeenCalledOnce();
+    expect(queue.backfillMetricCounts).not.toHaveBeenCalled();
   });
 
   it("does not continue queue backfills after force-stop and restart", async () => {

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -566,14 +566,16 @@ export class NuqFdbSweeper {
           partition: bucket,
           run: async claim => {
             await this.renewClaim(claim);
-            await slots.sweepExpiredBucket(
-              now,
-              bucket,
-              this.guard(claim),
-              due =>
-                this.observeDue(claim, "external_expiry", due, key =>
-                  Number(claim.ks.unpack(key)[4]),
-                ),
+            const guard = this.guard(claim);
+            const observedDue: [Buffer, Buffer][] = [];
+            await slots.sweepExpiredBucket(now, bucket, guard, due =>
+              observedDue.push(...due),
+            );
+            await slots.sweepExpiredPgBucket(now, bucket, guard, due =>
+              observedDue.push(...due),
+            );
+            this.observeDue(claim, "external_expiry", observedDue, key =>
+              Number(claim.ks.unpack(key)[4]),
             );
           },
         });

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -1272,14 +1272,16 @@ export class NuqFdbSweeper {
               await tn.get(ks.jobStatus(id)),
             );
             if (status?.s === "ingesting" && status.op === op) {
-              await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
-                teamId: meta.o,
-                kind: ks.migrationObjectKind,
-                objectId: id,
-                allowMissingRecordPin: true,
-                residue: {},
-                terminal: true,
-              });
+              if (meta.o) {
+                await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+                  teamId: meta.o,
+                  kind: ks.migrationObjectKind,
+                  objectId: id,
+                  allowMissingRecordPin: true,
+                  residue: {},
+                  terminal: true,
+                });
+              }
               deleteJobRecords(tn, ks, id);
               await alignQueueMetricStatus(tn, ks, id);
             }
@@ -1415,8 +1417,10 @@ export class NuqFdbSweeper {
     observedTaskKey: Buffer,
   ): Promise<void> {
     const ks = queue.ks;
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < PARTITION_WORK_BUDGET_MS) {
+    // Once a group task is claimed, finish its resumable pages while renewing
+    // ownership. Yielding at the partition budget can strand the only task
+    // behind its still-live lease, so a concurrent sweeper cannot continue it.
+    while (true) {
       await this.renewClaim(claim);
       const result = await this.db.doTn(async tn => {
         await this.guardClaim(tn, claim);

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -51,8 +51,13 @@ import {
   validateJobMigrationInTxn,
   runtimeMigrationPin,
 } from "./ops";
-import { nuqFdbMigrationStore } from "./migration-store";
-import { ACTIVE_GROUP_MAX_AGE_MS, prepareGroupSweepTaskInTxn } from "./groups";
+import { MigrationStoreError, nuqFdbMigrationStore } from "./migration-store";
+import {
+  ACTIVE_GROUP_MAX_AGE_MS,
+  LEGACY_GROUP_OWNER_INDEX_PHASE,
+  NuQFdbJobGroup,
+  prepareGroupSweepTaskInTxn,
+} from "./groups";
 import { NuQFdbQueue } from "./queue";
 import { ExternalSlotSweepGuard, NuqFdbExternalSlots } from "./slots";
 
@@ -531,6 +536,29 @@ export class NuqFdbSweeper {
           phase: "legacy-all-group-index",
           partition: 0,
           run: claim => this.indexLegacyGroups(queue, claim),
+        },
+        {
+          ks: queue.ks,
+          phase: LEGACY_GROUP_OWNER_INDEX_PHASE,
+          partition: 0,
+          run: async claim => {
+            await this.renewClaim(claim);
+            if (!queue.groupOps) return;
+            try {
+              await new NuQFdbJobGroup(
+                queue.ks,
+                queue.groupOps,
+              ).backfillLegacyOwnerIndex(SWEEP_BATCH * 2);
+            } catch (error) {
+              if (
+                error instanceof MigrationStoreError &&
+                error.code === "NUQ_FDB_GROUP_OWNER_INDEX_NOT_READY"
+              ) {
+                return;
+              }
+              throw error;
+            }
+          },
         },
         {
           ks: queue.ks,

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -628,7 +628,11 @@ export class NuqFdbSweeper {
       ) {
         return;
       }
-      await queue.backfillMetricCounts(100, config.NUQ_FDB_METRICS_V2_ACTIVATE);
+      if (!config.NUQ_FDB_METRICS_V2_ACTIVATE) {
+        await queue.invalidateMetricCounterGeneration();
+      } else {
+        await queue.backfillMetricCounts(100, true);
+      }
       if (
         lifecycleGeneration !== undefined &&
         lifecycleGeneration !== this.runGeneration

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -47,8 +47,12 @@ import {
   setGroupJobIndex,
   GroupJobIndexValue,
   alignQueueMetricStatus,
+  reconcileJobMigrationInTxn,
+  validateJobMigrationInTxn,
+  runtimeMigrationPin,
 } from "./ops";
-import { ACTIVE_GROUP_MAX_AGE_MS } from "./groups";
+import { nuqFdbMigrationStore } from "./migration-store";
+import { ACTIVE_GROUP_MAX_AGE_MS, prepareGroupSweepTaskInTxn } from "./groups";
 import { NuQFdbQueue } from "./queue";
 import { ExternalSlotSweepGuard, NuqFdbExternalSlots } from "./slots";
 
@@ -153,6 +157,8 @@ function entryFromMeta(id: string, meta: JobMeta): QueueEntry {
     f: meta.f,
     c: meta.c,
     to: meta.to,
+    mb: meta.mb,
+    mg: meta.mg,
   };
 }
 
@@ -1004,6 +1010,7 @@ export class NuqFdbSweeper {
           if (!meta) return;
           const entry = entryFromMeta(id, meta);
           if (st.st < MAX_STALLS) {
+            await validateJobMigrationInTxn(tn, ks, entry);
             pushReady(tn, ks, entry, txc);
             setStatusQueued(tn, ks, id, st.st + 1);
             await alignQueueMetricStatus(tn, ks, id);
@@ -1012,6 +1019,15 @@ export class NuqFdbSweeper {
               bumpGroupStatusCount(tn, ks, meta.g, "queued", 1);
             }
           } else {
+            await reconcileJobMigrationInTxn(
+              tn,
+              ks,
+              entry,
+              {},
+              {
+                terminal: true,
+              },
+            );
             tn.set(
               ks.jobStatus(id),
               encodeJson({
@@ -1099,6 +1115,16 @@ export class NuqFdbSweeper {
           if (!st || st.s !== "pending" || !st.loc) return;
           const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
           if (!meta) return;
+          const entry = entryFromMeta(id, meta);
+          await reconcileJobMigrationInTxn(
+            tn,
+            ks,
+            entry,
+            {},
+            {
+              terminal: true,
+            },
+          );
           clearPendingPlacement(
             tn,
             ks,
@@ -1113,7 +1139,7 @@ export class NuqFdbSweeper {
             await releaseSlotsAndPromote(
               tn,
               ks,
-              entryFromMeta(id, meta),
+              entry,
               { team: false, key: st.loc.k === "tq", crawl: true },
               now,
               txc,
@@ -1246,6 +1272,14 @@ export class NuqFdbSweeper {
               await tn.get(ks.jobStatus(id)),
             );
             if (status?.s === "ingesting" && status.op === op) {
+              await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+                teamId: meta.o,
+                kind: ks.migrationObjectKind,
+                objectId: id,
+                allowMissingRecordPin: true,
+                residue: {},
+                terminal: true,
+              });
               deleteJobRecords(tn, ks, id);
               await alignQueueMetricStatus(tn, ks, id);
             }
@@ -1421,6 +1455,16 @@ export class NuqFdbSweeper {
             continue;
           }
           if (st.s === "pending" && st.loc) {
+            const entry = entryFromMeta(id, meta);
+            await reconcileJobMigrationInTxn(
+              tn,
+              ks,
+              entry,
+              {},
+              {
+                terminal: true,
+              },
+            );
             clearPendingPlacement(
               tn,
               ks,
@@ -1447,6 +1491,16 @@ export class NuqFdbSweeper {
             await alignQueueMetricStatus(tn, ks, id);
             cleaned++;
           } else if (g.z && (st.s === "queued" || st.s === "active")) {
+            const entry = entryFromMeta(id, meta);
+            await reconcileJobMigrationInTxn(
+              tn,
+              ks,
+              entry,
+              {},
+              {
+                terminal: true,
+              },
+            );
             tn.set(
               ks.jobStatus(id),
               encodeJson({
@@ -1461,7 +1515,7 @@ export class NuqFdbSweeper {
             await releaseSlotsAndPromote(
               tn,
               ks,
-              entryFromMeta(id, meta),
+              entry,
               { team: true, key: true, crawl: true },
               now,
               newTxContext(),
@@ -1701,6 +1755,15 @@ export class NuqFdbSweeper {
         return "done";
       }
       if (g.s === "active") {
+        await prepareGroupSweepTaskInTxn(tn, gid, g);
+        await nuqFdbMigrationStore.reconcileManagedObjectInTxn(tn, {
+          teamId: g.o,
+          kind: "group",
+          objectId: gid,
+          recordPin: runtimeMigrationPin(g),
+          residue: {},
+          terminal: true,
+        });
         const nextAt = now + ABANDONED_GROUP_DRAIN_GRACE_MS;
         const nextGeneration = randomUUID();
         tn.set(

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, test, vi } from "vitest";
+import type {
+  MigrationObjectPin,
+  MigrationTeamState,
+} from "./nuq-fdb/migration-store";
+import {
+  DurableNuQPgPublicationAdapter,
+  reconcileDesiredTeamBackend,
+  reconcilePgResidueFence,
+  resolveAuthoritativeObjectBackend,
+  stableTransitionOperationId,
+  type NuQMigrationStorePort,
+} from "./nuq-migration-control";
+
+function state(
+  overrides: Partial<MigrationTeamState> = {},
+): MigrationTeamState {
+  return {
+    schemaVersion: 1,
+    teamId: "team",
+    revision: 1,
+    maxGeneration: 1,
+    activeBackend: "pg",
+    activeGeneration: 1,
+    phase: "PG_ONLY",
+    ...overrides,
+  };
+}
+
+function pin(
+  objectId: string,
+  overrides: Partial<MigrationObjectPin> = {},
+): MigrationObjectPin {
+  const zero = {
+    capacity_team_pending: 0,
+    capacity_key_pending: 0,
+    capacity_crawl_pending: 0,
+    capacity_delayed: 0,
+    capacity_ready_active: 0,
+    capacity_external_holders: 0,
+    control_groups: 0,
+    control_crawl_finished: 0,
+    control_sweeper_tasks: 0,
+    intent_unresolved: 1,
+  };
+  return {
+    schemaVersion: 1,
+    teamId: "team",
+    kind: "scrape_job",
+    objectId,
+    backend: "pg",
+    generation: 1,
+    lifecycle: "prepared",
+    revision: 1,
+    admission: "new-root",
+    initialResidue: zero,
+    residue: zero,
+    ...overrides,
+  };
+}
+
+function storeMock(
+  overrides: Partial<NuQMigrationStorePort> = {},
+): NuQMigrationStorePort {
+  return {
+    inspectState: vi.fn(),
+    resolveSteady: vi.fn(),
+    initializeLegacyTeam: vi.fn(),
+    beginTransition: vi.fn(),
+    cancelTransition: vi.fn(),
+    finalSeal: vi.fn(),
+    inspectTeamPins: vi.fn(),
+    inspectPin: vi.fn(),
+    preparePinnedObject: vi.fn(),
+    preparePinnedObjects: vi.fn(),
+    transitionObjectResidue: vi.fn(),
+    completePinnedObject: vi.fn(),
+    ...overrides,
+  } as NuQMigrationStorePort;
+}
+
+describe("durable team state decisions", () => {
+  test("flag changes begin with stable operation IDs and fail admission retryably", async () => {
+    const current = state();
+    const store = storeMock({
+      resolveSteady: vi.fn().mockResolvedValue({
+        status: "transition-required",
+        state: current,
+      }),
+      beginTransition: vi.fn().mockResolvedValue(
+        state({
+          revision: 2,
+          maxGeneration: 2,
+          phase: "DRAINING_TO_FDB",
+          targetBackend: "fdb",
+          targetGeneration: 2,
+          transitionOperationId: stableTransitionOperationId(current, "fdb"),
+        }),
+      ),
+    });
+
+    await expect(
+      reconcileDesiredTeamBackend(store, "team", "fdb"),
+    ).rejects.toMatchObject({
+      code: "NUQ_MIGRATION_IN_PROGRESS",
+      retryable: true,
+    });
+    expect(store.beginTransition).toHaveBeenCalledWith({
+      teamId: "team",
+      targetBackend: "fdb",
+      operationId: "nuq-router/v1/team/team/after-generation/1/to/fdb",
+      expectedRevision: 1,
+    });
+  });
+
+  test("a flag flap cancels the same durable transition operation", async () => {
+    const draining = state({
+      revision: 2,
+      maxGeneration: 2,
+      phase: "DRAINING_TO_FDB",
+      targetBackend: "fdb",
+      targetGeneration: 2,
+      transitionOperationId: "stable-transition",
+    });
+    const cancelled = state({ revision: 3, maxGeneration: 2 });
+    const store = storeMock({
+      resolveSteady: vi.fn().mockResolvedValue({
+        status: "cancel-required",
+        state: draining,
+      }),
+      cancelTransition: vi.fn().mockResolvedValue(cancelled),
+    });
+
+    await expect(
+      reconcileDesiredTeamBackend(store, "team", "pg"),
+    ).resolves.toEqual(cancelled);
+    expect(store.cancelTransition).toHaveBeenCalledWith({
+      teamId: "team",
+      transitionOperationId: "stable-transition",
+      expectedRevision: 2,
+    });
+  });
+});
+
+describe("authoritative backend resolution", () => {
+  const base = {
+    kind: "scrape_job" as const,
+    objectId: "job",
+    readPin: vi.fn().mockResolvedValue(null),
+    probeFdb: vi.fn().mockResolvedValue(false),
+    probePg: vi.fn().mockResolvedValue(false),
+  };
+
+  test("a corrupt marker is repaired when exactly one backend contains the job", async () => {
+    const repairMarker = vi.fn();
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: "corrupt",
+        probePg: vi.fn().mockResolvedValue(true),
+        repairMarker,
+      }),
+    ).resolves.toBe("pg");
+    expect(repairMarker).toHaveBeenCalledWith("pg");
+  });
+
+  test("failed Redis hint repair cannot override an authoritative result", async () => {
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: null,
+        probeFdb: vi.fn().mockResolvedValue(true),
+        repairMarker: vi.fn().mockRejectedValue(new Error("Redis down")),
+      }),
+    ).resolves.toBe("fdb");
+  });
+
+  test("both-present is deterministic even when the marker names one backend", async () => {
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: "pg",
+        probeFdb: vi.fn().mockResolvedValue(true),
+        probePg: vi.fn().mockResolvedValue(true),
+      }),
+    ).rejects.toMatchObject({ code: "NUQ_ROUTER_BOTH_BACKENDS_PRESENT" });
+  });
+
+  test("corrupt marker without an authoritative record is deterministic", async () => {
+    await expect(
+      resolveAuthoritativeObjectBackend({ ...base, marker: "corrupt" }),
+    ).rejects.toMatchObject({ code: "NUQ_ROUTER_CORRUPT_BACKEND_MARKER" });
+  });
+
+  test("FDB unavailability never probes or falls back to PG", async () => {
+    const probePg = vi.fn().mockResolvedValue(true);
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: null,
+        readPin: vi.fn().mockRejectedValue(new Error("FDB down")),
+        probePg,
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_ROUTER_FDB_UNAVAILABLE",
+      retryable: true,
+    });
+    expect(probePg).not.toHaveBeenCalled();
+  });
+});
+
+test("PG residue reconciliation changes only the durable seal fence", async () => {
+  const existing = pin("pg-residue/team", {
+    kind: "cross_store_intent",
+    residue: { ...pin("unused").residue, intent_unresolved: 1 },
+  });
+  const store = storeMock({
+    inspectPin: vi.fn().mockResolvedValue(existing),
+    transitionObjectResidue: vi.fn().mockImplementation(async input => ({
+      ...existing,
+      residue: {
+        ...existing.residue,
+        intent_unresolved: input.residue.intent_unresolved ?? 0,
+      },
+    })),
+  });
+
+  await expect(
+    reconcilePgResidueFence(store, {
+      teamId: "team",
+      total: 0,
+      observationId: "pg-snapshot-2",
+    }),
+  ).resolves.toMatchObject({ residue: { intent_unresolved: 0 } });
+  expect(store.transitionObjectResidue).toHaveBeenCalledWith({
+    teamId: "team",
+    kind: "cross_store_intent",
+    objectId: "pg-residue/team",
+    operationId: "nuq-router/v1/pg-residue/pg-snapshot-2/pin-revision/1",
+    fromLifecycle: "prepared",
+    toLifecycle: "prepared",
+    residue: { intent_unresolved: 0 },
+  });
+  expect(store.finalSeal).not.toHaveBeenCalled();
+});
+
+test("PG publication adapter prepares and resolves every intent exact-once", async () => {
+  const pins = new Map<string, MigrationObjectPin>();
+  const operations = new Map<string, MigrationObjectPin>();
+  const prepare = vi.fn(async input => {
+    const existing = pins.get(input.objectId);
+    if (existing) return existing;
+    const prepared = pin(input.objectId, {
+      teamId: input.teamId,
+      admission:
+        input.admission.type === "new-root"
+          ? "new-root"
+          : "pinned-continuation",
+      sourceKind:
+        input.admission.type === "pinned-continuation"
+          ? input.admission.source.kind
+          : undefined,
+      sourceObjectId:
+        input.admission.type === "pinned-continuation"
+          ? input.admission.source.objectId
+          : undefined,
+    });
+    pins.set(input.objectId, prepared);
+    return prepared;
+  });
+  const store = storeMock({
+    preparePinnedObject: prepare,
+    preparePinnedObjects: vi.fn(async inputs =>
+      Promise.all(inputs.map(prepare)),
+    ),
+    inspectPin: vi.fn(async (_kind, objectId) => pins.get(objectId) ?? null),
+    transitionObjectResidue: vi.fn(async input => {
+      const replay = operations.get(input.operationId);
+      if (replay) return replay;
+      const next = pin(input.objectId, {
+        ...pins.get(input.objectId),
+        lifecycle: input.toLifecycle,
+        residue: {
+          ...pin(input.objectId).residue,
+          intent_unresolved: 0,
+          capacity_team_pending: input.residue.capacity_team_pending ?? 0,
+          capacity_ready_active: input.residue.capacity_ready_active ?? 0,
+        },
+      });
+      operations.set(input.operationId, next);
+      pins.set(input.objectId, next);
+      return next;
+    }),
+  });
+  const adapter = new DurableNuQPgPublicationAdapter(store);
+  const publication = {
+    id: "job",
+    ownerId: "team",
+    groupId: "crawl",
+    placement: "backlog" as const,
+  };
+
+  await adapter.prepare([publication]);
+  await adapter.prepare([publication]);
+  await adapter.complete([publication], "published");
+  await adapter.complete([publication], "published");
+  await adapter.complete([publication], "promoted");
+  await adapter.complete([publication], "promoted");
+
+  expect(store.preparePinnedObjects).toHaveBeenNthCalledWith(1, [
+    {
+      teamId: "team",
+      kind: "scrape_job",
+      objectId: "job",
+      admission: {
+        type: "pinned-continuation",
+        source: { kind: "group", objectId: "crawl" },
+      },
+      requiredBackend: "pg",
+      residue: { intent_unresolved: 1 },
+    },
+  ]);
+  expect(operations).toHaveLength(2);
+  expect(pins.get("job")).toMatchObject({
+    lifecycle: "active",
+    residue: { intent_unresolved: 0, capacity_ready_active: 1 },
+  });
+});

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -73,7 +73,7 @@ function storeMock(
     beginTransition: vi.fn(),
     cancelTransition: vi.fn(),
     finalSeal: vi.fn(),
-    inspectTeamPins: vi.fn(),
+    inspectTeamPinsPage: vi.fn(),
     inspectPin: vi.fn(),
     preparePinnedObject: vi.fn(),
     preparePinnedObjects: vi.fn(),
@@ -426,8 +426,43 @@ test("PG residue reconciliation changes only the durable seal fence", async () =
     fromLifecycle: "prepared",
     toLifecycle: "prepared",
     residue: { intent_unresolved: 0 },
+    expectedRevision: 1,
   });
   expect(store.finalSeal).not.toHaveBeenCalled();
+});
+
+test("source residue commit-unknown retry replays its exact bounded operation", async () => {
+  const existing = pin("pg-residue/team/generation/1", {
+    kind: "cross_store_intent",
+    revision: 2,
+    residue: { ...pin("unused").residue, intent_unresolved: 0 },
+    lastOperation: {
+      schemaVersion: 1,
+      operationId: "nuq-router/v1/pg-residue/stable-observation/pin-revision/1",
+      fromLifecycle: "prepared",
+      toLifecycle: "prepared",
+      residue: { ...pin("unused").residue, intent_unresolved: 0 },
+      resultRevision: 2,
+    },
+  });
+  const transitionObjectResidue = vi.fn().mockResolvedValue(existing);
+  const store = storeMock({
+    inspectState: vi.fn().mockResolvedValue(state()),
+    inspectPin: vi.fn().mockResolvedValue(existing),
+    transitionObjectResidue,
+  });
+
+  await reconcilePgResidueFence(store, {
+    teamId: "team",
+    total: 0,
+    observationId: "stable-observation",
+  });
+  expect(transitionObjectResidue).toHaveBeenCalledWith(
+    expect.objectContaining({
+      operationId: "nuq-router/v1/pg-residue/stable-observation/pin-revision/1",
+      expectedRevision: 1,
+    }),
+  );
 });
 
 test("PG residue fence explicitly adopts the draining source generation", async () => {

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -324,6 +324,51 @@ describe("authoritative backend resolution", () => {
     ).rejects.toMatchObject({ code: "NUQ_ROUTER_BOTH_BACKENDS_PRESENT" });
   });
 
+  test("a live pin with no backend object is unresolved, never silently routed", async () => {
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: "pg",
+        readPin: vi.fn().mockResolvedValue(
+          pin("job", {
+            lifecycle: "active",
+            residue: { ...pin("job").residue, capacity_ready_active: 1 },
+          }),
+        ),
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_ROUTER_LIVE_PIN_OBJECT_MISSING",
+      retryable: true,
+    });
+  });
+
+  test("a terminal tombstone remains authoritative after object retention", async () => {
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: null,
+        readPin: vi.fn().mockResolvedValue(
+          pin("job", {
+            lifecycle: "terminal",
+            residue: { ...pin("job").residue, intent_unresolved: 0 },
+          }),
+        ),
+      }),
+    ).resolves.toBe("pg");
+  });
+
+  test("a stale valid marker is cleared and fails deterministically", async () => {
+    const repairMarker = vi.fn();
+    await expect(
+      resolveAuthoritativeObjectBackend({
+        ...base,
+        marker: "fdb",
+        repairMarker,
+      }),
+    ).rejects.toMatchObject({ code: "NUQ_ROUTER_STALE_BACKEND_MARKER" });
+    expect(repairMarker).toHaveBeenCalledWith(null);
+  });
+
   test("corrupt marker without an authoritative record is deterministic", async () => {
     await expect(
       resolveAuthoritativeObjectBackend({ ...base, marker: "corrupt" }),

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -8,6 +8,7 @@ import {
   discoverLegacyTeamBackend,
   hasLegacyFdbTeamResidue,
   reconcileDesiredTeamBackend,
+  reconcileFdbResidueFence,
   reconcilePgResidueFence,
   recoverLegacyTeamState,
   resolveAuthoritativeObjectBackend,
@@ -393,11 +394,12 @@ describe("authoritative backend resolution", () => {
 });
 
 test("PG residue reconciliation changes only the durable seal fence", async () => {
-  const existing = pin("pg-residue/team", {
+  const existing = pin("pg-residue/team/generation/1", {
     kind: "cross_store_intent",
     residue: { ...pin("unused").residue, intent_unresolved: 1 },
   });
   const store = storeMock({
+    inspectState: vi.fn().mockResolvedValue(state()),
     inspectPin: vi.fn().mockResolvedValue(existing),
     transitionObjectResidue: vi.fn().mockImplementation(async input => ({
       ...existing,
@@ -418,7 +420,7 @@ test("PG residue reconciliation changes only the durable seal fence", async () =
   expect(store.transitionObjectResidue).toHaveBeenCalledWith({
     teamId: "team",
     kind: "cross_store_intent",
-    objectId: "pg-residue/team",
+    objectId: "pg-residue/team/generation/1",
     operationId: "nuq-router/v1/pg-residue/pg-snapshot-2/pin-revision/1",
     fromLifecycle: "prepared",
     toLifecycle: "prepared",
@@ -428,7 +430,7 @@ test("PG residue reconciliation changes only the durable seal fence", async () =
 });
 
 test("PG residue fence explicitly adopts the draining source generation", async () => {
-  const adopted = pin("pg-residue/team", {
+  const adopted = pin("pg-residue/team/generation/1", {
     kind: "cross_store_intent",
     admission: "legacy-backfill",
   });
@@ -457,13 +459,56 @@ test("PG residue fence explicitly adopts the draining source generation", async 
   expect(store.preparePinnedObject).toHaveBeenCalledWith({
     teamId: "team",
     kind: "cross_store_intent",
-    objectId: "pg-residue/team",
+    objectId: "pg-residue/team/generation/1",
     admission: {
       type: "legacy-backfill",
       backend: "pg",
       generation: 1,
     },
     requiredBackend: "pg",
+    residue: { intent_unresolved: 1 },
+  });
+});
+
+test("source residue fences are isolated by backend and never-reused generation", async () => {
+  const adopted = pin("fdb-residue/team/generation/7", {
+    kind: "cross_store_intent",
+    backend: "fdb",
+    generation: 7,
+    admission: "legacy-backfill",
+  });
+  const store = storeMock({
+    inspectState: vi.fn().mockResolvedValue(
+      state({
+        activeBackend: "fdb",
+        activeGeneration: 7,
+        maxGeneration: 7,
+        phase: "DRAINING_TO_PG",
+        targetBackend: "pg",
+        targetGeneration: 8,
+      }),
+    ),
+    inspectPin: vi.fn().mockResolvedValue(null),
+    preparePinnedObject: vi.fn().mockResolvedValue(adopted),
+  });
+
+  await expect(
+    reconcileFdbResidueFence(store, {
+      teamId: "team",
+      total: 2,
+      observationId: "legacy-fdb-snapshot",
+    }),
+  ).resolves.toEqual(adopted);
+  expect(store.preparePinnedObject).toHaveBeenCalledWith({
+    teamId: "team",
+    kind: "cross_store_intent",
+    objectId: "fdb-residue/team/generation/7",
+    admission: {
+      type: "legacy-backfill",
+      backend: "fdb",
+      generation: 7,
+    },
+    requiredBackend: "fdb",
     residue: { intent_unresolved: 1 },
   });
 });

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -575,7 +575,11 @@ test("PG publication adapter prepares and resolves every intent exact-once", asy
   await adapter.complete([publication], "published");
   await adapter.complete([publication], "promoted");
   await adapter.complete([publication], "promoted");
+  // A later incompatible stable-ID retry compensates only a newly prepared
+  // intent; it must not terminalize this prior active publication.
+  await adapter.complete([publication], "compensated");
 
+  expect(store.completePinnedObject).not.toHaveBeenCalled();
   expect(store.preparePinnedObjects).toHaveBeenNthCalledWith(1, [
     {
       teamId: "team",

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -234,6 +234,7 @@ describe("legacy team authority discovery", () => {
       hasLegacyFdbTeamResidue({
         scrapePending: 0,
         scrapeActive: 0,
+        scrapeIndexedLive: false,
         crawlFinishedPending: 0,
         crawlFinishedActive: 0,
         crawlFinishedIndexedLive: true,

--- a/apps/api/src/services/worker/nuq-migration-control.test.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.test.ts
@@ -5,8 +5,11 @@ import type {
 } from "./nuq-fdb/migration-store";
 import {
   DurableNuQPgPublicationAdapter,
+  discoverLegacyTeamBackend,
+  hasLegacyFdbTeamResidue,
   reconcileDesiredTeamBackend,
   reconcilePgResidueFence,
+  recoverLegacyTeamState,
   resolveAuthoritativeObjectBackend,
   stableTransitionOperationId,
   type NuQMigrationStorePort,
@@ -80,6 +83,88 @@ function storeMock(
 }
 
 describe("durable team state decisions", () => {
+  test("uninitialized teams use caller-discovered FDB authority", async () => {
+    const recovered = state({
+      activeBackend: "fdb",
+      phase: "FDB_ONLY",
+    });
+    const store = storeMock({
+      resolveSteady: vi.fn().mockResolvedValue({
+        status: "legacy-uninitialized",
+      }),
+      initializeLegacyTeam: vi.fn().mockResolvedValue(recovered),
+    });
+    const discover = vi.fn().mockResolvedValue("fdb");
+
+    await expect(
+      reconcileDesiredTeamBackend(store, "team", "fdb", discover),
+    ).resolves.toEqual(recovered);
+    expect(discover).toHaveBeenCalledOnce();
+    expect(store.initializeLegacyTeam).toHaveBeenCalledWith(
+      "team",
+      "fdb",
+      "nuq-router/v1/team/team/initialize/fdb",
+      { ifAbsent: true },
+    );
+  });
+
+  test("initialize-if-absent trusts a concurrent durable winner", async () => {
+    const winner = state({
+      revision: 2,
+      maxGeneration: 2,
+      activeBackend: "fdb",
+      activeGeneration: 1,
+      phase: "DRAINING_TO_PG",
+      targetBackend: "pg",
+      targetGeneration: 2,
+      transitionOperationId: "winner",
+    });
+    const store = storeMock({
+      resolveSteady: vi.fn().mockResolvedValue({
+        status: "legacy-uninitialized",
+      }),
+      inspectState: vi.fn().mockResolvedValue(null),
+      initializeLegacyTeam: vi.fn().mockResolvedValue(winner),
+    });
+
+    await expect(
+      reconcileDesiredTeamBackend(store, "team", "pg", async () => "pg"),
+    ).resolves.toEqual(winner);
+    expect(store.initializeLegacyTeam).toHaveBeenCalledWith(
+      "team",
+      "pg",
+      "nuq-router/v1/team/team/initialize/pg",
+      { ifAbsent: true },
+    );
+    expect(store.beginTransition).not.toHaveBeenCalled();
+    expect(store.cancelTransition).not.toHaveBeenCalled();
+  });
+
+  test("router bootstrap recovery returns an existing transitional winner unchanged", async () => {
+    const winner = state({
+      revision: 2,
+      maxGeneration: 2,
+      activeBackend: "fdb",
+      activeGeneration: 1,
+      phase: "DRAINING_TO_PG",
+      targetBackend: "pg",
+      targetGeneration: 2,
+      transitionOperationId: "winner",
+    });
+    const discover = vi.fn().mockResolvedValue("pg");
+    const store = storeMock({
+      inspectState: vi.fn().mockResolvedValue(winner),
+    });
+
+    await expect(
+      recoverLegacyTeamState(store, "team", discover),
+    ).resolves.toEqual(winner);
+    expect(discover).not.toHaveBeenCalled();
+    expect(store.initializeLegacyTeam).not.toHaveBeenCalled();
+    expect(store.beginTransition).not.toHaveBeenCalled();
+    expect(store.cancelTransition).not.toHaveBeenCalled();
+  });
+
   test("flag changes begin with stable operation IDs and fail admission retryably", async () => {
     const current = state();
     const store = storeMock({
@@ -100,7 +185,7 @@ describe("durable team state decisions", () => {
     });
 
     await expect(
-      reconcileDesiredTeamBackend(store, "team", "fdb"),
+      reconcileDesiredTeamBackend(store, "team", "fdb", async () => "pg"),
     ).rejects.toMatchObject({
       code: "NUQ_MIGRATION_IN_PROGRESS",
       retryable: true,
@@ -132,13 +217,66 @@ describe("durable team state decisions", () => {
     });
 
     await expect(
-      reconcileDesiredTeamBackend(store, "team", "pg"),
+      reconcileDesiredTeamBackend(store, "team", "pg", async () => "pg"),
     ).resolves.toEqual(cancelled);
     expect(store.cancelTransition).toHaveBeenCalledWith({
       teamId: "team",
       transitionOperationId: "stable-transition",
       expectedRevision: 2,
     });
+  });
+});
+
+describe("legacy team authority discovery", () => {
+  test("crawl-finished-only FDB residue is not classified empty", () => {
+    expect(
+      hasLegacyFdbTeamResidue({
+        scrapePending: 0,
+        scrapeActive: 0,
+        crawlFinishedPending: 0,
+        crawlFinishedActive: 0,
+        crawlFinishedIndexedLive: true,
+        activeGroups: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test("FDB residue recovers FDB authority instead of defaulting to PG", async () => {
+    await expect(
+      discoverLegacyTeamBackend({
+        teamId: "team",
+        probeFdbResidue: vi.fn().mockResolvedValue(true),
+        probePgResidue: vi.fn().mockResolvedValue(false),
+        emptyBackend: "pg",
+      }),
+    ).resolves.toBe("fdb");
+  });
+
+  test("both-present is corruption", async () => {
+    await expect(
+      discoverLegacyTeamBackend({
+        teamId: "team",
+        probeFdbResidue: vi.fn().mockResolvedValue(true),
+        probePgResidue: vi.fn().mockResolvedValue(true),
+        emptyBackend: "pg",
+      }),
+    ).rejects.toMatchObject({ code: "NUQ_ROUTER_BOTH_BACKENDS_PRESENT" });
+  });
+
+  test("FDB unavailability is retryable and never probes PG", async () => {
+    const probePgResidue = vi.fn().mockResolvedValue(true);
+    await expect(
+      discoverLegacyTeamBackend({
+        teamId: "team",
+        probeFdbResidue: vi.fn().mockRejectedValue(new Error("FDB down")),
+        probePgResidue,
+        emptyBackend: "pg",
+      }),
+    ).rejects.toMatchObject({
+      code: "NUQ_ROUTER_FDB_UNAVAILABLE",
+      retryable: true,
+    });
+    expect(probePgResidue).not.toHaveBeenCalled();
   });
 });
 
@@ -242,6 +380,47 @@ test("PG residue reconciliation changes only the durable seal fence", async () =
     residue: { intent_unresolved: 0 },
   });
   expect(store.finalSeal).not.toHaveBeenCalled();
+});
+
+test("PG residue fence explicitly adopts the draining source generation", async () => {
+  const adopted = pin("pg-residue/team", {
+    kind: "cross_store_intent",
+    admission: "legacy-backfill",
+  });
+  const store = storeMock({
+    inspectPin: vi.fn().mockResolvedValue(null),
+    inspectState: vi.fn().mockResolvedValue(
+      state({
+        revision: 2,
+        maxGeneration: 2,
+        phase: "DRAINING_TO_FDB",
+        targetBackend: "fdb",
+        targetGeneration: 2,
+        transitionOperationId: "transition",
+      }),
+    ),
+    preparePinnedObject: vi.fn().mockResolvedValue(adopted),
+  });
+
+  await expect(
+    reconcilePgResidueFence(store, {
+      teamId: "team",
+      total: 4,
+      observationId: "recovery",
+    }),
+  ).resolves.toEqual(adopted);
+  expect(store.preparePinnedObject).toHaveBeenCalledWith({
+    teamId: "team",
+    kind: "cross_store_intent",
+    objectId: "pg-residue/team",
+    admission: {
+      type: "legacy-backfill",
+      backend: "pg",
+      generation: 1,
+    },
+    requiredBackend: "pg",
+    residue: { intent_unresolved: 1 },
+  });
 });
 
 test("PG publication adapter prepares and resolves every intent exact-once", async () => {

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -126,6 +126,25 @@ export class NuQRouterPinMismatchError extends NuQRouterError {
   }
 }
 
+export class NuQRouterLivePinMissingError extends NuQRouterError {
+  constructor(kind: string, objectId: string, lifecycle: string) {
+    super(
+      "NUQ_ROUTER_LIVE_PIN_OBJECT_MISSING",
+      `${kind}/${objectId} has a ${lifecycle} durable pin but no backend object`,
+      true,
+    );
+  }
+}
+
+export class NuQRouterStaleMarkerError extends NuQRouterError {
+  constructor(kind: string, objectId: string, marker: MigrationBackend) {
+    super(
+      "NUQ_ROUTER_STALE_BACKEND_MARKER",
+      `${kind}/${objectId} has a stale ${marker} marker and no durable record`,
+    );
+  }
+}
+
 export class NuQRouterObjectNotFoundError extends NuQRouterError {
   constructor(kind: string, objectId: string) {
     super("NUQ_ROUTER_OBJECT_NOT_FOUND", `${kind}/${objectId} was not found`);
@@ -257,7 +276,7 @@ export async function resolveAuthoritativeObjectBackend(input: {
   readPin: () => Promise<MigrationObjectPin | null>;
   probeFdb: () => Promise<boolean>;
   probePg: () => Promise<boolean>;
-  repairMarker?: (backend: MigrationBackend) => Promise<void> | void;
+  repairMarker?: (backend: MigrationBackend | null) => Promise<void> | void;
 }): Promise<MigrationBackend | null> {
   const { kind, objectId } = input;
   let pin: MigrationObjectPin | null;
@@ -281,19 +300,39 @@ export async function resolveAuthoritativeObjectBackend(input: {
   if (pin && actual && pin.backend !== actual) {
     throw new NuQRouterPinMismatchError(kind, objectId, pin.backend, actual);
   }
-  const backend = actual ?? pin?.backend ?? null;
-  if (backend) {
-    if (input.marker !== backend) {
+  if (actual) {
+    if (input.marker !== actual) {
       try {
-        await input.repairMarker?.(backend);
+        await input.repairMarker?.(actual);
       } catch {
         // A Redis hint repair is never part of the authoritative decision.
       }
     }
-    return backend;
+    return actual;
+  }
+  if (pin) {
+    if (pin.lifecycle !== "terminal") {
+      throw new NuQRouterLivePinMissingError(kind, objectId, pin.lifecycle);
+    }
+    if (input.marker !== pin.backend) {
+      try {
+        await input.repairMarker?.(pin.backend);
+      } catch {
+        // The terminal tombstone remains authoritative without its hint.
+      }
+    }
+    return pin.backend;
   }
   if (input.marker === "corrupt") {
     throw new NuQRouterCorruptMarkerError(kind, objectId);
+  }
+  if (input.marker) {
+    try {
+      await input.repairMarker?.(null);
+    } catch {
+      // Still return the deterministic stale-marker error.
+    }
+    throw new NuQRouterStaleMarkerError(kind, objectId, input.marker);
   }
   return null;
 }

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -1,0 +1,434 @@
+import type {
+  MigrationBackend,
+  MigrationObjectKind,
+  MigrationObjectPin,
+  MigrationResidue,
+  MigrationSteadyResolution,
+  MigrationTeamState,
+  PreparePinnedObjectInput,
+  TransitionObjectResidueInput,
+  CompletePinnedObjectInput,
+} from "./nuq-fdb/migration-store";
+import type {
+  NuQPgPublication,
+  NuQPgPublicationAdapter,
+  NuQPgPublicationOutcome,
+} from "./nuq-pg-publication";
+
+export interface NuQMigrationStorePort {
+  inspectState(teamId: string): Promise<MigrationTeamState | null>;
+  resolveSteady(
+    teamId: string,
+    desiredBackend: MigrationBackend,
+  ): Promise<MigrationSteadyResolution>;
+  initializeLegacyTeam(
+    teamId: string,
+    backend: MigrationBackend,
+    operationId: string,
+  ): Promise<MigrationTeamState>;
+  beginTransition(input: {
+    teamId: string;
+    targetBackend: MigrationBackend;
+    operationId: string;
+    expectedRevision?: number;
+  }): Promise<MigrationTeamState>;
+  cancelTransition(input: {
+    teamId: string;
+    transitionOperationId: string;
+    expectedRevision?: number;
+  }): Promise<MigrationTeamState>;
+  finalSeal(input: {
+    teamId: string;
+    transitionOperationId: string;
+    expectedRevision?: number;
+  }): Promise<MigrationTeamState>;
+  inspectTeamPins(teamId: string): Promise<MigrationObjectPin[]>;
+  inspectPin(
+    kind: MigrationObjectKind,
+    objectId: string,
+  ): Promise<MigrationObjectPin | null>;
+  preparePinnedObject(
+    input: PreparePinnedObjectInput,
+  ): Promise<MigrationObjectPin>;
+  preparePinnedObjects(
+    inputs: readonly PreparePinnedObjectInput[],
+  ): Promise<MigrationObjectPin[]>;
+  transitionObjectResidue(
+    input: TransitionObjectResidueInput,
+  ): Promise<MigrationObjectPin>;
+  completePinnedObject(
+    input: CompletePinnedObjectInput,
+  ): Promise<MigrationObjectPin>;
+}
+
+export class NuQRouterError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly retryable = false,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = this.constructor.name;
+  }
+}
+
+export class NuQRouterMigrationInProgressError extends NuQRouterError {
+  constructor(teamId: string, operationId: string) {
+    super(
+      "NUQ_MIGRATION_IN_PROGRESS",
+      `team ${teamId} is changing queue backends (${operationId})`,
+      true,
+    );
+  }
+}
+
+export class NuQRouterBackendUnavailableError extends NuQRouterError {
+  constructor(kind: string, objectId: string, cause?: unknown) {
+    super(
+      "NUQ_ROUTER_FDB_UNAVAILABLE",
+      `cannot authoritatively resolve ${kind}/${objectId}`,
+      true,
+    );
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export class NuQRouterBothBackendsError extends NuQRouterError {
+  constructor(kind: string, objectId: string) {
+    super(
+      "NUQ_ROUTER_BOTH_BACKENDS_PRESENT",
+      `${kind}/${objectId} exists in both pg and fdb`,
+    );
+  }
+}
+
+export class NuQRouterCorruptMarkerError extends NuQRouterError {
+  constructor(kind: string, objectId: string) {
+    super(
+      "NUQ_ROUTER_CORRUPT_BACKEND_MARKER",
+      `${kind}/${objectId} has a corrupt backend marker and no authoritative record`,
+    );
+  }
+}
+
+export class NuQRouterPinMismatchError extends NuQRouterError {
+  constructor(
+    kind: string,
+    objectId: string,
+    pinned: MigrationBackend,
+    actual: MigrationBackend,
+  ) {
+    super(
+      "NUQ_ROUTER_PIN_BACKEND_MISMATCH",
+      `${kind}/${objectId} is pinned to ${pinned} but exists in ${actual}`,
+    );
+  }
+}
+
+export class NuQRouterObjectNotFoundError extends NuQRouterError {
+  constructor(kind: string, objectId: string) {
+    super("NUQ_ROUTER_OBJECT_NOT_FOUND", `${kind}/${objectId} was not found`);
+  }
+}
+
+export type BackendMarker = MigrationBackend | "corrupt" | null;
+
+export function stableLegacyInitializationOperationId(teamId: string): string {
+  return `nuq-router/v1/team/${teamId}/initialize/pg`;
+}
+
+export function stableTransitionOperationId(
+  state: MigrationTeamState,
+  targetBackend: MigrationBackend,
+): string {
+  return `nuq-router/v1/team/${state.teamId}/after-generation/${state.maxGeneration}/to/${targetBackend}`;
+}
+
+/**
+ * Resolve the desired flag against durable FDB state. A flag is a request, not
+ * routing authority. This function starts/cancels transitions but never seals
+ * one; finalSeal is reserved for a reconciler after durable residue is zero.
+ */
+export async function reconcileDesiredTeamBackend(
+  store: NuQMigrationStorePort,
+  teamId: string,
+  desiredBackend: MigrationBackend,
+): Promise<MigrationTeamState> {
+  let resolution = await store.resolveSteady(teamId, desiredBackend);
+  if (resolution.status === "legacy-uninitialized") {
+    await store.initializeLegacyTeam(
+      teamId,
+      "pg",
+      stableLegacyInitializationOperationId(teamId),
+    );
+    resolution = await store.resolveSteady(teamId, desiredBackend);
+  }
+
+  if (resolution.status === "legacy-uninitialized") {
+    throw new NuQRouterError(
+      "NUQ_MIGRATION_INITIALIZATION_NOT_VISIBLE",
+      `team ${teamId} initialization did not become visible`,
+      true,
+    );
+  }
+  if (resolution.status === "steady") return resolution.state;
+  if (resolution.status === "cancel-required") {
+    return await store.cancelTransition({
+      teamId,
+      transitionOperationId: resolution.state.transitionOperationId!,
+      expectedRevision: resolution.state.revision,
+    });
+  }
+  if (resolution.status === "transition-required") {
+    const operationId = stableTransitionOperationId(
+      resolution.state,
+      desiredBackend,
+    );
+    await store.beginTransition({
+      teamId,
+      targetBackend: desiredBackend,
+      operationId,
+      expectedRevision: resolution.state.revision,
+    });
+    throw new NuQRouterMigrationInProgressError(teamId, operationId);
+  }
+  throw new NuQRouterMigrationInProgressError(
+    teamId,
+    resolution.state.transitionOperationId!,
+  );
+}
+
+export async function resolveAuthoritativeObjectBackend(input: {
+  kind: MigrationObjectKind;
+  objectId: string;
+  marker: BackendMarker;
+  readPin: () => Promise<MigrationObjectPin | null>;
+  probeFdb: () => Promise<boolean>;
+  probePg: () => Promise<boolean>;
+  repairMarker?: (backend: MigrationBackend) => Promise<void> | void;
+}): Promise<MigrationBackend | null> {
+  const { kind, objectId } = input;
+  let pin: MigrationObjectPin | null;
+  let fdbPresent: boolean;
+  try {
+    // Both reads are FDB-authoritative. Do not probe PG if FDB is unavailable:
+    // doing so would turn an outage into an unsafe PG fallback.
+    [pin, fdbPresent] = await Promise.all([input.readPin(), input.probeFdb()]);
+  } catch (error) {
+    throw new NuQRouterBackendUnavailableError(kind, objectId, error);
+  }
+  const pgPresent = await input.probePg();
+  if (fdbPresent && pgPresent) {
+    throw new NuQRouterBothBackendsError(kind, objectId);
+  }
+  const actual: MigrationBackend | null = fdbPresent
+    ? "fdb"
+    : pgPresent
+      ? "pg"
+      : null;
+  if (pin && actual && pin.backend !== actual) {
+    throw new NuQRouterPinMismatchError(kind, objectId, pin.backend, actual);
+  }
+  const backend = actual ?? pin?.backend ?? null;
+  if (backend) {
+    if (input.marker !== backend) {
+      try {
+        await input.repairMarker?.(backend);
+      } catch {
+        // A Redis hint repair is never part of the authoritative decision.
+      }
+    }
+    return backend;
+  }
+  if (input.marker === "corrupt") {
+    throw new NuQRouterCorruptMarkerError(kind, objectId);
+  }
+  return null;
+}
+
+function publicationResidue(
+  publication: NuQPgPublication,
+  outcome: NuQPgPublicationOutcome,
+): Partial<MigrationResidue> {
+  return outcome === "promoted" || publication.placement === "active"
+    ? { capacity_ready_active: 1 }
+    : { capacity_team_pending: 1 };
+}
+
+function publicationOperationId(
+  publication: NuQPgPublication,
+  outcome: NuQPgPublicationOutcome,
+): string {
+  return `nuq-router/v1/pg-publication/${publication.id}/${outcome}`;
+}
+
+/**
+ * FDB intent first, PG/Redis publication second, durable resolution last.
+ * The stable per-job operation IDs make complete retries exact-once.
+ */
+export class DurableNuQPgPublicationAdapter implements NuQPgPublicationAdapter {
+  constructor(private readonly store: NuQMigrationStorePort) {}
+
+  public async prepare(
+    publications: readonly NuQPgPublication[],
+  ): Promise<void> {
+    const seen = new Set<string>();
+    for (const publication of publications) {
+      if (seen.has(publication.id)) {
+        throw new NuQRouterError(
+          "NUQ_PG_PUBLICATION_DUPLICATE_ID",
+          `publication batch repeats ${publication.id}`,
+        );
+      }
+      seen.add(publication.id);
+    }
+    const pins = await this.store.preparePinnedObjects(
+      publications.map(publication => ({
+        teamId: publication.ownerId,
+        kind: "scrape_job" as const,
+        objectId: publication.id,
+        admission: publication.groupId
+          ? ({
+              type: "pinned-continuation",
+              source: { kind: "group", objectId: publication.groupId },
+            } as const)
+          : ({ type: "new-root" } as const),
+        requiredBackend: "pg" as const,
+        residue: { intent_unresolved: 1 },
+      })),
+    );
+    for (let index = 0; index < publications.length; index++) {
+      const publication = publications[index];
+      const pin = pins[index];
+      if (pin.backend !== "pg") {
+        throw new NuQRouterPinMismatchError(
+          "scrape_job",
+          publication.id,
+          pin.backend,
+          "pg",
+        );
+      }
+      if (pin.lifecycle === "terminal") {
+        throw new NuQRouterError(
+          "NUQ_PG_PUBLICATION_TERMINAL_PIN",
+          `scrape_job/${publication.id} cannot be republished`,
+        );
+      }
+    }
+  }
+
+  public async complete(
+    publications: readonly NuQPgPublication[],
+    outcome: NuQPgPublicationOutcome,
+  ): Promise<void> {
+    for (const publication of publications) {
+      if (outcome === "compensated") {
+        await this.store.completePinnedObject({
+          teamId: publication.ownerId,
+          kind: "scrape_job",
+          objectId: publication.id,
+          operationId: publicationOperationId(publication, outcome),
+          fromLifecycle: "prepared",
+        });
+      } else {
+        const pin = await this.store.inspectPin("scrape_job", publication.id);
+        if (!pin) {
+          throw new NuQRouterError(
+            "NUQ_MIGRATION_PIN_NOT_FOUND",
+            `scrape_job/${publication.id} has no publication pin`,
+          );
+        }
+        if (outcome === "promoted" && pin.lifecycle === "prepared") {
+          await this.store.transitionObjectResidue({
+            teamId: publication.ownerId,
+            kind: "scrape_job",
+            objectId: publication.id,
+            operationId: publicationOperationId(publication, "published"),
+            fromLifecycle: "prepared",
+            toLifecycle: "active",
+            residue: publicationResidue(publication, "published"),
+          });
+        }
+        await this.store.transitionObjectResidue({
+          teamId: publication.ownerId,
+          kind: "scrape_job",
+          objectId: publication.id,
+          operationId: publicationOperationId(publication, outcome),
+          fromLifecycle: outcome === "promoted" ? "active" : "prepared",
+          toLifecycle: "active",
+          residue: publicationResidue(publication, outcome),
+        });
+      }
+    }
+  }
+
+  public async retire(
+    kind: "scrape_job" | "crawl_finished",
+    objectId: string,
+  ): Promise<void> {
+    const pin = await this.store.inspectPin(kind, objectId);
+    if (!pin || pin.lifecycle === "terminal") return;
+    await this.store.completePinnedObject({
+      teamId: pin.teamId,
+      kind,
+      objectId,
+      operationId: `nuq-router/v1/pg-terminal/${kind}/${objectId}`,
+      fromLifecycle: pin.lifecycle,
+    });
+  }
+}
+
+export function pgResidueFenceObjectId(teamId: string): string {
+  return `pg-residue/${teamId}`;
+}
+
+/**
+ * Persist one unresolved fence while authoritative PG residue is non-zero.
+ * observationId must be stable across retry of the same PG snapshot and unique
+ * for a later observation (including A -> B -> A). The reconciler must call
+ * this before finalSeal; finalSeal only reads durable FDB counters.
+ */
+export async function reconcilePgResidueFence(
+  store: NuQMigrationStorePort,
+  input: {
+    teamId: string;
+    total: number;
+    observationId: string;
+  },
+): Promise<MigrationObjectPin> {
+  if (!Number.isSafeInteger(input.total) || input.total < 0) {
+    throw new NuQRouterError(
+      "NUQ_MIGRATION_INVALID_PG_RESIDUE",
+      "PG residue total must be a nonnegative safe integer",
+    );
+  }
+  const objectId = pgResidueFenceObjectId(input.teamId);
+  let pin = await store.inspectPin("cross_store_intent", objectId);
+  if (!pin) {
+    pin = await store.preparePinnedObject({
+      teamId: input.teamId,
+      kind: "cross_store_intent",
+      objectId,
+      admission: { type: "new-root" },
+      residue: { intent_unresolved: input.total === 0 ? 0 : 1 },
+    });
+    return pin;
+  }
+  if (pin.backend !== "pg" || pin.lifecycle === "terminal") {
+    throw new NuQRouterPinMismatchError(
+      "cross_store_intent",
+      objectId,
+      pin.backend,
+      "pg",
+    );
+  }
+  return await store.transitionObjectResidue({
+    teamId: input.teamId,
+    kind: "cross_store_intent",
+    objectId,
+    operationId: `nuq-router/v1/pg-residue/${input.observationId}/pin-revision/${pin.revision}`,
+    fromLifecycle: pin.lifecycle,
+    toLifecycle: pin.lifecycle,
+    residue: { intent_unresolved: input.total === 0 ? 0 : 1 },
+  });
+}

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -469,72 +469,102 @@ export class DurableNuQPgPublicationAdapter implements NuQPgPublicationAdapter {
   }
 }
 
-export function pgResidueFenceObjectId(teamId: string): string {
-  return `pg-residue/${teamId}`;
+export function sourceResidueFenceObjectId(
+  teamId: string,
+  backend: MigrationBackend,
+  generation: number,
+): string {
+  return `${backend}-residue/${teamId}/generation/${generation}`;
 }
 
 /**
- * Persist one unresolved fence while authoritative PG residue is non-zero.
- * observationId must be stable across retry of the same PG snapshot and unique
- * for a later observation (including A -> B -> A). The reconciler must call
- * this before finalSeal; finalSeal only reads durable FDB counters.
+ * Persist one unresolved fence while residue observed outside the generation
+ * counters is non-zero. A separate fence is burned for every never-reused
+ * source generation, so a later PG -> FDB -> PG cycle cannot reopen a closed
+ * generation's pin. observationId must identify the exact observation retry.
  */
-export async function reconcilePgResidueFence(
+export async function reconcileSourceResidueFence(
   store: NuQMigrationStorePort,
   input: {
     teamId: string;
+    backend: MigrationBackend;
     total: number;
     observationId: string;
   },
 ): Promise<MigrationObjectPin> {
   if (!Number.isSafeInteger(input.total) || input.total < 0) {
     throw new NuQRouterError(
-      "NUQ_MIGRATION_INVALID_PG_RESIDUE",
-      "PG residue total must be a nonnegative safe integer",
+      "NUQ_MIGRATION_INVALID_SOURCE_RESIDUE",
+      "source residue total must be a nonnegative safe integer",
     );
   }
-  const objectId = pgResidueFenceObjectId(input.teamId);
+  const state = await store.inspectState(input.teamId);
+  if (!state || state.activeBackend !== input.backend) {
+    throw new NuQRouterError(
+      "NUQ_MIGRATION_SOURCE_NOT_ACTIVE",
+      `team ${input.teamId} has no active ${input.backend} generation for residue adoption`,
+    );
+  }
+  const objectId = sourceResidueFenceObjectId(
+    input.teamId,
+    input.backend,
+    state.activeGeneration,
+  );
   let pin = await store.inspectPin("cross_store_intent", objectId);
   if (!pin) {
-    const state = await store.inspectState(input.teamId);
-    if (!state || state.activeBackend !== "pg") {
-      throw new NuQRouterError(
-        "NUQ_MIGRATION_PG_SOURCE_NOT_ACTIVE",
-        `team ${input.teamId} has no active PG generation for residue adoption`,
-      );
-    }
     pin = await store.preparePinnedObject({
       teamId: input.teamId,
       kind: "cross_store_intent",
       objectId,
-      admission:
-        state.phase === "DRAINING_TO_FDB"
-          ? {
-              type: "legacy-backfill",
-              backend: "pg",
-              generation: state.activeGeneration,
-            }
-          : { type: "new-root" },
-      requiredBackend: "pg",
+      admission: {
+        type: "legacy-backfill",
+        backend: input.backend,
+        generation: state.activeGeneration,
+      },
+      requiredBackend: input.backend,
       residue: { intent_unresolved: input.total === 0 ? 0 : 1 },
     });
     return pin;
   }
-  if (pin.backend !== "pg" || pin.lifecycle === "terminal") {
+  if (
+    pin.backend !== input.backend ||
+    pin.generation !== state.activeGeneration ||
+    pin.lifecycle === "terminal"
+  ) {
     throw new NuQRouterPinMismatchError(
       "cross_store_intent",
       objectId,
       pin.backend,
-      "pg",
+      input.backend,
     );
   }
   return await store.transitionObjectResidue({
     teamId: input.teamId,
     kind: "cross_store_intent",
     objectId,
-    operationId: `nuq-router/v1/pg-residue/${input.observationId}/pin-revision/${pin.revision}`,
+    operationId: `nuq-router/v1/${input.backend}-residue/${input.observationId}/pin-revision/${pin.revision}`,
     fromLifecycle: pin.lifecycle,
     toLifecycle: pin.lifecycle,
     residue: { intent_unresolved: input.total === 0 ? 0 : 1 },
+  });
+}
+
+export async function reconcilePgResidueFence(
+  store: NuQMigrationStorePort,
+  input: { teamId: string; total: number; observationId: string },
+): Promise<MigrationObjectPin> {
+  return await reconcileSourceResidueFence(store, {
+    ...input,
+    backend: "pg",
+  });
+}
+
+export async function reconcileFdbResidueFence(
+  store: NuQMigrationStorePort,
+  input: { teamId: string; total: number; observationId: string },
+): Promise<MigrationObjectPin> {
+  return await reconcileSourceResidueFence(store, {
+    ...input,
+    backend: "fdb",
   });
 }

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -359,7 +359,18 @@ function publicationOperationId(
  * The stable per-job operation IDs make complete retries exact-once.
  */
 export class DurableNuQPgPublicationAdapter implements NuQPgPublicationAdapter {
-  constructor(private readonly store: NuQMigrationStorePort) {}
+  constructor(
+    private readonly store: NuQMigrationStorePort,
+    private readonly validatePublicationUnderLock: (
+      jobIds: readonly string[],
+    ) => Promise<void> = async () => {},
+  ) {}
+
+  public async validateUnderPublicationLock(
+    jobIds: readonly string[],
+  ): Promise<void> {
+    await this.validatePublicationUnderLock(jobIds);
+  }
 
   public async prepare(
     publications: readonly NuQPgPublication[],

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -4,6 +4,7 @@ import type {
   MigrationObjectPin,
   MigrationResidue,
   MigrationSteadyResolution,
+  MigrationTeamPinsPage,
   MigrationTeamState,
   PreparePinnedObjectInput,
   TransitionObjectResidueInput,
@@ -43,7 +44,13 @@ export interface NuQMigrationStorePort {
     transitionOperationId: string;
     expectedRevision?: number;
   }): Promise<MigrationTeamState>;
-  inspectTeamPins(teamId: string): Promise<MigrationObjectPin[]>;
+  inspectTeamPinsPage(
+    teamId: string,
+    options: {
+      limit: number;
+      cursor?: { kind: MigrationObjectKind; objectId: string };
+    },
+  ): Promise<MigrationTeamPinsPage>;
   inspectPin(
     kind: MigrationObjectKind,
     objectId: string,
@@ -510,6 +517,10 @@ export function sourceResidueFenceObjectId(
  * counters is non-zero. A separate fence is burned for every never-reused
  * source generation, so a later PG -> FDB -> PG cycle cannot reopen a closed
  * generation's pin. observationId must identify the exact observation retry.
+ * This bounded token reconciles commit-unknown only while it is the pin's
+ * current last operation. A caller retrying the outer reconciliation after an
+ * error must re-read the source; a superseded stale observation has no source
+ * epoch and is intentionally not replayable.
  */
 export async function reconcileSourceResidueFence(
   store: NuQMigrationStorePort,
@@ -566,14 +577,27 @@ export async function reconcileSourceResidueFence(
       input.backend,
     );
   }
+  const intentUnresolved = input.total === 0 ? 0 : 1;
+  const operationPrefix = `nuq-router/v1/${input.backend}-residue/${input.observationId}/pin-revision/`;
+  const replay =
+    pin.lastOperation?.operationId.startsWith(operationPrefix) === true &&
+    pin.lastOperation.fromLifecycle === pin.lifecycle &&
+    pin.lastOperation.toLifecycle === pin.lifecycle &&
+    pin.lastOperation.residue.intent_unresolved === intentUnresolved &&
+    Object.entries(pin.lastOperation.residue).every(
+      ([counter, value]) => counter === "intent_unresolved" || value === 0,
+    )
+      ? pin.lastOperation
+      : undefined;
   return await store.transitionObjectResidue({
     teamId: input.teamId,
     kind: "cross_store_intent",
     objectId,
-    operationId: `nuq-router/v1/${input.backend}-residue/${input.observationId}/pin-revision/${pin.revision}`,
+    operationId: replay?.operationId ?? `${operationPrefix}${pin.revision}`,
     fromLifecycle: pin.lifecycle,
     toLifecycle: pin.lifecycle,
-    residue: { intent_unresolved: input.total === 0 ? 0 : 1 },
+    residue: { intent_unresolved: intentUnresolved },
+    expectedRevision: replay ? replay.resultRevision - 1 : pin.revision,
   });
 }
 

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -156,6 +156,7 @@ export type BackendMarker = MigrationBackend | "corrupt" | null;
 export function hasLegacyFdbTeamResidue(input: {
   scrapePending: number;
   scrapeActive: number;
+  scrapeIndexedLive: boolean;
   crawlFinishedPending: number;
   crawlFinishedActive: number;
   crawlFinishedIndexedLive: boolean;

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -25,6 +25,7 @@ export interface NuQMigrationStorePort {
     teamId: string,
     backend: MigrationBackend,
     operationId: string,
+    options?: { ifAbsent?: boolean },
   ): Promise<MigrationTeamState>;
   beginTransition(input: {
     teamId: string;
@@ -133,8 +134,50 @@ export class NuQRouterObjectNotFoundError extends NuQRouterError {
 
 export type BackendMarker = MigrationBackend | "corrupt" | null;
 
-export function stableLegacyInitializationOperationId(teamId: string): string {
-  return `nuq-router/v1/team/${teamId}/initialize/pg`;
+export function hasLegacyFdbTeamResidue(input: {
+  scrapePending: number;
+  scrapeActive: number;
+  crawlFinishedPending: number;
+  crawlFinishedActive: number;
+  crawlFinishedIndexedLive: boolean;
+  activeGroups: number;
+}): boolean {
+  return Object.values(input).some(value =>
+    typeof value === "boolean" ? value : value > 0,
+  );
+}
+
+/**
+ * Discover legacy team authority before initializing durable state. FDB must
+ * be probed first: its unavailability is retryable and must never be re-read as
+ * an empty result that falls through to PG.
+ */
+export async function discoverLegacyTeamBackend(input: {
+  teamId: string;
+  probeFdbResidue: () => Promise<boolean>;
+  probePgResidue: () => Promise<boolean>;
+  emptyBackend: MigrationBackend;
+}): Promise<MigrationBackend> {
+  let fdbPresent: boolean;
+  try {
+    fdbPresent = await input.probeFdbResidue();
+  } catch (error) {
+    throw new NuQRouterBackendUnavailableError("team", input.teamId, error);
+  }
+  const pgPresent = await input.probePgResidue();
+  if (fdbPresent && pgPresent) {
+    throw new NuQRouterBothBackendsError("team", input.teamId);
+  }
+  if (fdbPresent) return "fdb";
+  if (pgPresent) return "pg";
+  return input.emptyBackend;
+}
+
+export function stableLegacyInitializationOperationId(
+  teamId: string,
+  backend: MigrationBackend,
+): string {
+  return `nuq-router/v1/team/${teamId}/initialize/${backend}`;
 }
 
 export function stableTransitionOperationId(
@@ -142,6 +185,24 @@ export function stableTransitionOperationId(
   targetBackend: MigrationBackend,
 ): string {
   return `nuq-router/v1/team/${state.teamId}/after-generation/${state.maxGeneration}/to/${targetBackend}`;
+}
+
+export async function recoverLegacyTeamState(
+  store: NuQMigrationStorePort,
+  teamId: string,
+  discoverLegacyBackend: () => Promise<MigrationBackend>,
+): Promise<MigrationTeamState> {
+  const existing = await store.inspectState(teamId);
+  if (existing) return existing;
+  const legacyBackend = await discoverLegacyBackend();
+  // A concurrent initializer wins authoritatively. `ifAbsent` returns its
+  // state instead of interpreting stale discovery as a rollout request.
+  return await store.initializeLegacyTeam(
+    teamId,
+    legacyBackend,
+    stableLegacyInitializationOperationId(teamId, legacyBackend),
+    { ifAbsent: true },
+  );
 }
 
 /**
@@ -153,23 +214,14 @@ export async function reconcileDesiredTeamBackend(
   store: NuQMigrationStorePort,
   teamId: string,
   desiredBackend: MigrationBackend,
+  discoverLegacyBackend: () => Promise<MigrationBackend>,
 ): Promise<MigrationTeamState> {
   let resolution = await store.resolveSteady(teamId, desiredBackend);
   if (resolution.status === "legacy-uninitialized") {
-    await store.initializeLegacyTeam(
-      teamId,
-      "pg",
-      stableLegacyInitializationOperationId(teamId),
-    );
-    resolution = await store.resolveSteady(teamId, desiredBackend);
-  }
-
-  if (resolution.status === "legacy-uninitialized") {
-    throw new NuQRouterError(
-      "NUQ_MIGRATION_INITIALIZATION_NOT_VISIBLE",
-      `team ${teamId} initialization did not become visible`,
-      true,
-    );
+    // This invocation had no durable state when it began. Return whichever
+    // initialization won; do not reinterpret stale discovery/the flag as a
+    // begin/cancel request against a concurrent winner.
+    return await recoverLegacyTeamState(store, teamId, discoverLegacyBackend);
   }
   if (resolution.status === "steady") return resolution.state;
   if (resolution.status === "cancel-required") {
@@ -405,11 +457,26 @@ export async function reconcilePgResidueFence(
   const objectId = pgResidueFenceObjectId(input.teamId);
   let pin = await store.inspectPin("cross_store_intent", objectId);
   if (!pin) {
+    const state = await store.inspectState(input.teamId);
+    if (!state || state.activeBackend !== "pg") {
+      throw new NuQRouterError(
+        "NUQ_MIGRATION_PG_SOURCE_NOT_ACTIVE",
+        `team ${input.teamId} has no active PG generation for residue adoption`,
+      );
+    }
     pin = await store.preparePinnedObject({
       teamId: input.teamId,
       kind: "cross_store_intent",
       objectId,
-      admission: { type: "new-root" },
+      admission:
+        state.phase === "DRAINING_TO_FDB"
+          ? {
+              type: "legacy-backfill",
+              backend: "pg",
+              generation: state.activeGeneration,
+            }
+          : { type: "new-root" },
+      requiredBackend: "pg",
       residue: { intent_unresolved: input.total === 0 ? 0 : 1 },
     });
     return pin;

--- a/apps/api/src/services/worker/nuq-migration-control.ts
+++ b/apps/api/src/services/worker/nuq-migration-control.ts
@@ -413,7 +413,20 @@ export class DurableNuQPgPublicationAdapter implements NuQPgPublicationAdapter {
     outcome: NuQPgPublicationOutcome,
   ): Promise<void> {
     for (const publication of publications) {
+      const pin = await this.store.inspectPin("scrape_job", publication.id);
+      if (!pin) {
+        throw new NuQRouterError(
+          "NUQ_MIGRATION_PIN_NOT_FOUND",
+          `scrape_job/${publication.id} has no publication pin`,
+        );
+      }
       if (outcome === "compensated") {
+        // A stable-ID retry may discover an incompatible row after an earlier
+        // publication already activated this pin. Roll back only this call's
+        // still-prepared intent; never retire prior live work.
+        if (pin.lifecycle === "active" || pin.lifecycle === "terminal") {
+          continue;
+        }
         await this.store.completePinnedObject({
           teamId: publication.ownerId,
           kind: "scrape_job",
@@ -421,35 +434,38 @@ export class DurableNuQPgPublicationAdapter implements NuQPgPublicationAdapter {
           operationId: publicationOperationId(publication, outcome),
           fromLifecycle: "prepared",
         });
-      } else {
-        const pin = await this.store.inspectPin("scrape_job", publication.id);
-        if (!pin) {
-          throw new NuQRouterError(
-            "NUQ_MIGRATION_PIN_NOT_FOUND",
-            `scrape_job/${publication.id} has no publication pin`,
-          );
-        }
-        if (outcome === "promoted" && pin.lifecycle === "prepared") {
-          await this.store.transitionObjectResidue({
-            teamId: publication.ownerId,
-            kind: "scrape_job",
-            objectId: publication.id,
-            operationId: publicationOperationId(publication, "published"),
-            fromLifecycle: "prepared",
-            toLifecycle: "active",
-            residue: publicationResidue(publication, "published"),
-          });
-        }
+        continue;
+      }
+      if (pin.lifecycle === "terminal") {
+        throw new NuQRouterError(
+          "NUQ_PG_PUBLICATION_TERMINAL_PIN",
+          `scrape_job/${publication.id} cannot be republished`,
+        );
+      }
+      if (outcome === "published" && pin.lifecycle === "active") {
+        // Compatible stable-ID publication replay.
+        continue;
+      }
+      if (outcome === "promoted" && pin.lifecycle === "prepared") {
         await this.store.transitionObjectResidue({
           teamId: publication.ownerId,
           kind: "scrape_job",
           objectId: publication.id,
-          operationId: publicationOperationId(publication, outcome),
-          fromLifecycle: outcome === "promoted" ? "active" : "prepared",
+          operationId: publicationOperationId(publication, "published"),
+          fromLifecycle: "prepared",
           toLifecycle: "active",
-          residue: publicationResidue(publication, outcome),
+          residue: publicationResidue(publication, "published"),
         });
       }
+      await this.store.transitionObjectResidue({
+        teamId: publication.ownerId,
+        kind: "scrape_job",
+        objectId: publication.id,
+        operationId: publicationOperationId(publication, outcome),
+        fromLifecycle: outcome === "promoted" ? "active" : "prepared",
+        toLifecycle: "active",
+        residue: publicationResidue(publication, outcome),
+      });
     }
   }
 

--- a/apps/api/src/services/worker/nuq-pg-publication.test.ts
+++ b/apps/api/src/services/worker/nuq-pg-publication.test.ts
@@ -25,7 +25,12 @@ test("unregistered PG publication boundary fails closed", async () => {
 test("injectable PG publication boundary forwards prepare and complete", async () => {
   const prepare = vi.fn(async () => {});
   const complete = vi.fn(async () => {});
-  setNuQPgPublicationAdapter({ prepare, complete, retire: vi.fn() });
+  setNuQPgPublicationAdapter({
+    prepare,
+    validateUnderPublicationLock: vi.fn(),
+    complete,
+    retire: vi.fn(),
+  });
 
   const prepared = await prepareNuQPgPublication([publication]);
   setNuQPgPublicationAdapter(null);

--- a/apps/api/src/services/worker/nuq-pg-publication.test.ts
+++ b/apps/api/src/services/worker/nuq-pg-publication.test.ts
@@ -14,10 +14,18 @@ const publication: NuQPgPublication = {
 
 afterEach(() => setNuQPgPublicationAdapter(null));
 
+test("unregistered PG publication boundary fails closed", async () => {
+  setNuQPgPublicationAdapter(null);
+  await expect(prepareNuQPgPublication([publication])).rejects.toMatchObject({
+    code: "NUQ_PG_PUBLICATION_ADAPTER_UNAVAILABLE",
+    retryable: true,
+  });
+});
+
 test("injectable PG publication boundary forwards prepare and complete", async () => {
   const prepare = vi.fn(async () => {});
   const complete = vi.fn(async () => {});
-  setNuQPgPublicationAdapter({ prepare, complete });
+  setNuQPgPublicationAdapter({ prepare, complete, retire: vi.fn() });
 
   const prepared = await prepareNuQPgPublication([publication]);
   setNuQPgPublicationAdapter(null);

--- a/apps/api/src/services/worker/nuq-pg-publication.test.ts
+++ b/apps/api/src/services/worker/nuq-pg-publication.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  completePreparedNuQPgPublication,
+  prepareNuQPgPublication,
+  setNuQPgPublicationAdapter,
+  type NuQPgPublication,
+} from "./nuq-pg-publication";
+
+const publication: NuQPgPublication = {
+  id: "018f0000-0000-7000-8000-000000000001",
+  ownerId: "018f0000-0000-7000-8000-000000000002",
+  placement: "backlog",
+};
+
+afterEach(() => setNuQPgPublicationAdapter(null));
+
+test("injectable PG publication boundary forwards prepare and complete", async () => {
+  const prepare = vi.fn(async () => {});
+  const complete = vi.fn(async () => {});
+  setNuQPgPublicationAdapter({ prepare, complete });
+
+  const prepared = await prepareNuQPgPublication([publication]);
+  setNuQPgPublicationAdapter(null);
+  await completePreparedNuQPgPublication(prepared);
+
+  expect(prepare).toHaveBeenCalledWith([publication]);
+  expect(complete).toHaveBeenCalledWith([publication], "published");
+});

--- a/apps/api/src/services/worker/nuq-pg-publication.ts
+++ b/apps/api/src/services/worker/nuq-pg-publication.ts
@@ -17,6 +17,7 @@ export type NuQPgPublicationOutcome = "published" | "promoted" | "compensated";
  */
 export interface NuQPgPublicationAdapter {
   prepare(publications: readonly NuQPgPublication[]): Promise<void>;
+  validateUnderPublicationLock(jobIds: readonly string[]): Promise<void>;
   complete(
     publications: readonly NuQPgPublication[],
     outcome: NuQPgPublicationOutcome,
@@ -43,6 +44,9 @@ const failClosedAdapter: NuQPgPublicationAdapter = {
   async prepare() {
     throw new NuQPgPublicationAdapterUnavailableError();
   },
+  async validateUnderPublicationLock() {
+    throw new NuQPgPublicationAdapterUnavailableError();
+  },
   async complete() {
     throw new NuQPgPublicationAdapterUnavailableError();
   },
@@ -53,6 +57,7 @@ const failClosedAdapter: NuQPgPublicationAdapter = {
 
 export const passthroughNuQPgPublicationAdapter: NuQPgPublicationAdapter = {
   async prepare() {},
+  async validateUnderPublicationLock() {},
   async complete() {},
   async retire() {},
 };
@@ -68,6 +73,12 @@ export function setNuQPgPublicationAdapter(
   next: NuQPgPublicationAdapter | null,
 ): void {
   adapter = next ?? failClosedAdapter;
+}
+
+export async function validateNuQPgPublicationUnderLock(
+  jobIds: readonly string[],
+): Promise<void> {
+  if (jobIds.length > 0) await adapter.validateUnderPublicationLock(jobIds);
 }
 
 export async function prepareNuQPgPublication(

--- a/apps/api/src/services/worker/nuq-pg-publication.ts
+++ b/apps/api/src/services/worker/nuq-pg-publication.ts
@@ -7,7 +7,7 @@ export type NuQPgPublication = {
   placement: NuQPgPublicationPlacement;
 };
 
-export type NuQPgPublicationOutcome = "published" | "compensated";
+export type NuQPgPublicationOutcome = "published" | "promoted" | "compensated";
 
 /**
  * Boundary for the durable generation intent which must surround PG + Redis
@@ -21,14 +21,43 @@ export interface NuQPgPublicationAdapter {
     publications: readonly NuQPgPublication[],
     outcome: NuQPgPublicationOutcome,
   ): Promise<void>;
+  retire(
+    kind: "scrape_job" | "crawl_finished",
+    objectId: string,
+  ): Promise<void>;
 }
 
-const noOpAdapter: NuQPgPublicationAdapter = {
-  async prepare() {},
-  async complete() {},
+export class NuQPgPublicationAdapterUnavailableError extends Error {
+  public readonly code = "NUQ_PG_PUBLICATION_ADAPTER_UNAVAILABLE";
+  public readonly retryable = true;
+
+  constructor() {
+    super(
+      "NUQ_PG_PUBLICATION_ADAPTER_UNAVAILABLE: durable PG publication adapter is not registered",
+    );
+    this.name = this.constructor.name;
+  }
+}
+
+const failClosedAdapter: NuQPgPublicationAdapter = {
+  async prepare() {
+    throw new NuQPgPublicationAdapterUnavailableError();
+  },
+  async complete() {
+    throw new NuQPgPublicationAdapterUnavailableError();
+  },
+  async retire() {
+    throw new NuQPgPublicationAdapterUnavailableError();
+  },
 };
 
-let adapter: NuQPgPublicationAdapter = noOpAdapter;
+export const passthroughNuQPgPublicationAdapter: NuQPgPublicationAdapter = {
+  async prepare() {},
+  async complete() {},
+  async retire() {},
+};
+
+let adapter: NuQPgPublicationAdapter = passthroughNuQPgPublicationAdapter;
 
 export type PreparedNuQPgPublication = {
   publications: readonly NuQPgPublication[];
@@ -38,7 +67,7 @@ export type PreparedNuQPgPublication = {
 export function setNuQPgPublicationAdapter(
   next: NuQPgPublicationAdapter | null,
 ): void {
-  adapter = next ?? noOpAdapter;
+  adapter = next ?? failClosedAdapter;
 }
 
 export async function prepareNuQPgPublication(
@@ -53,9 +82,28 @@ export async function completePreparedNuQPgPublication(
   prepared: PreparedNuQPgPublication,
   outcome: NuQPgPublicationOutcome = "published",
 ): Promise<void> {
-  if (prepared.publications.length > 0) {
-    await prepared.adapter.complete(prepared.publications, outcome);
+  await completePreparedNuQPgPublicationSubset(
+    prepared,
+    prepared.publications,
+    outcome,
+  );
+}
+
+export async function completePreparedNuQPgPublicationSubset(
+  prepared: PreparedNuQPgPublication,
+  publications: readonly NuQPgPublication[],
+  outcome: NuQPgPublicationOutcome,
+): Promise<void> {
+  if (publications.length > 0) {
+    await prepared.adapter.complete(publications, outcome);
   }
+}
+
+export async function retireNuQPgObject(
+  kind: "scrape_job" | "crawl_finished",
+  objectId: string,
+): Promise<void> {
+  await adapter.retire(kind, objectId);
 }
 
 export async function completeNuQPgPublication(

--- a/apps/api/src/services/worker/nuq-pg-publication.ts
+++ b/apps/api/src/services/worker/nuq-pg-publication.ts
@@ -1,0 +1,66 @@
+export type NuQPgPublicationPlacement = "active" | "backlog";
+
+export type NuQPgPublication = {
+  id: string;
+  ownerId: string;
+  groupId?: string;
+  placement: NuQPgPublicationPlacement;
+};
+
+export type NuQPgPublicationOutcome = "published" | "compensated";
+
+/**
+ * Boundary for the durable generation intent which must surround PG + Redis
+ * publication during the queue migration. The router integration will replace
+ * this no-op adapter with generation-aware prepare/complete operations. Keep
+ * this module PG-only: it must remain importable without native FDB bindings.
+ */
+export interface NuQPgPublicationAdapter {
+  prepare(publications: readonly NuQPgPublication[]): Promise<void>;
+  complete(
+    publications: readonly NuQPgPublication[],
+    outcome: NuQPgPublicationOutcome,
+  ): Promise<void>;
+}
+
+const noOpAdapter: NuQPgPublicationAdapter = {
+  async prepare() {},
+  async complete() {},
+};
+
+let adapter: NuQPgPublicationAdapter = noOpAdapter;
+
+export type PreparedNuQPgPublication = {
+  publications: readonly NuQPgPublication[];
+  adapter: NuQPgPublicationAdapter;
+};
+
+export function setNuQPgPublicationAdapter(
+  next: NuQPgPublicationAdapter | null,
+): void {
+  adapter = next ?? noOpAdapter;
+}
+
+export async function prepareNuQPgPublication(
+  publications: readonly NuQPgPublication[],
+): Promise<PreparedNuQPgPublication> {
+  const prepared = { publications, adapter };
+  if (publications.length > 0) await prepared.adapter.prepare(publications);
+  return prepared;
+}
+
+export async function completePreparedNuQPgPublication(
+  prepared: PreparedNuQPgPublication,
+  outcome: NuQPgPublicationOutcome = "published",
+): Promise<void> {
+  if (prepared.publications.length > 0) {
+    await prepared.adapter.complete(prepared.publications, outcome);
+  }
+}
+
+export async function completeNuQPgPublication(
+  publications: readonly NuQPgPublication[],
+  outcome: NuQPgPublicationOutcome = "published",
+): Promise<void> {
+  if (publications.length > 0) await adapter.complete(publications, outcome);
+}

--- a/apps/api/src/services/worker/nuq-reconciler-worker.ts
+++ b/apps/api/src/services/worker/nuq-reconciler-worker.ts
@@ -4,10 +4,8 @@ import "../sentry";
 import { setSentryServiceTag } from "../sentry";
 import { logger as _logger } from "../../lib/logger";
 import { reconcileConcurrencyQueue } from "../../lib/concurrency-queue-reconciler";
-import { Counter, register } from "prom-client";
+import { Counter, Gauge, register } from "prom-client";
 import Express from "express";
-
-const RECONCILER_INTERVAL_MS = 60 * 1000;
 
 const reconcilerRunsTotal = new Counter({
   name: "concurrency_queue_reconciler_runs_total",
@@ -24,11 +22,43 @@ const reconcilerJobsRecoveredTotal = new Counter({
   help: "Total drifted jobs recovered by the reconciler",
 });
 
+const migrationGcRunsTotal = new Counter({
+  name: "nuq_migration_gc_runs_total",
+  help: "NuQ migration GC category runs",
+  labelNames: ["category"] as const,
+});
+const migrationGcPagesTotal = new Counter({
+  name: "nuq_migration_gc_pages_total",
+  help: "Bounded NuQ migration GC pages processed",
+  labelNames: ["category"] as const,
+});
+const migrationGcItemsTotal = new Counter({
+  name: "nuq_migration_gc_items_total",
+  help: "NuQ migration GC items by outcome",
+  labelNames: ["category", "outcome"] as const,
+});
+const migrationGcErrorsTotal = new Counter({
+  name: "nuq_migration_gc_errors_total",
+  help: "NuQ migration GC category errors",
+  labelNames: ["category"] as const,
+});
+const migrationGcDueBacklog = new Gauge({
+  name: "nuq_migration_gc_due_backlog",
+  help: "Exact number of due NuQ migration GC items",
+  labelNames: ["category"] as const,
+});
+const migrationGcOldestOverdueSeconds = new Gauge({
+  name: "nuq_migration_gc_oldest_overdue_seconds",
+  help: "Age in seconds of the oldest due NuQ migration GC item",
+  labelNames: ["category"] as const,
+});
+
 (async () => {
   setSentryServiceTag("nuq-reconciler-worker");
 
   let isShuttingDown = false;
   let reconcilerInFlight = false;
+  const shutdownController = new AbortController();
 
   const app = Express();
 
@@ -64,6 +94,7 @@ const reconcilerJobsRecoveredTotal = new Counter({
   async function shutdown() {
     if (isShuttingDown) return;
     isShuttingDown = true;
+    shutdownController.abort();
     _logger.info("NuQ reconciler worker shutting down");
 
     while (reconcilerInFlight) {
@@ -82,19 +113,67 @@ const reconcilerJobsRecoveredTotal = new Counter({
     process.on("SIGTERM", shutdown);
   }
 
+  const sleep = async (ms: number) => {
+    if (shutdownController.signal.aborted) return;
+    await new Promise<void>(resolve => {
+      const timer = setTimeout(resolve, ms);
+      shutdownController.signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+  };
+
   while (!isShuttingDown) {
+    let nextIntervalMs = config.NUQ_RECONCILER_IDLE_INTERVAL_MS;
     if (!reconcilerInFlight) {
       reconcilerInFlight = true;
 
       try {
         const summary = await reconcileConcurrencyQueue({
           logger: _logger,
+          signal: shutdownController.signal,
         });
 
         reconcilerRunsTotal.inc();
         reconcilerJobsRecoveredTotal.inc(
           summary.jobsRequeued + summary.jobsStarted,
         );
+        nextIntervalMs = summary.migrationGc.hasMore
+          ? config.NUQ_RECONCILER_BACKLOG_RETRY_MS
+          : config.NUQ_RECONCILER_IDLE_INTERVAL_MS;
+        for (const [category, stats] of Object.entries(
+          summary.migrationGc.categories,
+        )) {
+          migrationGcRunsTotal.inc({ category });
+          migrationGcPagesTotal.inc({ category }, stats.pages);
+          migrationGcItemsTotal.inc(
+            { category, outcome: "processed" },
+            stats.processed,
+          );
+          migrationGcItemsTotal.inc(
+            { category, outcome: "removed" },
+            stats.removed,
+          );
+          migrationGcItemsTotal.inc(
+            { category, outcome: "retained" },
+            stats.retained,
+          );
+          migrationGcItemsTotal.inc(
+            { category, outcome: "stale" },
+            stats.stale,
+          );
+          migrationGcErrorsTotal.inc({ category }, stats.errors);
+          migrationGcDueBacklog.set({ category }, stats.dueBacklog);
+          migrationGcOldestOverdueSeconds.set(
+            { category },
+            stats.oldestOverdueMs / 1000,
+          );
+        }
 
         _logger.info("Concurrency queue reconciler run complete", summary);
       } catch (error) {
@@ -105,6 +184,6 @@ const reconcilerJobsRecoveredTotal = new Counter({
       }
     }
 
-    await new Promise(resolve => setTimeout(resolve, RECONCILER_INTERVAL_MS));
+    await sleep(nextIntervalMs);
   }
 })();

--- a/apps/api/src/services/worker/nuq-reconciler-worker.ts
+++ b/apps/api/src/services/worker/nuq-reconciler-worker.ts
@@ -4,7 +4,7 @@ import "../sentry";
 import { setSentryServiceTag } from "../sentry";
 import { logger as _logger } from "../../lib/logger";
 import { reconcileConcurrencyQueue } from "../../lib/concurrency-queue-reconciler";
-import { Counter, Gauge, register } from "prom-client";
+import { Counter, Gauge, Histogram, register } from "prom-client";
 import Express from "express";
 
 const reconcilerRunsTotal = new Counter({
@@ -52,6 +52,16 @@ const migrationGcOldestOverdueSeconds = new Gauge({
   help: "Age in seconds of the oldest due NuQ migration GC item",
   labelNames: ["category"] as const,
 });
+const migrationGcRunDurationSeconds = new Histogram({
+  name: "nuq_migration_gc_run_duration_seconds",
+  help: "Duration of each bounded migration GC run",
+  buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 40, 60],
+});
+const migrationGcProcessedRate = new Gauge({
+  name: "nuq_migration_gc_processed_items_per_second",
+  help: "Observed item processing rate during the latest GC run",
+  labelNames: ["category"] as const,
+});
 
 (async () => {
   setSentryServiceTag("nuq-reconciler-worker");
@@ -71,7 +81,9 @@ const migrationGcOldestOverdueSeconds = new Gauge({
     }
   });
   app.get("/health", (_, res) => {
-    res.status(200).send("OK");
+    res
+      .status(isShuttingDown ? 503 : 200)
+      .send(isShuttingDown ? "STOPPING" : "OK");
   });
 
   const server = app.listen(
@@ -96,16 +108,22 @@ const migrationGcOldestOverdueSeconds = new Gauge({
     isShuttingDown = true;
     shutdownController.abort();
     _logger.info("NuQ reconciler worker shutting down");
+    server.close();
 
-    while (reconcilerInFlight) {
-      _logger.info("Waiting for in-flight reconciliation to complete...");
-      await new Promise(resolve => setTimeout(resolve, 1000));
+    const graceMs = 15_000;
+    const deadline = Date.now() + graceMs;
+    while (reconcilerInFlight && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 100));
     }
-
-    server.close(() => {
-      _logger.info("NuQ reconciler worker shut down");
-      process.exit(0);
-    });
+    if (reconcilerInFlight) {
+      _logger.error("Reconciler did not stop within shutdown grace", {
+        graceMs,
+      });
+      server.closeAllConnections();
+      process.exit(1);
+    }
+    _logger.info("NuQ reconciler worker shut down");
+    process.exit(0);
   }
 
   if (require.main === module) {
@@ -146,6 +164,9 @@ const migrationGcOldestOverdueSeconds = new Gauge({
         nextIntervalMs = summary.migrationGc.hasMore
           ? config.NUQ_RECONCILER_BACKLOG_RETRY_MS
           : config.NUQ_RECONCILER_IDLE_INTERVAL_MS;
+        migrationGcRunDurationSeconds.observe(
+          summary.migrationGc.elapsedMs / 1000,
+        );
         for (const [category, stats] of Object.entries(
           summary.migrationGc.categories,
         )) {
@@ -172,6 +193,12 @@ const migrationGcOldestOverdueSeconds = new Gauge({
           migrationGcOldestOverdueSeconds.set(
             { category },
             stats.oldestOverdueMs / 1000,
+          );
+          migrationGcProcessedRate.set(
+            { category },
+            summary.migrationGc.elapsedMs > 0
+              ? (stats.processed * 1000) / summary.migrationGc.elapsedMs
+              : 0,
           );
         }
 

--- a/apps/api/src/services/worker/nuq-router-gc.test.ts
+++ b/apps/api/src/services/worker/nuq-router-gc.test.ts
@@ -1,0 +1,173 @@
+import { vi } from "vitest";
+
+vi.mock("../../services/rate-limiter", () => ({
+  redisRateLimitClient: { on: vi.fn() },
+  getRateLimiter: vi.fn(),
+}));
+
+vi.mock("../../services/redis", () => ({
+  redisEvictConnection: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+  getValue: vi.fn(),
+  setValue: vi.fn(),
+  deleteKey: vi.fn(),
+}));
+
+import { sweepNuQMigrationGc, type NuQMigrationGcCategory } from "./nuq-router";
+
+function scheduler(initial: Partial<Record<NuQMigrationGcCategory, number>>) {
+  const due: Record<NuQMigrationGcCategory, number> = {
+    terminal_pin: initial.terminal_pin ?? 0,
+    control_history: initial.control_history ?? 0,
+    closed_generation: initial.closed_generation ?? 0,
+    redis_cleanup: initial.redis_cleanup ?? 0,
+  };
+  const calls: NuQMigrationGcCategory[] = [];
+  const dependencies = {
+    fdbEnabled: () => true,
+    inspectFdb: vi.fn(async () => ({
+      pin: { due: due.terminal_pin, oldestDueAt: 1, oldestOverdueMs: 10 },
+      control: {
+        due: due.control_history,
+        oldestDueAt: due.control_history ? 1 : null,
+        oldestOverdueMs: due.control_history ? 10 : 0,
+      },
+      generation: {
+        due: due.closed_generation,
+        oldestDueAt: due.closed_generation ? 1 : null,
+        oldestOverdueMs: due.closed_generation ? 10 : 0,
+      },
+    })),
+    inspectRedis: vi.fn(async () => ({
+      total: due.redis_cleanup,
+      due: due.redis_cleanup,
+      oldestDueAt: due.redis_cleanup ? 1 : null,
+      oldestOverdueMs: due.redis_cleanup ? 10 : 0,
+    })),
+    sweepCategory: vi.fn(
+      async (category: NuQMigrationGcCategory, _now: number, limit: number) => {
+        calls.push(category);
+        const read = Math.min(limit, due[category]);
+        due[category] -= read;
+        return { read, removed: read, retained: 0, stale: 0 };
+      },
+    ),
+  };
+  return { dependencies, due, calls };
+}
+
+describe("NuQ migration GC work scheduler", () => {
+  test("drains sustained arrivals above 100 per run with fair bounded pages", async () => {
+    const fake = scheduler({ terminal_pin: 260, redis_cleanup: 230 });
+    const result = await sweepNuQMigrationGc({
+      dependencies: fake.dependencies,
+      pageLimit: 100,
+      maxPages: 32,
+      workBudgetMs: 10_000,
+      now: () => 1_000,
+    });
+
+    expect(result).toMatchObject({
+      processed: 490,
+      removed: 490,
+      hasMore: false,
+      stopReason: "idle",
+    });
+    expect(result.pages).toBe(6);
+    expect(fake.calls).toEqual([
+      "terminal_pin",
+      "redis_cleanup",
+      "terminal_pin",
+      "redis_cleanup",
+      "terminal_pin",
+      "redis_cleanup",
+    ]);
+    expect(
+      fake.dependencies.sweepCategory.mock.calls.every(call => call[2] <= 100),
+    ).toBe(true);
+  });
+
+  test("page cap leaves exact backlog for a short retry", async () => {
+    const fake = scheduler({ terminal_pin: 350 });
+    const result = await sweepNuQMigrationGc({
+      dependencies: fake.dependencies,
+      pageLimit: 100,
+      maxPages: 2,
+      workBudgetMs: 10_000,
+    });
+
+    expect(result).toMatchObject({
+      pages: 2,
+      processed: 200,
+      hasMore: true,
+      stopReason: "page-cap",
+      categories: { terminal_pin: { dueBacklog: 150 } },
+    });
+  });
+
+  test("wall budget and abort bound work between pages", async () => {
+    const fake = scheduler({ terminal_pin: 350 });
+    let monotonic = 0;
+    const budgeted = await sweepNuQMigrationGc({
+      dependencies: fake.dependencies,
+      pageLimit: 100,
+      maxPages: 20,
+      workBudgetMs: 15,
+      monotonicNow: () => (monotonic += 10),
+    });
+    expect(budgeted).toMatchObject({
+      pages: 1,
+      processed: 100,
+      hasMore: true,
+      stopReason: "budget",
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const aborted = await sweepNuQMigrationGc({
+      dependencies: scheduler({ terminal_pin: 1 }).dependencies,
+      signal: controller.signal,
+      maxPages: 20,
+      workBudgetMs: 10_000,
+    });
+    expect(aborted).toMatchObject({
+      pages: 0,
+      hasMore: true,
+      stopReason: "aborted",
+    });
+  });
+
+  test("idle and retained/rescheduled work do not hot loop", async () => {
+    const idle = scheduler({});
+    await expect(
+      sweepNuQMigrationGc({
+        dependencies: idle.dependencies,
+        maxPages: 128,
+        workBudgetMs: 10_000,
+      }),
+    ).resolves.toMatchObject({ pages: 0, hasMore: false, stopReason: "idle" });
+    expect(idle.dependencies.sweepCategory).not.toHaveBeenCalled();
+
+    const retained = scheduler({ closed_generation: 1 });
+    retained.dependencies.sweepCategory.mockImplementationOnce(
+      async (category: NuQMigrationGcCategory) => {
+        retained.due[category]--;
+        return { read: 1, removed: 0, retained: 1, stale: 0 };
+      },
+    );
+    const result = await sweepNuQMigrationGc({
+      dependencies: retained.dependencies,
+      maxPages: 128,
+      workBudgetMs: 10_000,
+    });
+    expect(result).toMatchObject({
+      pages: 1,
+      retained: 1,
+      hasMore: false,
+      stopReason: "idle",
+    });
+  });
+});

--- a/apps/api/src/services/worker/nuq-router-gc.test.ts
+++ b/apps/api/src/services/worker/nuq-router-gc.test.ts
@@ -1,5 +1,34 @@
 import { vi } from "vitest";
 
+vi.mock("../../controllers/auth", () => ({
+  getACUCTeam: vi.fn(),
+}));
+
+vi.mock("../../lib/deployment", () => ({
+  isSelfHosted: vi.fn(() => false),
+}));
+
+vi.mock("./nuq", () => ({
+  scrapeQueue: {},
+  crawlFinishedQueue: {},
+  crawlGroup: {},
+  getNuQPgOwnerLiveResidue: vi.fn(),
+}));
+
+vi.mock("../../lib/concurrency-redis", () => ({
+  constructConcurrencyLimitKey: vi.fn(),
+  finalizeConcurrencyLimitActiveJobRollback: vi.fn(),
+  getConcurrencyLimitActiveJobsCount: vi.fn(),
+  getConcurrencyRollbackCleanupBacklog: vi.fn(),
+  getTeamQueueLimit: vi.fn(),
+  pushConcurrencyLimitActiveJob: vi.fn(),
+  recoverConcurrencyLimitRollbacks: vi.fn(),
+  removeConcurrencyLimitActiveJob: vi.fn(),
+  renewConcurrencyLimitActiveJob: vi.fn(),
+  reserveConcurrencyLimitActiveJob: vi.fn(),
+  rollbackConcurrencyLimitActiveJob: vi.fn(),
+}));
+
 vi.mock("../../services/rate-limiter", () => ({
   redisRateLimitClient: { on: vi.fn() },
   getRateLimiter: vi.fn(),
@@ -14,6 +43,16 @@ vi.mock("../../services/redis", () => ({
   getValue: vi.fn(),
   setValue: vi.fn(),
   deleteKey: vi.fn(),
+}));
+
+vi.mock("../queue-service", () => ({
+  getRedisConnection: () => ({
+    eval: vi.fn(),
+    zscore: vi.fn(),
+    zrangebyscore: vi.fn(),
+    zcard: vi.fn(),
+    zcount: vi.fn(),
+  }),
 }));
 
 import { sweepNuQMigrationGc, type NuQMigrationGcCategory } from "./nuq-router";
@@ -89,6 +128,34 @@ describe("NuQ migration GC work scheduler", () => {
       fake.dependencies.sweepCategory.mock.calls.every(call => call[2] <= 100),
     ).toBe(true);
   });
+
+  test("one isolated replica exceeds the documented arrival target at representative page latency", async () => {
+    const fake = scheduler({ terminal_pin: 10_000 });
+    fake.dependencies.sweepCategory.mockImplementation(
+      async (category: NuQMigrationGcCategory, _now: number, limit: number) => {
+        await new Promise(resolve => setTimeout(resolve, 20));
+        fake.calls.push(category);
+        const read = Math.min(limit, fake.due[category]);
+        fake.due[category] -= read;
+        return { read, removed: read, retained: 0, stale: 0 };
+      },
+    );
+
+    const result = await sweepNuQMigrationGc({
+      dependencies: fake.dependencies,
+      pageLimit: 100,
+      maxPages: 128,
+      workBudgetMs: 10_000,
+    });
+    const rate = (result.processed * 1000) / result.elapsedMs;
+
+    expect(result.processed).toBe(10_000);
+    expect(result.hasMore).toBe(false);
+    expect(rate).toBeGreaterThanOrEqual(2_000);
+    expect(
+      fake.dependencies.sweepCategory.mock.calls.every(call => call[2] <= 100),
+    ).toBe(true);
+  }, 15_000);
 
   test("page cap leaves exact backlog for a short retry", async () => {
     const fake = scheduler({ terminal_pin: 350 });

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -6,13 +6,13 @@ import { getACUCTeam } from "../../controllers/auth";
 import { redisEvictConnection } from "../../services/redis";
 import { isSelfHosted } from "../../lib/deployment";
 import { getApiKeyConcurrencyLimit } from "../../lib/api-key-concurrency";
-import { redlock } from "../redlock";
 import { getRedisConnection } from "../queue-service";
 import {
   getTeamQueueLimit,
   getConcurrencyLimitActiveJobsCount,
   pushConcurrencyLimitActiveJob,
   removeConcurrencyLimitActiveJob,
+  constructConcurrencyLimitKey,
 } from "../../lib/concurrency-redis";
 import {
   NuQJob,
@@ -22,6 +22,9 @@ import {
   scrapeQueue as scrapeQueuePg,
   crawlFinishedQueue as crawlFinishedQueuePg,
   crawlGroup as crawlGroupPg,
+  getNuQPgOwnerLiveResidue,
+  type NuQPgOwnerLiveResidue,
+  type NuQRemovedJobResidue,
 } from "./nuq";
 import {
   scrapeQueueFdb,
@@ -321,27 +324,20 @@ export function backlogTimeoutMsForGate(timeoutMs: number): Date {
   return new Date(Date.now() + timeoutMs);
 }
 
-// PG and FDB cannot share a transaction, so serialize cross-ledger admission
-// while taking the combined occupancy snapshot and reserving the chosen
-// backend. Redlock's using() extends this lease while a large enqueue runs.
+// Compatibility boundary for callers while durable generation admission is
+// integrated. A Redis lease cannot make PG/FDB admission atomic and must not
+// be treated as a correctness primitive.
 export async function withTeamMigrationAdmission<T>(
-  teamId: string,
+  _teamId: string,
   operation: () => Promise<T>,
 ): Promise<T> {
-  if (!fdbQueueEnabled() || (fdbForced() && isSelfHosted())) {
-    return await operation();
-  }
-  return await redlock.using(
-    [`nuq:migration-admission:${teamId}`],
-    30_000,
-    {},
-    async signal => {
-      if (signal.aborted) throw signal.error;
-      const result = await operation();
-      if (signal.aborted) throw signal.error;
-      return result;
-    },
-  );
+  return await operation();
+}
+
+export async function getAuthoritativePgOwnerLiveResidue(
+  ownerId: string,
+): Promise<NuQPgOwnerLiveResidue> {
+  return await getNuQPgOwnerLiveResidue(ownerId);
 }
 
 export async function fdbEnqueueScrapeJobs(
@@ -440,6 +436,49 @@ export async function fdbEnqueueScrapeJobs(
 }
 
 // === Routed scrape queue
+
+const pgRemoveResidueKey = (id: string) => `nuq:pg_remove_residue:${id}`;
+
+async function cleanPgRedisJobResidue(
+  id: string,
+  removed: NuQRemovedJobResidue | null,
+  queuedPayload: string | null,
+): Promise<void> {
+  let payload: any = null;
+  if (queuedPayload) {
+    try {
+      payload = JSON.parse(queuedPayload);
+    } catch {
+      // The payload key is deleted below even when corrupt.
+    }
+  }
+  const data = (removed?.data as any) ?? payload?.data;
+  const ownerId = removed?.ownerId ?? data?.team_id;
+  const groupId = removed?.groupId ?? data?.crawl_id;
+  const redis = getRedisConnection();
+  const queueKeys = await redis.smembers("concurrency-limit-queues");
+  const pipeline = redis.pipeline();
+  pipeline.del(`cq-job:${id}`);
+  pipeline.del(`cq-claim:${id}`);
+  pipeline.del(pgRemoveResidueKey(id));
+  for (const queueKey of queueKeys) pipeline.zrem(queueKey, id);
+  if (ownerId) {
+    pipeline.zrem(constructConcurrencyLimitKey(ownerId), id);
+    pipeline.zrem(`concurrency-limit-queue:${ownerId}`, id);
+  }
+  if (groupId) pipeline.zrem(`crawl-concurrency-limiter:${groupId}`, id);
+  const results = await pipeline.exec();
+  const failures =
+    results?.filter(
+      (result): result is [Error, unknown] => result[0] instanceof Error,
+    ) ?? [];
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map(([error]) => error),
+      `Failed to remove Redis queue residue for ${id}`,
+    );
+  }
+}
 
 class RoutedScrapeQueue {
   // in-flight jobs taken by THIS process, so renew/finish/fail can route
@@ -643,7 +682,49 @@ class RoutedScrapeQueue {
       await fdbMutation(() => scrapeQueueFdb.removeJob(id, logger));
       return;
     }
-    await scrapeQueuePg.removeJob(id, logger);
+    const redis = getRedisConnection();
+    const [queuedPayload, priorDescriptor, active, backlog] = await Promise.all(
+      [
+        redis.get(`cq-job:${id}`),
+        redis.get(pgRemoveResidueKey(id)),
+        scrapeQueuePg.getJob(id, logger),
+        scrapeQueuePg.getJobsFromBacklog([id], logger),
+      ],
+    );
+    const existing = active ?? backlog[0] ?? null;
+    if (existing) {
+      // Persist the routing metadata before deleting PG. A retry after process
+      // death or a Redis pipeline failure can still remove team/crawl residue.
+      await redis.set(
+        pgRemoveResidueKey(id),
+        JSON.stringify({
+          id,
+          ownerId: existing.ownerId,
+          groupId: existing.groupId,
+          data: {},
+        }),
+        "EX",
+        24 * 60 * 60,
+      );
+    }
+    const removed = await scrapeQueuePg.removeJobResidue(id, logger);
+    let descriptor = removed;
+    if (!descriptor && priorDescriptor) {
+      try {
+        descriptor = JSON.parse(priorDescriptor) as NuQRemovedJobResidue;
+      } catch {
+        // Corrupt descriptor is deleted by the cleanup pipeline.
+      }
+    }
+    if (!descriptor && existing) {
+      descriptor = {
+        id,
+        ownerId: existing.ownerId,
+        groupId: existing.groupId,
+        data: {},
+      };
+    }
+    await cleanPgRedisJobResidue(id, descriptor, queuedPayload);
   }
 
   public async removeJobs(

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -245,53 +245,60 @@ async function legacyGenerationForBackend(
 }
 
 async function reconcileTerminalPgPins(teamId: string): Promise<void> {
-  const pins = (await nuqFdbMigrationStore.inspectTeamPins(teamId)).filter(
-    pin => pin.backend === "pg" && pin.lifecycle !== "terminal",
-  );
-  const jobPins = pins.filter(pin => pin.kind === "scrape_job");
-  if (jobPins.length > 0) {
-    const ids = jobPins.map(pin => pin.objectId);
-    const [jobs, backlog] = await Promise.all([
-      scrapeQueuePg.getJobs(ids),
-      scrapeQueuePg.getJobsFromBacklog(ids),
-    ]);
-    const byId = new Map([...jobs, ...backlog].map(job => [job.id, job]));
-    for (const pin of jobPins) {
-      const job = byId.get(pin.objectId);
-      const terminal = job?.status === "completed" || job?.status === "failed";
-      // A missing prepared object may still be between FDB intent commit and
-      // PG publication. Only an observed terminal row, or disappearance after
-      // durable activation, proves that its residue can be retired.
-      if (terminal || (!job && pin.lifecycle === "active")) {
-        await completeRoutingPin(pin, "pg-reconcile-terminal");
+  let cursor: { kind: MigrationObjectKind; objectId: string } | undefined;
+  do {
+    const page = await nuqFdbMigrationStore.inspectTeamPinsPage(teamId, {
+      limit: 100,
+      cursor,
+    });
+    const pins = page.pins.filter(pin => pin.backend === "pg");
+    const jobPins = pins.filter(pin => pin.kind === "scrape_job");
+    if (jobPins.length > 0) {
+      const ids = jobPins.map(pin => pin.objectId);
+      const [jobs, backlog] = await Promise.all([
+        scrapeQueuePg.getJobs(ids),
+        scrapeQueuePg.getJobsFromBacklog(ids),
+      ]);
+      const byId = new Map([...jobs, ...backlog].map(job => [job.id, job]));
+      for (const pin of jobPins) {
+        const job = byId.get(pin.objectId);
+        const terminal =
+          job?.status === "completed" || job?.status === "failed";
+        // A missing prepared object may still be between FDB intent commit and
+        // PG publication. Only an observed terminal row, or disappearance after
+        // durable activation, proves that its residue can be retired.
+        if (terminal || (!job && pin.lifecycle === "active")) {
+          await completeRoutingPin(pin, "pg-reconcile-terminal");
+        }
       }
     }
-  }
-  for (const pin of pins) {
-    if (pin.kind === "group") {
-      const group = await crawlGroupPg.getGroup(pin.objectId);
-      if (
-        (group && group.status !== "active") ||
-        (!group && pin.lifecycle === "active")
-      ) {
-        await completeRoutingPin(pin, "pg-reconcile-terminal");
-      }
-    } else if (pin.kind === "external_holder") {
-      // Redis disappearance is not terminal evidence (flushes/failovers lose
-      // this hint). Explicit release or the corrected durable holder-expiry
-      // reconciler owns retirement, so an orphan conservatively blocks seal.
-      continue;
-    } else if (pin.kind === "crawl_finished") {
-      const job = await crawlFinishedQueuePg.getJob(pin.objectId);
-      if (
-        job?.status === "completed" ||
-        job?.status === "failed" ||
-        (!job && pin.lifecycle === "active")
-      ) {
-        await completeRoutingPin(pin, "pg-reconcile-terminal");
+    for (const pin of pins) {
+      if (pin.kind === "group") {
+        const group = await crawlGroupPg.getGroup(pin.objectId);
+        if (
+          (group && group.status !== "active") ||
+          (!group && pin.lifecycle === "active")
+        ) {
+          await completeRoutingPin(pin, "pg-reconcile-terminal");
+        }
+      } else if (pin.kind === "external_holder") {
+        // Redis disappearance is not terminal evidence (flushes/failovers lose
+        // this hint). Explicit release or the corrected durable holder-expiry
+        // reconciler owns retirement, so an orphan conservatively blocks seal.
+        continue;
+      } else if (pin.kind === "crawl_finished") {
+        const job = await crawlFinishedQueuePg.getJob(pin.objectId);
+        if (
+          job?.status === "completed" ||
+          job?.status === "failed" ||
+          (!job && pin.lifecycle === "active")
+        ) {
+          await completeRoutingPin(pin, "pg-reconcile-terminal");
+        }
       }
     }
-  }
+    cursor = page.nextCursor;
+  } while (cursor);
 }
 
 async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -32,12 +32,14 @@ import {
   crawlGroupFdb,
   externalSlotsFdb,
   externalSlotMigrationObjectId,
+  pgJobRemovalsFdb,
   isFdbConfigured,
   nuqFdbHealthCheck,
   withFdbTimeout,
   NuQFdbQueue,
   NuQFdbJob,
   nuqFdbMigrationStore,
+  type DurablePgJobRemoval,
   type MigrationObjectKind,
   type MigrationObjectPin,
 } from "./nuq-fdb";
@@ -79,7 +81,9 @@ export function fdbQueueEnabled(): boolean {
 // configured, publication fails closed unless its durable pin/intent commits.
 setNuQPgPublicationAdapter(
   fdbQueueEnabled()
-    ? new DurableNuQPgPublicationAdapter(nuqFdbMigrationStore)
+    ? new DurableNuQPgPublicationAdapter(nuqFdbMigrationStore, jobIds =>
+        pgJobRemovalsFdb.assertPublishable(jobIds),
+      )
     : passthroughNuQPgPublicationAdapter,
 );
 
@@ -771,15 +775,24 @@ async function acquireExternalSlot(
   const backend = pin?.backend ?? (await authoritativeTeamBackend(teamId));
   if (backend === "fdb") {
     await fdbMutation(() => externalSlotsFdb.acquire(teamId, holderId, ttlMs));
+    await activateRoutingPin(
+      pin,
+      { capacity_external_holders: 1 },
+      "external-holder-active",
+    );
   } else {
-    await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
+    const now = Date.now();
+    if (pin) {
+      // Publish the durable deadline before crossing the Redis boundary. A
+      // crash or ambiguous Redis result can conservatively overcount only
+      // until this exact generation expires; it cannot strand a prepared pin.
+      await fdbMutation(() =>
+        externalSlotsFdb.renewPg(teamId, holderId, now + ttlMs),
+      );
+    }
+    await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs, now);
     await syncFdbLimitToPgOccupancy(teamId);
   }
-  await activateRoutingPin(
-    pin,
-    { capacity_external_holders: 1 },
-    "external-holder-active",
-  );
 }
 
 export async function reserveExternalSlot(
@@ -816,11 +829,14 @@ export async function mirrorExternalSlotRelease(
     const backend = pin?.backend ?? (fdbForced() ? "fdb" : "pg");
     if (backend === "fdb") {
       await fdbMutation(() => externalSlotsFdb.release(teamId, holderId));
+      await completeRoutingPin(pin, "external-holder-terminal");
     } else {
       await removeConcurrencyLimitActiveJob(teamId, holderId);
       await syncFdbLimitToPgOccupancy(teamId);
+      if (pin) {
+        await fdbMutation(() => externalSlotsFdb.releasePg(teamId, holderId));
+      }
     }
-    await completeRoutingPin(pin, "external-holder-terminal");
   });
 }
 
@@ -1043,6 +1059,23 @@ export async function fdbEnqueueScrapeJobs(
 // === Routed scrape queue
 
 const pgRemoveResidueKey = (id: string) => `nuq:pg_remove_residue:${id}`;
+
+function durablePgRemovalDescriptor(
+  removed: Pick<NuQRemovedJobResidue, "id" | "ownerId" | "groupId">,
+): DurablePgJobRemoval {
+  return {
+    schemaVersion: 1,
+    id: removed.id,
+    ...(removed.ownerId ? { ownerId: removed.ownerId } : {}),
+    ...(removed.groupId ? { groupId: removed.groupId } : {}),
+  };
+}
+
+function redisRemovalDescriptor(
+  descriptor: DurablePgJobRemoval,
+): NuQRemovedJobResidue {
+  return { ...descriptor, data: {} };
+}
 
 async function cleanPgRedisJobResidue(
   id: string,
@@ -1284,23 +1317,57 @@ class RoutedScrapeQueue {
   }
 
   public async removeJob(id: string, logger: Logger = _logger): Promise<void> {
+    const redis = getRedisConnection();
+    // A PG delete can commit before Redis cleanup. Consult its durable cleanup
+    // descriptor and PG pin before the generic resolver, which correctly
+    // rejects a missing object with a live pin but cannot finish this saga.
+    const [durableDescriptor, priorDescriptor, initialPin] = await Promise.all([
+      fdbQueueEnabled() ? pgJobRemovalsFdb.inspect(id) : Promise.resolve(null),
+      redis.get(pgRemoveResidueKey(id)),
+      inspectRoutingPin("scrape_job", id),
+    ]);
+    const recoverLegacyDeletedJob =
+      durableDescriptor === null &&
+      priorDescriptor !== null &&
+      initialPin?.backend === "pg" &&
+      !(await pgHasScrapeJob(id));
+    if (
+      (durableDescriptor !== null || recoverLegacyDeletedJob) &&
+      initialPin?.backend === "pg"
+    ) {
+      const queuedPayload = await redis.get(`cq-job:${id}`);
+      let descriptor = durableDescriptor
+        ? redisRemovalDescriptor(durableDescriptor)
+        : null;
+      if (!descriptor && priorDescriptor) {
+        try {
+          descriptor = JSON.parse(priorDescriptor) as NuQRemovedJobResidue;
+        } catch {
+          // Corrupt legacy Redis descriptors still route to idempotent cleanup.
+        }
+      }
+      const removed = await scrapeQueuePg.removeJobResidue(id, logger);
+      await cleanPgRedisJobResidue(id, removed ?? descriptor, queuedPayload);
+      await completeRoutingPin(initialPin, "job-remove");
+      if (durableDescriptor) {
+        await fdbMutation(() => pgJobRemovalsFdb.complete(id));
+      }
+      return;
+    }
+
     const backend = await getJobQueueBackend(id);
     if (!backend) return;
-    const pin = await inspectRoutingPin("scrape_job", id);
+    const pin = initialPin ?? (await inspectRoutingPin("scrape_job", id));
     if (backend === "fdb") {
       await fdbMutation(() => scrapeQueueFdb.removeJob(id, logger));
       await completeRoutingPin(pin, "job-remove");
       return;
     }
-    const redis = getRedisConnection();
-    const [queuedPayload, priorDescriptor, active, backlog] = await Promise.all(
-      [
-        redis.get(`cq-job:${id}`),
-        redis.get(pgRemoveResidueKey(id)),
-        scrapeQueuePg.getJob(id, logger),
-        scrapeQueuePg.getJobsFromBacklog([id], logger),
-      ],
-    );
+    const [queuedPayload, active, backlog] = await Promise.all([
+      redis.get(`cq-job:${id}`),
+      scrapeQueuePg.getJob(id, logger),
+      scrapeQueuePg.getJobsFromBacklog([id], logger),
+    ]);
     const existing = active ?? backlog[0] ?? null;
     if (existing) {
       // Persist the routing metadata before deleting PG. A retry after process
@@ -1313,19 +1380,26 @@ class RoutedScrapeQueue {
           groupId: existing.groupId,
           data: {},
         }),
-        "EX",
-        24 * 60 * 60,
       );
     }
-    const removed = await scrapeQueuePg.removeJobResidue(id, logger);
+    const removed = await scrapeQueuePg.removeJobResidue(
+      id,
+      logger,
+      pin
+        ? async rows => {
+            const row = rows[0];
+            if (!row) {
+              throw new Error(
+                `PG removal lost job ${id} before durable fencing`,
+              );
+            }
+            await fdbMutation(() =>
+              pgJobRemovalsFdb.begin(durablePgRemovalDescriptor(row)),
+            );
+          }
+        : undefined,
+    );
     let descriptor = removed;
-    if (!descriptor && priorDescriptor) {
-      try {
-        descriptor = JSON.parse(priorDescriptor) as NuQRemovedJobResidue;
-      } catch {
-        // Corrupt descriptor is deleted by the cleanup pipeline.
-      }
-    }
     if (!descriptor && existing) {
       descriptor = {
         id,
@@ -1336,6 +1410,7 @@ class RoutedScrapeQueue {
     }
     await cleanPgRedisJobResidue(id, descriptor, queuedPayload);
     await completeRoutingPin(pin, "job-remove");
+    if (pin) await fdbMutation(() => pgJobRemovalsFdb.complete(id));
   }
 
   public async removeJobs(
@@ -1518,22 +1593,39 @@ class RoutedCrawlGroup {
         opts.backend,
       );
     }
-    const group =
-      backend === "fdb"
-        ? ((await fdbMutation(() =>
-            crawlGroupFdb.addGroup(
-              id,
-              ownerId,
-              ttl,
-              {
-                maxConcurrency: opts?.maxConcurrency,
-                delaySeconds: opts?.delaySeconds,
-              },
-              logger,
-            ),
-          )) as NuQJobGroupInstance)
-        : await crawlGroupPg.addGroup(id, ownerId, ttl, logger);
-    await activateRoutingPin(pin, { control_groups: 1 }, "group-active");
+    let group: NuQJobGroupInstance;
+    try {
+      group =
+        backend === "fdb"
+          ? ((await fdbMutation(() =>
+              crawlGroupFdb.addGroup(
+                id,
+                ownerId,
+                ttl,
+                {
+                  maxConcurrency: opts?.maxConcurrency,
+                  delaySeconds: opts?.delaySeconds,
+                },
+                logger,
+              ),
+            )) as NuQJobGroupInstance)
+          : await crawlGroupPg.addGroup(id, ownerId, ttl, logger);
+    } catch (error) {
+      if (backend === "pg" && pin?.lifecycle === "prepared") {
+        // The advisory publication lock waits out an earlier ambiguous commit.
+        // Compensate only when that serialized observation proves no PG row.
+        const existing = await crawlGroupPg.resolveGroupPublication(id);
+        if (!existing) {
+          await completeRoutingPin(pin, "group-publication-compensated");
+        }
+      }
+      throw error;
+    }
+    if (group.status === "active") {
+      await activateRoutingPin(pin, { control_groups: 1 }, "group-active");
+    } else {
+      await completeRoutingPin(pin, "group-publication-terminal");
+    }
     void markBackend(groupBackendKey(id), backend).catch(error =>
       _logger.warn("Failed to cache group backend", {
         module: "nuq-router",

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -50,6 +50,7 @@ import {
   hasLegacyFdbTeamResidue,
   reconcileDesiredTeamBackend,
   recoverLegacyTeamState,
+  reconcileFdbResidueFence,
   reconcilePgResidueFence,
   resolveAuthoritativeObjectBackend,
   type BackendMarker,
@@ -109,37 +110,42 @@ async function desiredTeamBackend(teamId: string): Promise<QueueBackend> {
   return acuc?.flags?.nuqFdb === true ? "fdb" : "pg";
 }
 
+async function hasAuthoritativeFdbTeamResidue(
+  teamId: string,
+): Promise<boolean> {
+  return await optionalFdbRead(async () => {
+    const [
+      scrapePending,
+      scrapeActive,
+      crawlFinishedPending,
+      crawlFinishedActive,
+      crawlFinishedIndexedLive,
+      groups,
+    ] = await Promise.all([
+      scrapeQueueFdb.getTeamPendingCount(teamId),
+      scrapeQueueFdb.getTeamActiveCount(teamId),
+      crawlFinishedQueueFdb.getTeamPendingCount(teamId),
+      crawlFinishedQueueFdb.getTeamActiveCount(teamId),
+      crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
+      crawlGroupFdb.getOngoingByOwner(teamId),
+    ]);
+    return hasLegacyFdbTeamResidue({
+      scrapePending,
+      scrapeActive,
+      crawlFinishedPending,
+      crawlFinishedActive,
+      crawlFinishedIndexedLive,
+      activeGroups: groups.length,
+    });
+  });
+}
+
 async function discoverLegacyTeamAuthority(
   teamId: string,
 ): Promise<QueueBackend> {
   return await discoverLegacyTeamBackend({
     teamId,
-    probeFdbResidue: () =>
-      optionalFdbRead(async () => {
-        const [
-          scrapePending,
-          scrapeActive,
-          crawlFinishedPending,
-          crawlFinishedActive,
-          crawlFinishedIndexedLive,
-          groups,
-        ] = await Promise.all([
-          scrapeQueueFdb.getTeamPendingCount(teamId),
-          scrapeQueueFdb.getTeamActiveCount(teamId),
-          crawlFinishedQueueFdb.getTeamPendingCount(teamId),
-          crawlFinishedQueueFdb.getTeamActiveCount(teamId),
-          crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
-          crawlGroupFdb.getOngoingByOwner(teamId),
-        ]);
-        return hasLegacyFdbTeamResidue({
-          scrapePending,
-          scrapeActive,
-          crawlFinishedPending,
-          crawlFinishedActive,
-          crawlFinishedIndexedLive,
-          activeGroups: groups.length,
-        });
-      }),
+    probeFdbResidue: () => hasAuthoritativeFdbTeamResidue(teamId),
     probePgResidue: async () => {
       const [residue, redisOccupancy] = await Promise.all([
         getNuQPgOwnerLiveResidue(teamId),
@@ -245,11 +251,25 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
         observationId: `${teamId}/${current!.revision}/${pgResidueTotal === 0 ? "zero" : "nonzero"}`,
       }),
     );
-    // TODO(corrected-core): only the reconciler may call finalSeal after every
-    // queue/group/slot/sweeper mutation uses generation accounting in its own
-    // FDB transaction and publishes an authoritative readiness decision. This
-    // router refreshes durable PG residue but never infers seal readiness from
-    // an out-of-transaction PG/Redis observation.
+  }
+
+  // Existing FDB records from before generation hooks cannot be reconstructed
+  // from the new counters alone. Keep one generation-scoped durable fence until
+  // the authoritative source ledgers are empty; this also covers legacy
+  // external slots through the team's active count.
+  if (
+    desired === "pg" &&
+    current.activeBackend === "fdb" &&
+    (current.phase === "FDB_ONLY" || current.phase === "DRAINING_TO_PG")
+  ) {
+    const hasFdbResidue = await hasAuthoritativeFdbTeamResidue(teamId);
+    await fdbMutation(() =>
+      reconcileFdbResidueFence(nuqFdbMigrationStore, {
+        teamId,
+        total: hasFdbResidue ? 1 : 0,
+        observationId: `${teamId}/${current!.revision}/${hasFdbResidue ? "nonzero" : "zero"}`,
+      }),
+    );
   }
 
   if (current?.activeBackend === desired && current.phase !== "ERROR") {

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -301,6 +301,14 @@ async function markBackend(key: string, backend: QueueBackend): Promise<void> {
   await redisEvictConnection.set(key, backend, "EX", 30 * 24 * 60 * 60);
 }
 
+async function repairBackendMarker(
+  key: string,
+  backend: QueueBackend | null,
+): Promise<void> {
+  if (backend) await markBackend(key, backend);
+  else await redisEvictConnection.del(key);
+}
+
 async function markJobBackend(
   jobId: string,
   backend: QueueBackend,
@@ -360,7 +368,8 @@ async function getCrawlQueueBackend(
         async () => (await crawlGroupFdb.getGroup(crawlId)) !== null,
       ),
     probePg: async () => (await crawlGroupPg.getGroup(crawlId)) !== null,
-    repairMarker: backend => markBackend(groupBackendKey(crawlId), backend),
+    repairMarker: backend =>
+      repairBackendMarker(groupBackendKey(crawlId), backend),
   });
   if (
     backend === "pg" &&
@@ -442,7 +451,7 @@ async function getJobQueueBackend(
     probeFdb: () =>
       optionalFdbRead(probes.hasFdbJob ?? (() => scrapeQueueFdb.hasJob(jobId))),
     probePg: probes.hasPgJob ?? (() => pgHasScrapeJob(jobId)),
-    repairMarker: backend => markJobBackend(jobId, backend),
+    repairMarker: backend => repairBackendMarker(jobBackendKey(jobId), backend),
   });
 }
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -44,6 +44,7 @@ import type { QueueOperationOptions } from "./nuq-worker-runtime";
 import {
   DurableNuQPgPublicationAdapter,
   NuQRouterBothBackendsError,
+  NuQRouterError,
   NuQRouterObjectNotFoundError,
   NuQRouterPinMismatchError,
   discoverLegacyTeamBackend,
@@ -140,6 +141,22 @@ async function hasAuthoritativeFdbTeamResidue(
   });
 }
 
+async function requireFdbCoreMetricReadiness(): Promise<void> {
+  const [scrape, crawlFinished] = await optionalFdbRead(() =>
+    Promise.all([
+      scrapeQueueFdb.getMetricCounterBackfillStatus(),
+      crawlFinishedQueueFdb.getMetricCounterBackfillStatus(),
+    ]),
+  );
+  if (scrape?.phase !== "ready" || crawlFinished?.phase !== "ready") {
+    throw new NuQRouterError(
+      "NUQ_FDB_CORE_METRICS_NOT_READY",
+      "NuQ FDB migration is frozen until scrape and crawl_finished metric counters are ready",
+      true,
+    );
+  }
+}
+
 async function discoverLegacyTeamAuthority(
   teamId: string,
 ): Promise<QueueBackend> {
@@ -217,6 +234,9 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
     nuqFdbMigrationStore.inspectState(teamId),
   );
   if (!current) {
+    // Authority discovery must not trust indexes that can still be written by
+    // a pre-protocol binary. Core readiness is the release-B deployment fence.
+    await requireFdbCoreMetricReadiness();
     current = await fdbMutation(() =>
       recoverLegacyTeamState(nuqFdbMigrationStore, teamId, () =>
         discoverLegacyTeamAuthority(teamId),
@@ -225,6 +245,14 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
     // Discovery may have lost an initialize-if-absent race. Trust the durable
     // winner exactly as returned; desired begin/cancel is a subsequent request.
     return current.activeBackend;
+  }
+
+  const advancingRequestedTransition =
+    ((current.phase === "PG_ONLY" || current.phase === "FDB_ONLY") &&
+      current.activeBackend !== desired) ||
+    current.targetBackend === desired;
+  if (advancingRequestedTransition) {
+    await requireFdbCoreMetricReadiness();
   }
 
   // Before pausing PG admissions, snapshot authoritative legacy PG residue
@@ -272,7 +300,20 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
     );
   }
 
-  if (current?.activeBackend === desired && current.phase !== "ERROR") {
+  if (
+    current.targetBackend === desired &&
+    current.transitionOperationId !== undefined
+  ) {
+    current = await fdbMutation(() =>
+      nuqFdbMigrationStore.finalSeal({
+        teamId,
+        transitionOperationId: current!.transitionOperationId!,
+        expectedRevision: current!.revision,
+      }),
+    );
+  }
+
+  if (current.activeBackend === desired && current.phase !== "ERROR") {
     if (current.phase === "PG_ONLY" || current.phase === "FDB_ONLY") {
       return current.activeBackend;
     }

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -36,19 +36,30 @@ import {
   withFdbTimeout,
   NuQFdbQueue,
   NuQFdbJob,
+  nuqFdbMigrationStore,
+  type MigrationObjectKind,
+  type MigrationObjectPin,
 } from "./nuq-fdb";
 import type { QueueOperationOptions } from "./nuq-worker-runtime";
+import {
+  DurableNuQPgPublicationAdapter,
+  NuQRouterBothBackendsError,
+  NuQRouterObjectNotFoundError,
+  NuQRouterPinMismatchError,
+  reconcileDesiredTeamBackend,
+  reconcilePgResidueFence,
+  resolveAuthoritativeObjectBackend,
+  type BackendMarker,
+} from "./nuq-migration-control";
+import {
+  passthroughNuQPgPublicationAdapter,
+  setNuQPgPublicationAdapter,
+} from "./nuq-pg-publication";
 
-// Dual-backend router for the NuQ migration to FoundationDB. Exports the same
-// `scrapeQueue` / `crawlFinishedQueue` / `crawlGroup` names as ./nuq so call
-// sites only swap their import path. Routing rules:
-//  - new crawls: team flag (TeamFlags.nuqFdb) or NUQ_BACKEND=fdb decides; the
-//    choice is pinned in StoredCrawl.queueBackend so a crawl never spans
-//    backends
-//  - reads: stored crawl/job backend markers decide the backend; unmarked jobs
-//    default to PG so FDB outages do not affect non-FDB traffic
-//  - workers: production workers consume PG and FDB via separate entrypoints;
-//    this class still tracks in-flight backend for direct/router test consumers
+// Dual-backend router for the NuQ migration to FoundationDB. FDB migration
+// state and object pins are authoritative; Redis backend markers are repairable
+// hints only. Production workers still consume PG and FDB via separate
+// entrypoints, while this class tracks in-flight backend for direct consumers.
 
 export type QueueBackend = "pg" | "fdb";
 
@@ -58,8 +69,18 @@ export function fdbQueueEnabled(): boolean {
   return isFdbConfigured();
 }
 
+// PG-only deployments deliberately opt into passthrough. Once FDB migration is
+// configured, publication fails closed unless its durable pin/intent commits.
+setNuQPgPublicationAdapter(
+  fdbQueueEnabled()
+    ? new DurableNuQPgPublicationAdapter(nuqFdbMigrationStore)
+    : passthroughNuQPgPublicationAdapter,
+);
+
 function fdbForced(): boolean {
-  return config.NUQ_BACKEND === "fdb";
+  // Self-hosted forced-FDB deployments have no legacy PG ledger to migrate.
+  // Cloud-wide forcing still flows through durable per-team state.
+  return config.NUQ_BACKEND === "fdb" && isSelfHosted();
 }
 
 const FDB_OPTIONAL_OP_TIMEOUT_MS = 500;
@@ -79,113 +100,319 @@ async function fdbMutation<T>(operation: () => Promise<T>): Promise<T> {
   return await operation();
 }
 
-const teamFdbStateKey = (teamId: string) => `nuq:fdb_team:${teamId}`;
+async function desiredTeamBackend(teamId: string): Promise<QueueBackend> {
+  if (config.NUQ_BACKEND === "fdb") return "fdb";
+  const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
+  return acuc?.flags?.nuqFdb === true ? "fdb" : "pg";
+}
 
-async function markFdbTeamState(teamId: string): Promise<void> {
-  // One bounded key per migrated team is the durable drain barrier. Failure is
-  // fatal before the first FDB enqueue, so rollback can always identify teams
-  // whose pinned FDB work may remain.
-  await getRedisConnection().set(teamFdbStateKey(teamId), "1");
+async function reconcileTerminalPgPins(teamId: string): Promise<void> {
+  const pins = (await nuqFdbMigrationStore.inspectTeamPins(teamId)).filter(
+    pin => pin.backend === "pg" && pin.lifecycle !== "terminal",
+  );
+  const jobPins = pins.filter(pin => pin.kind === "scrape_job");
+  if (jobPins.length > 0) {
+    const ids = jobPins.map(pin => pin.objectId);
+    const [jobs, backlog] = await Promise.all([
+      scrapeQueuePg.getJobs(ids),
+      scrapeQueuePg.getJobsFromBacklog(ids),
+    ]);
+    const byId = new Map([...jobs, ...backlog].map(job => [job.id, job]));
+    for (const pin of jobPins) {
+      const job = byId.get(pin.objectId);
+      const terminal = job?.status === "completed" || job?.status === "failed";
+      // A missing prepared object may still be between FDB intent commit and
+      // PG publication. Only an observed terminal row, or disappearance after
+      // durable activation, proves that its residue can be retired.
+      if (terminal || (!job && pin.lifecycle === "active")) {
+        await completeRoutingPin(pin, "pg-reconcile-terminal");
+      }
+    }
+  }
+  for (const pin of pins) {
+    if (pin.kind === "group") {
+      const group = await crawlGroupPg.getGroup(pin.objectId);
+      if (
+        (group && group.status !== "active") ||
+        (!group && pin.lifecycle === "active")
+      ) {
+        await completeRoutingPin(pin, "pg-reconcile-terminal");
+      }
+    } else if (pin.kind === "external_holder") {
+      const present = await getRedisConnection().zscore(
+        constructConcurrencyLimitKey(teamId),
+        pin.objectId,
+      );
+      if (present === null && pin.lifecycle === "active") {
+        await completeRoutingPin(pin, "pg-reconcile-terminal");
+      }
+    } else if (pin.kind === "crawl_finished") {
+      const job = await crawlFinishedQueuePg.getJob(pin.objectId);
+      if (
+        job?.status === "completed" ||
+        job?.status === "failed" ||
+        (!job && pin.lifecycle === "active")
+      ) {
+        await completeRoutingPin(pin, "pg-reconcile-terminal");
+      }
+    }
+  }
+}
+
+async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
+  if (!fdbQueueEnabled()) return "pg";
+  if (fdbForced()) return "fdb";
+  const desired = await desiredTeamBackend(teamId);
+  let current = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectState(teamId),
+  );
+  if (!current) {
+    current = await fdbMutation(() =>
+      reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, "pg"),
+    );
+  }
+
+  // Before pausing PG admissions, snapshot authoritative legacy PG residue
+  // into a durable FDB fence. During drain, refresh the fence first and ask
+  // finalSeal to decide exclusively from durable counters.
+  if (
+    desired === "fdb" &&
+    current?.activeBackend === "pg" &&
+    (current.phase === "PG_ONLY" || current.phase === "DRAINING_TO_FDB")
+  ) {
+    await fdbMutation(() => reconcileTerminalPgPins(teamId));
+    const [residue, redisOccupancy] = await Promise.all([
+      getNuQPgOwnerLiveResidue(teamId),
+      getConcurrencyLimitActiveJobsCount(teamId),
+    ]);
+    // Redis is authoritative only for legacy external holders, not backend
+    // routing. Including all PG occupancy is conservative and prevents a
+    // pre-control-plane holder from becoming invisible to the seal.
+    const pgResidueTotal = residue.total + redisOccupancy;
+    await fdbMutation(() =>
+      reconcilePgResidueFence(nuqFdbMigrationStore, {
+        teamId,
+        total: pgResidueTotal,
+        observationId: `${teamId}/${current!.revision}/${pgResidueTotal === 0 ? "zero" : "nonzero"}`,
+      }),
+    );
+    if (
+      current.phase === "DRAINING_TO_FDB" &&
+      pgResidueTotal === 0 &&
+      current.transitionOperationId
+    ) {
+      current = await fdbMutation(() =>
+        nuqFdbMigrationStore.finalSeal({
+          teamId,
+          transitionOperationId: current!.transitionOperationId!,
+          expectedRevision: current!.revision,
+        }),
+      );
+    }
+  }
+
+  if (
+    desired === "pg" &&
+    current?.phase === "DRAINING_TO_PG" &&
+    current.transitionOperationId
+  ) {
+    current = await fdbMutation(() =>
+      nuqFdbMigrationStore.finalSeal({
+        teamId,
+        transitionOperationId: current!.transitionOperationId!,
+        expectedRevision: current!.revision,
+      }),
+    );
+  }
+
+  if (current?.activeBackend === desired && current.phase !== "ERROR") {
+    if (current.phase === "PG_ONLY" || current.phase === "FDB_ONLY") {
+      return current.activeBackend;
+    }
+  }
+  const state = await fdbMutation(() =>
+    reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, desired),
+  );
+  return state.activeBackend;
 }
 
 async function teamUsesFdbLedger(teamId: string): Promise<boolean> {
   if (!fdbQueueEnabled()) return false;
   if (fdbForced()) return true;
-  if (await isFdbTeam(teamId)) return true;
-  return (await getRedisConnection().get(teamFdbStateKey(teamId))) === "1";
+  const state = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectState(teamId),
+  );
+  if (!state) return (await authoritativeTeamBackend(teamId)) === "fdb";
+  return state.activeBackend === "fdb" || state.targetBackend === "fdb";
 }
 
-// Whether NEW work for this team should go to FDB. Existing crawls follow
-// their StoredCrawl.queueBackend marker instead.
+// Whether NEW root work may use FDB. A flag only requests a durable state
+// transition; transition phases reject admission with a retryable error.
 export async function isFdbTeam(teamId: string | undefined): Promise<boolean> {
-  if (!fdbQueueEnabled()) return false;
-  if (fdbForced()) return true;
-  if (!teamId) return false;
-  let enabled = false;
-  try {
-    const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
-    enabled = acuc?.flags?.nuqFdb === true;
-  } catch (error) {
-    _logger.warn("Failed to resolve nuqFdb team flag, defaulting to pg", {
-      module: "nuq-router",
-      teamId,
-      error,
-    });
-  }
-  if (enabled) await markFdbTeamState(teamId);
-  return enabled;
+  if (!teamId || !fdbQueueEnabled()) return false;
+  return (await authoritativeTeamBackend(teamId)) === "fdb";
 }
 
 export async function resolveNewGroupBackend(
   teamId: string,
 ): Promise<QueueBackend> {
-  return (await isFdbTeam(teamId)) ? "fdb" : "pg";
+  return await authoritativeTeamBackend(teamId);
 }
 
-// Reads only the queueBackend marker off the stored crawl. Deliberately not
-// getCrawl() -- importing crawl-redis pulls the whole scraper tree in.
-async function getCrawlQueueBackend(
-  crawlId: string,
-): Promise<QueueBackend | null> {
-  if (fdbForced()) return "fdb";
-  const raw = await redisEvictConnection.get("crawl:" + crawlId);
-  if (raw) {
-    try {
-      const sc = JSON.parse(raw);
-      if (sc?.queueBackend === "fdb") return "fdb";
-      // Stored crawls predating the rollout have no marker and are PG.
-      if (sc) return "pg";
-    } catch {
-      // Fall through to the authoritative FDB group probe.
-    }
-  }
-  if (!fdbQueueEnabled()) return raw ? "pg" : null;
-  const group = await optionalFdbRead(() => crawlGroupFdb.getGroup(crawlId));
-  return group ? "fdb" : raw ? "pg" : null;
+function decodeBackendMarker(raw: string | null): BackendMarker {
+  if (raw === null) return null;
+  return raw === "pg" || raw === "fdb" ? raw : "corrupt";
 }
 
+const groupBackendKey = (groupId: string) => `nuq:group_backend:${groupId}`;
 const jobBackendKey = (jobId: string) => `nuq:job_backend:${jobId}`;
+
+async function markBackend(key: string, backend: QueueBackend): Promise<void> {
+  if (fdbForced()) return;
+  await redisEvictConnection.set(key, backend, "EX", 30 * 24 * 60 * 60);
+}
 
 async function markJobBackend(
   jobId: string,
   backend: QueueBackend,
 ): Promise<void> {
-  if (fdbForced()) return;
-  // This is only a bounded cache; never trust its absence. FDB job metadata
-  // remains the durable source of truth after expiry or a failed write.
-  await redisEvictConnection.set(
-    jobBackendKey(jobId),
-    backend,
-    "EX",
-    30 * 24 * 60 * 60,
-  );
+  await markBackend(jobBackendKey(jobId), backend);
+}
+
+async function readRedisBackendHint(key: string): Promise<string | null> {
+  try {
+    return await redisEvictConnection.get(key);
+  } catch (error) {
+    _logger.warn("Failed to read Redis backend hint", {
+      module: "nuq-router",
+      key,
+      error,
+    });
+    return null;
+  }
+}
+
+async function pgHasScrapeJob(jobId: string): Promise<boolean> {
+  if (await scrapeQueuePg.getJob(jobId)) return true;
+  return (await scrapeQueuePg.getJobsFromBacklog([jobId])).length > 0;
+}
+
+async function getCrawlQueueBackend(
+  crawlId: string,
+): Promise<QueueBackend | null> {
+  if (fdbForced()) return "fdb";
+  const [markerRaw, crawlRaw] = await Promise.all([
+    readRedisBackendHint(groupBackendKey(crawlId)),
+    readRedisBackendHint("crawl:" + crawlId),
+  ]);
+  let marker = decodeBackendMarker(markerRaw);
+  if (marker === null && crawlRaw) {
+    try {
+      const stored = JSON.parse(crawlRaw);
+      marker =
+        stored?.queueBackend === "pg" || stored?.queueBackend === "fdb"
+          ? stored.queueBackend
+          : stored?.queueBackend === undefined
+            ? null
+            : "corrupt";
+    } catch {
+      marker = "corrupt";
+    }
+  }
+  if (!fdbQueueEnabled()) return crawlRaw ? "pg" : null;
+  const backend = await resolveAuthoritativeObjectBackend({
+    kind: "group",
+    objectId: crawlId,
+    marker,
+    readPin: () =>
+      optionalFdbRead(() => nuqFdbMigrationStore.inspectPin("group", crawlId)),
+    probeFdb: () =>
+      optionalFdbRead(
+        async () => (await crawlGroupFdb.getGroup(crawlId)) !== null,
+      ),
+    probePg: async () => (await crawlGroupPg.getGroup(crawlId)) !== null,
+    repairMarker: backend => markBackend(groupBackendKey(crawlId), backend),
+  });
+  if (
+    backend === "pg" &&
+    !(await optionalFdbRead(() =>
+      nuqFdbMigrationStore.inspectPin("group", crawlId),
+    ))
+  ) {
+    const group = await crawlGroupPg.getGroup(crawlId);
+    if (!group) return null;
+    let state = await optionalFdbRead(() =>
+      nuqFdbMigrationStore.inspectState(group.ownerId),
+    );
+    if (!state) {
+      state = await fdbMutation(() =>
+        reconcileDesiredTeamBackend(nuqFdbMigrationStore, group.ownerId, "pg"),
+      );
+    }
+    let generation = state.activeGeneration;
+    if (state.activeBackend !== "pg") {
+      if (group.status === "active") {
+        throw new NuQRouterPinMismatchError("group", crawlId, "fdb", "pg");
+      }
+      generation = 0;
+      for (let candidate = state.maxGeneration; candidate >= 1; candidate--) {
+        const record = await optionalFdbRead(() =>
+          nuqFdbMigrationStore.inspectGeneration(group.ownerId, candidate),
+        );
+        if (record.generation.backend === "pg") {
+          generation = candidate;
+          break;
+        }
+      }
+      if (generation === 0) {
+        throw new NuQRouterPinMismatchError("group", crawlId, "fdb", "pg");
+      }
+    }
+    await fdbMutation(() =>
+      nuqFdbMigrationStore.preparePinnedObject({
+        teamId: group.ownerId,
+        kind: "group",
+        objectId: crawlId,
+        admission: {
+          type: "legacy-backfill",
+          backend: "pg",
+          generation,
+          terminal: group.status !== "active",
+        },
+        residue: { control_groups: group.status === "active" ? 1 : 0 },
+      }),
+    );
+  }
+  return backend;
 }
 
 async function getJobQueueBackend(
   jobId: string,
   hint?: QueueBackend,
-  hasFdbJob: () => Promise<boolean> = () => scrapeQueueFdb.hasJob(jobId),
-): Promise<QueueBackend> {
-  if (hint) return hint;
+  probes: {
+    kind?: MigrationObjectKind;
+    hasFdbJob?: () => Promise<boolean>;
+    hasPgJob?: () => Promise<boolean>;
+  } = {},
+): Promise<QueueBackend | null> {
   if (fdbForced()) return "fdb";
-  if ((await redisEvictConnection.get(jobBackendKey(jobId))) === "fdb") {
-    return "fdb";
-  }
+  const cachedMarker = decodeBackendMarker(
+    await readRedisBackendHint(jobBackendKey(jobId)),
+  );
+  const marker = cachedMarker ?? hint ?? null;
   if (!fdbQueueEnabled()) return "pg";
-
-  // Redis marker writes are best-effort and old markers may have expired.
-  // Probe the durable FDB record before routing a wait/remove/read to PG.
-  if (await optionalFdbRead(hasFdbJob)) {
-    void markJobBackend(jobId, "fdb").catch(error =>
-      _logger.warn("Failed to repair FDB job backend marker", {
-        module: "nuq-router",
-        jobId,
-        error,
-      }),
-    );
-    return "fdb";
-  }
-  return "pg";
+  const kind = probes.kind ?? "scrape_job";
+  return await resolveAuthoritativeObjectBackend({
+    kind,
+    objectId: jobId,
+    marker,
+    readPin: () =>
+      optionalFdbRead(() => nuqFdbMigrationStore.inspectPin(kind, jobId)),
+    probeFdb: () =>
+      optionalFdbRead(probes.hasFdbJob ?? (() => scrapeQueueFdb.hasJob(jobId))),
+    probePg: probes.hasPgJob ?? (() => pgHasScrapeJob(jobId)),
+    repairMarker: backend => markJobBackend(jobId, backend),
+  });
 }
 
 // Which backend a job belongs to at enqueue time. Crawl jobs follow their
@@ -196,9 +423,12 @@ export async function resolveJobBackend(
   if (!fdbQueueEnabled()) return "pg";
   if (fdbForced()) return "fdb";
   if (data.crawl_id) {
-    return (await getCrawlQueueBackend(data.crawl_id)) ?? "pg";
+    const backend = await getCrawlQueueBackend(data.crawl_id);
+    if (!backend)
+      throw new NuQRouterObjectNotFoundError("group", data.crawl_id);
+    return backend;
   }
-  return (await isFdbTeam(data.team_id)) ? "fdb" : "pg";
+  return await authoritativeTeamBackend(data.team_id);
 }
 
 function tagFdbJob<T extends object>(job: T): T & { backend: "fdb" } {
@@ -206,25 +436,173 @@ function tagFdbJob<T extends object>(job: T): T & { backend: "fdb" } {
   return job as T & { backend: "fdb" };
 }
 
+async function prepareRoutingPin(input: {
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  sourceGroupId?: string;
+}): Promise<MigrationObjectPin | null> {
+  if (!fdbQueueEnabled() || fdbForced()) return null;
+  return await fdbMutation(() =>
+    nuqFdbMigrationStore.preparePinnedObject({
+      teamId: input.teamId,
+      kind: input.kind,
+      objectId: input.objectId,
+      admission: input.sourceGroupId
+        ? {
+            type: "pinned-continuation",
+            source: { kind: "group", objectId: input.sourceGroupId },
+          }
+        : { type: "new-root" },
+      // This pre-intent is deliberately durable before a backend mutation.
+      // TODO(corrected-core): queue/group/slot mutations and sweeper lifecycle
+      // generation accounting must compose the exported *InTxn hooks in their
+      // own FDB transaction. Until then an ambiguous outcome remains fenced;
+      // this prototype does not pretend the separate transactions are atomic.
+      residue: { intent_unresolved: 1 },
+    }),
+  );
+}
+
+async function activateRoutingPin(
+  pin: MigrationObjectPin | null,
+  residue: Partial<
+    Record<
+      | "capacity_team_pending"
+      | "capacity_ready_active"
+      | "capacity_external_holders"
+      | "control_groups",
+      number
+    >
+  >,
+  operation: string,
+): Promise<void> {
+  if (!pin || pin.lifecycle === "active") return;
+  if (pin.lifecycle === "terminal") {
+    throw new Error(
+      `Cannot reactivate terminal migration pin ${pin.kind}/${pin.objectId}`,
+    );
+  }
+  await fdbMutation(() =>
+    nuqFdbMigrationStore.transitionObjectResidue({
+      teamId: pin.teamId,
+      kind: pin.kind,
+      objectId: pin.objectId,
+      operationId: `nuq-router/v1/${operation}/${pin.objectId}`,
+      fromLifecycle: "prepared",
+      toLifecycle: "active",
+      residue,
+    }),
+  );
+}
+
+async function inspectRoutingPin(
+  kind: MigrationObjectKind,
+  objectId: string,
+): Promise<MigrationObjectPin | null> {
+  if (!fdbQueueEnabled() || fdbForced()) return null;
+  return await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin(kind, objectId),
+  );
+}
+
+async function completeRoutingPin(
+  pin: MigrationObjectPin | null,
+  operation: string,
+): Promise<void> {
+  if (!pin || pin.lifecycle === "terminal") return;
+  const fromLifecycle = pin.lifecycle;
+  await fdbMutation(() =>
+    nuqFdbMigrationStore.completePinnedObject({
+      teamId: pin.teamId,
+      kind: pin.kind,
+      objectId: pin.objectId,
+      operationId: `nuq-router/v1/${operation}/${pin.objectId}`,
+      fromLifecycle,
+    }),
+  );
+}
+
 // === External capacity holders (browser sessions, sync scrapes)
 //
-// Non-queue work that occupies team capacity mirrors itself into whichever
-// ledger the team runs on. Mismatched acquire/release pairs (flag flipped
-// mid-hold) self-heal: Redis entries expire by score, FDB external slots are
-// reaped by the sweeper.
+// Non-queue work that occupies team capacity is durably pinned. Renew/release
+// follows that pin even if the rollout flag changes mid-hold.
 
 async function acquireExternalSlot(
   teamId: string,
   holderId: string,
   ttlMs: number,
 ): Promise<void> {
-  if (await isFdbTeam(teamId)) {
-    if (!isSelfHosted()) await markFdbTeamState(teamId);
-    await fdbMutation(() => externalSlotsFdb.acquire(teamId, holderId, ttlMs));
-    return;
+  let existingPin =
+    !fdbQueueEnabled() || fdbForced()
+      ? null
+      : await optionalFdbRead(() =>
+          nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+        );
+  if (!existingPin && fdbQueueEnabled() && !fdbForced()) {
+    let state = await optionalFdbRead(() =>
+      nuqFdbMigrationStore.inspectState(teamId),
+    );
+    if (!state) {
+      state = await fdbMutation(() =>
+        reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, "pg"),
+      );
+    }
+    const [fdbPresent, pgPresent] = await Promise.all([
+      optionalFdbRead(() => externalSlotsFdb.has(teamId, holderId)),
+      getRedisConnection().zscore(
+        constructConcurrencyLimitKey(teamId),
+        holderId,
+      ),
+    ]);
+    if (fdbPresent && pgPresent !== null) {
+      throw new NuQRouterBothBackendsError("external_holder", holderId);
+    }
+    const legacyBackend = fdbPresent ? "fdb" : pgPresent !== null ? "pg" : null;
+    if (legacyBackend) {
+      if (state.activeBackend !== legacyBackend) {
+        throw new NuQRouterPinMismatchError(
+          "external_holder",
+          holderId,
+          state.activeBackend,
+          legacyBackend,
+        );
+      }
+      existingPin = await fdbMutation(() =>
+        nuqFdbMigrationStore.preparePinnedObject({
+          teamId,
+          kind: "external_holder",
+          objectId: holderId,
+          admission: {
+            type: "legacy-backfill",
+            backend: legacyBackend,
+            generation: state.activeGeneration,
+          },
+          residue: { capacity_external_holders: 1 },
+        }),
+      );
+    }
   }
-  await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
-  await syncFdbLimitToPgOccupancy(teamId);
+  if (!existingPin) await authoritativeTeamBackend(teamId);
+  const pin =
+    existingPin ??
+    (await prepareRoutingPin({
+      teamId,
+      kind: "external_holder",
+      objectId: holderId,
+    }));
+  const backend = pin?.backend ?? (await authoritativeTeamBackend(teamId));
+  if (backend === "fdb") {
+    await fdbMutation(() => externalSlotsFdb.acquire(teamId, holderId, ttlMs));
+  } else {
+    await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
+    await syncFdbLimitToPgOccupancy(teamId);
+  }
+  await activateRoutingPin(
+    pin,
+    { capacity_external_holders: 1 },
+    "external-holder-active",
+  );
 }
 
 export async function reserveExternalSlot(
@@ -257,18 +635,20 @@ export async function mirrorExternalSlotRelease(
   holderId: string,
 ): Promise<void> {
   await withTeamMigrationAdmission(teamId, async () => {
-    // The flag may flip while a holder is alive. Route by the durable slot,
-    // rather than today's flag, so rollback cannot leak FDB occupancy.
-    if (
-      fdbForced() ||
-      ((await teamUsesFdbLedger(teamId)) &&
-        (await optionalFdbRead(() => externalSlotsFdb.has(teamId, holderId))))
-    ) {
+    const pin =
+      !fdbQueueEnabled() || fdbForced()
+        ? null
+        : await optionalFdbRead(() =>
+            nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+          );
+    const backend = pin?.backend ?? (fdbForced() ? "fdb" : "pg");
+    if (backend === "fdb") {
       await fdbMutation(() => externalSlotsFdb.release(teamId, holderId));
-      return;
+    } else {
+      await removeConcurrencyLimitActiveJob(teamId, holderId);
+      await syncFdbLimitToPgOccupancy(teamId);
     }
-    await removeConcurrencyLimitActiveJob(teamId, holderId);
-    await syncFdbLimitToPgOccupancy(teamId);
+    await completeRoutingPin(pin, "external-holder-terminal");
   });
 }
 
@@ -324,13 +704,17 @@ export function backlogTimeoutMsForGate(timeoutMs: number): Date {
   return new Date(Date.now() + timeoutMs);
 }
 
-// Compatibility boundary for callers while durable generation admission is
-// integrated. A Redis lease cannot make PG/FDB admission atomic and must not
-// be treated as a correctness primitive.
+// Compatibility boundary retained for callers that release/renew existing
+// work. It only verifies that durable FDB authority is reachable. New-root and
+// continuation admission happens through conflictful object-pin operations,
+// not a process-local critical section.
 export async function withTeamMigrationAdmission<T>(
-  _teamId: string,
+  teamId: string,
   operation: () => Promise<T>,
 ): Promise<T> {
+  if (fdbQueueEnabled() && !fdbForced()) {
+    await optionalFdbRead(() => nuqFdbMigrationStore.inspectState(teamId));
+  }
   return await operation();
 }
 
@@ -355,7 +739,39 @@ export async function fdbEnqueueScrapeJobs(
   backloggedCount: number;
   teamLimit: number | null;
 }> {
-  if (!isSelfHosted()) await markFdbTeamState(teamId);
+  const pins =
+    !fdbQueueEnabled() || fdbForced()
+      ? jobs.map(() => null)
+      : await fdbMutation(() =>
+          nuqFdbMigrationStore.preparePinnedObjects(
+            jobs.map(job => ({
+              teamId,
+              kind: "scrape_job" as const,
+              objectId: job.jobId,
+              admission: job.data.crawl_id
+                ? ({
+                    type: "pinned-continuation",
+                    source: {
+                      kind: "group",
+                      objectId: job.data.crawl_id,
+                    },
+                  } as const)
+                : ({ type: "new-root" } as const),
+              requiredBackend: "fdb" as const,
+              residue: { intent_unresolved: 1 },
+            })),
+          ),
+        );
+  for (const pin of pins) {
+    if (pin && pin.backend !== "fdb") {
+      throw new NuQRouterPinMismatchError(
+        pin.kind,
+        pin.objectId,
+        pin.backend,
+        "fdb",
+      );
+    }
+  }
   let teamLimit: number | null = null;
   if (!isSelfHosted() && !fdbForced()) {
     const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
@@ -419,6 +835,17 @@ export async function fdbEnqueueScrapeJobs(
   );
 
   const tagged = results.map(r => tagFdbJob(r as NuQJob<ScrapeJobData>));
+  await Promise.all(
+    tagged.map((job, index) =>
+      activateRoutingPin(
+        pins[index],
+        job.status === "backlog"
+          ? { capacity_team_pending: 1 }
+          : { capacity_ready_active: 1 },
+        "fdb-job-active",
+      ),
+    ),
+  );
   for (const job of tagged) {
     void markJobBackend(job.id, "fdb").catch(error =>
       _logger.warn("Failed to cache FDB job backend", {
@@ -534,26 +961,19 @@ class RoutedScrapeQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
-    if (backend === "fdb") {
-      const finished = await fdbMutation(() =>
-        scrapeQueueFdb.jobFinish(
-          id,
-          lock,
-          returnvalue,
-          logger,
-          operation,
-        ),
+    const finished =
+      backend === "fdb"
+        ? await fdbMutation(() =>
+            scrapeQueueFdb.jobFinish(id, lock, returnvalue, logger, operation),
+          )
+        : await scrapeQueuePg.jobFinish(id, lock, returnvalue, logger);
+    if (finished) {
+      this.inflightBackend.delete(id);
+      await completeRoutingPin(
+        await inspectRoutingPin("scrape_job", id),
+        "job-finish",
       );
-      if (finished) this.inflightBackend.delete(id);
-      return finished;
     }
-    const finished = await scrapeQueuePg.jobFinish(
-      id,
-      lock,
-      returnvalue,
-      logger,
-    );
-    if (finished) this.inflightBackend.delete(id);
     return finished;
   }
 
@@ -565,15 +985,19 @@ class RoutedScrapeQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
-    if (backend === "fdb") {
-      const failed = await fdbMutation(() =>
-        scrapeQueueFdb.jobFail(id, lock, failedReason, logger, operation),
+    const failed =
+      backend === "fdb"
+        ? await fdbMutation(() =>
+            scrapeQueueFdb.jobFail(id, lock, failedReason, logger, operation),
+          )
+        : await scrapeQueuePg.jobFail(id, lock, failedReason, logger);
+    if (failed) {
+      this.inflightBackend.delete(id);
+      await completeRoutingPin(
+        await inspectRoutingPin("scrape_job", id),
+        "job-fail",
       );
-      if (failed) this.inflightBackend.delete(id);
-      return failed;
     }
-    const failed = await scrapeQueuePg.jobFail(id, lock, failedReason, logger);
-    if (failed) this.inflightBackend.delete(id);
     return failed;
   }
 
@@ -581,7 +1005,9 @@ class RoutedScrapeQueue {
     id: string,
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData> | null> {
-    if ((await getJobQueueBackend(id)) === "fdb") {
+    const backend = await getJobQueueBackend(id);
+    if (!backend) return null;
+    if (backend === "fdb") {
       const job = await optionalFdbRead(() =>
         scrapeQueueFdb.getJob(id, logger),
       );
@@ -680,8 +1106,12 @@ class RoutedScrapeQueue {
   }
 
   public async removeJob(id: string, logger: Logger = _logger): Promise<void> {
-    if ((await getJobQueueBackend(id)) === "fdb") {
+    const backend = await getJobQueueBackend(id);
+    if (!backend) return;
+    const pin = await inspectRoutingPin("scrape_job", id);
+    if (backend === "fdb") {
       await fdbMutation(() => scrapeQueueFdb.removeJob(id, logger));
+      await completeRoutingPin(pin, "job-remove");
       return;
     }
     const redis = getRedisConnection();
@@ -727,6 +1157,7 @@ class RoutedScrapeQueue {
       };
     }
     await cleanPgRedisJobResidue(id, descriptor, queuedPayload);
+    await completeRoutingPin(pin, "job-remove");
   }
 
   public async removeJobs(
@@ -744,7 +1175,9 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
     backendHint?: QueueBackend,
   ): Promise<T> {
-    if ((await getJobQueueBackend(id, backendHint)) === "fdb") {
+    const backend = await getJobQueueBackend(id, backendHint);
+    if (!backend) throw new NuQRouterObjectNotFoundError("scrape_job", id);
+    if (backend === "fdb") {
       // Waiting is intentionally long-lived; callers pass the real scrape
       // timeout. The backend hint from the enqueue result also avoids any
       // dependency on the best-effort Redis marker.
@@ -863,9 +1296,12 @@ class RoutedCrawlFinishedQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<any> | null> {
     if (
-      (await getJobQueueBackend(id, undefined, () =>
-        crawlFinishedQueueFdb.hasJob(id),
-      )) === "fdb"
+      (await getJobQueueBackend(id, undefined, {
+        kind: "crawl_finished",
+        hasFdbJob: () => crawlFinishedQueueFdb.hasJob(id),
+        hasPgJob: async () =>
+          (await crawlFinishedQueuePg.getJob(id, logger)) !== null,
+      })) === "fdb"
     ) {
       const job = await optionalFdbRead(() =>
         crawlFinishedQueueFdb.getJob(id, logger),
@@ -890,23 +1326,44 @@ class RoutedCrawlGroup {
     },
     logger: Logger = _logger,
   ): Promise<NuQJobGroupInstance> {
-    if (opts?.backend === "fdb") {
-      if (!isSelfHosted()) await markFdbTeamState(ownerId);
-      const g = await fdbMutation(() =>
-        crawlGroupFdb.addGroup(
-          id,
-          ownerId,
-          ttl,
-          {
-            maxConcurrency: opts.maxConcurrency,
-            delaySeconds: opts.delaySeconds,
-          },
-          logger,
-        ),
+    const pin = await prepareRoutingPin({
+      teamId: ownerId,
+      kind: "group",
+      objectId: id,
+    });
+    const backend = pin?.backend ?? opts?.backend ?? "pg";
+    if (opts?.backend && opts.backend !== backend) {
+      throw new NuQRouterPinMismatchError(
+        "group",
+        id,
+        pin?.backend ?? backend,
+        opts.backend,
       );
-      return g as NuQJobGroupInstance;
     }
-    return crawlGroupPg.addGroup(id, ownerId, ttl, logger);
+    const group =
+      backend === "fdb"
+        ? ((await fdbMutation(() =>
+            crawlGroupFdb.addGroup(
+              id,
+              ownerId,
+              ttl,
+              {
+                maxConcurrency: opts?.maxConcurrency,
+                delaySeconds: opts?.delaySeconds,
+              },
+              logger,
+            ),
+          )) as NuQJobGroupInstance)
+        : await crawlGroupPg.addGroup(id, ownerId, ttl, logger);
+    await activateRoutingPin(pin, { control_groups: 1 }, "group-active");
+    void markBackend(groupBackendKey(id), backend).catch(error =>
+      _logger.warn("Failed to cache group backend", {
+        module: "nuq-router",
+        groupId: id,
+        error,
+      }),
+    );
+    return group;
   }
 
   public async getGroup(
@@ -937,6 +1394,10 @@ class RoutedCrawlGroup {
     // stops new FDB groups; pinned groups remain authoritative until drained.
     const pg = await crawlGroupPg.getOngoingByOwner(ownerId, logger);
     const seen = new Set(fdb.map(g => g.id));
+    const duplicate = pg.find(group => seen.has(group.id));
+    if (duplicate) {
+      throw new NuQRouterBothBackendsError("group", duplicate.id);
+    }
     return [
       ...(fdb as NuQJobGroupInstance[]),
       ...pg.filter(g => !seen.has(g.id)),
@@ -951,7 +1412,16 @@ class RoutedCrawlGroup {
   ): Promise<boolean> {
     const backend = await getCrawlQueueBackend(id);
     if (backend !== "fdb" && !(backend === null && fdbForced())) return false;
-    return await fdbMutation(() => crawlGroupFdb.cancelGroup(id, logger));
+    const cancelled = await fdbMutation(() =>
+      crawlGroupFdb.cancelGroup(id, logger),
+    );
+    if (cancelled) {
+      await completeRoutingPin(
+        await inspectRoutingPin("group", id),
+        "group-cancel",
+      );
+    }
+    return cancelled;
   }
 }
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -579,17 +579,21 @@ async function activateRoutingPin(
   operation: string,
 ): Promise<void> {
   if (!pin || pin.lifecycle === "active") return;
-  if (pin.lifecycle === "terminal") {
-    throw new Error(
-      `Cannot reactivate terminal migration pin ${pin.kind}/${pin.objectId}`,
-    );
+  const current = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin(pin.kind, pin.objectId),
+  );
+  if (current?.lifecycle === "active" || current?.lifecycle === "terminal") {
+    return;
+  }
+  if (!current) {
+    throw new Error(`Missing migration pin ${pin.kind}/${pin.objectId}`);
   }
   await fdbMutation(() =>
     nuqFdbMigrationStore.transitionObjectResidue({
-      teamId: pin.teamId,
-      kind: pin.kind,
-      objectId: pin.objectId,
-      operationId: `nuq-router/v1/${operation}/${pin.objectId}`,
+      teamId: current.teamId,
+      kind: current.kind,
+      objectId: current.objectId,
+      operationId: `nuq-router/v1/${operation}/${current.objectId}`,
       fromLifecycle: "prepared",
       toLifecycle: "active",
       residue,

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -571,13 +571,20 @@ async function completeRoutingPin(
   operation: string,
 ): Promise<void> {
   if (!pin || pin.lifecycle === "terminal") return;
-  const fromLifecycle = pin.lifecycle;
+  // FDB runtime mutations terminalize their pin in the same transaction. The
+  // router may hold the pre-mutation snapshot, so re-read before applying the
+  // cross-store completion used by PG paths.
+  const current = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin(pin.kind, pin.objectId),
+  );
+  if (!current || current.lifecycle === "terminal") return;
+  const fromLifecycle = current.lifecycle;
   await fdbMutation(() =>
     nuqFdbMigrationStore.completePinnedObject({
-      teamId: pin.teamId,
-      kind: pin.kind,
-      objectId: pin.objectId,
-      operationId: `nuq-router/v1/${operation}/${pin.objectId}`,
+      teamId: current.teamId,
+      kind: current.kind,
+      objectId: current.objectId,
+      operationId: `nuq-router/v1/${operation}/${current.objectId}`,
       fromLifecycle,
     }),
   );

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -17,6 +17,9 @@ import {
   reserveConcurrencyLimitActiveJob,
   rollbackConcurrencyLimitActiveJob,
   constructConcurrencyLimitKey,
+  getConcurrencyRollbackCleanupBacklog,
+  recoverConcurrencyLimitRollbacks,
+  type ConcurrencyRollbackCleanupBacklog,
 } from "../../lib/concurrency-redis";
 import {
   NuQJob,
@@ -43,7 +46,10 @@ import {
   NuQFdbQueue,
   NuQFdbJob,
   nuqFdbMigrationStore,
+  MIGRATION_GC_PARTITIONS,
   type DurablePgJobRemoval,
+  type MigrationGcAuthority,
+  type MigrationGcBacklog,
   type MigrationObjectKind,
   type MigrationObjectPin,
   type MigrationResidue,
@@ -785,94 +791,403 @@ async function completeRoutingPin(
   );
 }
 
-/** One bounded production GC tick. Runtime FDB rows are checked in the same
- * transaction as tombstone deletion; PG and Redis-holder probes are bounded
- * point reads followed by that FDB CAS. */
-export async function sweepNuQMigrationGc(): Promise<void> {
-  if (!fdbQueueEnabled()) return;
-  await nuqFdbMigrationStore.sweepTerminalPins({
-    pgObjectExists: async pin => {
-      if (pin.backend !== "pg") return false;
-      if (pin.kind === "scrape_job") return await pgHasScrapeJob(pin.objectId);
-      if (pin.kind === "group") {
-        return (await crawlGroupPg.getGroup(pin.objectId)) !== null;
-      }
-      if (pin.kind === "crawl_finished") {
-        return (await crawlFinishedQueuePg.getJob(pin.objectId)) !== null;
-      }
-      if (pin.kind === "external_holder") {
-        const prefix = `${pin.teamId}/`;
-        if (!pin.objectId.startsWith(prefix)) return true;
-        return (
-          (await getRedisConnection().zscore(
-            constructConcurrencyLimitKey(pin.teamId),
-            pin.objectId.slice(prefix.length),
-          )) !== null
-        );
-      }
-      return false;
-    },
-    fdbReferenceExistsInTxn: async (tn, pin) => {
-      if (pin.kind === "scrape_job") {
-        const [status, meta, ownerIndex, removal] = await Promise.all([
-          tn.get(scrapeQueueFdb.ks.jobStatus(pin.objectId)),
-          tn.get(scrapeQueueFdb.ks.jobMeta(pin.objectId)),
-          tn.get(scrapeQueueFdb.ks.ownerLiveJob(pin.teamId, pin.objectId)),
-          pgJobRemovalsFdb.hasInTxn(tn, pin.objectId),
-        ]);
-        return Boolean(status || meta || ownerIndex || removal);
-      }
-      if (pin.kind === "crawl_finished") {
-        const [status, meta, ownerIndex] = await Promise.all([
-          tn.get(crawlFinishedQueueFdb.ks.jobStatus(pin.objectId)),
-          tn.get(crawlFinishedQueueFdb.ks.jobMeta(pin.objectId)),
-          tn.get(
-            crawlFinishedQueueFdb.ks.ownerLiveJob(pin.teamId, pin.objectId),
-          ),
-        ]);
-        return Boolean(status || meta || ownerIndex);
-      }
-      if (pin.kind === "group") {
-        const [meta, ownerIndex, cancelTask, legacyCancelTask, cancelCursor] =
-          await Promise.all([
-            tn.get(crawlGroupFdb.ks.groupMeta(pin.objectId)),
-            tn.get(crawlGroupFdb.ks.ongoingGroup(pin.teamId, pin.objectId)),
-            tn.get(crawlGroupFdb.ks.taskGroupCancel(pin.objectId)),
-            tn.get(crawlGroupFdb.ks.pack(["task", "gcancel", pin.objectId])),
-            tn.get(crawlGroupFdb.ks.groupCancelCursor(pin.objectId)),
-          ]);
-        return Boolean(
-          meta || ownerIndex || cancelTask || legacyCancelTask || cancelCursor,
-        );
-      }
-      if (pin.kind === "external_holder") {
-        const prefix = `${pin.teamId}/`;
-        if (!pin.objectId.startsWith(prefix)) return true;
-        return await externalSlotsFdb.hasMigrationReferenceInTxn(
-          tn,
-          pin.teamId,
+// Runtime FDB rows are checked in the same transaction as tombstone deletion;
+// PG and Redis-holder probes are bounded point reads followed by that FDB CAS.
+const migrationGcAuthority: MigrationGcAuthority = {
+  pgObjectExists: async pin => {
+    if (pin.backend !== "pg") return false;
+    if (pin.kind === "scrape_job") return await pgHasScrapeJob(pin.objectId);
+    if (pin.kind === "group") {
+      return (await crawlGroupPg.getGroup(pin.objectId)) !== null;
+    }
+    if (pin.kind === "crawl_finished") {
+      return (await crawlFinishedQueuePg.getJob(pin.objectId)) !== null;
+    }
+    if (pin.kind === "external_holder") {
+      const prefix = `${pin.teamId}/`;
+      if (!pin.objectId.startsWith(prefix)) return true;
+      return (
+        (await getRedisConnection().zscore(
+          constructConcurrencyLimitKey(pin.teamId),
           pin.objectId.slice(prefix.length),
-        );
-      }
-      if (pin.kind === "sweeper_task") {
-        const prefix = "group-cancel/";
-        if (!pin.objectId.startsWith(prefix)) return true;
-        const groupId = pin.objectId.slice(prefix.length);
-        const [task, legacyTask, cursor, group] = await Promise.all([
-          tn.get(crawlGroupFdb.ks.taskGroupCancel(groupId)),
-          tn.get(crawlGroupFdb.ks.pack(["task", "gcancel", groupId])),
-          tn.get(crawlGroupFdb.ks.groupCancelCursor(groupId)),
-          tn.get(crawlGroupFdb.ks.groupMeta(groupId)),
+        )) !== null
+      );
+    }
+    return false;
+  },
+  fdbReferenceExistsInTxn: async (tn, pin) => {
+    if (pin.kind === "scrape_job") {
+      const [status, meta, ownerIndex, removal] = await Promise.all([
+        tn.get(scrapeQueueFdb.ks.jobStatus(pin.objectId)),
+        tn.get(scrapeQueueFdb.ks.jobMeta(pin.objectId)),
+        tn.get(scrapeQueueFdb.ks.ownerLiveJob(pin.teamId, pin.objectId)),
+        pgJobRemovalsFdb.hasInTxn(tn, pin.objectId),
+      ]);
+      return Boolean(status || meta || ownerIndex || removal);
+    }
+    if (pin.kind === "crawl_finished") {
+      const [status, meta, ownerIndex] = await Promise.all([
+        tn.get(crawlFinishedQueueFdb.ks.jobStatus(pin.objectId)),
+        tn.get(crawlFinishedQueueFdb.ks.jobMeta(pin.objectId)),
+        tn.get(crawlFinishedQueueFdb.ks.ownerLiveJob(pin.teamId, pin.objectId)),
+      ]);
+      return Boolean(status || meta || ownerIndex);
+    }
+    if (pin.kind === "group") {
+      const [meta, ownerIndex, cancelTask, legacyCancelTask, cancelCursor] =
+        await Promise.all([
+          tn.get(crawlGroupFdb.ks.groupMeta(pin.objectId)),
+          tn.get(crawlGroupFdb.ks.ongoingGroup(pin.teamId, pin.objectId)),
+          tn.get(crawlGroupFdb.ks.taskGroupCancel(pin.objectId)),
+          tn.get(crawlGroupFdb.ks.pack(["task", "gcancel", pin.objectId])),
+          tn.get(crawlGroupFdb.ks.groupCancelCursor(pin.objectId)),
         ]);
-        return Boolean(task || legacyTask || cursor || group);
+      return Boolean(
+        meta || ownerIndex || cancelTask || legacyCancelTask || cancelCursor,
+      );
+    }
+    if (pin.kind === "external_holder") {
+      const prefix = `${pin.teamId}/`;
+      if (!pin.objectId.startsWith(prefix)) return true;
+      return await externalSlotsFdb.hasMigrationReferenceInTxn(
+        tn,
+        pin.teamId,
+        pin.objectId.slice(prefix.length),
+      );
+    }
+    if (pin.kind === "sweeper_task") {
+      const prefix = "group-cancel/";
+      if (!pin.objectId.startsWith(prefix)) return true;
+      const groupId = pin.objectId.slice(prefix.length);
+      const [task, legacyTask, cursor, group] = await Promise.all([
+        tn.get(crawlGroupFdb.ks.taskGroupCancel(groupId)),
+        tn.get(crawlGroupFdb.ks.pack(["task", "gcancel", groupId])),
+        tn.get(crawlGroupFdb.ks.groupCancelCursor(groupId)),
+        tn.get(crawlGroupFdb.ks.groupMeta(groupId)),
+      ]);
+      return Boolean(task || legacyTask || cursor || group);
+    }
+    return false;
+  },
+};
+
+export type NuQMigrationGcCategory =
+  | "terminal_pin"
+  | "control_history"
+  | "closed_generation"
+  | "redis_cleanup";
+
+export type NuQMigrationGcCategoryStats = {
+  pages: number;
+  processed: number;
+  removed: number;
+  retained: number;
+  stale: number;
+  errors: number;
+  dueBacklog: number;
+  oldestOverdueMs: number;
+};
+
+export type NuQMigrationGcSweepStats = {
+  pages: number;
+  processed: number;
+  removed: number;
+  retained: number;
+  stale: number;
+  errors: number;
+  hasMore: boolean;
+  elapsedMs: number;
+  stopReason: "idle" | "budget" | "page-cap" | "aborted" | "contended";
+  categories: Record<NuQMigrationGcCategory, NuQMigrationGcCategoryStats>;
+};
+
+type NuQMigrationGcPageResult = {
+  read: number;
+  removed: number;
+  retained: number;
+  stale: number;
+};
+
+type NuQMigrationGcSweepDependencies = {
+  fdbEnabled(): boolean;
+  inspectFdb(
+    now: number,
+  ): Promise<Record<"pin" | "control" | "generation", MigrationGcBacklog>>;
+  inspectRedis(now: number): Promise<ConcurrencyRollbackCleanupBacklog>;
+  sweepCategory(
+    category: NuQMigrationGcCategory,
+    now: number,
+    limit: number,
+    signal?: AbortSignal,
+  ): Promise<NuQMigrationGcPageResult | null>;
+};
+
+type NuQMigrationGcSweepOptions = {
+  workBudgetMs?: number;
+  maxPages?: number;
+  pageLimit?: number;
+  signal?: AbortSignal;
+  now?: () => number;
+  monotonicNow?: () => number;
+  /** Deterministic storage seam used by bounded scheduler tests. */
+  dependencies?: NuQMigrationGcSweepDependencies;
+};
+
+const productionMigrationGcDependencies: NuQMigrationGcSweepDependencies = {
+  fdbEnabled: fdbQueueEnabled,
+  inspectFdb: now => nuqFdbMigrationStore.inspectGcBacklog(now),
+  inspectRedis: getConcurrencyRollbackCleanupBacklog,
+  sweepCategory: async (category, now, limit, signal) => {
+    if (category === "redis_cleanup") {
+      const result = await recoverConcurrencyLimitRollbacks(limit);
+      return {
+        read: result.read,
+        removed: result.finalized,
+        retained: 0,
+        stale: result.fenced,
+      };
+    }
+    return category === "terminal_pin"
+      ? await nuqFdbMigrationStore.sweepTerminalPins(migrationGcAuthority, {
+          now,
+          limit,
+          signal,
+        })
+      : category === "control_history"
+        ? await nuqFdbMigrationStore.sweepControlHistory({
+            now,
+            limit,
+            signal,
+          })
+        : await nuqFdbMigrationStore.sweepClosedGenerations({
+            now,
+            limit,
+            signal,
+          });
+  },
+};
+
+const emptyGcCategoryStats = (): NuQMigrationGcCategoryStats => ({
+  pages: 0,
+  processed: 0,
+  removed: 0,
+  retained: 0,
+  stale: 0,
+  errors: 0,
+  dueBacklog: 0,
+  oldestOverdueMs: 0,
+});
+
+function validateGcRunBound(
+  value: number,
+  min: number,
+  max: number,
+  name: string,
+) {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new TypeError(`${name} must be between ${min} and ${max}`);
+  }
+}
+
+/** Drain fair, globally leased pages until the independent wall-clock or page
+ * bound is reached. Empty partitions are visited at most once per category,
+ * so retained work and lease contention cannot create an in-process hot loop. */
+export async function sweepNuQMigrationGc(
+  options: NuQMigrationGcSweepOptions = {},
+): Promise<NuQMigrationGcSweepStats> {
+  const workBudgetMs =
+    options.workBudgetMs ?? config.NUQ_MIGRATION_GC_WORK_BUDGET_MS;
+  const maxPages = options.maxPages ?? config.NUQ_MIGRATION_GC_MAX_PAGES;
+  const pageLimit = options.pageLimit ?? config.NUQ_MIGRATION_GC_PAGE_LIMIT;
+  validateGcRunBound(workBudgetMs, 1, 55_000, "GC work budget");
+  validateGcRunBound(maxPages, 1, 1024, "GC max pages");
+  validateGcRunBound(pageLimit, 1, 100, "GC page limit");
+
+  const wallNow = options.now ?? Date.now;
+  const monotonicNow = options.monotonicNow ?? (() => performance.now());
+  const dependencies =
+    options.dependencies ?? productionMigrationGcDependencies;
+  const started = monotonicNow();
+  const categories: Record<
+    NuQMigrationGcCategory,
+    NuQMigrationGcCategoryStats
+  > = {
+    terminal_pin: emptyGcCategoryStats(),
+    control_history: emptyGcCategoryStats(),
+    closed_generation: emptyGcCategoryStats(),
+    redis_cleanup: emptyGcCategoryStats(),
+  };
+  const enabled = new Set<NuQMigrationGcCategory>();
+  const remaining = new Map<NuQMigrationGcCategory, number>();
+
+  const observeFdb = async () => {
+    if (!dependencies.fdbEnabled()) return;
+    const observed = await dependencies.inspectFdb(wallNow());
+    const mappings: Array<[NuQMigrationGcCategory, MigrationGcBacklog]> = [
+      ["terminal_pin", observed.pin],
+      ["control_history", observed.control],
+      ["closed_generation", observed.generation],
+    ];
+    for (const [category, backlog] of mappings) {
+      categories[category].dueBacklog = backlog.due;
+      categories[category].oldestOverdueMs = backlog.oldestOverdueMs;
+      remaining.set(category, backlog.due);
+      enabled.add(category);
+    }
+  };
+  const observeRedis = async () => {
+    const observed: ConcurrencyRollbackCleanupBacklog =
+      await dependencies.inspectRedis(wallNow());
+    categories.redis_cleanup.dueBacklog = observed.due;
+    categories.redis_cleanup.oldestOverdueMs = observed.oldestOverdueMs;
+    remaining.set("redis_cleanup", observed.due);
+    enabled.add("redis_cleanup");
+  };
+
+  try {
+    await observeFdb();
+  } catch (error) {
+    categories.terminal_pin.errors++;
+    categories.control_history.errors++;
+    categories.closed_generation.errors++;
+    _logger.error("Failed to observe FDB migration GC backlog", { error });
+  }
+  try {
+    await observeRedis();
+  } catch (error) {
+    categories.redis_cleanup.errors++;
+    _logger.error("Failed to observe Redis cleanup backlog", { error });
+  }
+
+  const order: NuQMigrationGcCategory[] = [
+    "terminal_pin",
+    "control_history",
+    // Control history must be retired before its referenced generations.
+    "closed_generation",
+    "redis_cleanup",
+  ];
+  let pages = 0;
+  let emptyAttempts = 0;
+  let stopReason: NuQMigrationGcSweepStats["stopReason"] = "idle";
+
+  while (pages < maxPages) {
+    if (options.signal?.aborted) {
+      stopReason = "aborted";
+      break;
+    }
+    if (monotonicNow() - started >= workBudgetMs) {
+      stopReason = "budget";
+      break;
+    }
+    const category = order[0];
+    if (!enabled.has(category) || (remaining.get(category) ?? 0) <= 0) {
+      if (
+        order.every(
+          item => !enabled.has(item) || (remaining.get(item) ?? 0) <= 0,
+        )
+      ) {
+        stopReason = "idle";
+        break;
       }
-      return false;
-    },
-  });
-  // History is removed before generations so generation-control references
-  // naturally enforce the required ordering.
-  await nuqFdbMigrationStore.sweepControlHistory();
-  await nuqFdbMigrationStore.sweepClosedGenerations();
+      // Skipping is not a page and must still advance fairness.
+      order.push(order.shift()!);
+      continue;
+    }
+
+    const categoryStats = categories[category];
+    try {
+      const now = wallNow();
+      let read = 0;
+      let removed = 0;
+      let retained = 0;
+      let stale = 0;
+      const result = await dependencies.sweepCategory(
+        category,
+        now,
+        pageLimit,
+        options.signal,
+      );
+      if (result) {
+        read = result.read;
+        removed = result.removed;
+        retained = result.retained;
+        stale = result.stale;
+      }
+      pages++;
+      categoryStats.pages++;
+      categoryStats.processed += read;
+      categoryStats.removed += removed;
+      categoryStats.retained += retained;
+      categoryStats.stale += stale;
+      remaining.set(
+        category,
+        Math.max(0, (remaining.get(category) ?? 0) - read),
+      );
+      emptyAttempts = read === 0 ? emptyAttempts + 1 : 0;
+    } catch (error) {
+      pages++;
+      categoryStats.pages++;
+      categoryStats.errors++;
+      enabled.delete(category);
+      _logger.error("Migration GC category page failed", { category, error });
+    }
+
+    order.push(order.shift()!);
+    const activeFdbCategories = order.filter(
+      category =>
+        category !== "redis_cleanup" &&
+        enabled.has(category) &&
+        (remaining.get(category) ?? 0) > 0,
+    ).length;
+    if (
+      emptyAttempts >=
+      Math.max(1, activeFdbCategories) * MIGRATION_GC_PARTITIONS
+    ) {
+      stopReason = "contended";
+      break;
+    }
+  }
+  if (pages >= maxPages && stopReason === "idle") stopReason = "page-cap";
+
+  // Do not add observation work after shutdown was requested. The conservative
+  // remaining estimate keeps the worker on backlog cadence if it restarts.
+  if (!options.signal?.aborted) {
+    try {
+      await observeFdb();
+    } catch (error) {
+      categories.terminal_pin.errors++;
+      categories.control_history.errors++;
+      categories.closed_generation.errors++;
+      _logger.error("Failed to refresh FDB migration GC backlog", { error });
+    }
+    try {
+      await observeRedis();
+    } catch (error) {
+      categories.redis_cleanup.errors++;
+      _logger.error("Failed to refresh Redis cleanup backlog", { error });
+    }
+  }
+
+  const totals = Object.values(categories).reduce(
+    (sum, category) => ({
+      processed: sum.processed + category.processed,
+      removed: sum.removed + category.removed,
+      retained: sum.retained + category.retained,
+      stale: sum.stale + category.stale,
+      errors: sum.errors + category.errors,
+    }),
+    { processed: 0, removed: 0, retained: 0, stale: 0, errors: 0 },
+  );
+  return {
+    pages,
+    ...totals,
+    hasMore:
+      totals.errors > 0 ||
+      Object.values(categories).some(category => category.dueBacklog > 0),
+    elapsedMs: Math.max(0, monotonicNow() - started),
+    stopReason: options.signal?.aborted ? "aborted" : stopReason,
+    categories,
+  };
 }
 
 // === External capacity holders (browser sessions, sync scrapes)

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -590,17 +590,14 @@ async function acquireExternalSlot(
         ),
       );
     }
-    const [fdbPresent, pgPresent] = await Promise.all([
-      optionalFdbRead(() => externalSlotsFdb.has(teamId, holderId)),
-      getRedisConnection().zscore(
-        constructConcurrencyLimitKey(teamId),
-        holderId,
-      ),
-    ]);
-    if (fdbPresent && pgPresent !== null) {
-      throw new NuQRouterBothBackendsError("external_holder", holderId);
-    }
-    const legacyBackend = fdbPresent ? "fdb" : pgPresent !== null ? "pg" : null;
+    // Only the legacy PG holder ledger has a directly queryable per-holder
+    // record. Existing FDB holders remain safe through their durable slot TTL;
+    // without a migration pin a transition rejects renewal rather than guessing.
+    const pgPresent = await getRedisConnection().zscore(
+      constructConcurrencyLimitKey(teamId),
+      holderId,
+    );
+    const legacyBackend = pgPresent !== null ? "pg" : null;
     if (legacyBackend) {
       if (state.activeBackend !== legacyBackend) {
         throw new NuQRouterPinMismatchError(
@@ -694,50 +691,41 @@ export async function mirrorExternalSlotRelease(
   });
 }
 
-// Active count across both ledgers; a migrating team has load on both while
-// its old PG crawls drain.
-export async function syncFdbLimitToPgOccupancy(teamId: string): Promise<void> {
-  if (!(await teamUsesFdbLedger(teamId)) || isSelfHosted()) return;
-  const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
-  await reconcileFdbTeamLimit(teamId, acuc?.concurrency ?? 2);
-}
+// Compatibility hook for PG-only call sites. Pause/drain guarantees that PG
+// and FDB never admit concurrently, so no cross-ledger limit mirroring exists.
+export async function syncFdbLimitToPgOccupancy(
+  _teamId: string,
+): Promise<void> {}
 
-export async function reconcileFdbTeamLimit(
-  teamId: string,
-  teamLimit: number,
-): Promise<void> {
-  if (!fdbQueueEnabled()) return;
-  const externalActive = await getConcurrencyLimitActiveJobsCount(teamId);
-  await fdbMutation(() =>
-    scrapeQueueFdb.setTeamLimit(teamId, teamLimit, externalActive),
+async function activeTeamBackend(teamId: string): Promise<QueueBackend> {
+  if (!fdbQueueEnabled()) return "pg";
+  if (fdbForced()) return "fdb";
+  const state = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectState(teamId),
   );
+  return state?.activeBackend ?? (await authoritativeTeamBackend(teamId));
 }
 
 export async function getCombinedTeamPendingCount(
   teamId: string,
 ): Promise<number> {
-  const pgPending = await getRedisConnection().zcard(
-    `concurrency-limit-queue:${teamId}`,
-  );
-  if (!(await teamUsesFdbLedger(teamId))) return pgPending;
-  return (
-    pgPending +
-    (await optionalFdbRead(() => scrapeQueueFdb.getTeamPendingCount(teamId)))
-  );
+  if ((await activeTeamBackend(teamId)) === "fdb") {
+    return await optionalFdbRead(() =>
+      scrapeQueueFdb.getTeamPendingCount(teamId),
+    );
+  }
+  return await getRedisConnection().zcard(`concurrency-limit-queue:${teamId}`);
 }
 
 export async function getCombinedTeamActiveCount(
   teamId: string,
 ): Promise<number> {
-  const redisCount = await getConcurrencyLimitActiveJobsCount(teamId);
-  if (!(await teamUsesFdbLedger(teamId))) return redisCount;
-  // Always include FDB for migrated teams, even after the rollout flag is
-  // switched off. Pinned FDB crawls and standalone jobs keep draining and
-  // remain part of the team's one combined limit.
-  return (
-    redisCount +
-    (await optionalFdbRead(() => scrapeQueueFdb.getTeamActiveCount(teamId)))
-  );
+  if ((await activeTeamBackend(teamId)) === "fdb") {
+    return await optionalFdbRead(() =>
+      scrapeQueueFdb.getTeamActiveCount(teamId),
+    );
+  }
+  return await getConcurrencyLimitActiveJobsCount(teamId);
 }
 
 // === FDB enqueue (the whole gating block of queue-jobs collapses into this)
@@ -775,7 +763,7 @@ export async function fdbEnqueueScrapeJobs(
     backlogTimeoutMs: number;
   }[],
   teamId: string,
-  options?: { bypassGate?: boolean; reservedExternalPending?: number },
+  options?: { bypassGate?: boolean },
 ): Promise<{
   jobs: (NuQJob<ScrapeJobData> & { backend: "fdb" })[];
   backloggedCount: number;
@@ -841,14 +829,6 @@ export async function fdbEnqueueScrapeJobs(
     }
   }
 
-  const externalActive =
-    teamLimit === null ? 0 : await getConcurrencyLimitActiveJobsCount(teamId);
-  const externalPending =
-    teamLimit === null
-      ? 0
-      : (await getRedisConnection().zcard(
-          `concurrency-limit-queue:${teamId}`,
-        )) + (options?.reservedExternalPending ?? 0);
   const results = await fdbMutation(() =>
     scrapeQueueFdb.addJobs(
       jobs.map(j => ({
@@ -866,13 +846,7 @@ export async function fdbEnqueueScrapeJobs(
           timesOutAt: new Date(Date.now() + j.backlogTimeoutMs),
         },
       })),
-      {
-        teamLimit,
-        queueCap,
-        externalActive,
-        externalPending,
-        key: keyGate,
-      },
+      { teamLimit, queueCap, key: keyGate },
     ),
   );
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -576,7 +576,12 @@ async function getCrawlQueueBackend(
         crawlGroupFdb.restoreLegacyCancelledGroupOwnerIndex(crawlId),
       );
     }
-    if (!existingPin) {
+    if (group.status === "cancelled") {
+      // Adopt the group, establish its sweeper continuation, and terminalize
+      // group residue in one FDB transaction. Splitting generic adoption from
+      // continuation publication lets completion race between the two commits.
+      await fdbMutation(() => crawlGroupFdb.adoptLegacyCancelledGroup(crawlId));
+    } else if (!existingPin) {
       await adoptLegacyFdbObject({
         teamId: group.ownerId,
         kind: "group",
@@ -584,11 +589,6 @@ async function getCrawlQueueBackend(
         terminal: group.status === "completed",
         residue: { control_groups: group.status === "completed" ? 0 : 1 },
       });
-    }
-    // Always ensure the cancelled continuation. This repairs process death
-    // after group adoption but before sweeper work was published.
-    if (group.status === "cancelled") {
-      await fdbMutation(() => crawlGroupFdb.adoptLegacyCancelledGroup(crawlId));
     }
   } else if (backend === "pg" && !existingPin) {
     const group = await crawlGroupPg.getGroup(crawlId);
@@ -860,30 +860,24 @@ async function acquireExternalSlot(
     return;
   }
 
-  const pin =
-    existingPin ??
-    (await prepareRoutingPin({
-      teamId,
-      kind: "external_holder",
-      objectId: externalSlotMigrationObjectId(teamId, holderId),
-    }));
-  if (pin && pin.backend !== "pg") {
+  if (existingPin && existingPin.backend !== "pg") {
     throw new NuQRouterPinMismatchError(
-      pin.kind,
-      pin.objectId,
-      pin.backend,
+      existingPin.kind,
+      existingPin.objectId,
+      existingPin.backend,
       "pg",
     );
   }
   const now = Date.now();
-  if (pin) {
-    // Publish the durable deadline before crossing the Redis boundary. A
-    // crash or ambiguous Redis result can conservatively overcount only until
-    // this exact generation expires; it cannot strand a prepared pin.
-    await fdbMutation(() =>
-      externalSlotsFdb.renewPg(teamId, holderId, now + ttlMs),
-    );
-  }
+  // Prepare/adopt, activate, and publish the durable deadline in one FDB
+  // transaction before crossing the Redis boundary. A crash can conservatively
+  // overcount only until this exact generation expires; no prepared intent is
+  // left without a cleanup deadline.
+  await fdbMutation(() =>
+    externalSlotsFdb.renewPg(teamId, holderId, now + ttlMs, {
+      prepareMigrationPin: !existingPin,
+    }),
+  );
   await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
   await syncFdbLimitToPgOccupancy(teamId);
 }
@@ -970,11 +964,6 @@ export async function reserveExternalSlot(
 
     let pin = existingPin;
     try {
-      pin ??= await prepareRoutingPin({
-        teamId,
-        kind: "external_holder",
-        objectId: externalSlotMigrationObjectId(teamId, holderId),
-      });
       if (pin && pin.backend !== "pg") {
         throw new NuQRouterPinMismatchError(
           pin.kind,
@@ -983,14 +972,14 @@ export async function reserveExternalSlot(
           "pg",
         );
       }
-      if (pin) {
-        // Couple every successful Redis reservation/renewal to a durable,
-        // generation-fenced expiry. Redis disappearance alone is never
-        // terminal evidence; this deadline is the crash-recovery authority.
-        await fdbMutation(() =>
-          externalSlotsFdb.renewPg(teamId, holderId, Date.now() + ttlMs),
-        );
-      }
+      // The pin intent and its durable expiry are one FDB commit. Process death
+      // before this call leaves only an expiring Redis member; death afterward
+      // leaves an active generation-fenced deadline, never a prepared orphan.
+      await fdbMutation(() =>
+        externalSlotsFdb.renewPg(teamId, holderId, Date.now() + ttlMs, {
+          prepareMigrationPin: !pin,
+        }),
+      );
       return true;
     } catch (error) {
       // Do not tear down a pre-existing holder if only its renewal raced a

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -912,8 +912,12 @@ type NuQMigrationGcSweepDependencies = {
   fdbEnabled(): boolean;
   inspectFdb(
     now: number,
+    signal?: AbortSignal,
   ): Promise<Record<"pin" | "control" | "generation", MigrationGcBacklog>>;
-  inspectRedis(now: number): Promise<ConcurrencyRollbackCleanupBacklog>;
+  inspectRedis(
+    now: number,
+    signal?: AbortSignal,
+  ): Promise<ConcurrencyRollbackCleanupBacklog>;
   sweepCategory(
     category: NuQMigrationGcCategory,
     now: number,
@@ -933,13 +937,48 @@ type NuQMigrationGcSweepOptions = {
   dependencies?: NuQMigrationGcSweepDependencies;
 };
 
+const GC_EXTERNAL_OPERATION_TIMEOUT_MS = 10_000;
+
+async function boundedGcOperation<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal?.aborted) throw signal.reason ?? new Error("GC aborted");
+  let timer: NodeJS.Timeout | undefined;
+  let abort: (() => void) | undefined;
+  const stop = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("GC external operation timed out")),
+      GC_EXTERNAL_OPERATION_TIMEOUT_MS,
+    );
+    if (signal) {
+      abort = () => reject(signal.reason ?? new Error("GC aborted"));
+      signal.addEventListener("abort", abort, { once: true });
+    }
+  });
+  try {
+    return await Promise.race([operation, stop]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (signal && abort) signal.removeEventListener("abort", abort);
+  }
+}
+
 const productionMigrationGcDependencies: NuQMigrationGcSweepDependencies = {
   fdbEnabled: fdbQueueEnabled,
-  inspectFdb: now => nuqFdbMigrationStore.inspectGcBacklog(now),
-  inspectRedis: getConcurrencyRollbackCleanupBacklog,
+  inspectFdb: (now, signal) =>
+    boundedGcOperation(
+      nuqFdbMigrationStore.inspectGcBacklog(now, signal),
+      signal,
+    ),
+  inspectRedis: (now, signal) =>
+    boundedGcOperation(getConcurrencyRollbackCleanupBacklog(now), signal),
   sweepCategory: async (category, now, limit, signal) => {
     if (category === "redis_cleanup") {
-      const result = await recoverConcurrencyLimitRollbacks(limit);
+      const result = await boundedGcOperation(
+        recoverConcurrencyLimitRollbacks(limit),
+        signal,
+      );
       return {
         read: result.read,
         removed: result.finalized,
@@ -1008,6 +1047,18 @@ export async function sweepNuQMigrationGc(
   const dependencies =
     options.dependencies ?? productionMigrationGcDependencies;
   const started = monotonicNow();
+  const runController = new AbortController();
+  let budgetDeadlineReached = false;
+  const abortFromParent = () =>
+    runController.abort(options.signal?.reason ?? new Error("GC aborted"));
+  if (options.signal?.aborted) abortFromParent();
+  else
+    options.signal?.addEventListener("abort", abortFromParent, { once: true });
+  const budgetTimer = setTimeout(() => {
+    budgetDeadlineReached = true;
+    runController.abort(new Error("GC work budget exhausted"));
+  }, workBudgetMs);
+  const runSignal = runController.signal;
   const categories: Record<
     NuQMigrationGcCategory,
     NuQMigrationGcCategoryStats
@@ -1022,7 +1073,7 @@ export async function sweepNuQMigrationGc(
 
   const observeFdb = async () => {
     if (!dependencies.fdbEnabled()) return;
-    const observed = await dependencies.inspectFdb(wallNow());
+    const observed = await dependencies.inspectFdb(wallNow(), runSignal);
     const mappings: Array<[NuQMigrationGcCategory, MigrationGcBacklog]> = [
       ["terminal_pin", observed.pin],
       ["control_history", observed.control],
@@ -1037,7 +1088,7 @@ export async function sweepNuQMigrationGc(
   };
   const observeRedis = async () => {
     const observed: ConcurrencyRollbackCleanupBacklog =
-      await dependencies.inspectRedis(wallNow());
+      await dependencies.inspectRedis(wallNow(), runSignal);
     categories.redis_cleanup.dueBacklog = observed.due;
     categories.redis_cleanup.oldestOverdueMs = observed.oldestOverdueMs;
     remaining.set("redis_cleanup", observed.due);
@@ -1071,8 +1122,8 @@ export async function sweepNuQMigrationGc(
   let stopReason: NuQMigrationGcSweepStats["stopReason"] = "idle";
 
   while (pages < maxPages) {
-    if (options.signal?.aborted) {
-      stopReason = "aborted";
+    if (runSignal.aborted) {
+      stopReason = budgetDeadlineReached ? "budget" : "aborted";
       break;
     }
     if (monotonicNow() - started >= workBudgetMs) {
@@ -1105,7 +1156,7 @@ export async function sweepNuQMigrationGc(
         category,
         now,
         pageLimit,
-        options.signal,
+        runSignal,
       );
       if (result) {
         read = result.read;
@@ -1151,7 +1202,7 @@ export async function sweepNuQMigrationGc(
 
   // Do not add observation work after shutdown was requested. The conservative
   // remaining estimate keeps the worker on backlog cadence if it restarts.
-  if (!options.signal?.aborted) {
+  if (!runSignal.aborted) {
     try {
       await observeFdb();
     } catch (error) {
@@ -1178,6 +1229,8 @@ export async function sweepNuQMigrationGc(
     }),
     { processed: 0, removed: 0, retained: 0, stale: 0, errors: 0 },
   );
+  clearTimeout(budgetTimer);
+  options.signal?.removeEventListener("abort", abortFromParent);
   return {
     pages,
     ...totals,
@@ -1185,7 +1238,11 @@ export async function sweepNuQMigrationGc(
       totals.errors > 0 ||
       Object.values(categories).some(category => category.dueBacklog > 0),
     elapsedMs: Math.max(0, monotonicNow() - started),
-    stopReason: options.signal?.aborted ? "aborted" : stopReason,
+    stopReason: runSignal.aborted
+      ? budgetDeadlineReached
+        ? "budget"
+        : "aborted"
+      : stopReason,
     categories,
   };
 }

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -118,6 +118,7 @@ async function hasAuthoritativeFdbTeamResidue(
     const [
       scrapePending,
       scrapeActive,
+      scrapeIndexedLive,
       crawlFinishedPending,
       crawlFinishedActive,
       crawlFinishedIndexedLive,
@@ -125,6 +126,7 @@ async function hasAuthoritativeFdbTeamResidue(
     ] = await Promise.all([
       scrapeQueueFdb.getTeamPendingCount(teamId),
       scrapeQueueFdb.getTeamActiveCount(teamId),
+      scrapeQueueFdb.hasReadyOrActiveJobForOwner(teamId),
       crawlFinishedQueueFdb.getTeamPendingCount(teamId),
       crawlFinishedQueueFdb.getTeamActiveCount(teamId),
       crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
@@ -133,6 +135,7 @@ async function hasAuthoritativeFdbTeamResidue(
     return hasLegacyFdbTeamResidue({
       scrapePending,
       scrapeActive,
+      scrapeIndexedLive,
       crawlFinishedPending,
       crawlFinishedActive,
       crawlFinishedIndexedLive,
@@ -174,6 +177,50 @@ async function discoverLegacyTeamAuthority(
     // not a fallback after an unavailable FDB probe.
     emptyBackend: "pg",
   });
+}
+
+async function ensureMigrationTeamState(teamId: string) {
+  let state = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectState(teamId),
+  );
+  if (!state) {
+    await requireFdbCoreMetricReadiness();
+    state = await fdbMutation(() =>
+      recoverLegacyTeamState(nuqFdbMigrationStore, teamId, () =>
+        discoverLegacyTeamAuthority(teamId),
+      ),
+    );
+  }
+  return state;
+}
+
+async function legacyGenerationForBackend(
+  teamId: string,
+  backend: QueueBackend,
+  terminal: boolean,
+): Promise<number> {
+  const state = await ensureMigrationTeamState(teamId);
+  if (state.activeBackend === backend) return state.activeGeneration;
+  if (!terminal) {
+    throw new NuQRouterPinMismatchError(
+      "team",
+      teamId,
+      state.activeBackend,
+      backend,
+    );
+  }
+  for (let generation = state.maxGeneration; generation >= 1; generation--) {
+    const record = await optionalFdbRead(() =>
+      nuqFdbMigrationStore.inspectGeneration(teamId, generation),
+    );
+    if (record.generation.backend === backend) return generation;
+  }
+  throw new NuQRouterPinMismatchError(
+    "team",
+    teamId,
+    state.activeBackend,
+    backend,
+  );
 }
 
 async function reconcileTerminalPgPins(teamId: string): Promise<void> {
@@ -432,43 +479,42 @@ async function getCrawlQueueBackend(
     repairMarker: backend =>
       repairBackendMarker(groupBackendKey(crawlId), backend),
   });
-  if (
-    backend === "pg" &&
-    !(await optionalFdbRead(() =>
-      nuqFdbMigrationStore.inspectPin("group", crawlId),
-    ))
-  ) {
+  const existingPin = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin("group", crawlId),
+  );
+  if (backend === "fdb" && !existingPin) {
+    const group = await optionalFdbRead(() => crawlGroupFdb.getGroup(crawlId));
+    if (!group) return null;
+    const terminal = group.status !== "active";
+    const generation = await legacyGenerationForBackend(
+      group.ownerId,
+      "fdb",
+      terminal,
+    );
+    await fdbMutation(() =>
+      nuqFdbMigrationStore.preparePinnedObject({
+        teamId: group.ownerId,
+        kind: "group",
+        objectId: crawlId,
+        admission: {
+          type: "legacy-backfill",
+          backend: "fdb",
+          generation,
+          terminal,
+        },
+        requiredBackend: "fdb",
+        residue: { control_groups: terminal ? 0 : 1 },
+      }),
+    );
+  } else if (backend === "pg" && !existingPin) {
     const group = await crawlGroupPg.getGroup(crawlId);
     if (!group) return null;
-    let state = await optionalFdbRead(() =>
-      nuqFdbMigrationStore.inspectState(group.ownerId),
+    const terminal = group.status !== "active";
+    const generation = await legacyGenerationForBackend(
+      group.ownerId,
+      "pg",
+      terminal,
     );
-    if (!state) {
-      state = await fdbMutation(() =>
-        recoverLegacyTeamState(nuqFdbMigrationStore, group.ownerId, () =>
-          discoverLegacyTeamAuthority(group.ownerId),
-        ),
-      );
-    }
-    let generation = state.activeGeneration;
-    if (state.activeBackend !== "pg") {
-      if (group.status === "active") {
-        throw new NuQRouterPinMismatchError("group", crawlId, "fdb", "pg");
-      }
-      generation = 0;
-      for (let candidate = state.maxGeneration; candidate >= 1; candidate--) {
-        const record = await optionalFdbRead(() =>
-          nuqFdbMigrationStore.inspectGeneration(group.ownerId, candidate),
-        );
-        if (record.generation.backend === "pg") {
-          generation = candidate;
-          break;
-        }
-      }
-      if (generation === 0) {
-        throw new NuQRouterPinMismatchError("group", crawlId, "fdb", "pg");
-      }
-    }
     await fdbMutation(() =>
       nuqFdbMigrationStore.preparePinnedObject({
         teamId: group.ownerId,
@@ -478,9 +524,10 @@ async function getCrawlQueueBackend(
           type: "legacy-backfill",
           backend: "pg",
           generation,
-          terminal: group.status !== "active",
+          terminal,
         },
-        residue: { control_groups: group.status === "active" ? 1 : 0 },
+        requiredBackend: "pg",
+        residue: { control_groups: terminal ? 0 : 1 },
       }),
     );
   }
@@ -555,11 +602,9 @@ async function prepareRoutingPin(input: {
             source: { kind: "group", objectId: input.sourceGroupId },
           }
         : { type: "new-root" },
-      // This pre-intent is deliberately durable before a backend mutation.
-      // TODO(corrected-core): queue/group/slot mutations and sweeper lifecycle
-      // generation accounting must compose the exported *InTxn hooks in their
-      // own FDB transaction. Until then an ambiguous outcome remains fenced;
-      // this prototype does not pretend the separate transactions are atomic.
+      // The pre-intent fences an ambiguous call boundary. FDB runtime writers
+      // consume it into exact residue in the same transaction as their record
+      // mutation; PG publication resolves it through the durable saga adapter.
       residue: { intent_unresolved: 1 },
     }),
   );
@@ -640,60 +685,63 @@ async function completeRoutingPin(
 // Non-queue work that occupies team capacity is durably pinned. Renew/release
 // follows that pin even if the rollout flag changes mid-hold.
 
+async function inspectOrRecoverExternalSlotPin(
+  teamId: string,
+  holderId: string,
+): Promise<MigrationObjectPin | null> {
+  if (!fdbQueueEnabled() || fdbForced()) return null;
+  const existing = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+  );
+  if (existing) return existing;
+
+  // Query both holder ledgers before interpreting a legacy record. Redis loss
+  // is never evidence for FDB, and simultaneous presence is corruption.
+  const [pgScore, fdbPresent] = await Promise.all([
+    getRedisConnection().zscore(constructConcurrencyLimitKey(teamId), holderId),
+    optionalFdbRead(() => externalSlotsFdb.has(teamId, holderId)),
+  ]);
+  const pgPresent = pgScore !== null;
+  if (pgPresent && fdbPresent) {
+    throw new NuQRouterBothBackendsError("external_holder", holderId);
+  }
+  const backend: QueueBackend | null = pgPresent
+    ? "pg"
+    : fdbPresent
+      ? "fdb"
+      : null;
+  if (!backend) return null;
+  const state = await ensureMigrationTeamState(teamId);
+  if (state.activeBackend !== backend) {
+    throw new NuQRouterPinMismatchError(
+      "external_holder",
+      holderId,
+      state.activeBackend,
+      backend,
+    );
+  }
+  return await fdbMutation(() =>
+    nuqFdbMigrationStore.preparePinnedObject({
+      teamId,
+      kind: "external_holder",
+      objectId: holderId,
+      admission: {
+        type: "legacy-backfill",
+        backend,
+        generation: state.activeGeneration,
+      },
+      requiredBackend: backend,
+      residue: { capacity_external_holders: 1 },
+    }),
+  );
+}
+
 async function acquireExternalSlot(
   teamId: string,
   holderId: string,
   ttlMs: number,
 ): Promise<void> {
-  let existingPin =
-    !fdbQueueEnabled() || fdbForced()
-      ? null
-      : await optionalFdbRead(() =>
-          nuqFdbMigrationStore.inspectPin("external_holder", holderId),
-        );
-  if (!existingPin && fdbQueueEnabled() && !fdbForced()) {
-    let state = await optionalFdbRead(() =>
-      nuqFdbMigrationStore.inspectState(teamId),
-    );
-    if (!state) {
-      state = await fdbMutation(() =>
-        recoverLegacyTeamState(nuqFdbMigrationStore, teamId, () =>
-          discoverLegacyTeamAuthority(teamId),
-        ),
-      );
-    }
-    // Only the legacy PG holder ledger has a directly queryable per-holder
-    // record. Existing FDB holders remain safe through their durable slot TTL;
-    // without a migration pin a transition rejects renewal rather than guessing.
-    const pgPresent = await getRedisConnection().zscore(
-      constructConcurrencyLimitKey(teamId),
-      holderId,
-    );
-    const legacyBackend = pgPresent !== null ? "pg" : null;
-    if (legacyBackend) {
-      if (state.activeBackend !== legacyBackend) {
-        throw new NuQRouterPinMismatchError(
-          "external_holder",
-          holderId,
-          state.activeBackend,
-          legacyBackend,
-        );
-      }
-      existingPin = await fdbMutation(() =>
-        nuqFdbMigrationStore.preparePinnedObject({
-          teamId,
-          kind: "external_holder",
-          objectId: holderId,
-          admission: {
-            type: "legacy-backfill",
-            backend: legacyBackend,
-            generation: state.activeGeneration,
-          },
-          residue: { capacity_external_holders: 1 },
-        }),
-      );
-    }
-  }
+  const existingPin = await inspectOrRecoverExternalSlotPin(teamId, holderId);
   if (!existingPin) await authoritativeTeamBackend(teamId);
   const pin =
     existingPin ??
@@ -746,12 +794,7 @@ export async function mirrorExternalSlotRelease(
   holderId: string,
 ): Promise<void> {
   await withTeamMigrationAdmission(teamId, async () => {
-    const pin =
-      !fdbQueueEnabled() || fdbForced()
-        ? null
-        : await optionalFdbRead(() =>
-            nuqFdbMigrationStore.inspectPin("external_holder", holderId),
-          );
+    const pin = await inspectOrRecoverExternalSlotPin(teamId, holderId);
     const backend = pin?.backend ?? (fdbForced() ? "fdb" : "pg");
     if (backend === "fdb") {
       await fdbMutation(() => externalSlotsFdb.release(teamId, holderId));

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -46,7 +46,10 @@ import {
   NuQRouterBothBackendsError,
   NuQRouterObjectNotFoundError,
   NuQRouterPinMismatchError,
+  discoverLegacyTeamBackend,
+  hasLegacyFdbTeamResidue,
   reconcileDesiredTeamBackend,
+  recoverLegacyTeamState,
   reconcilePgResidueFence,
   resolveAuthoritativeObjectBackend,
   type BackendMarker,
@@ -106,6 +109,50 @@ async function desiredTeamBackend(teamId: string): Promise<QueueBackend> {
   return acuc?.flags?.nuqFdb === true ? "fdb" : "pg";
 }
 
+async function discoverLegacyTeamAuthority(
+  teamId: string,
+): Promise<QueueBackend> {
+  return await discoverLegacyTeamBackend({
+    teamId,
+    probeFdbResidue: () =>
+      optionalFdbRead(async () => {
+        const [
+          scrapePending,
+          scrapeActive,
+          crawlFinishedPending,
+          crawlFinishedActive,
+          crawlFinishedIndexedLive,
+          groups,
+        ] = await Promise.all([
+          scrapeQueueFdb.getTeamPendingCount(teamId),
+          scrapeQueueFdb.getTeamActiveCount(teamId),
+          crawlFinishedQueueFdb.getTeamPendingCount(teamId),
+          crawlFinishedQueueFdb.getTeamActiveCount(teamId),
+          crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
+          crawlGroupFdb.getOngoingByOwner(teamId),
+        ]);
+        return hasLegacyFdbTeamResidue({
+          scrapePending,
+          scrapeActive,
+          crawlFinishedPending,
+          crawlFinishedActive,
+          crawlFinishedIndexedLive,
+          activeGroups: groups.length,
+        });
+      }),
+    probePgResidue: async () => {
+      const [residue, redisOccupancy] = await Promise.all([
+        getNuQPgOwnerLiveResidue(teamId),
+        getConcurrencyLimitActiveJobsCount(teamId),
+      ]);
+      return residue.total + redisOccupancy > 0;
+    },
+    // This rollout starts from PG. Empty is an explicit deployment default,
+    // not a fallback after an unavailable FDB probe.
+    emptyBackend: "pg",
+  });
+}
+
 async function reconcileTerminalPgPins(teamId: string): Promise<void> {
   const pins = (await nuqFdbMigrationStore.inspectTeamPins(teamId)).filter(
     pin => pin.backend === "pg" && pin.lifecycle !== "terminal",
@@ -139,13 +186,10 @@ async function reconcileTerminalPgPins(teamId: string): Promise<void> {
         await completeRoutingPin(pin, "pg-reconcile-terminal");
       }
     } else if (pin.kind === "external_holder") {
-      const present = await getRedisConnection().zscore(
-        constructConcurrencyLimitKey(teamId),
-        pin.objectId,
-      );
-      if (present === null && pin.lifecycle === "active") {
-        await completeRoutingPin(pin, "pg-reconcile-terminal");
-      }
+      // Redis disappearance is not terminal evidence (flushes/failovers lose
+      // this hint). Explicit release or the corrected durable holder-expiry
+      // reconciler owns retirement, so an orphan conservatively blocks seal.
+      continue;
     } else if (pin.kind === "crawl_finished") {
       const job = await crawlFinishedQueuePg.getJob(pin.objectId);
       if (
@@ -168,8 +212,13 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
   );
   if (!current) {
     current = await fdbMutation(() =>
-      reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, "pg"),
+      recoverLegacyTeamState(nuqFdbMigrationStore, teamId, () =>
+        discoverLegacyTeamAuthority(teamId),
+      ),
     );
+    // Discovery may have lost an initialize-if-absent race. Trust the durable
+    // winner exactly as returned; desired begin/cancel is a subsequent request.
+    return current.activeBackend;
   }
 
   // Before pausing PG admissions, snapshot authoritative legacy PG residue
@@ -196,33 +245,11 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
         observationId: `${teamId}/${current!.revision}/${pgResidueTotal === 0 ? "zero" : "nonzero"}`,
       }),
     );
-    if (
-      current.phase === "DRAINING_TO_FDB" &&
-      pgResidueTotal === 0 &&
-      current.transitionOperationId
-    ) {
-      current = await fdbMutation(() =>
-        nuqFdbMigrationStore.finalSeal({
-          teamId,
-          transitionOperationId: current!.transitionOperationId!,
-          expectedRevision: current!.revision,
-        }),
-      );
-    }
-  }
-
-  if (
-    desired === "pg" &&
-    current?.phase === "DRAINING_TO_PG" &&
-    current.transitionOperationId
-  ) {
-    current = await fdbMutation(() =>
-      nuqFdbMigrationStore.finalSeal({
-        teamId,
-        transitionOperationId: current!.transitionOperationId!,
-        expectedRevision: current!.revision,
-      }),
-    );
+    // TODO(corrected-core): only the reconciler may call finalSeal after every
+    // queue/group/slot/sweeper mutation uses generation accounting in its own
+    // FDB transaction and publishes an authoritative readiness decision. This
+    // router refreshes durable PG residue but never infers seal readiness from
+    // an out-of-transaction PG/Redis observation.
   }
 
   if (current?.activeBackend === desired && current.phase !== "ERROR") {
@@ -231,7 +258,9 @@ async function authoritativeTeamBackend(teamId: string): Promise<QueueBackend> {
     }
   }
   const state = await fdbMutation(() =>
-    reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, desired),
+    reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, desired, () =>
+      discoverLegacyTeamAuthority(teamId),
+    ),
   );
   return state.activeBackend;
 }
@@ -346,7 +375,9 @@ async function getCrawlQueueBackend(
     );
     if (!state) {
       state = await fdbMutation(() =>
-        reconcileDesiredTeamBackend(nuqFdbMigrationStore, group.ownerId, "pg"),
+        recoverLegacyTeamState(nuqFdbMigrationStore, group.ownerId, () =>
+          discoverLegacyTeamAuthority(group.ownerId),
+        ),
       );
     }
     let generation = state.activeGeneration;
@@ -545,7 +576,9 @@ async function acquireExternalSlot(
     );
     if (!state) {
       state = await fdbMutation(() =>
-        reconcileDesiredTeamBackend(nuqFdbMigrationStore, teamId, "pg"),
+        recoverLegacyTeamState(nuqFdbMigrationStore, teamId, () =>
+          discoverLegacyTeamAuthority(teamId),
+        ),
       );
     }
     const [fdbPresent, pgPresent] = await Promise.all([

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -9,9 +9,13 @@ import { getApiKeyConcurrencyLimit } from "../../lib/api-key-concurrency";
 import { getRedisConnection } from "../queue-service";
 import {
   getTeamQueueLimit,
+  finalizeConcurrencyLimitActiveJobRollback,
   getConcurrencyLimitActiveJobsCount,
   pushConcurrencyLimitActiveJob,
   removeConcurrencyLimitActiveJob,
+  renewConcurrencyLimitActiveJob,
+  reserveConcurrencyLimitActiveJob,
+  rollbackConcurrencyLimitActiveJob,
   constructConcurrencyLimitKey,
 } from "../../lib/concurrency-redis";
 import {
@@ -771,7 +775,18 @@ async function acquireExternalSlot(
   ttlMs: number,
 ): Promise<void> {
   const existingPin = await inspectOrRecoverExternalSlotPin(teamId, holderId);
-  if (!existingPin) await authoritativeTeamBackend(teamId);
+  const backend =
+    existingPin?.backend ?? (await authoritativeTeamBackend(teamId));
+  if (backend === "fdb") {
+    // New FDB holders prepare/activate the durable pin together with the slot.
+    await fdbMutation(() =>
+      externalSlotsFdb.acquire(teamId, holderId, ttlMs, {
+        prepareMigrationPin: !existingPin && !fdbForced(),
+      }),
+    );
+    return;
+  }
+
   const pin =
     existingPin ??
     (await prepareRoutingPin({
@@ -779,27 +794,25 @@ async function acquireExternalSlot(
       kind: "external_holder",
       objectId: externalSlotMigrationObjectId(teamId, holderId),
     }));
-  const backend = pin?.backend ?? (await authoritativeTeamBackend(teamId));
-  if (backend === "fdb") {
-    await fdbMutation(() => externalSlotsFdb.acquire(teamId, holderId, ttlMs));
-    await activateRoutingPin(
-      pin,
-      { capacity_external_holders: 1 },
-      "external-holder-active",
+  if (pin && pin.backend !== "pg") {
+    throw new NuQRouterPinMismatchError(
+      pin.kind,
+      pin.objectId,
+      pin.backend,
+      "pg",
     );
-  } else {
-    const now = Date.now();
-    if (pin) {
-      // Publish the durable deadline before crossing the Redis boundary. A
-      // crash or ambiguous Redis result can conservatively overcount only
-      // until this exact generation expires; it cannot strand a prepared pin.
-      await fdbMutation(() =>
-        externalSlotsFdb.renewPg(teamId, holderId, now + ttlMs),
-      );
-    }
-    await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs, now);
-    await syncFdbLimitToPgOccupancy(teamId);
   }
+  const now = Date.now();
+  if (pin) {
+    // Publish the durable deadline before crossing the Redis boundary. A
+    // crash or ambiguous Redis result can conservatively overcount only until
+    // this exact generation expires; it cannot strand a prepared pin.
+    await fdbMutation(() =>
+      externalSlotsFdb.renewPg(teamId, holderId, now + ttlMs),
+    );
+  }
+  await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs, now);
+  await syncFdbLimitToPgOccupancy(teamId);
 }
 
 export async function reserveExternalSlot(
@@ -809,11 +822,181 @@ export async function reserveExternalSlot(
   concurrencyLimit: number,
 ): Promise<boolean> {
   return await withTeamMigrationAdmission(teamId, async () => {
-    if ((await getCombinedTeamActiveCount(teamId)) >= concurrencyLimit) {
+    const existingPin = await inspectOrRecoverExternalSlotPin(teamId, holderId);
+    const backend =
+      existingPin?.backend ?? (await authoritativeTeamBackend(teamId));
+
+    if (backend === "fdb") {
+      if (existingPin?.lifecycle === "terminal") return false;
+      return await fdbMutation(() =>
+        externalSlotsFdb.reserve(teamId, holderId, ttlMs, concurrencyLimit, {
+          prepareMigrationPin: !existingPin && !fdbForced(),
+        }),
+      );
+    }
+
+    // Redis is the PG capacity ledger. Its Lua reservation removes expired
+    // holders, checks the limit, and inserts/renews in one atomic operation.
+    // Reserve before preparing a cross-store pin so a definitive denial leaves
+    // no durable intent. The primitive retries one ambiguous reply by stable
+    // holder id, making a committed first attempt observable on the retry.
+    const reservation = await reserveConcurrencyLimitActiveJob(
+      teamId,
+      holderId,
+      concurrencyLimit,
+      ttlMs,
+    );
+    if (existingPin?.lifecycle === "terminal") {
+      if (reservation.cleanupToken) {
+        await finalizeConcurrencyLimitActiveJobRollback(
+          teamId,
+          holderId,
+          reservation.cleanupToken,
+        );
+      } else if (reservation.reserved && reservation.rollbackToken) {
+        if (
+          await rollbackConcurrencyLimitActiveJob(
+            teamId,
+            holderId,
+            reservation.rollbackToken,
+          )
+        ) {
+          await finalizeConcurrencyLimitActiveJobRollback(
+            teamId,
+            holderId,
+            reservation.rollbackToken,
+          );
+        }
+      } else if (reservation.reserved) {
+        // A terminal pin can never authorize a pre-existing unowned member.
+        await removeConcurrencyLimitActiveJob(teamId, holderId);
+      }
       return false;
     }
-    await acquireExternalSlot(teamId, holderId, ttlMs);
-    return true;
+    if (!reservation.reserved) {
+      if (reservation.cleanupToken) {
+        // Recover a process crash between guarded Redis rollback, durable pin
+        // completion, and tombstone finalization. The tombstone keeps new work
+        // out while this idempotent path retires the abandoned attempt.
+        await completeRoutingPin(
+          existingPin,
+          "external-holder-activation-rollback",
+        );
+        if (
+          !(await finalizeConcurrencyLimitActiveJobRollback(
+            teamId,
+            holderId,
+            reservation.cleanupToken,
+          ))
+        ) {
+          throw new Error("Failed to recover PG external-holder rollback");
+        }
+      }
+      return false;
+    }
+
+    let pin = existingPin;
+    try {
+      pin ??= await prepareRoutingPin({
+        teamId,
+        kind: "external_holder",
+        objectId: externalSlotMigrationObjectId(teamId, holderId),
+      });
+      if (pin && pin.backend !== "pg") {
+        throw new NuQRouterPinMismatchError(
+          pin.kind,
+          pin.objectId,
+          pin.backend,
+          "pg",
+        );
+      }
+      await activateRoutingPin(
+        pin,
+        { capacity_external_holders: 1 },
+        "external-holder-active",
+      );
+      return true;
+    } catch (error) {
+      // Do not tear down a pre-existing holder if only its renewal raced a
+      // migration error. A newly inserted PG holder has no valid active pin and
+      // must be removed before its prepared intent can be retired.
+      if (!reservation.newlyAcquired) throw error;
+      let rolledBack: boolean;
+      try {
+        if (!reservation.rollbackToken)
+          throw new Error("Missing rollback token");
+        rolledBack = await rollbackConcurrencyLimitActiveJob(
+          teamId,
+          holderId,
+          reservation.rollbackToken,
+        );
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "PG external-holder activation and Redis rollback both failed",
+        );
+      }
+      // A later attempt now owns this stable holder. Never delete its member or
+      // terminalize the shared durable pin from this stale failure path.
+      if (!rolledBack) throw error;
+      try {
+        const cleanupPin =
+          pin ??
+          (await inspectRoutingPin(
+            "external_holder",
+            externalSlotMigrationObjectId(teamId, holderId),
+          ));
+        await completeRoutingPin(
+          cleanupPin,
+          "external-holder-activation-rollback",
+        );
+        if (
+          !reservation.rollbackToken ||
+          !(await finalizeConcurrencyLimitActiveJobRollback(
+            teamId,
+            holderId,
+            reservation.rollbackToken,
+          ))
+        ) {
+          throw new Error("Failed to finalize PG external-holder rollback");
+        }
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "PG external-holder activation and durable rollback both failed",
+        );
+      }
+      throw error;
+    }
+  });
+}
+
+export async function renewExternalSlot(
+  teamId: string,
+  holderId: string,
+  ttlMs: number,
+): Promise<boolean> {
+  return await withTeamMigrationAdmission(teamId, async () => {
+    const pin = await inspectOrRecoverExternalSlotPin(teamId, holderId);
+    const backend = pin?.backend ?? (await authoritativeTeamBackend(teamId));
+    if (backend === "fdb") {
+      return await fdbMutation(() =>
+        externalSlotsFdb.renew(teamId, holderId, ttlMs),
+      );
+    }
+    const renewed = await renewConcurrencyLimitActiveJob(
+      teamId,
+      holderId,
+      ttlMs,
+    );
+    if (renewed) {
+      await activateRoutingPin(
+        pin,
+        { capacity_external_holders: 1 },
+        "external-holder-active",
+      );
+    }
+    return renewed;
   });
 }
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -238,9 +238,9 @@ async function legacyGenerationForBackend(
   }
   for (let generation = state.maxGeneration; generation >= 1; generation--) {
     const record = await optionalFdbRead(() =>
-      nuqFdbMigrationStore.inspectGeneration(teamId, generation),
+      nuqFdbMigrationStore.inspectGenerationIfPresent(teamId, generation),
     );
-    if (record.generation.backend === backend) return generation;
+    if (record?.generation.backend === backend) return generation;
   }
   return await fdbMutation(() =>
     nuqFdbMigrationStore.ensureTerminalLegacyGeneration(teamId, backend),
@@ -785,6 +785,96 @@ async function completeRoutingPin(
   );
 }
 
+/** One bounded production GC tick. Runtime FDB rows are checked in the same
+ * transaction as tombstone deletion; PG and Redis-holder probes are bounded
+ * point reads followed by that FDB CAS. */
+export async function sweepNuQMigrationGc(): Promise<void> {
+  if (!fdbQueueEnabled()) return;
+  await nuqFdbMigrationStore.sweepTerminalPins({
+    pgObjectExists: async pin => {
+      if (pin.backend !== "pg") return false;
+      if (pin.kind === "scrape_job") return await pgHasScrapeJob(pin.objectId);
+      if (pin.kind === "group") {
+        return (await crawlGroupPg.getGroup(pin.objectId)) !== null;
+      }
+      if (pin.kind === "crawl_finished") {
+        return (await crawlFinishedQueuePg.getJob(pin.objectId)) !== null;
+      }
+      if (pin.kind === "external_holder") {
+        const prefix = `${pin.teamId}/`;
+        if (!pin.objectId.startsWith(prefix)) return true;
+        return (
+          (await getRedisConnection().zscore(
+            constructConcurrencyLimitKey(pin.teamId),
+            pin.objectId.slice(prefix.length),
+          )) !== null
+        );
+      }
+      return false;
+    },
+    fdbReferenceExistsInTxn: async (tn, pin) => {
+      if (pin.kind === "scrape_job") {
+        const [status, meta, ownerIndex, removal] = await Promise.all([
+          tn.get(scrapeQueueFdb.ks.jobStatus(pin.objectId)),
+          tn.get(scrapeQueueFdb.ks.jobMeta(pin.objectId)),
+          tn.get(scrapeQueueFdb.ks.ownerLiveJob(pin.teamId, pin.objectId)),
+          pgJobRemovalsFdb.hasInTxn(tn, pin.objectId),
+        ]);
+        return Boolean(status || meta || ownerIndex || removal);
+      }
+      if (pin.kind === "crawl_finished") {
+        const [status, meta, ownerIndex] = await Promise.all([
+          tn.get(crawlFinishedQueueFdb.ks.jobStatus(pin.objectId)),
+          tn.get(crawlFinishedQueueFdb.ks.jobMeta(pin.objectId)),
+          tn.get(
+            crawlFinishedQueueFdb.ks.ownerLiveJob(pin.teamId, pin.objectId),
+          ),
+        ]);
+        return Boolean(status || meta || ownerIndex);
+      }
+      if (pin.kind === "group") {
+        const [meta, ownerIndex, cancelTask, legacyCancelTask, cancelCursor] =
+          await Promise.all([
+            tn.get(crawlGroupFdb.ks.groupMeta(pin.objectId)),
+            tn.get(crawlGroupFdb.ks.ongoingGroup(pin.teamId, pin.objectId)),
+            tn.get(crawlGroupFdb.ks.taskGroupCancel(pin.objectId)),
+            tn.get(crawlGroupFdb.ks.pack(["task", "gcancel", pin.objectId])),
+            tn.get(crawlGroupFdb.ks.groupCancelCursor(pin.objectId)),
+          ]);
+        return Boolean(
+          meta || ownerIndex || cancelTask || legacyCancelTask || cancelCursor,
+        );
+      }
+      if (pin.kind === "external_holder") {
+        const prefix = `${pin.teamId}/`;
+        if (!pin.objectId.startsWith(prefix)) return true;
+        return await externalSlotsFdb.hasMigrationReferenceInTxn(
+          tn,
+          pin.teamId,
+          pin.objectId.slice(prefix.length),
+        );
+      }
+      if (pin.kind === "sweeper_task") {
+        const prefix = "group-cancel/";
+        if (!pin.objectId.startsWith(prefix)) return true;
+        const groupId = pin.objectId.slice(prefix.length);
+        const [task, legacyTask, cursor, group] = await Promise.all([
+          tn.get(crawlGroupFdb.ks.taskGroupCancel(groupId)),
+          tn.get(crawlGroupFdb.ks.pack(["task", "gcancel", groupId])),
+          tn.get(crawlGroupFdb.ks.groupCancelCursor(groupId)),
+          tn.get(crawlGroupFdb.ks.groupMeta(groupId)),
+        ]);
+        return Boolean(task || legacyTask || cursor || group);
+      }
+      return false;
+    },
+  });
+  // History is removed before generations so generation-control references
+  // naturally enforce the required ordering.
+  await nuqFdbMigrationStore.sweepControlHistory();
+  await nuqFdbMigrationStore.sweepClosedGenerations();
+}
+
 // === External capacity holders (browser sessions, sync scrapes)
 //
 // Non-queue work that occupies team capacity is durably pinned. Renew/release
@@ -926,6 +1016,7 @@ export async function reserveExternalSlot(
             teamId,
             holderId,
             reservation.rollbackToken,
+            ttlMs,
           )
         ) {
           await finalizeConcurrencyLimitActiveJobRollback(
@@ -994,6 +1085,7 @@ export async function reserveExternalSlot(
           teamId,
           holderId,
           reservation.rollbackToken,
+          ttlMs,
         );
       } catch (cleanupError) {
         throw new AggregateError(

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -123,7 +123,7 @@ async function hasAuthoritativeFdbTeamResidue(
       crawlFinishedPending,
       crawlFinishedActive,
       crawlFinishedIndexedLive,
-      groups,
+      unfinishedGroups,
     ] = await Promise.all([
       scrapeQueueFdb.getTeamPendingCount(teamId),
       scrapeQueueFdb.getTeamActiveCount(teamId),
@@ -131,7 +131,7 @@ async function hasAuthoritativeFdbTeamResidue(
       crawlFinishedQueueFdb.getTeamPendingCount(teamId),
       crawlFinishedQueueFdb.getTeamActiveCount(teamId),
       crawlFinishedQueueFdb.hasReadyOrActiveJobForOwner(teamId),
-      crawlGroupFdb.getOngoingByOwner(teamId),
+      crawlGroupFdb.hasUnfinishedByOwner(teamId),
     ]);
     return hasLegacyFdbTeamResidue({
       scrapePending,
@@ -140,12 +140,28 @@ async function hasAuthoritativeFdbTeamResidue(
       crawlFinishedPending,
       crawlFinishedActive,
       crawlFinishedIndexedLive,
-      activeGroups: groups.length,
+      activeGroups: unfinishedGroups ? 1 : 0,
     });
   });
 }
 
 async function requireFdbCoreMetricReadiness(): Promise<void> {
+  // Release A (and rollback) runs with activation disabled. Invalidate any
+  // prior READY generation before it can be trusted by a later deployment;
+  // this is the production rollback caller for the core protocol.
+  if (!config.NUQ_FDB_METRICS_V2_ACTIVATE) {
+    await fdbMutation(() =>
+      Promise.all([
+        scrapeQueueFdb.invalidateMetricCounterGeneration(),
+        crawlFinishedQueueFdb.invalidateMetricCounterGeneration(),
+      ]),
+    );
+    throw new NuQRouterError(
+      "NUQ_FDB_CORE_METRICS_NOT_ACTIVATED",
+      "NuQ FDB migration is frozen until corrected-core metric activation is enabled",
+      true,
+    );
+  }
   const [scrape, crawlFinished] = await optionalFdbRead(() =>
     Promise.all([
       scrapeQueueFdb.getMetricCounterBackfillStatus(),
@@ -919,80 +935,109 @@ export async function fdbEnqueueScrapeJobs(
       );
     }
   }
-  let teamLimit: number | null = null;
-  if (!isSelfHosted() && !fdbForced()) {
-    const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
-    teamLimit = acuc?.concurrency ?? 2;
-  } else if (!isSelfHosted()) {
-    const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
-    teamLimit = acuc?.concurrency ?? null;
-  }
+  try {
+    let teamLimit: number | null = null;
+    if (!isSelfHosted() && !fdbForced()) {
+      const acuc = await getACUCTeam(
+        teamId,
+        false,
+        true,
+        RateLimiterMode.Crawl,
+      );
+      teamLimit = acuc?.concurrency ?? 2;
+    } else if (!isSelfHosted()) {
+      const acuc = await getACUCTeam(
+        teamId,
+        false,
+        true,
+        RateLimiterMode.Crawl,
+      );
+      teamLimit = acuc?.concurrency ?? null;
+    }
 
-  const queueCap =
-    teamLimit === null ? Number.MAX_SAFE_INTEGER : getTeamQueueLimit(teamLimit);
+    const queueCap =
+      teamLimit === null
+        ? Number.MAX_SAFE_INTEGER
+        : getTeamQueueLimit(teamLimit);
 
-  // API-key-scoped concurrency: applies when every job in the batch was
-  // requested with the same key (batches always are; child jobs inherit the
-  // kickoff's apiKeyId) and that key has a limit configured.
-  let keyGate: { id: string; limit: number } | null = null;
-  if (teamLimit !== null) {
-    const keyIds = new Set(jobs.map(j => j.data.apiKeyId ?? null));
-    const apiKeyId = keyIds.size === 1 ? [...keyIds][0] : null;
-    if (apiKeyId !== null) {
-      const keyLimit = await getApiKeyConcurrencyLimit(apiKeyId);
-      if (keyLimit !== null) {
-        keyGate = { id: String(apiKeyId), limit: keyLimit };
+    // API-key-scoped concurrency: applies when every job in the batch was
+    // requested with the same key (batches always are; child jobs inherit the
+    // kickoff's apiKeyId) and that key has a limit configured.
+    let keyGate: { id: string; limit: number } | null = null;
+    if (teamLimit !== null) {
+      const keyIds = new Set(jobs.map(j => j.data.apiKeyId ?? null));
+      const apiKeyId = keyIds.size === 1 ? [...keyIds][0] : null;
+      if (apiKeyId !== null) {
+        const keyLimit = await getApiKeyConcurrencyLimit(apiKeyId);
+        if (keyLimit !== null) {
+          keyGate = { id: String(apiKeyId), limit: keyLimit };
+        }
       }
     }
-  }
 
-  const results = await fdbMutation(() =>
-    scrapeQueueFdb.addJobs(
-      jobs.map(j => ({
-        id: j.jobId,
-        data: j.data,
-        options: {
-          priority: j.priority,
-          listenable: j.listenable ?? false,
-          ownerId: j.data.team_id ?? undefined,
-          groupId: j.data.crawl_id ?? undefined,
-          bypassGate:
-            options?.bypassGate ||
-            j.data.mode === "kickoff" ||
-            j.data.mode === "kickoff_sitemap",
-          timesOutAt: new Date(Date.now() + j.backlogTimeoutMs),
-        },
-      })),
-      { teamLimit, queueCap, key: keyGate },
-    ),
-  );
-
-  const tagged = results.map(r => tagFdbJob(r as NuQJob<ScrapeJobData>));
-  await Promise.all(
-    tagged.map((job, index) =>
-      activateRoutingPin(
-        pins[index],
-        job.status === "backlog"
-          ? { capacity_team_pending: 1 }
-          : { capacity_ready_active: 1 },
-        "fdb-job-active",
+    const results = await fdbMutation(() =>
+      scrapeQueueFdb.addJobs(
+        jobs.map(j => ({
+          id: j.jobId,
+          data: j.data,
+          options: {
+            priority: j.priority,
+            listenable: j.listenable ?? false,
+            ownerId: j.data.team_id ?? undefined,
+            groupId: j.data.crawl_id ?? undefined,
+            bypassGate:
+              options?.bypassGate ||
+              j.data.mode === "kickoff" ||
+              j.data.mode === "kickoff_sitemap",
+            timesOutAt: new Date(Date.now() + j.backlogTimeoutMs),
+          },
+        })),
+        { teamLimit, queueCap, key: keyGate },
       ),
-    ),
-  );
-  for (const job of tagged) {
-    void markJobBackend(job.id, "fdb").catch(error =>
-      _logger.warn("Failed to cache FDB job backend", {
-        module: "nuq-router",
-        jobId: job.id,
-        error,
-      }),
     );
+
+    const tagged = results.map(r => tagFdbJob(r as NuQJob<ScrapeJobData>));
+    await Promise.all(
+      tagged.map((job, index) =>
+        activateRoutingPin(
+          pins[index],
+          job.status === "backlog"
+            ? { capacity_team_pending: 1 }
+            : { capacity_ready_active: 1 },
+          "fdb-job-active",
+        ),
+      ),
+    );
+    for (const job of tagged) {
+      void markJobBackend(job.id, "fdb").catch(error =>
+        _logger.warn("Failed to cache FDB job backend", {
+          module: "nuq-router",
+          jobId: job.id,
+          error,
+        }),
+      );
+    }
+    return {
+      jobs: tagged,
+      backloggedCount: tagged.filter(j => j.status === "backlog").length,
+      teamLimit,
+    };
+  } catch (error) {
+    try {
+      await fdbMutation(() =>
+        scrapeQueueFdb.compensateRejectedMigrationJobs(
+          teamId,
+          jobs.map(job => job.jobId),
+        ),
+      );
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "FDB enqueue rejection and prepared-intent compensation both failed",
+      );
+    }
+    throw error;
   }
-  return {
-    jobs: tagged,
-    backloggedCount: tagged.filter(j => j.status === "backlog").length,
-    teamLimit,
-  };
 }
 
 // === Routed scrape queue

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -460,7 +460,6 @@ async function cleanPgRedisJobResidue(
   const pipeline = redis.pipeline();
   pipeline.del(`cq-job:${id}`);
   pipeline.del(`cq-claim:${id}`);
-  pipeline.del(pgRemoveResidueKey(id));
   for (const queueKey of queueKeys) pipeline.zrem(queueKey, id);
   if (ownerId) {
     pipeline.zrem(constructConcurrencyLimitKey(ownerId), id);
@@ -478,6 +477,9 @@ async function cleanPgRedisJobResidue(
       `Failed to remove Redis queue residue for ${id}`,
     );
   }
+  // Keep the recovery descriptor until every destructive cleanup command is
+  // known successful. A failed final DEL is harmless and retryable.
+  await redis.del(pgRemoveResidueKey(id));
 }
 
 class RoutedScrapeQueue {

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -46,6 +46,8 @@ import {
   type DurablePgJobRemoval,
   type MigrationObjectKind,
   type MigrationObjectPin,
+  type MigrationResidue,
+  type NuQFdbLegacyJobDescriptor,
 } from "./nuq-fdb";
 import type { QueueOperationOptions } from "./nuq-worker-runtime";
 import {
@@ -240,11 +242,63 @@ async function legacyGenerationForBackend(
     );
     if (record.generation.backend === backend) return generation;
   }
-  throw new NuQRouterPinMismatchError(
-    "team",
-    teamId,
-    state.activeBackend,
-    backend,
+  return await fdbMutation(() =>
+    nuqFdbMigrationStore.ensureTerminalLegacyGeneration(teamId, backend),
+  );
+}
+
+async function adoptLegacyFdbObject(input: {
+  teamId: string;
+  kind: MigrationObjectKind;
+  objectId: string;
+  residue: Partial<MigrationResidue>;
+  terminal: boolean;
+}): Promise<MigrationObjectPin> {
+  const existing = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin(input.kind, input.objectId),
+  );
+  if (existing) return existing;
+  const generation = await legacyGenerationForBackend(
+    input.teamId,
+    "fdb",
+    input.terminal,
+  );
+  const prepared = await fdbMutation(() =>
+    nuqFdbMigrationStore.preparePinnedObject({
+      teamId: input.teamId,
+      kind: input.kind,
+      objectId: input.objectId,
+      admission: {
+        type: "legacy-backfill",
+        backend: "fdb",
+        generation,
+        terminal: input.terminal,
+      },
+      requiredBackend: "fdb",
+      residue: input.residue,
+    }),
+  );
+  if (input.terminal || prepared.lifecycle === "active") return prepared;
+  const current = await optionalFdbRead(() =>
+    nuqFdbMigrationStore.inspectPin(input.kind, input.objectId),
+  );
+  if (
+    !current ||
+    current.lifecycle === "terminal" ||
+    current.lifecycle === "active"
+  ) {
+    return current ?? prepared;
+  }
+  return await fdbMutation(() =>
+    nuqFdbMigrationStore.transitionObjectResidue({
+      teamId: input.teamId,
+      kind: input.kind,
+      objectId: input.objectId,
+      operationId: `nuq-router/v1/legacy-fdb-adopt/${input.kind}/${input.objectId}`,
+      fromLifecycle: "prepared",
+      toLifecycle: "active",
+      residue: input.residue,
+    }),
   );
 }
 
@@ -514,30 +568,28 @@ async function getCrawlQueueBackend(
   const existingPin = await optionalFdbRead(() =>
     nuqFdbMigrationStore.inspectPin("group", crawlId),
   );
-  if (backend === "fdb" && !existingPin) {
+  if (backend === "fdb") {
     const group = await optionalFdbRead(() => crawlGroupFdb.getGroup(crawlId));
     if (!group) return null;
-    const terminal = group.status !== "active";
-    const generation = await legacyGenerationForBackend(
-      group.ownerId,
-      "fdb",
-      terminal,
-    );
-    await fdbMutation(() =>
-      nuqFdbMigrationStore.preparePinnedObject({
+    if (group.status === "cancelled") {
+      await fdbMutation(() =>
+        crawlGroupFdb.restoreLegacyCancelledGroupOwnerIndex(crawlId),
+      );
+    }
+    if (!existingPin) {
+      await adoptLegacyFdbObject({
         teamId: group.ownerId,
         kind: "group",
         objectId: crawlId,
-        admission: {
-          type: "legacy-backfill",
-          backend: "fdb",
-          generation,
-          terminal,
-        },
-        requiredBackend: "fdb",
-        residue: { control_groups: terminal ? 0 : 1 },
-      }),
-    );
+        terminal: group.status === "completed",
+        residue: { control_groups: group.status === "completed" ? 0 : 1 },
+      });
+    }
+    // Always ensure the cancelled continuation. This repairs process death
+    // after group adoption but before sweeper work was published.
+    if (group.status === "cancelled") {
+      await fdbMutation(() => crawlGroupFdb.adoptLegacyCancelledGroup(crawlId));
+    }
   } else if (backend === "pg" && !existingPin) {
     const group = await crawlGroupPg.getGroup(crawlId);
     if (!group) return null;
@@ -573,6 +625,7 @@ async function getJobQueueBackend(
     kind?: MigrationObjectKind;
     hasFdbJob?: () => Promise<boolean>;
     hasPgJob?: () => Promise<boolean>;
+    inspectFdbJob?: () => Promise<NuQFdbLegacyJobDescriptor | null>;
   } = {},
 ): Promise<QueueBackend | null> {
   if (fdbForced()) return "fdb";
@@ -582,7 +635,7 @@ async function getJobQueueBackend(
   const marker = cachedMarker ?? hint ?? null;
   if (!fdbQueueEnabled()) return "pg";
   const kind = probes.kind ?? "scrape_job";
-  return await resolveAuthoritativeObjectBackend({
+  const backend = await resolveAuthoritativeObjectBackend({
     kind,
     objectId: jobId,
     marker,
@@ -593,6 +646,26 @@ async function getJobQueueBackend(
     probePg: probes.hasPgJob ?? (() => pgHasScrapeJob(jobId)),
     repairMarker: backend => repairBackendMarker(jobBackendKey(jobId), backend),
   });
+  if (
+    backend === "fdb" &&
+    !(await optionalFdbRead(() => nuqFdbMigrationStore.inspectPin(kind, jobId)))
+  ) {
+    const descriptor = await optionalFdbRead(
+      probes.inspectFdbJob ??
+        (() => scrapeQueueFdb.inspectLegacyMigrationObject(jobId)),
+    );
+    if (!descriptor) {
+      throw new NuQRouterObjectNotFoundError(kind, jobId);
+    }
+    await adoptLegacyFdbObject({
+      teamId: descriptor.teamId,
+      kind,
+      objectId: jobId,
+      terminal: descriptor.terminal,
+      residue: descriptor.residue,
+    });
+  }
+  return backend;
 }
 
 // Which backend a job belongs to at enqueue time. Crawl jobs follow their
@@ -811,7 +884,7 @@ async function acquireExternalSlot(
       externalSlotsFdb.renewPg(teamId, holderId, now + ttlMs),
     );
   }
-  await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs, now);
+  await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
   await syncFdbLimitToPgOccupancy(teamId);
 }
 
@@ -910,11 +983,14 @@ export async function reserveExternalSlot(
           "pg",
         );
       }
-      await activateRoutingPin(
-        pin,
-        { capacity_external_holders: 1 },
-        "external-holder-active",
-      );
+      if (pin) {
+        // Couple every successful Redis reservation/renewal to a durable,
+        // generation-fenced expiry. Redis disappearance alone is never
+        // terminal evidence; this deadline is the crash-recovery authority.
+        await fdbMutation(() =>
+          externalSlotsFdb.renewPg(teamId, holderId, Date.now() + ttlMs),
+        );
+      }
       return true;
     } catch (error) {
       // Do not tear down a pre-existing holder if only its renewal raced a
@@ -989,11 +1065,11 @@ export async function renewExternalSlot(
       holderId,
       ttlMs,
     );
-    if (renewed) {
-      await activateRoutingPin(
-        pin,
-        { capacity_external_holders: 1 },
-        "external-holder-active",
+    if (renewed && pin) {
+      // Renewal publishes a fresh generation before protected work continues;
+      // stale sweeper rows conflict-check this record and cannot retire it.
+      await fdbMutation(() =>
+        externalSlotsFdb.renewPg(teamId, holderId, Date.now() + ttlMs),
       );
     }
     return renewed;
@@ -1742,6 +1818,8 @@ class RoutedCrawlFinishedQueue {
       (await getJobQueueBackend(id, undefined, {
         kind: "crawl_finished",
         hasFdbJob: () => crawlFinishedQueueFdb.hasJob(id),
+        inspectFdbJob: () =>
+          crawlFinishedQueueFdb.inspectLegacyMigrationObject(id),
         hasPgJob: async () =>
           (await crawlFinishedQueuePg.getJob(id, logger)) !== null,
       })) === "fdb"

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -6,6 +6,8 @@ import { getACUCTeam } from "../../controllers/auth";
 import { redisEvictConnection } from "../../services/redis";
 import { isSelfHosted } from "../../lib/deployment";
 import { getApiKeyConcurrencyLimit } from "../../lib/api-key-concurrency";
+import { redlock } from "../redlock";
+import { getRedisConnection } from "../queue-service";
 import {
   getTeamQueueLimit,
   getConcurrencyLimitActiveJobsCount,
@@ -57,31 +59,37 @@ function fdbForced(): boolean {
   return config.NUQ_BACKEND === "fdb";
 }
 
-const fdbFallbackLastWarn = new Map<string, number>();
 const FDB_OPTIONAL_OP_TIMEOUT_MS = 500;
 
-function logFdbFallback(
-  logger: Logger,
-  operation: string,
-  error: unknown,
-): void {
-  const now = Date.now();
-  const lastWarn = fdbFallbackLastWarn.get(operation) ?? 0;
-  if (now - lastWarn < 60_000) return;
-  fdbFallbackLastWarn.set(operation, now);
-  logger.warn("FDB queue operation failed, falling back to PG", {
-    module: "nuq-router",
-    operation,
-    error,
-  });
-}
-
-async function optionalFdb<T>(operation: () => Promise<T>): Promise<T> {
+async function optionalFdbRead<T>(operation: () => Promise<T>): Promise<T> {
   if (fdbForced()) return operation();
   if (!(await nuqFdbHealthCheck(FDB_OPTIONAL_OP_TIMEOUT_MS))) {
-    throw new Error("FDB health check failed before optional operation");
+    throw new Error("FDB health check failed before optional read");
   }
   return await withFdbTimeout(operation(), FDB_OPTIONAL_OP_TIMEOUT_MS);
+}
+
+// Mutations are deliberately never wrapped in a JavaScript timeout and never
+// fall back to PG. Await the definitive FDB retry loop; logical operations use
+// stable ids so commit-unknown retries reconcile rather than duplicate work.
+async function fdbMutation<T>(operation: () => Promise<T>): Promise<T> {
+  return await operation();
+}
+
+const teamFdbStateKey = (teamId: string) => `nuq:fdb_team:${teamId}`;
+
+async function markFdbTeamState(teamId: string): Promise<void> {
+  // One bounded key per migrated team is the durable drain barrier. Failure is
+  // fatal before the first FDB enqueue, so rollback can always identify teams
+  // whose pinned FDB work may remain.
+  await getRedisConnection().set(teamFdbStateKey(teamId), "1");
+}
+
+async function teamUsesFdbLedger(teamId: string): Promise<boolean> {
+  if (!fdbQueueEnabled()) return false;
+  if (fdbForced()) return true;
+  if (await isFdbTeam(teamId)) return true;
+  return (await getRedisConnection().get(teamFdbStateKey(teamId))) === "1";
 }
 
 // Whether NEW work for this team should go to FDB. Existing crawls follow
@@ -90,17 +98,19 @@ export async function isFdbTeam(teamId: string | undefined): Promise<boolean> {
   if (!fdbQueueEnabled()) return false;
   if (fdbForced()) return true;
   if (!teamId) return false;
+  let enabled = false;
   try {
     const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
-    return acuc?.flags?.nuqFdb === true;
+    enabled = acuc?.flags?.nuqFdb === true;
   } catch (error) {
     _logger.warn("Failed to resolve nuqFdb team flag, defaulting to pg", {
       module: "nuq-router",
       teamId,
       error,
     });
-    return false;
   }
+  if (enabled) await markFdbTeamState(teamId);
+  return enabled;
 }
 
 export async function resolveNewGroupBackend(
@@ -116,13 +126,19 @@ async function getCrawlQueueBackend(
 ): Promise<QueueBackend | null> {
   if (fdbForced()) return "fdb";
   const raw = await redisEvictConnection.get("crawl:" + crawlId);
-  if (!raw) return null;
-  try {
-    const sc = JSON.parse(raw);
-    return sc?.queueBackend === "fdb" ? "fdb" : sc ? "pg" : null;
-  } catch {
-    return null;
+  if (raw) {
+    try {
+      const sc = JSON.parse(raw);
+      if (sc?.queueBackend === "fdb") return "fdb";
+      // Stored crawls predating the rollout have no marker and are PG.
+      if (sc) return "pg";
+    } catch {
+      // Fall through to the authoritative FDB group probe.
+    }
   }
+  if (!fdbQueueEnabled()) return raw ? "pg" : null;
+  const group = await optionalFdbRead(() => crawlGroupFdb.getGroup(crawlId));
+  return group ? "fdb" : raw ? "pg" : null;
 }
 
 const jobBackendKey = (jobId: string) => `nuq:job_backend:${jobId}`;
@@ -132,19 +148,41 @@ async function markJobBackend(
   backend: QueueBackend,
 ): Promise<void> {
   if (fdbForced()) return;
+  // This is only a bounded cache; never trust its absence. FDB job metadata
+  // remains the durable source of truth after expiry or a failed write.
   await redisEvictConnection.set(
     jobBackendKey(jobId),
     backend,
     "EX",
-    24 * 60 * 60,
+    30 * 24 * 60 * 60,
   );
 }
 
-async function getJobQueueBackend(jobId: string): Promise<QueueBackend> {
+async function getJobQueueBackend(
+  jobId: string,
+  hint?: QueueBackend,
+  hasFdbJob: () => Promise<boolean> = () => scrapeQueueFdb.hasJob(jobId),
+): Promise<QueueBackend> {
+  if (hint) return hint;
   if (fdbForced()) return "fdb";
-  return (await redisEvictConnection.get(jobBackendKey(jobId))) === "fdb"
-    ? "fdb"
-    : "pg";
+  if ((await redisEvictConnection.get(jobBackendKey(jobId))) === "fdb") {
+    return "fdb";
+  }
+  if (!fdbQueueEnabled()) return "pg";
+
+  // Redis marker writes are best-effort and old markers may have expired.
+  // Probe the durable FDB record before routing a wait/remove/read to PG.
+  if (await optionalFdbRead(hasFdbJob)) {
+    void markJobBackend(jobId, "fdb").catch(error =>
+      _logger.warn("Failed to repair FDB job backend marker", {
+        module: "nuq-router",
+        jobId,
+        error,
+      }),
+    );
+    return "fdb";
+  }
+  return "pg";
 }
 
 // Which backend a job belongs to at enqueue time. Crawl jobs follow their
@@ -172,64 +210,138 @@ function tagFdbJob<T extends object>(job: T): T & { backend: "fdb" } {
 // mid-hold) self-heal: Redis entries expire by score, FDB external slots are
 // reaped by the sweeper.
 
-export async function mirrorExternalSlotAcquire(
+async function acquireExternalSlot(
   teamId: string,
   holderId: string,
   ttlMs: number,
 ): Promise<void> {
   if (await isFdbTeam(teamId)) {
-    try {
-      await optionalFdb(() =>
-        externalSlotsFdb.acquire(teamId, holderId, ttlMs),
-      );
-      return;
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(_logger, "mirrorExternalSlotAcquire", error);
-    }
+    if (!isSelfHosted()) await markFdbTeamState(teamId);
+    await fdbMutation(() => externalSlotsFdb.acquire(teamId, holderId, ttlMs));
+    return;
   }
   await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
+  await syncFdbLimitToPgOccupancy(teamId);
+}
+
+export async function reserveExternalSlot(
+  teamId: string,
+  holderId: string,
+  ttlMs: number,
+  concurrencyLimit: number,
+): Promise<boolean> {
+  return await withTeamMigrationAdmission(teamId, async () => {
+    if ((await getCombinedTeamActiveCount(teamId)) >= concurrencyLimit) {
+      return false;
+    }
+    await acquireExternalSlot(teamId, holderId, ttlMs);
+    return true;
+  });
+}
+
+export async function mirrorExternalSlotAcquire(
+  teamId: string,
+  holderId: string,
+  ttlMs: number,
+): Promise<void> {
+  await withTeamMigrationAdmission(teamId, async () =>
+    acquireExternalSlot(teamId, holderId, ttlMs),
+  );
 }
 
 export async function mirrorExternalSlotRelease(
   teamId: string,
   holderId: string,
 ): Promise<void> {
-  if (await isFdbTeam(teamId)) {
-    try {
-      await optionalFdb(() => externalSlotsFdb.release(teamId, holderId));
+  await withTeamMigrationAdmission(teamId, async () => {
+    // The flag may flip while a holder is alive. Route by the durable slot,
+    // rather than today's flag, so rollback cannot leak FDB occupancy.
+    if (
+      fdbForced() ||
+      ((await teamUsesFdbLedger(teamId)) &&
+        (await optionalFdbRead(() => externalSlotsFdb.has(teamId, holderId))))
+    ) {
+      await fdbMutation(() => externalSlotsFdb.release(teamId, holderId));
       return;
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(_logger, "mirrorExternalSlotRelease", error);
     }
-  }
-  await removeConcurrencyLimitActiveJob(teamId, holderId);
+    await removeConcurrencyLimitActiveJob(teamId, holderId);
+    await syncFdbLimitToPgOccupancy(teamId);
+  });
 }
 
 // Active count across both ledgers; a migrating team has load on both while
 // its old PG crawls drain.
+export async function syncFdbLimitToPgOccupancy(teamId: string): Promise<void> {
+  if (!(await teamUsesFdbLedger(teamId)) || isSelfHosted()) return;
+  const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
+  await reconcileFdbTeamLimit(teamId, acuc?.concurrency ?? 2);
+}
+
+export async function reconcileFdbTeamLimit(
+  teamId: string,
+  teamLimit: number,
+): Promise<void> {
+  if (!fdbQueueEnabled()) return;
+  const externalActive = await getConcurrencyLimitActiveJobsCount(teamId);
+  await fdbMutation(() =>
+    scrapeQueueFdb.setTeamLimit(teamId, teamLimit, externalActive),
+  );
+}
+
+export async function getCombinedTeamPendingCount(
+  teamId: string,
+): Promise<number> {
+  const pgPending = await getRedisConnection().zcard(
+    `concurrency-limit-queue:${teamId}`,
+  );
+  if (!(await teamUsesFdbLedger(teamId))) return pgPending;
+  return (
+    pgPending +
+    (await optionalFdbRead(() => scrapeQueueFdb.getTeamPendingCount(teamId)))
+  );
+}
+
 export async function getCombinedTeamActiveCount(
   teamId: string,
 ): Promise<number> {
   const redisCount = await getConcurrencyLimitActiveJobsCount(teamId);
-  if (!(await isFdbTeam(teamId))) return redisCount;
-  try {
-    return (
-      redisCount +
-      (await optionalFdb(() => scrapeQueueFdb.getTeamActiveCount(teamId)))
-    );
-  } catch (error) {
-    if (fdbForced()) throw error;
-    logFdbFallback(_logger, "getCombinedTeamActiveCount", error);
-    return redisCount;
-  }
+  if (!(await teamUsesFdbLedger(teamId))) return redisCount;
+  // Always include FDB for migrated teams, even after the rollout flag is
+  // switched off. Pinned FDB crawls and standalone jobs keep draining and
+  // remain part of the team's one combined limit.
+  return (
+    redisCount +
+    (await optionalFdbRead(() => scrapeQueueFdb.getTeamActiveCount(teamId)))
+  );
 }
 
 // === FDB enqueue (the whole gating block of queue-jobs collapses into this)
 
 export function backlogTimeoutMsForGate(timeoutMs: number): Date {
   return new Date(Date.now() + timeoutMs);
+}
+
+// PG and FDB cannot share a transaction, so serialize cross-ledger admission
+// while taking the combined occupancy snapshot and reserving the chosen
+// backend. Redlock's using() extends this lease while a large enqueue runs.
+export async function withTeamMigrationAdmission<T>(
+  teamId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!fdbQueueEnabled() || (fdbForced() && isSelfHosted())) {
+    return await operation();
+  }
+  return await redlock.using(
+    [`nuq:migration-admission:${teamId}`],
+    30_000,
+    {},
+    async signal => {
+      if (signal.aborted) throw signal.error;
+      const result = await operation();
+      if (signal.aborted) throw signal.error;
+      return result;
+    },
+  );
 }
 
 export async function fdbEnqueueScrapeJobs(
@@ -241,12 +353,13 @@ export async function fdbEnqueueScrapeJobs(
     backlogTimeoutMs: number;
   }[],
   teamId: string,
-  options?: { bypassGate?: boolean },
+  options?: { bypassGate?: boolean; reservedExternalPending?: number },
 ): Promise<{
   jobs: (NuQJob<ScrapeJobData> & { backend: "fdb" })[];
   backloggedCount: number;
   teamLimit: number | null;
 }> {
+  if (!isSelfHosted()) await markFdbTeamState(teamId);
   let teamLimit: number | null = null;
   if (!isSelfHosted() && !fdbForced()) {
     const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
@@ -274,7 +387,15 @@ export async function fdbEnqueueScrapeJobs(
     }
   }
 
-  const results = await optionalFdb(() =>
+  const externalActive =
+    teamLimit === null ? 0 : await getConcurrencyLimitActiveJobsCount(teamId);
+  const externalPending =
+    teamLimit === null
+      ? 0
+      : (await getRedisConnection().zcard(
+          `concurrency-limit-queue:${teamId}`,
+        )) + (options?.reservedExternalPending ?? 0);
+  const results = await fdbMutation(() =>
     scrapeQueueFdb.addJobs(
       jobs.map(j => ({
         id: j.jobId,
@@ -291,24 +412,25 @@ export async function fdbEnqueueScrapeJobs(
           timesOutAt: new Date(Date.now() + j.backlogTimeoutMs),
         },
       })),
-      { teamLimit, queueCap, key: keyGate },
+      {
+        teamLimit,
+        queueCap,
+        externalActive,
+        externalPending,
+        key: keyGate,
+      },
     ),
   );
 
   const tagged = results.map(r => tagFdbJob(r as NuQJob<ScrapeJobData>));
-  const markerResults = await Promise.allSettled(
-    tagged.map(job => markJobBackend(job.id, "fdb")),
-  );
-  const markerFailures = markerResults.filter(
-    (r): r is PromiseRejectedResult => r.status === "rejected",
-  );
-  if (markerFailures.length > 0) {
-    _logger.warn("Failed to mark some FDB job backends", {
-      module: "nuq-router",
-      failed: markerFailures.length,
-      total: markerResults.length,
-      errors: markerFailures.map(r => r.reason),
-    });
+  for (const job of tagged) {
+    void markJobBackend(job.id, "fdb").catch(error =>
+      _logger.warn("Failed to cache FDB job backend", {
+        module: "nuq-router",
+        jobId: job.id,
+        error,
+      }),
+    );
   }
   return {
     jobs: tagged,
@@ -331,19 +453,18 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
     operation?: QueueOperationOptions,
   ): Promise<NuQJob<ScrapeJobData> | null> {
-    if (fdbQueueEnabled()) {
-      try {
-        const job = await optionalFdb(() =>
-          scrapeQueueFdb.getJobToProcess(logger, operation),
-        );
-        if (job) {
-          this.inflightBackend.set(job.id, "fdb");
-          return tagFdbJob(job as NuQJob<ScrapeJobData>);
-        }
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.getJobToProcess", error);
+    // Optional deployments have dedicated PG and FDB consumers. Never race a
+    // mutating FDB take against PG fallback: an ambiguous FDB commit would
+    // otherwise lease an invisible "ghost" job while this worker runs PG work.
+    if (fdbForced()) {
+      const job = await fdbMutation(() =>
+        scrapeQueueFdb.getJobToProcess(logger, operation),
+      );
+      if (job) {
+        this.inflightBackend.set(job.id, "fdb");
+        return tagFdbJob(job as NuQJob<ScrapeJobData>);
       }
+      return null;
     }
     const job = await scrapeQueuePg.getJobToProcess();
     if (job) this.inflightBackend.set(job.id, "pg");
@@ -357,15 +478,9 @@ class RoutedScrapeQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     if (this.backendFor(id) === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          scrapeQueueFdb.renewLock(id, lock, logger, operation),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.renewLock", error);
-        return false;
-      }
+      return await fdbMutation(() =>
+        scrapeQueueFdb.renewLock(id, lock, logger, operation),
+      );
     }
     return scrapeQueuePg.renewLock(id, lock, logger);
   }
@@ -378,19 +493,27 @@ class RoutedScrapeQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          scrapeQueueFdb.jobFinish(id, lock, returnvalue, logger, operation),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.jobFinish", error);
-        return false;
-      }
+      const finished = await fdbMutation(() =>
+        scrapeQueueFdb.jobFinish(
+          id,
+          lock,
+          returnvalue,
+          logger,
+          operation,
+        ),
+      );
+      if (finished) this.inflightBackend.delete(id);
+      return finished;
     }
-    return scrapeQueuePg.jobFinish(id, lock, returnvalue, logger);
+    const finished = await scrapeQueuePg.jobFinish(
+      id,
+      lock,
+      returnvalue,
+      logger,
+    );
+    if (finished) this.inflightBackend.delete(id);
+    return finished;
   }
 
   public async jobFail(
@@ -401,19 +524,16 @@ class RoutedScrapeQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          scrapeQueueFdb.jobFail(id, lock, failedReason, logger, operation),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.jobFail", error);
-        return false;
-      }
+      const failed = await fdbMutation(() =>
+        scrapeQueueFdb.jobFail(id, lock, failedReason, logger, operation),
+      );
+      if (failed) this.inflightBackend.delete(id);
+      return failed;
     }
-    return scrapeQueuePg.jobFail(id, lock, failedReason, logger);
+    const failed = await scrapeQueuePg.jobFail(id, lock, failedReason, logger);
+    if (failed) this.inflightBackend.delete(id);
+    return failed;
   }
 
   public async getJob(
@@ -421,7 +541,9 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData> | null> {
     if ((await getJobQueueBackend(id)) === "fdb") {
-      const job = await optionalFdb(() => scrapeQueueFdb.getJob(id, logger));
+      const job = await optionalFdbRead(() =>
+        scrapeQueueFdb.getJob(id, logger),
+      );
       return job ? tagFdbJob(job as NuQJob<ScrapeJobData>) : null;
     }
     return scrapeQueuePg.getJob(id, logger);
@@ -437,7 +559,7 @@ class RoutedScrapeQueue {
     const pgIds = ids.filter((_, i) => backends[i] === "pg");
     const [fdbJobs, pgJobs] = await Promise.all([
       fdbIds.length > 0
-        ? optionalFdb(() => scrapeQueueFdb.getJobs(fdbIds, logger))
+        ? optionalFdbRead(() => scrapeQueueFdb.getJobs(fdbIds, logger))
         : Promise.resolve([] as NuQFdbJob<ScrapeJobData>[]),
       pgIds.length > 0
         ? scrapeQueuePg.getJobs(pgIds, logger)
@@ -481,7 +603,7 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData> | null> {
     if (await this.isFdbGroup(groupId)) {
-      const job = await optionalFdb(() =>
+      const job = await optionalFdbRead(() =>
         scrapeQueueFdb.getGroupAnyJob(groupId, ownerId, logger),
       );
       return job ? tagFdbJob(job as NuQJob<ScrapeJobData>) : null;
@@ -494,7 +616,7 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<Record<NuQJobStatus, number>> {
     if (await this.isFdbGroup(groupId)) {
-      return (await optionalFdb(() =>
+      return (await optionalFdbRead(() =>
         scrapeQueueFdb.getGroupNumericStats(groupId, logger),
       )) as Record<NuQJobStatus, number>;
     }
@@ -508,7 +630,7 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData>[]> {
     if (await this.isFdbGroup(groupId)) {
-      const jobs = await optionalFdb(() =>
+      const jobs = await optionalFdbRead(() =>
         scrapeQueueFdb.getCrawlJobsForListing(groupId, limit, offset, logger),
       );
       return jobs.map(j => tagFdbJob(j as NuQJob<ScrapeJobData>));
@@ -518,7 +640,7 @@ class RoutedScrapeQueue {
 
   public async removeJob(id: string, logger: Logger = _logger): Promise<void> {
     if ((await getJobQueueBackend(id)) === "fdb") {
-      await optionalFdb(() => scrapeQueueFdb.removeJob(id, logger));
+      await fdbMutation(() => scrapeQueueFdb.removeJob(id, logger));
       return;
     }
     await scrapeQueuePg.removeJob(id, logger);
@@ -537,11 +659,12 @@ class RoutedScrapeQueue {
     id: string,
     timeout: number | null,
     logger: Logger = _logger,
+    backendHint?: QueueBackend,
   ): Promise<T> {
-    if ((await getJobQueueBackend(id)) === "fdb") {
+    if ((await getJobQueueBackend(id, backendHint)) === "fdb") {
       // Waiting is intentionally long-lived; callers pass the real scrape
-      // timeout. optionalFdb is only for quick FDB reads/writes and applies a
-      // 500ms guard, which would incorrectly fail synchronous FDB-backed jobs.
+      // timeout. The backend hint from the enqueue result also avoids any
+      // dependency on the best-effort Redis marker.
       return scrapeQueueFdb.waitForJob(id, timeout, logger);
     }
     return scrapeQueuePg.waitForJob(id, timeout, logger) as Promise<T>;
@@ -561,19 +684,15 @@ class RoutedCrawlFinishedQueue {
     logger: Logger = _logger,
     operation?: QueueOperationOptions,
   ): Promise<NuQJob<any> | null> {
-    if (fdbQueueEnabled()) {
-      try {
-        const job = await optionalFdb(() =>
-          crawlFinishedQueueFdb.getJobToProcess(logger, operation),
-        );
-        if (job) {
-          this.inflightBackend.set(job.id, "fdb");
-          return tagFdbJob(job as NuQJob<any>);
-        }
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.getJobToProcess", error);
+    if (fdbForced()) {
+      const job = await fdbMutation(() =>
+        crawlFinishedQueueFdb.getJobToProcess(logger, operation),
+      );
+      if (job) {
+        this.inflightBackend.set(job.id, "fdb");
+        return tagFdbJob(job as NuQJob<any>);
       }
+      return null;
     }
     const job = await crawlFinishedQueuePg.getJobToProcess();
     if (job) this.inflightBackend.set(job.id, "pg");
@@ -587,15 +706,9 @@ class RoutedCrawlFinishedQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     if (this.inflightBackend.get(id) === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          crawlFinishedQueueFdb.renewLock(id, lock, logger, operation),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.renewLock", error);
-        return false;
-      }
+      return await fdbMutation(() =>
+        crawlFinishedQueueFdb.renewLock(id, lock, logger, operation),
+      );
     }
     return crawlFinishedQueuePg.renewLock(id, lock, logger);
   }
@@ -608,25 +721,27 @@ class RoutedCrawlFinishedQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.inflightBackend.get(id) ?? "pg";
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          crawlFinishedQueueFdb.jobFinish(
-            id,
-            lock,
-            returnvalue,
-            logger,
-            operation,
-          ),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.jobFinish", error);
-        return false;
-      }
+      const finished = await fdbMutation(() =>
+        crawlFinishedQueueFdb.jobFinish(
+          id,
+          lock,
+          returnvalue,
+          logger,
+          operation,
+        ),
+      );
+      if (finished) this.inflightBackend.delete(id);
+      return finished;
     }
-    return crawlFinishedQueuePg.jobFinish(id, lock, returnvalue, logger);
+    const finished = await crawlFinishedQueuePg.jobFinish(
+      id,
+      lock,
+      returnvalue,
+      logger,
+    );
+    if (finished) this.inflightBackend.delete(id);
+    return finished;
   }
 
   public async jobFail(
@@ -637,33 +752,39 @@ class RoutedCrawlFinishedQueue {
     operation?: QueueOperationOptions,
   ): Promise<boolean> {
     const backend = this.inflightBackend.get(id) ?? "pg";
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          crawlFinishedQueueFdb.jobFail(
-            id,
-            lock,
-            failedReason,
-            logger,
-            operation,
-          ),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.jobFail", error);
-        return false;
-      }
+      const failed = await fdbMutation(() =>
+        crawlFinishedQueueFdb.jobFail(
+          id,
+          lock,
+          failedReason,
+          logger,
+          operation,
+        ),
+      );
+      if (failed) this.inflightBackend.delete(id);
+      return failed;
     }
-    return crawlFinishedQueuePg.jobFail(id, lock, failedReason, logger);
+    const failed = await crawlFinishedQueuePg.jobFail(
+      id,
+      lock,
+      failedReason,
+      logger,
+    );
+    if (failed) this.inflightBackend.delete(id);
+    return failed;
   }
 
   public async getJob(
     id: string,
     logger: Logger = _logger,
   ): Promise<NuQJob<any> | null> {
-    if ((await getJobQueueBackend(id)) === "fdb") {
-      const job = await optionalFdb(() =>
+    if (
+      (await getJobQueueBackend(id, undefined, () =>
+        crawlFinishedQueueFdb.hasJob(id),
+      )) === "fdb"
+    ) {
+      const job = await optionalFdbRead(() =>
         crawlFinishedQueueFdb.getJob(id, logger),
       );
       return job ? tagFdbJob(job as NuQJob<any>) : null;
@@ -687,7 +808,8 @@ class RoutedCrawlGroup {
     logger: Logger = _logger,
   ): Promise<NuQJobGroupInstance> {
     if (opts?.backend === "fdb") {
-      const g = await optionalFdb(() =>
+      if (!isSelfHosted()) await markFdbTeamState(ownerId);
+      const g = await fdbMutation(() =>
         crawlGroupFdb.addGroup(
           id,
           ownerId,
@@ -710,7 +832,7 @@ class RoutedCrawlGroup {
   ): Promise<NuQJobGroupInstance | null> {
     const backend = await getCrawlQueueBackend(id);
     if (backend === "fdb" || (!backend && fdbForced())) {
-      return (await optionalFdb(() =>
+      return (await optionalFdbRead(() =>
         crawlGroupFdb.getGroup(id, logger),
       )) as NuQJobGroupInstance | null;
     }
@@ -721,20 +843,15 @@ class RoutedCrawlGroup {
     ownerId: string,
     logger: Logger = _logger,
   ): Promise<NuQJobGroupInstance[]> {
-    if (!(await isFdbTeam(ownerId))) {
+    if (!(await teamUsesFdbLedger(ownerId))) {
       return crawlGroupPg.getOngoingByOwner(ownerId, logger);
     }
-    let fdb: NuQJobGroupInstance[] = [];
-    try {
-      fdb = (await optionalFdb(() =>
-        crawlGroupFdb.getOngoingByOwner(ownerId, logger),
-      )) as NuQJobGroupInstance[];
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(logger, "crawlGroup.getOngoingByOwner", error);
-      return crawlGroupPg.getOngoingByOwner(ownerId, logger);
-    }
-    if (fdbForced()) return fdb as NuQJobGroupInstance[];
+    const fdb = (await optionalFdbRead(() =>
+      crawlGroupFdb.getOngoingByOwner(ownerId, logger),
+    )) as NuQJobGroupInstance[];
+    if (fdbForced()) return fdb;
+    // Query both ledgers regardless of today's flag. Turning the flag off only
+    // stops new FDB groups; pinned groups remain authoritative until drained.
     const pg = await crawlGroupPg.getOngoingByOwner(ownerId, logger);
     const seen = new Set(fdb.map(g => g.id));
     return [
@@ -751,13 +868,7 @@ class RoutedCrawlGroup {
   ): Promise<boolean> {
     const backend = await getCrawlQueueBackend(id);
     if (backend !== "fdb" && !(backend === null && fdbForced())) return false;
-    try {
-      return await optionalFdb(() => crawlGroupFdb.cancelGroup(id, logger));
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(logger, "crawlGroup.cancelGroup", error);
-      return false;
-    }
+    return await fdbMutation(() => crawlGroupFdb.cancelGroup(id, logger));
   }
 }
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -31,6 +31,7 @@ import {
   crawlFinishedQueueFdb,
   crawlGroupFdb,
   externalSlotsFdb,
+  externalSlotMigrationObjectId,
   isFdbConfigured,
   nuqFdbHealthCheck,
   withFdbTimeout,
@@ -690,8 +691,9 @@ async function inspectOrRecoverExternalSlotPin(
   holderId: string,
 ): Promise<MigrationObjectPin | null> {
   if (!fdbQueueEnabled() || fdbForced()) return null;
+  const pinId = externalSlotMigrationObjectId(teamId, holderId);
   const existing = await optionalFdbRead(() =>
-    nuqFdbMigrationStore.inspectPin("external_holder", holderId),
+    nuqFdbMigrationStore.inspectPin("external_holder", pinId),
   );
   if (existing) return existing;
 
@@ -724,7 +726,7 @@ async function inspectOrRecoverExternalSlotPin(
     nuqFdbMigrationStore.preparePinnedObject({
       teamId,
       kind: "external_holder",
-      objectId: holderId,
+      objectId: pinId,
       admission: {
         type: "legacy-backfill",
         backend,
@@ -748,7 +750,7 @@ async function acquireExternalSlot(
     (await prepareRoutingPin({
       teamId,
       kind: "external_holder",
-      objectId: holderId,
+      objectId: externalSlotMigrationObjectId(teamId, holderId),
     }));
   const backend = pin?.backend ?? (await authoritativeTeamBackend(teamId));
   if (backend === "fdb") {

--- a/apps/api/src/services/worker/nuq-worker-runner.ts
+++ b/apps/api/src/services/worker/nuq-worker-runner.ts
@@ -243,15 +243,15 @@ export async function runNuqWorker(options: {
               "Worker lost job ownership; terminating to abort stale side effects",
               { reason },
             );
-            // processJobInternal does not yet accept an AbortSignal. Exiting the
-            // single-job worker is the only hard cancellation boundary that
-            // prevents the stale owner from continuing crawl/scrape effects.
+            // The AbortSignal passed below cancels scraper engines immediately;
+            // process exit remains the final fence for non-cooperative external
+            // code in this single-job worker process.
             setImmediate(() => process.exit(1));
           },
           process: signal =>
             options.processJob
               ? options.processJob(job!, signal)
-              : processJobInternal(job!),
+              : processJobInternal(job!, signal),
         });
 
         if (result.status === "completed") {

--- a/apps/api/src/services/worker/nuq-worker.ts
+++ b/apps/api/src/services/worker/nuq-worker.ts
@@ -1,5 +1,7 @@
 import "dotenv/config";
 import "../sentry";
+// Registers the durable PG publication/terminal adapter when migration is configured.
+import "./nuq-router";
 import { setSentryServiceTag } from "../sentry";
 import { nuqGetLocalMetrics, nuqHealthCheck, scrapeQueue } from "./nuq";
 import { runNuqWorker } from "./nuq-worker-runner";

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -1,6 +1,6 @@
 import { Logger } from "winston";
 import { logger } from "../../lib/logger";
-import { Client, Pool } from "pg";
+import { Client, Pool, type PoolClient } from "pg";
 import { type ScrapeJobData } from "../../types";
 import { withSpan, setSpanAttributes } from "../../lib/otel-tracer";
 import amqp from "amqplib";
@@ -38,6 +38,7 @@ export type NuQJob<Data = any, ReturnValue = any> = {
   lock?: string;
   ownerId?: string;
   groupId?: string;
+  backloggedTimesOutAt?: Date;
 };
 
 type NuQJobOptions = {
@@ -48,6 +49,62 @@ type NuQJobOptions = {
   backlogged?: boolean;
   backloggedTimesOutAt?: Date;
 };
+
+export class NuQPublicationConflictError extends Error {
+  constructor(
+    public readonly jobId: string,
+    reason: string,
+  ) {
+    super(`NuQ publication conflict for ${jobId}: ${reason}`);
+    this.name = "NuQPublicationConflictError";
+  }
+}
+
+export type NuQRemovedJobResidue = {
+  id: string;
+  ownerId?: string;
+  groupId?: string;
+  data: unknown;
+};
+
+export type NuQPgOwnerLiveResidue = {
+  scrape: number;
+  backlog: number;
+  groups: number;
+  crawlFinished: number;
+  total: number;
+};
+
+function publicationComparableData(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const result = { ...(value as Record<string, unknown>) };
+  delete result.traceContext;
+  delete result.concurrencyLimited;
+  return result;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function canonicalJson(value: unknown): string {
+  // Match node-postgres JSONB parameter semantics first (toJSON, omitted
+  // undefined object fields, null array holes), then canonicalize key order.
+  return stableJson(JSON.parse(JSON.stringify(value) ?? "null"));
+}
+
+function canonicalUuid(value: string): string {
+  return value.toLowerCase();
+}
 
 type NuQOptions = {
   backlog?: boolean;
@@ -448,6 +505,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
     "listen_channel_id",
     "owner_id",
     "group_id",
+    "times_out_at",
   ];
 
   private rowToJob(
@@ -468,6 +526,9 @@ class NuQ<JobData = any, JobReturnValue = any> {
       lock: row.lock ?? undefined,
       ownerId: row.owner_id ?? undefined,
       groupId: row.group_id ?? undefined,
+      backloggedTimesOutAt: row.times_out_at
+        ? new Date(row.times_out_at)
+        : undefined,
     };
   }
 
@@ -481,6 +542,206 @@ class NuQ<JobData = any, JobReturnValue = any> {
       createdAt: new Date(row.createdAt),
       finishedAt: row.finishedAt ? new Date(row.finishedAt) : undefined,
     };
+  }
+
+  private assertPublicationCompatible(
+    row: any,
+    job: { id: string; data: JobData; options: NuQJobOptions },
+  ): void {
+    const expectedOwner =
+      normalizeOwnerId(job.options.ownerId)?.toLowerCase() ?? null;
+    const expectedGroup = job.options.groupId?.toLowerCase() ?? null;
+    if (
+      canonicalJson(publicationComparableData(row.data)) !==
+      canonicalJson(publicationComparableData(job.data))
+    ) {
+      throw new NuQPublicationConflictError(job.id, "data differs");
+    }
+    if (row.priority !== (job.options.priority ?? 0)) {
+      throw new NuQPublicationConflictError(job.id, "priority differs");
+    }
+    if ((row.owner_id ?? null) !== expectedOwner) {
+      throw new NuQPublicationConflictError(job.id, "owner differs");
+    }
+    if ((row.group_id ?? null) !== expectedGroup) {
+      throw new NuQPublicationConflictError(job.id, "group differs");
+    }
+    if (!!row.listen_channel_id !== !!job.options.listenable) {
+      throw new NuQPublicationConflictError(job.id, "listen mode differs");
+    }
+    if (!job.options.backlogged && row.backlogged) {
+      throw new NuQPublicationConflictError(
+        job.id,
+        "active publication already exists in backlog",
+      );
+    }
+  }
+
+  private async insertPublicationBatch(
+    client: PoolClient,
+    jobs: { id: string; data: JobData; options: NuQJobOptions }[],
+    backlogged: boolean,
+  ): Promise<Set<string>> {
+    const inserted = new Set<string>();
+    const columns = [
+      "id",
+      "data",
+      "priority",
+      "listen_channel_id",
+      "owner_id",
+      "group_id",
+      ...(backlogged ? ["times_out_at"] : []),
+    ];
+
+    for (let offset = 0; offset < jobs.length; offset += 1000) {
+      const batch = jobs.slice(offset, offset + 1000);
+      const params: unknown[] = [];
+      const values = batch.map((job, index) => {
+        const base = index * columns.length + 1;
+        params.push(
+          job.id,
+          job.data,
+          job.options.priority ?? 0,
+          job.options.listenable ? this.listenChannelId : null,
+          normalizeOwnerId(job.options.ownerId),
+          job.options.groupId ?? null,
+          ...(backlogged
+            ? [job.options.backloggedTimesOutAt?.toISOString() ?? null]
+            : []),
+        );
+        return `(${columns.map((_, column) => `$${base + column}`).join(", ")})`;
+      });
+      const result = await client.query(
+        `INSERT INTO ${this.queueName}${backlogged ? "_backlog" : ""} (${columns.join(", ")}) VALUES ${values.join(", ")} ON CONFLICT (id) DO NOTHING RETURNING id;`,
+        params,
+      );
+      for (const row of result.rows) inserted.add(row.id);
+    }
+    return inserted;
+  }
+
+  private async publishJobsIdempotently(
+    jobs: { id: string; data: JobData; options: NuQJobOptions }[],
+  ): Promise<{
+    jobs: NuQJob<JobData, JobReturnValue>[];
+    insertedIds: Set<string>;
+  }> {
+    if (jobs.length === 0) return { jobs: [], insertedIds: new Set() };
+    jobs = jobs.map(job => ({
+      ...job,
+      id: canonicalUuid(job.id),
+      options: {
+        ...job.options,
+        groupId: job.options.groupId
+          ? canonicalUuid(job.options.groupId)
+          : undefined,
+      },
+    }));
+    const expectedById = new Map<string, (typeof jobs)[number]>();
+    for (const job of jobs) {
+      if (expectedById.has(job.id)) {
+        throw new NuQPublicationConflictError(job.id, "duplicate input id");
+      }
+      if (job.options.backlogged && !this.options.backlog) {
+        throw new NuQPublicationConflictError(
+          job.id,
+          "queue does not support backlog publication",
+        );
+      }
+      expectedById.set(job.id, job);
+    }
+
+    const ids = [...expectedById.keys()].sort();
+    const client = await nuqPool.connect();
+    try {
+      await client.query("BEGIN");
+      // Serialize stable-ID publishers across the active/backlog tables. This
+      // closes the gap left by their independent primary keys.
+      await client.query(
+        `SELECT pg_advisory_xact_lock(hashtextextended(id, 0)) FROM unnest($1::text[]) AS ids(id) ORDER BY id;`,
+        [ids],
+      );
+
+      const readRows = async () => {
+        const active = (
+          await client.query(
+            `SELECT ${this.jobReturning.join(", ")}, false AS backlogged FROM ${this.queueName} WHERE id = ANY($1::uuid[]) FOR UPDATE;`,
+            [ids],
+          )
+        ).rows;
+        const backlog = this.options.backlog
+          ? (
+              await client.query(
+                `SELECT ${this.jobBacklogReturning.join(", ")}, true AS backlogged FROM ${this.queueName}_backlog WHERE id = ANY($1::uuid[]) FOR UPDATE;`,
+                [ids],
+              )
+            ).rows
+          : [];
+        return [...active, ...backlog];
+      };
+
+      let rows = await readRows();
+      const rowsById = new Map<string, any>();
+      for (const row of rows) {
+        if (rowsById.has(row.id)) {
+          throw new NuQPublicationConflictError(
+            row.id,
+            "id exists in active and backlog tables",
+          );
+        }
+        rowsById.set(row.id, row);
+        this.assertPublicationCompatible(row, expectedById.get(row.id)!);
+      }
+
+      const missing = jobs.filter(job => !rowsById.has(job.id));
+      const insertedIds = new Set<string>();
+      for (const backlogged of [false, true]) {
+        const partition = missing.filter(
+          job => !!job.options.backlogged === backlogged,
+        );
+        if (partition.length === 0) continue;
+        const inserted = await this.insertPublicationBatch(
+          client,
+          partition,
+          backlogged,
+        );
+        for (const id of inserted) insertedIds.add(id);
+      }
+
+      rows = await readRows();
+      rowsById.clear();
+      for (const row of rows) {
+        if (rowsById.has(row.id)) {
+          throw new NuQPublicationConflictError(
+            row.id,
+            "id exists in active and backlog tables",
+          );
+        }
+        rowsById.set(row.id, row);
+        this.assertPublicationCompatible(row, expectedById.get(row.id)!);
+      }
+      for (const id of ids) {
+        if (!rowsById.has(id)) {
+          throw new Error(
+            `NuQ publication did not materialize stable id ${id}`,
+          );
+        }
+      }
+
+      await client.query("COMMIT");
+      return {
+        jobs: jobs.map(job => {
+          const row = rowsById.get(job.id)!;
+          return this.rowToJob(row, row.backlogged)!;
+        }),
+        insertedIds,
+      };
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   public async getJob(
@@ -755,46 +1016,73 @@ class NuQ<JobData = any, JobReturnValue = any> {
     }
   }
 
+  public async removeJobResidue(
+    id: string,
+    _logger: Logger = logger,
+  ): Promise<NuQRemovedJobResidue | null> {
+    return (await this.removeJobsResidue([id], _logger))[0] ?? null;
+  }
+
   public async removeJob(
     id: string,
     _logger: Logger = logger,
   ): Promise<boolean> {
-    const start = Date.now();
-    try {
-      return (
-        (
-          await nuqPool.query(`DELETE FROM ${this.queueName} WHERE id = $1;`, [
-            id,
-          ])
-        ).rowCount !== 0
-      );
-    } finally {
-      _logger.info("nuqRemoveJob metrics", {
-        module: "nuq/metrics",
-        method: "nuqRemoveJob",
-        duration: Date.now() - start,
-        scrapeId: id,
-      });
-    }
+    return (await this.removeJobResidue(id, _logger)) !== null;
   }
 
-  public async removeJobs(
+  public async removeJobsResidue(
     ids: string[],
     _logger: Logger = logger,
-  ): Promise<number> {
-    if (ids.length === 0) return 0;
+  ): Promise<NuQRemovedJobResidue[]> {
+    if (ids.length === 0) return [];
+    ids = [...new Set(ids.map(canonicalUuid))];
 
     const start = Date.now();
+    const client = await nuqPool.connect();
     try {
-      return (
-        (
-          await nuqPool.query(
-            `DELETE FROM ${this.queueName} WHERE id = ANY($1::uuid[]);`,
-            [ids],
-          )
-        ).rowCount ?? 0
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT pg_advisory_xact_lock(hashtextextended(id, 0)) FROM unnest($1::text[]) AS ids(id) ORDER BY id;`,
+        [[...ids].sort()],
       );
+      const active = (
+        await client.query(
+          `DELETE FROM ${this.queueName} WHERE id = ANY($1::uuid[]) RETURNING id, owner_id, group_id, data;`,
+          [ids],
+        )
+      ).rows;
+      const backlog = this.options.backlog
+        ? (
+            await client.query(
+              `DELETE FROM ${this.queueName}_backlog WHERE id = ANY($1::uuid[]) RETURNING id, owner_id, group_id, data;`,
+              [ids],
+            )
+          ).rows
+        : [];
+      await client.query("COMMIT");
+
+      const removed = new Map<string, NuQRemovedJobResidue>();
+      for (const row of [...active, ...backlog]) {
+        // A corrupt duplicate can exist because the two tables have separate
+        // primary keys. Removal is deliberately healing: both rows are gone,
+        // and either copy carries enough metadata for Redis cleanup.
+        if (!removed.has(row.id)) {
+          removed.set(row.id, {
+            id: row.id,
+            ownerId: row.owner_id ?? undefined,
+            groupId: row.group_id ?? undefined,
+            data: row.data,
+          });
+        }
+      }
+      return ids
+        .map(id => removed.get(id))
+        .filter((row): row is NuQRemovedJobResidue => row !== undefined);
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
     } finally {
+      client.release();
       _logger.info("nuqRemoveJobs metrics", {
         module: "nuq/metrics",
         method: "nuqRemoveJobs",
@@ -804,7 +1092,44 @@ class NuQ<JobData = any, JobReturnValue = any> {
     }
   }
 
+  public async removeJobs(
+    ids: string[],
+    _logger: Logger = logger,
+  ): Promise<number> {
+    return (await this.removeJobsResidue(ids, _logger)).length;
+  }
+
   // === Producer
+  public async addJobWithPublicationState(
+    id: string,
+    data: JobData,
+    options: NuQJobOptions,
+  ): Promise<{
+    job: NuQJob<JobData, JobReturnValue>;
+    inserted: boolean;
+  }> {
+    const publication = await this.publishJobsIdempotently([
+      { id, data, options },
+    ]);
+    return {
+      job: publication.jobs[0]!,
+      inserted: publication.insertedIds.has(canonicalUuid(id)),
+    };
+  }
+
+  public async addJobsWithPublicationState(
+    jobs: Array<{
+      id: string;
+      data: JobData;
+      options: NuQJobOptions;
+    }>,
+  ): Promise<{
+    jobs: NuQJob<JobData, JobReturnValue>[];
+    insertedIds: Set<string>;
+  }> {
+    return await this.publishJobsIdempotently(jobs);
+  }
+
   public async addJob(
     id: string,
     data: JobData,
@@ -821,29 +1146,9 @@ class NuQ<JobData = any, JobReturnValue = any> {
 
       const start = Date.now();
       try {
-        const result = this.rowToJob(
-          (
-            await nuqPool.query(
-              `INSERT INTO ${this.queueName}${options.backlogged ? "_backlog" : ""} (id, data, priority, listen_channel_id, owner_id, group_id${options.backlogged ? ", times_out_at" : ""}) VALUES ($1, $2, $3, $4, $5, $6${options.backlogged ? ", $7" : ""}) RETURNING ${(options.backlogged ? this.jobBacklogReturning : this.jobReturning).join(", ")};`,
-              [
-                id,
-                data,
-                options.priority ?? 0,
-                options.listenable ? this.listenChannelId : null,
-                normalizeOwnerId(options.ownerId),
-                options.groupId ?? null,
-                ...(options.backlogged
-                  ? [
-                      options.backloggedTimesOutAt
-                        ? options.backloggedTimesOutAt.toISOString()
-                        : null,
-                    ]
-                  : []),
-              ],
-            )
-          ).rows[0],
-          options.backlogged,
-        )!;
+        const result = (
+          await this.publishJobsIdempotently([{ id, data, options }])
+        ).jobs[0]!;
 
         setSpanAttributes(span, {
           "nuq.job_created": true,
@@ -882,29 +1187,12 @@ class NuQ<JobData = any, JobReturnValue = any> {
 
       const start = Date.now();
       try {
-        const result = this.rowToJob(
-          (
-            await nuqPool.query(
-              `INSERT INTO ${this.queueName}${options.backlogged ? "_backlog" : ""} (id, data, priority, listen_channel_id, owner_id, group_id${options.backlogged ? ", times_out_at" : ""}) VALUES ($1, $2, $3, $4, $5, $6${options.backlogged ? ", $7" : ""}) ON CONFLICT (id) DO NOTHING RETURNING ${(options.backlogged ? this.jobBacklogReturning : this.jobReturning).join(", ")};`,
-              [
-                id,
-                data,
-                options.priority ?? 0,
-                options.listenable ? this.listenChannelId : null,
-                normalizeOwnerId(options.ownerId),
-                options.groupId ?? null,
-                ...(options.backlogged
-                  ? [
-                      options.backloggedTimesOutAt
-                        ? options.backloggedTimesOutAt.toISOString()
-                        : null,
-                    ]
-                  : []),
-              ],
-            )
-          ).rows[0],
-          options.backlogged,
-        );
+        const publication = await this.publishJobsIdempotently([
+          { id, data, options },
+        ]);
+        const result = publication.insertedIds.has(canonicalUuid(id))
+          ? publication.jobs[0]
+          : null;
 
         setSpanAttributes(span, {
           "nuq.job_created": result !== null,
@@ -946,109 +1234,9 @@ class NuQ<JobData = any, JobReturnValue = any> {
 
       const start = Date.now();
       try {
-        // Separate jobs into backlogged and non-backlogged groups
-        const regularJobs: typeof jobs = [];
-        const backloggedJobs: typeof jobs = [];
-
-        for (const job of jobs) {
-          if (job.options.backlogged) {
-            backloggedJobs.push(job);
-          } else {
-            regularJobs.push(job);
-          }
-        }
-
-        const results: NuQJob<JobData, JobReturnValue>[] = [];
-
-        // Batch size: 6 params per job, stay well under PG's 65535 param limit
-        // 1000 jobs = 6000 params, leaving plenty of headroom
-        const BATCH_SIZE = 1000;
-
-        // Helper function to build and execute bulk insert with batching
-        const bulkInsert = async (
-          jobsToInsert: typeof jobs,
-          tableSuffix: string,
-        ) => {
-          if (jobsToInsert.length === 0) return;
-
-          // Process in batches
-          for (
-            let offset = 0;
-            offset < jobsToInsert.length;
-            offset += BATCH_SIZE
-          ) {
-            const batch = jobsToInsert.slice(offset, offset + BATCH_SIZE);
-
-            // Build the VALUES clause and parameters array
-            const valuesPlaceholders: string[] = [];
-            const params: any[] = [];
-
-            const columns = [
-              "id",
-              "data",
-              "priority",
-              "listen_channel_id",
-              "owner_id",
-              "group_id",
-              ...(tableSuffix === "_backlog" ? ["times_out_at"] : []),
-            ];
-
-            for (let i = 0; i < batch.length; i++) {
-              const job = batch[i];
-              const baseIdx = i * columns.length + 1;
-
-              valuesPlaceholders.push(
-                `(${new Array(columns.length)
-                  .fill(0)
-                  .map((_, i) => "$" + (baseIdx + i))
-                  .join(", ")})`,
-              );
-
-              params.push(
-                ...[
-                  job.id,
-                  job.data,
-                  job.options.priority ?? 0,
-                  job.options.listenable ? this.listenChannelId : null,
-                  normalizeOwnerId(job.options.ownerId),
-                  job.options.groupId ?? null,
-                  ...(tableSuffix === "_backlog"
-                    ? [
-                        job.options.backloggedTimesOutAt
-                          ? job.options.backloggedTimesOutAt.toISOString()
-                          : null,
-                      ]
-                    : []),
-                ],
-              );
-            }
-
-            const query = `INSERT INTO ${this.queueName}${tableSuffix} (${columns.join(", ")}) VALUES ${valuesPlaceholders.join(", ")} RETURNING ${(tableSuffix === "_backlog" ? this.jobBacklogReturning : this.jobReturning).join(", ")};`;
-
-            const result = await nuqPool.query(query, params);
-
-            // Convert rows to jobs and maintain order
-            const jobMap = new Map(
-              result.rows.map(row => [
-                row.id,
-                this.rowToJob(row, tableSuffix === "_backlog")!,
-              ]),
-            );
-
-            for (const job of batch) {
-              const insertedJob = jobMap.get(job.id);
-              if (insertedJob) {
-                results.push(insertedJob);
-              }
-            }
-          }
-        };
-
-        // Insert regular jobs
-        await bulkInsert(regularJobs, "");
-
-        // Insert backlogged jobs
-        await bulkInsert(backloggedJobs, "_backlog");
+        const regularJobs = jobs.filter(job => !job.options.backlogged);
+        const backloggedJobs = jobs.filter(job => job.options.backlogged);
+        const results = (await this.publishJobsIdempotently(jobs)).jobs;
 
         setSpanAttributes(span, {
           "nuq.jobs_created": results.length,
@@ -1087,10 +1275,17 @@ class NuQ<JobData = any, JobReturnValue = any> {
       });
 
       const start = Date.now();
+      id = canonicalUuid(id);
+      const client = await nuqPool.connect();
       try {
-        const result = this.rowToJob(
+        await client.query("BEGIN");
+        await client.query(
+          `SELECT pg_advisory_xact_lock(hashtextextended($1, 0));`,
+          [id],
+        );
+        let result = this.rowToJob(
           (
-            await nuqPool.query(
+            await client.query(
               `
                 WITH ins AS (
                   INSERT INTO ${this.queueName} (id, data, created_at, priority, listen_channel_id, owner_id, group_id)
@@ -1111,15 +1306,13 @@ class NuQ<JobData = any, JobReturnValue = any> {
           ).rows[0],
         );
 
-        if (!result) {
-          return await this.addJobIfNotExists(id, data, {
-            ...options,
-            backlogged: false,
-          });
-        }
-
+        await client.query("COMMIT");
         return result;
+      } catch (error) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw error;
       } finally {
+        client.release();
         const duration = Date.now() - start;
         setSpanAttributes(span, {
           "nuq.duration_ms": duration,
@@ -1708,6 +1901,41 @@ class NuQJobGroup {
       }
     });
   }
+}
+
+export async function getNuQPgOwnerLiveResidue(
+  ownerId: string,
+): Promise<NuQPgOwnerLiveResidue> {
+  const normalizedOwnerId = normalizeOwnerId(ownerId);
+  const row = (
+    await nuqPool.query(
+      `SELECT
+         (SELECT count(*)::int FROM nuq.queue_scrape
+          WHERE owner_id = $1 AND status IN ('queued', 'active')) AS scrape,
+         (SELECT count(*)::int FROM nuq.queue_scrape_backlog
+          WHERE owner_id = $1) AS backlog,
+         (SELECT count(*)::int FROM nuq.group_crawl
+          WHERE owner_id = $1 AND status = 'active') AS groups,
+         (SELECT count(*)::int FROM nuq.queue_crawl_finished
+          WHERE owner_id = $1 AND status IN ('queued', 'active')) AS crawl_finished;`,
+      [normalizedOwnerId],
+    )
+  ).rows[0] as {
+    scrape: number;
+    backlog: number;
+    groups: number;
+    crawl_finished: number;
+  };
+  const result = {
+    scrape: Number(row.scrape),
+    backlog: Number(row.backlog),
+    groups: Number(row.groups),
+    crawlFinished: Number(row.crawl_finished),
+    total: 0,
+  };
+  result.total =
+    result.scrape + result.backlog + result.groups + result.crawlFinished;
+  return result;
 }
 
 export function nuqGetLocalMetrics(): string {

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -7,7 +7,10 @@ import amqp from "amqplib";
 import { normalizeOwnerId } from "../../lib/owner-id";
 import { config } from "../../config";
 import { nuqRedis } from "./redis";
-import { retireNuQPgObject } from "./nuq-pg-publication";
+import {
+  retireNuQPgObject,
+  validateNuQPgPublicationUnderLock,
+} from "./nuq-pg-publication";
 
 // === Basics
 
@@ -58,6 +61,16 @@ export class NuQPublicationConflictError extends Error {
   ) {
     super(`NuQ publication conflict for ${jobId}: ${reason}`);
     this.name = "NuQPublicationConflictError";
+  }
+}
+
+export class NuQGroupPublicationConflictError extends Error {
+  constructor(
+    public readonly groupId: string,
+    reason: string,
+  ) {
+    super(`NuQ group publication conflict for ${groupId}: ${reason}`);
+    this.name = "NuQGroupPublicationConflictError";
   }
 }
 
@@ -662,6 +675,9 @@ class NuQ<JobData = any, JobReturnValue = any> {
         `SELECT pg_advisory_xact_lock(hashtextextended(id, 0)) FROM unnest($1::text[]) AS ids(id) ORDER BY id;`,
         [ids],
       );
+      if (this.queueName === "nuq.queue_scrape") {
+        await validateNuQPgPublicationUnderLock(ids);
+      }
 
       const readRows = async () => {
         const active = (
@@ -1020,8 +1036,11 @@ class NuQ<JobData = any, JobReturnValue = any> {
   public async removeJobResidue(
     id: string,
     _logger: Logger = logger,
+    beforeCommit?: (removed: readonly NuQRemovedJobResidue[]) => Promise<void>,
   ): Promise<NuQRemovedJobResidue | null> {
-    return (await this.removeJobsResidue([id], _logger))[0] ?? null;
+    return (
+      (await this.removeJobsResidue([id], _logger, beforeCommit))[0] ?? null
+    );
   }
 
   public async removeJob(
@@ -1034,6 +1053,7 @@ class NuQ<JobData = any, JobReturnValue = any> {
   public async removeJobsResidue(
     ids: string[],
     _logger: Logger = logger,
+    beforeCommit?: (removed: readonly NuQRemovedJobResidue[]) => Promise<void>,
   ): Promise<NuQRemovedJobResidue[]> {
     if (ids.length === 0) return [];
     ids = [...new Set(ids.map(canonicalUuid))];
@@ -1060,8 +1080,6 @@ class NuQ<JobData = any, JobReturnValue = any> {
             )
           ).rows
         : [];
-      await client.query("COMMIT");
-
       const removed = new Map<string, NuQRemovedJobResidue>();
       for (const row of [...active, ...backlog]) {
         // A corrupt duplicate can exist because the two tables have separate
@@ -1076,9 +1094,15 @@ class NuQ<JobData = any, JobReturnValue = any> {
           });
         }
       }
-      return ids
+      const result = ids
         .map(id => removed.get(id))
         .filter((row): row is NuQRemovedJobResidue => row !== undefined);
+      // The callback runs after DELETE but before COMMIT while the stable-ID
+      // advisory locks are still held. Cross-store deletion intent therefore
+      // becomes durable before publishers can observe the row as absent.
+      if (beforeCommit) await beforeCommit(result);
+      await client.query("COMMIT");
+      return result;
     } catch (error) {
       await client.query("ROLLBACK").catch(() => {});
       throw error;
@@ -1805,9 +1829,58 @@ class NuQJobGroup {
       status: row.status,
       createdAt: new Date(row.created_at),
       ownerId: row.owner_id,
-      ttl: row.ttl,
+      ttl: Number(row.ttl),
       expiresAt: row.expires_at ? new Date(row.expires_at) : undefined,
     };
+  }
+
+  private assertPublicationCompatible(
+    row: any,
+    id: string,
+    ownerId: string,
+    ttl: number,
+  ): void {
+    if ((row.owner_id ?? null) !== normalizeOwnerId(ownerId)?.toLowerCase()) {
+      throw new NuQGroupPublicationConflictError(id, "owner differs");
+    }
+    if (Number(row.ttl) !== ttl) {
+      throw new NuQGroupPublicationConflictError(id, "ttl differs");
+    }
+  }
+
+  private async readPublicationWithLock(
+    client: PoolClient,
+    id: string,
+  ): Promise<any | null> {
+    await client.query(
+      "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0));",
+      [canonicalUuid(id)],
+    );
+    return (
+      (
+        await client.query(
+          `SELECT ${this.groupReturning.join(", ")} FROM ${this.groupName} WHERE id = $1 FOR UPDATE;`,
+          [canonicalUuid(id)],
+        )
+      ).rows[0] ?? null
+    );
+  }
+
+  public async resolveGroupPublication(
+    id: string,
+  ): Promise<NuQJobGroupInstance | null> {
+    const client = await nuqPool.connect();
+    try {
+      await client.query("BEGIN");
+      const row = await this.readPublicationWithLock(client, id);
+      await client.query("COMMIT");
+      return this.rowToGroup(row);
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   public async addGroup(
@@ -1817,29 +1890,50 @@ class NuQJobGroup {
     _logger: Logger = logger,
   ): Promise<NuQJobGroupInstance> {
     return withSpan("nuq.addGroup", async span => {
+      const stableId = canonicalUuid(id);
+      const stableTtl = ttl ?? 86400000;
       setSpanAttributes(span, {
         "nuq.group_name": this.groupName,
-        "nuq.group_id": id,
-        "nuq.ttl": ttl ?? 86400000,
+        "nuq.group_id": stableId,
+        "nuq.ttl": stableTtl,
       });
 
       const start = Date.now();
+      const client = await nuqPool.connect();
       try {
-        const result = this.rowToGroup(
-          (
-            await nuqPool.query(
-              `INSERT INTO ${this.groupName} (id, owner_id, ttl) VALUES ($1, $2, $3) RETURNING ${this.groupReturning.join(", ")};`,
-              [id, normalizeOwnerId(ownerId), ttl ?? 86400000],
-            )
-          ).rows[0],
-        )!;
+        await client.query("BEGIN");
+        await client.query(
+          "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0));",
+          [stableId],
+        );
+        const inserted = await client.query(
+          `INSERT INTO ${this.groupName} (id, owner_id, ttl) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING RETURNING id;`,
+          [stableId, normalizeOwnerId(ownerId), stableTtl],
+        );
+        const row = (
+          await client.query(
+            `SELECT ${this.groupReturning.join(", ")} FROM ${this.groupName} WHERE id = $1 FOR UPDATE;`,
+            [stableId],
+          )
+        ).rows[0];
+        if (!row) {
+          throw new Error(
+            `NuQ group publication did not materialize stable id ${stableId}`,
+          );
+        }
+        this.assertPublicationCompatible(row, stableId, ownerId, stableTtl);
+        await client.query("COMMIT");
+        const result = this.rowToGroup(row)!;
 
         setSpanAttributes(span, {
-          "nuq.group_created": true,
+          "nuq.group_created": inserted.rowCount === 1,
         });
-
         return result;
+      } catch (error) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw error;
       } finally {
+        client.release();
         const duration = Date.now() - start;
         setSpanAttributes(span, {
           "nuq.duration_ms": duration,
@@ -1848,7 +1942,7 @@ class NuQJobGroup {
           module: "nuq/metrics",
           method: "nuqAddGroup",
           duration,
-          groupId: id,
+          groupId: stableId,
         });
       }
     });

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -7,6 +7,7 @@ import amqp from "amqplib";
 import { normalizeOwnerId } from "../../lib/owner-id";
 import { config } from "../../config";
 import { nuqRedis } from "./redis";
+import { retireNuQPgObject } from "./nuq-pg-publication";
 
 // === Basics
 
@@ -1597,6 +1598,22 @@ class NuQ<JobData = any, JobReturnValue = any> {
           "nuq.job_finished": success,
         });
 
+        if (
+          this.queueName === "scrape" ||
+          this.queueName === "crawl_finished"
+        ) {
+          const terminal =
+            success ||
+            ["completed", "failed"].includes(
+              (await this.getJob(id, _logger))?.status ?? "",
+            );
+          if (terminal) {
+            await retireNuQPgObject(
+              this.queueName === "scrape" ? "scrape_job" : "crawl_finished",
+              id,
+            );
+          }
+        }
         return success;
       } finally {
         const duration = Date.now() - start;
@@ -1655,6 +1672,22 @@ class NuQ<JobData = any, JobReturnValue = any> {
           "nuq.job_failed": success,
         });
 
+        if (
+          this.queueName === "scrape" ||
+          this.queueName === "crawl_finished"
+        ) {
+          const terminal =
+            success ||
+            ["completed", "failed"].includes(
+              (await this.getJob(id, _logger))?.status ?? "",
+            );
+          if (terminal) {
+            await retireNuQPgObject(
+              this.queueName === "scrape" ? "scrape_job" : "crawl_finished",
+              id,
+            );
+          }
+        }
         return success;
       } finally {
         const duration = Date.now() - start;

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -268,7 +268,17 @@ function billThreatBlockedDiscoveries(
   });
 }
 
-async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
+function throwIfProtectionAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new ScrapeJobTimeoutError();
+}
+
+async function processJob(
+  job: NuQJob<ScrapeJobSingleUrls>,
+  protectionSignal?: AbortSignal,
+) {
   const logger = _logger.child({
     module: "queue-worker",
     method: "processJob",
@@ -302,6 +312,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
   let pipeline: ScrapeUrlResponse | null = null;
 
   try {
+    throwIfProtectionAborted(protectionSignal);
     if (remainingTime !== undefined && remainingTime < 0) {
       throw new ScrapeJobTimeoutError();
     }
@@ -319,6 +330,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
         startWebScraperPipeline({
           job,
           costTracking,
+          signal: protectionSignal,
         }),
         ...(remainingTime !== undefined
           ? [
@@ -338,6 +350,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
       }
     }
 
+    throwIfProtectionAborted(protectionSignal);
     try {
       signal?.throwIfAborted();
     } catch (e) {
@@ -388,6 +401,8 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
       document: doc,
     };
 
+    throwIfProtectionAborted(protectionSignal);
+
     // Ensure the parent `requests` row is committed before any child
     // `scrapes`/`parses` insert, to avoid a request_id FK violation. Runs on
     // both the crawl and single-scrape paths; only single scrapes actually
@@ -403,6 +418,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
       }
     }
 
+    throwIfProtectionAborted(protectionSignal);
     if (job.data.crawl_id) {
       const sc = (await getCrawl(job.data.crawl_id)) as StoredCrawl;
 
@@ -824,9 +840,13 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
       }
     }
 
+    throwIfProtectionAborted(protectionSignal);
     logger.info(`🐂 Job done ${job.id}`);
     return data;
   } catch (error) {
+    // A lost capacity/lease owner must not publish failure side effects after
+    // its protection boundary has been revoked.
+    throwIfProtectionAborted(protectionSignal);
     // Record top-level robots.txt rejections so crawl status can warn
     try {
       if (
@@ -1505,7 +1525,10 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
   }
 }
 
-export const processJobInternal = async (job: NuQJob<ScrapeJobData>) => {
+export const processJobInternal = async (
+  job: NuQJob<ScrapeJobData>,
+  protectionSignal?: AbortSignal,
+) => {
   const logger = _logger.child({
     module: "queue-worker",
     method: "processJobInternal",
@@ -1527,15 +1550,19 @@ export const processJobInternal = async (job: NuQJob<ScrapeJobData>) => {
           "worker.url": job.data.mode === "single_urls" ? job.data.url : "n/a",
         });
 
-        return processJobWithTracing(job, logger);
+        return processJobWithTracing(job, logger, protectionSignal);
       }),
     );
   } else {
-    return processJobWithTracing(job, logger);
+    return processJobWithTracing(job, logger, protectionSignal);
   }
 };
 
-async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
+async function processJobWithTracing(
+  job: NuQJob<ScrapeJobData>,
+  logger: any,
+  protectionSignal?: AbortSignal,
+) {
   // FDB-backed jobs hold their concurrency slot through the queue lease; the
   // Redis slot mirror and promotion-on-done below are PG-backend machinery
   const isFdbJob = (job as any).backend === "fdb";
@@ -1603,7 +1630,10 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
             throw (result as any).error;
           }
         } else {
-          const result = await processJob(job as NuQJob<ScrapeJobSingleUrls>);
+          const result = await processJob(
+            job as NuQJob<ScrapeJobSingleUrls>,
+            protectionSignal,
+          );
           if (result.success) {
             try {
               if (job.data.team_id) {

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -463,6 +463,7 @@ async function processJob(
         if (job.data.isCrawlSourceScrape && isHostnameDifferent) {
           // TODO: re-fetch sitemap for redirect target domain
           sc.originUrl = doc.metadata.url;
+          throwIfProtectionAborted(protectionSignal);
           await saveCrawl(job.data.crawl_id, sc);
         }
 
@@ -608,6 +609,7 @@ async function processJob(
                   { jobPriority, url: link },
                 );
 
+                throwIfProtectionAborted(protectionSignal);
                 await addScrapeJob(
                   {
                     url: link,
@@ -641,6 +643,7 @@ async function processJob(
                   jobPriority,
                 );
 
+                throwIfProtectionAborted(protectionSignal);
                 await addCrawlJob(job.data.crawl_id, jobId, logger);
                 logger.debug("Added job for URL " + JSON.stringify(link), {
                   jobPriority,
@@ -677,6 +680,7 @@ async function processJob(
         }
       }
 
+      throwIfProtectionAborted(protectionSignal);
       try {
         signal?.throwIfAborted();
       } catch (e) {
@@ -698,6 +702,7 @@ async function processJob(
       doc.metadata.creditsUsed = credits_billed ?? undefined;
 
       logger.debug("Logging job to DB...");
+      throwIfProtectionAborted(protectionSignal);
       await logScrape(
         {
           id: job.id,
@@ -721,6 +726,7 @@ async function processJob(
         true,
       );
 
+      throwIfProtectionAborted(protectionSignal);
       trackScrape({
         scrapeId: job.id,
         requestId: job.data.requestId ?? job.data.crawl_id ?? job.id,
@@ -742,6 +748,7 @@ async function processJob(
           v0: false,
         });
         if (sender) {
+          throwIfProtectionAborted(protectionSignal);
           logger.debug("Calling webhook with success...", {
             webhook: job.data.webhook,
           });
@@ -764,11 +771,14 @@ async function processJob(
         }
       }
 
+      throwIfProtectionAborted(protectionSignal);
       await recordMonitorScrapeSuccess(job, doc);
 
+      throwIfProtectionAborted(protectionSignal);
       logger.debug("Declaring job as done...");
       await addCrawlJobDone(job.data.crawl_id, job.id, true, logger);
     } else {
+      throwIfProtectionAborted(protectionSignal);
       try {
         signal?.throwIfAborted();
       } catch (e) {
@@ -789,6 +799,7 @@ async function processJob(
 
       doc.metadata.creditsUsed = credits_billed ?? undefined;
 
+      throwIfProtectionAborted(protectionSignal);
       const logScrapePromise = logScrape(
         {
           id: job.id,
@@ -812,6 +823,7 @@ async function processJob(
         false,
       );
 
+      throwIfProtectionAborted(protectionSignal);
       trackScrape({
         scrapeId: job.id,
         requestId: job.data.requestId ?? job.data.crawl_id ?? job.id,
@@ -825,6 +837,7 @@ async function processJob(
         zeroDataRetention: job.data.zeroDataRetention,
       }).catch(err => logger.warn("Scrape tracking failed", { error: err }));
 
+      throwIfProtectionAborted(protectionSignal);
       await recordMonitorScrapeSuccess(job, doc).catch(error =>
         logger.warn("Failed to record monitor scrape result", { error }),
       );
@@ -1132,7 +1145,10 @@ async function addKickoffSitemapJob(
   );
 }
 
-async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
+async function processKickoffJob(
+  job: NuQJob<ScrapeJobKickoff>,
+  protectionSignal?: AbortSignal,
+) {
   const logger = _logger.child({
     module: "queue-worker",
     method: "processKickoffJob",
@@ -1144,6 +1160,7 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
   });
 
   try {
+    throwIfProtectionAborted(protectionSignal);
     const sc = (await getCrawl(job.data.crawl_id)) as StoredCrawl;
     const crawler = crawlToCrawler(
       job.data.crawl_id,
@@ -1151,9 +1168,11 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
       (await getACUCTeam(job.data.team_id))?.flags ?? null,
     );
 
+    throwIfProtectionAborted(protectionSignal);
     logger.debug("Locking URL...");
     await lockURL(job.data.crawl_id, sc, job.data.url);
     const jobId = uuidv7();
+    throwIfProtectionAborted(protectionSignal);
     logger.debug("Adding scrape job to Redis...", { jobId });
     await addScrapeJob(
       {
@@ -1180,6 +1199,7 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
       jobId,
       await getJobPriority({ team_id: job.data.team_id, basePriority: 15 }),
     );
+    throwIfProtectionAborted(protectionSignal);
     logger.debug("Adding scrape job to BullMQ...", { jobId });
     await addCrawlJob(job.data.crawl_id, jobId, logger);
 
@@ -1194,6 +1214,7 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
         v0: Boolean(!job.data.v1),
       });
       if (sender) {
+        throwIfProtectionAborted(protectionSignal);
         sender.send(WebhookEvent.CRAWL_STARTED, { success: true });
       }
     }
@@ -1225,6 +1246,7 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
         attempts.push(urlRootSitemap.href);
 
         for (const attempt of attempts) {
+          throwIfProtectionAborted(protectionSignal);
           await addKickoffSitemapJob(attempt, job, sc, logger);
         }
       }
@@ -1327,22 +1349,26 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
       const lockedJobs = jobs.filter(x =>
         lockedIds.find(y => y.id === x.jobId),
       );
+      throwIfProtectionAborted(protectionSignal);
       logger.debug("Adding scrape jobs to Redis...");
       await addCrawlJobs(
         job.data.crawl_id,
         lockedJobs.map(x => x.jobId),
         logger,
       );
+      throwIfProtectionAborted(protectionSignal);
       logger.debug("Adding scrape jobs to BullMQ...");
       await addScrapeJobs(lockedJobs);
     }
 
     logger.debug("Done queueing jobs!");
 
+    throwIfProtectionAborted(protectionSignal);
     await finishCrawlKickoff(job.data.crawl_id);
 
     return { success: true };
   } catch (error) {
+    throwIfProtectionAborted(protectionSignal);
     logger.error("An error occurred!", { error });
     await finishCrawlKickoff(job.data.crawl_id);
     await setCrawlError(
@@ -1355,7 +1381,10 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
   }
 }
 
-async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
+async function processKickoffSitemapJob(
+  job: NuQJob<ScrapeJobKickoffSitemap>,
+  protectionSignal?: AbortSignal,
+) {
   const logger = _logger.child({
     module: "queue-worker",
     method: "processKickoffSitemapJob",
@@ -1365,9 +1394,10 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
     zeroDataRetention: job.data.zeroDataRetention ?? false,
   });
 
-  const sc = await getCrawl(job.data.crawl_id);
-
   try {
+    throwIfProtectionAborted(protectionSignal);
+    const sc = await getCrawl(job.data.crawl_id);
+    throwIfProtectionAborted(protectionSignal);
     if (!sc) {
       logger.error("Crawl not found");
       return { success: false, error: "Crawl not found" };
@@ -1388,6 +1418,7 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
       logger,
       isPreCrawl: sc.internalOptions?.isPreCrawl ?? false,
     });
+    throwIfProtectionAborted(protectionSignal);
 
     let passingURLs = (
       await crawler.filterLinks(
@@ -1488,11 +1519,13 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
         jobs.map(x => ({ id: x.jobId, url: x.data.url })),
       );
       const winningIds = new Set(urls.map(x => x.id));
+      throwIfProtectionAborted(protectionSignal);
       await addCrawlJobs(
         job.data.crawl_id,
         urls.map(x => x.id),
         logger,
       );
+      throwIfProtectionAborted(protectionSignal);
       await addScrapeJobs(jobs.filter(x => winningIds.has(x.jobId)));
 
       logger.debug("Done queueing jobs!");
@@ -1504,24 +1537,29 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
       });
 
       for (const sitemap of results.sitemaps) {
+        throwIfProtectionAborted(protectionSignal);
         await addKickoffSitemapJob(sitemap.href, job, sc, logger);
       }
 
       logger.debug("Done queueing sitemap jobs!");
     }
+    throwIfProtectionAborted(protectionSignal);
     return { success: true };
   } catch (error) {
+    throwIfProtectionAborted(protectionSignal);
     logger.error("An error occurred!", { error });
     return { success: false, error };
   } finally {
-    await redisEvictConnection.sadd(
-      "crawl:" + job.data.crawl_id + ":sitemap_jobs_done",
-      job.id,
-    );
-    await redisEvictConnection.expire(
-      "crawl:" + job.data.crawl_id + ":sitemap_jobs_done",
-      24 * 60 * 60,
-    );
+    if (!protectionSignal?.aborted) {
+      await redisEvictConnection.sadd(
+        "crawl:" + job.data.crawl_id + ":sitemap_jobs_done",
+        job.id,
+      );
+      await redisEvictConnection.expire(
+        "crawl:" + job.data.crawl_id + ":sitemap_jobs_done",
+        24 * 60 * 60,
+      );
+    }
   }
 }
 
@@ -1614,6 +1652,7 @@ async function processJobWithTracing(
         if (job.data.mode === "kickoff") {
           const result = await processKickoffJob(
             job as NuQJob<ScrapeJobKickoff>,
+            protectionSignal,
           );
           if (result.success) {
             return null;
@@ -1623,6 +1662,7 @@ async function processJobWithTracing(
         } else if (job.data.mode === "kickoff_sitemap") {
           const result = await processKickoffSitemapJob(
             job as NuQJob<ScrapeJobKickoffSitemap>,
+            protectionSignal,
           );
           if (result.success) {
             return null;

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -11,6 +11,10 @@ import {
   pushConcurrencyLimitActiveJob,
 } from "../../lib/concurrency-limit";
 import { addJobPriority, deleteJobPriority } from "../../lib/job-priority";
+import {
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "./nuq-router";
 import { cacheableLookup } from "../../scraper/scrapeURL/lib/cacheableLookup";
 import { v7 as uuidv7 } from "uuid";
 import {
@@ -1544,12 +1548,37 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
         job.data?.team_id &&
         !job.data.skipNuq
       ) {
-        extendLockInterval = setInterval(async () => {
-          await pushConcurrencyLimitActiveJob(
+        let reconciliationRunning = false;
+        extendLockInterval = setInterval(() => {
+          // Never let a slow/hung FDB reconciliation suppress the Redis TTL
+          // heartbeat that keeps this live PG job visible.
+          void pushConcurrencyLimitActiveJob(
             job.data.team_id,
             job.id,
             60 * 1000,
-          ); // 60s lock renew, just like in the queue
+          ).catch(error =>
+            _logger.warn("Failed to renew PG concurrency occupancy", {
+              jobId: job.id,
+              teamId: job.data.team_id,
+              error,
+            }),
+          );
+
+          if (reconciliationRunning) return;
+          reconciliationRunning = true;
+          void withTeamMigrationAdmission(job.data.team_id, async () =>
+            syncFdbLimitToPgOccupancy(job.data.team_id),
+          )
+            .catch(error =>
+              _logger.warn("Failed to reconcile FDB concurrency occupancy", {
+                jobId: job.id,
+                teamId: job.data.team_id,
+                error,
+              }),
+            )
+            .finally(() => {
+              reconciliationRunning = false;
+            });
         }, jobLockExtendInterval);
       }
 

--- a/apps/api/src/services/worker/team-semaphore.test.ts
+++ b/apps/api/src/services/worker/team-semaphore.test.ts
@@ -62,16 +62,34 @@ describe("team semaphore authoritative routed capacity", () => {
     controls.reserveResults = [true];
     controls.renewResult = renewalError;
 
+    let callbackAborted = false;
+    let sideEffectAfterAbort = false;
     const work = teamConcurrencySemaphore.withSemaphore(
       "team",
       "holder",
       1,
       new AbortController().signal,
       1_000,
-      async () => await new Promise<never>(() => {}),
+      async (_limited, signal) =>
+        await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              callbackAborted = true;
+              queueMicrotask(() => {
+                if (!signal.aborted) sideEffectAfterAbort = true;
+              });
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        }),
     );
 
     await expect(work).rejects.toBe(renewalError);
+    await Promise.resolve();
+    expect(callbackAborted).toBe(true);
+    expect(sideEffectAfterAbort).toBe(false);
     expect(controls.reserve).toHaveBeenCalledTimes(1);
     expect(controls.renew).toHaveBeenCalledTimes(1);
     expect(controls.release).toHaveBeenCalledWith("team", "holder");

--- a/apps/api/src/services/worker/team-semaphore.test.ts
+++ b/apps/api/src/services/worker/team-semaphore.test.ts
@@ -1,0 +1,163 @@
+import { vi } from "vitest";
+
+const controls = vi.hoisted(() => ({
+  reserveResults: [] as (boolean | Error)[],
+  renewResult: true as boolean | Error,
+  reserve: vi.fn(),
+  renew: vi.fn(),
+  release: vi.fn(),
+  redisScript: vi.fn(),
+}));
+
+vi.mock("../../lib/deployment", () => ({ isSelfHosted: vi.fn(() => false) }));
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock("./nuq-router", () => ({
+  reserveExternalSlot: controls.reserve.mockImplementation(async () => {
+    const result = controls.reserveResults.shift();
+    if (result instanceof Error) throw result;
+    return result ?? true;
+  }),
+  renewExternalSlot: controls.renew.mockImplementation(async () => {
+    if (controls.renewResult instanceof Error) throw controls.renewResult;
+    return controls.renewResult;
+  }),
+  mirrorExternalSlotRelease: controls.release.mockResolvedValue(undefined),
+}));
+vi.mock("./redis", () => ({
+  semaphoreKeys: (teamId: string) => ({ leases: `leases:${teamId}` }),
+  nuqRedis: {
+    scripts: {
+      semaphore: {
+        acquire: "acquire",
+        heartbeat: "heartbeat",
+        release: "release",
+      },
+    },
+    ensure: vi.fn(),
+    runScript: controls.redisScript,
+    zcard: vi.fn(),
+  },
+}));
+
+import { teamConcurrencySemaphore } from "./team-semaphore";
+
+describe("team semaphore authoritative routed capacity", () => {
+  beforeEach(() => {
+    controls.reserveResults = [];
+    controls.renewResult = true;
+    controls.reserve.mockClear();
+    controls.renew.mockClear();
+    controls.release.mockClear();
+    controls.redisScript.mockClear();
+  });
+
+  test("fails closed when durable holder renewal fails", async () => {
+    const renewalError = new Error("FDB renewal unavailable");
+    controls.reserveResults = [true];
+    controls.renewResult = renewalError;
+
+    const work = teamConcurrencySemaphore.withSemaphore(
+      "team",
+      "holder",
+      1,
+      new AbortController().signal,
+      1_000,
+      async () => await new Promise<never>(() => {}),
+    );
+
+    await expect(work).rejects.toBe(renewalError);
+    expect(controls.reserve).toHaveBeenCalledTimes(1);
+    expect(controls.renew).toHaveBeenCalledTimes(1);
+    expect(controls.release).toHaveBeenCalledWith("team", "holder");
+    expect(controls.redisScript).not.toHaveBeenCalled();
+  });
+
+  test("retries the authoritative reservation and reports capacity limiting", async () => {
+    vi.useFakeTimers();
+    try {
+      controls.reserveResults = [false, true];
+      const work = teamConcurrencySemaphore.withSemaphore(
+        "team",
+        "holder",
+        1,
+        new AbortController().signal,
+        1_000,
+        async limited => limited,
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(work).resolves.toBe(true);
+      expect(controls.reserve).toHaveBeenCalledTimes(2);
+      expect(controls.renew).toHaveBeenCalledTimes(1);
+      expect(controls.redisScript).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("releases a reservation that succeeds after the deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveReservation!: (reserved: boolean) => void;
+      controls.reserve.mockImplementationOnce(
+        async () =>
+          await new Promise<boolean>(resolve => {
+            resolveReservation = resolve;
+          }),
+      );
+      const func = vi.fn();
+      const work = teamConcurrencySemaphore.withSemaphore(
+        "team",
+        "late-holder",
+        1,
+        new AbortController().signal,
+        100,
+        func,
+      );
+      const rejection = expect(work).rejects.toMatchObject({
+        code: "SCRAPE_TIMEOUT",
+      });
+
+      await vi.advanceTimersByTimeAsync(101);
+      resolveReservation(true);
+      await rejection;
+      expect(func).not.toHaveBeenCalled();
+      expect(controls.release).toHaveBeenCalledWith("team", "late-holder");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not release or start work when reservation times out", async () => {
+    vi.useFakeTimers();
+    try {
+      controls.reserveResults = Array(20).fill(false);
+      const func = vi.fn();
+      const work = teamConcurrencySemaphore.withSemaphore(
+        "team",
+        "holder",
+        1,
+        new AbortController().signal,
+        100,
+        func,
+      );
+      const rejection = expect(work).rejects.toMatchObject({
+        code: "SCRAPE_TIMEOUT",
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+      await rejection;
+      expect(func).not.toHaveBeenCalled();
+      expect(controls.release).not.toHaveBeenCalled();
+      expect(controls.redisScript).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/api/src/services/worker/team-semaphore.test.ts
+++ b/apps/api/src/services/worker/team-semaphore.test.ts
@@ -2,7 +2,7 @@ import { vi } from "vitest";
 
 const controls = vi.hoisted(() => ({
   reserveResults: [] as (boolean | Error)[],
-  renewResult: true as boolean | Error,
+  renewResult: true as boolean | Error | Promise<boolean>,
   reserve: vi.fn(),
   renew: vi.fn(),
   release: vi.fn(),
@@ -25,7 +25,7 @@ vi.mock("./nuq-router", () => ({
   }),
   renewExternalSlot: controls.renew.mockImplementation(async () => {
     if (controls.renewResult instanceof Error) throw controls.renewResult;
-    return controls.renewResult;
+    return await controls.renewResult;
   }),
   mirrorExternalSlotRelease: controls.release.mockResolvedValue(undefined),
 }));
@@ -94,6 +94,42 @@ describe("team semaphore authoritative routed capacity", () => {
     expect(controls.renew).toHaveBeenCalledTimes(1);
     expect(controls.release).toHaveBeenCalledWith("team", "holder");
     expect(controls.redisScript).not.toHaveBeenCalled();
+  });
+
+  test("aborts protected work when an authoritative renewal hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      controls.reserveResults = [true];
+      controls.renewResult = new Promise<boolean>(() => {});
+      let callbackAborted = false;
+      const work = teamConcurrencySemaphore.withSemaphore(
+        "team",
+        "hung-renewal",
+        1,
+        new AbortController().signal,
+        60_000,
+        async (_limited, signal) =>
+          await new Promise<never>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                callbackAborted = true;
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          }),
+      );
+      const rejection = expect(work).rejects.toMatchObject({
+        code: "SCRAPE_TIMEOUT",
+      });
+      await vi.advanceTimersByTimeAsync(15_001);
+      await rejection;
+      expect(callbackAborted).toBe(true);
+      expect(controls.release).toHaveBeenCalledWith("team", "hung-renewal");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("retries the authoritative reservation and reports capacity limiting", async () => {

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -1,13 +1,7 @@
 import {
-  pushConcurrencyLimitActiveJob,
-  removeConcurrencyLimitActiveJob,
-} from "../../lib/concurrency-limit";
-import {
-  isFdbTeam,
-  syncFdbLimitToPgOccupancy,
-  withTeamMigrationAdmission,
+  mirrorExternalSlotAcquire,
+  mirrorExternalSlotRelease,
 } from "./nuq-router";
-import { externalSlotsFdb } from "./nuq-fdb";
 import { isSelfHosted } from "../../lib/deployment";
 import { ScrapeJobTimeoutError, TransportableError } from "../../lib/error";
 import { logger as _logger } from "../../lib/logger";
@@ -36,8 +30,7 @@ const semaphoreHoldDuration = new Histogram({
 const { scripts, runScript, ensure } = nuqRedis;
 
 const SEMAPHORE_TTL = 30 * 1000;
-type MirrorBackend = "pg" | "fdb";
-type MirrorState = { backend?: MirrorBackend };
+type MirrorState = { acquired: boolean };
 
 async function acquire(
   teamId: string,
@@ -207,43 +200,15 @@ function startHeartbeat(
 }
 
 // Sync scrapes occupy queue capacity so async jobs see the team's real load.
-// PG-backed teams mirror into the Redis ZSET; FDB-backed teams consume an
-// external slot on the FDB ledger.
-async function resolveMirrorBackend(teamId: string): Promise<MirrorBackend> {
-  return (await isFdbTeam(teamId)) ? "fdb" : "pg";
-}
-
-async function releaseMirrorBackend(
-  teamId: string,
-  holderId: string,
-  backend: MirrorBackend,
-): Promise<void> {
-  if (backend === "fdb") {
-    await externalSlotsFdb.release(teamId, holderId);
-  } else {
-    await removeConcurrencyLimitActiveJob(teamId, holderId);
-    await syncFdbLimitToPgOccupancy(teamId);
-  }
-}
-
+// Router-owned durable holder pins survive rollout flag changes and remove the
+// old convention that an in-memory backend choice was sufficient authority.
 async function mirrorSlotAcquire(
   teamId: string,
   holderId: string,
   state: MirrorState,
 ): Promise<void> {
-  // Pin the mirror ledger for the holder's lifetime. A transient FDB health
-  // failure or rollout-flag change must not move one holder between ledgers
-  // and double-count (or later release) both.
-  const backend = state.backend ?? (await resolveMirrorBackend(teamId));
-  state.backend = backend;
-  await withTeamMigrationAdmission(teamId, async () => {
-    if (backend === "fdb") {
-      await externalSlotsFdb.acquire(teamId, holderId, 60 * 1000);
-    } else {
-      await pushConcurrencyLimitActiveJob(teamId, holderId, 60 * 1000);
-      await syncFdbLimitToPgOccupancy(teamId);
-    }
-  });
+  await mirrorExternalSlotAcquire(teamId, holderId, 60 * 1000);
+  state.acquired = true;
 }
 
 async function mirrorSlotRelease(
@@ -251,12 +216,9 @@ async function mirrorSlotRelease(
   holderId: string,
   state: MirrorState,
 ): Promise<void> {
-  const backend = state.backend;
-  if (!backend) return;
-  await withTeamMigrationAdmission(teamId, async () =>
-    releaseMirrorBackend(teamId, holderId, backend),
-  );
-  state.backend = undefined;
+  if (!state.acquired) return;
+  await mirrorExternalSlotRelease(teamId, holderId);
+  state.acquired = false;
 }
 
 async function withSemaphore<T>(
@@ -284,7 +246,7 @@ async function withSemaphore<T>(
   });
 
   const endTimer = semaphoreHoldDuration.startTimer();
-  const mirrorState: MirrorState = {};
+  const mirrorState: MirrorState = { acquired: false };
   let hb: ReturnType<typeof startHeartbeat> | null = null;
 
   activeSemaphores.inc();

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -187,7 +187,7 @@ async function withSemaphore<T>(
   limit: number,
   signal: AbortSignal,
   timeoutMs: number,
-  func: (limited: boolean) => Promise<T>,
+  func: (limited: boolean, signal: AbortSignal) => Promise<T>,
 ): Promise<T> {
   // Bypass concurrency limits for self-hosted deployments
   if (isSelfHosted()) {
@@ -195,7 +195,7 @@ async function withSemaphore<T>(
       teamId,
       jobId: holderId,
     });
-    return await func(false);
+    return await func(false, signal);
   }
 
   // Reserve the backend-specific ledger shared with queue jobs. The legacy
@@ -215,15 +215,32 @@ async function withSemaphore<T>(
 
   const endTimer = semaphoreHoldDuration.startTimer();
   const mirrorState: MirrorState = { acquired: true };
+  const protection = new AbortController();
+  const abortProtection = () => protection.abort(signal.reason);
+  signal.addEventListener("abort", abortProtection, { once: true });
+  if (signal.aborted) abortProtection();
   let hb: ReturnType<typeof startHeartbeat> | null = null;
 
   activeSemaphores.inc();
   try {
     hb = startHeartbeat(teamId, holderId, SEMAPHORE_TTL / 2, mirrorState);
-
-    const result = await Promise.race([func(limited), hb.promise]);
-    return result;
+    const protectedWork = Promise.resolve().then(() =>
+      func(limited, protection.signal),
+    );
+    return await Promise.race([
+      protectedWork,
+      hb.promise.catch(async error => {
+        // Ownership loss is a cancellation boundary, not merely a competing
+        // rejected promise. Abort the callback and wait for its abort-aware
+        // cleanup before releasing the authoritative holder.
+        protection.abort(error);
+        await protectedWork.catch(() => undefined);
+        throw error;
+      }),
+    ]);
   } finally {
+    protection.abort();
+    signal.removeEventListener("abort", abortProtection);
     await hb?.stop();
 
     await mirrorSlotRelease(teamId, holderId, mirrorState).catch(() => {

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -1,6 +1,7 @@
 import {
-  mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  renewExternalSlot,
+  reserveExternalSlot,
 } from "./nuq-router";
 import { isSelfHosted } from "../../lib/deployment";
 import { ScrapeJobTimeoutError, TransportableError } from "../../lib/error";
@@ -53,7 +54,7 @@ async function acquire(
   };
 }
 
-async function acquireBlocking(
+async function acquireAuthoritativeBlocking(
   teamId: string,
   holderId: string,
   limit: number,
@@ -64,63 +65,32 @@ async function acquireBlocking(
     signal: AbortSignal;
   },
 ): Promise<{ limited: boolean; removed: number }> {
-  await ensure();
-
   const deadline = Date.now() + options.timeout_ms;
-  const keys = semaphoreKeys(teamId);
-
   let delay = options.base_delay_ms;
-  let totalRemoved = 0;
-  let failedOnce = false;
-
+  let limited = false;
   const endTimer = semaphoreAcquireDuration.startTimer();
 
-  do {
-    if (options.signal.aborted) {
+  while (true) {
+    if (options.signal.aborted || deadline < Date.now()) {
       throw new ScrapeJobTimeoutError();
     }
-
-    if (deadline < Date.now()) {
-      throw new ScrapeJobTimeoutError();
-    }
-
-    const [granted, _count, _removed] = await runScript<
-      [number, number, number]
-    >(
-      scripts.semaphore.acquire,
-      [keys.leases],
-      [holderId, limit, SEMAPHORE_TTL],
-    );
-
-    totalRemoved++;
-
-    if (granted === 1) {
+    if (await reserveExternalSlot(teamId, holderId, SEMAPHORE_TTL, limit)) {
+      // An unbounded FDB retry can outlive the caller's deadline. Never start
+      // protected work after a late reservation; release the owned holder first.
+      if (options.signal.aborted || deadline < Date.now()) {
+        await mirrorExternalSlotRelease(teamId, holderId);
+        throw new ScrapeJobTimeoutError();
+      }
       endTimer();
-      return { limited: failedOnce, removed: totalRemoved };
+      return { limited, removed: 0 };
     }
-
-    failedOnce = true;
-
+    limited = true;
     const jitter = Math.floor(
       Math.random() * Math.max(1, Math.floor(delay / 4)),
     );
-    await new Promise(r => setTimeout(r, delay + jitter));
-
+    await new Promise(resolve => setTimeout(resolve, delay + jitter));
     delay = Math.min(options.max_delay_ms, Math.floor(delay * 1.5));
-  } while (true);
-}
-
-async function heartbeat(teamId: string, holderId: string): Promise<boolean> {
-  await ensure();
-
-  const keys = semaphoreKeys(teamId);
-  return (
-    (await runScript<number>(
-      scripts.semaphore.heartbeat,
-      [keys.leases],
-      [holderId, SEMAPHORE_TTL],
-    )) === 1
-  );
+  }
 }
 
 async function release(teamId: string, holderId: string): Promise<void> {
@@ -163,30 +133,29 @@ function startHeartbeat(
   const promise = (async () => {
     try {
       while (!stopped) {
-        await mirrorSlotAcquire(teamId, holderId, mirrorState).catch(() => {
-          _logger.warn("Failed to update concurrency limit active job", {
-            teamId,
-            jobId: holderId,
-          });
-        });
-        if (stopped) break;
-
-        const ok = await heartbeat(teamId, holderId);
-        if (!ok) {
+        // This routed holder is the shared queue-capacity authority on both PG
+        // and FDB. A swept/expired holder must never be resurrected from a
+        // stale request limit; losing ownership makes protected work fail closed.
+        const renewed = await renewExternalSlot(
+          teamId,
+          holderId,
+          SEMAPHORE_TTL,
+        );
+        if (!renewed) {
           throw new TransportableError("SCRAPE_TIMEOUT", "heartbeat_failed");
         }
+        mirrorState.acquired = true;
         if (stopped) break;
         await sleep(intervalMs);
       }
     } catch (error) {
       if (!stopped) {
         _logger.error("Error in semaphore heartbeat loop", { error });
+        throw error;
       }
     }
 
-    return Promise.reject(
-      new Error("heartbeat loop stopped unexpectedly"),
-    ) as never;
+    throw new Error("heartbeat loop stopped unexpectedly");
   })();
 
   return {
@@ -202,15 +171,6 @@ function startHeartbeat(
 // Sync scrapes occupy queue capacity so async jobs see the team's real load.
 // Router-owned durable holder pins survive rollout flag changes and remove the
 // old convention that an in-memory backend choice was sufficient authority.
-async function mirrorSlotAcquire(
-  teamId: string,
-  holderId: string,
-  state: MirrorState,
-): Promise<void> {
-  await mirrorExternalSlotAcquire(teamId, holderId, 60 * 1000);
-  state.acquired = true;
-}
-
 async function mirrorSlotRelease(
   teamId: string,
   holderId: string,
@@ -238,20 +198,27 @@ async function withSemaphore<T>(
     return await func(false);
   }
 
-  const { limited } = await acquireBlocking(teamId, holderId, limit, {
-    base_delay_ms: 25,
-    max_delay_ms: 250,
-    timeout_ms: timeoutMs,
-    signal,
-  });
+  // Reserve the backend-specific ledger shared with queue jobs. The legacy
+  // `nuq:semaphore` ZSET counts only sync work and cannot safely govern this
+  // path during normal PG operation or a backend transition.
+  const { limited } = await acquireAuthoritativeBlocking(
+    teamId,
+    holderId,
+    limit,
+    {
+      base_delay_ms: 25,
+      max_delay_ms: 250,
+      timeout_ms: timeoutMs,
+      signal,
+    },
+  );
 
   const endTimer = semaphoreHoldDuration.startTimer();
-  const mirrorState: MirrorState = { acquired: false };
+  const mirrorState: MirrorState = { acquired: true };
   let hb: ReturnType<typeof startHeartbeat> | null = null;
 
   activeSemaphores.inc();
   try {
-    await mirrorSlotAcquire(teamId, holderId, mirrorState);
     hb = startHeartbeat(teamId, holderId, SEMAPHORE_TTL / 2, mirrorState);
 
     const result = await Promise.race([func(limited), hb.promise]);
@@ -268,8 +235,6 @@ async function withSemaphore<T>(
 
     activeSemaphores.dec();
     endTimer();
-
-    await release(teamId, holderId).catch(() => {});
   }
 }
 

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -136,11 +136,21 @@ function startHeartbeat(
         // This routed holder is the shared queue-capacity authority on both PG
         // and FDB. A swept/expired holder must never be resurrected from a
         // stale request limit; losing ownership makes protected work fail closed.
-        const renewed = await renewExternalSlot(
-          teamId,
-          holderId,
-          SEMAPHORE_TTL,
-        );
+        let renewalTimer: NodeJS.Timeout | undefined;
+        const renewed = await Promise.race([
+          renewExternalSlot(teamId, holderId, SEMAPHORE_TTL),
+          new Promise<never>((_, reject) => {
+            renewalTimer = setTimeout(
+              () =>
+                reject(
+                  new TransportableError("SCRAPE_TIMEOUT", "heartbeat_timeout"),
+                ),
+              intervalMs,
+            );
+          }),
+        ]).finally(() => {
+          if (renewalTimer) clearTimeout(renewalTimer);
+        });
         if (!renewed) {
           throw new TransportableError("SCRAPE_TIMEOUT", "heartbeat_failed");
         }

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -2,9 +2,12 @@ import {
   pushConcurrencyLimitActiveJob,
   removeConcurrencyLimitActiveJob,
 } from "../../lib/concurrency-limit";
-import { config } from "../../config";
-import { isFdbTeam } from "./nuq-router";
-import { externalSlotsFdb, nuqFdbHealthCheck, withFdbTimeout } from "./nuq-fdb";
+import {
+  isFdbTeam,
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "./nuq-router";
+import { externalSlotsFdb } from "./nuq-fdb";
 import { isSelfHosted } from "../../lib/deployment";
 import { ScrapeJobTimeoutError, TransportableError } from "../../lib/error";
 import { logger as _logger } from "../../lib/logger";
@@ -33,21 +36,8 @@ const semaphoreHoldDuration = new Histogram({
 const { scripts, runScript, ensure } = nuqRedis;
 
 const SEMAPHORE_TTL = 30 * 1000;
-const FDB_OPTIONAL_SLOT_TIMEOUT_MS = 500;
 type MirrorBackend = "pg" | "fdb";
-type MirrorState = { backend?: MirrorBackend; touched: Set<MirrorBackend> };
-
-function fdbForced(): boolean {
-  return config.NUQ_BACKEND === "fdb";
-}
-
-async function optionalFdbSlot<T>(operation: () => Promise<T>): Promise<T> {
-  if (fdbForced()) return operation();
-  if (!(await nuqFdbHealthCheck(FDB_OPTIONAL_SLOT_TIMEOUT_MS))) {
-    throw new Error("FDB health check failed before optional slot operation");
-  }
-  return await withFdbTimeout(operation(), FDB_OPTIONAL_SLOT_TIMEOUT_MS);
-}
+type MirrorState = { backend?: MirrorBackend };
 
 async function acquire(
   teamId: string,
@@ -220,9 +210,7 @@ function startHeartbeat(
 // PG-backed teams mirror into the Redis ZSET; FDB-backed teams consume an
 // external slot on the FDB ledger.
 async function resolveMirrorBackend(teamId: string): Promise<MirrorBackend> {
-  if (!(await isFdbTeam(teamId))) return "pg";
-  if (fdbForced()) return "fdb";
-  return (await nuqFdbHealthCheck(FDB_OPTIONAL_SLOT_TIMEOUT_MS)) ? "fdb" : "pg";
+  return (await isFdbTeam(teamId)) ? "fdb" : "pg";
 }
 
 async function releaseMirrorBackend(
@@ -231,9 +219,10 @@ async function releaseMirrorBackend(
   backend: MirrorBackend,
 ): Promise<void> {
   if (backend === "fdb") {
-    await optionalFdbSlot(() => externalSlotsFdb.release(teamId, holderId));
+    await externalSlotsFdb.release(teamId, holderId);
   } else {
     await removeConcurrencyLimitActiveJob(teamId, holderId);
+    await syncFdbLimitToPgOccupancy(teamId);
   }
 }
 
@@ -242,21 +231,19 @@ async function mirrorSlotAcquire(
   holderId: string,
   state: MirrorState,
 ): Promise<void> {
-  const backend = await resolveMirrorBackend(teamId);
-  if (backend === "fdb") {
-    await optionalFdbSlot(() =>
-      externalSlotsFdb.acquire(teamId, holderId, 60 * 1000),
-    );
-  } else {
-    await pushConcurrencyLimitActiveJob(teamId, holderId, 60 * 1000);
-  }
-  const previous = state.backend;
+  // Pin the mirror ledger for the holder's lifetime. A transient FDB health
+  // failure or rollout-flag change must not move one holder between ledgers
+  // and double-count (or later release) both.
+  const backend = state.backend ?? (await resolveMirrorBackend(teamId));
   state.backend = backend;
-  state.touched.add(backend);
-  if (previous && previous !== backend) {
-    await releaseMirrorBackend(teamId, holderId, previous);
-    state.touched.delete(previous);
-  }
+  await withTeamMigrationAdmission(teamId, async () => {
+    if (backend === "fdb") {
+      await externalSlotsFdb.acquire(teamId, holderId, 60 * 1000);
+    } else {
+      await pushConcurrencyLimitActiveJob(teamId, holderId, 60 * 1000);
+      await syncFdbLimitToPgOccupancy(teamId);
+    }
+  });
 }
 
 async function mirrorSlotRelease(
@@ -264,18 +251,12 @@ async function mirrorSlotRelease(
   holderId: string,
   state: MirrorState,
 ): Promise<void> {
-  const backends = Array.from(state.touched);
-  const results = await Promise.allSettled(
-    backends.map(backend => releaseMirrorBackend(teamId, holderId, backend)),
+  const backend = state.backend;
+  if (!backend) return;
+  await withTeamMigrationAdmission(teamId, async () =>
+    releaseMirrorBackend(teamId, holderId, backend),
   );
-  const failed = results.find(
-    (result): result is PromiseRejectedResult => result.status === "rejected",
-  );
-  if (failed) {
-    throw failed.reason;
-  }
   state.backend = undefined;
-  state.touched.clear();
 }
 
 async function withSemaphore<T>(
@@ -303,7 +284,7 @@ async function withSemaphore<T>(
   });
 
   const endTimer = semaphoreHoldDuration.startTimer();
-  const mirrorState: MirrorState = { touched: new Set() };
+  const mirrorState: MirrorState = {};
   let hb: ReturnType<typeof startHeartbeat> | null = null;
 
   activeSemaphores.inc();

--- a/apps/nuq-postgres/nuq.sql
+++ b/apps/nuq-postgres/nuq.sql
@@ -70,6 +70,8 @@ SET (autovacuum_vacuum_scale_factor = 0.01,
      autovacuum_vacuum_cost_delay = 0);
 
 CREATE INDEX IF NOT EXISTS queue_scrape_active_locked_at_idx ON nuq.queue_scrape USING btree (locked_at) WHERE (status = 'active'::nuq.job_status);
+-- Authoritative per-owner drain probe for PG/FDB generation transitions.
+CREATE INDEX IF NOT EXISTS nuq_queue_scrape_owner_live_idx ON nuq.queue_scrape (owner_id) WHERE status IN ('queued'::nuq.job_status, 'active'::nuq.job_status);
 CREATE INDEX IF NOT EXISTS nuq_queue_scrape_queued_optimal_2_idx ON nuq.queue_scrape (priority ASC, created_at ASC, id) WHERE (status = 'queued'::nuq.job_status);
 CREATE INDEX IF NOT EXISTS nuq_queue_scrape_failed_created_at_idx ON nuq.queue_scrape USING btree (created_at) WHERE (status = 'failed'::nuq.job_status);
 
@@ -206,6 +208,7 @@ SET (autovacuum_vacuum_scale_factor = 0.01,
      autovacuum_vacuum_cost_delay = 0);
 
 CREATE INDEX IF NOT EXISTS queue_crawl_finished_active_locked_at_idx ON nuq.queue_crawl_finished USING btree (locked_at) WHERE (status = 'active'::nuq.job_status);
+CREATE INDEX IF NOT EXISTS nuq_queue_crawl_finished_owner_live_idx ON nuq.queue_crawl_finished (owner_id) WHERE status IN ('queued'::nuq.job_status, 'active'::nuq.job_status);
 CREATE INDEX IF NOT EXISTS nuq_queue_crawl_finished_queued_optimal_2_idx ON nuq.queue_crawl_finished (priority ASC, created_at ASC, id) WHERE (status = 'queued'::nuq.job_status);
 CREATE INDEX IF NOT EXISTS nuq_queue_crawl_finished_failed_created_at_idx ON nuq.queue_crawl_finished USING btree (created_at) WHERE (status = 'failed'::nuq.job_status);
 CREATE INDEX IF NOT EXISTS nuq_queue_crawl_finished_completed_created_at_idx ON nuq.queue_crawl_finished USING btree (created_at) WHERE (status = 'completed'::nuq.job_status);
@@ -258,6 +261,7 @@ CREATE TABLE IF NOT EXISTS nuq.group_crawl (
 
 -- Index for group finish cron to find active groups
 CREATE INDEX IF NOT EXISTS idx_group_crawl_status ON nuq.group_crawl (status) WHERE status = 'active'::nuq.group_status;
+CREATE INDEX IF NOT EXISTS nuq_group_crawl_owner_live_idx ON nuq.group_crawl (owner_id) WHERE status = 'active'::nuq.group_status;
 
 -- Index for nuq_group_crawl_clean victim selection. The status='active'
 -- partial index above is the opposite predicate, so without this the cleaner


### PR DESCRIPTION
## Summary

- replace Redlock-based mixed-ledger admission with an FDB-authoritative per-team pause/drain state machine and never-reused generations
- pin every job, crawl/group, control task, and external holder to an immutable backend/generation
- add transaction-scoped generation hooks, exact per-generation residue accounting, bounded legacy adoption, and atomic seal fencing
- make PG publication/removal/compensation crash-durable and idempotent across ambiguous commits and Redis loss
- use one authoritative capacity ledger per active backend, including queue work, browser/session holders, and team semaphores
- fail closed on unavailable, contradictory, both-backend, stale-marker, and missing-continuation state
- add bounded migration metadata/history GC and Redis rollback recovery with horizontally scalable partition leases and backlog metrics
- abort protected scrape work when authoritative capacity ownership is lost

## Migration architecture

New unpinned admissions pause during a backend transition. Existing immutable-generation work drains on its pinned backend. Cutover occurs only after transactionally verified capacity residue reaches zero and the old generation is sealed.

Migration state changes, pin activation, residue increments/decrements, and final seals conflict in FoundationDB transactions. Redis routing markers are hints only. PostgreSQL publication and cleanup use durable operation/claim tokens and advisory-locked idempotent reconciliation.

Both bounded core metric controls must be READY in the same FDB transaction as migration initialization, transition begin, or final seal. Release-A/rollback invalidation therefore prevents migration cutover races.

## Bounded GC

Terminal object pins, operation history, and closed generations use versioned 32-partition time indexes, exact sharded due counters, renewable token-fenced leases, durable cursors, and bounded pages/work budgets. Canonical PG/FDB state is rechecked before deletion.

Redis rollback tombstones use exact-token TTL markers plus a bounded due ZSET; replacement/renewal tokens cannot be removed by stale cleanup.

The reconciler exports:

- `nuq_migration_gc_due_backlog{category}`
- `nuq_migration_gc_oldest_overdue_seconds{category}`
- bounded run/page/item/error metrics

Production infra must use minimum 2, maximum 32 reconciler replicas and scale from max-per-service backlog/oldest-age metrics before the first retained cohort becomes due. See `apps/api/NUQ_MIGRATION_GC_DEPLOYMENT.md`.

## Validation

Real isolated FoundationDB 7.2, PostgreSQL 17, and Redis validation includes:

- migration store, generation hooks, migration router/control, PG publication/removal, Redis-loss recovery, capacity/semaphore, core queue, sweeper lifecycle/scalability, runtime, and NuQ PostgreSQL suites
- final claim replay/takeover gate: 98 executions passed, including 20 repeated commit-unknown claim replays
- full migration-store: 27/27
- focused PG/FDB/Redis integration: 8/8
- migration router + control: 36/36
- GC throughput benchmark: at least 2,000 items/second with bounded pages and fair partition distribution
- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm knip`
- Prettier and `git diff --check`

Multiple independent architecture/correctness reviews covered transaction hooks, pause/drain sealing, cancelled-group recovery, readiness invalidation, PG saga replay, capacity atomicity, AbortSignal fencing, retention-safe GC, sustained throughput, exact commit-unknown accounting, renewable lease takeover, and idempotent claim replay. Final code candidate `76878a0588c7a11f756a80b87bb1684308157013` plus test-only CI stabilization through `20ada99bf42a9e8ffcc8edc8e9e2eafb483a085e` was approved with no remaining findings.

## Dependency

Draft/stacked on #3982 (`mogery/nuq-fdb-sweeper-lifecycle`), after #3984 and #3980. The full integrated CI matrix passed while temporarily based on `main`; this PR is now restored to its dependency base. Keep draft until dependencies merge, retarget sequentially, refresh final CI after each dependency merge, and verify production rollout/HPA prerequisites.
