### PR TITLE
Enable automatic restart for self-hosted Docker services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 name: firecrawl
 
 x-common-service: &common-service
+  restart: unless-stopped
   # NOTE: If you don't want to build the service locally,
   # comment out the build: statement and uncomment the image: statement
   # image: ghcr.io/firecrawl/firecrawl
@@ -61,6 +62,7 @@ x-common-env: &common-env
 
 services:
   playwright-service:
+    restart: unless-stopped
     # NOTE: If you don't want to build the service locally,
     # comment out the build: statement and uncomment the image: statement
     # image: ghcr.io/firecrawl/playwright-service:latest
@@ -119,6 +121,7 @@ services:
     memswap_limit: 8G
 
   redis:
+    restart: unless-stopped
     # NOTE: If you want to use Valkey (open source) instead of Redis (source available),
     # uncomment the Valkey statement and comment out the Redis statement.
     # Using Valkey with Firecrawl is untested and not guaranteed to work. Use with caution.
@@ -136,6 +139,7 @@ services:
         compress: "true"
 
   rabbitmq:
+    restart: unless-stopped
     image: rabbitmq:3-management
     networks:
       - backend
@@ -154,6 +158,7 @@ services:
         compress: "true"
 
   nuq-postgres:
+    restart: unless-stopped
     # NOTE: If you don't want to build the image locally,
     # comment out the build: statement and uncomment the image: statement
     # image: ghcr.io/firecrawl/nuq-postgres:latest
@@ -175,6 +180,7 @@ services:
   # NUQ_BACKEND=fdb; the api container reads the shared cluster file from the
   # fdb-cluster-file volume. Replaces nuq-postgres once stable.
   foundationdb:
+    restart: unless-stopped
     image: foundationdb/foundationdb:7.3.63
     environment:
       FDB_NETWORKING_MODE: container


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to all long-running Firecrawl Docker Compose services (api, playwright-service, redis, rabbitmq, nuq-postgres, foundationdb)
- Keeps the one-shot `foundationdb-init` container on `restart: "no"`

## Why
Self-hosted deployments should survive Docker daemon restarts and host reboots without manual `docker compose up`.

## Test plan
- [x] Applied locally; verified running containers report `unless-stopped` restart policy
- [ ] `docker compose up -d` on a fresh stack starts all services with the new policy

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable automatic restarts for self-hosted Docker deployments so the stack comes back after Docker or host reboots. Adds `restart: unless-stopped` to long-running services.

- **New Features**
  - Set `restart: unless-stopped` on all long-running services (`playwright-service`, `redis`, `rabbitmq`, `nuq-postgres`, `foundationdb`) via the common service config. One-shot init jobs remain no-restart.

- **Migration**
  - Run `docker compose up -d` to apply the new restart policy to existing containers.

<sup>Written for commit ade2e77adfd3416e22b782469acb92ae12ed81f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

