### PR TITLE
[codex] Avoid Redis counts in forced NuQ FDB capacity

### DIFF
--- a/apps/api/src/__tests__/nuq-fdb/core.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/core.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { vi } from "vitest";
 import { config } from "../../config";
 import {
   NuQFdbQueue,
@@ -10,6 +11,7 @@ import {
   getFdb,
 } from "../../services/worker/nuq-fdb/client";
 import { encodeI64, encodeJson } from "../../services/worker/nuq-fdb/keyspace";
+import { QueueFullError } from "../../lib/queue-full-error";
 
 // These tests exercise the FDB queue core directly against a real FoundationDB
 // cluster (no API server needed). They are skipped when FDB is not configured.
@@ -106,6 +108,37 @@ describeIf("NuQ FDB core", () => {
       expect(job?.returnvalue).toEqual({ result: "yay" });
     } else {
       expect(job?.returnvalue).toBeNull();
+    }
+  });
+
+  test("dequeue retry returns the original committed lease", async () => {
+    const { queue } = await makeCtx("take-retry");
+    const owner = freshOwner();
+    const ids = [randomUUID(), randomUUID()];
+    await queue.addJobs(
+      ids.map(id => ({ id, data: scrapeData(), options: { ownerId: owner } })),
+      UNLIMITED,
+    );
+
+    const db = (queue as any).db;
+    const originalDoTn = db.doTn.bind(db);
+    let retried = false;
+    const doTn = vi.spyOn(db, "doTn").mockImplementation(async (body, opts) => {
+      const first = await originalDoTn(body, opts);
+      if (!retried && first && (first as any).status === "active") {
+        retried = true;
+        return await originalDoTn(body, opts);
+      }
+      return first;
+    });
+    try {
+      const taken = await queue.getJobToProcess();
+      expect(taken).not.toBeNull();
+      expect(retried).toBe(true);
+      const statuses = (await queue.getJobs(ids)).map(job => job.status).sort();
+      expect(statuses).toEqual(["active", "queued"]);
+    } finally {
+      doTn.mockRestore();
     }
   });
 
@@ -239,7 +272,7 @@ describeIf("NuQ FDB core", () => {
     expect(promoted.id).toBe(highPrio);
   });
 
-  test("kickoff jobs bypass the gate and hold no slot", async () => {
+  test("kickoff jobs bypass admission but hold an occupancy slot", async () => {
     const { queue } = await makeCtx("kickoff");
     const owner = freshOwner();
     const kickoff = randomUUID();
@@ -249,13 +282,79 @@ describeIf("NuQ FDB core", () => {
       { ownerId: owner, bypassGate: true },
       gate(1),
     );
-    expect(await queue.getTeamActiveCount(owner)).toBe(0);
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
 
     const [k] = await takeAll(queue, 1);
     expect(k.id).toBe(kickoff);
-    expect(await queue.getTeamActiveCount(owner)).toBe(0);
+    expect(await queue.getTeamActiveCount(owner)).toBe(1);
     await queue.jobFinish(k.id, k.lock!, null);
     expect(await queue.getTeamActiveCount(owner)).toBe(0);
+  });
+
+  test("backlog cap charges only actual pending placements", async () => {
+    const { queue } = await makeCtx("qcap-placement");
+    const owner = freshOwner();
+    const jobs = [randomUUID(), randomUUID(), randomUUID()].map(id => ({
+      id,
+      data: scrapeData(),
+      options: { ownerId: owner },
+    }));
+    const placed = await queue.addJobs(jobs, gate(2, 1));
+    expect(placed.map(job => job.status)).toEqual([
+      "queued",
+      "queued",
+      "backlog",
+    ]);
+
+    const bypass = await queue.addJob(
+      randomUUID(),
+      { mode: "kickoff" },
+      { ownerId: owner, bypassGate: true },
+      gate(2, 1),
+    );
+    expect(bypass.status).toBe("queued");
+  });
+
+  test("concurrent admissions cannot exceed the backlog cap", async () => {
+    const { queue } = await makeCtx("qcap-concurrent");
+    const owner = freshOwner();
+    await queue.addJob(
+      randomUUID(),
+      scrapeData(),
+      { ownerId: owner },
+      gate(1, 1),
+    );
+    const adds = await Promise.allSettled(
+      [randomUUID(), randomUUID()].map(id =>
+        queue.addJob(id, scrapeData(), { ownerId: owner }, gate(1, 1)),
+      ),
+    );
+    expect(adds.filter(result => result.status === "fulfilled")).toHaveLength(
+      1,
+    );
+    expect(adds.filter(result => result.status === "rejected")).toHaveLength(1);
+  });
+
+  test("PG pending occupancy reduces the FDB backlog cap", async () => {
+    const { queue } = await makeCtx("qcap-combined");
+    const owner = freshOwner();
+    await queue.addJob(
+      randomUUID(),
+      scrapeData(),
+      { ownerId: owner },
+      gate(1, 2),
+    );
+    await expect(
+      queue.addJob(
+        randomUUID(),
+        scrapeData(),
+        { ownerId: owner },
+        {
+          ...gate(1, 2),
+          externalPending: 2,
+        },
+      ),
+    ).rejects.toBeInstanceOf(QueueFullError);
   });
 
   test("QueueFullError when the backlog cap is exceeded", async () => {

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -1,19 +1,56 @@
 import { randomUUID } from "crypto";
 import { vi } from "vitest";
+
+// This suite only exercises the routed FDB implementation. Keeping the PG
+// queue mocked avoids pulling scraper engine build artifacts into the focused
+// FoundationDB CI job.
+vi.mock("../../services/worker/nuq", () => {
+  const queue = {
+    getJobToProcess: vi.fn().mockResolvedValue(null),
+  };
+  return {
+    scrapeQueue: queue,
+    crawlFinishedQueue: queue,
+    crawlGroup: {},
+  };
+});
+vi.mock("../../services/ab-test", () => ({
+  abTestJob: vi.fn(),
+}));
+vi.mock("../../lib/crawl-redis", () => ({
+  getCrawl: vi.fn(),
+}));
+vi.mock("../../services/redlock", () => ({
+  redlock: {
+    using: vi.fn(
+      async (
+        _resources: string[],
+        _duration: number,
+        _options: object,
+        fn: (signal: { aborted: boolean; error?: Error }) => unknown,
+      ) => await fn({ aborted: false }),
+    ),
+  },
+}));
+
 import { config } from "../../config";
 import { redisEvictConnection } from "../../services/redis";
+import { getRedisConnection } from "../../services/queue-service";
 import {
   fdbQueueEnabled,
   isFdbTeam,
   resolveJobBackend,
   resolveNewGroupBackend,
   fdbEnqueueScrapeJobs,
+  getCombinedTeamActiveCount,
   scrapeQueue,
   crawlGroup,
   crawlFinishedQueue,
   mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
 } from "../../services/worker/nuq-router";
+import { waitForJob as waitForQueuedJob } from "../../services/queue-jobs";
 import { scrapeQueueFdb } from "../../services/worker/nuq-fdb";
 import {
   getNuqFdbDatabase,
@@ -160,6 +197,255 @@ describeIf("NuQ router (forced FDB mode)", () => {
     }
   });
 
+  test("marker failure or expiry cannot hide standalone FDB jobs", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const redisGet = vi.spyOn(redisEvictConnection, "get");
+    const redisSet = vi.spyOn(redisEvictConnection, "set");
+    config.NUQ_BACKEND = "pg";
+    try {
+      const teamId = randomUUID();
+      const jobId = randomUUID();
+      redisGet.mockResolvedValue(null);
+      redisSet.mockImplementation(async key => {
+        if (key === `nuq:fdb_team:${teamId}`) return "OK" as any;
+        throw new Error("marker unavailable");
+      });
+
+      const { jobs } = await fdbEnqueueScrapeJobs(
+        [
+          {
+            jobId,
+            data: {
+              mode: "single_urls",
+              url: "https://example.com",
+              team_id: teamId,
+            } as any,
+            priority: 0,
+            listenable: true,
+            backlogTimeoutMs: 60_000,
+          },
+        ],
+        teamId,
+      );
+
+      // The returned backend survives queue-jobs and can route a wait without
+      // consulting Redis. ID-only reads/removes recover from durable FDB state.
+      expect(jobs[0].backend).toBe("fdb");
+      expect((await scrapeQueue.getJob(jobId))?.id).toBe(jobId);
+      const wait = waitForQueuedJob(jobs[0], 15_000, false);
+      const taken = await scrapeQueueFdb.getJobToProcess();
+      expect(taken?.id).toBe(jobId);
+      await scrapeQueueFdb.jobFinish(jobId, taken!.lock!, { ok: true });
+      await expect(wait).resolves.toEqual({ ok: true });
+      await scrapeQueue.removeJob(jobId);
+
+      const cancelId = randomUUID();
+      await fdbEnqueueScrapeJobs(
+        [
+          {
+            jobId: cancelId,
+            data: {
+              mode: "single_urls",
+              url: "https://example.com/cancel",
+              team_id: teamId,
+            } as any,
+            priority: 0,
+            backlogTimeoutMs: 60_000,
+          },
+        ],
+        teamId,
+      );
+      // ID-only standalone cancellation also probes durable FDB state.
+      await scrapeQueue.removeJob(cancelId);
+      expect(await scrapeQueue.getJob(cancelId)).toBeNull();
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      redisGet.mockRestore();
+      redisSet.mockRestore();
+    }
+  });
+
+  test("repeated enqueue reconciles a late commit by stable job id", async () => {
+    const teamId = randomUUID();
+    const jobId = randomUUID();
+    const input = {
+      id: jobId,
+      data: {
+        mode: "single_urls",
+        url: "https://example.com",
+        team_id: teamId,
+      } as any,
+      options: {
+        ownerId: teamId,
+        priority: 0,
+        bypassGate: true,
+      },
+    };
+
+    const first = await scrapeQueueFdb.addJobs([input], {
+      teamLimit: 1,
+      queueCap: 10,
+    });
+    const retried = await scrapeQueueFdb.addJobs([input], {
+      teamLimit: 1,
+      queueCap: 10,
+    });
+    expect(first[0].id).toBe(jobId);
+    expect(retried[0].id).toBe(jobId);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    await scrapeQueueFdb.removeJob(jobId);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("PG occupancy reduces FDB admission and direct jobs keep occupancy parity", async () => {
+    const teamId = randomUUID();
+    const blockedId = randomUUID();
+    const directId = randomUUID();
+    const data = {
+      mode: "single_urls",
+      url: "https://example.com",
+      team_id: teamId,
+    } as any;
+
+    const blocked = await scrapeQueueFdb.addJob(
+      blockedId,
+      data,
+      { ownerId: teamId, priority: 0 },
+      { teamLimit: 2, externalActive: 2, queueCap: 10 },
+    );
+    expect(blocked.status).toBe("backlog");
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    await scrapeQueueFdb.removeJob(blockedId);
+
+    const direct = await scrapeQueueFdb.addJob(
+      directId,
+      data,
+      { ownerId: teamId, priority: 0, bypassGate: true },
+      { teamLimit: 1, queueCap: 10 },
+    );
+    expect(direct.status).toBe("queued");
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    await scrapeQueueFdb.removeJob(directId);
+    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+  });
+
+  test("flag rollback keeps crawl jobs pinned to their durable FDB group", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const redisGet = vi.spyOn(redisEvictConnection, "get");
+    const redisStateGet = vi.spyOn(getRedisConnection(), "get");
+    const redisCount = vi.spyOn(getRedisConnection(), "zcount");
+    const teamId = randomUUID();
+    const groupId = randomUUID();
+    const holderId = randomUUID();
+    try {
+      await crawlGroup.addGroup(groupId, teamId, 60_000, { backend: "fdb" });
+      await mirrorExternalSlotAcquire(teamId, holderId, 60_000);
+      config.NUQ_BACKEND = "pg";
+      redisGet.mockResolvedValue(null);
+      redisStateGet.mockImplementation(async key =>
+        key === `nuq:fdb_team:${teamId}` ? "1" : null,
+      );
+      redisCount.mockResolvedValue(0);
+
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(1);
+      await mirrorExternalSlotRelease(teamId, holderId);
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
+      await expect(
+        resolveJobBackend({
+          mode: "single_urls",
+          url: "https://example.com",
+          team_id: teamId,
+          crawl_id: groupId,
+        } as any),
+      ).resolves.toBe("fdb");
+      await expect(crawlGroup.cancelGroup(groupId)).resolves.toBe(true);
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      redisGet.mockRestore();
+      redisStateGet.mockRestore();
+      redisCount.mockRestore();
+    }
+  });
+
+  test("forced-cloud external-only occupancy survives rollback", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const previousDbAuth = config.USE_DB_AUTHENTICATION;
+    const redisStateSet = vi
+      .spyOn(getRedisConnection(), "set")
+      .mockResolvedValue("OK");
+    const redisStateGet = vi.spyOn(getRedisConnection(), "get");
+    const redisCount = vi
+      .spyOn(getRedisConnection(), "zcount")
+      .mockResolvedValue(0);
+    const teamId = randomUUID();
+    const holderId = randomUUID();
+    try {
+      config.NUQ_BACKEND = "fdb";
+      config.USE_DB_AUTHENTICATION = true;
+      await mirrorExternalSlotAcquire(teamId, holderId, 60_000);
+      expect(redisStateSet).toHaveBeenCalledWith(`nuq:fdb_team:${teamId}`, "1");
+
+      config.NUQ_BACKEND = "pg";
+      config.USE_DB_AUTHENTICATION = false;
+      redisStateGet.mockImplementation(async key =>
+        key === `nuq:fdb_team:${teamId}` ? "1" : null,
+      );
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(1);
+      await mirrorExternalSlotRelease(teamId, holderId);
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      config.USE_DB_AUTHENTICATION = previousDbAuth;
+      redisStateSet.mockRestore();
+      redisStateGet.mockRestore();
+      redisCount.mockRestore();
+    }
+  });
+
+  test("pure PG teams avoid FDB outages while migrated teams fail closed", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const redisStateGet = vi
+      .spyOn(getRedisConnection(), "get")
+      .mockResolvedValue(null);
+    const redisCount = vi
+      .spyOn(getRedisConnection(), "zcount")
+      .mockResolvedValue(0);
+    const fdbCount = vi
+      .spyOn(scrapeQueueFdb, "getTeamActiveCount")
+      .mockRejectedValue(new Error("FDB unavailable"));
+    const teamId = randomUUID();
+    config.NUQ_BACKEND = "pg";
+    try {
+      await expect(getCombinedTeamActiveCount(teamId)).resolves.toBe(0);
+      expect(fdbCount).not.toHaveBeenCalled();
+
+      redisStateGet.mockImplementation(async key =>
+        key === `nuq:fdb_team:${teamId}` ? "1" : null,
+      );
+      await expect(getCombinedTeamActiveCount(teamId)).rejects.toThrow(
+        "FDB unavailable",
+      );
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      redisStateGet.mockRestore();
+      redisCount.mockRestore();
+      fdbCount.mockRestore();
+    }
+  });
+
+  test("optional router never attempts an FDB dequeue before PG fallback", async () => {
+    const forcedBackend = config.NUQ_BACKEND;
+    const fdbTake = vi.spyOn(scrapeQueueFdb, "getJobToProcess");
+    config.NUQ_BACKEND = "pg";
+    try {
+      await scrapeQueue.getJobToProcess().catch(() => null);
+      expect(fdbTake).not.toHaveBeenCalled();
+    } finally {
+      config.NUQ_BACKEND = forcedBackend;
+      fdbTake.mockRestore();
+    }
+  });
+
   test("routed group lifecycle incl. crawl_finished consumption and cancel", async () => {
     const teamId = randomUUID();
     const gid = randomUUID();
@@ -225,11 +511,19 @@ describeIf("NuQ router (forced FDB mode)", () => {
     const holder = randomUUID();
     await mirrorExternalSlotAcquire(teamId, holder, 30_000);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+    await expect(
+      reserveExternalSlot(teamId, randomUUID(), 30_000, 1),
+    ).resolves.toBe(false);
     // re-acquire (heartbeat) must not double-count
     await mirrorExternalSlotAcquire(teamId, holder, 30_000);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
     await mirrorExternalSlotRelease(teamId, holder);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    const nextHolder = randomUUID();
+    await expect(
+      reserveExternalSlot(teamId, nextHolder, 30_000, 1),
+    ).resolves.toBe(true);
+    await mirrorExternalSlotRelease(teamId, nextHolder);
     // double release is a no-op
     await mirrorExternalSlotRelease(teamId, holder);
     expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);

--- a/apps/api/src/__tests__/nuq-fdb/router.test.ts
+++ b/apps/api/src/__tests__/nuq-fdb/router.test.ts
@@ -509,23 +509,37 @@ describeIf("NuQ router (forced FDB mode)", () => {
   test("external slot mirror consumes and releases FDB capacity", async () => {
     const teamId = randomUUID();
     const holder = randomUUID();
-    await mirrorExternalSlotAcquire(teamId, holder, 30_000);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
-    await expect(
-      reserveExternalSlot(teamId, randomUUID(), 30_000, 1),
-    ).resolves.toBe(false);
-    // re-acquire (heartbeat) must not double-count
-    await mirrorExternalSlotAcquire(teamId, holder, 30_000);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
-    await mirrorExternalSlotRelease(teamId, holder);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
-    const nextHolder = randomUUID();
-    await expect(
-      reserveExternalSlot(teamId, nextHolder, 30_000, 1),
-    ).resolves.toBe(true);
-    await mirrorExternalSlotRelease(teamId, nextHolder);
-    // double release is a no-op
-    await mirrorExternalSlotRelease(teamId, holder);
-    expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    const redis = getRedisConnection();
+    const redisActiveCount = vi
+      .spyOn(redis, "zcount")
+      .mockRejectedValue(new Error("forced FDB must not read Redis active"));
+    const redisPendingCount = vi
+      .spyOn(redis, "zcard")
+      .mockRejectedValue(new Error("forced FDB must not read Redis pending"));
+    try {
+      await mirrorExternalSlotAcquire(teamId, holder, 30_000);
+      expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+      await expect(
+        reserveExternalSlot(teamId, randomUUID(), 30_000, 1),
+      ).resolves.toBe(false);
+      expect(redisActiveCount).not.toHaveBeenCalled();
+      expect(redisPendingCount).not.toHaveBeenCalled();
+      // re-acquire (heartbeat) must not double-count
+      await mirrorExternalSlotAcquire(teamId, holder, 30_000);
+      expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(1);
+      await mirrorExternalSlotRelease(teamId, holder);
+      expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+      const nextHolder = randomUUID();
+      await expect(
+        reserveExternalSlot(teamId, nextHolder, 30_000, 1),
+      ).resolves.toBe(true);
+      await mirrorExternalSlotRelease(teamId, nextHolder);
+      // double release is a no-op
+      await mirrorExternalSlotRelease(teamId, holder);
+      expect(await scrapeQueueFdb.getTeamActiveCount(teamId)).toBe(0);
+    } finally {
+      redisActiveCount.mockRestore();
+      redisPendingCount.mockRestore();
+    }
   });
 });

--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -18,9 +18,8 @@ import {
   clearBrowserSessionPromptFlag,
 } from "../../lib/browser-sessions";
 import {
-  getCombinedTeamActiveCount,
-  mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
 } from "../../services/worker/nuq-router";
 import { RequestWithAuth } from "./types";
 import { billTeam } from "../../services/billing/credit_billing";
@@ -257,10 +256,14 @@ export async function browserCreateController(
 
   // 0b. Enforce concurrency limit (shared pool with scrape/crawl/interact)
   const concurrencyLimit = req.acuc?.concurrency ?? 2;
-  const activeCount = await getCombinedTeamActiveCount(req.auth.team_id);
-  if (activeCount >= concurrencyLimit) {
+  const reserved = await reserveExternalSlot(
+    req.auth.team_id,
+    sessionId,
+    ttl * 1000 + 60_000,
+    concurrencyLimit,
+  );
+  if (!reserved) {
     logger.warn("Concurrency limit reached for browser session", {
-      activeCount,
       limit: concurrencyLimit,
     });
     return res.status(429).json({
@@ -303,6 +306,9 @@ export async function browserCreateController(
     } catch (err) {
       // 409 means the profile is locked by another writer — don't retry
       if (err instanceof BrowserServiceError && err.status === 409) {
+        await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+          () => {},
+        );
         logger.warn("Profile is locked", {
           profileName: profile?.name,
           error: err,
@@ -327,6 +333,9 @@ export async function browserCreateController(
   }
 
   if (!svcResponse) {
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     logger.error("Failed to create browser session after all retries", {
       error: lastCreateError,
       attempts: MAX_CREATE_RETRIES,
@@ -374,6 +383,9 @@ export async function browserCreateController(
       "DELETE",
       `/browsers/${svcResponse.sessionId}`,
     ).catch(() => {});
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     return res.status(500).json({
       success: false,
       error: "Failed to persist browser session.",
@@ -382,12 +394,6 @@ export async function browserCreateController(
 
   // Invalidate cached count so next check reflects the new session
   invalidateActiveBrowserSessionCount(req.auth.team_id).catch(() => {});
-
-  // Register in the shared concurrency limiter so this session counts
-  // against the team's concurrent job limit while it's active.
-  mirrorExternalSlotAcquire(req.auth.team_id, sessionId, ttl * 1000).catch(
-    () => {},
-  );
 
   logger.info("Browser session created", {
     sessionId,

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -19,9 +19,8 @@ import {
 } from "../../lib/browser-sessions";
 import {} from "../../lib/concurrency-limit";
 import {
-  getCombinedTeamActiveCount,
-  mirrorExternalSlotAcquire,
   mirrorExternalSlotRelease,
+  reserveExternalSlot,
 } from "../../services/worker/nuq-router";
 import {
   browserServiceRequest,
@@ -595,8 +594,13 @@ async function createSessionForScrape(
 
   // Active session limit — uses the same concurrency pool as scrape/crawl
   const concurrencyLimit = req.acuc?.concurrency ?? 2;
-  const activeCount = await getCombinedTeamActiveCount(req.auth.team_id);
-  if (activeCount >= concurrencyLimit) {
+  const reserved = await reserveExternalSlot(
+    req.auth.team_id,
+    sessionId,
+    ttl * 1000 + 60_000,
+    concurrencyLimit,
+  );
+  if (!reserved) {
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
     return {
       status: 429,
@@ -644,6 +648,9 @@ async function createSessionForScrape(
       break;
     } catch (err) {
       if (err instanceof BrowserServiceError && err.status === 409) {
+        await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+          () => {},
+        );
         adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(
           () => {},
         );
@@ -670,6 +677,9 @@ async function createSessionForScrape(
   }
 
   if (!svcResponse) {
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
     logger.error("Failed to create browser session after all retries", {
       error: lastCreateError,
@@ -772,6 +782,9 @@ async function createSessionForScrape(
       );
     }
   } catch (err) {
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
     logger.error("Failed to initialize scrape browser session context", {
       error: err,
@@ -823,12 +836,6 @@ async function createSessionForScrape(
 
     invalidateActiveBrowserSessionCount(req.auth.team_id).catch(() => {});
 
-    // Register in the shared concurrency limiter so this session counts
-    // against the team's concurrent job limit while it's active.
-    mirrorExternalSlotAcquire(req.auth.team_id, sessionId, ttl * 1000).catch(
-      () => {},
-    );
-
     return { session };
   } catch (err) {
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});
@@ -839,6 +846,9 @@ async function createSessionForScrape(
       "DELETE",
       `/browsers/${svcResponse.sessionId}`,
     ).catch(() => {});
+    await mirrorExternalSlotRelease(req.auth.team_id, sessionId).catch(
+      () => {},
+    );
     return {
       status: 500,
       body: { success: false, error: "Failed to persist browser session." },

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -5,6 +5,11 @@ import { getCrawl, StoredCrawl } from "./crawl-redis";
 import { logger } from "./logger";
 import { abTestJob } from "../services/ab-test";
 import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
+import {
+  getCombinedTeamActiveCount,
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "../services/worker/nuq-router";
 export { QueueFullError } from "./queue-full-error";
 export {
   getTeamQueueLimit,
@@ -290,110 +295,123 @@ export async function getNextConcurrentJob(teamId: string): Promise<{
  */
 export async function concurrentJobDone(job: NuQJob<any>) {
   if (job.id && job.data && job.data.team_id) {
-    await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
-    await getRedisConnection().zrem(
-      constructQueueKey(job.data.team_id),
-      job.id,
-    );
-    await getRedisConnection().del(constructJobKey(job.id));
-    await cleanOldConcurrencyLimitEntries(job.data.team_id);
-    await cleanOldConcurrencyLimitedJobs(job.data.team_id);
-
-    if (job.data.crawl_id) {
-      await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
-      await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
-    }
-
-    const maxTeamConcurrency =
-      (
-        await getACUCTeam(
-          job.data.team_id,
-          false,
-          true,
-          job.data.is_extract ? RateLimiterMode.Extract : RateLimiterMode.Crawl,
-        )
-      )?.concurrency ?? 2;
-
-    let staleSkipped = 0;
-    while (staleSkipped < 100) {
-      const currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(job.data.team_id)
-      ).length;
-
-      if (currentActiveConcurrency >= maxTeamConcurrency) break;
-
-      const nextJob = await getNextConcurrentJob(job.data.team_id);
-      if (nextJob === null) break;
-
-      await pushConcurrencyLimitActiveJob(
-        job.data.team_id,
-        nextJob.job.id,
-        60 * 1000,
+    await withTeamMigrationAdmission(job.data.team_id, async () => {
+      await removeConcurrencyLimitActiveJob(job.data.team_id, job.id);
+      await getRedisConnection().zrem(
+        constructQueueKey(job.data.team_id),
+        job.id,
       );
+      await getRedisConnection().del(constructJobKey(job.id));
+      await cleanOldConcurrencyLimitEntries(job.data.team_id);
+      await cleanOldConcurrencyLimitedJobs(job.data.team_id);
 
-      if (nextJob.job.data.crawl_id) {
-        await pushCrawlConcurrencyLimitActiveJob(
-          nextJob.job.data.crawl_id,
+      if (job.data.crawl_id) {
+        await removeCrawlConcurrencyLimitActiveJob(job.data.crawl_id, job.id);
+        await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
+      }
+
+      const maxTeamConcurrency =
+        (
+          await getACUCTeam(
+            job.data.team_id,
+            false,
+            true,
+            job.data.is_extract
+              ? RateLimiterMode.Extract
+              : RateLimiterMode.Crawl,
+          )
+        )?.concurrency ?? 2;
+
+      // Releasing a legacy PG slot can raise the effective FDB limit and wake
+      // pending FDB work. Do this before deciding whether PG may promote.
+      await syncFdbLimitToPgOccupancy(job.data.team_id);
+
+      let staleSkipped = 0;
+      while (staleSkipped < 100) {
+        const currentActiveConcurrency = await getCombinedTeamActiveCount(
+          job.data.team_id,
+        );
+
+        if (currentActiveConcurrency >= maxTeamConcurrency) break;
+
+        const nextJob = await getNextConcurrentJob(job.data.team_id);
+        if (nextJob === null) break;
+
+        await pushConcurrencyLimitActiveJob(
+          job.data.team_id,
           nextJob.job.id,
           60 * 1000,
         );
+        await syncFdbLimitToPgOccupancy(job.data.team_id);
 
-        const sc = await getCrawl(nextJob.job.data.crawl_id);
-        if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
-          await new Promise(resolve =>
-            setTimeout(resolve, sc.crawlerOptions.delay * 1000),
+        if (nextJob.job.data.crawl_id) {
+          await pushCrawlConcurrencyLimitActiveJob(
+            nextJob.job.data.crawl_id,
+            nextJob.job.id,
+            60 * 1000,
           );
+
+          const sc = await getCrawl(nextJob.job.data.crawl_id);
+          if (sc !== null && typeof sc.crawlerOptions?.delay === "number") {
+            await new Promise(resolve =>
+              setTimeout(resolve, sc.crawlerOptions.delay * 1000),
+            );
+          }
         }
-      }
 
-      abTestJob(nextJob.job.data);
+        abTestJob(nextJob.job.data);
 
-      const promotedSuccessfully =
-        (await scrapeQueue.promoteJobFromBacklogOrAdd(
-          nextJob.job.id,
-          nextJob.job.data,
-          {
-            priority: nextJob.job.priority,
-            listenable: nextJob.job.listenable,
-            ownerId: nextJob.job.data.team_id ?? undefined,
-            groupId: nextJob.job.data.crawl_id ?? undefined,
-          },
-        )) !== null;
+        const promotedSuccessfully =
+          (await scrapeQueue.promoteJobFromBacklogOrAdd(
+            nextJob.job.id,
+            nextJob.job.data,
+            {
+              priority: nextJob.job.priority,
+              listenable: nextJob.job.listenable,
+              ownerId: nextJob.job.data.team_id ?? undefined,
+              groupId: nextJob.job.data.crawl_id ?? undefined,
+            },
+          )) !== null;
 
-      if (promotedSuccessfully) {
-        logger.debug("Successfully promoted concurrent queued job", {
-          teamId: job.data.team_id,
-          jobId: nextJob.job.id,
-          zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-        });
-        break;
-      } else {
-        logger.warn(
-          "Was unable to promote concurrent queued job as it already exists in the database",
-          {
+        if (promotedSuccessfully) {
+          logger.debug("Successfully promoted concurrent queued job", {
             teamId: job.data.team_id,
             jobId: nextJob.job.id,
             zeroDataRetention: nextJob.job.data?.zeroDataRetention,
-          },
-        );
-        await removeConcurrencyLimitActiveJob(job.data.team_id, nextJob.job.id);
-        if (nextJob.job.data.crawl_id) {
-          await removeCrawlConcurrencyLimitActiveJob(
-            nextJob.job.data.crawl_id,
+          });
+          break;
+        } else {
+          logger.warn(
+            "Was unable to promote concurrent queued job as it already exists in the database",
+            {
+              teamId: job.data.team_id,
+              jobId: nextJob.job.id,
+              zeroDataRetention: nextJob.job.data?.zeroDataRetention,
+            },
+          );
+          await removeConcurrencyLimitActiveJob(
+            job.data.team_id,
             nextJob.job.id,
           );
+          await syncFdbLimitToPgOccupancy(job.data.team_id);
+          if (nextJob.job.data.crawl_id) {
+            await removeCrawlConcurrencyLimitActiveJob(
+              nextJob.job.data.crawl_id,
+              nextJob.job.id,
+            );
+          }
+          staleSkipped++;
         }
-        staleSkipped++;
       }
-    }
 
-    if (staleSkipped >= 100) {
-      logger.warn(
-        "Skipped 100 stale entries in concurrency queue without a successful promotion",
-        {
-          teamId: job.data.team_id,
-        },
-      );
-    }
+      if (staleSkipped >= 100) {
+        logger.warn(
+          "Skipped 100 stale entries in concurrency queue without a successful promotion",
+          {
+            teamId: job.data.team_id,
+          },
+        );
+      }
+    });
   }
 }

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -3,6 +3,11 @@ import { validate as isUUID } from "uuid";
 import { getACUCTeam } from "../controllers/auth";
 import { getRedisConnection } from "../services/queue-service";
 import { scrapeQueue, type NuQJob } from "../services/worker/nuq";
+import {
+  getCombinedTeamActiveCount,
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "../services/worker/nuq-router";
 import { RateLimiterMode, type ScrapeJobData } from "../types";
 import {
   getConcurrencyLimitActiveJobs,
@@ -56,6 +61,42 @@ async function requeueJob(
     },
     getBacklogJobTimeout(job.data),
   );
+}
+
+async function reservePgActiveSlot(
+  ownerId: string,
+  jobId: string,
+): Promise<void> {
+  await pushConcurrencyLimitActiveJob(ownerId, jobId, 60 * 1000);
+  try {
+    await syncFdbLimitToPgOccupancy(ownerId);
+  } catch (error) {
+    await removeConcurrencyLimitActiveJob(ownerId, jobId);
+    throw error;
+  }
+}
+
+async function releasePgActiveSlot(
+  ownerId: string,
+  jobId: string,
+): Promise<void> {
+  await removeConcurrencyLimitActiveJob(ownerId, jobId);
+  await syncFdbLimitToPgOccupancy(ownerId);
+}
+
+async function rollbackPgReservations(
+  ownerId: string,
+  jobId: string,
+  crawlId?: string,
+): Promise<void> {
+  const removals: Promise<unknown>[] = [
+    removeConcurrencyLimitActiveJob(ownerId, jobId),
+  ];
+  if (crawlId) {
+    removals.push(removeCrawlConcurrencyLimitActiveJob(crawlId, jobId));
+  }
+  await Promise.allSettled(removals);
+  await syncFdbLimitToPgOccupancy(ownerId);
 }
 
 async function getQueuedJobIDs(teamId: string): Promise<Set<string>> {
@@ -125,6 +166,15 @@ async function reconcileTeam(
       activeCrawlCount++;
     }
   }
+  // FDB jobs are not represented in the PG job rows used for type splitting.
+  // Count them against either PG admission class so drift recovery cannot
+  // reopen a second ledger's worth of slots during migration.
+  const fdbActiveCount = Math.max(
+    0,
+    (await getCombinedTeamActiveCount(ownerId)) - activeJobs.length,
+  );
+  activeCrawlCount += fdbActiveCount;
+  activeExtractCount += fdbActiveCount;
 
   const jobsToStart: typeof jobsToRecover = [];
   const jobsToQueue: typeof jobsToRecover = [];
@@ -152,20 +202,27 @@ async function reconcileTeam(
   }
 
   for (const job of jobsToStart) {
-    const promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
-      job.id,
-      job.data,
-      {
-        priority: job.priority,
-        listenable: job.listenChannelId !== undefined,
-        ownerId: job.data.team_id ?? undefined,
-        groupId: job.data.crawl_id ?? undefined,
-      },
-    );
+    // Reserve the shared ledger before making the PG row runnable. If the
+    // promotion loses a race, roll the reservation back.
+    await reservePgActiveSlot(ownerId, job.id);
+    let promoted: NuQJob<ScrapeJobData> | null;
+    try {
+      promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
+        job.id,
+        job.data,
+        {
+          priority: job.priority,
+          listenable: job.listenChannelId !== undefined,
+          ownerId: job.data.team_id ?? undefined,
+          groupId: job.data.crawl_id ?? undefined,
+        },
+      );
+    } catch (error) {
+      await releasePgActiveSlot(ownerId, job.id);
+      throw error;
+    }
 
     if (promoted !== null) {
-      await pushConcurrencyLimitActiveJob(ownerId, job.id, 60 * 1000);
-
       if (job.data.crawl_id) {
         const sc = await getCrawl(job.data.crawl_id);
         if (sc?.crawlerOptions?.delay || sc?.maxConcurrency) {
@@ -179,6 +236,7 @@ async function reconcileTeam(
 
       jobsStarted++;
     } else {
+      await releasePgActiveSlot(ownerId, job.id);
       teamLogger.warn("Job promotion failed, re-queuing job", {
         jobId: job.id,
       });
@@ -216,6 +274,12 @@ async function drainQueue(
     if (isExtractJob(aj.data)) extractCount++;
     else crawlCount++;
   }
+  const fdbActiveCount = Math.max(
+    0,
+    (await getCombinedTeamActiveCount(ownerId)) - activeJobs.length,
+  );
+  crawlCount += fdbActiveCount;
+  extractCount += fdbActiveCount;
 
   let jobsPromoted = 0;
   let staleSkipped = 0;
@@ -250,38 +314,52 @@ async function drainQueue(
       continue;
     }
 
-    await pushConcurrencyLimitActiveJob(ownerId, nextJob.job.id, 60 * 1000);
-    if (nextJob.job.data.crawl_id) {
-      await pushCrawlConcurrencyLimitActiveJob(
-        nextJob.job.data.crawl_id,
+    await reservePgActiveSlot(ownerId, nextJob.job.id);
+    let crawlReserved = false;
+    let promoted: NuQJob<ScrapeJobData> | null;
+    try {
+      if (nextJob.job.data.crawl_id) {
+        await pushCrawlConcurrencyLimitActiveJob(
+          nextJob.job.data.crawl_id,
+          nextJob.job.id,
+          60 * 1000,
+        );
+        crawlReserved = true;
+      }
+      promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
         nextJob.job.id,
-        60 * 1000,
+        nextJob.job.data,
+        {
+          priority: nextJob.job.priority,
+          listenable: nextJob.job.listenable,
+          ownerId: nextJob.job.data.team_id ?? undefined,
+          groupId: nextJob.job.data.crawl_id ?? undefined,
+        },
       );
+    } catch (error) {
+      await rollbackPgReservations(
+        ownerId,
+        nextJob.job.id,
+        crawlReserved ? nextJob.job.data.crawl_id : undefined,
+      ).catch(cleanupError =>
+        teamLogger.error("Failed to roll back PG promotion reservations", {
+          jobId: nextJob.job.id,
+          cleanupError,
+        }),
+      );
+      throw error;
     }
-
-    const promoted = await scrapeQueue.promoteJobFromBacklogOrAdd(
-      nextJob.job.id,
-      nextJob.job.data,
-      {
-        priority: nextJob.job.priority,
-        listenable: nextJob.job.listenable,
-        ownerId: nextJob.job.data.team_id ?? undefined,
-        groupId: nextJob.job.data.crawl_id ?? undefined,
-      },
-    );
 
     if (promoted !== null) {
       if (isExtract) extractCount++;
       else crawlCount++;
       jobsPromoted++;
     } else {
-      await removeConcurrencyLimitActiveJob(ownerId, nextJob.job.id);
-      if (nextJob.job.data.crawl_id) {
-        await removeCrawlConcurrencyLimitActiveJob(
-          nextJob.job.data.crawl_id,
-          nextJob.job.id,
-        );
-      }
+      await rollbackPgReservations(
+        ownerId,
+        nextJob.job.id,
+        nextJob.job.data.crawl_id,
+      );
       staleSkipped++;
     }
   }
@@ -331,21 +409,23 @@ export async function reconcileConcurrencyQueue(
     const teamLogger = logger.child({ teamId: ownerId });
 
     try {
-      const teamResult = await reconcileTeam(ownerId, teamLogger);
-      if (teamResult !== null) {
-        result.teamsWithDrift++;
-        result.jobsStarted += teamResult.jobsStarted;
-        result.jobsRequeued += teamResult.jobsRequeued;
-      }
+      await withTeamMigrationAdmission(ownerId, async () => {
+        const teamResult = await reconcileTeam(ownerId, teamLogger);
+        if (teamResult !== null) {
+          result.teamsWithDrift++;
+          result.jobsStarted += teamResult.jobsStarted;
+          result.jobsRequeued += teamResult.jobsRequeued;
+        }
 
-      const drainResult = await drainQueue(ownerId, teamLogger);
-      if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
-        result.jobsStarted += drainResult.jobsPromoted;
-        teamLogger.info("Queue drain promoted jobs", {
-          jobsPromoted: drainResult.jobsPromoted,
-          staleSkipped: drainResult.staleSkipped,
-        });
-      }
+        const drainResult = await drainQueue(ownerId, teamLogger);
+        if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
+          result.jobsStarted += drainResult.jobsPromoted;
+          teamLogger.info("Queue drain promoted jobs", {
+            jobsPromoted: drainResult.jobsPromoted,
+            staleSkipped: drainResult.staleSkipped,
+          });
+        }
+      });
     } catch (error) {
       teamLogger.error("Failed to reconcile team, skipping", { error });
     }

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -2,8 +2,6 @@ import { v7 as uuidv7 } from "uuid";
 import { NotificationType, RateLimiterMode, ScrapeJobData } from "../types";
 import {
   cleanOldConcurrencyLimitEntries,
-  getConcurrencyLimitActiveJobs,
-  getConcurrencyQueueJobsCount,
   getCrawlConcurrencyLimitActiveJobs,
   getTeamQueueLimit,
   MAX_BACKLOG_TIMEOUT_MS,
@@ -27,8 +25,12 @@ import { abTestJob } from "./ab-test";
 import { NuQJob, scrapeQueue } from "./worker/nuq";
 import {
   fdbEnqueueScrapeJobs,
+  getCombinedTeamActiveCount,
+  getCombinedTeamPendingCount,
   resolveJobBackend,
+  withTeamMigrationAdmission,
   scrapeQueue as routedScrapeQueue,
+  type QueueBackend,
 } from "./worker/nuq-router";
 import {
   nuqFdbHealthCheck,
@@ -156,32 +158,38 @@ export async function _addScrapeJobToBullMQ(
   priority: number = 0,
   listenable: boolean = false,
 ): Promise<NuQJob<ScrapeJobData>> {
-  // direct adds bypass the gates; on the FDB backend that's a slotless enqueue
-  if ((await resolveJobBackend(webScraperOptions)) === "fdb") {
-    if (webScraperOptions.mode === "single_urls") {
-      abTestJob(webScraperOptions);
-    }
-    const { jobs } = await fdbEnqueueScrapeJobs(
-      [
-        {
-          jobId,
-          data: webScraperOptions,
-          priority,
-          listenable,
-          backlogTimeoutMs: backlogTimeoutMs(webScraperOptions),
-        },
-      ],
-      webScraperOptions.team_id,
-      { bypassGate: true },
-    );
-    return jobs[0];
-  }
+  return await withTeamMigrationAdmission(
+    webScraperOptions.team_id,
+    async () => {
+      // Direct adds bypass admission but occupy/release a team slot on both
+      // backends.
+      if ((await resolveJobBackend(webScraperOptions)) === "fdb") {
+        if (webScraperOptions.mode === "single_urls") {
+          abTestJob(webScraperOptions);
+        }
+        const { jobs } = await fdbEnqueueScrapeJobs(
+          [
+            {
+              jobId,
+              data: webScraperOptions,
+              priority,
+              listenable,
+              backlogTimeoutMs: backlogTimeoutMs(webScraperOptions),
+            },
+          ],
+          webScraperOptions.team_id,
+          { bypassGate: true },
+        );
+        return jobs[0];
+      }
 
-  return _addScrapeJobToBullMQPg(
-    webScraperOptions,
-    jobId,
-    priority,
-    listenable,
+      return _addScrapeJobToBullMQPg(
+        webScraperOptions,
+        jobId,
+        priority,
+        listenable,
+      );
+    },
   );
 }
 
@@ -411,16 +419,16 @@ async function addScrapeJobRaw(
     if (concurrencyLimited === null) {
       const now = Date.now();
       await cleanOldConcurrencyLimitEntries(webScraperOptions.team_id, now);
-      currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(webScraperOptions.team_id, now)
-      ).length;
+      currentActiveConcurrency = await getCombinedTeamActiveCount(
+        webScraperOptions.team_id,
+      );
       concurrencyLimited =
         currentActiveConcurrency >= maxConcurrency ? "yes" : "no";
     }
   }
 
   if (concurrencyLimited === "yes" || concurrencyLimited === "yes-crawl") {
-    const concurrencyQueueJobs = await getConcurrencyQueueJobsCount(
+    const concurrencyQueueJobs = await getCombinedTeamPendingCount(
       webScraperOptions.team_id,
     );
 
@@ -432,9 +440,9 @@ async function addScrapeJobRaw(
     if (currentActiveConcurrency === null) {
       const now = Date.now();
       await cleanOldConcurrencyLimitEntries(webScraperOptions.team_id, now);
-      currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(webScraperOptions.team_id, now)
-      ).length;
+      currentActiveConcurrency = await getCombinedTeamActiveCount(
+        webScraperOptions.team_id,
+      );
     }
 
     _logger.info("Adding scrape job to concurrency queue", {
@@ -511,13 +519,38 @@ export async function addScrapeJob(
     traceContext,
   };
 
-  return await addScrapeJobRaw(
-    optionsWithTrace,
-    jobId,
-    priority,
-    directToBullMQ,
-    listenable,
+  return await withTeamMigrationAdmission(
+    optionsWithTrace.team_id,
+    async () =>
+      await addScrapeJobRaw(
+        optionsWithTrace,
+        jobId,
+        priority,
+        directToBullMQ,
+        listenable,
+      ),
   );
+}
+
+async function preflightPgPartition(
+  teamId: string,
+  jobs: { data: ScrapeJobData }[],
+): Promise<void> {
+  if (jobs.length === 0 || isSelfHosted()) return;
+  const maxConcurrency =
+    (await getACUCTeam(teamId, false, true, RateLimiterMode.Scrape))
+      ?.concurrency ?? 2;
+  const active = await getCombinedTeamActiveCount(teamId);
+  const newlyPending = Math.max(
+    0,
+    jobs.length - Math.max(0, maxConcurrency - active),
+  );
+  if (newlyPending === 0) return;
+  const pending = await getCombinedTeamPendingCount(teamId);
+  const queueLimit = getTeamQueueLimit(maxConcurrency);
+  if (pending + newlyPending > queueLimit) {
+    throw new QueueFullError(pending, queueLimit);
+  }
 }
 
 export async function addScrapeJobs(
@@ -551,261 +584,268 @@ export async function addScrapeJobs(
   }
 
   for (const [teamId, allTeamJobs] of jobsByTeam) {
-    // jobs can split across backends mid-migration (old crawls drain on PG
-    // while the team's new crawls run on FDB); partition by job backend
-    const backendByJob = new Map<string, "pg" | "fdb">();
-    const backendByCrawl = new Map<string, "pg" | "fdb">();
-    for (const job of allTeamJobs) {
-      const crawlId = job.data.crawl_id;
-      if (crawlId && backendByCrawl.has(crawlId)) {
-        backendByJob.set(job.jobId, backendByCrawl.get(crawlId)!);
-        continue;
+    await withTeamMigrationAdmission(teamId, async () => {
+      // jobs can split across backends mid-migration (old crawls drain on PG
+      // while the team's new crawls run on FDB); partition by job backend
+      const backendByJob = new Map<string, "pg" | "fdb">();
+      const backendByCrawl = new Map<string, "pg" | "fdb">();
+      for (const job of allTeamJobs) {
+        const crawlId = job.data.crawl_id;
+        if (crawlId && backendByCrawl.has(crawlId)) {
+          backendByJob.set(job.jobId, backendByCrawl.get(crawlId)!);
+          continue;
+        }
+        const backend = await resolveJobBackend(job.data);
+        backendByJob.set(job.jobId, backend);
+        if (crawlId) backendByCrawl.set(crawlId, backend);
       }
-      const backend = await resolveJobBackend(job.data);
-      backendByJob.set(job.jobId, backend);
-      if (crawlId) backendByCrawl.set(crawlId, backend);
-    }
 
-    const fdbJobs = allTeamJobs.filter(
-      j => backendByJob.get(j.jobId) === "fdb",
-    );
-    if (fdbJobs.length > 0) {
-      const { backloggedCount, teamLimit } = await fdbEnqueueScrapeJobs(
-        fdbJobs.map(job => ({
-          jobId: job.jobId,
-          data: { ...job.data, traceContext },
-          priority: job.priority,
-          listenable: job.listenable,
-          backlogTimeoutMs: backlogTimeoutMs(job.data),
-        })),
-        teamId,
+      const fdbJobs = allTeamJobs.filter(
+        j => backendByJob.get(j.jobId) === "fdb",
       );
-      if (backloggedCount > 0) {
-        await maybeSendConcurrencyNotificationFdb(
+      const pgJobs = allTeamJobs.filter(
+        j => backendByJob.get(j.jobId) === "pg",
+      );
+      // Deterministic combined-cap failures must happen before either ledger
+      // commits. Stable ids then make transient second-ledger failures safe to
+      // retry without duplicating the already-committed partition.
+      await preflightPgPartition(teamId, pgJobs);
+      if (fdbJobs.length > 0) {
+        const { backloggedCount, teamLimit } = await fdbEnqueueScrapeJobs(
+          fdbJobs.map(job => ({
+            jobId: job.jobId,
+            data: { ...job.data, traceContext },
+            priority: job.priority,
+            listenable: job.listenable,
+            backlogTimeoutMs: backlogTimeoutMs(job.data),
+          })),
           teamId,
-          teamLimit,
-          isCrawlOrBatchScrape(fdbJobs[0].data),
+          // Reserve the worst-case future PG backlog before FDB commits. This
+          // makes deterministic combined-cap failure happen before either
+          // partition is visible; the exact PG planner may consume less.
+          { reservedExternalPending: pgJobs.length },
         );
+        if (backloggedCount > 0) {
+          await maybeSendConcurrencyNotificationFdb(
+            teamId,
+            teamLimit,
+            isCrawlOrBatchScrape(fdbJobs[0].data),
+          );
+        }
       }
-    }
 
-    const teamJobs = allTeamJobs.filter(
-      j => backendByJob.get(j.jobId) === "pg",
-    );
-    if (teamJobs.length === 0) continue;
-    // == Buckets for jobs ==
-    let jobsForcedToCQ: {
-      data: ScrapeJobData;
-      jobId: string;
-      priority: number;
-      listenable?: boolean;
-    }[] = [];
-
-    let jobsPotentiallyInCQ: {
-      data: ScrapeJobData;
-      jobId: string;
-      priority: number;
-      listenable?: boolean;
-    }[] = [];
-
-    // == Select jobs by crawl ID ==
-    const jobsByCrawlID = new Map<
-      string,
-      {
+      const teamJobs = pgJobs;
+      if (teamJobs.length === 0) return;
+      // == Buckets for jobs ==
+      let jobsForcedToCQ: {
         data: ScrapeJobData;
         jobId: string;
         priority: number;
         listenable?: boolean;
-      }[]
-    >();
+      }[] = [];
 
-    const jobsWithoutCrawlID: {
-      data: ScrapeJobData;
-      jobId: string;
-      priority: number;
-      listenable?: boolean;
-    }[] = [];
-    const crawlConcurrencyLimits: {
-      crawlId: string;
-      maxCrawlConcurrency: number;
-      currentCrawlConcurrency: number;
-      jobsCount: number;
-    }[] = [];
+      let jobsPotentiallyInCQ: {
+        data: ScrapeJobData;
+        jobId: string;
+        priority: number;
+        listenable?: boolean;
+      }[] = [];
 
-    for (const job of teamJobs) {
-      if (job.data.crawl_id) {
-        if (!jobsByCrawlID.has(job.data.crawl_id)) {
-          jobsByCrawlID.set(job.data.crawl_id, []);
+      // == Select jobs by crawl ID ==
+      const jobsByCrawlID = new Map<
+        string,
+        {
+          data: ScrapeJobData;
+          jobId: string;
+          priority: number;
+          listenable?: boolean;
+        }[]
+      >();
+
+      const jobsWithoutCrawlID: {
+        data: ScrapeJobData;
+        jobId: string;
+        priority: number;
+        listenable?: boolean;
+      }[] = [];
+      const crawlConcurrencyLimits: {
+        crawlId: string;
+        maxCrawlConcurrency: number;
+        currentCrawlConcurrency: number;
+        jobsCount: number;
+      }[] = [];
+
+      for (const job of teamJobs) {
+        if (job.data.crawl_id) {
+          if (!jobsByCrawlID.has(job.data.crawl_id)) {
+            jobsByCrawlID.set(job.data.crawl_id, []);
+          }
+          jobsByCrawlID.get(job.data.crawl_id)!.push(job);
+        } else {
+          jobsWithoutCrawlID.push(job);
         }
-        jobsByCrawlID.get(job.data.crawl_id)!.push(job);
-      } else {
-        jobsWithoutCrawlID.push(job);
       }
-    }
 
-    // == Select jobs by crawl ID ==
-    for (const [crawlID, crawlJobs] of jobsByCrawlID) {
-      const crawl = await getCrawl(crawlID);
-      const concurrencyLimit = !crawl
-        ? null
-        : crawl.crawlerOptions?.delay === undefined &&
-            crawl.maxConcurrency === undefined
+      // == Select jobs by crawl ID ==
+      for (const [crawlID, crawlJobs] of jobsByCrawlID) {
+        const crawl = await getCrawl(crawlID);
+        const concurrencyLimit = !crawl
           ? null
-          : (crawl.maxConcurrency ?? 1);
+          : crawl.crawlerOptions?.delay === undefined &&
+              crawl.maxConcurrency === undefined
+            ? null
+            : (crawl.maxConcurrency ?? 1);
 
-      if (concurrencyLimit === null) {
-        // All jobs may be in the CQ depending on the global team concurrency limit
-        jobsPotentiallyInCQ.push(...crawlJobs);
+        if (concurrencyLimit === null) {
+          // All jobs may be in the CQ depending on the global team concurrency limit
+          jobsPotentiallyInCQ.push(...crawlJobs);
+        } else {
+          const currentCrawlConcurrency = (
+            await getCrawlConcurrencyLimitActiveJobs(crawlID)
+          ).length;
+          const freeSlots = Math.max(
+            concurrencyLimit - currentCrawlConcurrency,
+            0,
+          );
+          const crawlLimitedJobs = crawlJobs.slice(freeSlots);
+
+          // The first n jobs may be in the CQ depending on the global team concurrency limit
+          jobsPotentiallyInCQ.push(...crawlJobs.slice(0, freeSlots));
+
+          // Every job after that must be in the CQ, as the crawl concurrency limit has been reached
+          jobsForcedToCQ.push(...crawlLimitedJobs);
+
+          if (crawlLimitedJobs.length > 0) {
+            crawlConcurrencyLimits.push({
+              crawlId: crawlID,
+              maxCrawlConcurrency: concurrencyLimit,
+              currentCrawlConcurrency,
+              jobsCount: crawlLimitedJobs.length,
+            });
+          }
+        }
+      }
+
+      // All jobs without a crawl ID may be in the CQ depending on the global team concurrency limit
+      jobsPotentiallyInCQ.push(...jobsWithoutCrawlID);
+
+      // Bypass concurrency limits for self-hosted deployments
+      let addToBull: typeof jobsPotentiallyInCQ;
+      let addToCQ: typeof jobsPotentiallyInCQ;
+      let maxConcurrency = 0;
+      let currentActiveConcurrency: number | null = null;
+      let countCanBeDirectlyAdded = 0;
+
+      if (isSelfHosted()) {
+        // For self-hosted, add all jobs directly to BullMQ
+        addToBull = jobsPotentiallyInCQ;
+        addToCQ = jobsForcedToCQ;
       } else {
-        const currentCrawlConcurrency = (
-          await getCrawlConcurrencyLimitActiveJobs(crawlID)
-        ).length;
-        const freeSlots = Math.max(
-          concurrencyLimit - currentCrawlConcurrency,
+        const now = Date.now();
+        maxConcurrency =
+          (await getACUCTeam(teamId, false, true, RateLimiterMode.Scrape))
+            ?.concurrency ?? 2;
+        await cleanOldConcurrencyLimitEntries(teamId, now);
+
+        currentActiveConcurrency = await getCombinedTeamActiveCount(teamId);
+
+        countCanBeDirectlyAdded = Math.max(
+          maxConcurrency - currentActiveConcurrency,
           0,
         );
-        const crawlLimitedJobs = crawlJobs.slice(freeSlots);
 
-        // The first n jobs may be in the CQ depending on the global team concurrency limit
-        jobsPotentiallyInCQ.push(...crawlJobs.slice(0, freeSlots));
+        addToBull = jobsPotentiallyInCQ.slice(0, countCanBeDirectlyAdded);
+        addToCQ = jobsPotentiallyInCQ
+          .slice(countCanBeDirectlyAdded)
+          .concat(jobsForcedToCQ);
 
-        // Every job after that must be in the CQ, as the crawl concurrency limit has been reached
-        jobsForcedToCQ.push(...crawlLimitedJobs);
-
-        if (crawlLimitedJobs.length > 0) {
-          crawlConcurrencyLimits.push({
-            crawlId: crawlID,
-            maxCrawlConcurrency: concurrencyLimit,
-            currentCrawlConcurrency,
-            jobsCount: crawlLimitedJobs.length,
-          });
+        if (addToCQ.length > 0) {
+          const currentQueueSize = await getCombinedTeamPendingCount(teamId);
+          const queueLimit = getTeamQueueLimit(maxConcurrency);
+          if (currentQueueSize + addToCQ.length > queueLimit) {
+            throw new QueueFullError(currentQueueSize, queueLimit);
+          }
         }
       }
-    }
-
-    // All jobs without a crawl ID may be in the CQ depending on the global team concurrency limit
-    jobsPotentiallyInCQ.push(...jobsWithoutCrawlID);
-
-    // Bypass concurrency limits for self-hosted deployments
-    let addToBull: typeof jobsPotentiallyInCQ;
-    let addToCQ: typeof jobsPotentiallyInCQ;
-    let maxConcurrency = 0;
-    let currentActiveConcurrency: number | null = null;
-    let countCanBeDirectlyAdded = 0;
-
-    if (isSelfHosted()) {
-      // For self-hosted, add all jobs directly to BullMQ
-      addToBull = jobsPotentiallyInCQ;
-      addToCQ = jobsForcedToCQ;
-    } else {
-      const now = Date.now();
-      maxConcurrency =
-        (await getACUCTeam(teamId, false, true, RateLimiterMode.Scrape))
-          ?.concurrency ?? 2;
-      await cleanOldConcurrencyLimitEntries(teamId, now);
-
-      currentActiveConcurrency = (
-        await getConcurrencyLimitActiveJobs(teamId, now)
-      ).length;
-
-      countCanBeDirectlyAdded = Math.max(
-        maxConcurrency - currentActiveConcurrency,
-        0,
-      );
-
-      addToBull = jobsPotentiallyInCQ.slice(0, countCanBeDirectlyAdded);
-      addToCQ = jobsPotentiallyInCQ
-        .slice(countCanBeDirectlyAdded)
-        .concat(jobsForcedToCQ);
 
       if (addToCQ.length > 0) {
-        const currentQueueSize = await getConcurrencyQueueJobsCount(teamId);
-        const queueLimit = getTeamQueueLimit(maxConcurrency);
-        if (currentQueueSize + addToCQ.length > queueLimit) {
-          throw new QueueFullError(currentQueueSize, queueLimit);
+        const crawlConcurrencyLimitedJobs = crawlConcurrencyLimits.reduce(
+          (sum, x) => sum + x.jobsCount,
+          0,
+        );
+        const teamConcurrencyLimitedJobs = Math.max(
+          addToCQ.length - crawlConcurrencyLimitedJobs,
+          0,
+        );
+
+        if (currentActiveConcurrency === null) {
+          const now = Date.now();
+          await cleanOldConcurrencyLimitEntries(teamId, now);
+          currentActiveConcurrency = await getCombinedTeamActiveCount(teamId);
+        }
+
+        _logger.info("Adding scrape jobs to concurrency queue", {
+          teamId,
+          concurrencyLimitReason:
+            teamConcurrencyLimitedJobs > 0 && crawlConcurrencyLimitedJobs > 0
+              ? "team-and-crawl"
+              : crawlConcurrencyLimitedJobs > 0
+                ? "crawl"
+                : "team",
+          maxConcurrency,
+          currentConcurrency: currentActiveConcurrency,
+          jobsCount: addToCQ.length,
+          teamConcurrencyLimitedJobs,
+          crawlConcurrencyLimitedJobs,
+          crawlConcurrencyLimits,
+        });
+      }
+
+      // equals 2x the max concurrency (only check for non-self-hosted)
+      if (
+        !isSelfHosted() &&
+        jobsPotentiallyInCQ.length - countCanBeDirectlyAdded > maxConcurrency
+      ) {
+        // logger.info(`Concurrency limited 2x (multiple) - Concurrency queue jobs: ${addToCQ.length} Max concurrency: ${maxConcurrency} Team ID: ${jobs[0].data.team_id}`);
+        // Only send notification if it's not a crawl or batch scrape
+        if (!isCrawlOrBatchScrape(jobs[0].data)) {
+          const shouldSendNotification =
+            await shouldSendConcurrencyLimitNotification(jobs[0].data.team_id);
+          if (shouldSendNotification) {
+            sendNotificationWithCustomDays(
+              jobs[0].data.team_id,
+              NotificationType.CONCURRENCY_LIMIT_REACHED,
+              15,
+              false,
+              true,
+            ).catch(error => {
+              _logger.error(
+                "Error sending notification (concurrency limit reached)",
+                { error },
+              );
+            });
+          }
         }
       }
-    }
 
-    if (addToCQ.length > 0) {
-      const crawlConcurrencyLimitedJobs = crawlConcurrencyLimits.reduce(
-        (sum, x) => sum + x.jobsCount,
-        0,
-      );
-      const teamConcurrencyLimitedJobs = Math.max(
-        addToCQ.length - crawlConcurrencyLimitedJobs,
-        0,
+      await _addScrapeJobsToConcurrencyQueue(
+        addToCQ.map(job => ({
+          jobId: job.jobId,
+          data: { ...job.data, traceContext },
+          priority: job.priority,
+          listenable: job.listenable,
+        })),
       );
 
-      if (currentActiveConcurrency === null) {
-        const now = Date.now();
-        await cleanOldConcurrencyLimitEntries(teamId, now);
-        currentActiveConcurrency = (
-          await getConcurrencyLimitActiveJobs(teamId, now)
-        ).length;
-      }
-
-      _logger.info("Adding scrape jobs to concurrency queue", {
-        teamId,
-        concurrencyLimitReason:
-          teamConcurrencyLimitedJobs > 0 && crawlConcurrencyLimitedJobs > 0
-            ? "team-and-crawl"
-            : crawlConcurrencyLimitedJobs > 0
-              ? "crawl"
-              : "team",
-        maxConcurrency,
-        currentConcurrency: currentActiveConcurrency,
-        jobsCount: addToCQ.length,
-        teamConcurrencyLimitedJobs,
-        crawlConcurrencyLimitedJobs,
-        crawlConcurrencyLimits,
-      });
-    }
-
-    // equals 2x the max concurrency (only check for non-self-hosted)
-    if (
-      !isSelfHosted() &&
-      jobsPotentiallyInCQ.length - countCanBeDirectlyAdded > maxConcurrency
-    ) {
-      // logger.info(`Concurrency limited 2x (multiple) - Concurrency queue jobs: ${addToCQ.length} Max concurrency: ${maxConcurrency} Team ID: ${jobs[0].data.team_id}`);
-      // Only send notification if it's not a crawl or batch scrape
-      if (!isCrawlOrBatchScrape(jobs[0].data)) {
-        const shouldSendNotification =
-          await shouldSendConcurrencyLimitNotification(jobs[0].data.team_id);
-        if (shouldSendNotification) {
-          sendNotificationWithCustomDays(
-            jobs[0].data.team_id,
-            NotificationType.CONCURRENCY_LIMIT_REACHED,
-            15,
-            false,
-            true,
-          ).catch(error => {
-            _logger.error(
-              "Error sending notification (concurrency limit reached)",
-              { error },
-            );
-          });
-        }
-      }
-    }
-
-    await _addScrapeJobsToConcurrencyQueue(
-      addToCQ.map(job => ({
-        jobId: job.jobId,
-        data: { ...job.data, traceContext },
-        priority: job.priority,
-        listenable: job.listenable,
-      })),
-    );
-
-    await _addScrapeJobsToBullMQ(
-      addToBull.map(job => ({
-        jobId: job.jobId,
-        data: { ...job.data, traceContext },
-        priority: job.priority,
-        listenable: job.listenable,
-      })),
-    );
+      await _addScrapeJobsToBullMQ(
+        addToBull.map(job => ({
+          jobId: job.jobId,
+          data: { ...job.data, traceContext },
+          priority: job.priority,
+          listenable: job.listenable,
+        })),
+      );
+    });
   }
 }
 
@@ -816,6 +856,11 @@ export async function waitForJob(
   logger: Logger = _logger,
 ): Promise<Document> {
   const jobId = typeof job == "string" ? job : job.id;
+  const backend =
+    typeof job === "string"
+      ? undefined
+      : ((job as NuQJob<ScrapeJobData> & { backend?: QueueBackend }).backend ??
+        undefined);
   const isConcurrencyLimited = !!(typeof job === "string");
 
   let timeoutHandle: NodeJS.Timeout | null = null;
@@ -827,6 +872,7 @@ export async function waitForJob(
           jobId,
           timeout !== null ? timeout + 100 : null,
           logger,
+          backend,
         ),
         timeout !== null
           ? new Promise<Document>((_resolve, reject) => {

--- a/apps/api/src/services/worker/nuq-fdb/client.ts
+++ b/apps/api/src/services/worker/nuq-fdb/client.ts
@@ -51,6 +51,9 @@ function timeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
+// Only use this for side-effect-free reads. It bounds caller latency but does
+// not cancel the underlying Promise. Mutations must await a definitive FDB
+// result and must never fall back to PG after an ambiguous result.
 export async function withFdbTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -69,11 +72,11 @@ export async function nuqFdbHealthCheck(timeoutMs = 1000): Promise<boolean> {
   }
 
   try {
-    await timeout(
-      getNuqFdbDatabase().doTn(async tn => {
+    await getNuqFdbDatabase().doTn(
+      async tn => {
         await tn.getReadVersion();
-      }),
-      timeoutMs,
+      },
+      { timeout: timeoutMs },
     );
     lastHealthCheck = { checkedAt: now, timeoutMs, ok: true };
     return true;

--- a/apps/api/src/services/worker/nuq-fdb/keyspace.ts
+++ b/apps/api/src/services/worker/nuq-fdb/keyspace.ts
@@ -44,6 +44,7 @@ export type JobMeta = {
   f: number; // flags
   to?: number; // backlog timesOutAt ms
   dc: number; // data chunk count
+  h?: string; // immutable enqueue payload/options fingerprint
 };
 
 export type JobStatusRecord = {
@@ -166,6 +167,9 @@ export class NuqFdbKeyspace {
   }
   jobRange(id: string) {
     return this.packRange(["j", id]);
+  }
+  takeOperation(id: string): Buffer {
+    return this.pack(["takeop", id]);
   }
 
   // === Team gate

--- a/apps/api/src/services/worker/nuq-fdb/queue.ts
+++ b/apps/api/src/services/worker/nuq-fdb/queue.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import type { Transaction } from "foundationdb";
 import { Logger } from "winston";
 import { logger as _logger } from "../../../lib/logger";
@@ -44,6 +44,7 @@ import {
   appendKeyPending,
   appendCrawlPending,
   popTeamPending,
+  promoteEntryToReady,
   setStatusQueued,
   setStatusPending,
   clearPendingPlacement,
@@ -112,6 +113,11 @@ export type NuQFdbGate = {
   // null = unlimited (self-hosted)
   teamLimit: number | null;
   queueCap: number;
+  // Capacity already occupied by the team's legacy PG ledger. The router
+  // samples this while holding the cross-backend admission lock.
+  externalActive?: number;
+  // Pending jobs already held by the legacy PG concurrency queue.
+  externalPending?: number;
   // API-key-scoped concurrency limit; null/absent = the key is unlimited.
   // Only applies when the batch is team-gated (teamLimit !== null).
   key?: { id: string; limit: number } | null;
@@ -126,6 +132,7 @@ type AddJobInput<Data> = {
 type PreparedAddJob<Data> = AddJobInput<Data> & {
   dataBuf: Buffer;
   dataChunks: Buffer[];
+  fingerprint: string;
   estimatedAffectedBytes: number;
 };
 
@@ -259,22 +266,30 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   ): PreparedAddJob<JobData> {
     const dataBuf = Buffer.from(JSON.stringify(job.data ?? null), "utf8");
     const dataChunks = chunkBuffer(dataBuf, DATA_CHUNK_BYTES);
+    const fingerprint = createHash("sha256")
+      .update(
+        JSON.stringify({
+          data: job.data ?? null,
+          priority: job.options.priority ?? 0,
+          listenable: job.options.listenable ?? false,
+          ownerId,
+          groupId: job.options.groupId ?? null,
+          bypassGate: job.options.bypassGate ?? false,
+        }),
+      )
+      .digest("hex");
+    const prepared = { ...job, dataBuf, dataChunks, fingerprint };
     const estimatedAffectedBytes = this.estimateEnqueueAffectedBytes(
-      job,
+      prepared,
       ownerId,
       keyId,
       dataChunks,
     );
-    return {
-      ...job,
-      dataBuf,
-      dataChunks,
-      estimatedAffectedBytes,
-    };
+    return { ...prepared, estimatedAffectedBytes };
   }
 
   private estimateEnqueueAffectedBytes(
-    job: AddJobInput<JobData>,
+    job: AddJobInput<JobData> & { fingerprint: string },
     ownerId: string | null,
     keyId: string | null,
     dataChunks: Buffer[],
@@ -310,6 +325,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       f: entry.f,
       to: entry.to,
       dc: dataChunks.length,
+      h: job.fingerprint,
     };
 
     let bytes =
@@ -390,33 +406,61 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     return await this.db.doTn(async tn => {
       const txc = newTxContext();
       const now = Date.now();
-      const out: NuQFdbJob<JobData, JobReturnValue>[] = [];
+      const out = new Map<string, NuQFdbJob<JobData, JobReturnValue>>();
+
+      // addJobs is retried after an ambiguous commit using the same stable job
+      // ids. Reconcile those ids inside the transaction so a late/unknown
+      // commit cannot increment gates or create queue entries twice.
+      const newJobs: PreparedAddJob<JobData>[] = [];
+      for (const job of jobs) {
+        const existingStatus = await tn.get(ks.jobStatus(job.id));
+        if (!existingStatus) {
+          newJobs.push(job);
+          continue;
+        }
+        const existingMeta = decodeJson<JobMeta>(
+          await tn.get(ks.jobMeta(job.id)),
+        );
+        const existing = await this.readJob(tn, job.id);
+        if (
+          !existing ||
+          normalizeOwnerId(existing.ownerId) !== ownerId ||
+          existing.groupId !== job.options.groupId ||
+          (existingMeta?.h !== undefined && existingMeta.h !== job.fingerprint)
+        ) {
+          throw new Error(`NuQ FDB job id ${job.id} is already reserved`);
+        }
+        out.set(job.id, existing);
+      }
 
       let free = Infinity;
+      let existingPending = 0;
       if (gate.teamLimit !== null && ownerId !== null) {
+        const effectiveLimit = Math.max(
+          0,
+          gate.teamLimit - (gate.externalActive ?? 0),
+        );
         const storedBuf = await tn.get(ks.teamLimit(ownerId));
         const stored = storedBuf ? decodeI64(storedBuf) : null;
-        if (stored !== gate.teamLimit) {
-          tn.set(ks.teamLimit(ownerId), encodeI64(gate.teamLimit));
-          if (stored !== null && gate.teamLimit > stored) {
+        if (stored !== effectiveLimit) {
+          tn.set(ks.teamLimit(ownerId), encodeI64(effectiveLimit));
+          if (stored !== null && effectiveLimit > stored) {
             tn.set(ks.taskTeamRaise(ownerId), EMPTY);
           }
         }
 
-        const pend = decodeI64(
-          await tn.snapshot().get(ks.teamPendingCount(ownerId)),
-        );
-        if (pend + jobs.length > gate.queueCap) {
-          throw new QueueFullError(pend, gate.queueCap);
-        }
+        // A normal read conflicts concurrent FDB admissions. Charge only jobs
+        // actually placed pending below; ready/direct jobs do not consume the
+        // backlog cap.
+        existingPending = decodeI64(await tn.get(ks.teamPendingCount(ownerId)));
 
         // big-limit teams tolerate a small admission overshoot in exchange for
         // a conflict-free read; small-limit teams get the strict read
         const active =
-          gate.teamLimit >= 256
+          effectiveLimit >= 256
             ? decodeI64(await tn.snapshot().get(ks.teamActive(ownerId)))
             : decodeI64(await tn.get(ks.teamActive(ownerId)));
-        free = Math.max(0, gate.teamLimit - active);
+        free = Math.max(0, effectiveLimit - active);
       }
 
       // API-key gate state; only meaningful inside the team-gated world
@@ -440,7 +484,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const groupMetas = new Map<string, GroupMeta | null>();
       const crawlFree = new Map<string, number>();
       if (this.options.hasGroups) {
-        for (const j of jobs) {
+        for (const j of newJobs) {
           const gid = j.options.groupId;
           if (!gid || groupMetas.has(gid)) continue;
           const gMeta = decodeJson<GroupMeta>(await tn.get(ks.groupMeta(gid)));
@@ -457,12 +501,17 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
       let granted = 0;
       let keyGranted = 0;
+      let pendingAdded = 0;
       const crawlAcquired = new Map<string, number>();
 
-      for (const j of jobs) {
+      for (const j of newJobs) {
         const gid = j.options.groupId;
         const gMeta = gid ? groupMetas.get(gid) : null;
         const groupLive = !!gMeta && gMeta.s === "active";
+        // PG records every owned direct/queued job in its active occupancy
+        // ledger, including self-hosted unlimited mode. FDB does the same for
+        // metrics and exact release parity; a null limit only disables gating.
+        const occupiesTeamSlot = ownerId !== null;
         const gated = gate.teamLimit !== null && !j.options.bypassGate;
         const crawlGated = gated && !!gid && groupLive && crawlFree.has(gid!);
         const keyGated = gated && keyId !== null;
@@ -472,7 +521,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           (j.data as any)?.mode === "single_urls";
 
         let flags = 0;
-        if (gated) flags |= F_GATED;
+        // Direct and kickoff jobs bypass admission, not accounting. PG adds
+        // them to the active ledger too, and FDB must release the same slot on
+        // terminal completion.
+        if (occupiesTeamSlot) flags |= F_GATED;
         if (crawlGated) flags |= F_CRAWL_GATED;
         if (keyGated) flags |= F_KEY_GATED;
         if (j.options.listenable) flags |= F_LISTENABLE;
@@ -501,6 +553,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           f: flags,
           to: timesOutAt,
           dc: j.dataChunks.length,
+          h: j.fingerprint,
         };
         tn.set(ks.jobMeta(j.id), encodeJson(meta));
         j.dataChunks.forEach((chunk, ci) =>
@@ -509,6 +562,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
         let placedStatus: NuqFdbJobStatus;
         if (!gated) {
+          if (occupiesTeamSlot) granted++;
           pushReady(tn, ks, entry, txc);
           setStatusQueued(tn, ks, j.id);
           placedStatus = "queued";
@@ -547,13 +601,15 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           }
         }
 
+        if (placedStatus === "pending") pendingAdded++;
+
         if (groupLive && gid) {
           tn.add(ks.groupRemaining(gid), ONE);
           setGroupJobIndex(tn, ks, gid, j.id, countable, placedStatus);
           if (countable) bumpGroupStatusCount(tn, ks, gid, placedStatus, 1);
         }
 
-        out.push({
+        out.set(j.id, {
           id: j.id,
           status: placedStatus === "pending" ? "backlog" : "queued",
           createdAt: new Date(now),
@@ -562,6 +618,16 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
           ownerId: entry.o || undefined,
           groupId: gid,
         });
+      }
+
+      if (gate.teamLimit !== null && ownerId !== null) {
+        const effectiveQueueCap = Math.max(
+          0,
+          gate.queueCap - (gate.externalPending ?? 0),
+        );
+        if (existingPending + pendingAdded > effectiveQueueCap) {
+          throw new QueueFullError(existingPending, effectiveQueueCap);
+        }
       }
 
       if (granted > 0 && ownerId !== null) {
@@ -574,7 +640,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         tn.add(ks.groupCrawlActive(gid), encodeI64(n));
       }
 
-      return out;
+      return jobs.map(job => out.get(job.id)!);
     });
   }
 
@@ -584,6 +650,8 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     logger: Logger = _logger,
   ): Promise<NuQFdbJob<JobData, JobReturnValue> | null> {
     const startedAt = Date.now();
+    // Stable across every transaction retry/probe in this logical dequeue.
+    const takeOperationId = randomUUID();
     // blind random probes win at high occupancy (no coordination, conflicts
     // spread across shards); the occupancy scan below covers the sparse case
     const PROBES = 4;
@@ -592,7 +660,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
     while (tried.size < PROBES) {
       const shard = Math.floor(Math.random() * READY_SHARDS);
       if (tried.has(shard)) continue;
-      const result = await this.takeFromShard(shard);
+      const result = await this.takeFromShard(shard, takeOperationId);
       if (result === "empty") {
         tried.add(shard);
         continue;
@@ -641,7 +709,7 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       if (tried.has(shard)) continue;
       for (let attempt = 0; attempt < 4; attempt++) {
         fallbackAttempts++;
-        const result = await this.takeFromShard(shard);
+        const result = await this.takeFromShard(shard, takeOperationId);
         if (result === "empty") {
           fallbackEmpty++;
           break;
@@ -689,11 +757,44 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
 
   private async takeFromShard(
     shard: number,
+    takeOperationId: string,
   ): Promise<NuQFdbJob<JobData, JobReturnValue> | "empty" | "dropped"> {
     const ks = this.ks;
-    return await this.db.doTn(async tn => {
+    const result = await this.db.doTn(async tn => {
       const txc = newTxContext();
       const now = Date.now();
+      const prior = decodeJson<{ i: string; l: string; e: number }>(
+        await tn.get(ks.takeOperation(takeOperationId)),
+      );
+      if (prior) {
+        const st = decodeJson<JobStatusRecord>(
+          await tn.snapshot().get(ks.jobStatus(prior.i)),
+        );
+        const meta = decodeJson<JobMeta>(
+          await tn.snapshot().get(ks.jobMeta(prior.i)),
+        );
+        if (!st || st.s !== "active" || st.l !== prior.l || !meta) {
+          throw new Error("FDB dequeue operation result is inconsistent");
+        }
+        const dataRange = ks.jobDataRange(prior.i);
+        const dataParts = await tn
+          .snapshot()
+          .getRangeAll(dataRange.begin, dataRange.end);
+        const data = JSON.parse(
+          Buffer.concat(dataParts.map(([, v]) => v as Buffer)).toString("utf8"),
+        );
+        return {
+          id: prior.i,
+          status: "active" as const,
+          createdAt: new Date(meta.c),
+          priority: meta.p,
+          data,
+          lock: prior.l,
+          leaseExpiresAt: new Date(prior.e),
+          ownerId: meta.o || undefined,
+          groupId: meta.g,
+        };
+      }
       const range = ks.readyShardRange(shard);
       const head = await tn.getRangeAll(range.begin, range.end, { limit: 1 });
       if (head.length === 0) return "empty";
@@ -756,6 +857,10 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
       const rec: JobStatusRecord = { s: "active", l: lock, e: exp, st: st.st };
       tn.set(ks.jobStatus(e.i), encodeJson(rec));
       tn.set(ks.lease(timeBucket(e.i), exp, e.i), encodeJson({ l: lock }));
+      tn.set(
+        ks.takeOperation(takeOperationId),
+        encodeJson({ i: e.i, l: lock, e: exp }),
+      );
       if (e.g && e.f & F_COUNTABLE) {
         bumpGroupStatusCount(tn, ks, e.g, "queued", -1);
         bumpGroupStatusCount(tn, ks, e.g, "active", 1);
@@ -774,6 +879,20 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
         groupId: meta.g,
       };
     });
+    if (typeof result === "object") {
+      // The record only bridges doTn retries. Best-effort cleanup must not hide
+      // a definitively leased job from the worker.
+      void this.db
+        .doTn(async tn => tn.clear(ks.takeOperation(takeOperationId)))
+        .catch(error =>
+          _logger.warn("Failed to clear FDB dequeue operation record", {
+            queueName: this.queueName,
+            takeOperationId,
+            error,
+          }),
+        );
+    }
+    return result;
   }
 
   // === Leases
@@ -1317,6 +1436,39 @@ export class NuQFdbQueue<JobData = any, JobReturnValue = any> {
   }
 
   // === Introspection used by status/admin endpoints
+
+  public async setTeamLimit(
+    teamId: string,
+    teamLimit: number,
+    externalActive: number,
+  ): Promise<void> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return;
+    const effectiveLimit = Math.max(0, teamLimit - externalActive);
+    await this.db.doTn(async tn => {
+      const stored = decodeI64(await tn.get(this.ks.teamLimit(owner)));
+      if (stored === effectiveLimit) return;
+      tn.set(this.ks.teamLimit(owner), encodeI64(effectiveLimit));
+      if (effectiveLimit > stored) {
+        // Fill newly available capacity in this transaction. The caller holds
+        // the cross-ledger admission lock, so PG observes the promoted FDB
+        // occupancy before deciding whether it may promote its own backlog.
+        const active = decodeI64(await tn.get(this.ks.teamActive(owner)));
+        let free = Math.min(Math.max(0, effectiveLimit - active), 32);
+        let promoted = 0;
+        const txc = newTxContext();
+        while (free > 0) {
+          const entry = await popTeamPending(tn, this.ks, owner);
+          if (!entry) break;
+          promoteEntryToReady(tn, this.ks, entry, txc);
+          promoted++;
+          free--;
+        }
+        if (promoted > 0) bumpTeamActive(tn, this.ks, owner, promoted);
+        if (free === 0) tn.set(this.ks.taskTeamRaise(owner), EMPTY);
+      }
+    });
+  }
 
   public async getTeamActiveCount(teamId: string): Promise<number> {
     const owner = normalizeOwnerId(teamId);

--- a/apps/api/src/services/worker/nuq-fdb/slots.ts
+++ b/apps/api/src/services/worker/nuq-fdb/slots.ts
@@ -75,6 +75,14 @@ export class NuqFdbExternalSlots {
     });
   }
 
+  public async has(teamId: string, holderId: string): Promise<boolean> {
+    const owner = normalizeOwnerId(teamId);
+    if (owner === null) return false;
+    return await this.db.doTn(async tn =>
+      Boolean(await tn.snapshot().get(this.key(owner, holderId))),
+    );
+  }
+
   // Releases the slot, handing it to a pending job when one exists.
   public async release(teamId: string, holderId: string): Promise<void> {
     const owner = normalizeOwnerId(teamId);

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -6,6 +6,8 @@ import { getACUCTeam } from "../../controllers/auth";
 import { redisEvictConnection } from "../../services/redis";
 import { isSelfHosted } from "../../lib/deployment";
 import { getApiKeyConcurrencyLimit } from "../../lib/api-key-concurrency";
+import { redlock } from "../redlock";
+import { getRedisConnection } from "../queue-service";
 import {
   getTeamQueueLimit,
   getConcurrencyLimitActiveJobsCount,
@@ -56,31 +58,37 @@ function fdbForced(): boolean {
   return config.NUQ_BACKEND === "fdb";
 }
 
-const fdbFallbackLastWarn = new Map<string, number>();
 const FDB_OPTIONAL_OP_TIMEOUT_MS = 500;
 
-function logFdbFallback(
-  logger: Logger,
-  operation: string,
-  error: unknown,
-): void {
-  const now = Date.now();
-  const lastWarn = fdbFallbackLastWarn.get(operation) ?? 0;
-  if (now - lastWarn < 60_000) return;
-  fdbFallbackLastWarn.set(operation, now);
-  logger.warn("FDB queue operation failed, falling back to PG", {
-    module: "nuq-router",
-    operation,
-    error,
-  });
-}
-
-async function optionalFdb<T>(operation: () => Promise<T>): Promise<T> {
+async function optionalFdbRead<T>(operation: () => Promise<T>): Promise<T> {
   if (fdbForced()) return operation();
   if (!(await nuqFdbHealthCheck(FDB_OPTIONAL_OP_TIMEOUT_MS))) {
-    throw new Error("FDB health check failed before optional operation");
+    throw new Error("FDB health check failed before optional read");
   }
   return await withFdbTimeout(operation(), FDB_OPTIONAL_OP_TIMEOUT_MS);
+}
+
+// Mutations are deliberately never wrapped in a JavaScript timeout and never
+// fall back to PG. Await the definitive FDB retry loop; logical operations use
+// stable ids so commit-unknown retries reconcile rather than duplicate work.
+async function fdbMutation<T>(operation: () => Promise<T>): Promise<T> {
+  return await operation();
+}
+
+const teamFdbStateKey = (teamId: string) => `nuq:fdb_team:${teamId}`;
+
+async function markFdbTeamState(teamId: string): Promise<void> {
+  // One bounded key per migrated team is the durable drain barrier. Failure is
+  // fatal before the first FDB enqueue, so rollback can always identify teams
+  // whose pinned FDB work may remain.
+  await getRedisConnection().set(teamFdbStateKey(teamId), "1");
+}
+
+async function teamUsesFdbLedger(teamId: string): Promise<boolean> {
+  if (!fdbQueueEnabled()) return false;
+  if (fdbForced()) return true;
+  if (await isFdbTeam(teamId)) return true;
+  return (await getRedisConnection().get(teamFdbStateKey(teamId))) === "1";
 }
 
 // Whether NEW work for this team should go to FDB. Existing crawls follow
@@ -89,17 +97,19 @@ export async function isFdbTeam(teamId: string | undefined): Promise<boolean> {
   if (!fdbQueueEnabled()) return false;
   if (fdbForced()) return true;
   if (!teamId) return false;
+  let enabled = false;
   try {
     const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
-    return acuc?.flags?.nuqFdb === true;
+    enabled = acuc?.flags?.nuqFdb === true;
   } catch (error) {
     _logger.warn("Failed to resolve nuqFdb team flag, defaulting to pg", {
       module: "nuq-router",
       teamId,
       error,
     });
-    return false;
   }
+  if (enabled) await markFdbTeamState(teamId);
+  return enabled;
 }
 
 export async function resolveNewGroupBackend(
@@ -115,13 +125,19 @@ async function getCrawlQueueBackend(
 ): Promise<QueueBackend | null> {
   if (fdbForced()) return "fdb";
   const raw = await redisEvictConnection.get("crawl:" + crawlId);
-  if (!raw) return null;
-  try {
-    const sc = JSON.parse(raw);
-    return sc?.queueBackend === "fdb" ? "fdb" : sc ? "pg" : null;
-  } catch {
-    return null;
+  if (raw) {
+    try {
+      const sc = JSON.parse(raw);
+      if (sc?.queueBackend === "fdb") return "fdb";
+      // Stored crawls predating the rollout have no marker and are PG.
+      if (sc) return "pg";
+    } catch {
+      // Fall through to the authoritative FDB group probe.
+    }
   }
+  if (!fdbQueueEnabled()) return raw ? "pg" : null;
+  const group = await optionalFdbRead(() => crawlGroupFdb.getGroup(crawlId));
+  return group ? "fdb" : raw ? "pg" : null;
 }
 
 const jobBackendKey = (jobId: string) => `nuq:job_backend:${jobId}`;
@@ -131,19 +147,41 @@ async function markJobBackend(
   backend: QueueBackend,
 ): Promise<void> {
   if (fdbForced()) return;
+  // This is only a bounded cache; never trust its absence. FDB job metadata
+  // remains the durable source of truth after expiry or a failed write.
   await redisEvictConnection.set(
     jobBackendKey(jobId),
     backend,
     "EX",
-    24 * 60 * 60,
+    30 * 24 * 60 * 60,
   );
 }
 
-async function getJobQueueBackend(jobId: string): Promise<QueueBackend> {
+async function getJobQueueBackend(
+  jobId: string,
+  hint?: QueueBackend,
+  hasFdbJob: () => Promise<boolean> = () => scrapeQueueFdb.hasJob(jobId),
+): Promise<QueueBackend> {
+  if (hint) return hint;
   if (fdbForced()) return "fdb";
-  return (await redisEvictConnection.get(jobBackendKey(jobId))) === "fdb"
-    ? "fdb"
-    : "pg";
+  if ((await redisEvictConnection.get(jobBackendKey(jobId))) === "fdb") {
+    return "fdb";
+  }
+  if (!fdbQueueEnabled()) return "pg";
+
+  // Redis marker writes are best-effort and old markers may have expired.
+  // Probe the durable FDB record before routing a wait/remove/read to PG.
+  if (await optionalFdbRead(hasFdbJob)) {
+    void markJobBackend(jobId, "fdb").catch(error =>
+      _logger.warn("Failed to repair FDB job backend marker", {
+        module: "nuq-router",
+        jobId,
+        error,
+      }),
+    );
+    return "fdb";
+  }
+  return "pg";
 }
 
 // Which backend a job belongs to at enqueue time. Crawl jobs follow their
@@ -171,64 +209,138 @@ function tagFdbJob<T extends object>(job: T): T & { backend: "fdb" } {
 // mid-hold) self-heal: Redis entries expire by score, FDB external slots are
 // reaped by the sweeper.
 
-export async function mirrorExternalSlotAcquire(
+async function acquireExternalSlot(
   teamId: string,
   holderId: string,
   ttlMs: number,
 ): Promise<void> {
   if (await isFdbTeam(teamId)) {
-    try {
-      await optionalFdb(() =>
-        externalSlotsFdb.acquire(teamId, holderId, ttlMs),
-      );
-      return;
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(_logger, "mirrorExternalSlotAcquire", error);
-    }
+    if (!isSelfHosted()) await markFdbTeamState(teamId);
+    await fdbMutation(() => externalSlotsFdb.acquire(teamId, holderId, ttlMs));
+    return;
   }
   await pushConcurrencyLimitActiveJob(teamId, holderId, ttlMs);
+  await syncFdbLimitToPgOccupancy(teamId);
+}
+
+export async function reserveExternalSlot(
+  teamId: string,
+  holderId: string,
+  ttlMs: number,
+  concurrencyLimit: number,
+): Promise<boolean> {
+  return await withTeamMigrationAdmission(teamId, async () => {
+    if ((await getCombinedTeamActiveCount(teamId)) >= concurrencyLimit) {
+      return false;
+    }
+    await acquireExternalSlot(teamId, holderId, ttlMs);
+    return true;
+  });
+}
+
+export async function mirrorExternalSlotAcquire(
+  teamId: string,
+  holderId: string,
+  ttlMs: number,
+): Promise<void> {
+  await withTeamMigrationAdmission(teamId, async () =>
+    acquireExternalSlot(teamId, holderId, ttlMs),
+  );
 }
 
 export async function mirrorExternalSlotRelease(
   teamId: string,
   holderId: string,
 ): Promise<void> {
-  if (await isFdbTeam(teamId)) {
-    try {
-      await optionalFdb(() => externalSlotsFdb.release(teamId, holderId));
+  await withTeamMigrationAdmission(teamId, async () => {
+    // The flag may flip while a holder is alive. Route by the durable slot,
+    // rather than today's flag, so rollback cannot leak FDB occupancy.
+    if (
+      fdbForced() ||
+      ((await teamUsesFdbLedger(teamId)) &&
+        (await optionalFdbRead(() => externalSlotsFdb.has(teamId, holderId))))
+    ) {
+      await fdbMutation(() => externalSlotsFdb.release(teamId, holderId));
       return;
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(_logger, "mirrorExternalSlotRelease", error);
     }
-  }
-  await removeConcurrencyLimitActiveJob(teamId, holderId);
+    await removeConcurrencyLimitActiveJob(teamId, holderId);
+    await syncFdbLimitToPgOccupancy(teamId);
+  });
 }
 
 // Active count across both ledgers; a migrating team has load on both while
 // its old PG crawls drain.
+export async function syncFdbLimitToPgOccupancy(teamId: string): Promise<void> {
+  if (!(await teamUsesFdbLedger(teamId)) || isSelfHosted()) return;
+  const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
+  await reconcileFdbTeamLimit(teamId, acuc?.concurrency ?? 2);
+}
+
+export async function reconcileFdbTeamLimit(
+  teamId: string,
+  teamLimit: number,
+): Promise<void> {
+  if (!fdbQueueEnabled()) return;
+  const externalActive = await getConcurrencyLimitActiveJobsCount(teamId);
+  await fdbMutation(() =>
+    scrapeQueueFdb.setTeamLimit(teamId, teamLimit, externalActive),
+  );
+}
+
+export async function getCombinedTeamPendingCount(
+  teamId: string,
+): Promise<number> {
+  const pgPending = await getRedisConnection().zcard(
+    `concurrency-limit-queue:${teamId}`,
+  );
+  if (!(await teamUsesFdbLedger(teamId))) return pgPending;
+  return (
+    pgPending +
+    (await optionalFdbRead(() => scrapeQueueFdb.getTeamPendingCount(teamId)))
+  );
+}
+
 export async function getCombinedTeamActiveCount(
   teamId: string,
 ): Promise<number> {
   const redisCount = await getConcurrencyLimitActiveJobsCount(teamId);
-  if (!(await isFdbTeam(teamId))) return redisCount;
-  try {
-    return (
-      redisCount +
-      (await optionalFdb(() => scrapeQueueFdb.getTeamActiveCount(teamId)))
-    );
-  } catch (error) {
-    if (fdbForced()) throw error;
-    logFdbFallback(_logger, "getCombinedTeamActiveCount", error);
-    return redisCount;
-  }
+  if (!(await teamUsesFdbLedger(teamId))) return redisCount;
+  // Always include FDB for migrated teams, even after the rollout flag is
+  // switched off. Pinned FDB crawls and standalone jobs keep draining and
+  // remain part of the team's one combined limit.
+  return (
+    redisCount +
+    (await optionalFdbRead(() => scrapeQueueFdb.getTeamActiveCount(teamId)))
+  );
 }
 
 // === FDB enqueue (the whole gating block of queue-jobs collapses into this)
 
 export function backlogTimeoutMsForGate(timeoutMs: number): Date {
   return new Date(Date.now() + timeoutMs);
+}
+
+// PG and FDB cannot share a transaction, so serialize cross-ledger admission
+// while taking the combined occupancy snapshot and reserving the chosen
+// backend. Redlock's using() extends this lease while a large enqueue runs.
+export async function withTeamMigrationAdmission<T>(
+  teamId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!fdbQueueEnabled() || (fdbForced() && isSelfHosted())) {
+    return await operation();
+  }
+  return await redlock.using(
+    [`nuq:migration-admission:${teamId}`],
+    30_000,
+    {},
+    async signal => {
+      if (signal.aborted) throw signal.error;
+      const result = await operation();
+      if (signal.aborted) throw signal.error;
+      return result;
+    },
+  );
 }
 
 export async function fdbEnqueueScrapeJobs(
@@ -240,12 +352,13 @@ export async function fdbEnqueueScrapeJobs(
     backlogTimeoutMs: number;
   }[],
   teamId: string,
-  options?: { bypassGate?: boolean },
+  options?: { bypassGate?: boolean; reservedExternalPending?: number },
 ): Promise<{
   jobs: (NuQJob<ScrapeJobData> & { backend: "fdb" })[];
   backloggedCount: number;
   teamLimit: number | null;
 }> {
+  if (!isSelfHosted()) await markFdbTeamState(teamId);
   let teamLimit: number | null = null;
   if (!isSelfHosted() && !fdbForced()) {
     const acuc = await getACUCTeam(teamId, false, true, RateLimiterMode.Crawl);
@@ -273,7 +386,15 @@ export async function fdbEnqueueScrapeJobs(
     }
   }
 
-  const results = await optionalFdb(() =>
+  const externalActive =
+    teamLimit === null ? 0 : await getConcurrencyLimitActiveJobsCount(teamId);
+  const externalPending =
+    teamLimit === null
+      ? 0
+      : (await getRedisConnection().zcard(
+          `concurrency-limit-queue:${teamId}`,
+        )) + (options?.reservedExternalPending ?? 0);
+  const results = await fdbMutation(() =>
     scrapeQueueFdb.addJobs(
       jobs.map(j => ({
         id: j.jobId,
@@ -290,24 +411,25 @@ export async function fdbEnqueueScrapeJobs(
           timesOutAt: new Date(Date.now() + j.backlogTimeoutMs),
         },
       })),
-      { teamLimit, queueCap, key: keyGate },
+      {
+        teamLimit,
+        queueCap,
+        externalActive,
+        externalPending,
+        key: keyGate,
+      },
     ),
   );
 
   const tagged = results.map(r => tagFdbJob(r as NuQJob<ScrapeJobData>));
-  const markerResults = await Promise.allSettled(
-    tagged.map(job => markJobBackend(job.id, "fdb")),
-  );
-  const markerFailures = markerResults.filter(
-    (r): r is PromiseRejectedResult => r.status === "rejected",
-  );
-  if (markerFailures.length > 0) {
-    _logger.warn("Failed to mark some FDB job backends", {
-      module: "nuq-router",
-      failed: markerFailures.length,
-      total: markerResults.length,
-      errors: markerFailures.map(r => r.reason),
-    });
+  for (const job of tagged) {
+    void markJobBackend(job.id, "fdb").catch(error =>
+      _logger.warn("Failed to cache FDB job backend", {
+        module: "nuq-router",
+        jobId: job.id,
+        error,
+      }),
+    );
   }
   return {
     jobs: tagged,
@@ -329,19 +451,18 @@ class RoutedScrapeQueue {
   public async getJobToProcess(
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData> | null> {
-    if (fdbQueueEnabled()) {
-      try {
-        const job = await optionalFdb(() =>
-          scrapeQueueFdb.getJobToProcess(logger),
-        );
-        if (job) {
-          this.inflightBackend.set(job.id, "fdb");
-          return tagFdbJob(job as NuQJob<ScrapeJobData>);
-        }
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.getJobToProcess", error);
+    // Optional deployments have dedicated PG and FDB consumers. Never race a
+    // mutating FDB take against PG fallback: an ambiguous FDB commit would
+    // otherwise lease an invisible "ghost" job while this worker runs PG work.
+    if (fdbForced()) {
+      const job = await fdbMutation(() =>
+        scrapeQueueFdb.getJobToProcess(logger),
+      );
+      if (job) {
+        this.inflightBackend.set(job.id, "fdb");
+        return tagFdbJob(job as NuQJob<ScrapeJobData>);
       }
+      return null;
     }
     const job = await scrapeQueuePg.getJobToProcess();
     if (job) this.inflightBackend.set(job.id, "pg");
@@ -354,15 +475,9 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<boolean> {
     if (this.backendFor(id) === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          scrapeQueueFdb.renewLock(id, lock, logger),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.renewLock", error);
-        return false;
-      }
+      return await fdbMutation(() =>
+        scrapeQueueFdb.renewLock(id, lock, logger),
+      );
     }
     return scrapeQueuePg.renewLock(id, lock, logger);
   }
@@ -374,19 +489,21 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          scrapeQueueFdb.jobFinish(id, lock, returnvalue, logger),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.jobFinish", error);
-        return false;
-      }
+      const finished = await fdbMutation(() =>
+        scrapeQueueFdb.jobFinish(id, lock, returnvalue, logger),
+      );
+      if (finished) this.inflightBackend.delete(id);
+      return finished;
     }
-    return scrapeQueuePg.jobFinish(id, lock, returnvalue, logger);
+    const finished = await scrapeQueuePg.jobFinish(
+      id,
+      lock,
+      returnvalue,
+      logger,
+    );
+    if (finished) this.inflightBackend.delete(id);
+    return finished;
   }
 
   public async jobFail(
@@ -396,19 +513,16 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<boolean> {
     const backend = this.backendFor(id);
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          scrapeQueueFdb.jobFail(id, lock, failedReason, logger),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "scrape.jobFail", error);
-        return false;
-      }
+      const failed = await fdbMutation(() =>
+        scrapeQueueFdb.jobFail(id, lock, failedReason, logger),
+      );
+      if (failed) this.inflightBackend.delete(id);
+      return failed;
     }
-    return scrapeQueuePg.jobFail(id, lock, failedReason, logger);
+    const failed = await scrapeQueuePg.jobFail(id, lock, failedReason, logger);
+    if (failed) this.inflightBackend.delete(id);
+    return failed;
   }
 
   public async getJob(
@@ -416,7 +530,9 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData> | null> {
     if ((await getJobQueueBackend(id)) === "fdb") {
-      const job = await optionalFdb(() => scrapeQueueFdb.getJob(id, logger));
+      const job = await optionalFdbRead(() =>
+        scrapeQueueFdb.getJob(id, logger),
+      );
       return job ? tagFdbJob(job as NuQJob<ScrapeJobData>) : null;
     }
     return scrapeQueuePg.getJob(id, logger);
@@ -432,7 +548,7 @@ class RoutedScrapeQueue {
     const pgIds = ids.filter((_, i) => backends[i] === "pg");
     const [fdbJobs, pgJobs] = await Promise.all([
       fdbIds.length > 0
-        ? optionalFdb(() => scrapeQueueFdb.getJobs(fdbIds, logger))
+        ? optionalFdbRead(() => scrapeQueueFdb.getJobs(fdbIds, logger))
         : Promise.resolve([] as NuQFdbJob<ScrapeJobData>[]),
       pgIds.length > 0
         ? scrapeQueuePg.getJobs(pgIds, logger)
@@ -476,7 +592,7 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData> | null> {
     if (await this.isFdbGroup(groupId)) {
-      const job = await optionalFdb(() =>
+      const job = await optionalFdbRead(() =>
         scrapeQueueFdb.getGroupAnyJob(groupId, ownerId, logger),
       );
       return job ? tagFdbJob(job as NuQJob<ScrapeJobData>) : null;
@@ -489,7 +605,7 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<Record<NuQJobStatus, number>> {
     if (await this.isFdbGroup(groupId)) {
-      return (await optionalFdb(() =>
+      return (await optionalFdbRead(() =>
         scrapeQueueFdb.getGroupNumericStats(groupId, logger),
       )) as Record<NuQJobStatus, number>;
     }
@@ -503,7 +619,7 @@ class RoutedScrapeQueue {
     logger: Logger = _logger,
   ): Promise<NuQJob<ScrapeJobData>[]> {
     if (await this.isFdbGroup(groupId)) {
-      const jobs = await optionalFdb(() =>
+      const jobs = await optionalFdbRead(() =>
         scrapeQueueFdb.getCrawlJobsForListing(groupId, limit, offset, logger),
       );
       return jobs.map(j => tagFdbJob(j as NuQJob<ScrapeJobData>));
@@ -513,7 +629,7 @@ class RoutedScrapeQueue {
 
   public async removeJob(id: string, logger: Logger = _logger): Promise<void> {
     if ((await getJobQueueBackend(id)) === "fdb") {
-      await optionalFdb(() => scrapeQueueFdb.removeJob(id, logger));
+      await fdbMutation(() => scrapeQueueFdb.removeJob(id, logger));
       return;
     }
     await scrapeQueuePg.removeJob(id, logger);
@@ -532,11 +648,12 @@ class RoutedScrapeQueue {
     id: string,
     timeout: number | null,
     logger: Logger = _logger,
+    backendHint?: QueueBackend,
   ): Promise<T> {
-    if ((await getJobQueueBackend(id)) === "fdb") {
+    if ((await getJobQueueBackend(id, backendHint)) === "fdb") {
       // Waiting is intentionally long-lived; callers pass the real scrape
-      // timeout. optionalFdb is only for quick FDB reads/writes and applies a
-      // 500ms guard, which would incorrectly fail synchronous FDB-backed jobs.
+      // timeout. The backend hint from the enqueue result also avoids any
+      // dependency on the best-effort Redis marker.
       return scrapeQueueFdb.waitForJob(id, timeout, logger);
     }
     return scrapeQueuePg.waitForJob(id, timeout, logger) as Promise<T>;
@@ -555,19 +672,15 @@ class RoutedCrawlFinishedQueue {
   public async getJobToProcess(
     logger: Logger = _logger,
   ): Promise<NuQJob<any> | null> {
-    if (fdbQueueEnabled()) {
-      try {
-        const job = await optionalFdb(() =>
-          crawlFinishedQueueFdb.getJobToProcess(logger),
-        );
-        if (job) {
-          this.inflightBackend.set(job.id, "fdb");
-          return tagFdbJob(job as NuQJob<any>);
-        }
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.getJobToProcess", error);
+    if (fdbForced()) {
+      const job = await fdbMutation(() =>
+        crawlFinishedQueueFdb.getJobToProcess(logger),
+      );
+      if (job) {
+        this.inflightBackend.set(job.id, "fdb");
+        return tagFdbJob(job as NuQJob<any>);
       }
+      return null;
     }
     const job = await crawlFinishedQueuePg.getJobToProcess();
     if (job) this.inflightBackend.set(job.id, "pg");
@@ -580,15 +693,9 @@ class RoutedCrawlFinishedQueue {
     logger: Logger = _logger,
   ): Promise<boolean> {
     if (this.inflightBackend.get(id) === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          crawlFinishedQueueFdb.renewLock(id, lock, logger),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.renewLock", error);
-        return false;
-      }
+      return await fdbMutation(() =>
+        crawlFinishedQueueFdb.renewLock(id, lock, logger),
+      );
     }
     return crawlFinishedQueuePg.renewLock(id, lock, logger);
   }
@@ -600,19 +707,21 @@ class RoutedCrawlFinishedQueue {
     logger: Logger = _logger,
   ): Promise<boolean> {
     const backend = this.inflightBackend.get(id) ?? "pg";
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          crawlFinishedQueueFdb.jobFinish(id, lock, returnvalue, logger),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.jobFinish", error);
-        return false;
-      }
+      const finished = await fdbMutation(() =>
+        crawlFinishedQueueFdb.jobFinish(id, lock, returnvalue, logger),
+      );
+      if (finished) this.inflightBackend.delete(id);
+      return finished;
     }
-    return crawlFinishedQueuePg.jobFinish(id, lock, returnvalue, logger);
+    const finished = await crawlFinishedQueuePg.jobFinish(
+      id,
+      lock,
+      returnvalue,
+      logger,
+    );
+    if (finished) this.inflightBackend.delete(id);
+    return finished;
   }
 
   public async jobFail(
@@ -622,27 +731,33 @@ class RoutedCrawlFinishedQueue {
     logger: Logger = _logger,
   ): Promise<boolean> {
     const backend = this.inflightBackend.get(id) ?? "pg";
-    this.inflightBackend.delete(id);
     if (backend === "fdb") {
-      try {
-        return await optionalFdb(() =>
-          crawlFinishedQueueFdb.jobFail(id, lock, failedReason, logger),
-        );
-      } catch (error) {
-        if (fdbForced()) throw error;
-        logFdbFallback(logger, "crawlFinished.jobFail", error);
-        return false;
-      }
+      const failed = await fdbMutation(() =>
+        crawlFinishedQueueFdb.jobFail(id, lock, failedReason, logger),
+      );
+      if (failed) this.inflightBackend.delete(id);
+      return failed;
     }
-    return crawlFinishedQueuePg.jobFail(id, lock, failedReason, logger);
+    const failed = await crawlFinishedQueuePg.jobFail(
+      id,
+      lock,
+      failedReason,
+      logger,
+    );
+    if (failed) this.inflightBackend.delete(id);
+    return failed;
   }
 
   public async getJob(
     id: string,
     logger: Logger = _logger,
   ): Promise<NuQJob<any> | null> {
-    if ((await getJobQueueBackend(id)) === "fdb") {
-      const job = await optionalFdb(() =>
+    if (
+      (await getJobQueueBackend(id, undefined, () =>
+        crawlFinishedQueueFdb.hasJob(id),
+      )) === "fdb"
+    ) {
+      const job = await optionalFdbRead(() =>
         crawlFinishedQueueFdb.getJob(id, logger),
       );
       return job ? tagFdbJob(job as NuQJob<any>) : null;
@@ -666,7 +781,8 @@ class RoutedCrawlGroup {
     logger: Logger = _logger,
   ): Promise<NuQJobGroupInstance> {
     if (opts?.backend === "fdb") {
-      const g = await optionalFdb(() =>
+      if (!isSelfHosted()) await markFdbTeamState(ownerId);
+      const g = await fdbMutation(() =>
         crawlGroupFdb.addGroup(
           id,
           ownerId,
@@ -689,7 +805,7 @@ class RoutedCrawlGroup {
   ): Promise<NuQJobGroupInstance | null> {
     const backend = await getCrawlQueueBackend(id);
     if (backend === "fdb" || (!backend && fdbForced())) {
-      return (await optionalFdb(() =>
+      return (await optionalFdbRead(() =>
         crawlGroupFdb.getGroup(id, logger),
       )) as NuQJobGroupInstance | null;
     }
@@ -700,20 +816,15 @@ class RoutedCrawlGroup {
     ownerId: string,
     logger: Logger = _logger,
   ): Promise<NuQJobGroupInstance[]> {
-    if (!(await isFdbTeam(ownerId))) {
+    if (!(await teamUsesFdbLedger(ownerId))) {
       return crawlGroupPg.getOngoingByOwner(ownerId, logger);
     }
-    let fdb: NuQJobGroupInstance[] = [];
-    try {
-      fdb = (await optionalFdb(() =>
-        crawlGroupFdb.getOngoingByOwner(ownerId, logger),
-      )) as NuQJobGroupInstance[];
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(logger, "crawlGroup.getOngoingByOwner", error);
-      return crawlGroupPg.getOngoingByOwner(ownerId, logger);
-    }
-    if (fdbForced()) return fdb as NuQJobGroupInstance[];
+    const fdb = (await optionalFdbRead(() =>
+      crawlGroupFdb.getOngoingByOwner(ownerId, logger),
+    )) as NuQJobGroupInstance[];
+    if (fdbForced()) return fdb;
+    // Query both ledgers regardless of today's flag. Turning the flag off only
+    // stops new FDB groups; pinned groups remain authoritative until drained.
     const pg = await crawlGroupPg.getOngoingByOwner(ownerId, logger);
     const seen = new Set(fdb.map(g => g.id));
     return [
@@ -730,13 +841,7 @@ class RoutedCrawlGroup {
   ): Promise<boolean> {
     const backend = await getCrawlQueueBackend(id);
     if (backend !== "fdb" && !(backend === null && fdbForced())) return false;
-    try {
-      return await optionalFdb(() => crawlGroupFdb.cancelGroup(id, logger));
-    } catch (error) {
-      if (fdbForced()) throw error;
-      logFdbFallback(logger, "crawlGroup.cancelGroup", error);
-      return false;
-    }
+    return await fdbMutation(() => crawlGroupFdb.cancelGroup(id, logger));
   }
 }
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -290,6 +290,11 @@ export async function reconcileFdbTeamLimit(
 export async function getCombinedTeamPendingCount(
   teamId: string,
 ): Promise<number> {
+  if (fdbForced() && isSelfHosted()) {
+    return await optionalFdbRead(() =>
+      scrapeQueueFdb.getTeamPendingCount(teamId),
+    );
+  }
   const pgPending = await getRedisConnection().zcard(
     `concurrency-limit-queue:${teamId}`,
   );
@@ -303,6 +308,11 @@ export async function getCombinedTeamPendingCount(
 export async function getCombinedTeamActiveCount(
   teamId: string,
 ): Promise<number> {
+  if (fdbForced() && isSelfHosted()) {
+    return await optionalFdbRead(() =>
+      scrapeQueueFdb.getTeamActiveCount(teamId),
+    );
+  }
   const redisCount = await getConcurrencyLimitActiveJobsCount(teamId);
   if (!(await teamUsesFdbLedger(teamId))) return redisCount;
   // Always include FDB for migrated teams, even after the rollout flag is

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -11,6 +11,10 @@ import {
   pushConcurrencyLimitActiveJob,
 } from "../../lib/concurrency-limit";
 import { addJobPriority, deleteJobPriority } from "../../lib/job-priority";
+import {
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "./nuq-router";
 import { cacheableLookup } from "../../scraper/scrapeURL/lib/cacheableLookup";
 import { v7 as uuidv7 } from "uuid";
 import {
@@ -1544,12 +1548,37 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
         job.data?.team_id &&
         !job.data.skipNuq
       ) {
-        extendLockInterval = setInterval(async () => {
-          await pushConcurrencyLimitActiveJob(
+        let reconciliationRunning = false;
+        extendLockInterval = setInterval(() => {
+          // Never let a slow/hung FDB reconciliation suppress the Redis TTL
+          // heartbeat that keeps this live PG job visible.
+          void pushConcurrencyLimitActiveJob(
             job.data.team_id,
             job.id,
             60 * 1000,
-          ); // 60s lock renew, just like in the queue
+          ).catch(error =>
+            _logger.warn("Failed to renew PG concurrency occupancy", {
+              jobId: job.id,
+              teamId: job.data.team_id,
+              error,
+            }),
+          );
+
+          if (reconciliationRunning) return;
+          reconciliationRunning = true;
+          void withTeamMigrationAdmission(job.data.team_id, async () =>
+            syncFdbLimitToPgOccupancy(job.data.team_id),
+          )
+            .catch(error =>
+              _logger.warn("Failed to reconcile FDB concurrency occupancy", {
+                jobId: job.id,
+                teamId: job.data.team_id,
+                error,
+              }),
+            )
+            .finally(() => {
+              reconciliationRunning = false;
+            });
         }, jobLockExtendInterval);
       }
 

--- a/apps/api/src/services/worker/team-semaphore.ts
+++ b/apps/api/src/services/worker/team-semaphore.ts
@@ -2,9 +2,12 @@ import {
   pushConcurrencyLimitActiveJob,
   removeConcurrencyLimitActiveJob,
 } from "../../lib/concurrency-limit";
-import { config } from "../../config";
-import { isFdbTeam } from "./nuq-router";
-import { externalSlotsFdb, nuqFdbHealthCheck, withFdbTimeout } from "./nuq-fdb";
+import {
+  isFdbTeam,
+  syncFdbLimitToPgOccupancy,
+  withTeamMigrationAdmission,
+} from "./nuq-router";
+import { externalSlotsFdb } from "./nuq-fdb";
 import { isSelfHosted } from "../../lib/deployment";
 import { ScrapeJobTimeoutError, TransportableError } from "../../lib/error";
 import { logger as _logger } from "../../lib/logger";
@@ -33,21 +36,8 @@ const semaphoreHoldDuration = new Histogram({
 const { scripts, runScript, ensure } = nuqRedis;
 
 const SEMAPHORE_TTL = 30 * 1000;
-const FDB_OPTIONAL_SLOT_TIMEOUT_MS = 500;
 type MirrorBackend = "pg" | "fdb";
-type MirrorState = { backend?: MirrorBackend; touched: Set<MirrorBackend> };
-
-function fdbForced(): boolean {
-  return config.NUQ_BACKEND === "fdb";
-}
-
-async function optionalFdbSlot<T>(operation: () => Promise<T>): Promise<T> {
-  if (fdbForced()) return operation();
-  if (!(await nuqFdbHealthCheck(FDB_OPTIONAL_SLOT_TIMEOUT_MS))) {
-    throw new Error("FDB health check failed before optional slot operation");
-  }
-  return await withFdbTimeout(operation(), FDB_OPTIONAL_SLOT_TIMEOUT_MS);
-}
+type MirrorState = { backend?: MirrorBackend };
 
 async function acquire(
   teamId: string,
@@ -220,9 +210,7 @@ function startHeartbeat(
 // PG-backed teams mirror into the Redis ZSET; FDB-backed teams consume an
 // external slot on the FDB ledger.
 async function resolveMirrorBackend(teamId: string): Promise<MirrorBackend> {
-  if (!(await isFdbTeam(teamId))) return "pg";
-  if (fdbForced()) return "fdb";
-  return (await nuqFdbHealthCheck(FDB_OPTIONAL_SLOT_TIMEOUT_MS)) ? "fdb" : "pg";
+  return (await isFdbTeam(teamId)) ? "fdb" : "pg";
 }
 
 async function releaseMirrorBackend(
@@ -231,9 +219,10 @@ async function releaseMirrorBackend(
   backend: MirrorBackend,
 ): Promise<void> {
   if (backend === "fdb") {
-    await optionalFdbSlot(() => externalSlotsFdb.release(teamId, holderId));
+    await externalSlotsFdb.release(teamId, holderId);
   } else {
     await removeConcurrencyLimitActiveJob(teamId, holderId);
+    await syncFdbLimitToPgOccupancy(teamId);
   }
 }
 
@@ -242,21 +231,19 @@ async function mirrorSlotAcquire(
   holderId: string,
   state: MirrorState,
 ): Promise<void> {
-  const backend = await resolveMirrorBackend(teamId);
-  if (backend === "fdb") {
-    await optionalFdbSlot(() =>
-      externalSlotsFdb.acquire(teamId, holderId, 60 * 1000),
-    );
-  } else {
-    await pushConcurrencyLimitActiveJob(teamId, holderId, 60 * 1000);
-  }
-  const previous = state.backend;
+  // Pin the mirror ledger for the holder's lifetime. A transient FDB health
+  // failure or rollout-flag change must not move one holder between ledgers
+  // and double-count (or later release) both.
+  const backend = state.backend ?? (await resolveMirrorBackend(teamId));
   state.backend = backend;
-  state.touched.add(backend);
-  if (previous && previous !== backend) {
-    await releaseMirrorBackend(teamId, holderId, previous);
-    state.touched.delete(previous);
-  }
+  await withTeamMigrationAdmission(teamId, async () => {
+    if (backend === "fdb") {
+      await externalSlotsFdb.acquire(teamId, holderId, 60 * 1000);
+    } else {
+      await pushConcurrencyLimitActiveJob(teamId, holderId, 60 * 1000);
+      await syncFdbLimitToPgOccupancy(teamId);
+    }
+  });
 }
 
 async function mirrorSlotRelease(
@@ -264,18 +251,12 @@ async function mirrorSlotRelease(
   holderId: string,
   state: MirrorState,
 ): Promise<void> {
-  const backends = Array.from(state.touched);
-  const results = await Promise.allSettled(
-    backends.map(backend => releaseMirrorBackend(teamId, holderId, backend)),
+  const backend = state.backend;
+  if (!backend) return;
+  await withTeamMigrationAdmission(teamId, async () =>
+    releaseMirrorBackend(teamId, holderId, backend),
   );
-  const failed = results.find(
-    (result): result is PromiseRejectedResult => result.status === "rejected",
-  );
-  if (failed) {
-    throw failed.reason;
-  }
   state.backend = undefined;
-  state.touched.clear();
 }
 
 async function withSemaphore<T>(
@@ -303,7 +284,7 @@ async function withSemaphore<T>(
   });
 
   const endTimer = semaphoreHoldDuration.startTimer();
-  const mirrorState: MirrorState = { touched: new Set() };
+  const mirrorState: MirrorState = {};
   let hb: ReturnType<typeof startHeartbeat> | null = null;
 
   activeSemaphores.inc();


### PR DESCRIPTION
## Summary
- bypass Redis active/pending capacity counters when NuQ is forced to FDB in self-hosted mode
- add a regression assertion to the external slot mirror router test so Redis `zcount`/`zcard` usage fails fast instead of timing out

This is a stacked fix for PR #3983 / Actions run 29060837617, where `src/__tests__/nuq-fdb/router.test.ts > NuQ router (forced FDB mode) > external slot mirror consumes and releases FDB capacity` timed out in `NuQ FoundationDB core tests`.

## Validation
- `pnpm exec prettier --write src/__tests__/nuq-fdb/router.test.ts src/services/worker/nuq-router.ts`
- `git diff --check`
- `pnpm build`
- attempted local `FDB_CLUSTER_FILE=/tmp/codex-nuq-fdb-router.cluster npx vitest run src/__tests__/nuq-fdb/router.test.ts -t "external slot mirror consumes and releases FDB capacity" --reporter=default`; local run did not complete in the local FDB setup, so the authoritative runtime validation is the GitHub `NuQ FoundationDB core tests` job on this PR.

Labels `codex` and `codex-automation` were requested in the automation prompt, but this repo currently does not define either label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid Redis counts when NuQ is forced to FDB in self-hosted mode. The router now uses FDB-only capacity counts, preventing timeouts and ensuring correct accounting.

- **Bug Fixes**
  - Short-circuit in `getCombinedTeamPendingCount` and `getCombinedTeamActiveCount` to read counts from FDB when `fdbForced()` and `isSelfHosted()` are true.
  - Updated the external slot mirror test to spy on Redis `zcount`/`zcard` and fail if they’re called in forced FDB mode.

<sup>Written for commit 2f64f8eaa70862eed712fbd3dc3e65ec57e46ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

