### PR TITLE
fix(nuq-fdb): harden core queue correctness

### DIFF
--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -447,6 +447,54 @@ describeIf("NuQ FDB core", () => {
     );
   });
 
+  test("metric backfill enrolls legacy jobs without negative transition debt", async () => {
+    const { queue } = await makeCtx("metric-backfill");
+    const owner = freshOwner();
+    const ids = [randomUUID(), randomUUID(), randomUUID()];
+    await queue.addJobs(
+      ids.map(id => ({
+        id,
+        data: scrapeData(),
+        options: { ownerId: owner },
+      })),
+      gate(1),
+    );
+    const [active] = await takeAll(queue, 1);
+
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.clear(queue.ks.metricBackfillDone());
+      tn.clear(queue.ks.metricBackfillCursor());
+      for (const id of ids) tn.clear(queue.ks.jobMetricTracked(id));
+      for (const status of ["queued", "active", "pending"]) {
+        const range = queue.ks.metricStatusRange(status);
+        tn.clearRange(range.begin, range.end);
+      }
+    });
+    await expect(queue.getMetrics()).rejects.toThrow(
+      "NuQ FDB metrics are initializing",
+    );
+
+    // This legacy transition happens before enrollment. It must not subtract
+    // from empty counters; the backfill observes the post-transition states.
+    await queue.jobFinish(active.id, active.lock!, null);
+
+    let initialized = false;
+    for (let page = 0; page < 100 && !initialized; page++) {
+      initialized = await queue.backfillMetricCounts(5);
+    }
+    expect(initialized).toBe(true);
+    const metrics = await queue.getMetrics();
+    expect(metrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="queued"} 1`,
+    );
+    expect(metrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="active"} 0`,
+    );
+    expect(metrics).toContain(
+      `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="backlog"} 1`,
+    );
+  });
+
   test("promotion respects priority order", async () => {
     const { queue } = await makeCtx("priority");
     const owner = freshOwner();

--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -166,6 +166,47 @@ describeIf("NuQ FDB core", () => {
     expect((await group.getGroup(gid))?.status).toBe("completed");
   });
 
+  test("structurally distinct ID lists cannot share an ingest manifest", async () => {
+    let stopFirst = true;
+    const { queue } = await makeCtx("ingest-identity-encoding", {
+      testHooks: {
+        afterManifest: async () => {
+          if (!stopFirst) return;
+          stopFirst = false;
+          throw new Error("stop first ingest after manifest");
+        },
+      },
+    });
+    const owner = freshOwner();
+    const inputs = (ids: string[]) =>
+      ids.map(id => ({
+        id,
+        data: scrapeData(),
+        options: { ownerId: owner },
+      }));
+    const firstIds = ["a\0b", "c"];
+    const secondIds = ["a", "b\0c"];
+
+    await expect(queue.addJobs(inputs(firstIds), UNLIMITED)).rejects.toThrow(
+      "stop first ingest after manifest",
+    );
+    await expect(queue.addJobs(inputs(secondIds), UNLIMITED)).resolves.toEqual(
+      expect.arrayContaining(
+        secondIds.map(id => expect.objectContaining({ id })),
+      ),
+    );
+    await expect(queue.addJobs(inputs(firstIds), UNLIMITED)).resolves.toEqual(
+      expect.arrayContaining(
+        firstIds.map(id => expect.objectContaining({ id })),
+      ),
+    );
+
+    const taken = await takeAll(queue, 4);
+    expect(new Set(taken.map(job => job.id))).toEqual(
+      new Set([...firstIds, ...secondIds]),
+    );
+  });
+
   test("dequeue recovers the original claim after simulated commit_unknown_result", async () => {
     let inject = true;
     const { queue } = await makeCtx("claim-unknown", {

--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -9,7 +9,8 @@ import {
   getNuqFdbDatabase,
   getFdb,
 } from "../../services/worker/nuq-fdb/client";
-import { encodeI64, encodeJson } from "../../services/worker/nuq-fdb/keyspace";
+import { decodeI64, encodeJson } from "../../services/worker/nuq-fdb/keyspace";
+import { newTxContext, uvSuffix } from "../../services/worker/nuq-fdb/ops";
 
 // These tests exercise the FDB queue core directly against a real FoundationDB
 // cluster (no API server needed). They are skipped when FDB is not configured.
@@ -32,7 +33,10 @@ type Ctx = {
 
 // Each test gets its own queue keyspace so leaked jobs (some tests leave them
 // behind on purpose) can never bleed into other tests' takes.
-async function makeCtx(name: string): Promise<Ctx> {
+async function makeCtx(
+  name: string,
+  overrides: Partial<ConstructorParameters<typeof NuQFdbQueue>[1]> = {},
+): Promise<Ctx> {
   const scrapeName = `t-${RUN}-${name}`;
   const finishedName = `t-${RUN}-${name}-fin`;
   createdQueueNames.push(scrapeName, finishedName);
@@ -40,6 +44,7 @@ async function makeCtx(name: string): Promise<Ctx> {
     hasGroups: true,
     finishedQueueName: finishedName,
     leaseMs: TEST_LEASE_MS,
+    ...overrides,
   });
   const finishedQueue = new NuQFdbQueue(finishedName, { hasGroups: false });
   const group = new NuQFdbJobGroup(queue.ks, queue.groupOps!);
@@ -124,6 +129,198 @@ describeIf("NuQ FDB core", () => {
     expect(await queue.jobFail(id, job.lock!, "nope")).toBe(false);
   });
 
+  test("duplicate IDs are idempotent within and across enqueue calls", async () => {
+    const { queue, group } = await makeCtx("enqueue-idempotent");
+    const owner = freshOwner();
+    const gid = randomUUID();
+    const id = randomUUID();
+    await group.addGroup(gid, owner, undefined, { maxConcurrency: 1 });
+    const input = {
+      id,
+      data: scrapeData(),
+      options: { ownerId: owner, groupId: gid },
+    };
+    const strictGate = {
+      teamLimit: 1,
+      queueCap: 10,
+      key: { id: randomUUID(), limit: 1 },
+    };
+
+    const first = await queue.addJobs([input, input, input], strictGate);
+    expect(first).toHaveLength(3);
+    expect(first.every(job => job.id === id)).toBe(true);
+    await queue.addJob(
+      id,
+      scrapeData({ ignored: true }),
+      { ownerId: owner, groupId: gid },
+      strictGate,
+    );
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
+    expect((await queue.getGroupNumericStats(gid)).queued).toBe(1);
+
+    const taken = await takeAll(queue, 10);
+    expect(taken.map(job => job.id)).toEqual([id]);
+    await queue.jobFinish(id, taken[0].lock!, null);
+    expect(await queue.getWorkerLoadCount()).toBe(0);
+    expect(await queue.getTeamActiveCount(owner)).toBe(0);
+    expect((await group.getGroup(gid))?.status).toBe("completed");
+  });
+
+  test("dequeue recovers the original claim after simulated commit_unknown_result", async () => {
+    let inject = true;
+    const { queue } = await makeCtx("claim-unknown", {
+      testHooks: {
+        simulateClaimCommitUnknown: () => {
+          if (!inject) return false;
+          inject = false;
+          return true;
+        },
+      },
+    });
+    const id = randomUUID();
+    await queue.addJob(id, scrapeData(), { ownerId: freshOwner() }, UNLIMITED);
+
+    const job = await queue.getJobToProcess();
+    expect(job?.id).toBe(id);
+    expect(await queue.getJobToProcess()).toBeNull();
+    expect(await queue.jobFinish(id, job!.lock!, null)).toBe(true);
+  });
+
+  test("a failed >250-job stage stays invisible and resumes without duplicates", async () => {
+    let failAfterFirstBatch = true;
+    const { queue, finishedQueue, group, sweeper } = await makeCtx(
+      "bulk-resume",
+      {
+        testHooks: {
+          afterStageBatch: async batch => {
+            if (batch === 1 && failAfterFirstBatch) {
+              failAfterFirstBatch = false;
+              throw new Error("injected later stage failure");
+            }
+          },
+        },
+      },
+    );
+    const owner = freshOwner();
+    const gid = randomUUID();
+    await group.addGroup(gid, owner);
+    const inputs = Array.from({ length: 251 }, () => ({
+      id: randomUUID(),
+      data: scrapeData({ traceContext: "first-attempt" }),
+      options: { ownerId: owner, groupId: gid },
+    }));
+
+    await expect(queue.addJobs(inputs, UNLIMITED)).rejects.toThrow(
+      "injected later stage failure",
+    );
+    const early = await takeAll(queue, 251);
+    expect(early).toEqual([]);
+    expect((await group.getGroup(gid))?.status).toBe("active");
+    expect(await finishedQueue.getJobToProcess()).toBeNull();
+
+    const resumed = await queue.addJobs(
+      inputs.map(input => ({
+        ...input,
+        data: { ...input.data, traceContext: "regenerated-retry-trace" },
+        options: {
+          ...input.options,
+          timesOutAt: new Date(Date.now() + 60_000),
+        },
+      })),
+      gate(1),
+    );
+    expect(resumed).toHaveLength(251);
+    expect(resumed.every(job => job.status === "queued")).toBe(true);
+    const later = await takeAll(queue, 251);
+    const seen = new Set(later.map(job => job.id));
+    expect(seen.size).toBe(251);
+    await Promise.all(
+      later.map(job => queue.jobFinish(job.id, job.lock!, null)),
+    );
+    await sweeper.sweepOnce();
+    expect((await group.getGroup(gid))?.status).toBe("completed");
+    expect(await finishedQueue.getJobToProcess()).not.toBeNull();
+  }, 60_000);
+
+  test("a concurrent retry cannot recreate a manifest after publication", async () => {
+    let manifestCalls = 0;
+    let publishCalls = 0;
+    let signalPublished!: () => void;
+    let releasePublisher!: () => void;
+    const published = new Promise<void>(resolve => (signalPublished = resolve));
+    const holdPublisher = new Promise<void>(
+      resolve => (releasePublisher = resolve),
+    );
+    const { queue } = await makeCtx("manifest-publish-race", {
+      testHooks: {
+        afterManifest: async () => {
+          manifestCalls++;
+          if (manifestCalls === 2)
+            throw new Error("retry stopped after manifest");
+        },
+        afterPublishBatch: async () => {
+          publishCalls++;
+          if (publishCalls === 1) {
+            signalPublished();
+            await holdPublisher;
+          }
+        },
+      },
+    });
+    const owner = freshOwner();
+    const inputs = Array.from({ length: 251 }, () => ({
+      id: randomUUID(),
+      data: scrapeData(),
+      options: { ownerId: owner },
+    }));
+
+    const first = queue.addJobs(inputs, UNLIMITED);
+    await published;
+    await expect(queue.addJobs(inputs, UNLIMITED)).rejects.toThrow(
+      "retry stopped after manifest",
+    );
+    releasePublisher();
+    await expect(first).resolves.toHaveLength(251);
+  }, 30_000);
+
+  test("a later oversized job fails before any bulk enqueue reservation", async () => {
+    const { queue } = await makeCtx("bulk-preflight");
+    const owner = freshOwner();
+    const firstId = randomUUID();
+    const inputs = Array.from({ length: 250 }, (_, i) => ({
+      id: i === 0 ? firstId : randomUUID(),
+      data: scrapeData(),
+      options: { ownerId: owner },
+    }));
+    inputs.push({
+      id: randomUUID(),
+      data: scrapeData({ blob: "x".repeat(9 * 1024 * 1024) }),
+      options: { ownerId: owner },
+    });
+
+    await expect(queue.addJobs(inputs, UNLIMITED)).rejects.toThrow(
+      /too large to enqueue safely/,
+    );
+    expect(await queue.getJob(firstId)).toBeNull();
+    expect(await queue.getJobToProcess()).toBeNull();
+  });
+
+  test("a 2,000-job ingest stages and publishes in bounded transactions", async () => {
+    const { queue } = await makeCtx("bulk-publication-bounded");
+    const owner = freshOwner();
+    const ids = Array.from({ length: 2_000 }, () => randomUUID());
+    const jobs = await queue.addJobs(
+      ids.map(id => ({
+        id,
+        data: scrapeData(),
+        options: { ownerId: owner },
+      })),
+      UNLIMITED,
+    );
+    expect(jobs).toHaveLength(2_000);
+    expect(new Set(jobs.map(job => job.id)).size).toBe(2_000);
+  }, 60_000);
+
   test("team concurrency gate: limit 2 admits 2, backlogs the rest, promotes on finish", async () => {
     const { queue } = await makeCtx("teamgate");
     const owner = freshOwner();
@@ -184,15 +381,24 @@ describeIf("NuQ FDB core", () => {
     for (const j of rest) await queue.jobFinish(j.id, j.lock!, null);
     expect(await queue.getTeamActiveCount(owner)).toBe(0);
     expect(await queue.getTeamPendingCount(owner)).toBe(0);
+    expect((await queue.getTeamActiveCounts()).has(owner)).toBe(false);
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(await tn.get(queue.ks.teamActiveIndex(owner))).toBeFalsy();
+    });
   });
 
   test("metrics count pending teams even without active index entries", async () => {
     const { queue } = await makeCtx("pending-metrics");
     const owner = freshOwner();
 
-    await getNuqFdbDatabase().doTn(async tn => {
-      tn.set(queue.ks.teamPendingCount(owner), encodeI64(4));
-    });
+    await queue.addJobs(
+      Array.from({ length: 4 }, () => ({
+        id: randomUUID(),
+        data: scrapeData(),
+        options: { ownerId: owner },
+      })),
+      gate(0),
+    );
 
     const metrics = await queue.getMetrics();
     expect(metrics).toContain(
@@ -282,6 +488,28 @@ describeIf("NuQ FDB core", () => {
         gate(1, 2),
       ),
     ).rejects.toThrow(/queue limit reached/i);
+  });
+
+  test("a late queue-cap rejection releases partial ingest reservations", async () => {
+    const { queue } = await makeCtx("qfull-bulk-abort");
+    const owner = freshOwner();
+    const ids = Array.from({ length: 300 }, () => randomUUID());
+    await expect(
+      queue.addJobs(
+        ids.map(id => ({
+          id,
+          data: scrapeData(),
+          options: { ownerId: owner },
+        })),
+        gate(0, 250),
+      ),
+    ).rejects.toThrow(/queue limit reached/i);
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(decodeI64(await tn.get(queue.ks.teamIngestReserved(owner)))).toBe(
+        0,
+      );
+    });
+    expect(await queue.getJobs(ids)).toEqual([]);
   });
 
   test("group lifecycle: numeric stats, finish detection, crawl_finished emission", async () => {
@@ -458,6 +686,55 @@ describeIf("NuQ FDB core", () => {
     expect(await queue.jobFinish(id, job.lock!, null)).toBe(true);
   }, 30_000);
 
+  test("renewLock conflicts cleanly with a concurrent finish", async () => {
+    const { queue, sweeper } = await makeCtx("renew-finish-race");
+    for (let i = 0; i < 20; i++) {
+      const id = randomUUID();
+      await queue.addJob(
+        id,
+        scrapeData(),
+        { ownerId: freshOwner() },
+        UNLIMITED,
+      );
+      const job = await queue.getJobToProcess();
+      const [renewed, finished] = await Promise.all([
+        queue.renewLock(id, job!.lock!),
+        queue.jobFinish(id, job!.lock!, null),
+      ]);
+      expect(finished).toBe(true);
+      expect(typeof renewed).toBe("boolean");
+      await sweeper.sweepOnce();
+      expect((await queue.getJob(id))?.status).toBe("completed");
+    }
+  }, 30_000);
+
+  test("renewLock cannot resurrect a concurrently reaped lease", async () => {
+    const { queue, sweeper } = await makeCtx("renew-reap-race", {
+      leaseMs: 100,
+    });
+    const id = randomUUID();
+    await queue.addJob(id, scrapeData(), { ownerId: freshOwner() }, UNLIMITED);
+    const original = await queue.getJobToProcess();
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    const [renewed] = await Promise.all([
+      queue.renewLock(id, original!.lock!),
+      sweeper.sweepOnce(),
+    ]);
+    const after = await queue.getJob(id);
+    expect(["active", "queued"]).toContain(after?.status);
+    if (after?.status === "active") {
+      expect(renewed).toBe(true);
+      expect(await queue.jobFinish(id, original!.lock!, null)).toBe(true);
+    } else {
+      expect(renewed).toBe(false);
+      expect(await queue.jobFinish(id, original!.lock!, null)).toBe(false);
+      const retried = await queue.getJobToProcess();
+      expect(await queue.jobFinish(id, retried!.lock!, null)).toBe(true);
+    }
+    expect((await queue.getJob(id))?.status).toBe("completed");
+  });
+
   test("backlog timeout: pending jobs are silently dropped at their deadline", async () => {
     const { queue, sweeper } = await makeCtx("bto");
     const owner = freshOwner();
@@ -524,7 +801,7 @@ describeIf("NuQ FDB core", () => {
     await finishedQueue.jobFinish(fin!.id, fin!.lock!, null);
   });
 
-  test("group cancellation scans past stale group-index rows before clearing task", async () => {
+  test("group cancellation persists its cursor past 25k stale index rows", async () => {
     const { queue, group, sweeper } = await makeCtx("cancel-stale-index");
     const db = getNuqFdbDatabase();
     const owner = freshOwner();
@@ -533,7 +810,7 @@ describeIf("NuQ FDB core", () => {
     await group.addGroup(gid, owner);
 
     await db.doTn(async tn => {
-      for (let i = 0; i < 600; i++) {
+      for (let i = 0; i < 25_100; i++) {
         tn.set(
           queue.ks.groupJob(gid, `0000-stale-${String(i).padStart(4, "0")}`),
           encodeJson({ m: 1, s: "pending" }),
@@ -555,13 +832,18 @@ describeIf("NuQ FDB core", () => {
 
     expect(await group.cancelGroup(gid)).toBe(true);
     await sweeper.sweepOnce();
+    expect(await queue.getTeamPendingCount(owner)).toBe(1);
+    await getNuqFdbDatabase().doTn(async tn => {
+      expect(await tn.get(queue.ks.taskGroupCancel(gid))).toBeTruthy();
+    });
+    await sweeper.sweepOnce();
 
     expect(await queue.getJob(pendingId)).toBeNull();
     expect(await queue.getTeamPendingCount(owner)).toBe(0);
     await db.doTn(async tn => {
       expect(await tn.get(queue.ks.taskGroupCancel(gid))).toBeFalsy();
     });
-  });
+  }, 60_000);
 
   test("waitForJob resolves on completion and rejects on failure", async () => {
     const { queue } = await makeCtx("wait");
@@ -608,6 +890,35 @@ describeIf("NuQ FDB core", () => {
     expect(j?.returnvalue?.blob?.length).toBe(300 * 1024);
   });
 
+  test("self-host values and UTF-8 failure reasons stay within FDB bounds", async () => {
+    if (!expectInlineReturnvalue) return;
+    const { queue } = await makeCtx("value-bounds");
+    const owner = freshOwner();
+
+    const completedId = randomUUID();
+    await queue.addJob(
+      completedId,
+      scrapeData(),
+      { ownerId: owner },
+      UNLIMITED,
+    );
+    const completed = await queue.getJobToProcess();
+    expect(
+      await queue.jobFinish(completedId, completed!.lock!, {
+        blob: "x".repeat(9 * 1024 * 1024),
+      }),
+    ).toBe(true);
+    expect((await queue.getJob(completedId))?.returnvalue).toBeNull();
+
+    const failedId = randomUUID();
+    await queue.addJob(failedId, scrapeData(), { ownerId: owner }, UNLIMITED);
+    const failed = await queue.getJobToProcess();
+    await queue.jobFail(failedId, failed!.lock!, "🔥".repeat(100_000));
+    const reason = (await queue.getJob(failedId))?.failedReason ?? "";
+    expect(Buffer.byteLength(reason, "utf8")).toBeLessThanOrEqual(90 * 1024);
+    expect(reason.endsWith("�")).toBe(false);
+  }, 30_000);
+
   test("getCrawlJobsForListing paginates completed jobs in finish order", async () => {
     const { queue, group } = await makeCtx("listing");
     const owner = freshOwner();
@@ -637,6 +948,42 @@ describeIf("NuQ FDB core", () => {
     expect(page2.map(j => j.id)).toEqual(finishOrder.slice(3));
   });
 
+  test("crawl listing handles deep offsets in bounded transactions", async () => {
+    const { queue } = await makeCtx("listing-deep");
+    const db = getNuqFdbDatabase();
+    const owner = freshOwner();
+    const gid = randomUUID();
+    const ids = Array.from(
+      { length: 1205 },
+      (_, i) => `deep-${String(i).padStart(4, "0")}`,
+    );
+
+    for (let start = 0; start < ids.length; start += 100) {
+      await db.doTn(async tn => {
+        const txc = newTxContext();
+        for (const id of ids.slice(start, start + 100)) {
+          tn.set(
+            queue.ks.jobMeta(id),
+            encodeJson({ c: Date.now(), p: 0, o: owner, g: gid, f: 0, dc: 1 }),
+          );
+          tn.set(
+            queue.ks.jobStatus(id),
+            encodeJson({ s: "completed", st: 0, fa: Date.now() }),
+          );
+          tn.set(queue.ks.jobData(id, 0), encodeJson(scrapeData()));
+          tn.setVersionstampSuffixedKey(
+            queue.ks.groupDonePrefix(gid),
+            Buffer.from(id),
+            uvSuffix(txc),
+          );
+        }
+      });
+    }
+
+    const page = await queue.getCrawlJobsForListing(gid, 5, 1200);
+    expect(page.map(job => job.id)).toEqual(ids.slice(1200));
+  });
+
   test("getGroupAnyJob returns a single_urls member and checks ownership", async () => {
     const { queue, group } = await makeCtx("anyjob");
     const owner = freshOwner();
@@ -656,6 +1003,35 @@ describeIf("NuQ FDB core", () => {
 
     const [j] = await takeAll(queue, 1);
     await queue.jobFinish(j.id, j.lock!, null);
+  });
+
+  test("getGroupAnyJob scans beyond deep non-countable prefixes", async () => {
+    const { queue, group } = await makeCtx("anyjob-deep");
+    const owner = freshOwner();
+    const gid = randomUUID();
+    const id = "zzzz-countable-member";
+    await group.addGroup(gid, owner);
+    await getNuqFdbDatabase().doTn(async tn => {
+      for (let i = 0; i < 2100; i++) {
+        tn.set(
+          queue.ks.groupJob(
+            gid,
+            `0000-non-countable-${String(i).padStart(4, "0")}`,
+          ),
+          encodeJson({ m: 0, s: "completed" }),
+        );
+      }
+    });
+    await queue.addJob(
+      id,
+      scrapeData(),
+      { ownerId: owner, groupId: gid },
+      gate(10),
+    );
+
+    expect((await queue.getGroupAnyJob(gid, owner))?.id).toBe(id);
+    const job = await queue.getJobToProcess();
+    await queue.jobFinish(job!.id, job!.lock!, null);
   });
 
   // A completed crawl member must retain its input data so the crawl-finish job
@@ -730,6 +1106,29 @@ describeIf("NuQ FDB core", () => {
     await queue.jobFinish(j.id, j.lock!, null);
   });
 
+  test("removeJobs deduplicates and removes mixed ready/backlog jobs in bounded parallel batches", async () => {
+    const { queue, group, sweeper } = await makeCtx("remove-many");
+    const owner = freshOwner();
+    const gid = randomUUID();
+    const ids = Array.from({ length: 40 }, () => randomUUID());
+    await group.addGroup(gid, owner);
+    await queue.addJobs(
+      ids.map(id => ({
+        id,
+        data: scrapeData(),
+        options: { ownerId: owner, groupId: gid },
+      })),
+      gate(10),
+    );
+
+    await queue.removeJobs([...ids, ...ids.slice(0, 10)]);
+    await sweeper.sweepOnce();
+    expect(await queue.getTeamActiveCount(owner)).toBe(0);
+    expect(await queue.getTeamPendingCount(owner)).toBe(0);
+    expect(await queue.getJobToProcess()).toBeNull();
+    expect((await group.getGroup(gid))?.status).toBe("completed");
+  });
+
   test("limit raise promotes backlogged jobs via the sweeper", async () => {
     const { queue, sweeper } = await makeCtx("raise");
     const owner = freshOwner();
@@ -764,7 +1163,31 @@ describeIf("NuQ FDB core", () => {
     await queue.jobFinish(last.id, last.lock!, null);
   });
 
-  test("group TTL cleanup removes job records", async () => {
+  test("parallel releases converge exactly after a team limit is lowered", async () => {
+    const { queue } = await makeCtx("limit-lower");
+    const owner = freshOwner();
+    const ids = Array.from({ length: 20 }, () => randomUUID());
+    await queue.addJobs(
+      ids.map(id => ({
+        id,
+        data: scrapeData(),
+        options: { ownerId: owner },
+      })),
+      gate(10),
+    );
+    const active = await takeAll(queue, 10);
+    expect(active).toHaveLength(10);
+
+    await queue.addJob(randomUUID(), scrapeData(), { ownerId: owner }, gate(2));
+    await Promise.all(
+      active.map(job => queue.jobFinish(job.id, job.lock!, null)),
+    );
+    expect(await queue.getTeamActiveCount(owner)).toBe(2);
+    const promoted = await takeAll(queue, 10);
+    expect(promoted).toHaveLength(2);
+  });
+
+  test("group TTL cleanup resumes after more than 40k members", async () => {
     const { queue, group, sweeper } = await makeCtx("gttl");
     const owner = freshOwner();
     const gid = randomUUID();
@@ -781,10 +1204,22 @@ describeIf("NuQ FDB core", () => {
     await queue.jobFinish(j.id, j.lock!, null);
 
     expect((await group.getGroup(gid))?.status).toBe("completed");
+    for (let start = 0; start < 40_001; start += 5_000) {
+      await getNuqFdbDatabase().doTn(async tn => {
+        for (let i = start; i < Math.min(start + 5_000, 40_001); i++) {
+          tn.set(
+            queue.ks.groupJob(gid, `synthetic-${String(i).padStart(5, "0")}`),
+            encodeJson({ m: 0, s: "completed" }),
+          );
+        }
+      });
+    }
     await new Promise(resolve => setTimeout(resolve, 1100));
+    await sweeper.sweepOnce();
+    expect(await group.getGroup(gid)).not.toBeNull();
     await sweeper.sweepOnce();
 
     expect(await group.getGroup(gid)).toBeNull();
     expect(await queue.getJob(id)).toBeNull();
-  });
+  }, 60_000);
 });

--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -47,6 +47,8 @@ async function makeCtx(
     ...overrides,
   });
   const finishedQueue = new NuQFdbQueue(finishedName, { hasGroups: false });
+  await queue.backfillMetricCounts(100, true);
+  await finishedQueue.backfillMetricCounts(100, true);
   const group = new NuQFdbJobGroup(queue.ks, queue.groupOps!);
   const sweeper = new NuqFdbSweeper([queue, finishedQueue]);
   return { queue, finishedQueue, group, sweeper };

--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -9,7 +9,15 @@ import {
   getNuqFdbDatabase,
   getFdb,
 } from "../../services/worker/nuq-fdb/client";
-import { decodeI64, encodeJson } from "../../services/worker/nuq-fdb/keyspace";
+import {
+  decodeI64,
+  encodeI64,
+  encodeJson,
+  fnv1a,
+  METRIC_SHARDS,
+  METRIC_STATUSES,
+  NuqFdbMetricStatus,
+} from "../../services/worker/nuq-fdb/keyspace";
 import { newTxContext, uvSuffix } from "../../services/worker/nuq-fdb/ops";
 
 // These tests exercise the FDB queue core directly against a real FoundationDB
@@ -47,11 +55,22 @@ async function makeCtx(
     ...overrides,
   });
   const finishedQueue = new NuQFdbQueue(finishedName, { hasGroups: false });
-  await queue.backfillMetricCounts(100, true);
-  await finishedQueue.backfillMetricCounts(100, true);
+  await activateMetricGeneration(queue);
+  await activateMetricGeneration(finishedQueue);
   const group = new NuQFdbJobGroup(queue.ks, queue.groupOps!);
   const sweeper = new NuqFdbSweeper([queue, finishedQueue]);
   return { queue, finishedQueue, group, sweeper };
+}
+
+async function activateMetricGeneration(
+  queue: NuQFdbQueue,
+  batchSize = 100,
+): Promise<void> {
+  await queue.beginMetricCounterBackfill();
+  for (let page = 0; page < 10_000; page++) {
+    if (await queue.backfillMetricCounts(batchSize)) return;
+  }
+  throw new Error("metric generation did not become READY");
 }
 
 async function takeAll(
@@ -80,6 +99,55 @@ const gate = (limit: number, cap: number = 1_000_000) => ({
   teamLimit: limit,
   queueCap: cap,
 });
+
+async function readMetricInvariant(queue: NuQFdbQueue): Promise<{
+  generation: string;
+  ledger: Map<string, NuqFdbMetricStatus>;
+  counts: Record<NuqFdbMetricStatus, number>;
+}> {
+  const control = await queue.getMetricCounterBackfillStatus();
+  if (!control) throw new Error("metric control is absent");
+  return await getNuqFdbDatabase().doTn(async tn => {
+    const ledgerRange = queue.ks.metricLedgerRange(control.generation);
+    const rows = await tn
+      .snapshot()
+      .getRangeAll(ledgerRange.begin, ledgerRange.end);
+    const ledger = new Map<string, NuqFdbMetricStatus>();
+    for (const [key, value] of rows) {
+      ledger.set(
+        queue.ks.unpackId(key as Buffer),
+        (value as Buffer).toString("utf8") as NuqFdbMetricStatus,
+      );
+    }
+    const counts = Object.fromEntries(
+      await Promise.all(
+        METRIC_STATUSES.map(async status => [
+          status,
+          (
+            await Promise.all(
+              Array.from({ length: METRIC_SHARDS }, (_, shard) =>
+                tn
+                  .snapshot()
+                  .get(queue.ks.metricCount(control.generation, status, shard)),
+              ),
+            )
+          ).reduce((sum, value) => sum + decodeI64(value), 0),
+        ]),
+      ),
+    ) as Record<NuqFdbMetricStatus, number>;
+    return { generation: control.generation, ledger, counts };
+  });
+}
+
+function countsFromLedger(
+  ledger: Map<string, NuqFdbMetricStatus>,
+): Record<NuqFdbMetricStatus, number> {
+  const counts = Object.fromEntries(
+    METRIC_STATUSES.map(status => [status, 0]),
+  ) as Record<NuqFdbMetricStatus, number>;
+  for (const status of ledger.values()) counts[status]++;
+  return counts;
+}
 
 describeIf("NuQ FDB core", () => {
   afterAll(async () => {
@@ -449,8 +517,14 @@ describeIf("NuQ FDB core", () => {
     );
   });
 
-  test("metric backfill enrolls legacy jobs without negative transition debt", async () => {
+  test("fresh generation backfills legacy jobs and all terminal statuses", async () => {
     const { queue } = await makeCtx("metric-backfill");
+    const prior = await queue.getMetricCounterBackfillStatus();
+    expect(prior?.phase).toBe("ready");
+    expect(
+      await queue.invalidateMetricCounterGeneration(prior!.generation),
+    ).toBe(true);
+
     const owner = freshOwner();
     const ids = [randomUUID(), randomUUID(), randomUUID()];
     await queue.addJobs(
@@ -462,26 +536,17 @@ describeIf("NuQ FDB core", () => {
       gate(1),
     );
     const [active] = await takeAll(queue, 1);
-
-    await getNuqFdbDatabase().doTn(async tn => {
-      tn.clear(queue.ks.metricBackfillDone());
-      tn.clear(queue.ks.metricBackfillCursor());
-      for (const id of ids) tn.clear(queue.ks.jobMetricTracked(id));
-      for (const status of ["queued", "active", "pending"]) {
-        const range = queue.ks.metricStatusRange(status);
-        tn.clearRange(range.begin, range.end);
-      }
-    });
+    // A release-A transition while control is absent must remain valid legacy
+    // state and must not write into the invalidated generation.
+    await queue.jobFinish(active.id, active.lock!, null);
     await expect(queue.getMetrics()).rejects.toThrow(
       "NuQ FDB metrics are initializing",
     );
 
-    // This legacy transition happens before enrollment. It must not subtract
-    // from empty counters; the backfill observes the post-transition states.
-    await queue.jobFinish(active.id, active.lock!, null);
-
+    const building = await queue.beginMetricCounterBackfill();
+    expect(building.phase).toBe("backfill-jobs");
     let initialized = false;
-    for (let page = 0; page < 100 && !initialized; page++) {
+    for (let page = 0; page < 500 && !initialized; page++) {
       initialized = await queue.backfillMetricCounts(5);
     }
     expect(initialized).toBe(true);
@@ -490,11 +555,266 @@ describeIf("NuQ FDB core", () => {
       `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="queued"} 1`,
     );
     expect(metrics).toContain(
-      `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="active"} 0`,
+      `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="completed"} 1`,
     );
     expect(metrics).toContain(
       `nuq_fdb_queue_t_${RUN}_metric_backfill_job_count{status="backlog"} 1`,
     );
+  });
+
+  test("backfill pages raw legacy keys, survives cursor replay, and removes ledger orphans", async () => {
+    const { queue } = await makeCtx("metric-cursors");
+    const prior = await queue.getMetricCounterBackfillStatus();
+    await queue.invalidateMetricCounterGeneration(prior!.generation);
+
+    const owner = freshOwner();
+    const statuses = [
+      "pending",
+      "queued",
+      "active",
+      "completed",
+      "failed",
+    ] as const;
+    await getNuqFdbDatabase().doTn(async tn => {
+      for (const status of statuses) {
+        const id = `legacy-${status}`;
+        tn.set(
+          queue.ks.jobMeta(id),
+          encodeJson({ c: Date.now(), p: 0, o: owner, f: 0, dc: 120 }),
+        );
+        tn.set(queue.ks.jobStatus(id), encodeJson({ s: status, st: 0 }));
+        // Interleaved payload keys force many raw-key pages for one job.
+        for (let chunk = 0; chunk < 120; chunk++) {
+          tn.set(queue.ks.jobData(id, chunk), Buffer.from("x"));
+        }
+      }
+      tn.set(
+        queue.ks.jobMeta("legacy-cancelled"),
+        encodeJson({ c: Date.now(), p: 0, o: owner, f: 0, dc: 0 }),
+      );
+      tn.set(
+        queue.ks.jobStatus("legacy-cancelled"),
+        encodeJson({ s: "cancelled", st: 0 }),
+      );
+      tn.set(
+        queue.ks.jobMeta("legacy-ingesting"),
+        encodeJson({ c: Date.now(), p: 0, o: owner, f: 0, dc: 0 }),
+      );
+      tn.set(
+        queue.ks.jobStatus("legacy-ingesting"),
+        encodeJson({ s: "ingesting", st: 0 }),
+      );
+      tn.set(
+        queue.ks.jobStatus("status-only-tombstone"),
+        encodeJson({ s: "queued", st: 0 }),
+      );
+      tn.set(
+        queue.ks.jobMeta("meta-only-tombstone"),
+        encodeJson({ c: Date.now(), p: 0, o: owner, f: 0, dc: 0 }),
+      );
+    });
+
+    const building = await queue.beginMetricCounterBackfill();
+    expect(await queue.backfillMetricCounts(7)).toBe(false);
+    const cursor = await getNuqFdbDatabase().doTn(tn =>
+      tn.get(queue.ks.metricJobsCursor(building.generation)),
+    );
+    expect(cursor).toBeTruthy();
+
+    // Replay a committed page as if a process crashed before observing its
+    // result. Status-valued membership makes the repeat exactly idempotent.
+    await getNuqFdbDatabase().doTn(async tn => {
+      const range = queue.ks.jobRootRange();
+      tn.set(queue.ks.metricJobsCursor(building.generation), range.begin);
+      const orphan = "000-ledger-orphan";
+      tn.set(
+        queue.ks.metricLedger(building.generation, orphan),
+        Buffer.from("queued"),
+      );
+      tn.add(
+        queue.ks.metricCount(
+          building.generation,
+          "queued",
+          fnv1a(orphan) % METRIC_SHARDS,
+        ),
+        encodeI64(1),
+      );
+    });
+
+    // A protocol-aware insertion behind the durable cursor self-enrolls. A
+    // deletion during discovery atomically removes canonical state + ledger.
+    const newId = "000-new-behind-cursor";
+    await queue.addJob(newId, scrapeData(), { ownerId: owner }, UNLIMITED);
+    expect(await queue.removeJob("legacy-failed")).toBe(true);
+
+    await activateMetricGeneration(queue, 7);
+    const invariant = await readMetricInvariant(queue);
+    expect(invariant.ledger.get(newId)).toBe("queued");
+    expect(invariant.ledger.has("legacy-failed")).toBe(false);
+    expect(invariant.ledger.has("000-ledger-orphan")).toBe(false);
+    expect(invariant.ledger.has("legacy-cancelled")).toBe(false);
+    expect(invariant.ledger.has("legacy-ingesting")).toBe(false);
+    expect(invariant.ledger.has("status-only-tombstone")).toBe(false);
+    expect(invariant.counts).toEqual(countsFromLedger(invariant.ledger));
+    expect(invariant.counts).toEqual({
+      pending: 1,
+      queued: 2,
+      active: 1,
+      completed: 1,
+      failed: 0,
+    });
+  }, 60_000);
+
+  test("activation conflicts converge and rollback invalidation fences stale generations", async () => {
+    const { queue } = await makeCtx("metric-activation");
+    const ready = await queue.getMetricCounterBackfillStatus();
+    await queue.invalidateMetricCounterGeneration(ready!.generation);
+
+    const controls = await Promise.all(
+      Array.from({ length: 12 }, () => queue.beginMetricCounterBackfill()),
+    );
+    expect(new Set(controls.map(control => control.generation)).size).toBe(1);
+    const firstGeneration = controls[0].generation;
+    expect(
+      await queue.invalidateMetricCounterGeneration("wrong-generation"),
+    ).toBe(false);
+    expect((await queue.getMetricCounterBackfillStatus())?.generation).toBe(
+      firstGeneration,
+    );
+    expect(await queue.invalidateMetricCounterGeneration(firstGeneration)).toBe(
+      true,
+    );
+    await expect(queue.getMetrics()).rejects.toThrow(
+      "NuQ FDB metrics are initializing",
+    );
+
+    const next = await queue.beginMetricCounterBackfill();
+    expect(next.generation).not.toBe(firstGeneration);
+    await activateMetricGeneration(queue, 3);
+    expect((await queue.getMetricCounterBackfillStatus())?.phase).toBe("ready");
+  });
+
+  test("randomized lifecycle preserves canonical ledger and exact counters", async () => {
+    const { queue, sweeper } = await makeCtx("metric-randomized");
+    const owner = freshOwner();
+    const ids = Array.from(
+      { length: 40 },
+      (_, index) => `random-${String(index).padStart(3, "0")}`,
+    );
+    await queue.addJobs(
+      ids.map(id => ({
+        id,
+        data: scrapeData(),
+        options: { ownerId: owner },
+      })),
+      gate(13),
+    );
+    const active = await takeAll(queue, 13);
+    for (let index = 0; index < active.length; index++) {
+      if (index % 3 === 0) {
+        await queue.jobFinish(active[index].id, active[index].lock!, null);
+      } else if (index % 3 === 1) {
+        await queue.jobFail(active[index].id, active[index].lock!, "failed");
+      } else {
+        await queue.removeJob(active[index].id);
+      }
+    }
+    for (let index = 0; index < ids.length; index += 7) {
+      await queue.removeJob(ids[index]);
+    }
+    await sweeper.sweepOnce();
+
+    const invariant = await readMetricInvariant(queue);
+    expect(invariant.counts).toEqual(countsFromLedger(invariant.ledger));
+    for (const id of ids) {
+      const job = await queue.getJob(id);
+      const expected =
+        job?.status === "backlog"
+          ? "pending"
+          : job?.status === "queued" ||
+              job?.status === "active" ||
+              job?.status === "completed" ||
+              job?.status === "failed"
+            ? job.status
+            : undefined;
+      expect(invariant.ledger.get(id)).toBe(expected);
+    }
+  }, 30_000);
+
+  test("dequeue never waits for capped fire-and-forget claim cleanup", async () => {
+    let cleanupCalls = 0;
+    const never = new Promise<void>(() => {});
+    const { queue } = await makeCtx("claim-cleanup-cap", {
+      testHooks: {
+        runClaimCleanup: async () => {
+          cleanupCalls++;
+          await never;
+        },
+      },
+    });
+    const ids = Array.from({ length: 12 }, () => randomUUID());
+    await queue.addJobs(
+      ids.map(id => ({ id, data: scrapeData(), options: {} })),
+      UNLIMITED,
+    );
+
+    const startedAt = Date.now();
+    const jobs = await takeAll(queue, ids.length);
+    expect(jobs).toHaveLength(ids.length);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(cleanupCalls).toBe(8);
+    expect(queue.getClaimCleanupInFlightForTest()).toBe(8);
+    const claims = await getNuqFdbDatabase().doTn(async tn => {
+      const range = queue.ks.claimRange();
+      return await tn.snapshot().getRangeAll(range.begin, range.end);
+    });
+    expect(claims).toHaveLength(ids.length);
+  });
+
+  test("claim cleanup errors fall back to expiry GC without racing live markers", async () => {
+    const { queue, sweeper } = await makeCtx("claim-cleanup-gc", {
+      leaseMs: 80,
+      testHooks: {
+        runClaimCleanup: async () => {
+          throw new Error("cleanup unavailable");
+        },
+      },
+    });
+    await queue.addJob(randomUUID(), scrapeData(), {}, UNLIMITED);
+    const job = await queue.getJobToProcess();
+    expect(job).not.toBeNull();
+
+    const futureOp = randomUUID();
+    const futureExpiry = Date.now() + 200;
+    await getNuqFdbDatabase().doTn(async tn => {
+      tn.set(
+        queue.ks.claim(futureOp),
+        encodeJson({ i: "future", l: "lock", e: futureExpiry }),
+      );
+      tn.set(queue.ks.claimExpiry(Date.now() - 1, futureOp), Buffer.alloc(0));
+      tn.set(queue.ks.claimExpiry(futureExpiry, futureOp), Buffer.alloc(0));
+    });
+    await sweeper.sweepOnce();
+    expect(
+      await getNuqFdbDatabase().doTn(tn => tn.get(queue.ks.claim(futureOp))),
+    ).toBeTruthy();
+
+    await new Promise(resolve => setTimeout(resolve, 250));
+    await sweeper.sweepOnce();
+    const remaining = await getNuqFdbDatabase().doTn(async tn => {
+      const claimRange = queue.ks.claimRange();
+      const expiryRange = queue.ks.claimExpiryRange();
+      return {
+        claims: await tn
+          .snapshot()
+          .getRangeAll(claimRange.begin, claimRange.end),
+        expiries: await tn
+          .snapshot()
+          .getRangeAll(expiryRange.begin, expiryRange.end),
+      };
+    });
+    expect(remaining.claims).toEqual([]);
+    expect(remaining.expiries).toEqual([]);
   });
 
   test("promotion respects priority order", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/ready-shards.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/ready-shards.test.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "crypto";
+
+vi.mock("../../config", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../config")>();
+  return {
+    ...actual,
+    config: { ...actual.config, NUQ_FDB_READY_SHARDS: 2 },
+  };
+});
+
+import { config } from "../../config";
+import { NuQFdbQueue } from "../../services/worker/nuq-fdb";
+import {
+  getFdb,
+  getNuqFdbDatabase,
+} from "../../services/worker/nuq-fdb/client";
+
+const describeIf = config.FDB_CLUSTER_FILE ? describe : describe.skip;
+
+describeIf("NuQ FDB small ready-shard configurations", () => {
+  test("READY_SHARDS < 4 never spins while probing an empty queue", async () => {
+    const name = `t-small-shards-${randomUUID()}`;
+    const queue = new NuQFdbQueue(name, { hasGroups: false });
+    const id = randomUUID();
+    await queue.addJob(
+      id,
+      { hello: "world" },
+      { ownerId: randomUUID() },
+      { teamLimit: null, queueCap: 100 },
+    );
+
+    const job = await queue.getJobToProcess();
+    expect(job?.id).toBe(id);
+    await queue.jobFinish(id, job!.lock!, null);
+    await expect(queue.getJobToProcess()).resolves.toBeNull();
+
+    const range = getFdb().tuple.range(["nuq", name]);
+    await getNuqFdbDatabase().doTn(async tn =>
+      tn.clearRange(range.begin as Buffer, range.end as Buffer),
+    );
+  });
+});

--- a/apps/api/src/__tests__/nuq-fdb/stress.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/stress.test.ts
@@ -88,6 +88,51 @@ describeIf("NuQ FDB concurrency stress", () => {
     expect(await queue.getTeamPendingCount(owner)).toBe(0);
   }, 120_000);
 
+  test(">=256 concurrent producers obey strict admission and the queue-cap boundary", async () => {
+    const strictName = `t-${RUN}-strict-256`;
+    queueNames.push(strictName);
+    const strictQueue: NuQFdbQueue = new NuQFdbQueue(strictName, {
+      hasGroups: true,
+    });
+    const owner = randomUUID();
+    const inputs = Array.from({ length: 256 }, () => ({
+      id: randomUUID(),
+      data: { mode: "single_urls", url: "https://example.com" },
+      options: { ownerId: owner },
+    }));
+    await Promise.all(
+      inputs.map(input =>
+        strictQueue.addJob(input.id, input.data, input.options, {
+          teamLimit: 256,
+          queueCap: 1_000_000,
+        }),
+      ),
+    );
+    expect(await strictQueue.getTeamActiveCount(owner)).toBe(256);
+    expect(await strictQueue.getTeamPendingCount(owner)).toBe(0);
+
+    const capName = `t-${RUN}-cap-256`;
+    queueNames.push(capName);
+    const capQueue: NuQFdbQueue = new NuQFdbQueue(capName, {
+      hasGroups: true,
+    });
+    const capOwner = randomUUID();
+    const attempts = await Promise.allSettled(
+      Array.from({ length: 256 }, () =>
+        capQueue.addJob(
+          randomUUID(),
+          { mode: "single_urls", url: "https://example.com" },
+          { ownerId: capOwner },
+          { teamLimit: 0, queueCap: 100 },
+        ),
+      ),
+    );
+    expect(
+      attempts.filter(result => result.status === "fulfilled"),
+    ).toHaveLength(100);
+    expect(await capQueue.getTeamPendingCount(capOwner)).toBe(100);
+  }, 180_000);
+
   test("parallel enqueuers + workers with a crawl gate stay within both limits", async () => {
     const name = `t-${RUN}-stress2`;
     queueNames.push(name);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -142,6 +142,9 @@ const configSchema = z.object({
   NUQ_FDB_TIME_BUCKETS: emptyStringAsDefault(
     z.coerce.number().int().positive().default(16),
   ),
+  // Two-phase rollout gate. Enable only after every FDB queue writer is on a
+  // version that understands maintained metric membership.
+  NUQ_FDB_METRICS_V2_ACTIVATE: z.stringbool().default(false),
 
   // Google Cloud Storage
   GCS_BUCKET_NAME: z.string().optional(),

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -24,6 +24,7 @@ import {
   setStatusQueued,
   setGroupJobIndex,
   bumpGroupStatusCount,
+  bumpQueueStatus,
 } from "./ops";
 
 export type NuQFdbGroupStatus = "active" | "completed" | "cancelled";
@@ -100,6 +101,11 @@ export class NuqFdbGroupOps {
     now: number,
     txc: TxContext,
   ): Promise<boolean> {
+    // A multi-transaction enqueue holds this barrier from reservation through
+    // its final publish, so an empty prefix of the batch cannot finish the
+    // group while later chunks are still invisible.
+    const ingests = decodeI64(await tn.get(this.ks.groupIngestCount(gid)));
+    if (ingests > 0) return false;
     const gMeta = decodeJson<GroupMeta>(await tn.get(this.ks.groupMeta(gid)));
     if (!gMeta || gMeta.s === "completed") {
       tn.clear(this.ks.taskGroupFinish(gid));
@@ -127,6 +133,7 @@ export class NuqFdbGroupOps {
       };
       pushReady(tn, this.finishedKs, entry, txc);
       setStatusQueued(tn, this.finishedKs, fid);
+      bumpQueueStatus(tn, this.finishedKs, fid, "queued", 1);
       // pointer for group TTL cleanup to find the finished job's records
       tn.set(this.ks.groupFinishedJob(gid), Buffer.from(fid, "utf8"));
     }

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -122,6 +122,7 @@ export class NuqFdbGroupOps {
       const fid = randomUUID();
       const meta: JobMeta = { c: now, p: 0, o: gMeta.o, g: gid, f: 0, dc: 1 };
       tn.set(this.finishedKs.jobMeta(fid), encodeJson(meta));
+      tn.set(this.finishedKs.jobMetricTracked(fid), EMPTY);
       tn.set(this.finishedKs.jobData(fid, 0), encodeJson({}));
       const entry: QueueEntry = {
         i: fid,
@@ -133,7 +134,7 @@ export class NuqFdbGroupOps {
       };
       pushReady(tn, this.finishedKs, entry, txc);
       setStatusQueued(tn, this.finishedKs, fid);
-      bumpQueueStatus(tn, this.finishedKs, fid, "queued", 1);
+      await bumpQueueStatus(tn, this.finishedKs, fid, "queued", 1);
       // pointer for group TTL cleanup to find the finished job's records
       tn.set(this.ks.groupFinishedJob(gid), Buffer.from(fid, "utf8"));
     }

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -24,7 +24,7 @@ import {
   setStatusQueued,
   setGroupJobIndex,
   bumpGroupStatusCount,
-  bumpQueueStatus,
+  enrollQueueStatus,
 } from "./ops";
 
 export type NuQFdbGroupStatus = "active" | "completed" | "cancelled";
@@ -122,7 +122,6 @@ export class NuqFdbGroupOps {
       const fid = randomUUID();
       const meta: JobMeta = { c: now, p: 0, o: gMeta.o, g: gid, f: 0, dc: 1 };
       tn.set(this.finishedKs.jobMeta(fid), encodeJson(meta));
-      tn.set(this.finishedKs.jobMetricTracked(fid), EMPTY);
       tn.set(this.finishedKs.jobData(fid, 0), encodeJson({}));
       const entry: QueueEntry = {
         i: fid,
@@ -134,7 +133,7 @@ export class NuqFdbGroupOps {
       };
       pushReady(tn, this.finishedKs, entry, txc);
       setStatusQueued(tn, this.finishedKs, fid);
-      await bumpQueueStatus(tn, this.finishedKs, fid, "queued", 1);
+      await enrollQueueStatus(tn, this.finishedKs, fid, "queued");
       // pointer for group TTL cleanup to find the finished job's records
       tn.set(this.ks.groupFinishedJob(gid), Buffer.from(fid, "utf8"));
     }

--- a/apps/api/src/services/worker/nuq-fdb/groups.ts
+++ b/apps/api/src/services/worker/nuq-fdb/groups.ts
@@ -24,7 +24,7 @@ import {
   setStatusQueued,
   setGroupJobIndex,
   bumpGroupStatusCount,
-  enrollQueueStatus,
+  alignQueueMetricStatus,
 } from "./ops";
 
 export type NuQFdbGroupStatus = "active" | "completed" | "cancelled";
@@ -133,7 +133,7 @@ export class NuqFdbGroupOps {
       };
       pushReady(tn, this.finishedKs, entry, txc);
       setStatusQueued(tn, this.finishedKs, fid);
-      await enrollQueueStatus(tn, this.finishedKs, fid, "queued");
+      await alignQueueMetricStatus(tn, this.finishedKs, fid);
       // pointer for group TTL cleanup to find the finished job's records
       tn.set(this.ks.groupFinishedJob(gid), Buffer.from(fid, "utf8"));
     }

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -68,13 +68,11 @@ firecrawl_nuq_fdb_pending_jobs ${workerLoad}
 ${scrapeQueueMetrics}${crawlFinishedQueueMetrics}${workerLoadFamily(workerLoad)}`;
   } catch (error) {
     if (error instanceof NuqFdbMetricsInitializingError) {
-      // Release A must preserve the established autoscaling family while the
-      // fixed generation is absent/building. Do not expose partial new
-      // families; the legacy fixed-shard/lease fallback is removed only at
-      // READY.
-      const workerLoad = await scrapeQueueFdb.getLegacyWorkerLoadCount();
+      // Release A exposes only readiness. Existing HPA metrics remain absent
+      // until the fixed-width generation is exact and READY; rollout holds the
+      // current replica floor and freezes new migration cutovers meanwhile.
       return `${readiness}firecrawl_nuq_fdb_metrics_ready 0
-${workerLoadFamily(workerLoad)}`;
+`;
     }
     throw error;
   }

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -51,6 +51,11 @@ export async function nuqFdbGetMetrics(): Promise<string> {
   const readiness = `# HELP firecrawl_nuq_fdb_metrics_ready Whether maintained FDB queue metrics are fully initialized
 # TYPE firecrawl_nuq_fdb_metrics_ready gauge
 `;
+  const workerLoadFamily = (workerLoad: number) =>
+    `# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+# TYPE firecrawl_nuq_fdb_pending_jobs gauge
+firecrawl_nuq_fdb_pending_jobs ${workerLoad}
+`;
   try {
     const [scrapeQueueMetrics, crawlFinishedQueueMetrics, workerLoad] =
       await Promise.all([
@@ -60,14 +65,16 @@ export async function nuqFdbGetMetrics(): Promise<string> {
       ]);
 
     return `${readiness}firecrawl_nuq_fdb_metrics_ready 1
-${scrapeQueueMetrics}${crawlFinishedQueueMetrics}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
-# TYPE firecrawl_nuq_fdb_pending_jobs gauge
-firecrawl_nuq_fdb_pending_jobs ${workerLoad}
-`;
+${scrapeQueueMetrics}${crawlFinishedQueueMetrics}${workerLoadFamily(workerLoad)}`;
   } catch (error) {
     if (error instanceof NuqFdbMetricsInitializingError) {
+      // Release A must preserve the established autoscaling family while the
+      // fixed generation is absent/building. Do not expose partial new
+      // families; the legacy fixed-shard/lease fallback is removed only at
+      // READY.
+      const workerLoad = await scrapeQueueFdb.getLegacyWorkerLoadCount();
       return `${readiness}firecrawl_nuq_fdb_metrics_ready 0
-`;
+${workerLoadFamily(workerLoad)}`;
     }
     throw error;
   }

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -1,11 +1,21 @@
 import type { ScrapeJobData } from "../../../types";
-import { NuQFdbQueue, QueueFullError, normalizeOwnerId } from "./queue";
+import {
+  NuQFdbQueue,
+  QueueFullError,
+  normalizeOwnerId,
+  NuqFdbMetricsInitializingError,
+} from "./queue";
 import { NuQFdbJobGroup } from "./groups";
 import { NuqFdbSweeper } from "./sweeper";
 import { NuqFdbExternalSlots } from "./slots";
 import { isFdbConfigured, nuqFdbHealthCheck, withFdbTimeout } from "./client";
 
-export { NuQFdbQueue, QueueFullError, normalizeOwnerId } from "./queue";
+export {
+  NuQFdbQueue,
+  QueueFullError,
+  normalizeOwnerId,
+  NuqFdbMetricsInitializingError,
+} from "./queue";
 export type {
   NuQFdbJob,
   NuQFdbJobOptions,
@@ -38,17 +48,29 @@ export const crawlGroupFdb = new NuQFdbJobGroup(
 export const externalSlotsFdb = new NuqFdbExternalSlots(scrapeQueueFdb.ks);
 
 export async function nuqFdbGetMetrics(): Promise<string> {
-  const [scrapeQueueMetrics, crawlFinishedQueueMetrics, workerLoad] =
-    await Promise.all([
-      scrapeQueueFdb.getMetrics(),
-      crawlFinishedQueueFdb.getMetrics(),
-      scrapeQueueFdb.getWorkerLoadCount(),
-    ]);
+  const readiness = `# HELP firecrawl_nuq_fdb_metrics_ready Whether maintained FDB queue metrics are fully initialized
+# TYPE firecrawl_nuq_fdb_metrics_ready gauge
+`;
+  try {
+    const [scrapeQueueMetrics, crawlFinishedQueueMetrics, workerLoad] =
+      await Promise.all([
+        scrapeQueueFdb.getMetrics(),
+        crawlFinishedQueueFdb.getMetrics(),
+        scrapeQueueFdb.getWorkerLoadCount(),
+      ]);
 
-  return `${scrapeQueueMetrics}${crawlFinishedQueueMetrics}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+    return `${readiness}firecrawl_nuq_fdb_metrics_ready 1
+${scrapeQueueMetrics}${crawlFinishedQueueMetrics}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
 # TYPE firecrawl_nuq_fdb_pending_jobs gauge
 firecrawl_nuq_fdb_pending_jobs ${workerLoad}
 `;
+  } catch (error) {
+    if (error instanceof NuqFdbMetricsInitializingError) {
+      return `${readiness}firecrawl_nuq_fdb_metrics_ready 0
+`;
+    }
+    throw error;
+  }
 }
 
 let sweeper: NuqFdbSweeper | null = null;

--- a/apps/api/src/services/worker/nuq-fdb/index.ts
+++ b/apps/api/src/services/worker/nuq-fdb/index.ts
@@ -38,13 +38,14 @@ export const crawlGroupFdb = new NuQFdbJobGroup(
 export const externalSlotsFdb = new NuqFdbExternalSlots(scrapeQueueFdb.ks);
 
 export async function nuqFdbGetMetrics(): Promise<string> {
-  const [queueMetrics, workerLoad] = await Promise.all([
-    scrapeQueueFdb.getMetrics(),
-    scrapeQueueFdb.getWorkerLoadCount(),
-  ]);
+  const [scrapeQueueMetrics, crawlFinishedQueueMetrics, workerLoad] =
+    await Promise.all([
+      scrapeQueueFdb.getMetrics(),
+      crawlFinishedQueueFdb.getMetrics(),
+      scrapeQueueFdb.getWorkerLoadCount(),
+    ]);
 
-  return `${queueMetrics}
-# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+  return `${scrapeQueueMetrics}${crawlFinishedQueueMetrics}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
 # TYPE firecrawl_nuq_fdb_pending_jobs gauge
 firecrawl_nuq_fdb_pending_jobs ${workerLoad}
 `;

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -9,8 +9,10 @@ export { normalizeOwnerId } from "../../../lib/owner-id";
 export const READY_SHARDS = config.NUQ_FDB_READY_SHARDS;
 export const TEAM_PENDING_SHARDS = config.NUQ_FDB_TEAM_PENDING_SHARDS;
 export const TIME_BUCKETS = config.NUQ_FDB_TIME_BUCKETS;
+export const METRIC_SHARDS = 32;
 
 export type NuqFdbJobStatus =
+  | "ingesting" // reserved by a resumable multi-transaction enqueue
   | "pending" // waiting for a concurrency slot (externally: "backlog")
   | "queued" // holds its slots, in a ready shard
   | "active"
@@ -53,6 +55,23 @@ export type JobStatusRecord = {
   st: number; // stall count
   fa?: number; // finishedAt ms
   loc?: PendingLoc;
+  op?: string; // ingest operation while s === "ingesting"
+};
+
+export type IngestMeta = {
+  o: string; // normalized owner id (or empty for ungated/self-hosted)
+  c: number; // creation time
+  x: number; // abandoned-ingest cleanup time
+  r: number; // team queue-cap reservations not yet published
+  l: number | null; // frozen team limit
+  q: number; // frozen team queue cap
+  k?: { id: string; limit: number } | null; // frozen API-key gate
+};
+
+export type ClaimRecord = {
+  i: string;
+  l: string;
+  e: number;
 };
 
 // Entry stored in ready shards, pending queues and the delay index.
@@ -168,6 +187,44 @@ export class NuqFdbKeyspace {
     return this.packRange(["j", id]);
   }
 
+  // === Resumable enqueue / commit-unknown claim records
+  ingest(op: string): Buffer {
+    return this.pack(["ing", op, "meta"]);
+  }
+  ingestJob(op: string, id: string): Buffer {
+    return this.pack(["ing", op, "jobs", id]);
+  }
+  ingestJobRange(op: string) {
+    return this.packRange(["ing", op, "jobs"]);
+  }
+  ingestGroup(op: string, gid: string): Buffer {
+    return this.pack(["ing", op, "groups", gid]);
+  }
+  ingestGroupRange(op: string) {
+    return this.packRange(["ing", op, "groups"]);
+  }
+  ingestExpiry(atMs: number, op: string): Buffer {
+    return this.pack(["ingexp", atMs, op]);
+  }
+  ingestExpiryScanRange(untilMs: number) {
+    return {
+      begin: this.pack(["ingexp"]),
+      end: this.pack(["ingexp", untilMs]),
+    };
+  }
+  claim(op: string): Buffer {
+    return this.pack(["claim", op]);
+  }
+  claimExpiry(atMs: number, op: string): Buffer {
+    return this.pack(["claimexp", atMs, op]);
+  }
+  claimExpiryScanRange(untilMs: number) {
+    return {
+      begin: this.pack(["claimexp"]),
+      end: this.pack(["claimexp", untilMs]),
+    };
+  }
+
   // === Team gate
   teamLimit(tid: string): Buffer {
     return this.pack(["t", tid, "limit"]);
@@ -186,6 +243,9 @@ export class NuqFdbKeyspace {
   }
   teamPendingCount(tid: string): Buffer {
     return this.pack(["t", tid, "pend"]);
+  }
+  teamIngestReserved(tid: string): Buffer {
+    return this.pack(["t", tid, "ing"]);
   }
   teamShardCount(tid: string, shard: number): Buffer {
     return this.pack(["t", tid, "qn", shard]);
@@ -237,6 +297,9 @@ export class NuqFdbKeyspace {
   }
   groupCrawlActive(gid: string): Buffer {
     return this.pack(["g", gid, "cact"]);
+  }
+  groupIngestCount(gid: string): Buffer {
+    return this.pack(["g", gid, "ing"]);
   }
   groupStatusCount(gid: string, status: string): Buffer {
     return this.pack(["g", gid, "n", status]);
@@ -295,6 +358,14 @@ export class NuqFdbKeyspace {
   }
   readyShardCountRange() {
     return this.packRange(["rn"]);
+  }
+
+  // === Maintained queue metrics
+  metricCount(status: string, shard: number): Buffer {
+    return this.pack(["mn", status, shard]);
+  }
+  metricStatusRange(status: string) {
+    return this.packRange(["mn", status]);
   }
 
   // === Time-ordered indexes (sweeper-owned)

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -162,8 +162,14 @@ export class NuqFdbKeyspace {
   }
 
   // === Job records
+  jobRootRange() {
+    return this.packRange(["j"]);
+  }
   jobMeta(id: string): Buffer {
     return this.pack(["j", id, "m"]);
+  }
+  jobMetricTracked(id: string): Buffer {
+    return this.pack(["j", id, "mt"]);
   }
   jobStatus(id: string): Buffer {
     return this.pack(["j", id, "s"]);
@@ -366,6 +372,12 @@ export class NuqFdbKeyspace {
   }
   metricStatusRange(status: string) {
     return this.packRange(["mn", status]);
+  }
+  metricBackfillCursor(): Buffer {
+    return this.pack(["mn-backfill", "cursor"]);
+  }
+  metricBackfillDone(): Buffer {
+    return this.pack(["mn-backfill", "done"]);
   }
 
   // === Time-ordered indexes (sweeper-owned)

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -10,6 +10,21 @@ export const READY_SHARDS = config.NUQ_FDB_READY_SHARDS;
 export const TEAM_PENDING_SHARDS = config.NUQ_FDB_TEAM_PENDING_SHARDS;
 export const TIME_BUCKETS = config.NUQ_FDB_TIME_BUCKETS;
 export const METRIC_SHARDS = 32;
+export const METRIC_STATUSES = [
+  "pending",
+  "queued",
+  "active",
+  "completed",
+  "failed",
+] as const;
+export type NuqFdbMetricStatus = (typeof METRIC_STATUSES)[number];
+export type NuqFdbMetricPhase = "backfill-jobs" | "backfill-ledger" | "ready";
+export type NuqFdbMetricControl = {
+  format: 3;
+  generation: string;
+  phase: NuqFdbMetricPhase;
+  shards: 32;
+};
 
 export type NuqFdbJobStatus =
   | "ingesting" // reserved by a resumable multi-transaction enqueue
@@ -168,9 +183,6 @@ export class NuqFdbKeyspace {
   jobMeta(id: string): Buffer {
     return this.pack(["j", id, "m"]);
   }
-  jobMetricTracked(id: string): Buffer {
-    return this.pack(["j", id, "mt"]);
-  }
   jobStatus(id: string): Buffer {
     return this.pack(["j", id, "s"]);
   }
@@ -221,8 +233,14 @@ export class NuqFdbKeyspace {
   claim(op: string): Buffer {
     return this.pack(["claim", op]);
   }
+  claimRange() {
+    return this.packRange(["claim"]);
+  }
   claimExpiry(atMs: number, op: string): Buffer {
     return this.pack(["claimexp", atMs, op]);
+  }
+  claimExpiryRange() {
+    return this.packRange(["claimexp"]);
   }
   claimExpiryScanRange(untilMs: number) {
     return {
@@ -366,21 +384,31 @@ export class NuqFdbKeyspace {
     return this.packRange(["rn"]);
   }
 
-  // === Maintained queue metrics
-  metricCount(status: string, shard: number): Buffer {
-    return this.pack(["mn", status, shard]);
+  // === Generation-scoped maintained queue metrics
+  // Writers always normal-read the stable control key, including while it is
+  // absent. Generation data is immutable after invalidation and therefore can
+  // never leak into a later activation.
+  metricControl(): Buffer {
+    return this.pack(["metrics", "v3", "ctl"]);
   }
-  metricStatusRange(status: string) {
-    return this.packRange(["mn", status]);
+  metricCount(
+    generation: string,
+    status: NuqFdbMetricStatus,
+    shard: number,
+  ): Buffer {
+    return this.pack(["metrics", "v3", "gen", generation, "n", status, shard]);
   }
-  metricBackfillActive(): Buffer {
-    return this.pack(["mn-backfill", "active-v2"]);
+  metricLedger(generation: string, id: string): Buffer {
+    return this.pack(["metrics", "v3", "gen", generation, "status", id]);
   }
-  metricBackfillCursor(): Buffer {
-    return this.pack(["mn-backfill", "cursor"]);
+  metricLedgerRange(generation: string) {
+    return this.packRange(["metrics", "v3", "gen", generation, "status"]);
   }
-  metricBackfillDone(): Buffer {
-    return this.pack(["mn-backfill", "done"]);
+  metricJobsCursor(generation: string): Buffer {
+    return this.pack(["metrics", "v3", "gen", generation, "cursor", "jobs"]);
+  }
+  metricLedgerCursor(generation: string): Buffer {
+    return this.pack(["metrics", "v3", "gen", generation, "cursor", "ledger"]);
   }
 
   // === Time-ordered indexes (sweeper-owned)

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -373,6 +373,9 @@ export class NuqFdbKeyspace {
   metricStatusRange(status: string) {
     return this.packRange(["mn", status]);
   }
+  metricBackfillActive(): Buffer {
+    return this.pack(["mn-backfill", "active-v2"]);
+  }
   metricBackfillCursor(): Buffer {
     return this.pack(["mn-backfill", "cursor"]);
   }

--- a/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
@@ -101,7 +101,10 @@ describe("NuQ FDB metrics", () => {
     await expect(queue.getMetrics()).rejects.toThrow(
       "NuQ FDB metrics are initializing",
     );
-    expect(get).toHaveBeenCalledTimes(1);
+    await expect(queue.getWorkerLoadCount()).rejects.toThrow(
+      "NuQ FDB metrics are initializing",
+    );
+    expect(get).toHaveBeenCalledTimes(2);
   });
 
   test("negative fixed counters surface corruption instead of being clamped", async () => {
@@ -137,20 +140,20 @@ describe("NuQ FDB metrics", () => {
     );
   });
 
-  test("release A preserves only legacy worker load while fixed counters build", async () => {
+  test("release A exposes only readiness while fixed counters build", async () => {
     vi.spyOn(scrapeQueueFdb, "getMetrics").mockRejectedValue(
       new NuqFdbMetricsInitializingError("initializing"),
     );
     vi.spyOn(crawlFinishedQueueFdb, "getMetrics").mockResolvedValue(
       CRAWL_FINISHED_METRICS,
     );
-    vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockResolvedValue(5);
-    vi.spyOn(scrapeQueueFdb, "getLegacyWorkerLoadCount").mockResolvedValue(5);
+    vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockRejectedValue(
+      new NuqFdbMetricsInitializingError("initializing"),
+    );
 
     const output = await nuqFdbGetMetrics();
-    expect(output).toBe(
-      `${READINESS}firecrawl_nuq_fdb_metrics_ready 0\n${WORKER_LOAD}`,
-    );
+    expect(output).toBe(`${READINESS}firecrawl_nuq_fdb_metrics_ready 0\n`);
+    expect(output).not.toContain("firecrawl_nuq_fdb_pending_jobs");
     expect(output).not.toContain("nuq_fdb_queue_scrape_job_count");
     expect(output).not.toContain("nuq_fdb_queue_crawl_finished_job_count");
   });

--- a/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
@@ -29,8 +29,12 @@ describe("NuQ FDB metrics", () => {
   test("queue output has an exact fixed-width read footprint", async () => {
     const queue = new NuQFdbQueue("scrape", { hasGroups: false });
     let queueCardinality = 1;
+    let initialized = true;
     const get = vi.fn(async (key: Buffer) => {
       const [, , family, status, shard] = queue.ks.unpack(key);
+      if (family === "mn-backfill" && status === "done") {
+        return initialized ? Buffer.alloc(0) : undefined;
+      }
       if (family !== "mn" || shard !== 0) return undefined;
       if (status === "queued") return encodeI64(2);
       if (status === "active") return encodeI64(3);
@@ -53,7 +57,7 @@ describe("NuQ FDB metrics", () => {
     });
 
     expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 1);
     expect(getRangeAll).not.toHaveBeenCalled();
 
     get.mockClear();
@@ -61,7 +65,15 @@ describe("NuQ FDB metrics", () => {
     queueCardinality = 1_000_000;
 
     expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 1);
+    expect(getRangeAll).not.toHaveBeenCalled();
+
+    get.mockClear();
+    initialized = false;
+    await expect(queue.getMetrics()).rejects.toThrow(
+      "NuQ FDB metrics are initializing",
+    );
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 1);
     expect(getRangeAll).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { encodeI64, METRIC_SHARDS } from "./keyspace";
 import { crawlFinishedQueueFdb, nuqFdbGetMetrics, scrapeQueueFdb } from ".";
-import { NuQFdbQueue } from "./queue";
+import { NuQFdbQueue, NuqFdbMetricsInitializingError } from "./queue";
+
+const READINESS = `# HELP firecrawl_nuq_fdb_metrics_ready Whether maintained FDB queue metrics are fully initialized
+# TYPE firecrawl_nuq_fdb_metrics_ready gauge
+`;
 
 const SCRAPE_METRICS = `# HELP nuq_fdb_queue_scrape_job_count Number of FDB jobs in each status
 # TYPE nuq_fdb_queue_scrape_job_count gauge
@@ -32,8 +36,11 @@ describe("NuQ FDB metrics", () => {
     let initialized = true;
     const get = vi.fn(async (key: Buffer) => {
       const [, , family, status, shard] = queue.ks.unpack(key);
-      if (family === "mn-backfill" && status === "done") {
-        return initialized ? Buffer.alloc(0) : undefined;
+      if (
+        family === "mn-backfill" &&
+        (status === "active-v2" || status === "done")
+      ) {
+        return initialized ? Buffer.from("generation") : undefined;
       }
       if (family !== "mn" || shard !== 0) return undefined;
       if (status === "queued") return encodeI64(2);
@@ -57,7 +64,7 @@ describe("NuQ FDB metrics", () => {
     });
 
     expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 1);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 2);
     expect(getRangeAll).not.toHaveBeenCalled();
 
     get.mockClear();
@@ -65,7 +72,7 @@ describe("NuQ FDB metrics", () => {
     queueCardinality = 1_000_000;
 
     expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 1);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 2);
     expect(getRangeAll).not.toHaveBeenCalled();
 
     get.mockClear();
@@ -73,7 +80,7 @@ describe("NuQ FDB metrics", () => {
     await expect(queue.getMetrics()).rejects.toThrow(
       "NuQ FDB metrics are initializing",
     );
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 1);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 2);
     expect(getRangeAll).not.toHaveBeenCalled();
   });
 
@@ -85,9 +92,24 @@ describe("NuQ FDB metrics", () => {
     vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockResolvedValue(5);
 
     await expect(nuqFdbGetMetrics()).resolves
-      .toBe(`${SCRAPE_METRICS}${CRAWL_FINISHED_METRICS}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+      .toBe(`${READINESS}firecrawl_nuq_fdb_metrics_ready 1
+${SCRAPE_METRICS}${CRAWL_FINISHED_METRICS}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
 # TYPE firecrawl_nuq_fdb_pending_jobs gauge
 firecrawl_nuq_fdb_pending_jobs 5
 `);
+  });
+
+  test("exported collector remains scrapeable while counters initialize", async () => {
+    vi.spyOn(scrapeQueueFdb, "getMetrics").mockRejectedValue(
+      new NuqFdbMetricsInitializingError("initializing"),
+    );
+    vi.spyOn(crawlFinishedQueueFdb, "getMetrics").mockResolvedValue(
+      CRAWL_FINISHED_METRICS,
+    );
+    vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockResolvedValue(5);
+
+    await expect(nuqFdbGetMetrics()).resolves.toBe(
+      `${READINESS}firecrawl_nuq_fdb_metrics_ready 0\n`,
+    );
   });
 });

--- a/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { encodeI64, METRIC_SHARDS } from "./keyspace";
+import { crawlFinishedQueueFdb, nuqFdbGetMetrics, scrapeQueueFdb } from ".";
+import { NuQFdbQueue } from "./queue";
+
+const SCRAPE_METRICS = `# HELP nuq_fdb_queue_scrape_job_count Number of FDB jobs in each status
+# TYPE nuq_fdb_queue_scrape_job_count gauge
+nuq_fdb_queue_scrape_job_count{status="queued"} 2
+nuq_fdb_queue_scrape_job_count{status="active"} 3
+nuq_fdb_queue_scrape_job_count{status="completed"} 0
+nuq_fdb_queue_scrape_job_count{status="failed"} 0
+nuq_fdb_queue_scrape_job_count{status="backlog"} 4
+`;
+
+const CRAWL_FINISHED_METRICS = `# HELP nuq_fdb_queue_crawl_finished_job_count Number of FDB jobs in each status
+# TYPE nuq_fdb_queue_crawl_finished_job_count gauge
+nuq_fdb_queue_crawl_finished_job_count{status="queued"} 7
+nuq_fdb_queue_crawl_finished_job_count{status="active"} 0
+nuq_fdb_queue_crawl_finished_job_count{status="completed"} 0
+nuq_fdb_queue_crawl_finished_job_count{status="failed"} 0
+nuq_fdb_queue_crawl_finished_job_count{status="backlog"} 0
+`;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("NuQ FDB metrics", () => {
+  test("queue output has an exact fixed-width read footprint", async () => {
+    const queue = new NuQFdbQueue("scrape", { hasGroups: false });
+    let queueCardinality = 1;
+    const get = vi.fn(async (key: Buffer) => {
+      const [, , family, status, shard] = queue.ks.unpack(key);
+      if (family !== "mn" || shard !== 0) return undefined;
+      if (status === "queued") return encodeI64(2);
+      if (status === "active") return encodeI64(3);
+      if (status === "pending") return encodeI64(4);
+      return undefined;
+    });
+    // This models the unbounded queue data a range scan would encounter. The
+    // collector must never invoke it, at either cardinality.
+    const getRangeAll = vi.fn(async () =>
+      Array.from({ length: queueCardinality }, () => [
+        Buffer.alloc(0),
+        Buffer.alloc(0),
+      ]),
+    );
+    const snapshot = () => ({ get, getRangeAll });
+    Object.defineProperty(queue, "db", {
+      value: {
+        doTn: async (fn: (tn: unknown) => unknown) => fn({ snapshot }),
+      },
+    });
+
+    expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS);
+    expect(getRangeAll).not.toHaveBeenCalled();
+
+    get.mockClear();
+    getRangeAll.mockClear();
+    queueCardinality = 1_000_000;
+
+    expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
+    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS);
+    expect(getRangeAll).not.toHaveBeenCalled();
+  });
+
+  test("exported collector composes both exact queue families", async () => {
+    vi.spyOn(scrapeQueueFdb, "getMetrics").mockResolvedValue(SCRAPE_METRICS);
+    vi.spyOn(crawlFinishedQueueFdb, "getMetrics").mockResolvedValue(
+      CRAWL_FINISHED_METRICS,
+    );
+    vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockResolvedValue(5);
+
+    await expect(nuqFdbGetMetrics()).resolves
+      .toBe(`${SCRAPE_METRICS}${CRAWL_FINISHED_METRICS}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+# TYPE firecrawl_nuq_fdb_pending_jobs gauge
+firecrawl_nuq_fdb_pending_jobs 5
+`);
+  });
+});

--- a/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
+++ b/apps/api/src/services/worker/nuq-fdb/metrics.test.ts
@@ -1,18 +1,27 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { encodeI64, METRIC_SHARDS } from "./keyspace";
+import {
+  encodeI64,
+  encodeJson,
+  METRIC_SHARDS,
+  NuqFdbMetricControl,
+} from "./keyspace";
 import { crawlFinishedQueueFdb, nuqFdbGetMetrics, scrapeQueueFdb } from ".";
 import { NuQFdbQueue, NuqFdbMetricsInitializingError } from "./queue";
 
 const READINESS = `# HELP firecrawl_nuq_fdb_metrics_ready Whether maintained FDB queue metrics are fully initialized
 # TYPE firecrawl_nuq_fdb_metrics_ready gauge
 `;
+const WORKER_LOAD = `# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
+# TYPE firecrawl_nuq_fdb_pending_jobs gauge
+firecrawl_nuq_fdb_pending_jobs 5
+`;
 
 const SCRAPE_METRICS = `# HELP nuq_fdb_queue_scrape_job_count Number of FDB jobs in each status
 # TYPE nuq_fdb_queue_scrape_job_count gauge
 nuq_fdb_queue_scrape_job_count{status="queued"} 2
 nuq_fdb_queue_scrape_job_count{status="active"} 3
-nuq_fdb_queue_scrape_job_count{status="completed"} 0
-nuq_fdb_queue_scrape_job_count{status="failed"} 0
+nuq_fdb_queue_scrape_job_count{status="completed"} 6
+nuq_fdb_queue_scrape_job_count{status="failed"} 7
 nuq_fdb_queue_scrape_job_count{status="backlog"} 4
 `;
 
@@ -20,86 +29,115 @@ const CRAWL_FINISHED_METRICS = `# HELP nuq_fdb_queue_crawl_finished_job_count Nu
 # TYPE nuq_fdb_queue_crawl_finished_job_count gauge
 nuq_fdb_queue_crawl_finished_job_count{status="queued"} 7
 nuq_fdb_queue_crawl_finished_job_count{status="active"} 0
-nuq_fdb_queue_crawl_finished_job_count{status="completed"} 0
-nuq_fdb_queue_crawl_finished_job_count{status="failed"} 0
+nuq_fdb_queue_crawl_finished_job_count{status="completed"} 8
+nuq_fdb_queue_crawl_finished_job_count{status="failed"} 1
 nuq_fdb_queue_crawl_finished_job_count{status="backlog"} 0
 `;
+
+const CONTROL: NuqFdbMetricControl = {
+  format: 3,
+  generation: "generation",
+  phase: "ready",
+  shards: 32,
+};
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("NuQ FDB metrics", () => {
-  test("queue output has an exact fixed-width read footprint", async () => {
+  test("READY output performs exactly one control plus 5x32 point reads", async () => {
     const queue = new NuQFdbQueue("scrape", { hasGroups: false });
-    let queueCardinality = 1;
-    let initialized = true;
     const get = vi.fn(async (key: Buffer) => {
-      const [, , family, status, shard] = queue.ks.unpack(key);
-      if (
-        family === "mn-backfill" &&
-        (status === "active-v2" || status === "done")
-      ) {
-        return initialized ? Buffer.from("generation") : undefined;
+      const parts = queue.ks.unpack(key);
+      if (parts[2] === "metrics" && parts[4] === "ctl") {
+        return encodeJson(CONTROL);
       }
-      if (family !== "mn" || shard !== 0) return undefined;
-      if (status === "queued") return encodeI64(2);
-      if (status === "active") return encodeI64(3);
-      if (status === "pending") return encodeI64(4);
-      return undefined;
+      if (
+        parts[2] !== "metrics" ||
+        parts[4] !== "gen" ||
+        parts[5] !== CONTROL.generation ||
+        parts[6] !== "n" ||
+        parts[8] !== 0
+      ) {
+        return undefined;
+      }
+      const values: Record<string, number> = {
+        pending: 4,
+        queued: 2,
+        active: 3,
+        completed: 6,
+        failed: 7,
+      };
+      return encodeI64(values[String(parts[7])] ?? 0);
     });
-    // This models the unbounded queue data a range scan would encounter. The
-    // collector must never invoke it, at either cardinality.
-    const getRangeAll = vi.fn(async () =>
-      Array.from({ length: queueCardinality }, () => [
-        Buffer.alloc(0),
-        Buffer.alloc(0),
-      ]),
-    );
-    const snapshot = () => ({ get, getRangeAll });
+    const getRangeAll = vi.fn(async () => {
+      throw new Error("fixed collector must not range-read");
+    });
     Object.defineProperty(queue, "db", {
       value: {
-        doTn: async (fn: (tn: unknown) => unknown) => fn({ snapshot }),
+        doTn: async (fn: (tn: unknown) => unknown) =>
+          fn({ snapshot: () => ({ get, getRangeAll }) }),
       },
     });
 
     expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 2);
-    expect(getRangeAll).not.toHaveBeenCalled();
-
-    get.mockClear();
-    getRangeAll.mockClear();
-    queueCardinality = 1_000_000;
-
-    expect(await queue.getMetrics()).toBe(SCRAPE_METRICS);
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 2);
-    expect(getRangeAll).not.toHaveBeenCalled();
-
-    get.mockClear();
-    initialized = false;
-    await expect(queue.getMetrics()).rejects.toThrow(
-      "NuQ FDB metrics are initializing",
-    );
-    expect(get).toHaveBeenCalledTimes(3 * METRIC_SHARDS + 2);
+    expect(get).toHaveBeenCalledTimes(1 + 5 * METRIC_SHARDS);
     expect(getRangeAll).not.toHaveBeenCalled();
   });
 
-  test("exported collector composes both exact queue families", async () => {
+  test("non-READY output reads only control and exposes no fixed family", async () => {
+    const queue = new NuQFdbQueue("scrape", { hasGroups: false });
+    const get = vi.fn(async () =>
+      encodeJson({ ...CONTROL, phase: "backfill-jobs" }),
+    );
+    Object.defineProperty(queue, "db", {
+      value: {
+        doTn: async (fn: (tn: unknown) => unknown) =>
+          fn({ snapshot: () => ({ get }) }),
+      },
+    });
+
+    await expect(queue.getMetrics()).rejects.toThrow(
+      "NuQ FDB metrics are initializing",
+    );
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  test("negative fixed counters surface corruption instead of being clamped", async () => {
+    const queue = new NuQFdbQueue("scrape", { hasGroups: false });
+    const get = vi.fn(async (key: Buffer) => {
+      const parts = queue.ks.unpack(key);
+      if (parts[4] === "ctl") return encodeJson(CONTROL);
+      return parts[7] === "queued" && parts[8] === 0
+        ? encodeI64(-1)
+        : undefined;
+    });
+    Object.defineProperty(queue, "db", {
+      value: {
+        doTn: async (fn: (tn: unknown) => unknown) =>
+          fn({ snapshot: () => ({ get }) }),
+      },
+    });
+
+    await expect(queue.getMetrics()).rejects.toThrow(
+      "Corrupt NuQ FDB metric counter queued: -1",
+    );
+  });
+
+  test("exported collector composes READY fixed families", async () => {
     vi.spyOn(scrapeQueueFdb, "getMetrics").mockResolvedValue(SCRAPE_METRICS);
     vi.spyOn(crawlFinishedQueueFdb, "getMetrics").mockResolvedValue(
       CRAWL_FINISHED_METRICS,
     );
     vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockResolvedValue(5);
 
-    await expect(nuqFdbGetMetrics()).resolves
-      .toBe(`${READINESS}firecrawl_nuq_fdb_metrics_ready 1
-${SCRAPE_METRICS}${CRAWL_FINISHED_METRICS}# HELP firecrawl_nuq_fdb_pending_jobs Number of FDB scrape jobs currently admitted to workers or waiting in ready shards
-# TYPE firecrawl_nuq_fdb_pending_jobs gauge
-firecrawl_nuq_fdb_pending_jobs 5
-`);
+    await expect(nuqFdbGetMetrics()).resolves.toBe(
+      `${READINESS}firecrawl_nuq_fdb_metrics_ready 1\n${SCRAPE_METRICS}${CRAWL_FINISHED_METRICS}${WORKER_LOAD}`,
+    );
   });
 
-  test("exported collector remains scrapeable while counters initialize", async () => {
+  test("release A preserves only legacy worker load while fixed counters build", async () => {
     vi.spyOn(scrapeQueueFdb, "getMetrics").mockRejectedValue(
       new NuqFdbMetricsInitializingError("initializing"),
     );
@@ -107,9 +145,13 @@ firecrawl_nuq_fdb_pending_jobs 5
       CRAWL_FINISHED_METRICS,
     );
     vi.spyOn(scrapeQueueFdb, "getWorkerLoadCount").mockResolvedValue(5);
+    vi.spyOn(scrapeQueueFdb, "getLegacyWorkerLoadCount").mockResolvedValue(5);
 
-    await expect(nuqFdbGetMetrics()).resolves.toBe(
-      `${READINESS}firecrawl_nuq_fdb_metrics_ready 0\n`,
+    const output = await nuqFdbGetMetrics();
+    expect(output).toBe(
+      `${READINESS}firecrawl_nuq_fdb_metrics_ready 0\n${WORKER_LOAD}`,
     );
+    expect(output).not.toContain("nuq_fdb_queue_scrape_job_count");
+    expect(output).not.toContain("nuq_fdb_queue_crawl_finished_job_count");
   });
 });

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -18,6 +18,8 @@ import {
   F_CRAWL_GATED,
   F_COUNTABLE,
   F_KEY_GATED,
+  METRIC_SHARDS,
+  fnv1a,
 } from "./keyspace";
 
 export const ONE = encodeI64(1);
@@ -36,9 +38,33 @@ export function bumpTeamActive(
   delta: number,
 ): void {
   if (delta === 0) return;
-  const encoded = encodeI64(delta);
-  tn.add(ks.teamActive(teamId), encoded);
-  tn.add(ks.teamActiveIndex(teamId), encoded);
+  tn.add(ks.teamActive(teamId), encodeI64(delta));
+  // This is a compact presence index, not a second counter. Zero transitions
+  // use setTeamActive below and remove the key entirely.
+  if (delta > 0) tn.set(ks.teamActiveIndex(teamId), EMPTY);
+}
+
+export function setTeamActive(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  teamId: string,
+  count: number,
+): void {
+  const next = Math.max(0, count);
+  tn.set(ks.teamActive(teamId), encodeI64(next));
+  if (next === 0) tn.clear(ks.teamActiveIndex(teamId));
+  else tn.set(ks.teamActiveIndex(teamId), EMPTY);
+}
+
+export function bumpQueueStatus(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  id: string,
+  status: "pending" | "queued" | "active",
+  delta: 1 | -1,
+): void {
+  const shard = fnv1a(id) % METRIC_SHARDS;
+  tn.add(ks.metricCount(status, shard), delta === 1 ? ONE : MINUS_ONE);
 }
 
 // Per-transaction-attempt context. uv makes versionstamp-suffixed keys unique
@@ -161,6 +187,8 @@ export function promoteEntryToReady(
 ): void {
   pushReady(tn, ks, e, txc);
   setStatusQueued(tn, ks, e.i);
+  bumpQueueStatus(tn, ks, e.i, "pending", -1);
+  bumpQueueStatus(tn, ks, e.i, "queued", 1);
   if (e.g && e.f & F_COUNTABLE) {
     tn.add(ks.groupStatusCount(e.g, "pending"), MINUS_ONE);
     tn.add(ks.groupStatusCount(e.g, "queued"), ONE);
@@ -213,9 +241,9 @@ export function clearPendingPlacement(
 
 // === Pending queue pops
 
-// Pops the best entry from a team's pending shards. Snapshot-reads the shard
-// occupancy counters and probes up to 3 non-empty shards. Returns null if all
-// probed shards are empty.
+// Pops the best entry from a team's pending shards. The occupancy read is
+// intentionally conflicting: otherwise a slot releaser can miss a concurrent
+// append and commit a free slot plus a stranded backlog entry (lost wake-up).
 export async function popTeamPending(
   tn: Transaction,
   ks: NuqFdbKeyspace,
@@ -223,7 +251,7 @@ export async function popTeamPending(
 ): Promise<QueueEntry | null> {
   const startedAt = Date.now();
   const range = ks.teamShardCountRange(tid);
-  const counts = await tn.snapshot().getRangeAll(range.begin, range.end);
+  const counts = await tn.getRangeAll(range.begin, range.end);
   const nonEmpty: number[] = [];
   for (const [key, value] of counts) {
     if (decodeI64(value as Buffer) > 0)
@@ -345,14 +373,14 @@ export async function releaseSlotsAndPromote(
 
   // Limit-lowering convergence: if the team is over its limit, don't hand off.
   let overLimit = false;
-  let limit = Infinity;
+  let active = 0;
   if (held.team) {
     const limitBuf = await tn.get(ks.teamLimit(tid)); // cold key, rarely written
-    if (limitBuf) {
-      limit = decodeI64(limitBuf);
-      const snapActive = decodeI64(await tn.snapshot().get(ks.teamActive(tid)));
-      overLimit = snapActive > limit;
-    }
+    const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
+    // Serialize parallel releases while a lowered limit converges. Snapshot
+    // reads can make several releasers all swallow the same last excess slot.
+    active = decodeI64(await tn.get(ks.teamActive(tid)));
+    overLimit = active > limit;
   }
 
   let teamHead: QueueEntry | null | "consumed" = null;
@@ -370,7 +398,7 @@ export async function releaseSlotsAndPromote(
     const kLimitBuf = await tn.get(ks.keyLimit(e.k!)); // cold key
     if (kLimitBuf) {
       const kLimit = decodeI64(kLimitBuf);
-      const kActive = decodeI64(await tn.snapshot().get(ks.keyActive(e.k!)));
+      const kActive = decodeI64(await tn.get(ks.keyActive(e.k!)));
       keyOverLimit = kActive > kLimit;
     }
     if (keyOverLimit) {
@@ -399,9 +427,7 @@ export async function releaseSlotsAndPromote(
   let crawlPromoted: QueueEntry | null = null;
   let crawlDelaySeconds = 0;
   if (holdsCrawl) {
-    const gMeta = decodeJson<GroupMeta>(
-      await tn.snapshot().get(ks.groupMeta(e.g!)),
-    );
+    const gMeta = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(e.g!)));
     if (gMeta && gMeta.s === "active") {
       crawlPromoted = await popCrawlPending(tn, ks, e.g!);
       if (crawlPromoted) {
@@ -472,7 +498,7 @@ export async function releaseSlotsAndPromote(
     } else if (teamHead !== null) {
       promoteEntryToReady(tn, ks, teamHead, txc);
     } else {
-      bumpTeamActive(tn, ks, tid, -1);
+      setTeamActive(tn, ks, tid, active - 1);
     }
   }
 }

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -56,13 +56,17 @@ export function setTeamActive(
   else tn.set(ks.teamActiveIndex(teamId), EMPTY);
 }
 
-export function bumpQueueStatus(
+export async function bumpQueueStatus(
   tn: Transaction,
   ks: NuqFdbKeyspace,
   id: string,
   status: "pending" | "queued" | "active",
   delta: 1 | -1,
-): void {
+): Promise<void> {
+  // Counters were introduced after the queue keyspace. Legacy jobs are
+  // enrolled by the durable sweeper backfill; until then their transitions
+  // must not create negative counter debt.
+  if (!(await tn.get(ks.jobMetricTracked(id)))) return;
   const shard = fnv1a(id) % METRIC_SHARDS;
   tn.add(ks.metricCount(status, shard), delta === 1 ? ONE : MINUS_ONE);
 }
@@ -179,16 +183,16 @@ export function clearBacklogTimeout(
 
 // Moves a pending entry into a ready shard, with group counter upkeep.
 // Callers are responsible for slot accounting.
-export function promoteEntryToReady(
+export async function promoteEntryToReady(
   tn: Transaction,
   ks: NuqFdbKeyspace,
   e: QueueEntry,
   txc: TxContext,
-): void {
+): Promise<void> {
   pushReady(tn, ks, e, txc);
   setStatusQueued(tn, ks, e.i);
-  bumpQueueStatus(tn, ks, e.i, "pending", -1);
-  bumpQueueStatus(tn, ks, e.i, "queued", 1);
+  await bumpQueueStatus(tn, ks, e.i, "pending", -1);
+  await bumpQueueStatus(tn, ks, e.i, "queued", 1);
   if (e.g && e.f & F_COUNTABLE) {
     tn.add(ks.groupStatusCount(e.g, "pending"), MINUS_ONE);
     tn.add(ks.groupStatusCount(e.g, "queued"), ONE);
@@ -411,7 +415,7 @@ export async function releaseSlotsAndPromote(
         keyHandedOff = true;
         // the key head now owns the freed key slot; it still needs a team slot
         if (teamSlotFree()) {
-          promoteEntryToReady(tn, ks, keyHead, txc);
+          await promoteEntryToReady(tn, ks, keyHead, txc);
           teamHead = "consumed";
         } else if (!held.team) {
           await admitThroughTeamGate(tn, ks, keyHead, txc);
@@ -474,7 +478,7 @@ export async function releaseSlotsAndPromote(
         setStatusPending(tn, ks, j2.i, loc);
       } else if (teamSlotFree()) {
         // the freed team slot goes directly to the crawl-promoted job
-        promoteEntryToReady(tn, ks, j2, txc);
+        await promoteEntryToReady(tn, ks, j2, txc);
         teamHead = "consumed";
       } else if (!held.team) {
         // no team slot was freed here (job removal/cancellation paths), so the
@@ -496,7 +500,7 @@ export async function releaseSlotsAndPromote(
     if (teamHead === "consumed") {
       // slot handed to the key head or crawlPromoted above
     } else if (teamHead !== null) {
-      promoteEntryToReady(tn, ks, teamHead, txc);
+      await promoteEntryToReady(tn, ks, teamHead, txc);
     } else {
       setTeamActive(tn, ks, tid, active - 1);
     }
@@ -518,7 +522,7 @@ export async function admitThroughTeamGate(
   const active = decodeI64(await tn.get(ks.teamActive(e.o)));
   if (active < limit) {
     bumpTeamActive(tn, ks, e.o, 1);
-    promoteEntryToReady(tn, ks, e, txc);
+    await promoteEntryToReady(tn, ks, e, txc);
   } else {
     const loc = appendTeamPending(tn, ks, e);
     setStatusPending(tn, ks, e.i, loc);

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -56,6 +56,24 @@ export function setTeamActive(
   else tn.set(ks.teamActiveIndex(teamId), EMPTY);
 }
 
+export async function enrollQueueStatus(
+  tn: Transaction,
+  ks: NuqFdbKeyspace,
+  id: string,
+  status: "pending" | "queued" | "active",
+): Promise<void> {
+  // Activation is an explicit second rollout after all pre-membership writers
+  // have drained. Compatibility-version writers observe this shared key even
+  // when their local activation flag remains off.
+  const generation = await tn.get(ks.metricBackfillActive());
+  if (!generation) return;
+  const membership = await tn.get(ks.jobMetricTracked(id));
+  if (membership && (membership as Buffer).equals(generation as Buffer)) return;
+  tn.set(ks.jobMetricTracked(id), generation as Buffer);
+  const shard = fnv1a(id) % METRIC_SHARDS;
+  tn.add(ks.metricCount(status, shard), ONE);
+}
+
 export async function bumpQueueStatus(
   tn: Transaction,
   ks: NuqFdbKeyspace,
@@ -63,10 +81,14 @@ export async function bumpQueueStatus(
   status: "pending" | "queued" | "active",
   delta: 1 | -1,
 ): Promise<void> {
-  // Counters were introduced after the queue keyspace. Legacy jobs are
-  // enrolled by the durable sweeper backfill; until then their transitions
-  // must not create negative counter debt.
-  if (!(await tn.get(ks.jobMetricTracked(id)))) return;
+  // Legacy jobs are enrolled by the durable sweeper backfill. Until then their
+  // transitions must not create negative counter debt.
+  const generation = await tn.get(ks.metricBackfillActive());
+  if (!generation) return;
+  const membership = await tn.get(ks.jobMetricTracked(id));
+  if (!membership || !(membership as Buffer).equals(generation as Buffer)) {
+    return;
+  }
   const shard = fnv1a(id) % METRIC_SHARDS;
   tn.add(ks.metricCount(status, shard), delta === 1 ? ONE : MINUS_ONE);
 }

--- a/apps/api/src/services/worker/nuq-fdb/ops.ts
+++ b/apps/api/src/services/worker/nuq-fdb/ops.ts
@@ -3,6 +3,7 @@ import { logger as _logger } from "../../../lib/logger";
 import {
   NuqFdbKeyspace,
   QueueEntry,
+  JobMeta,
   JobStatusRecord,
   GroupMeta,
   PendingLoc,
@@ -19,6 +20,9 @@ import {
   F_COUNTABLE,
   F_KEY_GATED,
   METRIC_SHARDS,
+  METRIC_STATUSES,
+  NuqFdbMetricControl,
+  NuqFdbMetricStatus,
   fnv1a,
 } from "./keyspace";
 
@@ -56,41 +60,65 @@ export function setTeamActive(
   else tn.set(ks.teamActiveIndex(teamId), EMPTY);
 }
 
-export async function enrollQueueStatus(
-  tn: Transaction,
-  ks: NuqFdbKeyspace,
-  id: string,
-  status: "pending" | "queued" | "active",
-): Promise<void> {
-  // Activation is an explicit second rollout after all pre-membership writers
-  // have drained. Compatibility-version writers observe this shared key even
-  // when their local activation flag remains off.
-  const generation = await tn.get(ks.metricBackfillActive());
-  if (!generation) return;
-  const membership = await tn.get(ks.jobMetricTracked(id));
-  if (membership && (membership as Buffer).equals(generation as Buffer)) return;
-  tn.set(ks.jobMetricTracked(id), generation as Buffer);
-  const shard = fnv1a(id) % METRIC_SHARDS;
-  tn.add(ks.metricCount(status, shard), ONE);
+function decodeMetricControl(
+  value: Buffer | undefined | null,
+): NuqFdbMetricControl | null {
+  const control = decodeJson<NuqFdbMetricControl>(value);
+  if (!control) return null;
+  if (
+    control.format !== 3 ||
+    control.shards !== METRIC_SHARDS ||
+    !control.generation ||
+    !["backfill-jobs", "backfill-ledger", "ready"].includes(control.phase)
+  ) {
+    throw new Error("Unsupported NuQ FDB metric control record");
+  }
+  return control;
 }
 
-export async function bumpQueueStatus(
+export function canonicalQueueMetricStatus(
+  meta: JobMeta | null,
+  status: JobStatusRecord | null,
+): NuqFdbMetricStatus | null {
+  if (!meta || !status) return null;
+  return METRIC_STATUSES.includes(status.s as NuqFdbMetricStatus)
+    ? (status.s as NuqFdbMetricStatus)
+    : null;
+}
+
+// Reconciles the one status-valued ledger row with the final canonical job
+// state. The stable control read is deliberately normal (even when absent), so
+// activation/invalidation conflicts with every protocol-aware lifecycle write.
+// The ledger and both counter deltas commit atomically with the job mutation.
+export async function alignQueueMetricStatus(
   tn: Transaction,
   ks: NuqFdbKeyspace,
   id: string,
-  status: "pending" | "queued" | "active",
-  delta: 1 | -1,
 ): Promise<void> {
-  // Legacy jobs are enrolled by the durable sweeper backfill. Until then their
-  // transitions must not create negative counter debt.
-  const generation = await tn.get(ks.metricBackfillActive());
-  if (!generation) return;
-  const membership = await tn.get(ks.jobMetricTracked(id));
-  if (!membership || !(membership as Buffer).equals(generation as Buffer)) {
-    return;
+  const control = decodeMetricControl(await tn.get(ks.metricControl()));
+  if (!control) return;
+  const [meta, status] = await Promise.all([
+    tn.get(ks.jobMeta(id)).then(value => decodeJson<JobMeta>(value)),
+    tn.get(ks.jobStatus(id)).then(value => decodeJson<JobStatusRecord>(value)),
+  ]);
+  const next = canonicalQueueMetricStatus(meta, status);
+  const ledgerKey = ks.metricLedger(control.generation, id);
+  const priorBuf = await tn.get(ledgerKey);
+  const prior = priorBuf?.toString("utf8") as NuqFdbMetricStatus | undefined;
+  if (prior !== undefined && !METRIC_STATUSES.includes(prior)) {
+    throw new Error(`Invalid NuQ FDB metric ledger status for ${id}`);
   }
+  if (prior === next) return;
   const shard = fnv1a(id) % METRIC_SHARDS;
-  tn.add(ks.metricCount(status, shard), delta === 1 ? ONE : MINUS_ONE);
+  if (prior !== undefined) {
+    tn.add(ks.metricCount(control.generation, prior, shard), MINUS_ONE);
+  }
+  if (next === null) {
+    tn.clear(ledgerKey);
+  } else {
+    tn.add(ks.metricCount(control.generation, next, shard), ONE);
+    tn.set(ledgerKey, Buffer.from(next, "utf8"));
+  }
 }
 
 // Per-transaction-attempt context. uv makes versionstamp-suffixed keys unique
@@ -213,8 +241,7 @@ export async function promoteEntryToReady(
 ): Promise<void> {
   pushReady(tn, ks, e, txc);
   setStatusQueued(tn, ks, e.i);
-  await bumpQueueStatus(tn, ks, e.i, "pending", -1);
-  await bumpQueueStatus(tn, ks, e.i, "queued", 1);
+  await alignQueueMetricStatus(tn, ks, e.i);
   if (e.g && e.f & F_COUNTABLE) {
     tn.add(ks.groupStatusCount(e.g, "pending"), MINUS_ONE);
     tn.add(ks.groupStatusCount(e.g, "queued"), ONE);
@@ -444,6 +471,7 @@ export async function releaseSlotsAndPromote(
         } else {
           const loc = appendTeamPending(tn, ks, keyHead);
           setStatusPending(tn, ks, keyHead.i, loc);
+          await alignQueueMetricStatus(tn, ks, keyHead.i);
         }
       }
     }
@@ -474,6 +502,7 @@ export async function releaseSlotsAndPromote(
       const notBefore = now + crawlDelaySeconds * 1000;
       tn.set(ks.delayed(timeBucket(j2.i), notBefore, j2.i), encodeJson(j2));
       setStatusPending(tn, ks, j2.i, { k: "dl", at: notBefore });
+      await alignQueueMetricStatus(tn, ks, j2.i);
     } else {
       // key gate for the crawl-promoted job
       const j2KeyGated = !!j2.k && !!(j2.f & F_KEY_GATED);
@@ -498,6 +527,7 @@ export async function releaseSlotsAndPromote(
         // waits in the key gate; keeps the crawl slot
         const loc = appendKeyPending(tn, ks, j2);
         setStatusPending(tn, ks, j2.i, loc);
+        await alignQueueMetricStatus(tn, ks, j2.i);
       } else if (teamSlotFree()) {
         // the freed team slot goes directly to the crawl-promoted job
         await promoteEntryToReady(tn, ks, j2, txc);
@@ -510,6 +540,7 @@ export async function releaseSlotsAndPromote(
         // waits in the team gate; keeps the crawl + key slots
         const loc = appendTeamPending(tn, ks, j2);
         setStatusPending(tn, ks, j2.i, loc);
+        await alignQueueMetricStatus(tn, ks, j2.i);
       }
     }
   }
@@ -548,6 +579,7 @@ export async function admitThroughTeamGate(
   } else {
     const loc = appendTeamPending(tn, ks, e);
     setStatusPending(tn, ks, e.i, loc);
+    await alignQueueMetricStatus(tn, ks, e.i);
   }
 }
 
@@ -566,6 +598,7 @@ export async function admitThroughGates(
     if (kActive >= kLimit) {
       const loc = appendKeyPending(tn, ks, e);
       setStatusPending(tn, ks, e.i, loc);
+      await alignQueueMetricStatus(tn, ks, e.i);
       return;
     }
     tn.add(ks.keyActive(e.k), ONE);

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -2134,36 +2134,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     });
   }
 
-  public async getLegacyWorkerLoadCount(): Promise<number> {
-    const ks = this.ks;
-    return await this.db.doTn(async tn => {
-      const [readyRows, activeRows] = await Promise.all([
-        tn
-          .snapshot()
-          .getRangeAll(
-            ks.readyShardCountRange().begin,
-            ks.readyShardCountRange().end,
-          ),
-        tn.snapshot().getRangeAll(ks.leaseRange().begin, ks.leaseRange().end),
-      ]);
-      const queued = readyRows.reduce(
-        (sum, [, value]) => sum + Math.max(0, decodeI64(value as Buffer)),
-        0,
-      );
-      return queued + activeRows.length;
-    });
-  }
-
   public async getWorkerLoadCount(): Promise<number> {
-    try {
-      const counts = await this.getMetricCounts();
-      return counts.queued + counts.active;
-    } catch (error) {
-      if (error instanceof NuqFdbMetricsInitializingError) {
-        return await this.getLegacyWorkerLoadCount();
-      }
-      throw error;
-    }
+    const counts = await this.getMetricCounts();
+    return counts.queued + counts.active;
   }
 
   private async getMetricCounts(): Promise<Record<NuQJobStatusCompat, number>> {

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import type {
   Transaction,
   TransactionOptionCode as FdbTransactionOptionCode,
@@ -29,6 +29,8 @@ import {
   F_GACC,
   F_KEY_GATED,
   normalizeOwnerId,
+  IngestMeta,
+  ClaimRecord,
 } from "./keyspace";
 
 export { normalizeOwnerId, F_GACC };
@@ -55,6 +57,7 @@ import {
   setGroupJobIndex,
   bumpGroupStatusCount,
   bumpTeamActive,
+  bumpQueueStatus,
   GroupJobIndexValue,
 } from "./ops";
 import { NuqFdbGroupOps } from "./groups";
@@ -73,6 +76,9 @@ const FDB_TRANSACTION_BYTE_LIMIT = 10_000_000;
 const ENQUEUE_BATCH_BYTE_BUDGET = 750 * 1024;
 const ENQUEUE_SINGLE_JOB_BYTE_LIMIT = 8 * 1024 * 1024;
 const ENQUEUE_MAX_JOBS_PER_TRANSACTION = 250;
+const MAX_INLINE_RETURNVALUE_BYTES = 8 * 1024 * 1024;
+const MAX_FAILED_REASON_BYTES = 90 * 1024;
+const INGEST_TTL_MS = 60 * 60 * 1000;
 
 export { QueueFullError };
 
@@ -140,6 +146,19 @@ type PreparedAddJob<Data> = AddJobInput<Data> & {
   estimatedAffectedBytes: number;
 };
 
+type IngestJobPlan = {
+  h: string;
+  p: number;
+  o: string;
+  g?: string;
+  b: boolean;
+  l: boolean;
+  to?: number;
+  dc: number;
+  ct: boolean;
+  z: boolean;
+};
+
 function chunkBuffer(buf: Buffer, size: number): Buffer[] {
   const chunks: Buffer[] = [];
   for (let i = 0; i < buf.length; i += size) {
@@ -150,19 +169,38 @@ function chunkBuffer(buf: Buffer, size: number): Buffer[] {
 
 function externalStatus(s: NuqFdbJobStatus): NuQJobStatusCompat | null {
   if (s === "pending") return "backlog";
-  if (s === "cancelled") return null; // cancelled jobs read as gone, like PG row deletes
+  if (s === "ingesting" || s === "cancelled") return null;
   return s;
 }
+
+function truncateUtf8(value: string, maxBytes: number): Buffer {
+  const buf = Buffer.from(value, "utf8");
+  if (buf.length <= maxBytes) return buf;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end);
+}
+
+class IngestBusyError extends Error {}
+class IngestValidationError extends Error {}
 
 function encodedJsonBytes(v: any): number {
   return Buffer.byteLength(JSON.stringify(v), "utf8");
 }
 
+function semanticDataHash(value: unknown): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify(value ?? null, (key, nested) =>
+        key === "traceContext" ? undefined : nested,
+      ),
+    )
+    .digest("hex");
+}
+
 export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   public readonly ks: NuqFdbKeyspace;
   public readonly groupOps: NuqFdbGroupOps | null;
-  // worker-local lease expiry tracking so renewLock can stay a blind write
-  private leaseExps: Map<string, number> = new Map();
 
   constructor(
     public readonly queueName: string,
@@ -173,6 +211,13 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       finishedQueueName?: string;
       // lease duration override, used by tests
       leaseMs?: number;
+      // Deterministic fault/race injection for the FDB integration tests.
+      testHooks?: {
+        afterManifest?: () => Promise<void>;
+        afterStageBatch?: (batch: number) => Promise<void>;
+        afterPublishBatch?: (batch: number) => Promise<void>;
+        simulateClaimCommitUnknown?: () => boolean;
+      };
     },
   ) {
     this.ks = new NuqFdbKeyspace(queueName);
@@ -217,13 +262,18 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     if (jobs.some(j => normalizeOwnerId(j.options.ownerId) !== ownerId)) {
       throw new Error("addJobs requires all jobs to share an owner");
     }
+    if (gate.teamLimit !== null && ownerId === null) {
+      throw new Error("Team-gated jobs require an owner");
+    }
 
-    const prepared = jobs.map(j =>
+    // Duplicate IDs in one call are one logical enqueue. Preserve the API's
+    // output cardinality/order below while ensuring each ID is placed once.
+    const byId = new Map<string, AddJobInput<JobData>>();
+    for (const job of jobs) if (!byId.has(job.id)) byId.set(job.id, job);
+    const uniqueInputs = [...byId.values()];
+    const prepared = uniqueInputs.map(j =>
       this.prepareAddJob(j, ownerId, gate.key?.id ?? null),
     );
-    const results: NuQFdbJob<JobData, JobReturnValue>[] = [];
-    let batch: PreparedAddJob<JobData>[] = [];
-    let batchBytes = 0;
 
     for (const job of prepared) {
       if (job.estimatedAffectedBytes > ENQUEUE_SINGLE_JOB_BYTE_LIMIT) {
@@ -231,7 +281,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           `NuQ FDB job ${job.id} is too large to enqueue safely: estimated ${job.estimatedAffectedBytes} bytes of affected data exceeds ${ENQUEUE_SINGLE_JOB_BYTE_LIMIT}`,
         );
       }
-
       if (job.estimatedAffectedBytes > ENQUEUE_BATCH_BYTE_BUDGET) {
         logger.warn("NuQ FDB enqueue job exceeds batch budget", {
           canonicalLog: "nuq-fdb/enqueue_batch",
@@ -242,25 +291,88 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           transactionByteLimit: FDB_TRANSACTION_BYTE_LIMIT,
         });
       }
+    }
 
+    // The stable operation identity intentionally excludes regenerated request
+    // fields (deadlines, trace context, changing limits). The first caller's
+    // gate and per-job plan are persisted; retries attach to that plan.
+    const op = createHash("sha256")
+      .update(this.queueName)
+      .update("\0")
+      .update(ownerId ?? "")
+      .update("\0")
+      .update(uniqueInputs.map(job => job.id).join("\0"))
+      .digest("hex");
+    await this.initIngest(op, ownerId, gate);
+
+    const batches: PreparedAddJob<JobData>[][] = [];
+    let batch: PreparedAddJob<JobData>[] = [];
+    let batchBytes = 0;
+    for (const job of prepared) {
       if (
         batch.length > 0 &&
         (batchBytes + job.estimatedAffectedBytes > ENQUEUE_BATCH_BYTE_BUDGET ||
           batch.length >= ENQUEUE_MAX_JOBS_PER_TRANSACTION)
       ) {
-        results.push(...(await this.addJobsBatch(batch, ownerId, gate)));
+        batches.push(batch);
         batch = [];
         batchBytes = 0;
       }
-
       batch.push(job);
       batchBytes += job.estimatedAffectedBytes;
     }
+    if (batch.length > 0) batches.push(batch);
 
-    if (batch.length > 0) {
-      results.push(...(await this.addJobsBatch(batch, ownerId, gate)));
+    // Persist the complete small manifest before claiming any IDs. This
+    // freezes deadlines/options across a process-level retry without putting
+    // the unbounded manifest in one FDB transaction.
+    for (const manifestBatch of batches) {
+      await this.persistIngestPlanBatch(op, manifestBatch);
     }
-    return results;
+    await this.options.testHooks?.afterManifest?.();
+    try {
+      for (let batchNumber = 0; batchNumber < batches.length; batchNumber++) {
+        for (let attempt = 0; ; attempt++) {
+          try {
+            await this.reserveAndStageBatch(op, batches[batchNumber]);
+            break;
+          } catch (error) {
+            if (!(error instanceof IngestBusyError) || attempt >= 100)
+              throw error;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+        }
+        await this.options.testHooks?.afterStageBatch?.(batchNumber + 1);
+      }
+    } catch (error) {
+      if (
+        error instanceof QueueFullError ||
+        error instanceof IngestValidationError ||
+        error instanceof IngestBusyError
+      ) {
+        await this.abortIngest(op);
+      }
+      throw error;
+    }
+
+    for (let i = 0; i < batches.length; i++) {
+      await this.publishIngestBatch(op, batches[i]);
+      await this.options.testHooks?.afterPublishBatch?.(i + 1);
+    }
+    await this.finalizeIngest(op);
+
+    const stored = await this.getJobs(
+      uniqueInputs.map(j => j.id),
+      logger,
+    );
+    const storedById = new Map(stored.map(job => [job.id, job]));
+    return jobs.map(j => {
+      const storedJob = storedById.get(j.id);
+      if (!storedJob) {
+        throw new Error(`Job ${j.id} disappeared after enqueue publication`);
+      }
+      return storedJob;
+    });
   }
 
   private prepareAddJob(
@@ -392,16 +504,199 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     return bytes + 4096;
   }
 
-  private async addJobsBatch(
-    jobs: PreparedAddJob<JobData>[],
+  private async initIngest(
+    op: string,
     ownerId: string | null,
     gate: NuQFdbGate,
-  ): Promise<NuQFdbJob<JobData, JobReturnValue>[]> {
+  ): Promise<void> {
     const ks = this.ks;
-    return await this.db.doTn(async tn => {
+    await this.db.doTn(async tn => {
+      if (await tn.get(ks.ingest(op))) return;
+      const createdAt = Date.now();
+      const meta: IngestMeta = {
+        o: ownerId ?? "",
+        c: createdAt,
+        x: createdAt + INGEST_TTL_MS,
+        r: 0,
+        l: gate.teamLimit,
+        q: gate.queueCap,
+        k: gate.key ?? null,
+      };
+      tn.set(ks.ingest(op), encodeJson(meta));
+      tn.set(ks.ingestExpiry(meta.x, op), EMPTY);
+    });
+  }
+
+  private async persistIngestPlanBatch(
+    op: string,
+    jobs: PreparedAddJob<JobData>[],
+  ): Promise<void> {
+    const ks = this.ks;
+    await this.db.doTn(async tn => {
+      const opMeta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+      if (!opMeta) return;
+      const [existing, statuses] = await Promise.all([
+        Promise.all(jobs.map(job => tn.get(ks.ingestJob(op, job.id)))),
+        Promise.all(jobs.map(job => tn.get(ks.jobStatus(job.id)))),
+      ]);
+      for (let i = 0; i < jobs.length; i++) {
+        // A published/existing status is authoritative. This normal read
+        // conflicts with publication, so a concurrent retry cannot recreate
+        // a manifest row after publish cleared it.
+        if (existing[i] || statuses[i]) continue;
+        const job = jobs[i];
+        const plan: IngestJobPlan = {
+          h: semanticDataHash(job.data),
+          p: job.options.priority ?? 0,
+          o: opMeta.o,
+          g: job.options.groupId,
+          b: !!job.options.bypassGate,
+          l: !!job.options.listenable,
+          to: job.options.timesOutAt?.getTime(),
+          dc: job.dataChunks.length,
+          ct: (job.data as any)?.mode === "single_urls",
+          z: !!(job.data as any)?.zeroDataRetention,
+        };
+        tn.set(ks.ingestJob(op, job.id), encodeJson(plan));
+      }
+    });
+  }
+
+  private async reserveAndStageBatch(
+    op: string,
+    jobs: PreparedAddJob<JobData>[],
+  ): Promise<void> {
+    const ks = this.ks;
+    await this.db.doTn(async tn => {
+      const opMeta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+      if (!opMeta) return;
+      const [statuses, planValues] = await Promise.all([
+        Promise.all(jobs.map(job => tn.get(ks.jobStatus(job.id)))),
+        Promise.all(jobs.map(job => tn.get(ks.ingestJob(op, job.id)))),
+      ]);
+      const fresh: { job: PreparedAddJob<JobData>; plan: IngestJobPlan }[] = [];
+      for (let i = 0; i < jobs.length; i++) {
+        const status = decodeJson<JobStatusRecord>(statuses[i]);
+        const plan = decodeJson<IngestJobPlan>(planValues[i]);
+        if (!plan) continue;
+        if (status?.s === "ingesting" && status.op !== op) {
+          throw new IngestBusyError(`Job ${jobs[i].id} is being ingested`);
+        }
+        if (status?.s === "cancelled") {
+          throw new IngestValidationError(
+            `Job ${jobs[i].id} was cancelled and is not reusable yet`,
+          );
+        }
+        if (!status) {
+          if (semanticDataHash(jobs[i].data) !== plan.h) {
+            throw new IngestValidationError(
+              `Job ${jobs[i].id} changed during ingest retry`,
+            );
+          }
+          fresh.push({ job: jobs[i], plan });
+        } else if (status.s !== "ingesting") {
+          tn.clear(ks.ingestJob(op, jobs[i].id));
+        }
+      }
+      if (fresh.length === 0) return;
+
+      const gated = fresh.filter(
+        ({ plan }) => opMeta.l !== null && !plan.b,
+      ).length;
+      if (gated > 0 && opMeta.o) {
+        const [pendingBuf, reservedBuf] = await Promise.all([
+          tn.get(ks.teamPendingCount(opMeta.o)),
+          tn.get(ks.teamIngestReserved(opMeta.o)),
+        ]);
+        const pending = decodeI64(pendingBuf);
+        const reserved = decodeI64(reservedBuf);
+        if (pending + reserved + gated > opMeta.q) {
+          throw new QueueFullError(pending + reserved, opMeta.q);
+        }
+        tn.add(ks.teamIngestReserved(opMeta.o), encodeI64(gated));
+        const storedBuf = await tn.get(ks.teamLimit(opMeta.o));
+        const stored = storedBuf ? decodeI64(storedBuf) : null;
+        if (stored !== opMeta.l) {
+          tn.set(ks.teamLimit(opMeta.o), encodeI64(opMeta.l!));
+          if (stored !== null && opMeta.l! > stored) {
+            tn.set(ks.taskTeamRaise(opMeta.o), EMPTY);
+          }
+        }
+      }
+
+      if (this.options.hasGroups) {
+        for (const gid of new Set(fresh.map(({ plan }) => plan.g))) {
+          if (!gid || (await tn.get(ks.ingestGroup(op, gid)))) continue;
+          const groupMeta = decodeJson<GroupMeta>(
+            await tn.get(ks.groupMeta(gid)),
+          );
+          if (groupMeta?.s !== "active") {
+            throw new IngestValidationError(
+              `Cannot enqueue job into non-active group ${gid}`,
+            );
+          }
+          tn.set(ks.ingestGroup(op, gid), EMPTY);
+          tn.add(ks.groupIngestCount(gid), ONE);
+        }
+      }
+
+      tn.set(ks.ingest(op), encodeJson({ ...opMeta, r: opMeta.r + gated }));
+      for (const { job } of fresh) {
+        tn.set(
+          ks.jobStatus(job.id),
+          encodeJson({ s: "ingesting", st: 0, op } satisfies JobStatusRecord),
+        );
+        job.dataChunks.forEach((chunk, chunkIndex) =>
+          tn.set(ks.jobData(job.id, chunkIndex), chunk),
+        );
+      }
+    });
+  }
+
+  private async publishIngestBatch(
+    op: string,
+    jobs: PreparedAddJob<JobData>[],
+  ): Promise<void> {
+    const ks = this.ks;
+    await this.db.doTn(async tn => {
       const txc = newTxContext();
       const now = Date.now();
-      const out: NuQFdbJob<JobData, JobReturnValue>[] = [];
+      const opMeta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+      if (!opMeta) return;
+      const [statuses, planValues] = await Promise.all([
+        Promise.all(jobs.map(job => tn.get(ks.jobStatus(job.id)))),
+        Promise.all(jobs.map(job => tn.get(ks.ingestJob(op, job.id)))),
+      ]);
+      const publishJobs = jobs.flatMap((job, i) => {
+        const status = decodeJson<JobStatusRecord>(statuses[i]);
+        const plan = decodeJson<IngestJobPlan>(planValues[i]);
+        if (status?.s !== "ingesting" || status.op !== op || !plan) return [];
+        return [
+          {
+            ...job,
+            data: {
+              mode: plan.ct ? "single_urls" : undefined,
+              zeroDataRetention: plan.z,
+            } as JobData,
+            dataChunks: new Array<Buffer>(plan.dc),
+            options: {
+              ownerId: plan.o || undefined,
+              groupId: plan.g,
+              priority: plan.p,
+              bypassGate: plan.b,
+              listenable: plan.l,
+              timesOutAt: plan.to === undefined ? undefined : new Date(plan.to),
+            },
+          },
+        ];
+      });
+      if (publishJobs.length === 0) return;
+      const ownerId = opMeta.o || null;
+      const gate: NuQFdbGate = {
+        teamLimit: opMeta.l,
+        queueCap: opMeta.q,
+        key: opMeta.k,
+      };
 
       let free = Infinity;
       if (gate.teamLimit !== null && ownerId !== null) {
@@ -414,19 +709,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           }
         }
 
-        const pend = decodeI64(
-          await tn.snapshot().get(ks.teamPendingCount(ownerId)),
-        );
-        if (pend + jobs.length > gate.queueCap) {
-          throw new QueueFullError(pend, gate.queueCap);
-        }
-
-        // big-limit teams tolerate a small admission overshoot in exchange for
-        // a conflict-free read; small-limit teams get the strict read
-        const active =
-          gate.teamLimit >= 256
-            ? decodeI64(await tn.snapshot().get(ks.teamActive(ownerId)))
-            : decodeI64(await tn.get(ks.teamActive(ownerId)));
+        // Strict for every limit, including >=256. The ingest reservation
+        // bounds queue admission; this conflicting read bounds active slots.
+        const active = decodeI64(await tn.get(ks.teamActive(ownerId)));
         free = Math.max(0, gate.teamLimit - active);
       }
 
@@ -451,7 +736,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const groupMetas = new Map<string, GroupMeta | null>();
       const crawlFree = new Map<string, number>();
       if (this.options.hasGroups) {
-        for (const j of jobs) {
+        for (const j of publishJobs) {
           const gid = j.options.groupId;
           if (!gid || groupMetas.has(gid)) continue;
           const gMeta = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
@@ -470,16 +755,17 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       let keyGranted = 0;
       const crawlAcquired = new Map<string, number>();
 
-      for (const j of jobs) {
+      for (const j of publishJobs) {
         const gid = j.options.groupId;
         const gMeta = gid ? groupMetas.get(gid) : null;
-        const groupLive = !!gMeta && gMeta.s === "active";
+        const groupAccounted = !!gMeta && !!gid && gMeta.s !== "completed";
         const gated = gate.teamLimit !== null && !j.options.bypassGate;
-        const crawlGated = gated && !!gid && groupLive && crawlFree.has(gid!);
+        const crawlGated =
+          gated && !!gid && gMeta?.s === "active" && crawlFree.has(gid!);
         const keyGated = gated && keyId !== null;
         const countable =
           this.options.hasGroups &&
-          groupLive &&
+          groupAccounted &&
           (j.data as any)?.mode === "single_urls";
 
         let flags = 0;
@@ -489,7 +775,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         if (j.options.listenable) flags |= F_LISTENABLE;
         if ((j.data as any)?.zeroDataRetention) flags |= F_ZDR;
         if (countable) flags |= F_COUNTABLE;
-        if (groupLive) flags |= F_GACC;
+        if (groupAccounted) flags |= F_GACC;
 
         const timesOutAt = gated ? j.options.timesOutAt?.getTime() : undefined;
         const entry: QueueEntry = {
@@ -514,9 +800,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           dc: j.dataChunks.length,
         };
         tn.set(ks.jobMeta(j.id), encodeJson(meta));
-        j.dataChunks.forEach((chunk, ci) =>
-          tn.set(ks.jobData(j.id, ci), chunk),
-        );
 
         let placedStatus: NuqFdbJobStatus;
         if (!gated) {
@@ -558,22 +841,22 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           }
         }
 
-        if (groupLive && gid) {
+        bumpQueueStatus(
+          tn,
+          ks,
+          j.id,
+          placedStatus === "pending" ? "pending" : "queued",
+          1,
+        );
+        if (groupAccounted && gid) {
           tn.add(ks.groupRemaining(gid), ONE);
           setGroupJobIndex(tn, ks, gid, j.id, countable, placedStatus);
           if (countable) bumpGroupStatusCount(tn, ks, gid, placedStatus, 1);
+          if (gMeta?.s === "cancelled") {
+            tn.set(ks.taskGroupCancel(gid), EMPTY);
+          }
         }
-
-        out.push({
-          backend: "fdb",
-          id: j.id,
-          status: placedStatus === "pending" ? "backlog" : "queued",
-          createdAt: new Date(now),
-          priority: entry.p,
-          data: j.data,
-          ownerId: entry.o || undefined,
-          groupId: gid,
-        });
+        tn.clear(ks.ingestJob(op, j.id));
       }
 
       if (granted > 0 && ownerId !== null) {
@@ -586,8 +869,127 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         tn.add(ks.groupCrawlActive(gid), encodeI64(n));
       }
 
-      return out;
+      const releasedReservations = publishJobs.filter(
+        job => gate.teamLimit !== null && !job.options.bypassGate,
+      ).length;
+      if (releasedReservations > 0 && ownerId !== null) {
+        tn.add(
+          ks.teamIngestReserved(ownerId),
+          encodeI64(-releasedReservations),
+        );
+      }
+      tn.set(
+        ks.ingest(op),
+        encodeJson({
+          ...opMeta,
+          r: Math.max(0, opMeta.r - releasedReservations),
+        } satisfies IngestMeta),
+      );
     });
+  }
+
+  private async abortIngest(op: string): Promise<void> {
+    const ks = this.ks;
+    for (;;) {
+      const done = await this.db.doTn(async tn => {
+        const opMeta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+        if (!opMeta) return true;
+        const jobsRange = ks.ingestJobRange(op);
+        const jobs = await tn.getRangeAll(jobsRange.begin, jobsRange.end, {
+          limit: 200,
+        });
+        for (const [jobKey] of jobs) {
+          const id = ks.unpackId(jobKey as Buffer);
+          const status = decodeJson<JobStatusRecord>(
+            await tn.get(ks.jobStatus(id)),
+          );
+          if (status?.s === "ingesting" && status.op === op) {
+            deleteJobRecords(tn, ks, id);
+          }
+          tn.clear(jobKey as Buffer);
+        }
+        if (jobs.length > 0) return false;
+        const groupsRange = ks.ingestGroupRange(op);
+        const groups = await tn.getRangeAll(
+          groupsRange.begin,
+          groupsRange.end,
+          { limit: 200 },
+        );
+        for (const [groupKey] of groups) {
+          const gid = ks.unpackId(groupKey as Buffer);
+          tn.clear(groupKey as Buffer);
+          tn.add(ks.groupIngestCount(gid), MINUS_ONE);
+          tn.set(ks.taskGroupFinish(gid), EMPTY);
+        }
+        if (groups.length > 0) return false;
+        if (opMeta.r > 0 && opMeta.o) {
+          tn.add(ks.teamIngestReserved(opMeta.o), encodeI64(-opMeta.r));
+        }
+        tn.clear(ks.ingestExpiry(opMeta.x, op));
+        tn.clear(ks.ingest(op));
+        return true;
+      });
+      if (done) return;
+    }
+  }
+
+  private async finalizeIngest(op: string): Promise<void> {
+    const ks = this.ks;
+    for (let attempt = 0; ; attempt++) {
+      const state = await this.db.doTn(async tn => {
+        const opMeta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+        if (!opMeta) return "done" as const;
+        const jobsRange = ks.ingestJobRange(op);
+        // This must be a conflicting range read: a concurrent persister may
+        // not insert a manifest after we decide the operation is empty.
+        const remainingJobs = await tn.getRangeAll(
+          jobsRange.begin,
+          jobsRange.end,
+          { limit: 200 },
+        );
+        if (remainingJobs.length > 0) {
+          let waiting = false;
+          for (const [jobKey] of remainingJobs) {
+            const id = ks.unpackId(jobKey as Buffer);
+            const status = decodeJson<JobStatusRecord>(
+              await tn.get(ks.jobStatus(id)),
+            );
+            if (status?.s === "ingesting" && status.op === op) {
+              waiting = true;
+            } else {
+              // Defensive cleanup for a retry that stopped after persisting a
+              // plan for an already-existing job.
+              tn.clear(jobKey as Buffer);
+            }
+          }
+          return waiting ? ("waiting" as const) : ("progress" as const);
+        }
+        const groupRange = ks.ingestGroupRange(op);
+        const groups = await tn.getRangeAll(groupRange.begin, groupRange.end, {
+          limit: 200,
+        });
+        for (const [groupKey] of groups) {
+          const gid = ks.unpackId(groupKey as Buffer);
+          tn.clear(groupKey as Buffer);
+          tn.add(ks.groupIngestCount(gid), MINUS_ONE);
+          tn.set(ks.taskGroupFinish(gid), EMPTY);
+        }
+        if (groups.length > 0) return "progress" as const;
+        if (opMeta.r > 0 && opMeta.o) {
+          tn.add(ks.teamIngestReserved(opMeta.o), encodeI64(-opMeta.r));
+        }
+        tn.clear(ks.ingestExpiry(opMeta.x, op));
+        tn.clear(ks.ingest(op));
+        return "done" as const;
+      });
+      if (state === "done") return;
+      if (state === "waiting") {
+        if (attempt >= 100) {
+          throw new IngestBusyError(`Ingest ${op} is still being published`);
+        }
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+    }
   }
 
   // === Take (worker dequeue)
@@ -610,7 +1012,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     };
     // blind random probes win at high occupancy (no coordination, conflicts
     // spread across shards); the occupancy scan below covers the sparse case
-    const PROBES = 4;
+    const PROBES = Math.min(4, READY_SHARDS);
     const tried = new Set<number>();
     let randomDropped = 0;
     while (tried.size < PROBES) {
@@ -627,7 +1029,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         randomDropped++;
         continue;
       }
-      this.leaseExps.set(result.id, result.leaseExpiresAt!.getTime());
       logger.debug("NuQ FDB dequeue attempt", {
         canonicalLog: "nuq-fdb/dequeue",
         queueName: this.queueName,
@@ -681,7 +1082,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           fallbackDropped++;
           continue;
         }
-        this.leaseExps.set(result.id, result.leaseExpiresAt!.getTime());
         logger.debug("NuQ FDB dequeue attempt", {
           canonicalLog: "nuq-fdb/dequeue",
           queueName: this.queueName,
@@ -723,9 +1123,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     operation?: { timeoutMs: number },
   ): Promise<NuQFdbJob<JobData, JobReturnValue> | "empty" | "dropped"> {
     const ks = this.ks;
-    return await this.db.doTn(async tn => {
+    const op = randomUUID();
+    const claimTransaction = async (
+      tn: Transaction,
+    ): Promise<NuQFdbJob<JobData, JobReturnValue> | "empty" | "dropped"> => {
       if (operation)
         tn.setOption(TransactionOptionCode.Timeout, operation.timeoutMs);
+      const prior = decodeJson<ClaimRecord>(await tn.get(ks.claim(op)));
+      if (prior) return await this.readClaimedJob(tn, prior);
       const txc = newTxContext();
       const now = Date.now();
       const range = ks.readyShardRange(shard);
@@ -743,9 +1148,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       }
 
       if (e.g && this.options.hasGroups) {
-        const gMeta = decodeJson<GroupMeta>(
-          await tn.snapshot().get(ks.groupMeta(e.g)),
-        );
+        const gMeta = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(e.g)));
         if (gMeta && gMeta.s === "cancelled") {
           // lazy cancellation: this job dies at take time
           if (e.f & F_GACC) {
@@ -760,6 +1163,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
               tn.set(ks.taskGroupFinish(e.g), EMPTY);
             }
           }
+          bumpQueueStatus(tn, ks, e.i, "queued", -1);
           deleteJobRecords(tn, ks, e.i);
           await releaseSlotsAndPromote(
             tn,
@@ -776,7 +1180,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const meta = decodeJson<JobMeta>(
         await tn.snapshot().get(ks.jobMeta(e.i)),
       );
-      if (!meta) return "dropped";
+      if (!meta) {
+        bumpQueueStatus(tn, ks, e.i, "queued", -1);
+        return "dropped";
+      }
       const dataRange = ks.jobDataRange(e.i);
       const dataParts = await tn
         .snapshot()
@@ -790,6 +1197,13 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const rec: JobStatusRecord = { s: "active", l: lock, e: exp, st: st.st };
       tn.set(ks.jobStatus(e.i), encodeJson(rec));
       tn.set(ks.lease(timeBucket(e.i), exp, e.i), encodeJson({ l: lock }));
+      tn.set(
+        ks.claim(op),
+        encodeJson({ i: e.i, l: lock, e: exp } satisfies ClaimRecord),
+      );
+      tn.set(ks.claimExpiry(exp, op), EMPTY);
+      bumpQueueStatus(tn, ks, e.i, "queued", -1);
+      bumpQueueStatus(tn, ks, e.i, "active", 1);
       if (e.g && e.f & F_COUNTABLE) {
         bumpGroupStatusCount(tn, ks, e.g, "queued", -1);
         bumpGroupStatusCount(tn, ks, e.g, "active", 1);
@@ -808,7 +1222,52 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         ownerId: meta.o || undefined,
         groupId: meta.g,
       };
-    });
+    };
+    let result = await this.db.doTn(claimTransaction);
+    if (this.options.testHooks?.simulateClaimCommitUnknown?.()) {
+      // Model the binding retrying our closure after the first commit became
+      // ambiguous. The operation marker must return the original claim.
+      result = await this.db.doTn(claimTransaction);
+    }
+    // The marker must survive retries of the claim transaction, then can be
+    // discarded. A failed cleanup is harmless and never affects accounting.
+    await this.db
+      .doTn(async tn => {
+        const marker = decodeJson<ClaimRecord>(await tn.get(ks.claim(op)));
+        if (marker) tn.clear(ks.claimExpiry(marker.e, op));
+        tn.clear(ks.claim(op));
+      })
+      .catch(() => {});
+    return result;
+  }
+
+  private async readClaimedJob(
+    tn: Transaction,
+    claim: ClaimRecord,
+  ): Promise<NuQFdbJob<JobData, JobReturnValue> | "dropped"> {
+    const meta = decodeJson<JobMeta>(await tn.get(this.ks.jobMeta(claim.i)));
+    const status = decodeJson<JobStatusRecord>(
+      await tn.get(this.ks.jobStatus(claim.i)),
+    );
+    if (!meta || status?.s !== "active" || status.l !== claim.l) {
+      return "dropped";
+    }
+    const range = this.ks.jobDataRange(claim.i);
+    const parts = await tn.getRangeAll(range.begin, range.end);
+    const data = JSON.parse(
+      Buffer.concat(parts.map(([, value]) => value as Buffer)).toString("utf8"),
+    );
+    return {
+      id: claim.i,
+      status: "active",
+      createdAt: new Date(meta.c),
+      priority: meta.p,
+      data,
+      lock: claim.l,
+      leaseExpiresAt: new Date(claim.e),
+      ownerId: meta.o || undefined,
+      groupId: meta.g,
+    };
   }
 
   // === Leases
@@ -819,37 +1278,27 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     logger: Logger = _logger,
     operation?: { timeoutMs: number },
   ): Promise<boolean> {
-    const oldExp = this.leaseExps.get(id);
-    if (oldExp === undefined) return false;
     const ks = this.ks;
+    // Stable across a commit_unknown_result retry of this renewal.
     const newExp = Date.now() + (this.options.leaseMs ?? LEASE_MS);
-    try {
-      await this.db.doTn(async tn => {
-        if (operation)
-          tn.setOption(TransactionOptionCode.Timeout, operation.timeoutMs);
-        // blind writes only; the sweeper validates the lock before reaping
-        tn.clear(ks.lease(timeBucket(id), oldExp, id));
-        tn.set(ks.lease(timeBucket(id), newExp, id), encodeJson({ l: lock }));
-        // the lease index moved, keep the status record's expiry in sync for
-        // observability; only the worker holding the lock writes this
-        // This must be a conflictful read. If the sweeper requeues between the
-        // read and commit, FDB retries us and the lock check fences this worker
-        // instead of recreating an active lease beside a ready queue entry.
-        const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));
-        if (!st || st.s !== "active" || st.l !== lock) {
-          throw new LockLostError();
-        }
-        tn.set(ks.jobStatus(id), encodeJson({ ...st, e: newExp }));
-      });
-    } catch (e) {
-      if (e instanceof LockLostError) {
-        this.leaseExps.delete(id);
-        return false;
+    return await this.db.doTn(async tn => {
+      if (operation)
+        tn.setOption(TransactionOptionCode.Timeout, operation.timeoutMs);
+      // A normal status read makes renew conflict with finish, cancellation and
+      // reap. The status' lock/expiry, not worker-local memory, is authoritative.
+      const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));
+      if (!st || st.s !== "active" || st.l !== lock) return false;
+      if (st.e !== undefined) {
+        tn.clear(ks.lease(timeBucket(id), st.e, id));
       }
-      throw e;
-    }
-    this.leaseExps.set(id, newExp);
-    return true;
+      const effectiveExp = Math.max(newExp, st.e ?? 0);
+      tn.set(
+        ks.lease(timeBucket(id), effectiveExp, id),
+        encodeJson({ l: lock }),
+      );
+      tn.set(ks.jobStatus(id), encodeJson({ ...st, e: effectiveExp }));
+      return true;
+    });
   }
 
   // === Finish / fail
@@ -919,16 +1368,20 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           !(meta.f & F_ZDR)
         ) {
           const buf = Buffer.from(JSON.stringify(returnvalue), "utf8");
-          chunkBuffer(buf, DATA_CHUNK_BYTES).forEach((chunk, ci) =>
-            tn.set(ks.jobReturnvalue(id, ci), chunk),
-          );
+          if (buf.length <= MAX_INLINE_RETURNVALUE_BYTES) {
+            chunkBuffer(buf, DATA_CHUNK_BYTES).forEach((chunk, ci) =>
+              tn.set(ks.jobReturnvalue(id, ci), chunk),
+            );
+          }
         }
       } else {
         tn.set(
           ks.jobFailedReason(id),
-          Buffer.from((failedReason ?? "").slice(0, DATA_CHUNK_BYTES), "utf8"),
+          truncateUtf8(failedReason ?? "", MAX_FAILED_REASON_BYTES),
         );
       }
+
+      bumpQueueStatus(tn, ks, id, "active", -1);
 
       // Shed job input data early on cloud (results live in GCS) and always for
       // ZDR. Group members are exempt on the plain cloud path: the crawl-finish
@@ -981,7 +1434,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       }
       return true;
     });
-    if (ok) this.leaseExps.delete(id);
     return ok;
   }
 
@@ -1069,11 +1521,15 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   ): Promise<NuQFdbJob<JobData, JobReturnValue>[]> {
     if (ids.length === 0) return [];
     const out: NuQFdbJob<JobData, JobReturnValue>[] = [];
-    const BATCH = 100;
-    for (let i = 0; i < ids.length; i += BATCH) {
-      const batch = ids.slice(i, i + BATCH);
-      const jobs = await this.db.doTn(async tn =>
-        Promise.all(batch.map(id => this.readJob(tn, id))),
+    // A job may contain ~8MiB input and ~8MiB inline output. Keep each job in
+    // its own transaction, with bounded parallelism, rather than materializing
+    // up to 100 giant jobs under one read version/heap burst.
+    const CONCURRENCY = 16;
+    for (let i = 0; i < ids.length; i += CONCURRENCY) {
+      const jobs = await Promise.all(
+        ids
+          .slice(i, i + CONCURRENCY)
+          .map(id => this.db.doTn(async tn => this.readJob(tn, id))),
       );
       out.push(
         ...jobs.filter(
@@ -1129,6 +1585,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const accounted = !!(meta.f & F_GACC) && !!meta.g && !!this.groupOps;
 
       if (st.s === "pending") {
+        bumpQueueStatus(tn, ks, id, "pending", -1);
         clearPendingPlacement(
           tn,
           ks,
@@ -1159,6 +1616,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         }
         deleteJobRecords(tn, ks, id);
       } else if (st.s === "queued" || st.s === "active") {
+        bumpQueueStatus(tn, ks, id, st.s, -1);
         tn.set(
           ks.jobStatus(id),
           encodeJson({ s: "cancelled", st: st.st } satisfies JobStatusRecord),
@@ -1205,8 +1663,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     ids: string[],
     logger: Logger = _logger,
   ): Promise<void> {
-    for (const id of ids) {
-      await this.removeJob(id, logger);
+    const uniqueIds = [...new Set(ids)];
+    const CONCURRENCY = 16;
+    for (let i = 0; i < uniqueIds.length; i += CONCURRENCY) {
+      await Promise.all(
+        uniqueIds
+          .slice(i, i + CONCURRENCY)
+          .map(id => this.removeJob(id, logger)),
+      );
     }
   }
 
@@ -1311,35 +1775,31 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   ): Promise<NuQFdbJob<JobData, JobReturnValue> | null> {
     const ks = this.ks;
     const owner = normalizeOwnerId(ownerId);
-    const candidateId = await this.db.doTn(async tn => {
-      const r = ks.groupJobRange(groupId);
-      let begin: Buffer | FdbKeySelector = r.begin;
-      // scan for the first countable (single_urls) member
-      for (let scanned = 0; scanned < 2000; ) {
-        const batch = await tn
-          .snapshot()
-          .getRangeAll(begin as any, r.end, { limit: 200 });
-        if (batch.length === 0) return null;
-        for (const [key, value] of batch) {
-          const gj = decodeJson<GroupJobIndexValue>(value as Buffer);
-          if (gj?.m === 1) return ks.unpackId(key as Buffer);
-        }
-        scanned += batch.length;
-        const lastKey = batch[batch.length - 1][0] as Buffer;
-        begin = {
-          key: lastKey,
-          orEqual: true,
-          offset: 1,
-          _isKeySelector: true,
-        };
+    const range = ks.groupJobRange(groupId);
+    let begin: Buffer | FdbKeySelector = range.begin;
+    // Page across transactions so a deep group cannot hit FDB's five-second
+    // transaction lifetime or silently stop after an arbitrary member count.
+    while (true) {
+      const page = await this.db.doTn(async tn =>
+        tn.snapshot().getRangeAll(begin as any, range.end, { limit: 200 }),
+      );
+      if (page.length === 0) return null;
+      for (const [key, value] of page) {
+        const gj = decodeJson<GroupJobIndexValue>(value as Buffer);
+        if (gj?.m !== 1) continue;
+        const job = await this.getJob(ks.unpackId(key as Buffer), logger);
+        if (!job) continue;
+        if (owner !== null && job.ownerId !== owner) return null;
+        return job;
       }
-      return null;
-    });
-    if (!candidateId) return null;
-    const job = await this.getJob(candidateId, logger);
-    if (!job) return null;
-    if (owner !== null && job.ownerId !== owner) return null;
-    return job;
+      const lastKey = page[page.length - 1][0] as Buffer;
+      begin = {
+        key: lastKey,
+        orEqual: true,
+        offset: 1,
+        _isKeySelector: true,
+      };
+    }
   }
 
   public async getCrawlJobsForListing(
@@ -1349,15 +1809,31 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     logger: Logger = _logger,
   ): Promise<NuQFdbJob<JobData, JobReturnValue>[]> {
     const ks = this.ks;
-    const ids = await this.db.doTn(async tn => {
-      const r = ks.groupDoneRange(groupId);
-      const rows = await tn
-        .snapshot()
-        .getRangeAll(r.begin, r.end, { limit: offset + limit });
-      return rows
-        .slice(offset)
-        .map(([, value]) => (value as Buffer).toString("utf8"));
-    });
+    const range = ks.groupDoneRange(groupId);
+    const ids: string[] = [];
+    let begin: Buffer | FdbKeySelector = range.begin;
+    let skipped = 0;
+    while (ids.length < limit) {
+      const pageSize = Math.min(500, offset - skipped + (limit - ids.length));
+      const rows = await this.db.doTn(async tn =>
+        tn.snapshot().getRangeAll(begin as any, range.end, {
+          limit: Math.max(1, pageSize),
+        }),
+      );
+      if (rows.length === 0) break;
+      for (const [, value] of rows) {
+        if (skipped < offset) skipped++;
+        else if (ids.length < limit)
+          ids.push((value as Buffer).toString("utf8"));
+      }
+      const lastKey = rows[rows.length - 1][0] as Buffer;
+      begin = {
+        key: lastKey,
+        orEqual: true,
+        offset: 1,
+        _isKeySelector: true,
+      };
+    }
     const jobs = await this.getJobs(ids, logger);
     const byId = new Map(jobs.map(j => [j.id, j]));
     return ids
@@ -1383,19 +1859,39 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   public async getTeamActiveCounts(): Promise<Map<string, number>> {
     const ks = this.ks;
-    return await this.db.doTn(async tn => {
-      const r = ks.teamActiveIndexRange();
-      const rows = await tn.snapshot().getRangeAll(r.begin, r.end);
-      const counts = new Map<string, number>();
-      for (const [key, value] of rows) {
-        const parts = ks.unpack(key as Buffer);
-        const teamId = parts[3];
-        if (typeof teamId !== "string") continue;
-        const count = Math.max(0, decodeI64(value as Buffer));
-        if (count > 0) counts.set(teamId, count);
-      }
-      return counts;
-    });
+    const range = ks.teamActiveIndexRange();
+    const counts = new Map<string, number>();
+    let begin: Buffer | FdbKeySelector = range.begin;
+    while (true) {
+      const page = await this.db.doTn(async tn => {
+        const rows = await tn.getRangeAll(begin as any, range.end, {
+          limit: 500,
+        });
+        const values: Array<[string, number]> = [];
+        for (const [key] of rows) {
+          const parts = ks.unpack(key as Buffer);
+          const teamId = parts[3];
+          if (typeof teamId !== "string") continue;
+          const count = Math.max(
+            0,
+            decodeI64(await tn.get(ks.teamActive(teamId))),
+          );
+          if (count > 0) values.push([teamId, count]);
+          else tn.clear(key as Buffer); // clean legacy zero-valued index rows
+        }
+        return { rows, values };
+      });
+      for (const [teamId, count] of page.values) counts.set(teamId, count);
+      if (page.rows.length < 500) break;
+      const lastKey = page.rows[page.rows.length - 1][0] as Buffer;
+      begin = {
+        key: lastKey,
+        orEqual: true,
+        offset: 1,
+        _isKeySelector: true,
+      };
+    }
+    return counts;
   }
 
   public async getTeamPendingCount(teamId: string): Promise<number> {
@@ -1410,57 +1906,32 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   }
 
   public async getWorkerLoadCount(): Promise<number> {
-    const ks = this.ks;
-    return await this.db.doTn(async tn => {
-      const [readyRows, activeRows] = await Promise.all([
-        tn
-          .snapshot()
-          .getRangeAll(
-            ks.readyShardCountRange().begin,
-            ks.readyShardCountRange().end,
-          ),
-        tn.snapshot().getRangeAll(ks.leaseRange().begin, ks.leaseRange().end),
-      ]);
-      const queued = readyRows.reduce(
-        (sum, [, value]) => sum + Math.max(0, decodeI64(value as Buffer)),
-        0,
-      );
-      return queued + activeRows.length;
-    });
+    const counts = await this.getMetricCounts();
+    return counts.queued + counts.active;
   }
 
   private async getMetricCounts(): Promise<Record<NuQJobStatusCompat, number>> {
     const ks = this.ks;
     return await this.db.doTn(async tn => {
-      const [readyRows, activeRows, teamRows] = await Promise.all([
-        tn
-          .snapshot()
-          .getRangeAll(
-            ks.readyShardCountRange().begin,
-            ks.readyShardCountRange().end,
-          ),
-        tn.snapshot().getRangeAll(ks.leaseRange().begin, ks.leaseRange().end),
-        tn.snapshot().getRangeAll(ks.teamRange().begin, ks.teamRange().end),
-      ]);
-
-      const queued = readyRows.reduce(
-        (sum, [, value]) => sum + Math.max(0, decodeI64(value as Buffer)),
-        0,
+      const internal = ["queued", "active", "pending"] as const;
+      const rows = await Promise.all(
+        internal.map(status => {
+          const range = ks.metricStatusRange(status);
+          return tn.snapshot().getRangeAll(range.begin, range.end);
+        }),
       );
-
-      let backlog = 0;
-      for (const [key, value] of teamRows) {
-        const parts = ks.unpack(key as Buffer);
-        if (parts[4] !== "pend") continue;
-        backlog += Math.max(0, decodeI64(value as Buffer));
-      }
-
+      const totals = rows.map(statusRows =>
+        statusRows.reduce(
+          (sum, [, value]) => sum + decodeI64(value as Buffer),
+          0,
+        ),
+      );
       return {
-        queued,
-        active: activeRows.length,
+        queued: Math.max(0, totals[0]),
+        active: Math.max(0, totals[1]),
         completed: 0,
         failed: 0,
-        backlog,
+        backlog: Math.max(0, totals[2]),
       };
     });
   }
@@ -1483,5 +1954,3 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       .join("\n")}\n`;
   }
 }
-
-class LockLostError extends Error {}

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -298,11 +298,13 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     // fields (deadlines, trace context, changing limits). The first caller's
     // gate and per-job plan are persisted; retries attach to that plan.
     const op = createHash("sha256")
-      .update(this.queueName)
-      .update("\0")
-      .update(ownerId ?? "")
-      .update("\0")
-      .update(uniqueInputs.map(job => job.id).join("\0"))
+      .update(
+        JSON.stringify([
+          this.queueName,
+          ownerId,
+          uniqueInputs.map(job => job.id),
+        ]),
+      )
       .digest("hex");
     await this.initIngest(op, ownerId, gate);
 

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -443,6 +443,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       encodedJsonBytes(meta) +
       ks.jobStatus(job.id).length +
       encodedJsonBytes({ s: "pending", st: 0 }) +
+      ks.jobMetricTracked(job.id).length +
+      1 +
       ks.readyPrefix(READY_SHARDS - 1, priority).length +
       encodedJsonBytes(entry) +
       ks.readyShardCount(READY_SHARDS - 1).length +
@@ -515,6 +517,16 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const ks = this.ks;
     await this.db.doTn(async tn => {
       if (await tn.get(ks.ingest(op))) return;
+      if (
+        !(await tn.get(ks.metricBackfillDone())) &&
+        !(await tn.get(ks.metricBackfillCursor()))
+      ) {
+        const jobs = ks.jobRootRange();
+        const existing = await tn.getRangeAll(jobs.begin, jobs.end, {
+          limit: 1,
+        });
+        if (existing.length === 0) tn.set(ks.metricBackfillDone(), EMPTY);
+      }
       const createdAt = Date.now();
       const meta: IngestMeta = {
         o: ownerId ?? "",
@@ -803,6 +815,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           dc: j.dataChunks.length,
         };
         tn.set(ks.jobMeta(j.id), encodeJson(meta));
+        tn.set(ks.jobMetricTracked(j.id), EMPTY);
 
         let placedStatus: NuqFdbJobStatus;
         if (!gated) {
@@ -844,7 +857,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           }
         }
 
-        bumpQueueStatus(
+        await bumpQueueStatus(
           tn,
           ks,
           j.id,
@@ -1166,7 +1179,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
               tn.set(ks.taskGroupFinish(e.g), EMPTY);
             }
           }
-          bumpQueueStatus(tn, ks, e.i, "queued", -1);
+          await bumpQueueStatus(tn, ks, e.i, "queued", -1);
           deleteJobRecords(tn, ks, e.i);
           await releaseSlotsAndPromote(
             tn,
@@ -1184,7 +1197,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         await tn.snapshot().get(ks.jobMeta(e.i)),
       );
       if (!meta) {
-        bumpQueueStatus(tn, ks, e.i, "queued", -1);
+        await bumpQueueStatus(tn, ks, e.i, "queued", -1);
         return "dropped";
       }
       const dataRange = ks.jobDataRange(e.i);
@@ -1205,8 +1218,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         encodeJson({ i: e.i, l: lock, e: exp } satisfies ClaimRecord),
       );
       tn.set(ks.claimExpiry(exp, op), EMPTY);
-      bumpQueueStatus(tn, ks, e.i, "queued", -1);
-      bumpQueueStatus(tn, ks, e.i, "active", 1);
+      await bumpQueueStatus(tn, ks, e.i, "queued", -1);
+      await bumpQueueStatus(tn, ks, e.i, "active", 1);
       if (e.g && e.f & F_COUNTABLE) {
         bumpGroupStatusCount(tn, ks, e.g, "queued", -1);
         bumpGroupStatusCount(tn, ks, e.g, "active", 1);
@@ -1385,7 +1398,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         );
       }
 
-      bumpQueueStatus(tn, ks, id, "active", -1);
+      await bumpQueueStatus(tn, ks, id, "active", -1);
 
       // Shed job input data early on cloud (results live in GCS) and always for
       // ZDR. Group members are exempt on the plain cloud path: the crawl-finish
@@ -1589,7 +1602,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const accounted = !!(meta.f & F_GACC) && !!meta.g && !!this.groupOps;
 
       if (st.s === "pending") {
-        bumpQueueStatus(tn, ks, id, "pending", -1);
+        await bumpQueueStatus(tn, ks, id, "pending", -1);
         clearPendingPlacement(
           tn,
           ks,
@@ -1620,7 +1633,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         }
         deleteJobRecords(tn, ks, id);
       } else if (st.s === "queued" || st.s === "active") {
-        bumpQueueStatus(tn, ks, id, st.s, -1);
+        await bumpQueueStatus(tn, ks, id, st.s, -1);
         tn.set(
           ks.jobStatus(id),
           encodeJson({ s: "cancelled", st: st.st } satisfies JobStatusRecord),
@@ -1909,6 +1922,53 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     );
   }
 
+  // Enrolls one bounded page of jobs created before maintained counters were
+  // introduced. A per-job marker and normal status reads make this conflict
+  // safely with concurrent transitions. Metrics stay unavailable until the
+  // durable cursor reaches the end, rather than reporting partial counts.
+  public async backfillMetricCounts(batchSize = 100): Promise<boolean> {
+    const ks = this.ks;
+    return await this.db.doTn(async tn => {
+      if (await tn.get(ks.metricBackfillDone())) return true;
+      const range = ks.jobRootRange();
+      const cursor = await tn.get(ks.metricBackfillCursor());
+      const begin = cursor
+        ? Buffer.concat([cursor as Buffer, Buffer.from([0])])
+        : range.begin;
+      const rows = await tn.getRangeAll(begin, range.end, {
+        limit: Math.max(1, batchSize),
+      });
+
+      for (const [key, value] of rows) {
+        const parts = ks.unpack(key as Buffer);
+        if (parts[4] !== "m" || typeof parts[3] !== "string") continue;
+        const id = parts[3];
+        if (await tn.get(ks.jobMetricTracked(id))) continue;
+        const meta = decodeJson<JobMeta>(value as Buffer);
+        const status = decodeJson<JobStatusRecord>(
+          await tn.get(ks.jobStatus(id)),
+        );
+        if (!meta || !status) continue;
+        tn.set(ks.jobMetricTracked(id), EMPTY);
+        if (
+          status.s === "pending" ||
+          status.s === "queued" ||
+          status.s === "active"
+        ) {
+          await bumpQueueStatus(tn, ks, id, status.s, 1);
+        }
+      }
+
+      if (rows.length < Math.max(1, batchSize)) {
+        tn.clear(ks.metricBackfillCursor());
+        tn.set(ks.metricBackfillDone(), EMPTY);
+        return true;
+      }
+      tn.set(ks.metricBackfillCursor(), rows[rows.length - 1][0] as Buffer);
+      return false;
+    });
+  }
+
   public async getWorkerLoadCount(): Promise<number> {
     const counts = await this.getMetricCounts();
     return counts.queued + counts.active;
@@ -1918,18 +1978,24 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const ks = this.ks;
     return await this.db.doTn(async tn => {
       const internal = ["queued", "active", "pending"] as const;
-      // Read only the fixed-width maintained counter set. Point reads make the
-      // scrape footprint exactly statuses * METRIC_SHARDS regardless of jobs,
-      // teams, leases, ready entries, or unexpected keys in these prefixes.
-      const rows = await Promise.all(
-        internal.map(status =>
-          Promise.all(
-            Array.from({ length: METRIC_SHARDS }, (_, shard) =>
-              tn.snapshot().get(ks.metricCount(status, shard)),
+      // Read only the fixed-width maintained counter set plus its readiness
+      // marker. The scrape footprint is independent of jobs, teams, leases,
+      // ready entries, and unexpected keys in these prefixes.
+      const [ready, rows] = await Promise.all([
+        tn.snapshot().get(ks.metricBackfillDone()),
+        Promise.all(
+          internal.map(status =>
+            Promise.all(
+              Array.from({ length: METRIC_SHARDS }, (_, shard) =>
+                tn.snapshot().get(ks.metricCount(status, shard)),
+              ),
             ),
           ),
         ),
-      );
+      ]);
+      if (!ready) {
+        throw new Error("NuQ FDB metrics are initializing");
+      }
       const totals = rows.map(statusRows =>
         statusRows.reduce((sum, value) => sum + decodeI64(value), 0),
       );

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -58,6 +58,7 @@ import {
   setGroupJobIndex,
   bumpGroupStatusCount,
   bumpTeamActive,
+  enrollQueueStatus,
   bumpQueueStatus,
   GroupJobIndexValue,
 } from "./ops";
@@ -184,6 +185,7 @@ function truncateUtf8(value: string, maxBytes: number): Buffer {
 
 class IngestBusyError extends Error {}
 class IngestValidationError extends Error {}
+export class NuqFdbMetricsInitializingError extends Error {}
 
 function encodedJsonBytes(v: any): number {
   return Buffer.byteLength(JSON.stringify(v), "utf8");
@@ -517,15 +519,23 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const ks = this.ks;
     await this.db.doTn(async tn => {
       if (await tn.get(ks.ingest(op))) return;
+      const metricGeneration = await tn.get(ks.metricBackfillActive());
+      const completedGeneration = await tn.get(ks.metricBackfillDone());
       if (
-        !(await tn.get(ks.metricBackfillDone())) &&
+        metricGeneration &&
+        (!completedGeneration ||
+          !(completedGeneration as Buffer).equals(
+            metricGeneration as Buffer,
+          )) &&
         !(await tn.get(ks.metricBackfillCursor()))
       ) {
         const jobs = ks.jobRootRange();
         const existing = await tn.getRangeAll(jobs.begin, jobs.end, {
           limit: 1,
         });
-        if (existing.length === 0) tn.set(ks.metricBackfillDone(), EMPTY);
+        if (existing.length === 0) {
+          tn.set(ks.metricBackfillDone(), metricGeneration as Buffer);
+        }
       }
       const createdAt = Date.now();
       const meta: IngestMeta = {
@@ -815,7 +825,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           dc: j.dataChunks.length,
         };
         tn.set(ks.jobMeta(j.id), encodeJson(meta));
-        tn.set(ks.jobMetricTracked(j.id), EMPTY);
 
         let placedStatus: NuqFdbJobStatus;
         if (!gated) {
@@ -857,12 +866,11 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           }
         }
 
-        await bumpQueueStatus(
+        await enrollQueueStatus(
           tn,
           ks,
           j.id,
           placedStatus === "pending" ? "pending" : "queued",
-          1,
         );
         if (groupAccounted && gid) {
           tn.add(ks.groupRemaining(gid), ONE);
@@ -1926,10 +1934,36 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   // introduced. A per-job marker and normal status reads make this conflict
   // safely with concurrent transitions. Metrics stay unavailable until the
   // durable cursor reaches the end, rather than reporting partial counts.
-  public async backfillMetricCounts(batchSize = 100): Promise<boolean> {
+  public async backfillMetricCounts(
+    batchSize = 100,
+    activate = false,
+  ): Promise<boolean> {
     const ks = this.ks;
+    const requestedGeneration = Buffer.from(randomUUID(), "utf8");
     return await this.db.doTn(async tn => {
-      if (await tn.get(ks.metricBackfillDone())) return true;
+      let generation = await tn.get(ks.metricBackfillActive());
+      if (!generation) {
+        if (!activate) return false;
+        // Activation is allowed only after old writers have drained. Start
+        // from a fresh bounded generation so an interrupted pre-activation
+        // attempt cannot leak stale values into the authoritative counters.
+        for (const status of ["pending", "queued", "active"]) {
+          for (let shard = 0; shard < METRIC_SHARDS; shard++) {
+            tn.clear(ks.metricCount(status, shard));
+          }
+        }
+        tn.clear(ks.metricBackfillCursor());
+        tn.clear(ks.metricBackfillDone());
+        tn.set(ks.metricBackfillActive(), requestedGeneration);
+        generation = requestedGeneration;
+      }
+      const completedGeneration = await tn.get(ks.metricBackfillDone());
+      if (
+        completedGeneration &&
+        (completedGeneration as Buffer).equals(generation as Buffer)
+      ) {
+        return true;
+      }
       const range = ks.jobRootRange();
       const cursor = await tn.get(ks.metricBackfillCursor());
       const begin = cursor
@@ -1943,25 +1977,29 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         const parts = ks.unpack(key as Buffer);
         if (parts[4] !== "m" || typeof parts[3] !== "string") continue;
         const id = parts[3];
-        if (await tn.get(ks.jobMetricTracked(id))) continue;
+        const membership = await tn.get(ks.jobMetricTracked(id));
+        if (membership && (membership as Buffer).equals(generation as Buffer)) {
+          continue;
+        }
         const meta = decodeJson<JobMeta>(value as Buffer);
         const status = decodeJson<JobStatusRecord>(
           await tn.get(ks.jobStatus(id)),
         );
         if (!meta || !status) continue;
-        tn.set(ks.jobMetricTracked(id), EMPTY);
         if (
           status.s === "pending" ||
           status.s === "queued" ||
           status.s === "active"
         ) {
-          await bumpQueueStatus(tn, ks, id, status.s, 1);
+          await enrollQueueStatus(tn, ks, id, status.s);
+        } else {
+          tn.set(ks.jobMetricTracked(id), generation as Buffer);
         }
       }
 
       if (rows.length < Math.max(1, batchSize)) {
         tn.clear(ks.metricBackfillCursor());
-        tn.set(ks.metricBackfillDone(), EMPTY);
+        tn.set(ks.metricBackfillDone(), generation as Buffer);
         return true;
       }
       tn.set(ks.metricBackfillCursor(), rows[rows.length - 1][0] as Buffer);
@@ -1981,7 +2019,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       // Read only the fixed-width maintained counter set plus its readiness
       // marker. The scrape footprint is independent of jobs, teams, leases,
       // ready entries, and unexpected keys in these prefixes.
-      const [ready, rows] = await Promise.all([
+      const [generation, ready, rows] = await Promise.all([
+        tn.snapshot().get(ks.metricBackfillActive()),
         tn.snapshot().get(ks.metricBackfillDone()),
         Promise.all(
           internal.map(status =>
@@ -1993,8 +2032,14 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           ),
         ),
       ]);
-      if (!ready) {
-        throw new Error("NuQ FDB metrics are initializing");
+      if (
+        !generation ||
+        !ready ||
+        !(ready as Buffer).equals(generation as Buffer)
+      ) {
+        throw new NuqFdbMetricsInitializingError(
+          "NuQ FDB metrics are initializing",
+        );
       }
       const totals = rows.map(statusRows =>
         statusRows.reduce((sum, value) => sum + decodeI64(value), 0),

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -21,6 +21,7 @@ import {
   decodeJson,
   timeBucket,
   READY_SHARDS,
+  METRIC_SHARDS,
   F_GATED,
   F_CRAWL_GATED,
   F_LISTENABLE,
@@ -1258,6 +1259,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       Buffer.concat(parts.map(([, value]) => value as Buffer)).toString("utf8"),
     );
     return {
+      backend: "fdb",
       id: claim.i,
       status: "active",
       createdAt: new Date(meta.c),
@@ -1914,17 +1916,20 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const ks = this.ks;
     return await this.db.doTn(async tn => {
       const internal = ["queued", "active", "pending"] as const;
+      // Read only the fixed-width maintained counter set. Point reads make the
+      // scrape footprint exactly statuses * METRIC_SHARDS regardless of jobs,
+      // teams, leases, ready entries, or unexpected keys in these prefixes.
       const rows = await Promise.all(
-        internal.map(status => {
-          const range = ks.metricStatusRange(status);
-          return tn.snapshot().getRangeAll(range.begin, range.end);
-        }),
+        internal.map(status =>
+          Promise.all(
+            Array.from({ length: METRIC_SHARDS }, (_, shard) =>
+              tn.snapshot().get(ks.metricCount(status, shard)),
+            ),
+          ),
+        ),
       );
       const totals = rows.map(statusRows =>
-        statusRows.reduce(
-          (sum, [, value]) => sum + decodeI64(value as Buffer),
-          0,
-        ),
+        statusRows.reduce((sum, value) => sum + decodeI64(value), 0),
       );
       return {
         queued: Math.max(0, totals[0]),

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -22,6 +22,9 @@ import {
   timeBucket,
   READY_SHARDS,
   METRIC_SHARDS,
+  METRIC_STATUSES,
+  NuqFdbMetricControl,
+  NuqFdbMetricStatus,
   F_GATED,
   F_CRAWL_GATED,
   F_LISTENABLE,
@@ -58,8 +61,7 @@ import {
   setGroupJobIndex,
   bumpGroupStatusCount,
   bumpTeamActive,
-  enrollQueueStatus,
-  bumpQueueStatus,
+  alignQueueMetricStatus,
   GroupJobIndexValue,
 } from "./ops";
 import { NuqFdbGroupOps } from "./groups";
@@ -68,6 +70,8 @@ import { NuqFdbGroupOps } from "./groups";
 // importing queue types does not eagerly load libfdb_c in PG-only processes.
 const TransactionOptionCode = {
   Timeout: 500 as FdbTransactionOptionCode,
+  RetryLimit: 501 as FdbTransactionOptionCode,
+  MaxRetryDelay: 502 as FdbTransactionOptionCode,
 };
 
 const DATA_CHUNK_BYTES = 90 * 1024;
@@ -81,6 +85,10 @@ const ENQUEUE_MAX_JOBS_PER_TRANSACTION = 250;
 const MAX_INLINE_RETURNVALUE_BYTES = 8 * 1024 * 1024;
 const MAX_FAILED_REASON_BYTES = 90 * 1024;
 const INGEST_TTL_MS = 60 * 60 * 1000;
+const CLAIM_CLEANUP_MAX_IN_FLIGHT = 8;
+const CLAIM_CLEANUP_TIMEOUT_MS = 250;
+const CLAIM_CLEANUP_RETRY_LIMIT = 1;
+const CLAIM_CLEANUP_MAX_RETRY_DELAY_MS = 25;
 
 export { QueueFullError };
 
@@ -204,6 +212,7 @@ function semanticDataHash(value: unknown): string {
 export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   public readonly ks: NuqFdbKeyspace;
   public readonly groupOps: NuqFdbGroupOps | null;
+  private claimCleanupInFlight = 0;
 
   constructor(
     public readonly queueName: string,
@@ -220,6 +229,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         afterStageBatch?: (batch: number) => Promise<void>;
         afterPublishBatch?: (batch: number) => Promise<void>;
         simulateClaimCommitUnknown?: () => boolean;
+        runClaimCleanup?: (cleanup: () => Promise<void>) => Promise<void>;
       };
     },
   ) {
@@ -445,8 +455,17 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       encodedJsonBytes(meta) +
       ks.jobStatus(job.id).length +
       encodedJsonBytes({ s: "pending", st: 0 }) +
-      ks.jobMetricTracked(job.id).length +
-      1 +
+      // One generation ledger row and two fixed-counter atomic mutations are
+      // the worst-case metric transition footprint.
+      ks.metricLedger("00000000-0000-0000-0000-000000000000", job.id).length +
+      "completed".length +
+      2 *
+        (ks.metricCount(
+          "00000000-0000-0000-0000-000000000000",
+          "completed",
+          METRIC_SHARDS - 1,
+        ).length +
+          8) +
       ks.readyPrefix(READY_SHARDS - 1, priority).length +
       encodedJsonBytes(entry) +
       ks.readyShardCount(READY_SHARDS - 1).length +
@@ -519,24 +538,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     const ks = this.ks;
     await this.db.doTn(async tn => {
       if (await tn.get(ks.ingest(op))) return;
-      const metricGeneration = await tn.get(ks.metricBackfillActive());
-      const completedGeneration = await tn.get(ks.metricBackfillDone());
-      if (
-        metricGeneration &&
-        (!completedGeneration ||
-          !(completedGeneration as Buffer).equals(
-            metricGeneration as Buffer,
-          )) &&
-        !(await tn.get(ks.metricBackfillCursor()))
-      ) {
-        const jobs = ks.jobRootRange();
-        const existing = await tn.getRangeAll(jobs.begin, jobs.end, {
-          limit: 1,
-        });
-        if (existing.length === 0) {
-          tn.set(ks.metricBackfillDone(), metricGeneration as Buffer);
-        }
-      }
+      // Even an ingest that only creates the untracked "ingesting" state must
+      // conflict with activation/invalidation. Publication performs the actual
+      // canonical ledger alignment.
+      await tn.get(ks.metricControl());
       const createdAt = Date.now();
       const meta: IngestMeta = {
         o: ownerId ?? "",
@@ -674,6 +679,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         job.dataChunks.forEach((chunk, chunkIndex) =>
           tn.set(ks.jobData(job.id, chunkIndex), chunk),
         );
+        await alignQueueMetricStatus(tn, ks, job.id);
       }
     });
   }
@@ -866,12 +872,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           }
         }
 
-        await enrollQueueStatus(
-          tn,
-          ks,
-          j.id,
-          placedStatus === "pending" ? "pending" : "queued",
-        );
+        await alignQueueMetricStatus(tn, ks, j.id);
         if (groupAccounted && gid) {
           tn.add(ks.groupRemaining(gid), ONE);
           setGroupJobIndex(tn, ks, gid, j.id, countable, placedStatus);
@@ -929,6 +930,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           );
           if (status?.s === "ingesting" && status.op === op) {
             deleteJobRecords(tn, ks, id);
+            await alignQueueMetricStatus(tn, ks, id);
           }
           tn.clear(jobKey as Buffer);
         }
@@ -1167,7 +1169,9 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
       const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(e.i)));
       if (!st || st.s !== "queued") {
-        // tombstone (removed job) -- slots were released by the remover
+        // Tombstone (removed job) -- slots were released by the remover. The
+        // placement GC still participates in the metric control protocol.
+        await alignQueueMetricStatus(tn, ks, e.i);
         return "dropped";
       }
 
@@ -1187,8 +1191,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
               tn.set(ks.taskGroupFinish(e.g), EMPTY);
             }
           }
-          await bumpQueueStatus(tn, ks, e.i, "queued", -1);
           deleteJobRecords(tn, ks, e.i);
+          await alignQueueMetricStatus(tn, ks, e.i);
           await releaseSlotsAndPromote(
             tn,
             ks,
@@ -1205,7 +1209,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         await tn.snapshot().get(ks.jobMeta(e.i)),
       );
       if (!meta) {
-        await bumpQueueStatus(tn, ks, e.i, "queued", -1);
+        await alignQueueMetricStatus(tn, ks, e.i);
         return "dropped";
       }
       const dataRange = ks.jobDataRange(e.i);
@@ -1226,8 +1230,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         encodeJson({ i: e.i, l: lock, e: exp } satisfies ClaimRecord),
       );
       tn.set(ks.claimExpiry(exp, op), EMPTY);
-      await bumpQueueStatus(tn, ks, e.i, "queued", -1);
-      await bumpQueueStatus(tn, ks, e.i, "active", 1);
+      await alignQueueMetricStatus(tn, ks, e.i);
       if (e.g && e.f & F_COUNTABLE) {
         bumpGroupStatusCount(tn, ks, e.g, "queued", -1);
         bumpGroupStatusCount(tn, ks, e.g, "active", 1);
@@ -1253,16 +1256,50 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       // ambiguous. The operation marker must return the original claim.
       result = await this.db.doTn(claimTransaction);
     }
-    // The marker must survive retries of the claim transaction, then can be
-    // discarded. A failed cleanup is harmless and never affects accounting.
-    await this.db
-      .doTn(async tn => {
-        const marker = decodeJson<ClaimRecord>(await tn.get(ks.claim(op)));
-        if (marker) tn.clear(ks.claimExpiry(marker.e, op));
-        tn.clear(ks.claim(op));
-      })
-      .catch(() => {});
+    // A definite result may return immediately. Marker cleanup is best-effort,
+    // bounded per queue, and has no wait queue; durable claimExpiry is the
+    // fallback whenever the cap, timeout, error, or process exit wins.
+    if (result !== "empty" && result !== "dropped") {
+      this.scheduleClaimCleanup(op);
+    }
     return result;
+  }
+
+  private scheduleClaimCleanup(op: string): void {
+    if (this.claimCleanupInFlight >= CLAIM_CLEANUP_MAX_IN_FLIGHT) return;
+    this.claimCleanupInFlight++;
+    const cleanup = async () => {
+      await this.db.doTn(async tn => {
+        tn.setOption(TransactionOptionCode.Timeout, CLAIM_CLEANUP_TIMEOUT_MS);
+        tn.setOption(
+          TransactionOptionCode.RetryLimit,
+          CLAIM_CLEANUP_RETRY_LIMIT,
+        );
+        tn.setOption(
+          TransactionOptionCode.MaxRetryDelay,
+          CLAIM_CLEANUP_MAX_RETRY_DELAY_MS,
+        );
+        const marker = decodeJson<ClaimRecord>(await tn.get(this.ks.claim(op)));
+        if (marker) tn.clear(this.ks.claimExpiry(marker.e, op));
+        tn.clear(this.ks.claim(op));
+      });
+    };
+    const run = this.options.testHooks?.runClaimCleanup;
+    void (run ? run(cleanup) : cleanup())
+      .catch(error => {
+        _logger.debug("NuQ FDB claim cleanup deferred to sweeper", {
+          canonicalLog: "nuq-fdb/claim_cleanup_deferred",
+          queueName: this.queueName,
+          error,
+        });
+      })
+      .finally(() => {
+        this.claimCleanupInFlight--;
+      });
+  }
+
+  public getClaimCleanupInFlightForTest(): number {
+    return this.claimCleanupInFlight;
   }
 
   private async readClaimedJob(
@@ -1322,6 +1359,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         encodeJson({ l: lock }),
       );
       tn.set(ks.jobStatus(id), encodeJson({ ...st, e: effectiveExp }));
+      await alignQueueMetricStatus(tn, ks, id);
       return true;
     });
   }
@@ -1370,12 +1408,21 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const txc = newTxContext();
       const now = Date.now();
       const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));
-      if (!st) return false;
+      if (!st) {
+        await alignQueueMetricStatus(tn, ks, id);
+        return false;
+      }
       // idempotency: a commit_unknown_result retry lands here
-      if (st.s === outcome && st.l === lock) return true;
+      if (st.s === outcome && st.l === lock) {
+        await alignQueueMetricStatus(tn, ks, id);
+        return true;
+      }
       if (st.s !== "active" || st.l !== lock) return false;
       const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
-      if (!meta) return false;
+      if (!meta) {
+        await alignQueueMetricStatus(tn, ks, id);
+        return false;
+      }
 
       const rec: JobStatusRecord = {
         s: outcome,
@@ -1406,7 +1453,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         );
       }
 
-      await bumpQueueStatus(tn, ks, id, "active", -1);
+      await alignQueueMetricStatus(tn, ks, id);
 
       // Shed job input data early on cloud (results live in GCS) and always for
       // ZDR. Group members are exempt on the plain cloud path: the crawl-finish
@@ -1593,9 +1640,15 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const txc = newTxContext();
       const now = Date.now();
       const st = decodeJson<JobStatusRecord>(await tn.get(ks.jobStatus(id)));
-      if (!st || st.s === "cancelled") return false;
+      if (!st || st.s === "cancelled") {
+        await alignQueueMetricStatus(tn, ks, id);
+        return false;
+      }
       const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
-      if (!meta) return false;
+      if (!meta) {
+        await alignQueueMetricStatus(tn, ks, id);
+        return false;
+      }
       const entry: QueueEntry = {
         i: id,
         o: meta.o,
@@ -1610,7 +1663,6 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const accounted = !!(meta.f & F_GACC) && !!meta.g && !!this.groupOps;
 
       if (st.s === "pending") {
-        await bumpQueueStatus(tn, ks, id, "pending", -1);
         clearPendingPlacement(
           tn,
           ks,
@@ -1640,8 +1692,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           tn.set(ks.taskGroupFinish(meta.g!), EMPTY);
         }
         deleteJobRecords(tn, ks, id);
+        await alignQueueMetricStatus(tn, ks, id);
       } else if (st.s === "queued" || st.s === "active") {
-        await bumpQueueStatus(tn, ks, id, st.s, -1);
         tn.set(
           ks.jobStatus(id),
           encodeJson({ s: "cancelled", st: st.st } satisfies JobStatusRecord),
@@ -1672,6 +1724,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           ),
           EMPTY,
         );
+        await alignQueueMetricStatus(tn, ks, id);
       } else {
         // terminal: drop the records, like the PG row delete
         if (accounted) {
@@ -1679,6 +1732,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           if (countable) bumpGroupStatusCount(tn, ks, meta.g!, st.s, -1);
         }
         deleteJobRecords(tn, ks, id);
+        await alignQueueMetricStatus(tn, ks, id);
       }
       return true;
     });
@@ -1930,126 +1984,228 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     );
   }
 
-  // Enrolls one bounded page of jobs created before maintained counters were
-  // introduced. A per-job marker and normal status reads make this conflict
-  // safely with concurrent transitions. Metrics stay unavailable until the
-  // durable cursor reaches the end, rather than reporting partial counts.
+  private decodeMetricControl(
+    value: Buffer | undefined | null,
+  ): NuqFdbMetricControl | null {
+    const control = decodeJson<NuqFdbMetricControl>(value);
+    if (!control) return null;
+    if (
+      control.format !== 3 ||
+      control.shards !== METRIC_SHARDS ||
+      !control.generation ||
+      !["backfill-jobs", "backfill-ledger", "ready"].includes(control.phase)
+    ) {
+      throw new Error("Unsupported NuQ FDB metric control record");
+    }
+    return control;
+  }
+
+  // Explicit release-B activation API. Concurrent callers converge on the one
+  // generation that wins the normal control-key conflict.
+  public async beginMetricCounterBackfill(): Promise<NuqFdbMetricControl> {
+    const requested: NuqFdbMetricControl = {
+      format: 3,
+      generation: randomUUID(),
+      phase: "backfill-jobs",
+      shards: METRIC_SHARDS,
+    };
+    return await this.db.doTn(async tn => {
+      const current = this.decodeMetricControl(
+        await tn.get(this.ks.metricControl()),
+      );
+      if (current) return current;
+      tn.set(this.ks.metricControl(), encodeJson(requested));
+      return requested;
+    });
+  }
+
+  public async getMetricCounterBackfillStatus(): Promise<NuqFdbMetricControl | null> {
+    return await this.db.doTn(async tn =>
+      this.decodeMetricControl(
+        await tn.snapshot().get(this.ks.metricControl()),
+      ),
+    );
+  }
+
+  // Deployment rollback must call this before any pre-protocol writer returns.
+  // Old generation keys intentionally remain isolated for later bounded GC.
+  public async invalidateMetricCounterGeneration(
+    expectedGeneration?: string,
+  ): Promise<boolean> {
+    return await this.db.doTn(async tn => {
+      const control = this.decodeMetricControl(
+        await tn.get(this.ks.metricControl()),
+      );
+      if (!control) return true;
+      if (
+        expectedGeneration !== undefined &&
+        control.generation !== expectedGeneration
+      ) {
+        return false;
+      }
+      tn.clear(this.ks.metricControl());
+      return true;
+    });
+  }
+
+  // Advances one durable raw-key page. Job discovery intentionally scans every
+  // legacy job key so status-only tombstones and jobs with very large payloads
+  // are handled exactly. The second, separately enumerable ledger pass removes
+  // orphans before READY. Cursor, all alignments, and phase change are atomic.
   public async backfillMetricCounts(
     batchSize = 100,
     activate = false,
   ): Promise<boolean> {
-    const ks = this.ks;
-    const requestedGeneration = Buffer.from(randomUUID(), "utf8");
+    if (activate) await this.beginMetricCounterBackfill();
+    const pageSize = Math.max(1, batchSize);
     return await this.db.doTn(async tn => {
-      let generation = await tn.get(ks.metricBackfillActive());
-      if (!generation) {
-        if (!activate) return false;
-        // Activation is allowed only after old writers have drained. Start
-        // from a fresh bounded generation so an interrupted pre-activation
-        // attempt cannot leak stale values into the authoritative counters.
-        for (const status of ["pending", "queued", "active"]) {
-          for (let shard = 0; shard < METRIC_SHARDS; shard++) {
-            tn.clear(ks.metricCount(status, shard));
+      const control = this.decodeMetricControl(
+        await tn.get(this.ks.metricControl()),
+      );
+      if (!control) return false;
+      if (control.phase === "ready") return true;
+
+      if (control.phase === "backfill-jobs") {
+        const range = this.ks.jobRootRange();
+        const cursor = await tn.get(
+          this.ks.metricJobsCursor(control.generation),
+        );
+        const begin = cursor
+          ? Buffer.concat([cursor as Buffer, Buffer.from([0])])
+          : range.begin;
+        const rows = await tn.getRangeAll(begin, range.end, {
+          limit: pageSize,
+        });
+        const ids = new Set<string>();
+        for (const [key] of rows) {
+          const parts = this.ks.unpack(key as Buffer);
+          if (parts[2] === "j" && typeof parts[3] === "string") {
+            ids.add(parts[3]);
           }
         }
-        tn.clear(ks.metricBackfillCursor());
-        tn.clear(ks.metricBackfillDone());
-        tn.set(ks.metricBackfillActive(), requestedGeneration);
-        generation = requestedGeneration;
+        for (const id of ids) {
+          await alignQueueMetricStatus(tn, this.ks, id);
+        }
+        if (rows.length < pageSize) {
+          tn.clear(this.ks.metricJobsCursor(control.generation));
+          tn.set(
+            this.ks.metricControl(),
+            encodeJson({ ...control, phase: "backfill-ledger" }),
+          );
+        } else {
+          tn.set(
+            this.ks.metricJobsCursor(control.generation),
+            rows[rows.length - 1][0] as Buffer,
+          );
+        }
+        return false;
       }
-      const completedGeneration = await tn.get(ks.metricBackfillDone());
-      if (
-        completedGeneration &&
-        (completedGeneration as Buffer).equals(generation as Buffer)
-      ) {
-        return true;
-      }
-      const range = ks.jobRootRange();
-      const cursor = await tn.get(ks.metricBackfillCursor());
+
+      const range = this.ks.metricLedgerRange(control.generation);
+      const cursor = await tn.get(
+        this.ks.metricLedgerCursor(control.generation),
+      );
       const begin = cursor
         ? Buffer.concat([cursor as Buffer, Buffer.from([0])])
         : range.begin;
       const rows = await tn.getRangeAll(begin, range.end, {
-        limit: Math.max(1, batchSize),
+        limit: pageSize,
       });
-
-      for (const [key, value] of rows) {
-        const parts = ks.unpack(key as Buffer);
-        if (parts[4] !== "m" || typeof parts[3] !== "string") continue;
-        const id = parts[3];
-        const membership = await tn.get(ks.jobMetricTracked(id));
-        if (membership && (membership as Buffer).equals(generation as Buffer)) {
-          continue;
-        }
-        const meta = decodeJson<JobMeta>(value as Buffer);
-        const status = decodeJson<JobStatusRecord>(
-          await tn.get(ks.jobStatus(id)),
+      for (const [key] of rows) {
+        await alignQueueMetricStatus(
+          tn,
+          this.ks,
+          this.ks.unpackId(key as Buffer),
         );
-        if (!meta || !status) continue;
-        if (
-          status.s === "pending" ||
-          status.s === "queued" ||
-          status.s === "active"
-        ) {
-          await enrollQueueStatus(tn, ks, id, status.s);
-        } else {
-          tn.set(ks.jobMetricTracked(id), generation as Buffer);
-        }
       }
-
-      if (rows.length < Math.max(1, batchSize)) {
-        tn.clear(ks.metricBackfillCursor());
-        tn.set(ks.metricBackfillDone(), generation as Buffer);
+      if (rows.length < pageSize) {
+        tn.clear(this.ks.metricLedgerCursor(control.generation));
+        tn.set(
+          this.ks.metricControl(),
+          encodeJson({ ...control, phase: "ready" }),
+        );
         return true;
       }
-      tn.set(ks.metricBackfillCursor(), rows[rows.length - 1][0] as Buffer);
+      tn.set(
+        this.ks.metricLedgerCursor(control.generation),
+        rows[rows.length - 1][0] as Buffer,
+      );
       return false;
     });
   }
 
+  public async getLegacyWorkerLoadCount(): Promise<number> {
+    const ks = this.ks;
+    return await this.db.doTn(async tn => {
+      const [readyRows, activeRows] = await Promise.all([
+        tn
+          .snapshot()
+          .getRangeAll(
+            ks.readyShardCountRange().begin,
+            ks.readyShardCountRange().end,
+          ),
+        tn.snapshot().getRangeAll(ks.leaseRange().begin, ks.leaseRange().end),
+      ]);
+      const queued = readyRows.reduce(
+        (sum, [, value]) => sum + Math.max(0, decodeI64(value as Buffer)),
+        0,
+      );
+      return queued + activeRows.length;
+    });
+  }
+
   public async getWorkerLoadCount(): Promise<number> {
-    const counts = await this.getMetricCounts();
-    return counts.queued + counts.active;
+    try {
+      const counts = await this.getMetricCounts();
+      return counts.queued + counts.active;
+    } catch (error) {
+      if (error instanceof NuqFdbMetricsInitializingError) {
+        return await this.getLegacyWorkerLoadCount();
+      }
+      throw error;
+    }
   }
 
   private async getMetricCounts(): Promise<Record<NuQJobStatusCompat, number>> {
     const ks = this.ks;
     return await this.db.doTn(async tn => {
-      const internal = ["queued", "active", "pending"] as const;
-      // Read only the fixed-width maintained counter set plus its readiness
-      // marker. The scrape footprint is independent of jobs, teams, leases,
-      // ready entries, and unexpected keys in these prefixes.
-      const [generation, ready, rows] = await Promise.all([
-        tn.snapshot().get(ks.metricBackfillActive()),
-        tn.snapshot().get(ks.metricBackfillDone()),
-        Promise.all(
-          internal.map(status =>
-            Promise.all(
-              Array.from({ length: METRIC_SHARDS }, (_, shard) =>
-                tn.snapshot().get(ks.metricCount(status, shard)),
-              ),
-            ),
-          ),
-        ),
-      ]);
-      if (
-        !generation ||
-        !ready ||
-        !(ready as Buffer).equals(generation as Buffer)
-      ) {
+      const snapshot = tn.snapshot();
+      // READY has one control read plus exactly 5x32 generation-scoped point
+      // reads. No job, ledger, placement, lease, or team range is touched.
+      const control = this.decodeMetricControl(
+        await snapshot.get(ks.metricControl()),
+      );
+      if (!control || control.phase !== "ready") {
         throw new NuqFdbMetricsInitializingError(
           "NuQ FDB metrics are initializing",
         );
       }
-      const totals = rows.map(statusRows =>
-        statusRows.reduce((sum, value) => sum + decodeI64(value), 0),
+      const rows = await Promise.all(
+        METRIC_STATUSES.map(status =>
+          Promise.all(
+            Array.from({ length: METRIC_SHARDS }, (_, shard) =>
+              snapshot.get(ks.metricCount(control.generation, status, shard)),
+            ),
+          ),
+        ),
       );
+      const totals = new Map<NuqFdbMetricStatus, number>();
+      METRIC_STATUSES.forEach((status, index) => {
+        const total = rows[index].reduce(
+          (sum, value) => sum + decodeI64(value),
+          0,
+        );
+        if (!Number.isSafeInteger(total) || total < 0) {
+          throw new Error(`Corrupt NuQ FDB metric counter ${status}: ${total}`);
+        }
+        totals.set(status, total);
+      });
       return {
-        queued: Math.max(0, totals[0]),
-        active: Math.max(0, totals[1]),
-        completed: 0,
-        failed: 0,
-        backlog: Math.max(0, totals[2]),
+        queued: totals.get("queued")!,
+        active: totals.get("active")!,
+        completed: totals.get("completed")!,
+        failed: totals.get("failed")!,
+        backlog: totals.get("pending")!,
       };
     });
   }

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -165,6 +165,7 @@ export class NuqFdbSweeper {
   public async sweepOnce(logger: Logger = _logger): Promise<void> {
     const now = Date.now();
     for (const queue of this.queues) {
+      await queue.backfillMetricCounts();
       await this.sweepLeases(queue, now, logger);
       await this.sweepBacklogTimeouts(queue, now, logger);
       await this.sweepDelayed(queue, now, logger);
@@ -252,8 +253,8 @@ export class NuqFdbSweeper {
             // requeue directly to ready -- the job retains its slots
             pushReady(tn, ks, entry, txc);
             setStatusQueued(tn, ks, id, st.st + 1);
-            bumpQueueStatus(tn, ks, id, "active", -1);
-            bumpQueueStatus(tn, ks, id, "queued", 1);
+            await bumpQueueStatus(tn, ks, id, "active", -1);
+            await bumpQueueStatus(tn, ks, id, "queued", 1);
             if (meta.g && meta.f & F_COUNTABLE) {
               bumpGroupStatusCount(tn, ks, meta.g, "active", -1);
               bumpGroupStatusCount(tn, ks, meta.g, "queued", 1);
@@ -271,7 +272,7 @@ export class NuqFdbSweeper {
               ks.jobFailedReason(id),
               Buffer.from(STALL_FAILED_REASON, "utf8"),
             );
-            bumpQueueStatus(tn, ks, id, "active", -1);
+            await bumpQueueStatus(tn, ks, id, "active", -1);
             if (meta.g && meta.f & F_GACC && queue.groupOps) {
               await queue.groupOps.terminalAccounting(
                 tn,
@@ -338,7 +339,7 @@ export class NuqFdbSweeper {
           if (!st || st.s !== "pending" || !st.loc) return;
           const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
           if (!meta) return;
-          bumpQueueStatus(tn, ks, id, "pending", -1);
+          await bumpQueueStatus(tn, ks, id, "pending", -1);
           clearPendingPlacement(
             tn,
             ks,
@@ -563,7 +564,7 @@ export class NuqFdbSweeper {
             if (!st || st.s !== "pending" || !st.loc) continue;
             const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
             if (!meta) continue;
-            bumpQueueStatus(tn, ks, id, "pending", -1);
+            await bumpQueueStatus(tn, ks, id, "pending", -1);
             clearPendingPlacement(
               tn,
               ks,
@@ -629,7 +630,7 @@ export class NuqFdbSweeper {
         while (free > 0) {
           const e = await popTeamPending(tn, ks, tid);
           if (!e) break;
-          promoteEntryToReady(tn, ks, e, txc);
+          await promoteEntryToReady(tn, ks, e, txc);
           promoted++;
           free--;
         }
@@ -740,7 +741,7 @@ export class NuqFdbSweeper {
               status?.s === "active" ||
               status?.s === "pending"
             ) {
-              bumpQueueStatus(tn, ks, id, status.s, -1);
+              await bumpQueueStatus(tn, ks, id, status.s, -1);
             }
             deleteJobRecords(tn, ks, id);
             tn.clear(mKey as Buffer);
@@ -764,7 +765,7 @@ export class NuqFdbSweeper {
             status?.s === "active" ||
             status?.s === "pending"
           ) {
-            bumpQueueStatus(tn, finishedKs, fid, status.s, -1);
+            await bumpQueueStatus(tn, finishedKs, fid, status.s, -1);
           }
           deleteJobRecords(tn, finishedKs, fid);
         }

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -19,6 +19,7 @@ import {
   F_COUNTABLE,
   F_GACC,
   F_KEY_GATED,
+  IngestMeta,
 } from "./keyspace";
 import {
   ONE,
@@ -41,6 +42,7 @@ import {
   bumpGroupStatusCount,
   bumpTeamActive,
   GroupJobIndexValue,
+  bumpQueueStatus,
 } from "./ops";
 import { NuQFdbQueue } from "./queue";
 import { NuqFdbExternalSlots } from "./slots";
@@ -166,6 +168,8 @@ export class NuqFdbSweeper {
       await this.sweepLeases(queue, now, logger);
       await this.sweepBacklogTimeouts(queue, now, logger);
       await this.sweepDelayed(queue, now, logger);
+      await this.sweepClaimMarkers(queue, now);
+      await this.sweepAbandonedIngests(queue, now);
       await this.sweepGroupFinishTasks(queue, now, logger);
       await this.sweepGroupCancelTasks(queue, now, logger);
       await this.sweepTeamRaiseTasks(queue, now, logger);
@@ -248,6 +252,8 @@ export class NuqFdbSweeper {
             // requeue directly to ready -- the job retains its slots
             pushReady(tn, ks, entry, txc);
             setStatusQueued(tn, ks, id, st.st + 1);
+            bumpQueueStatus(tn, ks, id, "active", -1);
+            bumpQueueStatus(tn, ks, id, "queued", 1);
             if (meta.g && meta.f & F_COUNTABLE) {
               bumpGroupStatusCount(tn, ks, meta.g, "active", -1);
               bumpGroupStatusCount(tn, ks, meta.g, "queued", 1);
@@ -265,6 +271,7 @@ export class NuqFdbSweeper {
               ks.jobFailedReason(id),
               Buffer.from(STALL_FAILED_REASON, "utf8"),
             );
+            bumpQueueStatus(tn, ks, id, "active", -1);
             if (meta.g && meta.f & F_GACC && queue.groupOps) {
               await queue.groupOps.terminalAccounting(
                 tn,
@@ -331,6 +338,7 @@ export class NuqFdbSweeper {
           if (!st || st.s !== "pending" || !st.loc) return;
           const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
           if (!meta) return;
+          bumpQueueStatus(tn, ks, id, "pending", -1);
           clearPendingPlacement(
             tn,
             ks,
@@ -404,6 +412,87 @@ export class NuqFdbSweeper {
     logSweepLag(logger, queue, "delay", stats);
   }
 
+  // === Commit-unknown claim marker GC
+
+  private async sweepClaimMarkers(
+    queue: NuQFdbQueue,
+    now: number,
+  ): Promise<void> {
+    const ks = queue.ks;
+    const range = ks.claimExpiryScanRange(now);
+    const due = await this.db.doTn(async tn =>
+      tn.snapshot().getRangeAll(range.begin, range.end, {
+        limit: SWEEP_BATCH,
+      }),
+    );
+    if (due.length === 0) return;
+    await this.db.doTn(async tn => {
+      for (const [key] of due) {
+        const op = ks.unpackId(key as Buffer);
+        tn.clear(ks.claim(op));
+        tn.clear(key as Buffer);
+      }
+    });
+  }
+
+  // === Abandoned resumable enqueues
+
+  private async sweepAbandonedIngests(
+    queue: NuQFdbQueue,
+    now: number,
+  ): Promise<void> {
+    const ks = queue.ks;
+    const range = ks.ingestExpiryScanRange(now);
+    const due = await this.db.doTn(async tn =>
+      tn.snapshot().getRangeAll(range.begin, range.end, { limit: 20 }),
+    );
+    for (const [expiryKey] of due) {
+      const op = ks.unpackId(expiryKey as Buffer);
+      await this.db.doTn(async tn => {
+        const meta = decodeJson<IngestMeta>(await tn.get(ks.ingest(op)));
+        if (!meta) {
+          tn.clear(expiryKey as Buffer);
+          return;
+        }
+        const jobsRange = ks.ingestJobRange(op);
+        const members = await tn.getRangeAll(jobsRange.begin, jobsRange.end, {
+          limit: SWEEP_BATCH,
+        });
+        for (const [memberKey] of members) {
+          const id = ks.unpackId(memberKey as Buffer);
+          const status = decodeJson<JobStatusRecord>(
+            await tn.get(ks.jobStatus(id)),
+          );
+          if (status?.s === "ingesting" && status.op === op) {
+            deleteJobRecords(tn, ks, id);
+          }
+          tn.clear(memberKey as Buffer);
+        }
+        if (members.length >= SWEEP_BATCH) return;
+
+        const groupsRange = ks.ingestGroupRange(op);
+        const groups = await tn.getRangeAll(
+          groupsRange.begin,
+          groupsRange.end,
+          { limit: SWEEP_BATCH },
+        );
+        for (const [groupKey] of groups) {
+          const gid = ks.unpackId(groupKey as Buffer);
+          tn.clear(groupKey as Buffer);
+          tn.add(ks.groupIngestCount(gid), MINUS_ONE);
+          tn.set(ks.taskGroupFinish(gid), EMPTY);
+        }
+        if (groups.length >= SWEEP_BATCH) return;
+
+        if (meta.r > 0 && meta.o) {
+          tn.add(ks.teamIngestReserved(meta.o), encodeI64(-meta.r));
+        }
+        tn.clear(ks.ingest(op));
+        tn.clear(expiryKey as Buffer);
+      });
+    }
+  }
+
   // === Group finish detection (backstop for the inline path)
 
   private async sweepGroupFinishTasks(
@@ -449,32 +538,32 @@ export class NuqFdbSweeper {
     for (const [key] of tasks) {
       const gid = ks.unpackId(key as Buffer);
       let exhausted = false;
-      let begin: Buffer | null = null;
-      // clean pending members in batches until none remain
+      // The task value is a durable cursor. A concurrent cancelled-group
+      // enqueue resets it to EMPTY and conflicts with this normal read, so a
+      // newly inserted member can never be skipped behind the cursor.
       for (let rounds = 0; rounds < 50 && !exhausted; rounds++) {
-        const result = await this.db.doTn(async tn => {
+        exhausted = await this.db.doTn(async tn => {
+          const cursor = await tn.get(key as Buffer);
+          if (!cursor) return true;
           const jr = ks.groupJobRange(gid);
-          const rangeBegin = begin ?? jr.begin;
+          const rangeBegin = cursor.length > 0 ? keyAfter(cursor) : jr.begin;
           const members = await tn
             .snapshot()
             .getRangeAll(rangeBegin, jr.end, { limit: 500 });
           let cleaned = 0;
+          let lastExamined: Buffer | undefined;
           for (const [mKey, mValue] of members) {
+            lastExamined = mKey as Buffer;
             const gj = decodeJson<GroupJobIndexValue>(mValue as Buffer);
             if (!gj || gj.s !== "pending") continue;
-            if (cleaned >= SWEEP_BATCH) {
-              return { exhausted: false, nextBegin: rangeBegin };
-            }
             const id = ks.unpackId(mKey as Buffer);
             const st = decodeJson<JobStatusRecord>(
               await tn.get(ks.jobStatus(id)),
             );
-            if (!st || st.s !== "pending" || !st.loc) {
-              // moved on; fix the index lazily
-              continue;
-            }
+            if (!st || st.s !== "pending" || !st.loc) continue;
             const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
             if (!meta) continue;
+            bumpQueueStatus(tn, ks, id, "pending", -1);
             clearPendingPlacement(
               tn,
               ks,
@@ -485,13 +574,9 @@ export class NuqFdbSweeper {
               st.loc,
               meta.to,
             );
-            // team-/key-pending/delayed members hold a crawl slot; the group
-            // is cancelled so there is nothing to promote -- just release it
             if (st.loc.k !== "gq" && meta.f & F_CRAWL_GATED) {
               tn.add(ks.groupCrawlActive(gid), MINUS_ONE);
             }
-            // team-pending members also hold a key slot; release it and let
-            // the raise task hand it to key-pending jobs outside this group
             if (st.loc.k === "tq" && meta.k && meta.f & F_KEY_GATED) {
               tn.add(ks.keyActive(meta.k), MINUS_ONE);
               tn.set(ks.taskKeyRaise(meta.k), EMPTY);
@@ -502,22 +587,16 @@ export class NuqFdbSweeper {
               bumpGroupStatusCount(tn, ks, gid, "pending", -1);
             deleteJobRecords(tn, ks, id);
             cleaned++;
+            if (cleaned >= SWEEP_BATCH) break;
           }
-          const lastKey = members[members.length - 1]?.[0] as
-            | Buffer
-            | undefined;
-          return {
-            exhausted: members.length < 500,
-            nextBegin: lastKey ? keyAfter(lastKey) : jr.end,
-          };
-        });
-        exhausted = result.exhausted;
-        begin = result.nextBegin;
-      }
-      if (exhausted) {
-        await this.db.doTn(async tn => {
-          tn.clear(key as Buffer);
-          tn.set(ks.taskGroupFinish(gid), EMPTY);
+          const done = members.length < 500 && cleaned < SWEEP_BATCH;
+          if (done) {
+            tn.clear(key as Buffer);
+            tn.set(ks.taskGroupFinish(gid), EMPTY);
+          } else if (lastExamined) {
+            tn.set(key as Buffer, lastExamined);
+          }
+          return done;
         });
       }
     }
@@ -537,7 +616,10 @@ export class NuqFdbSweeper {
     );
     for (const [key] of tasks) {
       const tid = ks.unpackId(key as Buffer);
-      const done = await this.db.doTn(async tn => {
+      await this.db.doTn(async tn => {
+        // Consume the generation in the same conflicting transaction as the
+        // drain so a concurrent raiser cannot have its signal cleared later.
+        if (!(await tn.get(key as Buffer))) return;
         const txc = newTxContext();
         const limitBuf = await tn.get(ks.teamLimit(tid));
         const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
@@ -553,11 +635,8 @@ export class NuqFdbSweeper {
         }
         if (promoted > 0) bumpTeamActive(tn, ks, tid, promoted);
         // done when no free slots remain or the pending queue is drained
-        return free > 0 || limit - active <= 0;
+        if (free > 0 || limit - active <= 0) tn.clear(key as Buffer);
       });
-      if (done) {
-        await this.db.doTn(async tn => tn.clear(key as Buffer));
-      }
     }
   }
 
@@ -576,7 +655,8 @@ export class NuqFdbSweeper {
     );
     for (const [key] of tasks) {
       const kid = ks.unpackId(key as Buffer);
-      const done = await this.db.doTn(async tn => {
+      await this.db.doTn(async tn => {
+        if (!(await tn.get(key as Buffer))) return;
         const txc = newTxContext();
         const limitBuf = await tn.get(ks.keyLimit(kid));
         const limit = limitBuf ? decodeI64(limitBuf) : Infinity;
@@ -592,11 +672,8 @@ export class NuqFdbSweeper {
         }
         if (promoted > 0) tn.add(ks.keyActive(kid), encodeI64(promoted));
         // done when no free slots remain or the pending queue is drained
-        return free > 0 || limit - active <= 0;
+        if (free > 0 || limit - active <= 0) tn.clear(key as Buffer);
       });
-      if (done) {
-        await this.db.doTn(async tn => tn.clear(key as Buffer));
-      }
     }
   }
 
@@ -655,19 +732,41 @@ export class NuqFdbSweeper {
             .getRangeAll(jr.begin, jr.end, { limit: 200 });
           for (const [mKey] of members) {
             const id = ks.unpackId(mKey as Buffer);
+            const status = decodeJson<JobStatusRecord>(
+              await tn.get(ks.jobStatus(id)),
+            );
+            if (
+              status?.s === "queued" ||
+              status?.s === "active" ||
+              status?.s === "pending"
+            ) {
+              bumpQueueStatus(tn, ks, id, status.s, -1);
+            }
             deleteJobRecords(tn, ks, id);
             tn.clear(mKey as Buffer);
           }
           return members.length < 200;
         });
       }
+      if (!drained) continue;
       await this.db.doTn(async tn => {
         const g = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
         // the crawl-finished job for this group lives in the finished queue
         const fjobBuf = await tn.get(ks.groupFinishedJob(gid));
         if (fjobBuf && queue.groupOps!.finishedKs) {
           const fid = fjobBuf.toString("utf8");
-          deleteJobRecords(tn, queue.groupOps!.finishedKs as any, fid);
+          const finishedKs = queue.groupOps!.finishedKs;
+          const status = decodeJson<JobStatusRecord>(
+            await tn.get(finishedKs.jobStatus(fid)),
+          );
+          if (
+            status?.s === "queued" ||
+            status?.s === "active" ||
+            status?.s === "pending"
+          ) {
+            bumpQueueStatus(tn, finishedKs, fid, status.s, -1);
+          }
+          deleteJobRecords(tn, finishedKs, fid);
         }
         const gr = ks.groupRange(gid);
         tn.clearRange(gr.begin, gr.end);

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { Logger } from "winston";
 import { logger as _logger } from "../../../lib/logger";
+import { config } from "../../../config";
 import { getNuqFdbDatabase } from "./client";
 import {
   NuqFdbKeyspace,
@@ -165,7 +166,7 @@ export class NuqFdbSweeper {
   public async sweepOnce(logger: Logger = _logger): Promise<void> {
     const now = Date.now();
     for (const queue of this.queues) {
-      await queue.backfillMetricCounts();
+      await queue.backfillMetricCounts(100, config.NUQ_FDB_METRICS_V2_ACTIVATE);
       await this.sweepLeases(queue, now, logger);
       await this.sweepBacklogTimeouts(queue, now, logger);
       await this.sweepDelayed(queue, now, logger);

--- a/apps/api/src/services/worker/nuq-fdb/sweeper.ts
+++ b/apps/api/src/services/worker/nuq-fdb/sweeper.ts
@@ -43,7 +43,7 @@ import {
   bumpGroupStatusCount,
   bumpTeamActive,
   GroupJobIndexValue,
-  bumpQueueStatus,
+  alignQueueMetricStatus,
 } from "./ops";
 import { NuQFdbQueue } from "./queue";
 import { NuqFdbExternalSlots } from "./slots";
@@ -254,8 +254,7 @@ export class NuqFdbSweeper {
             // requeue directly to ready -- the job retains its slots
             pushReady(tn, ks, entry, txc);
             setStatusQueued(tn, ks, id, st.st + 1);
-            await bumpQueueStatus(tn, ks, id, "active", -1);
-            await bumpQueueStatus(tn, ks, id, "queued", 1);
+            await alignQueueMetricStatus(tn, ks, id);
             if (meta.g && meta.f & F_COUNTABLE) {
               bumpGroupStatusCount(tn, ks, meta.g, "active", -1);
               bumpGroupStatusCount(tn, ks, meta.g, "queued", 1);
@@ -273,7 +272,7 @@ export class NuqFdbSweeper {
               ks.jobFailedReason(id),
               Buffer.from(STALL_FAILED_REASON, "utf8"),
             );
-            await bumpQueueStatus(tn, ks, id, "active", -1);
+            await alignQueueMetricStatus(tn, ks, id);
             if (meta.g && meta.f & F_GACC && queue.groupOps) {
               await queue.groupOps.terminalAccounting(
                 tn,
@@ -340,7 +339,6 @@ export class NuqFdbSweeper {
           if (!st || st.s !== "pending" || !st.loc) return;
           const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
           if (!meta) return;
-          await bumpQueueStatus(tn, ks, id, "pending", -1);
           clearPendingPlacement(
             tn,
             ks,
@@ -369,6 +367,7 @@ export class NuqFdbSweeper {
             tn.set(ks.taskGroupFinish(meta.g), EMPTY);
           }
           deleteJobRecords(tn, ks, id);
+          await alignQueueMetricStatus(tn, ks, id);
         });
         stats.processedCount++;
       }
@@ -406,6 +405,7 @@ export class NuqFdbSweeper {
           // the job already holds its crawl slot; admit through the key gate
           // and then the team gate
           await admitThroughGates(tn, ks, e, txc);
+          await alignQueueMetricStatus(tn, ks, e.i);
         });
         stats.processedCount++;
       }
@@ -430,9 +430,16 @@ export class NuqFdbSweeper {
     if (due.length === 0) return;
     await this.db.doTn(async tn => {
       for (const [key] of due) {
-        const op = ks.unpackId(key as Buffer);
-        tn.clear(ks.claim(op));
-        tn.clear(key as Buffer);
+        const expiryKey = key as Buffer;
+        const op = ks.unpackId(expiryKey);
+        const expiresAt = Number(ks.unpackId(expiryKey, 1));
+        const marker = decodeJson<{ e: number }>(await tn.get(ks.claim(op)));
+        if (marker && marker.e === expiresAt && marker.e <= now) {
+          tn.clear(ks.claim(op));
+        }
+        // Always discard the observed expiry row. A mismatched/live marker has
+        // its own later durable row and must survive this stale-row cleanup.
+        tn.clear(expiryKey);
       }
     });
   }
@@ -467,6 +474,7 @@ export class NuqFdbSweeper {
           );
           if (status?.s === "ingesting" && status.op === op) {
             deleteJobRecords(tn, ks, id);
+            await alignQueueMetricStatus(tn, ks, id);
           }
           tn.clear(memberKey as Buffer);
         }
@@ -565,7 +573,6 @@ export class NuqFdbSweeper {
             if (!st || st.s !== "pending" || !st.loc) continue;
             const meta = decodeJson<JobMeta>(await tn.get(ks.jobMeta(id)));
             if (!meta) continue;
-            await bumpQueueStatus(tn, ks, id, "pending", -1);
             clearPendingPlacement(
               tn,
               ks,
@@ -588,6 +595,7 @@ export class NuqFdbSweeper {
             if (meta.f & F_COUNTABLE)
               bumpGroupStatusCount(tn, ks, gid, "pending", -1);
             deleteJobRecords(tn, ks, id);
+            await alignQueueMetricStatus(tn, ks, id);
             cleaned++;
             if (cleaned >= SWEEP_BATCH) break;
           }
@@ -706,6 +714,7 @@ export class NuqFdbSweeper {
           ) {
             deleteJobRecords(tn, ks, id);
           }
+          await alignQueueMetricStatus(tn, ks, id);
         }
       });
     }
@@ -734,17 +743,8 @@ export class NuqFdbSweeper {
             .getRangeAll(jr.begin, jr.end, { limit: 200 });
           for (const [mKey] of members) {
             const id = ks.unpackId(mKey as Buffer);
-            const status = decodeJson<JobStatusRecord>(
-              await tn.get(ks.jobStatus(id)),
-            );
-            if (
-              status?.s === "queued" ||
-              status?.s === "active" ||
-              status?.s === "pending"
-            ) {
-              await bumpQueueStatus(tn, ks, id, status.s, -1);
-            }
             deleteJobRecords(tn, ks, id);
+            await alignQueueMetricStatus(tn, ks, id);
             tn.clear(mKey as Buffer);
           }
           return members.length < 200;
@@ -758,17 +758,8 @@ export class NuqFdbSweeper {
         if (fjobBuf && queue.groupOps!.finishedKs) {
           const fid = fjobBuf.toString("utf8");
           const finishedKs = queue.groupOps!.finishedKs;
-          const status = decodeJson<JobStatusRecord>(
-            await tn.get(finishedKs.jobStatus(fid)),
-          );
-          if (
-            status?.s === "queued" ||
-            status?.s === "active" ||
-            status?.s === "pending"
-          ) {
-            await bumpQueueStatus(tn, finishedKs, fid, status.s, -1);
-          }
           deleteJobRecords(tn, finishedKs, fid);
+          await alignQueueMetricStatus(tn, finishedKs, fid);
         }
         const gr = ks.groupRange(gid);
         tn.clearRange(gr.begin, gr.end);


### PR DESCRIPTION
## Summary

- make FDB enqueue/dequeue idempotent across retries and ambiguous commits
- stage large ingests in bounded transactions with durable plans, queue reservations, group barriers, rollback, and abandoned-operation cleanup
- enforce strict team/key/queue admission and make lock renewal conflict-safe
- fix lost wakeups, limit-change races, sparse ready-shard probing, and deep pagination/removal paths
- replace global metric scans with generation-scoped, fixed-width counters for scrape and crawl-finished queues
- bound inline values and truncate failure text safely by UTF-8 bytes

## Metric rollout safety

This PR is stacked on #3980 and introduces a two-release counter protocol for the existing v2 queue state:

1. **Release A:** deploy protocol-aware writers everywhere with metric activation disabled. Metrics emit only `firecrawl_nuq_fdb_metrics_ready 0`; existing replica floors must be held and new migration cutovers frozen.
2. Drain/fence every pre-protocol API, scrape worker, crawl-finished worker, sweeper, group completer, and in-flight transaction.
3. **Release B:** activate generation-scoped backfill. Durable raw-job and orphan-ledger cursors reconcile exact pending, queued, active, completed, and failed counts.
4. Enable queue HPA/migration expansion only after both queues report readiness `1` and their metric families are present.
5. Before rollback to pre-protocol code, invalidate both queue generations; the next upgrade rebuilds them.

READY collection performs one control read plus `5 × 32` point reads per queue. Pre-READY collection performs no queue/lease range scan.

## Validation

- real-FDB core suite: 45/45 passed
- worker runtime + metrics: 21/21 passed
- `pnpm exec tsc --noEmit`
- `pnpm knip`
- Prettier and `git diff --check`

## Review

Two independent final reviews approved `6bb76a01451d807b41535d3cdd37e9ac47f7cfc2` after verifying:

- rolling-upgrade counter exactness, terminal accounting, crash-resumable reconciliation, and rollback isolation
- bounded fire-and-forget claim cleanup with durable expiry fallback
- operation deadlines, commit-unknown idempotency, renewal fencing, and bounded worker drain

## Dependency

Draft/stacked on #3980 (`mogery/nuq-fdb-worker-runtime`). Keep this PR draft until #3980 merges and this branch is retargeted to `main` with final CI green.
