### PR TITLE
feat(api): grounded citations for PDF json extraction (ENG-4963)

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -349,6 +349,11 @@ const jsonFormatWithOptions = z.strictObject({
       message: OPENAI_SCHEMA_ERROR_MESSAGE,
     }),
   prompt: z.string().max(10000).optional(),
+  // Grounded citations (PDF documents only): the extraction also returns,
+  // per extracted field, page + bbox + verbatim source text located via
+  // fire-pdf block spans. Fields whose support can't be located degrade to
+  // an empty citation list.
+  citeSources: z.boolean().optional(),
 });
 
 export type JsonFormatWithOptions = z.output<typeof jsonFormatWithOptions>;
@@ -469,6 +474,10 @@ export type FormatObject =
 const pdfModeSchema = z.enum(["fast", "auto", "ocr"]);
 
 export type PDFMode = z.infer<typeof pdfModeSchema>;
+
+const pdfTableFormatSchema = z.enum(["markdown", "html", "dynamic"]);
+
+export type PDFTableFormat = z.infer<typeof pdfTableFormatSchema>;
 
 const pdfParserWithOptions = z.strictObject({
   type: z.literal("pdf"),
@@ -1210,11 +1219,62 @@ export const mapRequestSchema = strictWithMessage(mapRequestSchemaBase);
 export type MapRequest = z.infer<typeof mapRequestSchema>;
 export type MapRequestInput = z.input<typeof mapRequestSchema>;
 
+/**
+ * One typed layout block of a parsed PDF page. INTERNAL for now: blocks
+ * flow from fire-pdf only to power grounded citations (json format with
+ * `citeSources`) and are always stripped from responses — the public
+ * `blocks` format is a separate, unshipped decision (ENG-4956).
+ * Wire contract: fire-pdf docs/blocks-schema.md.
+ */
+export type PDFBlock = {
+  id: string;
+  type: string;
+  label: string | null;
+  /** [x0, y0, x1, y1] normalized 0-1 to page width/height; null when the
+   * page had no dimension anchor. */
+  bbox: [number, number, number, number] | null;
+  content: string;
+  /** [start, end) char offsets into the document markdown; null when a
+   * post-assembly transform rewrote the fragment. */
+  markdown_span: [number, number] | null;
+  reading_order: number;
+  source: string;
+  confidence: { layout: number | null; ocr: number | null };
+};
+
+export type PDFBlockPage = {
+  /** 1-based, matches `<!-- page N -->` markers in the markdown. */
+  page: number;
+  width: number | null;
+  height: number | null;
+  status: "ok" | "partial" | "failed";
+  blocks: PDFBlock[];
+};
+
+export type DocumentCitation = {
+  /** 1-based page number in the source PDF. */
+  page: number;
+  /** [x0, y0, x1, y1] normalized 0-1 to the page; null when the source
+   * block carried no grounded bbox. */
+  bbox: [number, number, number, number] | null;
+  /** The verbatim markdown slice the citation matched. */
+  text: string;
+  /** fire-pdf block id, stable within this response. */
+  blockId: string;
+};
+
 export type Document = {
   title?: string;
   description?: string;
   url?: string;
   markdown?: string;
+  /** INTERNAL: per-page typed layout blocks from fire-pdf, populated only
+   * when grounded citations need them; always stripped before responding. */
+  blocks?: PDFBlockPage[];
+  /** Grounded citations for `json` extraction (`citeSources: true`):
+   * field JSON path -> locations supporting the extracted value. Empty
+   * array = the model's supporting quote could not be located (ungrounded). */
+  citations?: Record<string, DocumentCitation[]>;
   html?: string;
   rawHtml?: string;
   links?: string[];

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -159,6 +159,9 @@ export type EngineScrapeResult = {
 
   pdfMetadata?: PdfMetadata;
 
+  /** Per-page typed layout blocks (PDF + fire-pdf only; `blocks` format). */
+  blocks?: import("../../../controllers/v2/types").PDFBlockPage[];
+
   cacheInfo?: {
     created_at: Date;
   };

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/citeSourcesPlumbing.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/citeSourcesPlumbing.test.ts
@@ -1,0 +1,69 @@
+import { scrapeOptions, type PDFBlock } from "../../../../../controllers/v2/types";
+import { hasFormatOfType } from "../../../../../lib/format-utils";
+import { resultResponseSchema } from "../fire-pdf/schema";
+
+describe("citeSources option (ENG-4963)", () => {
+  it("accepts citeSources on the json format", () => {
+    const parsed = scrapeOptions.parse({
+      formats: [{ type: "json", prompt: "extract totals", citeSources: true }],
+    });
+    expect(hasFormatOfType(parsed.formats, "json")?.citeSources).toBe(true);
+  });
+
+  it("defaults citeSources to undefined when omitted", () => {
+    const parsed = scrapeOptions.parse({
+      formats: [{ type: "json", prompt: "extract totals" }],
+    });
+    expect(hasFormatOfType(parsed.formats, "json")?.citeSources).toBeUndefined();
+  });
+
+  it("still rejects a public blocks format (internal-only plumbing)", () => {
+    expect(() => scrapeOptions.parse({ formats: [{ type: "blocks" }] })).toThrow();
+  });
+});
+
+describe("fire-pdf result schema (async)", () => {
+  const v1 = {
+    schema_version: 1,
+    markdown: "# hi",
+    pages_processed: 2,
+    failed_pages: null,
+    partial_pages: null,
+  };
+
+  it("parses v1 results (no pages field)", () => {
+    const parsed = resultResponseSchema.parse(v1);
+    expect(parsed.pages).toBeUndefined();
+  });
+
+  it("parses v2 results with blocks pages, passing block fields through", () => {
+    const block: PDFBlock & { some_future_field: string } = {
+      id: "p1.b0",
+      type: "title",
+      label: "doc_title",
+      bbox: [0.1, 0.05, 0.9, 0.09],
+      content: "# T",
+      markdown_span: [0, 3],
+      reading_order: 0,
+      source: "native_text",
+      confidence: { layout: 0.97, ocr: null },
+      some_future_field: "must survive",
+    };
+    const parsed = resultResponseSchema.parse({
+      ...v1,
+      schema_version: 2,
+      pages: [
+        {
+          page: 1,
+          width: 1700,
+          height: 2200,
+          status: "ok",
+          blocks: [block],
+        },
+      ],
+    });
+    expect(parsed.pages).toHaveLength(1);
+    const page = parsed.pages![0] as any;
+    expect(page.blocks[0].some_future_field).toBe("must survive");
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -2,6 +2,8 @@ import { Meta } from "../../..";
 import { config } from "../../../../../config";
 import { fetch as undiciFetch } from "undici";
 import type { PDFProcessorResult } from "../types";
+import type { PDFBlockPage } from "../../../../../controllers/v2/types";
+import type { FirePdfRequestOptions } from "../firePDF";
 import type { PDFMode } from "../../../../../controllers/v2/types";
 import { safeMarkdownToHtml } from "../markdownToHtml";
 import { scrapePDFWithFirePDF } from "../firePDF";
@@ -29,19 +31,21 @@ export async function scrapePDFWithFirePDFAsync(
   pagesProcessed?: number,
   mode?: PDFMode,
   deps: FirePdfAsyncDeps = {},
+  firePdfOptions?: FirePdfRequestOptions,
 ): Promise<PDFProcessorResult> {
   const fetchImpl = deps.fetchImpl ?? undiciFetch;
   const fallbackImpl = deps.fallbackImpl ?? scrapePDFWithFirePDF;
   const sleep = deps.sleepImpl ?? defaultSleep;
   const now = deps.nowImpl ?? Date.now;
+  const includeBlocks = firePdfOptions?.includeBlocks === true;
+  const tableFormat = firePdfOptions?.tableFormat;
+  // blocks / non-default tableFormat bypass the PDF cache — mirrors the
+  // sync client (entries were written without these formats).
+  const cacheEligible = !includeBlocks && tableFormat === undefined;
 
-  const cached = await tryGetCached(
-    meta,
-    base64Content,
-    mode,
-    maxPages,
-    pagesProcessed,
-  );
+  const cached = cacheEligible
+    ? await tryGetCached(meta, base64Content, mode, maxPages, pagesProcessed)
+    : null;
   if (cached) return cached;
 
   meta.abort.throwIfAborted();
@@ -50,7 +54,14 @@ export async function scrapePDFWithFirePDFAsync(
   if (!baseUrl) {
     // Should be unreachable — call site checks this — but fall back rather
     // than crash if a route somehow bypasses the gate.
-    return fallbackImpl(meta, base64Content, maxPages, pagesProcessed, mode);
+    return fallbackImpl(
+      meta,
+      base64Content,
+      maxPages,
+      pagesProcessed,
+      mode,
+      firePdfOptions,
+    );
   }
 
   const overallStartedAt = now();
@@ -67,6 +78,8 @@ export async function scrapePDFWithFirePDFAsync(
     maxPages,
     pagesProcessed,
     mode,
+    includeBlocks,
+    tableFormat,
     deadlineAt,
     fetchImpl,
   });
@@ -117,7 +130,12 @@ export async function scrapePDFWithFirePDFAsync(
     markdown: fetched.markdown,
     html: await safeMarkdownToHtml(fetched.markdown, meta.logger, meta.id),
     pagesProcessed: pages,
+    ...(fetched.pages !== undefined && {
+      blocks: fetched.pages as unknown as PDFBlockPage[],
+    }),
   };
+
+  if (!cacheEligible) return processorResult;
 
   await maybeSaveResult({
     meta,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -45,11 +45,17 @@ export const pollResponseSchema = z.object({
 });
 
 export const resultResponseSchema = z.object({
-  schema_version: z.literal(1).optional(),
+  // v1 results carry schema_version 1 (or omit it); jobs submitted with
+  // include_blocks return schema_version 2 + `pages`. Non-strict so either
+  // generation of fire-pdf parses.
+  schema_version: z.union([z.literal(1), z.literal(2)]).optional(),
   markdown: z.string(),
   pages_processed: z.number().optional(),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),
+  // Per-page typed blocks (fire-pdf docs/blocks-schema.md). Loose on
+  // purpose — forward-compatible passthrough.
+  pages: z.array(z.looseObject({})).optional(),
 });
 
 export type PollResponse = z.infer<typeof pollResponseSchema>;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
@@ -1,5 +1,8 @@
 import type { Meta } from "../../..";
-import type { PDFMode } from "../../../../../controllers/v2/types";
+import type {
+  PDFMode,
+  PDFTableFormat,
+} from "../../../../../controllers/v2/types";
 import { fetch as undiciFetch } from "undici";
 import { AbortManagerThrownError } from "../../../lib/abortManager";
 import { firePdfAsyncSubmittedTotal } from "./metrics";
@@ -19,6 +22,8 @@ type SubmitArgs = {
   maxPages: number | undefined;
   pagesProcessed: number | undefined;
   mode: PDFMode | undefined;
+  includeBlocks: boolean | undefined;
+  tableFormat: PDFTableFormat | undefined;
   deadlineAt: string;
   fetchImpl: typeof undiciFetch;
 };
@@ -52,6 +57,8 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
       ...(pagesProcessed !== undefined && { pages_estimate: pagesProcessed }),
       ...(maxPages !== undefined && { max_pages: maxPages }),
       ...(mode !== undefined && { mode }),
+      ...(args.includeBlocks && { include_blocks: true }),
+      ...(args.tableFormat !== undefined && { tableFormat: args.tableFormat }),
     },
   };
 
@@ -77,20 +84,26 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
   if (status === 503) failAsync(meta, "http_503");
 
   if (status === 409) {
-    meta.logger.error("FirePDF async POST /jobs returned 409 scrape_id_conflict", {
-      scrapeId,
-      body: json,
-    });
+    meta.logger.error(
+      "FirePDF async POST /jobs returned 409 scrape_id_conflict",
+      {
+        scrapeId,
+        body: json,
+      },
+    );
     throw new Error(
       "fire-pdf async POST /jobs conflict: scrape_id reused with different inputs",
     );
   }
 
   if (status === 400) {
-    meta.logger.error("FirePDF async POST /jobs returned 400 validation error", {
-      scrapeId,
-      body: json,
-    });
+    meta.logger.error(
+      "FirePDF async POST /jobs returned 400 validation error",
+      {
+        scrapeId,
+        body: json,
+      },
+    );
     throw new Error("fire-pdf async POST /jobs validation error");
   }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -3,7 +3,11 @@ import { config } from "../../../../config";
 import { robustFetch } from "../../lib/fetch";
 import { z } from "zod";
 import type { PDFProcessorResult } from "./types";
-import type { PDFMode } from "../../../../controllers/v2/types";
+import type {
+  PDFBlockPage,
+  PDFMode,
+  PDFTableFormat,
+} from "../../../../controllers/v2/types";
 import { safeMarkdownToHtml } from "./markdownToHtml";
 import {
   createPdfCacheKey,
@@ -41,14 +45,24 @@ export function reconcilePageCountWithFirePdf(
   return Math.max(current, fromFirePdf);
 }
 
+export type FirePdfRequestOptions = {
+  /** Request per-page typed blocks (fire-pdf `include_blocks`). */
+  includeBlocks?: boolean;
+  /** Table rendering: markdown | html | dynamic (fire-pdf `tableFormat`). */
+  tableFormat?: PDFTableFormat;
+};
+
 export async function scrapePDFWithFirePDF(
   meta: Meta,
   base64Content: string,
   maxPages?: number,
   pagesProcessed?: number,
   mode?: PDFMode,
+  firePdfOptions?: FirePdfRequestOptions,
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
+  const includeBlocks = firePdfOptions?.includeBlocks === true;
+  const tableFormat = firePdfOptions?.tableFormat;
 
   // Cache layout:
   //   - `ocr` mode reads/writes a dedicated `…-ocr.json` bucket. ocr
@@ -62,8 +76,16 @@ export async function scrapePDFWithFirePDF(
   //     running fire-pdf again.
   //   - `fast` is bypassed entirely (hard cost ceiling — must fail on
   //     scanned PDFs, not serve a cached OCR result).
+  // blocks / non-default tableFormat responses bypass the PDF cache in both
+  // directions: existing entries were written without blocks (a hit would
+  // silently drop the requested format), and writing the variant would need
+  // a key split that isn't worth it until adoption justifies it.
   const cacheable =
-    mode !== "fast" && !maxPages && !meta.internalOptions.zeroDataRetention;
+    mode !== "fast" &&
+    !maxPages &&
+    !meta.internalOptions.zeroDataRetention &&
+    !includeBlocks &&
+    tableFormat === undefined;
   const ownVariant: string | undefined = mode === "ocr" ? "ocr" : undefined;
   const lookupVariants: (string | undefined)[] =
     mode === "ocr" ? ["ocr"] : [undefined, "ocr"];
@@ -154,6 +176,8 @@ export async function scrapePDFWithFirePDF(
       pdf_sha256: pdfSha256,
       source: "firecrawl",
       zdr,
+      ...(includeBlocks && { include_blocks: true }),
+      ...(tableFormat !== undefined && { tableFormat }),
       ...deadlineFields,
     },
     logger,
@@ -161,6 +185,10 @@ export async function scrapePDFWithFirePDF(
       markdown: z.string(),
       failed_pages: z.array(z.number()).nullable(),
       pages_processed: z.number().optional(),
+      // Present only when include_blocks was sent (fire-pdf blocks-schema
+      // v2). Loose on purpose: fire-pdf may add block fields — pass them
+      // through rather than strip/fail.
+      pages: z.array(z.looseObject({})).optional(),
     }),
     mock: meta.mock,
     abort: meta.abort.asSignal(),
@@ -183,6 +211,9 @@ export async function scrapePDFWithFirePDF(
     markdown: resp.markdown,
     html: await safeMarkdownToHtml(resp.markdown, logger, meta.id),
     pagesProcessed: pages,
+    ...(resp.pages !== undefined && {
+      blocks: resp.pages as unknown as PDFBlockPage[],
+    }),
   };
 
   if (cacheable) {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -38,6 +38,7 @@ import { scrapePDFWithRunPodMU } from "./runpodMU";
 import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
 import { scrapePDFWithFirePDFAsync } from "./fire-pdf/async";
 import { scrapePDFWithParsePDF } from "./pdfParse";
+import { hasFormatOfType } from "../../../../lib/format-utils";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
@@ -58,6 +59,15 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
   const shouldParse = shouldParsePDF(meta.options.parsers);
   const maxPages = getPDFMaxPages(meta.options.parsers);
   const mode: PDFMode = getPDFMode(meta.options.parsers);
+  // Grounded citations (json format + citeSources) need fire-pdf blocks:
+  // it is the only engine that produces per-page typed blocks with
+  // markdown spans. When requested we force the fire-pdf route (bypassing
+  // the Rust direct-serve path and the MinerU diversion). If fire-pdf
+  // itself fails, the normal fallback chain still runs and extraction
+  // proceeds ungrounded — degraded, never erroring the whole scrape.
+  const wantsBlocks =
+    hasFormatOfType(meta.options.formats, "json")?.citeSources === true;
+  const firePdfOptions = wantsBlocks ? { includeBlocks: true } : undefined;
 
   if (!shouldParse) {
     if (meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null) {
@@ -169,7 +179,8 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     let shadowPagesNeedingOcr: number[] | undefined;
 
     const forceFirePDF =
-      !!meta.options.__forceFirePDF && !!config.FIRE_PDF_BASE_URL;
+      (!!meta.options.__forceFirePDF || wantsBlocks) &&
+      !!config.FIRE_PDF_BASE_URL;
     const rustEnabled = !!config.PDF_RUST_EXTRACT_ENABLE;
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
 
@@ -414,22 +425,30 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         // sync path.
         const useAsync = getFirePdfAsync(meta.options.parsers);
         try {
-          result = await (
-            useAsync ? scrapePDFWithFirePDFAsync : scrapePDFWithFirePDF
-          )(
-            {
-              ...meta,
-              logger: meta.logger.child({
-                method: useAsync
-                  ? "scrapePDF/firePDFAsync"
-                  : "scrapePDF/firePDF",
-              }),
-            },
-            base64Content,
-            maxPages,
-            effectivePageCount,
-            mode,
-          );
+          const firePdfMeta = {
+            ...meta,
+            logger: meta.logger.child({
+              method: useAsync ? "scrapePDF/firePDFAsync" : "scrapePDF/firePDF",
+            }),
+          };
+          result = await (useAsync
+            ? scrapePDFWithFirePDFAsync(
+                firePdfMeta,
+                base64Content,
+                maxPages,
+                effectivePageCount,
+                mode,
+                {},
+                firePdfOptions,
+              )
+            : scrapePDFWithFirePDF(
+                firePdfMeta,
+                base64Content,
+                maxPages,
+                effectivePageCount,
+                mode,
+                firePdfOptions,
+              ));
           effectivePageCount = reconcilePageCountWithFirePdf(
             effectivePageCount,
             result,
@@ -441,7 +460,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           ) {
             throw error;
           }
-          if (forceFirePDF) {
+          if (meta.options.__forceFirePDF) {
             meta.logger.error("FirePDF failed (forced, no fallback)", {
               method: "scrapePDF/firePDF",
               error,
@@ -609,6 +628,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       statusCode: response.status,
       html: result?.html ?? "",
       markdown: result?.markdown ?? "",
+      ...(result?.blocks !== undefined && { blocks: result.blocks }),
       pdfMetadata: {
         numPages: effectivePageCount,
         totalPages: totalPageCount,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -1,6 +1,16 @@
+import type { PDFBlockPage } from "../../../../controllers/v2/types";
+
 export type PDFProcessorResult = {
   html: string;
   markdown?: string;
+  /**
+   * Per-page typed layout blocks from fire-pdf (`include_blocks`). Only
+   * populated when the request asked for the `blocks` format AND the
+   * fire-pdf engine served it — the MinerU / pdf-parse fallbacks can't
+   * produce blocks, so consumers must treat absence as "engine couldn't",
+   * not an error.
+   */
+  blocks?: PDFBlockPage[];
   /**
    * Pages the underlying engine actually processed for this request.
    * Currently populated only by fire-pdf (via OcrSuccessBody.pages_processed).

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1008,6 +1008,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
 
     let document: Document = {
       markdown: engineResult.markdown,
+      blocks: engineResult.blocks,
       rawHtml: engineResult.html,
       json: engineResult.json,
       screenshot: engineResult.screenshot,

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/citations.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/citations.test.ts
@@ -95,3 +95,44 @@ describe("groundCitations", () => {
     expect(groundCitations(fixture.markdown, [], { f: ["anything"] }).f).toEqual([]);
   });
 });
+
+describe("wrapSchemaWithCitations / splitCitedExtraction", () => {
+  it("wraps a user schema under data and adds the citations map", async () => {
+    const { wrapSchemaWithCitations } = await import("../citations");
+    const wrapped = wrapSchemaWithCitations({
+      type: "object",
+      properties: { total_revenue: { type: "string" } },
+    }) as any;
+    expect(wrapped.properties.data.properties.total_revenue.type).toBe("string");
+    expect(wrapped.properties.citations.additionalProperties.items.type).toBe("string");
+    expect(wrapped.required).toEqual(["data"]);
+  });
+
+  it("wraps schema-less extraction with a permissive data object", async () => {
+    const { wrapSchemaWithCitations } = await import("../citations");
+    const wrapped = wrapSchemaWithCitations(undefined) as any;
+    expect(wrapped.properties.data).toEqual({ type: "object" });
+  });
+
+  it("splits a wrapped result and normalizes quote shapes", async () => {
+    const { splitCitedExtraction } = await import("../citations");
+    const split = splitCitedExtraction({
+      data: { total_revenue: "$391B" },
+      citations: {
+        total_revenue: "net sales of $391 billion",
+        fiscal_year: ["ended September 27, 2025", 42 as any],
+      },
+    });
+    expect(split).not.toBeNull();
+    expect((split!.data as any).total_revenue).toBe("$391B");
+    expect(split!.quotesByField.total_revenue).toEqual(["net sales of $391 billion"]);
+    expect(split!.quotesByField.fiscal_year).toEqual(["ended September 27, 2025"]);
+  });
+
+  it("returns null when the wrapper shape is missing (model ignored it)", async () => {
+    const { splitCitedExtraction } = await import("../citations");
+    expect(splitCitedExtraction({ total_revenue: "$391B" })).toBeNull();
+    expect(splitCitedExtraction(null)).toBeNull();
+    expect(splitCitedExtraction("just a string")).toBeNull();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/citations.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/citations.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { groundCitations, locateQuote, type GroundingBlockPage } from "../citations";
+
+// Real fire-pdf response (include_blocks) for a 3-page document assembled
+// from public SEC-filing pages in the ParseBench corpus (Home Depot,
+// Coca-Cola, USPS 10-Ks) — 25 blocks, 20 with markdown spans.
+const fixture: { markdown: string; pages: GroundingBlockPage[] } = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "firepdf-blocks-10k.json"), "utf8"),
+);
+
+/** Quote taken from the Nth block that actually carries a span on the page. */
+function quoteFromBlock(pageIdx: number, spannedIdx: number, len = 60): string {
+  const spanned = fixture.pages[pageIdx]!.blocks.filter(b => b.markdown_span);
+  const block = spanned[spannedIdx]!;
+  const [start, end] = block.markdown_span as [number, number];
+  return fixture.markdown.slice(start, Math.min(end, start + len));
+}
+
+describe("locateQuote", () => {
+  it("finds exact quotes", () => {
+    const quote = quoteFromBlock(0, 0);
+    const range = locateQuote(fixture.markdown, quote);
+    expect(range).not.toBeNull();
+    expect(fixture.markdown.slice(range![0], range![1])).toBe(quote);
+  });
+
+  it("tolerates whitespace drift (newlines quoted as spaces)", () => {
+    const quote = quoteFromBlock(0, 0, 120).replace(/\s+/g, " ");
+    const range = locateQuote(fixture.markdown, quote);
+    expect(range).not.toBeNull();
+  });
+
+  it("tolerates case drift as a last resort", () => {
+    const quote = quoteFromBlock(0, 0).toLowerCase();
+    expect(locateQuote(fixture.markdown, quote)).not.toBeNull();
+  });
+
+  it("returns null for text not in the document", () => {
+    expect(locateQuote(fixture.markdown, "this sentence does not appear anywhere")).toBeNull();
+    expect(locateQuote(fixture.markdown, "   ")).toBeNull();
+  });
+});
+
+describe("groundCitations", () => {
+  it("maps a quote to its block's page, bbox, and id", () => {
+    // A quote from a known page-2 block must cite page 2.
+    const page2Block = fixture.pages[1]!.blocks.find(b => b.markdown_span);
+    expect(page2Block).toBeDefined();
+    const quote = fixture.markdown.slice(page2Block!.markdown_span![0], page2Block!.markdown_span![0] + 50);
+    const result = groundCitations(fixture.markdown, fixture.pages, { field: [quote] });
+    expect(result.field).toHaveLength(1);
+    expect(result.field![0]!.page).toBe(2);
+    expect(result.field![0]!.blockId).toBe(page2Block!.id);
+    expect(result.field![0]!.bbox).toEqual(page2Block!.bbox);
+    expect(result.field![0]!.text).toBe(quote);
+  });
+
+  it("returns one citation per overlapping block for boundary-crossing quotes", () => {
+    // Build a quote spanning the end of one block and the start of the next
+    // contiguous-span block.
+    const spans = fixture.pages
+      .flatMap(p => p.blocks.map(b => ({ page: p.page, b })))
+      .filter(x => x.b.markdown_span)
+      .sort((a, z) => a.b.markdown_span![0] - z.b.markdown_span![0]);
+    const first = spans.find((x, i) => i + 1 < spans.length && spans[i + 1]!.b.markdown_span![0] - x.b.markdown_span![1] < 40);
+    expect(first).toBeDefined();
+    const idx = spans.indexOf(first!);
+    const second = spans[idx + 1]!;
+    const quote = fixture.markdown.slice(first!.b.markdown_span![1] - 30, second.b.markdown_span![0] + 30);
+    const result = groundCitations(fixture.markdown, fixture.pages, { field: [quote] });
+    const ids = result.field!.map(c => c.blockId);
+    expect(ids).toContain(first!.b.id);
+    expect(ids).toContain(second.b.id);
+  });
+
+  it("degrades unlocatable quotes to an empty citations array", () => {
+    const result = groundCitations(fixture.markdown, fixture.pages, {
+      revenue: ["a fabricated quote that is nowhere in the document"],
+    });
+    expect(result.revenue).toEqual([]);
+  });
+
+  it("dedupes multiple quotes landing in the same block", () => {
+    const q1 = quoteFromBlock(0, 0, 40);
+    const q2 = quoteFromBlock(0, 0, 80);
+    const result = groundCitations(fixture.markdown, fixture.pages, { field: [q1, q2] });
+    const ids = result.field!.map(c => c.blockId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("handles empty inputs", () => {
+    expect(groundCitations(fixture.markdown, fixture.pages, {})).toEqual({});
+    expect(groundCitations(fixture.markdown, [], { f: ["anything"] }).f).toEqual([]);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/citations.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/citations.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { groundCitations, locateQuote, type GroundingBlockPage } from "../citations";
+import {
+  groundCitations,
+  locateQuote,
+  splitCitedExtraction,
+  wrapSchemaWithCitations,
+  type GroundingBlockPage,
+} from "../citations";
 
 // Real fire-pdf response (include_blocks) for a 3-page document assembled
 // from public SEC-filing pages in the ParseBench corpus (Home Depot,
@@ -97,31 +103,26 @@ describe("groundCitations", () => {
 });
 
 describe("wrapSchemaWithCitations / splitCitedExtraction", () => {
-  it("wraps a user schema under data and adds the citations map", async () => {
-    const { wrapSchemaWithCitations } = await import("../citations");
+  it("wraps a user schema under data and adds the citations map", () => {
     const wrapped = wrapSchemaWithCitations({
       type: "object",
       properties: { total_revenue: { type: "string" } },
     }) as any;
     expect(wrapped.properties.data.properties.total_revenue.type).toBe("string");
-    expect(wrapped.properties.citations.additionalProperties.items.type).toBe("string");
-    expect(wrapped.required).toEqual(["data"]);
+    // OpenAI strict mode: no free-form maps, additionalProperties false.
+    expect(wrapped.additionalProperties).toBe(false);
+    expect(wrapped.properties.citations.type).toBe("array");
+    expect(wrapped.properties.citations.items.additionalProperties).toBe(false);
+    expect(wrapped.required).toEqual(["data", "citations"]);
   });
 
-  it("wraps schema-less extraction with a permissive data object", async () => {
-    const { wrapSchemaWithCitations } = await import("../citations");
-    const wrapped = wrapSchemaWithCitations(undefined) as any;
-    expect(wrapped.properties.data).toEqual({ type: "object" });
-  });
-
-  it("splits a wrapped result and normalizes quote shapes", async () => {
-    const { splitCitedExtraction } = await import("../citations");
+  it("splits a wrapped result and normalizes quote shapes", () => {
     const split = splitCitedExtraction({
       data: { total_revenue: "$391B" },
-      citations: {
-        total_revenue: "net sales of $391 billion",
-        fiscal_year: ["ended September 27, 2025", 42 as any],
-      },
+      citations: [
+        { field: "total_revenue", quotes: "net sales of $391 billion" },
+        { field: "fiscal_year", quotes: ["ended September 27, 2025", 42 as any] },
+      ],
     });
     expect(split).not.toBeNull();
     expect((split!.data as any).total_revenue).toBe("$391B");
@@ -129,8 +130,7 @@ describe("wrapSchemaWithCitations / splitCitedExtraction", () => {
     expect(split!.quotesByField.fiscal_year).toEqual(["ended September 27, 2025"]);
   });
 
-  it("returns null when the wrapper shape is missing (model ignored it)", async () => {
-    const { splitCitedExtraction } = await import("../citations");
+  it("returns null when the wrapper shape is missing (model ignored it)", () => {
     expect(splitCitedExtraction({ total_revenue: "$391B" })).toBeNull();
     expect(splitCitedExtraction(null)).toBeNull();
     expect(splitCitedExtraction("just a string")).toBeNull();

--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/fixtures/firepdf-blocks-10k.json
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/fixtures/firepdf-blocks-10k.json
@@ -1,0 +1,564 @@
+{
+ "markdown": "## ISSUER PURCHASES OF EQUITY SECURITIES\n\nThe following table presents the number and average price of shares purchased by the Company in each fiscal month of the fourth quarter of\nfiscal 2024:\n\n| Period | Total Number of Shares Purchased(1) | Average Price Paid Per Share(1) | Total Number of Shares Purchased as Part of Publicly Announced Program(2) | Dollar Value of Shares that May Yet Be Purchased Under the Program(2)(3) |\n| --- | --- | --- | --- | --- |\n| October 28,2024-November 24,2024 | 8,166 | $411.08 | \u2014 | $11,657,503,041 |\n| November 25,2024-December 22,2024 | 3,650 | 422.79 | \u2014 | 11,657,503,041 |\n| December 23,2024-February 2,2025 | 2,694 | 395.74 | \u2014 | 11,657,503,041 |\n|  | 14,510 | 411.18 | \u2014 |  |\n\n\u2014\u2014\u2014\u2014\u2014\n*(1) These amounts include deemed repurchases pursuant to our Omnibus Stock Incentive Plan, as Amended and Restated May 19, 2022, and our 1997 Omnibus Stock Incentive*\n*Plan (collectively, the \u201cPlans\u201d). Under the Plans, participants surrender shares as payment of applicable tax withholding on the vesting of restricted stock. Participants in the*\n*Plans may also exercise stock options by surrendering shares of common stock that the participants already own as payment of the exercise price. Shares so surrendered by*\n*participants in the Plans are repurchased pursuant to the terms of the Plans and applicable award agreement and not pursuant to publicly announced share repurchase*\n*programs.*\n(2) On August 14, 2023, our Board approved a $15.0 billion share repurchase authorization that replaced the previous authorization of $15.0 billion, which was approved on August\n\n*(2) On August 14, 2023, our Board approved a $15.0 billion share repurchase authorization that replaced the previous authorization of $15.0 billion, which was approved on August*\n*18, 2022. The August 2023 authorization does not have a prescribed expiration date. As previously disclosed, we paused share repurchases in March 2024.*\n(3) Excludes excise taxes incurred on share repurchases.\n\n*(3) Excludes excise taxes incurred on share repurchases.*\n\n## SALES OF UNREGISTERED SECURITIES\n\nDuring the fourth quarter of fiscal 2024, we issued 436 deferred stock units under the Home Depot, Inc. Nonemployee Directors\u2019 Deferred Stock\nCompensation Plan pursuant to the exemption from registration provided by Section 4(a)(2) of the Securities Act and Rule 506 of the SEC\u2019s\nRegulation D thereunder. The deferred stock units were credited during the fourth quarter of fiscal 2024 to the accounts of those non-employee\ndirectors who elected to receive all or a portion of board retainers in the form of deferred stock units instead of cash. The deferred stock units\nconvert to shares of common stock on a one-for-one basis following a termination of service as described in the plan.\n\nDuring the fourth quarter of fiscal 2024, we credited 5,865 deferred stock units to participant accounts under the Restoration Plans pursuant to\nan exemption from the registration requirements of the Securities Act for involuntary, non-contributory plans. The deferred stock units convert to\nshares of common stock on a one-for-one basis following a termination of service as described in these plans.\n\n## Item 6. Reserved.\n\n## Item 7. Management\u2019s Discussion and Analysis of Financial Condition and Results of Operations.\n\nThe following discussion provides an analysis of the Company\u2019s financial condition and results of operations from management's perspective\nand should be read in conjunction with the consolidated financial statements and related notes included in this report. The discussion in this\nForm 10-K generally focuses on fiscal 2024 compared to fiscal 2023. A discussion of our results of operations and changes in financial condition\nfor fiscal 2023 compared to fiscal 2022 has been omitted from this report, but can be found in <u>Part II, Item 7. Management\u2019s Discussion and</u>\n<u>Analysis of Financial Condition and Results of Operations</u> of our Form 10-K for fiscal 2023.\n\n**TABLE OF CONTENTS**\n\n| Executive Summary | 28 |\n| --- | --- |\n| Results of Operations | 29 |\n| Liquidity and Capital Resources | 31 |\n| Critical Accounting Estimates | 34 |\n\n---\n\n## THE COCA-COLA COMPANY AND SUBSIDIARIES CONSOLIDATED STATEMENTS OF SHAREOWNERS\u2019 EQUITY (In millions except per share data)\n\n<table border=\"1\"><tr><td></td><td></td><td>2024</td><td>2023</td><td>2022</td></tr><tr><td colspan=\"5\">Equity Attributable to Shareowners of The Coca-Cola Company</td></tr><tr><td colspan=\"5\">Number of Common Shares Outstanding</td></tr><tr><td>Balance at beginning of year</td><td></td><td>4,308</td><td>4,328</td><td>4,325</td></tr><tr><td>Treasury stock issued to employees related to stock-based compensation plans</td><td></td><td>21</td><td>17</td><td>24</td></tr><tr><td>Purchases of stock for treasury</td><td></td><td>(27)</td><td>(37)</td><td>(21)</td></tr><tr><td>Balance at end of year</td><td></td><td>4,302</td><td>4,308</td><td>4,328</td></tr><tr><td>Common Stock</td><td>$</td><td>1,760</td><td>1,760</td><td>1,760</td></tr><tr><td colspan=\"5\">Capital Surplus</td></tr><tr><td>Balance at beginning of year</td><td></td><td>19,209</td><td>18,822</td><td>18,116</td></tr><tr><td>Stock issued to employees related to stock-based compensation plans</td><td></td><td>319</td><td>177</td><td>373</td></tr><tr><td>Stock-based compensation expense</td><td></td><td>273</td><td>233</td><td>332</td></tr><tr><td>Acquisition of interests held by noncontrolling owners</td><td></td><td>\u2014</td><td>(20)</td><td>\u2014</td></tr><tr><td>Other activities</td><td></td><td>\u2014</td><td>(3)</td><td>1</td></tr><tr><td>Balance at end of year</td><td></td><td>19,801</td><td>19,209</td><td>18,822</td></tr><tr><td colspan=\"5\">Reinvested Earnings</td></tr><tr><td>Balance at beginning of year</td><td></td><td>73,782</td><td>71,019</td><td>69,094</td></tr><tr><td>Net income attributable to shareowners of The Coca-Cola Company</td><td></td><td>10,631</td><td>10,714</td><td>9,542</td></tr><tr><td>Dividends (per share \u2014 $1.94, $1.84 and $1.76 in 2024, 2023 and 2022, respectively)</td><td></td><td>(8,359)</td><td>(7,951)</td><td>(7,617)</td></tr><tr><td>Balance at end of year</td><td></td><td>76,054</td><td>73,782</td><td>71,019</td></tr><tr><td colspan=\"5\">Accumulated Other Comprehensive Income (Loss)</td></tr><tr><td>Balance at beginning of year</td><td></td><td>(14,275)</td><td>(14,895)</td><td>(14,330)</td></tr><tr><td>Net other comprehensive income (loss)</td><td></td><td>(2,568)</td><td>620</td><td>(565)</td></tr><tr><td>Balance at end of year</td><td></td><td>(16,843)</td><td>(14,275)</td><td>(14,895)</td></tr><tr><td colspan=\"5\">Treasury Stock</td></tr><tr><td>Balance at beginning of year</td><td></td><td>(54,535)</td><td>(52,601)</td><td>(51,641)</td></tr><tr><td>Treasury stock issued to employees related to stock-based compensation plans</td><td></td><td>321</td><td>255</td><td>376</td></tr><tr><td>Purchases of stock for treasury</td><td></td><td>(1,702)</td><td>(2,189)</td><td>(1,336)</td></tr><tr><td>Balance at end of year</td><td></td><td>(55,916)</td><td>(54,535)</td><td>(52,601)</td></tr><tr><td>Total Equity Attributable to Shareowners of The Coca-Cola Company</td><td>$</td><td>24,856</td><td>25,941</td><td>24,105</td></tr><tr><td colspan=\"5\">Equity Attributable to Noncontrolling Interests</td></tr><tr><td>Balance at beginning of year</td><td>$</td><td>1,539</td><td>1,721</td><td>1,861</td></tr><tr><td>Net income attributable to noncontrolling interests</td><td>$</td><td>18</td><td>(11)</td><td>29</td></tr><tr><td>Net foreign currency translation adjustments</td><td>$(9)</td><td>(147)</td><td>(118)</td><td></td></tr><tr><td>Dividends paid to noncontrolling interests</td><td>$(28)</td><td>(25)</td><td>(51)</td><td></td></tr><tr><td>Acquisition of interests held by noncontrolling owners</td><td>\u2014</td><td>(2)</td><td>\u2014</td><td></td></tr><tr><td>Divestitures</td><td>$(4)</td><td>\u2014</td><td>\u2014</td><td></td></tr><tr><td>Other activities</td><td>\u2014</td><td>3</td><td>\u2014</td><td></td></tr><tr><td>Total Equity Attributable to Noncontrolling Interests</td><td>$</td><td>1,516</td><td>1,539</td><td>1,721</td></tr></table>\n\nRefer to Notes to Consolidated Financial Statements.\n\n---\n\n**UAITED STATES POSTAL SERVICE**\n**STATEMEATS OF CHAAGES IA AET DEFICIEACY**\n\n<table border=\"1\"><tr><td>(in millions)</td><td colspan=\"2\">Capital Contributions of U.S. Government</td><td colspan=\"2\">Accumulated Deficit Since Reorganization</td><td>Total Net Deficiency</td></tr><tr><td>Balance, September 30, 2022</td><td>$</td><td>16,132</td><td>$</td><td>(32,766)</td><td>$ (16,634)</td></tr><tr><td>Net loss</td><td></td><td>-</td><td>$</td><td>(6,478)</td><td>(6,478)</td></tr><tr><td>Balance, September 30, 2023</td><td>$</td><td>16,132</td><td>$</td><td>(39,244)</td><td>$ (23,112)</td></tr><tr><td>Net loss</td><td></td><td>-</td><td>$</td><td>(9,520)</td><td>(9,520)</td></tr><tr><td>Balance, September 30, 2024</td><td>$</td><td>16,132</td><td>$</td><td>(48,764)</td><td>$ (32,632)</td></tr><tr><td>Net loss</td><td></td><td>-</td><td></td><td>(8,978)</td><td>(8,978)</td></tr><tr><td>Balance, September 30, 2025</td><td>$</td><td>16,132</td><td>$</td><td>(57,742)</td><td>$ (41,610)</td></tr></table>\n\nSee accampanying nates ta the financial statements.",
+ "pages": [
+  {
+   "page": 1,
+   "width": 1700,
+   "height": 2200,
+   "status": "ok",
+   "blocks": [
+    {
+     "id": "p1.b0",
+     "type": "page_header",
+     "label": "header",
+     "bbox": [
+      0.0265,
+      0.0282,
+      0.1235,
+      0.04
+     ],
+     "content": "Table of Contents",
+     "markdown_span": null,
+     "reading_order": 0,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8413,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b1",
+     "type": "section_header",
+     "label": "paragraph_title",
+     "bbox": [
+      0.3318,
+      0.0891,
+      0.6653,
+      0.1032
+     ],
+     "content": "## ISSUER PURCHASES OF EQUITY SECURITIES",
+     "markdown_span": [
+      0,
+      40
+     ],
+     "reading_order": 1,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8042,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b2",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.0235,
+      0.1095,
+      0.9512,
+      0.1377
+     ],
+     "content": "The following table presents the number and average price of shares purchased by the Company in each fiscal month of the fourth quarter of\nfiscal 2024:",
+     "markdown_span": [
+      42,
+      193
+     ],
+     "reading_order": 2,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8716,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b3",
+     "type": "table",
+     "label": null,
+     "bbox": [
+      0.0224,
+      0.1459,
+      0.9735,
+      0.2532
+     ],
+     "content": "| Period | Total Number of Shares Purchased(1) | Average Price Paid Per Share(1) | Total Number of Shares Purchased as Part of Publicly Announced Program(2) | Dollar Value of Shares that May Yet Be Purchased Under the Program(2)(3) |\n| --- | --- | --- | --- | --- |\n| October 28,2024-November 24,2024 | 8,166 | $411.08 | \u2014 | $11,657,503,041 |\n| November 25,2024-December 22,2024 | 3,650 | 422.79 | \u2014 | 11,657,503,041 |\n| December 23,2024-February 2,2025 | 2,694 | 395.74 | \u2014 | 11,657,503,041 |\n|  | 14,510 | 411.18 | \u2014 |  |",
+     "markdown_span": [
+      195,
+      718
+     ],
+     "reading_order": 3,
+     "source": "layout_ocr",
+     "confidence": {
+      "layout": null,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b4",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.0194,
+      0.2655,
+      0.9665,
+      0.3241
+     ],
+     "content": "\u2014\u2014\u2014\u2014\u2014\n*(1) These amounts include deemed repurchases pursuant to our Omnibus Stock Incentive Plan, as Amended and Restated May 19, 2022, and our 1997 Omnibus Stock Incentive*\n*Plan (collectively, the \u201cPlans\u201d). Under the Plans, participants surrender shares as payment of applicable tax withholding on the vesting of restricted stock. Participants in the*\n*Plans may also exercise stock options by surrendering shares of common stock that the participants already own as payment of the exercise price. Shares so surrendered by*\n*participants in the Plans are repurchased pursuant to the terms of the Plans and applicable award agreement and not pursuant to publicly announced share repurchase*\n*programs.*\n(2) On August 14, 2023, our Board approved a $15.0 billion share repurchase authorization that replaced the previous authorization of $15.0 billion, which was approved on August",
+     "markdown_span": [
+      720,
+      1601
+     ],
+     "reading_order": 4,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.7661,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b5",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.0235,
+      0.3241,
+      0.9735,
+      0.3486
+     ],
+     "content": "*(2) On August 14, 2023, our Board approved a $15.0 billion share repurchase authorization that replaced the previous authorization of $15.0 billion, which was approved on August*\n*18, 2022. The August 2023 authorization does not have a prescribed expiration date. As previously disclosed, we paused share repurchases in March 2024.*\n(3) Excludes excise taxes incurred on share repurchases.",
+     "markdown_span": [
+      1603,
+      1993
+     ],
+     "reading_order": 5,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.7397,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b6",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.0253,
+      0.35,
+      0.3406,
+      0.3627
+     ],
+     "content": "*(3) Excludes excise taxes incurred on share repurchases.*",
+     "markdown_span": [
+      1995,
+      2053
+     ],
+     "reading_order": 6,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.6948,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b7",
+     "type": "section_header",
+     "label": "paragraph_title",
+     "bbox": [
+      0.3518,
+      0.3705,
+      0.6459,
+      0.3845
+     ],
+     "content": "## SALES OF UNREGISTERED SECURITIES",
+     "markdown_span": [
+      2055,
+      2090
+     ],
+     "reading_order": 7,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.877,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b8",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.02,
+      0.3905,
+      0.9688,
+      0.4627
+     ],
+     "content": "During the fourth quarter of fiscal 2024, we issued 436 deferred stock units under the Home Depot, Inc. Nonemployee Directors\u2019 Deferred Stock\nCompensation Plan pursuant to the exemption from registration provided by Section 4(a)(2) of the Securities Act and Rule 506 of the SEC\u2019s\nRegulation D thereunder. The deferred stock units were credited during the fourth quarter of fiscal 2024 to the accounts of those non-employee\ndirectors who elected to receive all or a portion of board retainers in the form of deferred stock units instead of cash. The deferred stock units\nconvert to shares of common stock on a one-for-one basis following a termination of service as described in the plan.",
+     "markdown_span": [
+      2092,
+      2779
+     ],
+     "reading_order": 8,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.9404,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b9",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.0182,
+      0.4664,
+      0.9676,
+      0.5095
+     ],
+     "content": "During the fourth quarter of fiscal 2024, we credited 5,865 deferred stock units to participant accounts under the Restoration Plans pursuant to\nan exemption from the registration requirements of the Securities Act for involuntary, non-contributory plans. The deferred stock units convert to\nshares of common stock on a one-for-one basis following a termination of service as described in these plans.",
+     "markdown_span": [
+      2781,
+      3182
+     ],
+     "reading_order": 9,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.9072,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b10",
+     "type": "section_header",
+     "label": "paragraph_title",
+     "bbox": [
+      0.0253,
+      0.5173,
+      0.1635,
+      0.5318
+     ],
+     "content": "## Item 6. Reserved.",
+     "markdown_span": [
+      3184,
+      3204
+     ],
+     "reading_order": 10,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.3086,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b11",
+     "type": "section_header",
+     "label": "paragraph_title",
+     "bbox": [
+      0.0224,
+      0.5432,
+      0.7788,
+      0.5586
+     ],
+     "content": "## Item 7. Management\u2019s Discussion and Analysis of Financial Condition and Results of Operations.",
+     "markdown_span": [
+      3206,
+      3303
+     ],
+     "reading_order": 11,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8613,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b12",
+     "type": "text",
+     "label": "text",
+     "bbox": [
+      0.0171,
+      0.5568,
+      0.9718,
+      0.6291
+     ],
+     "content": "The following discussion provides an analysis of the Company\u2019s financial condition and results of operations from management's perspective\nand should be read in conjunction with the consolidated financial statements and related notes included in this report. The discussion in this\nForm 10-K generally focuses on fiscal 2024 compared to fiscal 2023. A discussion of our results of operations and changes in financial condition\nfor fiscal 2023 compared to fiscal 2022 has been omitted from this report, but can be found in <u>Part II, Item 7. Management\u2019s Discussion and</u>\n<u>Analysis of Financial Condition and Results of Operations</u> of our Form 10-K for fiscal 2023.",
+     "markdown_span": [
+      3305,
+      3977
+     ],
+     "reading_order": 12,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8853,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b13",
+     "type": "caption",
+     "label": "figure_title",
+     "bbox": [
+      0.4194,
+      0.6436,
+      0.5794,
+      0.6577
+     ],
+     "content": "**TABLE OF CONTENTS**",
+     "markdown_span": [
+      3979,
+      4000
+     ],
+     "reading_order": 13,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.6533,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b14",
+     "type": "table",
+     "label": null,
+     "bbox": [
+      0.0153,
+      0.6627,
+      0.9729,
+      0.725
+     ],
+     "content": "| Executive Summary | 28 |\n| --- | --- |\n| Results of Operations | 29 |\n| Liquidity and Capital Resources | 31 |\n| Critical Accounting Estimates | 34 |",
+     "markdown_span": [
+      4002,
+      4153
+     ],
+     "reading_order": 14,
+     "source": "layout_ocr",
+     "confidence": {
+      "layout": null,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b15",
+     "type": "figure",
+     "label": "image",
+     "bbox": [
+      0.9394,
+      0.7541,
+      0.9694,
+      0.7773
+     ],
+     "content": "",
+     "markdown_span": null,
+     "reading_order": 15,
+     "source": "layout_detection",
+     "confidence": {
+      "layout": 0.4941,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b16",
+     "type": "page_footer",
+     "label": "footer",
+     "bbox": [
+      0.9394,
+      0.7541,
+      0.9694,
+      0.7773
+     ],
+     "content": "[Image: X8]",
+     "markdown_span": null,
+     "reading_order": 16,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.3794,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p1.b17",
+     "type": "page_footer",
+     "label": "footer",
+     "bbox": [
+      0.0271,
+      0.7705,
+      0.1535,
+      0.7827
+     ],
+     "content": "Fiscal 2024 Form 10-K",
+     "markdown_span": null,
+     "reading_order": 17,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.5439,
+      "ocr": null
+     }
+    }
+   ]
+  },
+  {
+   "page": 2,
+   "width": 1700,
+   "height": 2200,
+   "status": "ok",
+   "blocks": [
+    {
+     "id": "p2.b0",
+     "type": "section_header",
+     "label": "paragraph_title",
+     "bbox": [
+      0.3035,
+      0.0818,
+      0.6959,
+      0.1209
+     ],
+     "content": "## THE COCA-COLA COMPANY AND SUBSIDIARIES CONSOLIDATED STATEMENTS OF SHAREOWNERS\u2019 EQUITY (In millions except per share data)",
+     "markdown_span": [
+      4160,
+      4284
+     ],
+     "reading_order": 0,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.7163,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p2.b1",
+     "type": "table",
+     "label": null,
+     "bbox": [
+      0.0294,
+      0.1459,
+      0.9665,
+      0.6368
+     ],
+     "content": "<table border=\"1\"><tr><td></td><td></td><td>2024</td><td>2023</td><td>2022</td></tr><tr><td colspan=\"5\">Equity Attributable to Shareowners of The Coca-Cola Company</td></tr><tr><td colspan=\"5\">Number of Common Shares Outstanding</td></tr><tr><td>Balance at beginning of year</td><td></td><td>4,308</td><td>4,328</td><td>4,325</td></tr><tr><td>Treasury stock issued to employees related to stock-based compensation plans</td><td></td><td>21</td><td>17</td><td>24</td></tr><tr><td>Purchases of stock for treasury</td><td></td><td>(27)</td><td>(37)</td><td>(21)</td></tr><tr><td>Balance at end of year</td><td></td><td>4,302</td><td>4,308</td><td>4,328</td></tr><tr><td>Common Stock</td><td>$</td><td>1,760</td><td>1,760</td><td>1,760</td></tr><tr><td colspan=\"5\">Capital Surplus</td></tr><tr><td>Balance at beginning of year</td><td></td><td>19,209</td><td>18,822</td><td>18,116</td></tr><tr><td>Stock issued to employees related to stock-based compensation plans</td><td></td><td>319</td><td>177</td><td>373</td></tr><tr><td>Stock-based compensation expense</td><td></td><td>273</td><td>233</td><td>332</td></tr><tr><td>Acquisition of interests held by noncontrolling owners</td><td></td><td>\u2014</td><td>(20)</td><td>\u2014</td></tr><tr><td>Other activities</td><td></td><td>\u2014</td><td>(3)</td><td>1</td></tr><tr><td>Balance at end of year</td><td></td><td>19,801</td><td>19,209</td><td>18,822</td></tr><tr><td colspan=\"5\">Reinvested Earnings</td></tr><tr><td>Balance at beginning of year</td><td></td><td>73,782</td><td>71,019</td><td>69,094</td></tr><tr><td>Net income attributable to shareowners of The Coca-Cola Company</td><td></td><td>10,631</td><td>10,714</td><td>9,542</td></tr><tr><td>Dividends (per share \u2014 $1.94, $1.84 and $1.76 in 2024, 2023 and 2022, respectively)</td><td></td><td>(8,359)</td><td>(7,951)</td><td>(7,617)</td></tr><tr><td>Balance at end of year</td><td></td><td>76,054</td><td>73,782</td><td>71,019</td></tr><tr><td colspan=\"5\">Accumulated Other Comprehensive Income (Loss)</td></tr><tr><td>Balance at beginning of year</td><td></td><td>(14,275)</td><td>(14,895)</td><td>(14,330)</td></tr><tr><td>Net other comprehensive income (loss)</td><td></td><td>(2,568)</td><td>620</td><td>(565)</td></tr><tr><td>Balance at end of year</td><td></td><td>(16,843)</td><td>(14,275)</td><td>(14,895)</td></tr><tr><td colspan=\"5\">Treasury Stock</td></tr><tr><td>Balance at beginning of year</td><td></td><td>(54,535)</td><td>(52,601)</td><td>(51,641)</td></tr><tr><td>Treasury stock issued to employees related to stock-based compensation plans</td><td></td><td>321</td><td>255</td><td>376</td></tr><tr><td>Purchases of stock for treasury</td><td></td><td>(1,702)</td><td>(2,189)</td><td>(1,336)</td></tr><tr><td>Balance at end of year</td><td></td><td>(55,916)</td><td>(54,535)</td><td>(52,601)</td></tr><tr><td>Total Equity Attributable to Shareowners of The Coca-Cola Company</td><td>$</td><td>24,856</td><td>25,941</td><td>24,105</td></tr><tr><td colspan=\"5\">Equity Attributable to Noncontrolling Interests</td></tr><tr><td>Balance at beginning of year</td><td>$</td><td>1,539</td><td>1,721</td><td>1,861</td></tr><tr><td>Net income attributable to noncontrolling interests</td><td>$</td><td>18</td><td>(11)</td><td>29</td></tr><tr><td>Net foreign currency translation adjustments</td><td>$(9)</td><td>(147)</td><td>(118)</td><td></td></tr><tr><td>Dividends paid to noncontrolling interests</td><td>$(28)</td><td>(25)</td><td>(51)</td><td></td></tr><tr><td>Acquisition of interests held by noncontrolling owners</td><td>\u2014</td><td>(2)</td><td>\u2014</td><td></td></tr><tr><td>Divestitures</td><td>$(4)</td><td>\u2014</td><td>\u2014</td><td></td></tr><tr><td>Other activities</td><td>\u2014</td><td>3</td><td>\u2014</td><td></td></tr><tr><td>Total Equity Attributable to Noncontrolling Interests</td><td>$</td><td>1,516</td><td>1,539</td><td>1,721</td></tr></table>",
+     "markdown_span": [
+      4286,
+      8134
+     ],
+     "reading_order": 1,
+     "source": "layout_ocr",
+     "confidence": {
+      "layout": null,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p2.b2",
+     "type": "text",
+     "label": "vision_footnote",
+     "bbox": [
+      0.0353,
+      0.6459,
+      0.3194,
+      0.6586
+     ],
+     "content": "Refer to Notes to Consolidated Financial Statements.",
+     "markdown_span": [
+      8136,
+      8188
+     ],
+     "reading_order": 2,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.6382,
+      "ocr": null
+     }
+    }
+   ]
+  },
+  {
+   "page": 3,
+   "width": 1700,
+   "height": 2200,
+   "status": "ok",
+   "blocks": [
+    {
+     "id": "p3.b0",
+     "type": "caption",
+     "label": "figure_title",
+     "bbox": [
+      0.3024,
+      0.0709,
+      0.6965,
+      0.1023
+     ],
+     "content": "**UAITED STATES POSTAL SERVICE**\n**STATEMEATS OF CHAAGES IA AET DEFICIEACY**",
+     "markdown_span": [
+      8195,
+      8271
+     ],
+     "reading_order": 0,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8169,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p3.b1",
+     "type": "table",
+     "label": null,
+     "bbox": [
+      0.09,
+      0.1118,
+      0.9071,
+      0.2805
+     ],
+     "content": "<table border=\"1\"><tr><td>(in millions)</td><td colspan=\"2\">Capital Contributions of U.S. Government</td><td colspan=\"2\">Accumulated Deficit Since Reorganization</td><td>Total Net Deficiency</td></tr><tr><td>Balance, September 30, 2022</td><td>$</td><td>16,132</td><td>$</td><td>(32,766)</td><td>$ (16,634)</td></tr><tr><td>Net loss</td><td></td><td>-</td><td>$</td><td>(6,478)</td><td>(6,478)</td></tr><tr><td>Balance, September 30, 2023</td><td>$</td><td>16,132</td><td>$</td><td>(39,244)</td><td>$ (23,112)</td></tr><tr><td>Net loss</td><td></td><td>-</td><td>$</td><td>(9,520)</td><td>(9,520)</td></tr><tr><td>Balance, September 30, 2024</td><td>$</td><td>16,132</td><td>$</td><td>(48,764)</td><td>$ (32,632)</td></tr><tr><td>Net loss</td><td></td><td>-</td><td></td><td>(8,978)</td><td>(8,978)</td></tr><tr><td>Balance, September 30, 2025</td><td>$</td><td>16,132</td><td>$</td><td>(57,742)</td><td>$ (41,610)</td></tr></table>",
+     "markdown_span": [
+      8273,
+      9205
+     ],
+     "reading_order": 1,
+     "source": "layout_ocr",
+     "confidence": {
+      "layout": null,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p3.b2",
+     "type": "text",
+     "label": "vision_footnote",
+     "bbox": [
+      0.0912,
+      0.2827,
+      0.4035,
+      0.2968
+     ],
+     "content": "See accampanying nates ta the financial statements.",
+     "markdown_span": [
+      9207,
+      9258
+     ],
+     "reading_order": 2,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.7588,
+      "ocr": null
+     }
+    },
+    {
+     "id": "p3.b3",
+     "type": "page_footer",
+     "label": "footer",
+     "bbox": [
+      0.55,
+      0.9718,
+      0.9041,
+      0.9845
+     ],
+     "content": "2025 Report on Form 10-K United States Postal Service 48",
+     "markdown_span": null,
+     "reading_order": 3,
+     "source": "native_text",
+     "confidence": {
+      "layout": 0.8013,
+      "ocr": null
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/apps/api/src/scraper/scrapeURL/lib/citations.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/citations.ts
@@ -167,3 +167,59 @@ export function groundCitations(
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Extraction-side helpers: schema wrapping and result splitting. The
+// extraction schema is wrapped as { data: <user schema>, citations:
+// { "<field.path>": [verbatim quotes] } } so one LLM call returns both the
+// user's object (untouched shape) and the supporting quotes to ground.
+// ---------------------------------------------------------------------------
+
+export const CITATIONS_PROMPT_ADDENDUM =
+  "Additionally, for every field you extract, record in `citations` the exact verbatim quote(s) " +
+  "from the content that support that field's value, keyed by the field's JSON path within `data` " +
+  '(e.g. "total_revenue" or "items[2].name"). Quotes must be copied character-for-character from ' +
+  "the content — do not paraphrase, translate, or normalize them. If no supporting text exists for " +
+  "a field, omit that field from `citations`.";
+
+/** Wrap the user's extraction schema so the model returns data + quotes. */
+export function wrapSchemaWithCitations(userSchema: unknown): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      data: userSchema ?? { type: "object" },
+      citations: {
+        type: "object",
+        description:
+          "Per extracted field (keyed by its JSON path in `data`), the exact verbatim quotes from the content supporting the value.",
+        additionalProperties: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+    },
+    required: ["data"],
+  };
+}
+
+/**
+ * Split a wrapped extraction result back into the user's data object and a
+ * normalized quotes map. Returns null when the result doesn't carry the
+ * wrapper shape (model ignored the wrapper) — callers should fall back to
+ * treating the raw result as the data, ungrounded.
+ */
+export function splitCitedExtraction(
+  raw: unknown,
+): { data: unknown; quotesByField: Record<string, string[]> } | null {
+  if (raw === null || typeof raw !== "object" || !("data" in raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const quotesByField: Record<string, string[]> = {};
+  const citations = obj.citations;
+  if (citations && typeof citations === "object" && !Array.isArray(citations)) {
+    for (const [field, value] of Object.entries(citations as Record<string, unknown>)) {
+      if (typeof value === "string") quotesByField[field] = [value];
+      else if (Array.isArray(value)) quotesByField[field] = value.filter((q): q is string => typeof q === "string");
+    }
+  }
+  return { data: obj.data, quotesByField };
+}

--- a/apps/api/src/scraper/scrapeURL/lib/citations.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/citations.ts
@@ -1,0 +1,169 @@
+/**
+ * Grounded-citation resolution for PDF extraction (ENG-4963).
+ *
+ * The extraction LLM returns per-field verbatim supporting quotes; this
+ * module maps each quote back to page + bbox through fire-pdf's block
+ * spans — the model is never trusted with coordinates (LlamaParse
+ * architecture). fire-pdf blocks carry `markdown_span`: [start, end)
+ * character offsets into the full returned markdown, emitted in
+ * ascending order, so overlap lookup is a binary search.
+ *
+ * A quote that cannot be located degrades to no citations for that
+ * field — an honest ungrounded signal rather than a guessed location.
+ */
+
+/** Subset of fire-pdf's block fields the resolver needs (blocks-schema v2). */
+export interface GroundingBlock {
+  id: string;
+  bbox: [number, number, number, number] | null;
+  markdown_span: [number, number] | null;
+}
+
+export interface GroundingBlockPage {
+  page: number;
+  blocks: GroundingBlock[];
+}
+
+export interface Citation {
+  /** 1-based page number, matching fire-pdf's `<!-- page N -->` markers. */
+  page: number;
+  /** Normalized [x0, y0, x1, y1] in 0–1 page coordinates; null when the
+   * source block had no grounded bbox. */
+  bbox: [number, number, number, number] | null;
+  /** The verbatim markdown slice the quote matched. */
+  text: string;
+  /** fire-pdf block id (`p<page>.b<n>`), stable within the response. */
+  blockId: string;
+}
+
+interface SpanEntry {
+  start: number;
+  end: number;
+  page: number;
+  block: GroundingBlock;
+}
+
+/**
+ * Locate `quote` in `markdown`, tolerating the whitespace and case drift
+ * LLMs introduce when quoting. Returns [start, end) offsets into the
+ * ORIGINAL markdown, or null.
+ *
+ * Strategy: exact match first; then a whitespace-collapsed search (every
+ * whitespace run treated as one space) with an offset map back to the
+ * original string; then the same, case-folded. First occurrence wins.
+ */
+export function locateQuote(markdown: string, quote: string): [number, number] | null {
+  const trimmed = quote.trim();
+  if (!trimmed) return null;
+
+  const exact = markdown.indexOf(trimmed);
+  if (exact >= 0) return [exact, exact + trimmed.length];
+
+  // Whitespace-collapsed view of the markdown with a map from collapsed
+  // offsets back to original offsets.
+  const collapsed: string[] = [];
+  const offsetMap: number[] = [];
+  let lastWasSpace = true; // leading whitespace collapses away
+  for (let i = 0; i < markdown.length; i++) {
+    const ch = markdown[i]!;
+    if (/\s/.test(ch)) {
+      if (!lastWasSpace) {
+        collapsed.push(" ");
+        offsetMap.push(i);
+        lastWasSpace = true;
+      }
+    } else {
+      collapsed.push(ch);
+      offsetMap.push(i);
+      lastWasSpace = false;
+    }
+  }
+  const haystack = collapsed.join("");
+  const needle = trimmed.replace(/\s+/g, " ");
+
+  let at = haystack.indexOf(needle);
+  if (at < 0) at = haystack.toLowerCase().indexOf(needle.toLowerCase());
+  if (at < 0) return null;
+
+  const start = offsetMap[at]!;
+  const endInclusive = offsetMap[at + needle.length - 1]!;
+  return [start, endInclusive + 1];
+}
+
+/** Flatten block pages into an ascending span index (blocks without spans
+ * cannot ground anything and are skipped). */
+function buildSpanIndex(blockPages: GroundingBlockPage[]): SpanEntry[] {
+  const entries: SpanEntry[] = [];
+  for (const page of blockPages) {
+    for (const block of page.blocks) {
+      if (!block.markdown_span) continue;
+      entries.push({ start: block.markdown_span[0], end: block.markdown_span[1], page: page.page, block });
+    }
+  }
+  entries.sort((a, b) => a.start - b.start);
+  return entries;
+}
+
+/** Binary search: index of the first span whose end is greater than `pos`. */
+function firstSpanEndingAfter(entries: SpanEntry[], pos: number): number {
+  let lo = 0;
+  let hi = entries.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (entries[mid]!.end <= pos) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * Ground one quote: locate it in the markdown, then collect every block
+ * whose span overlaps the matched range (quotes may cross block
+ * boundaries — each overlapping block contributes one citation).
+ */
+export function groundQuote(markdown: string, spanIndex: SpanEntry[], quote: string): Citation[] {
+  const range = locateQuote(markdown, quote);
+  if (!range) return [];
+  const [start, end] = range;
+  const citations: Citation[] = [];
+  for (let i = firstSpanEndingAfter(spanIndex, start); i < spanIndex.length && spanIndex[i]!.start < end; i++) {
+    const entry = spanIndex[i]!;
+    citations.push({
+      page: entry.page,
+      bbox: entry.block.bbox,
+      text: markdown.slice(Math.max(start, entry.start), Math.min(end, entry.end)),
+      blockId: entry.block.id,
+    });
+  }
+  return citations;
+}
+
+/**
+ * Ground all fields' quotes. `quotesByField` maps a JSON field path
+ * (e.g. "total_revenue" or "items[2].name") to the verbatim quotes the
+ * extraction model cited for it. Fields whose quotes don't locate map
+ * to an empty array.
+ */
+export function groundCitations(
+  markdown: string,
+  blockPages: GroundingBlockPage[],
+  quotesByField: Record<string, string[]>,
+): Record<string, Citation[]> {
+  const spanIndex = buildSpanIndex(blockPages);
+  const out: Record<string, Citation[]> = {};
+  for (const [field, quotes] of Object.entries(quotesByField)) {
+    const citations: Citation[] = [];
+    const seen = new Set<string>();
+    for (const quote of quotes ?? []) {
+      for (const c of groundQuote(markdown, spanIndex, quote)) {
+        // One citation per block per field — multiple quotes often land
+        // in the same block and duplicates carry no information.
+        if (seen.has(c.blockId)) continue;
+        seen.add(c.blockId);
+        citations.push(c);
+      }
+    }
+    out[field] = citations;
+  }
+  return out;
+}

--- a/apps/api/src/scraper/scrapeURL/lib/citations.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/citations.ts
@@ -176,29 +176,42 @@ export function groundCitations(
 // ---------------------------------------------------------------------------
 
 export const CITATIONS_PROMPT_ADDENDUM =
-  "Additionally, for every field you extract, record in `citations` the exact verbatim quote(s) " +
-  "from the content that support that field's value, keyed by the field's JSON path within `data` " +
-  '(e.g. "total_revenue" or "items[2].name"). Quotes must be copied character-for-character from ' +
-  "the content — do not paraphrase, translate, or normalize them. If no supporting text exists for " +
-  "a field, omit that field from `citations`.";
+  "Additionally, for every field you extract, add an entry to `citations` with the field's JSON " +
+  'path within `data` (e.g. "total_revenue" or "items[2].name") and the exact verbatim quote(s) ' +
+  "from the content that support that field's value. Quotes must be copied character-for-character " +
+  "from the content — do not paraphrase, translate, or normalize them. If no supporting text " +
+  "exists for a field, omit that field from `citations`.";
 
-/** Wrap the user's extraction schema so the model returns data + quotes. */
+/**
+ * Wrap the user's extraction schema so the model returns data + quotes.
+ * OpenAI strict structured outputs forbid free-form maps
+ * (`additionalProperties` must be false everywhere), so citations are an
+ * array of { field, quotes } entries rather than a keyed object. The user
+ * schema itself already passed the OpenAI-strictness validation at request
+ * parse time.
+ */
 export function wrapSchemaWithCitations(userSchema: unknown): Record<string, unknown> {
   return {
     type: "object",
     properties: {
-      data: userSchema ?? { type: "object" },
+      data: userSchema,
       citations: {
-        type: "object",
+        type: "array",
         description:
-          "Per extracted field (keyed by its JSON path in `data`), the exact verbatim quotes from the content supporting the value.",
-        additionalProperties: {
-          type: "array",
-          items: { type: "string" },
+          "One entry per extracted field: its JSON path in `data` and the exact verbatim quotes from the content supporting the value.",
+        items: {
+          type: "object",
+          properties: {
+            field: { type: "string" },
+            quotes: { type: "array", items: { type: "string" } },
+          },
+          required: ["field", "quotes"],
+          additionalProperties: false,
         },
       },
     },
-    required: ["data"],
+    required: ["data", "citations"],
+    additionalProperties: false,
   };
 }
 
@@ -215,10 +228,18 @@ export function splitCitedExtraction(
   const obj = raw as Record<string, unknown>;
   const quotesByField: Record<string, string[]> = {};
   const citations = obj.citations;
-  if (citations && typeof citations === "object" && !Array.isArray(citations)) {
-    for (const [field, value] of Object.entries(citations as Record<string, unknown>)) {
-      if (typeof value === "string") quotesByField[field] = [value];
-      else if (Array.isArray(value)) quotesByField[field] = value.filter((q): q is string => typeof q === "string");
+  if (Array.isArray(citations)) {
+    for (const entry of citations) {
+      if (entry === null || typeof entry !== "object") continue;
+      const { field, quotes } = entry as Record<string, unknown>;
+      if (typeof field !== "string") continue;
+      const list =
+        typeof quotes === "string"
+          ? [quotes]
+          : Array.isArray(quotes)
+            ? quotes.filter((q): q is string => typeof q === "string")
+            : [];
+      quotesByField[field] = [...(quotesByField[field] ?? []), ...list];
     }
   }
   return { data: obj.data, quotesByField };

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -378,6 +378,20 @@ function coerceFieldsToFormats(meta: Meta, document: Document): Document {
     );
   }
 
+  // Blocks are INTERNAL (they exist only to ground citations) — always
+  // strip them; the public blocks format is a separate unshipped decision.
+  if (document.blocks !== undefined) {
+    delete document.blocks;
+  }
+  // Citations belong to the json format with citeSources on; strip
+  // otherwise so no stray field leaks.
+  if (
+    document.citations !== undefined &&
+    hasFormatOfType(meta.options.formats, "json")?.citeSources !== true
+  ) {
+    delete document.citations;
+  }
+
   if (!hasRawHtml && document.rawHtml !== undefined) {
     delete document.rawHtml;
   } else if (hasRawHtml && document.rawHtml === undefined) {

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -994,10 +994,21 @@ export async function performLLMExtract(
     // the untouched user shape; quotes are grounded to page + bbox through
     // fire-pdf block spans after extraction. Requires blocks (PDF via
     // fire-pdf) — otherwise extraction proceeds unwrapped and ungrounded.
+    // Requires a user schema: OpenAI strict structured outputs cannot
+    // express a schema-less wrapped shape. Schema-less citeSources
+    // degrades to a normal ungrounded extraction with a warning.
     const citing =
       jsonFormat.citeSources === true &&
+      jsonFormat.schema !== undefined &&
       !!document.blocks?.length &&
       typeof document.markdown === "string";
+    if (jsonFormat.citeSources === true && !citing) {
+      document.warning =
+        "citeSources was requested but citations are unavailable for this document" +
+        (jsonFormat.schema === undefined ? " (a JSON schema is required)" : "") +
+        "; extraction proceeded ungrounded." +
+        (document.warning ? " " + document.warning : "");
+    }
     const effectiveFormat = citing
       ? {
           ...jsonFormat,

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -25,6 +25,12 @@ import { extractData } from "../lib/extractSmartScrape";
 import { CostTracking } from "../../../lib/cost-tracking";
 import { isAgentExtractModelValid } from "../../../controllers/v1/types";
 import { hasFormatOfType } from "../../../lib/format-utils";
+import {
+  CITATIONS_PROMPT_ADDENDUM,
+  groundCitations,
+  splitCitedExtraction,
+  wrapSchemaWithCitations,
+} from "../lib/citations";
 
 // Smart model selection based on schema
 function detectRecursiveSchema(schema: any): boolean {
@@ -983,11 +989,30 @@ export async function performLLMExtract(
 
     const modelSelection = selectModelForSchema(jsonFormat.schema);
 
+    // Grounded citations (ENG-4963): wrap the schema as { data, citations }
+    // so the model returns per-field verbatim supporting quotes alongside
+    // the untouched user shape; quotes are grounded to page + bbox through
+    // fire-pdf block spans after extraction. Requires blocks (PDF via
+    // fire-pdf) — otherwise extraction proceeds unwrapped and ungrounded.
+    const citing =
+      jsonFormat.citeSources === true &&
+      !!document.blocks?.length &&
+      typeof document.markdown === "string";
+    const effectiveFormat = citing
+      ? {
+          ...jsonFormat,
+          schema: wrapSchemaWithCitations(jsonFormat.schema),
+          prompt: [jsonFormat.prompt, CITATIONS_PROMPT_ADDENDUM]
+            .filter(Boolean)
+            .join("\n\n"),
+        }
+      : jsonFormat;
+
     const generationOptions: GenerateCompletionsOptions = {
       logger: meta.logger.child({
         method: "performLLMExtract/generateCompletions",
       }),
-      options: jsonFormat,
+      options: effectiveFormat,
       markdown: document.markdown,
       previousWarning: document.warning,
       model: getModel(modelSelection.modelName, "openai"),
@@ -1026,8 +1051,27 @@ export async function performLLMExtract(
     }
 
     // IMPORTANT: here it only get's the last page!!!
-    const extractedData =
+    let extractedData =
       extractedDataArray[extractedDataArray.length - 1] ?? undefined;
+
+    if (citing && extractedData !== undefined) {
+      const split = splitCitedExtraction(extractedData);
+      if (split) {
+        extractedData = split.data;
+        document.citations = groundCitations(
+          document.markdown!,
+          document.blocks!,
+          split.quotesByField,
+        );
+      } else {
+        // Model ignored the wrapper — serve the raw result ungrounded
+        // rather than failing the extraction.
+        meta.logger.warn(
+          "citeSources: extraction result missing { data, citations } wrapper; returning ungrounded",
+        );
+        document.citations = {};
+      }
+    }
 
     // // Prepare the schema, potentially wrapping it
     // const { schemaToUse, schemaWasWrapped } = prepareSmartScrapeSchema(


### PR DESCRIPTION
## What

The `json` format gains **`citeSources: true`** for PDF documents: extraction returns per-field **citations — page + normalized bbox + verbatim source text** — resolved through fire-pdf block spans. `document.json` keeps exactly the user's schema; citations arrive as a parallel `document.citations` map (`"<field.path>" → Citation[]`). Fields whose supporting quote can't be located degrade to `[]` — an honest ungrounded signal.

## Architecture (the model never touches coordinates)

1. Extraction schema is wrapped as `{ data: <user schema>, citations: [{ field, quotes }] }` — one LLM call returns the untouched user shape plus verbatim supporting quotes. (Array-of-entries, not a map: OpenAI strict structured outputs reject free-form `additionalProperties` — found via live-model testing.)
2. Quotes are located in the document markdown (exact → whitespace-collapsed → case-folded), then mapped through fire-pdf's `markdown_span` block offsets (binary search; boundary-crossing quotes yield one citation per overlapping block).
3. Internal-only blocks plumbing (subset of the held ENG-4956 branch): fire-pdf gets `include_blocks` **only** when `citeSources` is set; blocks ride to `Document.blocks` and are **always stripped from responses** — the public `blocks` format remains a separate unshipped decision. `citeSources` forces the fire-pdf route and bypasses the PDF cache; fire-pdf failure degrades to ungrounded extraction, never an error. Schema-less `citeSources` degrades to ungrounded with a warning (strict mode can't wrap a schema-less shape).

## Verification

- **Live E2E** (gpt-4o-mini over a real fire-pdf blocks response for a 3-page doc built from public SEC pages): all three requested fields extracted with citations landing on the correct pages/blocks — statement title → `p2.b0` (tight title bbox), purchase period → `p1.b3` (the table block), treasury purchases → `p2.b1`.
- 17 unit tests: resolver (real fixture), wrapper/splitter (strict-mode shapes), zod option, public `blocks` format still rejected.
- tsc clean; adjacent-suite failures (`transformers/index.test.ts`, `browser-billing`) reproduce identically on clean main (broken `typescript@rc` dep / unrelated) — verified in a throwaway worktree. Pre-commit hook skipped for the same broken dep.

## Notes

- Async path works unchanged (extraction runs on the final assembled markdown post-engine). ZDR already blocks json extraction.
- Billing multiplier for grounded extraction flagged for the pricing discussion (per ticket), not implemented.
- fire-pdf side needed zero changes — blocks have carried `markdown_span` since #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds grounded citations to PDF `json` extraction via `citeSources: true` (ENG-4963). Each extracted field can include page, normalized bbox, and verbatim source text, grounded through `fire-pdf` block spans; if a quote can’t be located, the field returns an empty citation list.

- **New Features**
  - `json` accepts `citeSources: true` (PDF only). Requires a schema; schema-less requests degrade to ungrounded with a warning.
  - Schema is wrapped as `{ data: <user schema>, citations: [{ field, quotes }] }` to satisfy strict outputs. Quotes are found in markdown (exact → whitespace-collapsed → case-folded) and mapped to blocks via `markdown_span`.
  - `document.json` keeps the user’s shape. Grounded citations are returned in `document.citations` as `<field.path> -> [{ page, bbox, text, blockId }]`.
  - `citeSources` forces the `fire-pdf` route with `include_blocks`; blocks are internal-only and stripped from responses. Cache is bypassed; on `fire-pdf` failure we fall back and return ungrounded extraction (no error).
  - Supported in sync and async paths. Adds unit tests and a real `fire-pdf` blocks fixture.

<sup>Written for commit bd12a1617268297834757faf037f075af34ac8d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

