### PR TITLE
[codex] Use direct Google Drive downloads for file rewrites

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/__tests__/rewriteUrl.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/__tests__/rewriteUrl.test.ts
@@ -100,7 +100,7 @@ describe("rewriteUrl", () => {
       const url =
         "https://drive.google.com/file/d/1a2b3c4d5e6f7g8h9i0j/view?usp=sharing";
       expect(rewriteUrl(url)).toBe(
-        "https://drive.google.com/uc?export=download&id=1a2b3c4d5e6f7g8h9i0j",
+        "https://drive.usercontent.google.com/download?id=1a2b3c4d5e6f7g8h9i0j&export=download",
       );
     });
   });

--- a/apps/api/src/scraper/scrapeURL/lib/rewriteUrl.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/rewriteUrl.ts
@@ -31,7 +31,7 @@ export function rewriteUrl(url: string): string | undefined {
   ) {
     const id = url.match(/\/file\/d\/([-\w]+)/)?.[1];
     if (id) {
-      return `https://drive.google.com/uc?export=download&id=${id}`;
+      return `https://drive.usercontent.google.com/download?id=${id}&export=download`;
     }
   } else if (
     url.startsWith("https://docs.google.com/spreadsheets/d/") ||


### PR DESCRIPTION
## Summary
- rewrite Google Drive file links directly to `drive.usercontent.google.com/download` instead of the redirecting `drive.google.com/uc` endpoint
- update the focused rewriteUrl expectation for Drive file links

## Why
Self-hosted Server Test Suite run 29035703323 failed in `src/__tests__/snips/v2/scrape.test.ts > Scrape tests > URL rewriting > scrapes Google Drive text files correctly` because the scrape captured the Google Drive virus-scan / technical-difficulties interstitial instead of the text file body. Directing Drive file rewrites to the same final download endpoint avoids the interstitial surface while still fetching the real file content.

## Validation
- `curl -L --max-time 30 https://drive.usercontent.google.com/download?id=14m3ZVDnWJwwPSDHX6U6jkL7FXxOf6cHB\&export=download` returned `This is a simple TXT file.`
- `curl -L --max-time 30 https://drive.usercontent.google.com/download?id=1QrgvXM2F7sgSdrhoBfdp9IMBVhUk-Ueu\&export=download` returned a PDF header and `content-disposition: attachment; filename="sample_pdf.pdf"`
- `pnpm vitest run src/scraper/scrapeURL/lib/__tests__/rewriteUrl.test.ts -t "Google Drive"` passed
- `pnpm build` passed
- `git diff --check` passed

Notes:
- Full `rewriteUrl.test.ts` currently has unrelated pre-existing Google Docs/Slides expectation mismatches (`format=pdf` expected, `format=html` returned), so I used the focused Google Drive filter for this patch.
- `TEST_SUITE_SELF_HOSTED=true TEST_SUITE_WEBSITE=http://127.0.0.1:4321 TEST_API_KEY=test TEST_TEAM_ID=bypass PROXY_SERVER=http://127.0.0.1:9 pnpm harness pnpm vitest run src/__tests__/snips/v2/scrape.test.ts -t "scrapes Google Drive text files correctly"` failed locally with `ECONNREFUSED` because the custom harness command starts before API readiness. Retrying with `pnpm harness pnpm test:snips -- -t "scrapes Google Drive text files correctly"` used the readiness gate but broadened into other snip files and hit local missing Redis noise, so I stopped it and left the authoritative matrix to CI.

Labels:
- Requested labels `codex` and `codex-automation` are not present in `firecrawl/firecrawl`, so none were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite Google Drive file links to the direct download endpoint to bypass interstitial pages and reliably scrape file contents. Updates tests to expect `drive.usercontent.google.com/download`.

- **Bug Fixes**
  - Switch rewrite from `https://drive.google.com/uc?export=download&id=...` to `https://drive.usercontent.google.com/download?id=...&export=download` to avoid virus-scan/technical-difficulties interstitials.

<sup>Written for commit e050c57711b7ce8e1daedbd77a540b5a82a66b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

