### PR TITLE
feat(php-sdk): native tool classes for the Laravel AI SDK

### DIFF
--- a/.github/workflows/publish-php-sdk.yml
+++ b/.github/workflows/publish-php-sdk.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Tag release on firecrawl-php
         if: ${{ env.VERSION_INCREMENTED == 'true' }}
         run: |
-          VERSION=$(sed -nE "s/.*SDK_VERSION[[:space:]]*=[[:space:]]*'([0-9]+\.[0-9]+\.[0-9]+)'.*/\1/p" apps/php-sdk/src/Version.php)
+          # Same permissive extraction as check_version_has_incremented.py: the
+          # gate already validates the version, so any format it approves
+          # (including pre-releases) must reach the tag push.
+          VERSION=$(sed -nE "s/.*SDK_VERSION[[:space:]]*=[[:space:]]*'([^']+)'.*/\1/p" apps/php-sdk/src/Version.php)
           if [ -z "$VERSION" ]; then
             echo "Could not read SDK_VERSION from apps/php-sdk/src/Version.php" >&2
             exit 1

--- a/.github/workflows/publish-php-sdk.yml
+++ b/.github/workflows/publish-php-sdk.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'apps/php-sdk/**'
+      - '.github/workflows/publish-php-sdk.yml'
 
 jobs:
   publish:
@@ -61,6 +62,25 @@ jobs:
           git subtree split --prefix=apps/php-sdk -b php-sdk-split
           git remote add php-sdk git@github.com:firecrawl/firecrawl-php.git
           git push php-sdk php-sdk-split:main --force
+
+      - name: Tag release on firecrawl-php
+        if: ${{ env.VERSION_INCREMENTED == 'true' }}
+        run: |
+          VERSION=$(sed -nE "s/.*SDK_VERSION[[:space:]]*=[[:space:]]*'([0-9]+\.[0-9]+\.[0-9]+)'.*/\1/p" apps/php-sdk/src/Version.php)
+          if [ -z "$VERSION" ]; then
+            echo "Could not read SDK_VERSION from apps/php-sdk/src/Version.php" >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          # Packagist derives stable versions from git tags on the mirror repo;
+          # without a tag it only exposes dev-main, so constraints like ^1.9
+          # never resolve.
+          if git ls-remote --exit-code --tags php-sdk "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on firecrawl-php — skipping tag push."
+          else
+            git push php-sdk "php-sdk-split:refs/tags/${TAG}"
+            echo "Pushed ${TAG} to firecrawl-php"
+          fi
 
       - name: Notify Packagist
         if: ${{ env.VERSION_INCREMENTED == 'true' }}

--- a/apps/api/src/utils/integration.ts
+++ b/apps/api/src/utils/integration.ts
@@ -19,7 +19,6 @@ enum IntegrationEnum {
   HERMES = "hermes",
   GSTACK = "gstack",
   PROMETHEUS = "prometheus",
-  LARAVEL_AI = "laravel-ai",
 }
 
 export const integrationSchema = z

--- a/apps/api/src/utils/integration.ts
+++ b/apps/api/src/utils/integration.ts
@@ -19,6 +19,7 @@ enum IntegrationEnum {
   HERMES = "hermes",
   GSTACK = "gstack",
   PROMETHEUS = "prometheus",
+  LARAVEL_AI = "laravel-ai",
 }
 
 export const integrationSchema = z

--- a/apps/php-sdk/.gitignore
+++ b/apps/php-sdk/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 .phpstan-cache
 phpstan.neon
 .env
+/.phpunit.cache/

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   array; API key and config are reused from the existing Laravel integration.
   Requires `laravel/ai ^0.9` (PHP 8.3+, Laravel 12+) in the consuming app.
 
+### Fixed
+- `scrape()`, `search()`, and `map()` now throw `FirecrawlException` when the API
+  returns an HTTP 200 response with `success: false` (for example DNS resolution
+  failures), instead of silently hydrating an empty result.
+
 ## [1.3.0] - 2026-05-12
 
 ### Added

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Firecrawl PHP SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.9.0] - 2026-07-10
+## [Unreleased]
 
 ### Added
 - Laravel AI SDK integration: native tool classes `FirecrawlScrape`, `FirecrawlSearch`,

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Firecrawl PHP SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-07-10
+
+### Added
+- Laravel AI SDK integration: native tool classes `FirecrawlScrape`, `FirecrawlSearch`,
+  `FirecrawlMap`, and `FirecrawlCrawl` in `Firecrawl\Laravel\Tools`, plus a
+  `FirecrawlTools::all()` helper. Drop them into any `laravel/ai` agent's `tools()`
+  array — API key and config are reused from the existing Laravel integration.
+  Requires `laravel/ai ^0.9` (PHP 8.3+, Laravel 12+) in the consuming app.
+
 ## [1.3.0] - 2026-05-12
 
 ### Added

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Laravel AI SDK integration: native tool classes `FirecrawlScrape`, `FirecrawlSearch`,
   `FirecrawlMap`, and `FirecrawlCrawl` in `Firecrawl\Laravel\Tools`, plus a
   `FirecrawlTools::all()` helper. Drop them into any `laravel/ai` agent's `tools()`
-  array — API key and config are reused from the existing Laravel integration.
+  array; API key and config are reused from the existing Laravel integration.
   Requires `laravel/ai ^0.9` (PHP 8.3+, Laravel 12+) in the consuming app.
 
 ## [1.3.0] - 2026-05-12

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Requires `laravel/ai ^0.9` (PHP 8.3+, Laravel 12+) in the consuming app.
 - `CrawlOptions::with(idempotencyKey:)`: `startCrawl()` now sends the
   `x-idempotency-key` header, matching the existing batch scrape support.
+- `startCrawl()` and `getCrawlStatus()` accept an optional per-request
+  timeout in seconds.
 
 ### Fixed
 - `scrape()`, `search()`, and `map()` now throw `FirecrawlException` when the API

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Firecrawl PHP SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.0] - 2026-07-10
 
 ### Added
 - Laravel AI SDK integration: native tool classes `FirecrawlScrape`, `FirecrawlSearch`,

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FirecrawlTools::all()` helper. Drop them into any `laravel/ai` agent's `tools()`
   array; API key and config are reused from the existing Laravel integration.
   Requires `laravel/ai ^0.9` (PHP 8.3+, Laravel 12+) in the consuming app.
+- `CrawlOptions::with(idempotencyKey:)`: `startCrawl()` now sends the
+  `x-idempotency-key` header, matching the existing batch scrape support.
 
 ### Fixed
 - `scrape()`, `search()`, and `map()` now throw `FirecrawlException` when the API

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -461,11 +461,13 @@ new FirecrawlScrape(FirecrawlClient::create(apiKey: 'fc-other-key'));
 Tool failures (rate limits, timeouts, invalid URLs) are returned to the model
 as readable error strings rather than thrown, so agent runs degrade gracefully.
 
-`firecrawl_crawl` waits up to 55 seconds for the crawl to finish. If your
-agent runs inside a queued job, keep the crawl limit small or raise the
-worker's job timeout; on timeout the model receives a readable message and
-the crawl may still complete on the server. Extend `FirecrawlCrawl` and
-override `$timeoutSeconds` to change how long it waits.
+`firecrawl_crawl` waits up to 55 seconds for the crawl to finish and returns
+a JSON object with the crawl status and pages, so failed or partial crawls
+are visible to the model. If your agent runs inside a queued job, keep the
+crawl limit small or raise the worker's job timeout; on timeout the model
+receives a readable message and the crawl may still complete on the server.
+Extend `FirecrawlCrawl` and override `$timeoutSeconds` to change how long it
+waits.
 
 ## License
 

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -461,6 +461,12 @@ new FirecrawlScrape(FirecrawlClient::create(apiKey: 'fc-other-key'));
 Tool failures (rate limits, timeouts, invalid URLs) are returned to the model
 as readable error strings rather than thrown, so agent runs degrade gracefully.
 
+`firecrawl_crawl` waits up to 55 seconds for the crawl to finish. If your
+agent runs inside a queued job, keep the crawl limit small or raise the
+worker's job timeout, since a killed job orphans a crawl that is still
+running (and billed) on the server. Extend `FirecrawlCrawl` and override
+`$timeoutSeconds` to change how long it waits.
+
 ## License
 
 MIT

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -396,6 +396,9 @@ The SDK ships native tool classes for the [Laravel AI SDK](https://laravel.com/d
 composer require laravel/ai
 ```
 
+Note for contributors: `laravel/ai` is also a dev dependency of this package,
+so running the SDK's own test suite requires PHP 8.3+.
+
 Add Firecrawl capabilities to any agent, no MCP server or manual HTTP calls needed.
 The tools resolve the `FirecrawlClient` from the container, so your existing
 `config/firecrawl.php` / `FIRECRAWL_API_KEY` setup is reused as-is:

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -387,6 +387,80 @@ class MyController
 }
 ```
 
+### Laravel AI SDK Tools
+
+The SDK ships native tool classes for the [Laravel AI SDK](https://laravel.com/docs/ai-sdk)
+(`laravel/ai`, requires PHP 8.3+ and Laravel 12+):
+
+```bash
+composer require laravel/ai
+```
+
+Add Firecrawl capabilities to any agent — no MCP server or manual HTTP calls needed.
+The tools resolve the `FirecrawlClient` from the container, so your existing
+`config/firecrawl.php` / `FIRECRAWL_API_KEY` setup is reused as-is:
+
+```php
+use Firecrawl\Laravel\Tools\FirecrawlScrape;
+use Firecrawl\Laravel\Tools\FirecrawlSearch;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+class ResearchAssistant implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return 'You are a research assistant. Use the Firecrawl tools to find and read web content.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new FirecrawlScrape,
+            new FirecrawlSearch,
+        ];
+    }
+}
+
+$response = ResearchAssistant::make()->prompt('What does firecrawl.dev do?');
+```
+
+Available tools:
+
+| Class | Tool name | Wraps |
+|---|---|---|
+| `FirecrawlScrape` | `firecrawl_scrape` | Scrape one URL to markdown |
+| `FirecrawlSearch` | `firecrawl_search` | Web search with JSON results |
+| `FirecrawlMap` | `firecrawl_map` | Discover a site's URLs |
+| `FirecrawlCrawl` | `firecrawl_crawl` | Crawl multiple pages to markdown |
+
+Register all of them at once with the spread helper:
+
+```php
+use Firecrawl\Laravel\Tools\FirecrawlTools;
+
+public function tools(): iterable
+{
+    return [...FirecrawlTools::all()];
+}
+```
+
+Every tool also accepts an explicit client, for one-off credentials or use
+outside the container:
+
+```php
+use Firecrawl\Client\FirecrawlClient;
+
+new FirecrawlScrape(FirecrawlClient::create(apiKey: 'fc-other-key'));
+```
+
+Tool failures (rate limits, timeouts, invalid URLs) are returned to the model
+as readable error strings rather than thrown, so agent runs degrade gracefully.
+
 ## License
 
 MIT

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -463,9 +463,9 @@ as readable error strings rather than thrown, so agent runs degrade gracefully.
 
 `firecrawl_crawl` waits up to 55 seconds for the crawl to finish. If your
 agent runs inside a queued job, keep the crawl limit small or raise the
-worker's job timeout, since a killed job orphans a crawl that is still
-running (and billed) on the server. Extend `FirecrawlCrawl` and override
-`$timeoutSeconds` to change how long it waits.
+worker's job timeout; on timeout the model receives a readable message and
+the crawl may still complete on the server. Extend `FirecrawlCrawl` and
+override `$timeoutSeconds` to change how long it waits.
 
 ## License
 

--- a/apps/php-sdk/README.md
+++ b/apps/php-sdk/README.md
@@ -396,7 +396,7 @@ The SDK ships native tool classes for the [Laravel AI SDK](https://laravel.com/d
 composer require laravel/ai
 ```
 
-Add Firecrawl capabilities to any agent — no MCP server or manual HTTP calls needed.
+Add Firecrawl capabilities to any agent, no MCP server or manual HTTP calls needed.
 The tools resolve the `FirecrawlClient` from the container, so your existing
 `config/firecrawl.php` / `FIRECRAWL_API_KEY` setup is reused as-is:
 

--- a/apps/php-sdk/composer.json
+++ b/apps/php-sdk/composer.json
@@ -23,6 +23,7 @@
         "friendsofphp/php-cs-fixer": "^3",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
+        "laravel/ai": "^0.9",
         "orchestra/testbench": "^8|^9|^10",
         "pestphp/pest": "^2|^3",
         "phpstan/phpstan": "^1|^2",
@@ -30,7 +31,8 @@
     },
     "suggest": {
         "illuminate/contracts": "Required for Laravel integration (^10.0|^11.0|^12.0)",
-        "illuminate/support": "Required for Laravel integration (^10.0|^11.0|^12.0)"
+        "illuminate/support": "Required for Laravel integration (^10.0|^11.0|^12.0)",
+        "laravel/ai": "Required for the Laravel AI SDK tool classes in Firecrawl\\Laravel\\Tools (^0.9, needs PHP 8.3+ and Laravel 12+)"
     },
     "autoload": {
         "psr-4": {

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -262,11 +262,18 @@ final class FirecrawlClient
     public function startCrawl(string $url, ?CrawlOptions $options = null): CrawlResponse
     {
         $body = ['url' => $url];
+        $extraHeaders = [];
+
         if ($options !== null) {
+            $idempotencyKey = $options->getIdempotencyKey();
+            if ($idempotencyKey !== null && $idempotencyKey !== '') {
+                $extraHeaders['x-idempotency-key'] = $idempotencyKey;
+            }
+
             $body = array_merge($body, $options->toArray());
         }
 
-        return CrawlResponse::fromArray($this->http->post('/v2/crawl', $body));
+        return CrawlResponse::fromArray($this->http->post('/v2/crawl', $body, $extraHeaders));
     }
 
     /**

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -730,6 +730,10 @@ final class FirecrawlClient
     }
 
     /**
+     * The API reports some failures (for example DNS resolution errors) as
+     * HTTP 200 with a `success: false` body, verified against production, so
+     * status-code handling alone is not enough to detect them.
+     *
      * @param array<string, mixed> $response
      * @return array<string, mixed> the same response, if it does not signal failure
      */

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -730,10 +730,9 @@ final class FirecrawlClient
     }
 
     /**
-     * The API intentionally reports some failures (for example DNS resolution
-     * errors) as HTTP 200 with a `success: false` body, so for those the flag,
-     * not the status code, is the error signal. The Python and JS SDKs raise
-     * on it the same way.
+     * The API reports some failures (e.g. DNS resolution errors) as HTTP 200
+     * with a `success: false` body; the flag, not the status code, is the
+     * error signal for those.
      *
      * @param array<string, mixed> $response
      * @return array<string, mixed> the same response, if it does not signal failure

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -730,9 +730,10 @@ final class FirecrawlClient
     }
 
     /**
-     * The API reports some failures (for example DNS resolution errors) as
-     * HTTP 200 with a `success: false` body, verified against production, so
-     * status-code handling alone is not enough to detect them.
+     * The API intentionally reports some failures (for example DNS resolution
+     * errors) as HTTP 200 with a `success: false` body, so for those the flag,
+     * not the status code, is the error signal. The Python and JS SDKs raise
+     * on it the same way.
      *
      * @param array<string, mixed> $response
      * @return array<string, mixed> the same response, if it does not signal failure

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -259,8 +259,11 @@ final class FirecrawlClient
     /**
      * Start an async crawl job and return immediately.
      */
-    public function startCrawl(string $url, ?CrawlOptions $options = null): CrawlResponse
-    {
+    public function startCrawl(
+        string $url,
+        ?CrawlOptions $options = null,
+        ?float $requestTimeoutSeconds = null,
+    ): CrawlResponse {
         $body = ['url' => $url];
         $extraHeaders = [];
 
@@ -273,15 +276,17 @@ final class FirecrawlClient
             $body = array_merge($body, $options->toArray());
         }
 
-        return CrawlResponse::fromArray($this->http->post('/v2/crawl', $body, $extraHeaders));
+        return CrawlResponse::fromArray(
+            $this->http->post('/v2/crawl', $body, $extraHeaders, $requestTimeoutSeconds),
+        );
     }
 
     /**
      * Get the status and results of a crawl job.
      */
-    public function getCrawlStatus(string $jobId): CrawlJob
+    public function getCrawlStatus(string $jobId, ?float $requestTimeoutSeconds = null): CrawlJob
     {
-        return CrawlJob::fromArray($this->http->get("/v2/crawl/{$jobId}"));
+        return CrawlJob::fromArray($this->http->get("/v2/crawl/{$jobId}", $requestTimeoutSeconds));
     }
 
     /**

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -746,6 +746,11 @@ final class FirecrawlClient
      * with a `success: false` body; the flag, not the status code, is the
      * error signal for those.
      *
+     * Only the synchronous endpoints (scrape, search, map) run this check.
+     * Async crawl responses skip it deliberately: a failed start yields a
+     * null job ID that callers guard (pollCrawl() throws on it), and status
+     * polling exposes `status` explicitly on CrawlJob.
+     *
      * @param array<string, mixed> $response
      * @return array<string, mixed> the same response, if it does not signal failure
      */

--- a/apps/php-sdk/src/Client/FirecrawlClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlClient.php
@@ -112,7 +112,7 @@ final class FirecrawlClient
         }
         $body['origin'] ??= 'php-sdk@' . Version::SDK_VERSION;
 
-        $response = $this->http->post('/v2/scrape', $body);
+        $response = $this->assertSuccess($this->http->post('/v2/scrape', $body));
 
         return Document::fromArray($response['data'] ?? $response);
     }
@@ -387,7 +387,7 @@ final class FirecrawlClient
             $body = array_merge($body, $options->toArray());
         }
 
-        $response = $this->http->post('/v2/map', $body);
+        $response = $this->assertSuccess($this->http->post('/v2/map', $body));
 
         return MapData::fromArray($response['data'] ?? $response);
     }
@@ -554,7 +554,7 @@ final class FirecrawlClient
         }
         $body['origin'] ??= 'php-sdk@' . Version::SDK_VERSION;
 
-        $response = $this->http->post('/v2/search', $body);
+        $response = $this->assertSuccess($this->http->post('/v2/search', $body));
 
         return SearchData::fromArray($response['data'] ?? $response);
     }
@@ -727,6 +727,23 @@ final class FirecrawlClient
         if ($pollIntervalSec < 1) {
             throw new FirecrawlException('Poll interval must be at least 1 second, got ' . $pollIntervalSec);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $response
+     * @return array<string, mixed> the same response, if it does not signal failure
+     */
+    private function assertSuccess(array $response): array
+    {
+        if (($response['success'] ?? null) === false) {
+            $error = $response['error'] ?? null;
+
+            throw new FirecrawlException(is_string($error) && $error !== ''
+                ? $error
+                : 'The API reported the request as unsuccessful.');
+        }
+
+        return $response;
     }
 
     /**

--- a/apps/php-sdk/src/Client/FirecrawlHttpClient.php
+++ b/apps/php-sdk/src/Client/FirecrawlHttpClient.php
@@ -44,15 +44,15 @@ final class FirecrawlHttpClient
      * @param array<string, string> $extraHeaders
      * @return array<string, mixed>
      */
-    public function post(string $path, array $body, array $extraHeaders = []): array
+    public function post(string $path, array $body, array $extraHeaders = [], ?float $timeoutSeconds = null): array
     {
-        return $this->request('POST', $this->baseUrl . $path, $body, $extraHeaders);
+        return $this->request('POST', $this->baseUrl . $path, $body, $extraHeaders, timeoutSeconds: $timeoutSeconds);
     }
 
     /** @return array<string, mixed> */
-    public function get(string $path): array
+    public function get(string $path, ?float $timeoutSeconds = null): array
     {
-        return $this->request('GET', $this->baseUrl . $path);
+        return $this->request('GET', $this->baseUrl . $path, timeoutSeconds: $timeoutSeconds);
     }
 
     /** @return array<string, mixed> */
@@ -134,6 +134,7 @@ final class FirecrawlHttpClient
         array $body = [],
         array $extraHeaders = [],
         ?array $multipart = null,
+        ?float $timeoutSeconds = null,
     ): array {
         $defaultHeaders = [
             'Accept' => 'application/json',
@@ -155,6 +156,10 @@ final class FirecrawlHttpClient
             RequestOptions::HEADERS => $headers,
             RequestOptions::HTTP_ERRORS => false,
         ];
+
+        if ($timeoutSeconds !== null) {
+            $options[RequestOptions::TIMEOUT] = $timeoutSeconds;
+        }
 
         if ($multipart !== null) {
             $options[RequestOptions::MULTIPART] = $multipart;

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -16,7 +16,8 @@ class FirecrawlCrawl extends FirecrawlTool
     /**
      * Extenders can override this to wait longer, but the default keeps the
      * crawl inside typical queue worker timeouts (e.g. Laravel's default of
-     * 60 seconds) so a billed crawl is not orphaned when the job is killed.
+     * 60 seconds) so the tool returns a readable timeout message instead of
+     * dying with the job.
      */
     protected int $timeoutSeconds = 55;
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Firecrawl\Laravel\Tools;
 
-use Firecrawl\Exceptions\JobTimeoutException;
+use Firecrawl\Exceptions\FirecrawlException;
+use Firecrawl\Models\CrawlJob;
 use Firecrawl\Models\CrawlOptions;
-use Firecrawl\Models\Document;
 use Firecrawl\Models\ScrapeOptions;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Tools\Request;
@@ -14,10 +14,16 @@ use Laravel\Ai\Tools\Request;
 class FirecrawlCrawl extends FirecrawlTool
 {
     /**
+     * One wall-clock deadline covering the start request and all polling.
      * Kept below typical queue worker timeouts (Laravel defaults to 60
      * seconds); override to wait longer.
      */
     protected int $timeoutSeconds = 55;
+
+    protected int $pollIntervalSeconds = 2;
+
+    /** Per-page output ceiling; override to change. */
+    protected int $pageCharacterLimit = 15000;
 
     public function name(): string
     {
@@ -26,46 +32,96 @@ class FirecrawlCrawl extends FirecrawlTool
 
     public function description(): string
     {
-        return 'Crawl a website with Firecrawl starting from a URL, following its links and returning '
-            . 'each crawled page as a {url, markdown} object in a JSON array. This is a slower, '
-            . 'multi-page operation. Prefer firecrawl_scrape when you only need one known page, and '
-            . 'keep the page limit small. Waits up to about a minute for the crawl to finish.';
+        return 'Crawl a website with Firecrawl starting from a URL, following its links. Returns a '
+            . 'JSON object with the crawl status and a pages array of {url, markdown} objects. This '
+            . 'is a slower, multi-page operation. Prefer firecrawl_scrape when you only need one '
+            . 'known page, and keep the page limit small. Waits up to about a minute.';
     }
 
     public function handle(Request $request): string
     {
         return $this->guard(function () use ($request): string {
             $limit = min(max($request->integer('limit') ?: 5, 1), 25);
+            $deadline = time() + $this->timeoutSeconds;
 
-            try {
-                $job = $this->client()->crawl(
-                    (string) $request->string('url'),
-                    CrawlOptions::with(
-                        limit: $limit,
-                        scrapeOptions: ScrapeOptions::with(formats: ['markdown']),
-                        integration: self::INTEGRATION,
-                    ),
-                    timeoutSec: $this->timeoutSeconds,
-                );
-            } catch (JobTimeoutException) {
-                return "The crawl did not finish within {$this->timeoutSeconds} seconds. It may still "
-                    . 'complete on the server. Use a smaller limit, or scrape key pages individually '
-                    . 'with firecrawl_scrape.';
+            $start = $this->client()->startCrawl(
+                (string) $request->string('url'),
+                CrawlOptions::with(
+                    limit: $limit,
+                    scrapeOptions: ScrapeOptions::with(formats: ['markdown']),
+                    integration: self::INTEGRATION,
+                    idempotencyKey: bin2hex(random_bytes(16)),
+                ),
+            );
+
+            $jobId = $start->getId();
+            if ($jobId === null || $jobId === '') {
+                throw new FirecrawlException('Crawl start did not return a job ID.');
             }
 
-            $pages = array_map(fn (Document $document): array => [
+            $job = $this->client()->getCrawlStatus($jobId);
+
+            while (!$job->isDone()) {
+                if (time() >= $deadline) {
+                    return "The crawl did not finish within {$this->timeoutSeconds} seconds. It may still "
+                        . 'complete on the server. Use a smaller limit, or scrape key pages individually '
+                        . 'with firecrawl_scrape.';
+                }
+
+                sleep($this->pollIntervalSeconds);
+                $job = $this->client()->getCrawlStatus($jobId);
+            }
+
+            return $this->toJson($this->formatJob($job));
+        });
+    }
+
+    /**
+     * The status field keeps failed or cancelled crawls visible even when
+     * partial pages came back. Pagination cursors are reported, not
+     * followed, so the result stays one bounded response.
+     *
+     * @return array<string, mixed>
+     */
+    private function formatJob(CrawlJob $job): array
+    {
+        $pages = [];
+        $used = 0;
+        $omitted = 0;
+
+        foreach ($job->getData() as $document) {
+            $markdown = $this->truncate($this->documentContent($document), $this->pageCharacterLimit);
+
+            if ($pages !== [] && $used + mb_strlen($markdown) > $this->outputCharacterBudget) {
+                $omitted++;
+                continue;
+            }
+
+            $used += mb_strlen($markdown);
+            $pages[] = [
                 'url' => $document->getMetadata()['sourceURL']
                     ?? $document->getMetadata()['url']
                     ?? null,
-                'markdown' => $this->truncate($this->documentContent($document), 15000),
-            ], $job->getData());
+                'markdown' => $markdown,
+            ];
+        }
 
-            if ($pages === []) {
-                return "Crawl finished with status [{$job->getStatus()}] but returned no pages.";
-            }
+        $result = [
+            'status' => $job->getStatus(),
+            'completed' => $job->getCompleted(),
+            'total' => $job->getTotal(),
+            'pages' => $pages,
+        ];
 
-            return $this->toJson($pages);
-        });
+        if ($omitted > 0) {
+            $result['omittedPages'] = $omitted;
+        }
+
+        if ($job->getNext() !== null && $job->getNext() !== '') {
+            $result['note'] = 'More pages exist on the server than fit in this response.';
+        }
+
+        return $result;
     }
 
     /** @return array<string, \Illuminate\JsonSchema\Types\Type> */

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -14,9 +14,8 @@ use Laravel\Ai\Tools\Request;
 class FirecrawlCrawl extends FirecrawlTool
 {
     /**
-     * One wall-clock deadline covering the start request and all polling.
-     * Kept below typical queue worker timeouts (Laravel defaults to 60
-     * seconds); override to wait longer.
+     * Wall-clock limit for the start request and polling, kept below typical
+     * queue worker timeouts (Laravel defaults to 60 seconds).
      */
     protected int $timeoutSeconds = 55;
 
@@ -89,9 +88,8 @@ class FirecrawlCrawl extends FirecrawlTool
     }
 
     /**
-     * The status field keeps failed or cancelled crawls visible even when
-     * partial pages came back. Pagination cursors are reported, not
-     * followed, so the result stays one bounded response.
+     * Failed or cancelled crawls stay visible through the status field.
+     * Pagination cursors are reported, not followed.
      *
      * @return array<string, mixed>
      */

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -43,7 +43,7 @@ class FirecrawlCrawl extends FirecrawlTool
                 'url' => $document->getMetadata()['sourceURL']
                     ?? $document->getMetadata()['url']
                     ?? null,
-                'markdown' => $this->documentContent($document),
+                'markdown' => $this->truncate($this->documentContent($document), 15000),
             ], $job->getData());
 
             if ($pages === []) {

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -51,6 +51,7 @@ class FirecrawlCrawl extends FirecrawlTool
                     integration: self::INTEGRATION,
                     idempotencyKey: $this->newIdempotencyKey(),
                 ),
+                requestTimeoutSeconds: $this->remainingSeconds($deadline),
             );
 
             $jobId = $start->getId();
@@ -58,7 +59,7 @@ class FirecrawlCrawl extends FirecrawlTool
                 throw new FirecrawlException('Crawl start did not return a job ID.');
             }
 
-            $job = $this->client()->getCrawlStatus($jobId);
+            $job = $this->client()->getCrawlStatus($jobId, $this->remainingSeconds($deadline));
 
             while (!$job->isDone()) {
                 if (time() >= $deadline) {
@@ -68,11 +69,16 @@ class FirecrawlCrawl extends FirecrawlTool
                 }
 
                 sleep($this->pollIntervalSeconds);
-                $job = $this->client()->getCrawlStatus($jobId);
+                $job = $this->client()->getCrawlStatus($jobId, $this->remainingSeconds($deadline));
             }
 
             return $this->toJson($this->formatJob($job));
         });
+    }
+
+    private function remainingSeconds(int $deadline): float
+    {
+        return (float) max($deadline - time(), 1);
     }
 
     /**
@@ -100,20 +106,21 @@ class FirecrawlCrawl extends FirecrawlTool
         $omitted = 0;
 
         foreach ($job->getData() as $document) {
-            $markdown = $this->truncate($this->documentContent($document), $this->pageCharacterLimit);
+            $page = [
+                'url' => $document->getMetadata()['sourceURL']
+                    ?? $document->getMetadata()['url']
+                    ?? null,
+                'markdown' => $this->truncate($this->documentContent($document), $this->pageCharacterLimit),
+            ];
+            $length = mb_strlen($this->toJson($page));
 
-            if ($pages !== [] && $used + mb_strlen($markdown) > $this->outputCharacterBudget) {
+            if ($pages !== [] && $used + $length > $this->outputCharacterBudget) {
                 $omitted++;
                 continue;
             }
 
-            $used += mb_strlen($markdown);
-            $pages[] = [
-                'url' => $document->getMetadata()['sourceURL']
-                    ?? $document->getMetadata()['url']
-                    ?? null,
-                'markdown' => $markdown,
-            ];
+            $used += $length;
+            $pages[] = $page;
         }
 
         $result = [
@@ -128,7 +135,8 @@ class FirecrawlCrawl extends FirecrawlTool
         }
 
         if ($job->getNext() !== null && $job->getNext() !== '') {
-            $result['note'] = 'More pages exist on the server than fit in this response.';
+            $result['note'] = 'More pages exist on the server than fit in this response. '
+                . 'Use a smaller limit or scrape specific pages with firecrawl_scrape.';
         }
 
         return $result;

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -50,7 +50,7 @@ class FirecrawlCrawl extends FirecrawlTool
                     limit: $limit,
                     scrapeOptions: ScrapeOptions::with(formats: ['markdown']),
                     integration: self::INTEGRATION,
-                    idempotencyKey: bin2hex(random_bytes(16)),
+                    idempotencyKey: $this->newIdempotencyKey(),
                 ),
             );
 
@@ -74,6 +74,18 @@ class FirecrawlCrawl extends FirecrawlTool
 
             return $this->toJson($this->formatJob($job));
         });
+    }
+
+    /**
+     * The API only accepts UUID-formatted idempotency keys.
+     */
+    private function newIdempotencyKey(): string
+    {
+        $bytes = random_bytes(16);
+        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x40);
+        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($bytes), 4));
     }
 
     /**

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firecrawl\Laravel\Tools;
 
+use Firecrawl\Exceptions\JobTimeoutException;
 use Firecrawl\Models\CrawlOptions;
 use Firecrawl\Models\Document;
 use Firecrawl\Models\ScrapeOptions;
@@ -12,6 +13,13 @@ use Laravel\Ai\Tools\Request;
 
 class FirecrawlCrawl extends FirecrawlTool
 {
+    /**
+     * Extenders can override this to wait longer, but the default keeps the
+     * crawl inside typical queue worker timeouts (e.g. Laravel's default of
+     * 60 seconds) so a billed crawl is not orphaned when the job is killed.
+     */
+    protected int $timeoutSeconds = 55;
+
     public function name(): string
     {
         return 'firecrawl_crawl';
@@ -21,8 +29,8 @@ class FirecrawlCrawl extends FirecrawlTool
     {
         return 'Crawl a website with Firecrawl starting from a URL, following its links and returning '
             . 'each crawled page as a {url, markdown} object in a JSON array. This is a slower, '
-            . 'multi-page operation that waits for the crawl to finish. Prefer firecrawl_scrape when '
-            . 'you only need one known page, and keep the page limit small.';
+            . 'multi-page operation. Prefer firecrawl_scrape when you only need one known page, and '
+            . 'keep the page limit small. Waits up to about a minute for the crawl to finish.';
     }
 
     public function handle(Request $request): string
@@ -30,14 +38,21 @@ class FirecrawlCrawl extends FirecrawlTool
         return $this->guard(function () use ($request): string {
             $limit = min(max($request->integer('limit') ?: 5, 1), 25);
 
-            $job = $this->client()->crawl(
-                (string) $request->string('url'),
-                CrawlOptions::with(
-                    limit: $limit,
-                    scrapeOptions: ScrapeOptions::with(formats: ['markdown']),
-                    integration: self::INTEGRATION,
-                ),
-            );
+            try {
+                $job = $this->client()->crawl(
+                    (string) $request->string('url'),
+                    CrawlOptions::with(
+                        limit: $limit,
+                        scrapeOptions: ScrapeOptions::with(formats: ['markdown']),
+                        integration: self::INTEGRATION,
+                    ),
+                    timeoutSec: $this->timeoutSeconds,
+                );
+            } catch (JobTimeoutException) {
+                return "The crawl did not finish within {$this->timeoutSeconds} seconds. It may still "
+                    . 'complete on the server. Use a smaller limit, or scrape key pages individually '
+                    . 'with firecrawl_scrape.';
+            }
 
             $pages = array_map(fn (Document $document): array => [
                 'url' => $document->getMetadata()['sourceURL']

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -14,10 +14,8 @@ use Laravel\Ai\Tools\Request;
 class FirecrawlCrawl extends FirecrawlTool
 {
     /**
-     * Extenders can override this to wait longer, but the default keeps the
-     * crawl inside typical queue worker timeouts (e.g. Laravel's default of
-     * 60 seconds) so the tool returns a readable timeout message instead of
-     * dying with the job.
+     * Kept below typical queue worker timeouts (Laravel defaults to 60
+     * seconds); override to wait longer.
      */
     protected int $timeoutSeconds = 55;
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -21,7 +21,7 @@ class FirecrawlCrawl extends FirecrawlTool
     {
         return 'Crawl a website with Firecrawl starting from a URL, following its links and returning '
             . 'each crawled page as a {url, markdown} object in a JSON array. This is a slower, '
-            . 'multi-page operation that waits for the crawl to finish — prefer firecrawl_scrape when '
+            . 'multi-page operation that waits for the crawl to finish. Prefer firecrawl_scrape when '
             . 'you only need one known page, and keep the page limit small.';
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firecrawl\Laravel\Tools;
+
+use Firecrawl\Models\CrawlOptions;
+use Firecrawl\Models\Document;
+use Firecrawl\Models\ScrapeOptions;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+
+class FirecrawlCrawl extends FirecrawlTool
+{
+    public function name(): string
+    {
+        return 'firecrawl_crawl';
+    }
+
+    public function description(): string
+    {
+        return 'Crawl a website with Firecrawl starting from a URL, following its links and returning '
+            . 'each crawled page as a {url, markdown} object in a JSON array. This is a slower, '
+            . 'multi-page operation that waits for the crawl to finish — prefer firecrawl_scrape when '
+            . 'you only need one known page, and keep the page limit small.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return $this->guard(function () use ($request): string {
+            $limit = min(max($request->integer('limit') ?: 5, 1), 25);
+
+            $job = $this->client()->crawl(
+                (string) $request->string('url'),
+                CrawlOptions::with(
+                    limit: $limit,
+                    scrapeOptions: ScrapeOptions::with(formats: ['markdown']),
+                    integration: self::INTEGRATION,
+                ),
+            );
+
+            $pages = array_map(fn (Document $document): array => [
+                'url' => $document->getMetadata()['sourceURL']
+                    ?? $document->getMetadata()['url']
+                    ?? null,
+                'markdown' => $this->documentContent($document),
+            ], $job->getData());
+
+            if ($pages === []) {
+                return "Crawl finished with status [{$job->getStatus()}] but returned no pages.";
+            }
+
+            return json_encode($pages, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        });
+    }
+
+    /** @return array<string, \Illuminate\JsonSchema\Types\Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema->string()
+                ->description('The URL to start crawling from (e.g. https://example.com/docs).')
+                ->required(),
+            'limit' => $schema->integer()->min(1)->max(25)
+                ->description('Maximum number of pages to crawl. Defaults to 5, capped at 25 to keep responses manageable.'),
+        ];
+    }
+}

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlCrawl.php
@@ -50,7 +50,7 @@ class FirecrawlCrawl extends FirecrawlTool
                 return "Crawl finished with status [{$job->getStatus()}] but returned no pages.";
             }
 
-            return json_encode($pages, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+            return $this->toJson($pages);
         });
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
@@ -37,12 +37,12 @@ class FirecrawlMap extends FirecrawlTool
                 ),
             );
 
-            $links = array_values(array_map(static function (array $link): array {
+            $links = array_map(static function (array $link): array {
                 return array_filter(
                     ['url' => $link['url'] ?? null, 'title' => $link['title'] ?? null],
                     static fn (mixed $value): bool => $value !== null,
                 );
-            }, $map->getLinks()));
+            }, $map->getLinks());
 
             if ($links === []) {
                 return 'No URLs discovered.';

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
@@ -18,8 +18,8 @@ class FirecrawlMap extends FirecrawlTool
     public function description(): string
     {
         return 'Map a website with Firecrawl to discover the URLs it contains, returned as a JSON '
-            . 'array of {url, title} objects. Use this to find pages on a specific site — optionally '
-            . 'filtered by a search term — before scraping or crawling them.';
+            . 'array of {url, title} objects. Use this to find pages on a specific site, optionally '
+            . 'filtered by a search term, before scraping or crawling them.';
     }
 
     public function handle(Request $request): string

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
@@ -48,7 +48,7 @@ class FirecrawlMap extends FirecrawlTool
                 return 'No URLs discovered.';
             }
 
-            return $this->toJson($links);
+            return $this->toBudgetedJson($links);
         });
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firecrawl\Laravel\Tools;
+
+use Firecrawl\Models\MapOptions;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+
+class FirecrawlMap extends FirecrawlTool
+{
+    public function name(): string
+    {
+        return 'firecrawl_map';
+    }
+
+    public function description(): string
+    {
+        return 'Map a website with Firecrawl to discover the URLs it contains, returned as a JSON '
+            . 'array of {url, title} objects. Use this to find pages on a specific site — optionally '
+            . 'filtered by a search term — before scraping or crawling them.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return $this->guard(function () use ($request): string {
+            $limit = min(max($request->integer('limit') ?: 100, 1), 5000);
+            $search = (string) $request->string('search');
+
+            $map = $this->client()->map(
+                (string) $request->string('url'),
+                MapOptions::with(
+                    search: $search !== '' ? $search : null,
+                    limit: $limit,
+                    integration: self::INTEGRATION,
+                ),
+            );
+
+            $links = array_values(array_map(static function (array $link): array {
+                return array_filter(
+                    ['url' => $link['url'] ?? null, 'title' => $link['title'] ?? null],
+                    static fn (mixed $value): bool => $value !== null,
+                );
+            }, $map->getLinks()));
+
+            if ($links === []) {
+                return 'No URLs discovered.';
+            }
+
+            return json_encode($links, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        });
+    }
+
+    /** @return array<string, \Illuminate\JsonSchema\Types\Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema->string()
+                ->description('The base URL of the website to map (e.g. https://example.com).')
+                ->required(),
+            'search' => $schema->string()
+                ->description('Optional term to filter the discovered URLs by relevance (e.g. "docs").'),
+            'limit' => $schema->integer()->min(1)->max(5000)
+                ->description('Maximum number of URLs to return. Defaults to 100.'),
+        ];
+    }
+}

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
@@ -48,7 +48,7 @@ class FirecrawlMap extends FirecrawlTool
                 return 'No URLs discovered.';
             }
 
-            return json_encode($links, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+            return $this->toJson($links);
         });
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlMap.php
@@ -25,7 +25,7 @@ class FirecrawlMap extends FirecrawlTool
     public function handle(Request $request): string
     {
         return $this->guard(function () use ($request): string {
-            $limit = min(max($request->integer('limit') ?: 100, 1), 5000);
+            $limit = min(max($request->integer('limit') ?: 100, 1), 500);
             $search = (string) $request->string('search');
 
             $map = $this->client()->map(
@@ -61,7 +61,7 @@ class FirecrawlMap extends FirecrawlTool
                 ->required(),
             'search' => $schema->string()
                 ->description('Optional term to filter the discovered URLs by relevance (e.g. "docs").'),
-            'limit' => $schema->integer()->min(1)->max(5000)
+            'limit' => $schema->integer()->min(1)->max(500)
                 ->description('Maximum number of URLs to return. Defaults to 100.'),
         ];
     }

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlScrape.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlScrape.php
@@ -33,7 +33,7 @@ class FirecrawlScrape extends FirecrawlTool
                 ),
             );
 
-            return $this->documentContent($document);
+            return $this->truncate($this->documentContent($document), 80000);
         });
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlScrape.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlScrape.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firecrawl\Laravel\Tools;
+
+use Firecrawl\Models\ScrapeOptions;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+
+class FirecrawlScrape extends FirecrawlTool
+{
+    public function name(): string
+    {
+        return 'firecrawl_scrape';
+    }
+
+    public function description(): string
+    {
+        return 'Scrape a single web page with Firecrawl and return its content as clean markdown. '
+            . 'Use this when you already know the URL of the page you need to read. '
+            . 'Handles JavaScript-rendered pages, PDFs, and pages behind anti-bot protection.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return $this->guard(function () use ($request): string {
+            $document = $this->client()->scrape(
+                (string) $request->string('url'),
+                ScrapeOptions::with(
+                    formats: ['markdown'],
+                    integration: self::INTEGRATION,
+                ),
+            );
+
+            return $this->documentContent($document);
+        });
+    }
+
+    /** @return array<string, \Illuminate\JsonSchema\Types\Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'url' => $schema->string()
+                ->description('The absolute URL of the page to scrape, including the scheme (e.g. https://example.com/pricing).')
+                ->required(),
+        ];
+    }
+}

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlSearch.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlSearch.php
@@ -42,7 +42,7 @@ class FirecrawlSearch extends FirecrawlTool
                 return 'No results found.';
             }
 
-            return $this->toJson($web);
+            return $this->toBudgetedJson($web);
         });
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlSearch.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlSearch.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firecrawl\Laravel\Tools;
+
+use Firecrawl\Models\SearchOptions;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+
+class FirecrawlSearch extends FirecrawlTool
+{
+    public function name(): string
+    {
+        return 'firecrawl_search';
+    }
+
+    public function description(): string
+    {
+        return 'Search the web with Firecrawl and return matching results as a JSON array of '
+            . '{title, url, description} objects. Use this to find relevant pages when you do not '
+            . 'already know the URL. Follow up with firecrawl_scrape to read the full content of a result.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return $this->guard(function () use ($request): string {
+            $limit = min(max($request->integer('limit') ?: 5, 1), 20);
+
+            $results = $this->client()->search(
+                (string) $request->string('query'),
+                SearchOptions::with(limit: $limit, integration: self::INTEGRATION),
+            );
+
+            $web = array_map(static fn (array $item): array => [
+                'title' => $item['title'] ?? null,
+                'url' => $item['url'] ?? null,
+                'description' => $item['description'] ?? null,
+            ], $results->getWeb());
+
+            if ($web === []) {
+                return 'No results found.';
+            }
+
+            return json_encode($web, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        });
+    }
+
+    /** @return array<string, \Illuminate\JsonSchema\Types\Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()
+                ->description('The search query.')
+                ->required(),
+            'limit' => $schema->integer()->min(1)->max(20)
+                ->description('Maximum number of results to return. Defaults to 5.'),
+        ];
+    }
+}

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlSearch.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlSearch.php
@@ -42,7 +42,7 @@ class FirecrawlSearch extends FirecrawlTool
                 return 'No results found.';
             }
 
-            return json_encode($web, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+            return $this->toJson($web);
         });
     }
 

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -12,7 +12,11 @@ use Laravel\Ai\Contracts\Tool;
 
 abstract class FirecrawlTool implements Tool
 {
-    protected const INTEGRATION = 'laravel-ai';
+    // Prefixed with an underscore because the API's integration validator
+    // accepts any value starting with `_` on every deployed version, letting
+    // these tools work against lagging or self-hosted APIs with no deploy
+    // ordering requirement.
+    protected const INTEGRATION = '_laravel-ai';
 
     public function __construct(
         private ?FirecrawlClient $client = null,

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -52,8 +52,8 @@ abstract class FirecrawlTool implements Tool
     }
 
     /**
-     * Encode list items as JSON, dropping tail items when the result would
-     * exceed the output budget; a final {"omitted": N} element reports the cut.
+     * Drop tail items when the JSON would exceed the output budget; a final
+     * {"omitted": N} element reports the cut.
      *
      * @param list<array<string, mixed>> $items
      */

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firecrawl\Laravel\Tools;
+
+use Firecrawl\Client\FirecrawlClient;
+use Firecrawl\Exceptions\FirecrawlException;
+use Firecrawl\Models\Document;
+use Illuminate\Container\Container;
+use Laravel\Ai\Contracts\Tool;
+
+abstract class FirecrawlTool implements Tool
+{
+    protected const INTEGRATION = 'laravel-ai';
+
+    public function __construct(
+        private ?FirecrawlClient $client = null,
+    ) {}
+
+    protected function client(): FirecrawlClient
+    {
+        if ($this->client === null) {
+            /** @var FirecrawlClient $resolved */
+            $resolved = Container::getInstance()->make(FirecrawlClient::class);
+            $this->client = $resolved;
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * Run a Firecrawl call, returning failures as strings so the model can
+     * see the error and recover instead of aborting the whole agent run.
+     *
+     * @param callable(): string $callback
+     */
+    protected function guard(callable $callback): string
+    {
+        try {
+            return $callback();
+        } catch (FirecrawlException $exception) {
+            return 'Firecrawl request failed: ' . $exception->getMessage();
+        }
+    }
+
+    protected function documentContent(Document $document): string
+    {
+        $content = $document->getMarkdown()
+            ?? $document->getSummary()
+            ?? $document->getHtml()
+            ?? '';
+
+        if ($content === '') {
+            return 'No content was returned for this page.';
+        }
+
+        $warning = $document->getWarning();
+
+        return $warning !== null ? "Warning: {$warning}\n\n{$content}" : $content;
+    }
+}

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -32,6 +32,8 @@ abstract class FirecrawlTool implements Tool
     /**
      * Run a Firecrawl call, returning failures as strings so the model can
      * see the error and recover instead of aborting the whole agent run.
+     * Non-SDK failures (e.g. container resolution, JSON encoding) are also
+     * converted to strings so `handle()` never throws.
      *
      * @param callable(): string $callback
      */
@@ -41,7 +43,18 @@ abstract class FirecrawlTool implements Tool
             return $callback();
         } catch (FirecrawlException $exception) {
             return 'Firecrawl request failed: ' . $exception->getMessage();
+        } catch (\Throwable $exception) {
+            return 'Tool execution failed: ' . $exception->getMessage();
         }
+    }
+
+    /** @param array<int|string, mixed> $data */
+    protected function toJson(array $data): string
+    {
+        return json_encode(
+            $data,
+            JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR,
+        );
     }
 
     protected function documentContent(Document $document): string

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -16,6 +16,9 @@ abstract class FirecrawlTool implements Tool
     // deployed version, including older self-hosted instances.
     protected const INTEGRATION = '_laravel-ai';
 
+    /** Whole-result output ceiling; override to change. */
+    protected int $outputCharacterBudget = 100000;
+
     public function __construct(
         private ?FirecrawlClient $client = null,
     ) {}
@@ -46,6 +49,25 @@ abstract class FirecrawlTool implements Tool
         } catch (\Throwable $exception) {
             return 'Tool execution failed: ' . $exception->getMessage();
         }
+    }
+
+    /**
+     * Encode list items as JSON, dropping tail items when the result would
+     * exceed the output budget; a final {"omitted": N} element reports the cut.
+     *
+     * @param list<array<string, mixed>> $items
+     */
+    protected function toBudgetedJson(array $items): string
+    {
+        $json = $this->toJson($items);
+        $total = count($items);
+
+        while (mb_strlen($json) > $this->outputCharacterBudget && count($items) > 1) {
+            $items = array_slice($items, 0, (int) ceil(count($items) / 2));
+            $json = $this->toJson([...$items, ['omitted' => $total - count($items)]]);
+        }
+
+        return $json;
     }
 
     /** @param array<int|string, mixed> $data */

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -32,10 +32,8 @@ abstract class FirecrawlTool implements Tool
     }
 
     /**
-     * Run a Firecrawl call, returning failures as strings so the model can
-     * see the error and recover instead of aborting the whole agent run.
-     * Non-SDK failures (e.g. container resolution, JSON encoding) are also
-     * converted to strings so `handle()` never throws.
+     * Convert any failure into a readable string so `handle()` never throws
+     * and aborts the agent run.
      *
      * @param callable(): string $callback
      */
@@ -76,8 +74,7 @@ abstract class FirecrawlTool implements Tool
     }
 
     /**
-     * Trim tool output so a large page cannot overflow the model context
-     * or the consumer's conversation storage.
+     * Trim tool output so large pages do not overflow the model context.
      */
     protected function truncate(string $content, int $maxCharacters): string
     {

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -76,4 +76,20 @@ abstract class FirecrawlTool implements Tool
 
         return $warning !== null ? "Warning: {$warning}\n\n{$content}" : $content;
     }
+
+    /**
+     * Trim tool output so a large page cannot overflow the model context
+     * or the consumer's conversation storage.
+     */
+    protected function truncate(string $content, int $maxCharacters): string
+    {
+        if (mb_strlen($content) <= $maxCharacters) {
+            return $content;
+        }
+
+        $total = mb_strlen($content);
+
+        return mb_substr($content, 0, $maxCharacters)
+            . "\n\n[Truncated: showing the first {$maxCharacters} of {$total} characters.]";
+    }
 }

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -12,10 +12,8 @@ use Laravel\Ai\Contracts\Tool;
 
 abstract class FirecrawlTool implements Tool
 {
-    // Prefixed with an underscore because the API's integration validator
-    // accepts any value starting with `_` on every deployed version, letting
-    // these tools work against lagging or self-hosted APIs with no deploy
-    // ordering requirement.
+    // The underscore prefix passes the API's integration validator on every
+    // deployed version, including older self-hosted instances.
     protected const INTEGRATION = '_laravel-ai';
 
     public function __construct(

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTool.php
@@ -67,6 +67,10 @@ abstract class FirecrawlTool implements Tool
             $json = $this->toJson([...$items, ['omitted' => $total - count($items)]]);
         }
 
+        if (mb_strlen($json) > $this->outputCharacterBudget) {
+            $json = $this->toJson([['omitted' => $total]]);
+        }
+
         return $json;
     }
 
@@ -97,6 +101,7 @@ abstract class FirecrawlTool implements Tool
 
     /**
      * Trim tool output so large pages do not overflow the model context.
+     * The truncation notice fits inside the cap.
      */
     protected function truncate(string $content, int $maxCharacters): string
     {
@@ -105,8 +110,12 @@ abstract class FirecrawlTool implements Tool
         }
 
         $total = mb_strlen($content);
+        $suffix = "\n\n[Truncated: {$total} characters total.]";
 
-        return mb_substr($content, 0, $maxCharacters)
-            . "\n\n[Truncated: showing the first {$maxCharacters} of {$total} characters.]";
+        if ($maxCharacters <= mb_strlen($suffix)) {
+            return mb_substr($content, 0, $maxCharacters);
+        }
+
+        return mb_substr($content, 0, $maxCharacters - mb_strlen($suffix)) . $suffix;
     }
 }

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTools.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTools.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firecrawl\Laravel\Tools;
+
+use Firecrawl\Client\FirecrawlClient;
+
+final class FirecrawlTools
+{
+    private function __construct() {}
+
+    /**
+     * All core Firecrawl tools, ready to spread into an agent's tools() array:
+     * `return [...FirecrawlTools::all()];`
+     *
+     * @return list<FirecrawlTool>
+     */
+    public static function all(?FirecrawlClient $client = null): array
+    {
+        return [
+            new FirecrawlScrape($client),
+            new FirecrawlSearch($client),
+            new FirecrawlMap($client),
+            new FirecrawlCrawl($client),
+        ];
+    }
+}

--- a/apps/php-sdk/src/Laravel/Tools/FirecrawlTools.php
+++ b/apps/php-sdk/src/Laravel/Tools/FirecrawlTools.php
@@ -11,8 +11,7 @@ final class FirecrawlTools
     private function __construct() {}
 
     /**
-     * All core Firecrawl tools, ready to spread into an agent's tools() array:
-     * `return [...FirecrawlTools::all()];`
+     * All core Firecrawl tools, ready to spread into an agent's tools() array.
      *
      * @return list<FirecrawlTool>
      */

--- a/apps/php-sdk/src/Models/CrawlOptions.php
+++ b/apps/php-sdk/src/Models/CrawlOptions.php
@@ -29,6 +29,7 @@ final class CrawlOptions
         private readonly ?bool $regexOnFullURL = null,
         private readonly ?bool $zeroDataRetention = null,
         private readonly ?string $integration = null,
+        private readonly ?string $idempotencyKey = null,
     ) {}
 
     /**
@@ -54,13 +55,20 @@ final class CrawlOptions
         ?bool $regexOnFullURL = null,
         ?bool $zeroDataRetention = null,
         ?string $integration = null,
+        ?string $idempotencyKey = null,
     ): self {
         return new self(
             $prompt, $excludePaths, $includePaths, $maxDiscoveryDepth, $sitemap,
             $ignoreQueryParameters, $deduplicateSimilarURLs, $limit, $crawlEntireDomain,
             $allowExternalLinks, $allowSubdomains, $delay, $maxConcurrency, $webhook,
             $scrapeOptions, $regexOnFullURL, $zeroDataRetention, $integration,
+            $idempotencyKey,
         );
+    }
+
+    public function getIdempotencyKey(): ?string
+    {
+        return $this->idempotencyKey;
     }
 
     /** @return array<string, mixed> */

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.8.0';
+    public const SDK_VERSION = '1.9.0';
 }

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.9.0';
+    public const SDK_VERSION = '1.8.0';
 }

--- a/apps/php-sdk/tests/Pest.php
+++ b/apps/php-sdk/tests/Pest.php
@@ -2,4 +2,30 @@
 
 declare(strict_types=1);
 
+use Firecrawl\Client\FirecrawlClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+
 uses()->group('unit')->in('Unit');
+
+/**
+ * Build a FirecrawlClient whose HTTP layer is a Guzzle MockHandler queue.
+ * Pass an ArrayObject as $history to capture the requests that were sent.
+ *
+ * @param list<\GuzzleHttp\Psr7\Response> $responses
+ */
+function fakeFirecrawlClient(array $responses, ?ArrayObject $history = null): FirecrawlClient
+{
+    $stack = HandlerStack::create(new MockHandler($responses));
+
+    if ($history !== null) {
+        $stack->push(Middleware::history($history));
+    }
+
+    return FirecrawlClient::create(
+        apiKey: 'fc-test',
+        httpClient: new Client(['handler' => $stack, 'http_errors' => false]),
+    );
+}

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -77,8 +77,7 @@ it('reports a friendly message when the crawl exceeds its own timeout', function
         ])),
     ]);
 
-    // Anonymous subclass overrides the wait so the test does not sleep for
-    // the full production timeout.
+    // Override the wait so the test does not sleep for the production timeout.
     $tool = new class ($client) extends FirecrawlCrawl {
         protected int $timeoutSeconds = 1;
     };

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -66,6 +66,31 @@ it('reports crawls that finish without pages', function (): void {
     expect($result)->toBe('Crawl finished with status [failed] but returned no pages.');
 });
 
+it('reports a friendly message when the crawl exceeds its own timeout', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'scraping', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'scraping', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
+    ]);
+
+    // Anonymous subclass overrides the wait so the test does not sleep for
+    // the full production timeout.
+    $tool = new class ($client) extends FirecrawlCrawl {
+        protected int $timeoutSeconds = 1;
+    };
+
+    $result = $tool->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toBe(
+        'The crawl did not finish within 1 seconds. It may still complete on the server. '
+        . 'Use a smaller limit, or scrape key pages individually with firecrawl_scrape.',
+    );
+});
+
 it('returns API failures as readable strings instead of throwing', function (): void {
     $client = fakeFirecrawlClient([
         new Response(400, [], json_encode(['error' => 'Invalid URL'])),

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -35,7 +35,7 @@ it('crawls a site and returns pages as JSON', function (): void {
     expect($body['url'])->toBe('https://example.com');
     expect($body['limit'])->toBe(5);
     expect($body['scrapeOptions']['formats'])->toBe(['markdown']);
-    expect($body['integration'])->toBe('laravel-ai');
+    expect($body['integration'])->toBe('_laravel-ai');
 });
 
 it('clamps the page limit between 1 and 25', function (): void {

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -39,7 +39,8 @@ it('crawls a site and returns status and pages as JSON', function (): void {
     expect($body['limit'])->toBe(5);
     expect($body['scrapeOptions']['formats'])->toBe(['markdown']);
     expect($body['integration'])->toBe('_laravel-ai');
-    expect($history[0]['request']->getHeaderLine('x-idempotency-key'))->toMatch('/^[0-9a-f]{32}$/');
+    expect($history[0]['request']->getHeaderLine('x-idempotency-key'))
+        ->toMatch('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/');
 });
 
 it('clamps the page limit between 1 and 25', function (): void {
@@ -73,7 +74,7 @@ it('reuses the same idempotency key across HTTP retries of the start request', f
     $retryKey = $history[1]['request']->getHeaderLine('x-idempotency-key');
     expect($history[0]['request']->getMethod())->toBe('POST');
     expect($history[1]['request']->getMethod())->toBe('POST');
-    expect($firstKey)->toMatch('/^[0-9a-f]{32}$/');
+    expect($firstKey)->toMatch('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/');
     expect($retryKey)->toBe($firstKey);
 });
 

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Firecrawl\Laravel\Tools\FirecrawlCrawl;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Tools\Request;
+
+it('crawls a site and returns pages as JSON', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        // POST /v2/crawl — start the job
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        // GET /v2/crawl/job-1 — first poll, already completed
+        new Response(200, [], json_encode([
+            'success' => true,
+            'status' => 'completed',
+            'total' => 1,
+            'completed' => 1,
+            'data' => [
+                ['markdown' => '# Page 1', 'metadata' => ['sourceURL' => 'https://example.com/p1']],
+            ],
+        ])),
+    ], $history);
+
+    $result = (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect(json_decode($result, true))->toBe([
+        ['url' => 'https://example.com/p1', 'markdown' => '# Page 1'],
+    ]);
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['url'])->toBe('https://example.com');
+    expect($body['limit'])->toBe(5);
+    expect($body['scrapeOptions']['formats'])->toBe(['markdown']);
+    expect($body['integration'])->toBe('laravel-ai');
+});
+
+it('clamps the page limit between 1 and 25', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'completed', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
+    ], $history);
+
+    (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com', 'limit' => 500]));
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['limit'])->toBe(25);
+});
+
+it('reports crawls that finish without pages', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'failed', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
+    ]);
+
+    $result = (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toBe('Crawl finished with status [failed] but returned no pages.');
+});
+
+it('returns API failures as readable strings instead of throwing', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(400, [], json_encode(['error' => 'Invalid URL'])),
+    ]);
+
+    $result = (new FirecrawlCrawl($client))->handle(new Request(['url' => 'not-a-url']));
+
+    expect($result)->toStartWith('Firecrawl request failed:');
+});
+
+it('exposes name and a schema with required url and optional limit', function (): void {
+    $tool = new FirecrawlCrawl(fakeFirecrawlClient([]));
+
+    expect($tool->name())->toBe('firecrawl_crawl');
+
+    $types = $tool->schema(new JsonSchemaTypeFactory());
+    expect($types)->toHaveKeys(['url', 'limit']);
+
+    $jsonSchema = (new ObjectSchema($types))->toSchema();
+    expect($jsonSchema['required'])->toContain('url');
+    expect($jsonSchema['required'])->not->toContain('limit');
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -173,3 +173,20 @@ it('exposes name and a schema with required url and optional limit', function ()
     expect($jsonSchema['required'])->toContain('url');
     expect($jsonSchema['required'])->not->toContain('limit');
 });
+
+it('bounds each HTTP request by the remaining deadline', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'completed', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
+    ], $history);
+
+    (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
+
+    foreach ([0, 1] as $i) {
+        $timeout = $history[$i]['options'][GuzzleHttp\RequestOptions::TIMEOUT] ?? null;
+        expect($timeout)->toBeFloat()->toBeGreaterThan(0)->toBeLessThanOrEqual(55.0);
+    }
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -11,9 +11,7 @@ use Laravel\Ai\Tools\Request;
 it('crawls a site and returns pages as JSON', function (): void {
     $history = new ArrayObject();
     $client = fakeFirecrawlClient([
-        // POST /v2/crawl: start the job
         new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
-        // GET /v2/crawl/job-1: first poll, already completed
         new Response(200, [], json_encode([
             'success' => true,
             'status' => 'completed',
@@ -77,7 +75,6 @@ it('reports a friendly message when the crawl exceeds its own timeout', function
         ])),
     ]);
 
-    // Override the wait so the test does not sleep for the production timeout.
     $tool = new class ($client) extends FirecrawlCrawl {
         protected int $timeoutSeconds = 1;
     };

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -11,9 +11,9 @@ use Laravel\Ai\Tools\Request;
 it('crawls a site and returns pages as JSON', function (): void {
     $history = new ArrayObject();
     $client = fakeFirecrawlClient([
-        // POST /v2/crawl — start the job
+        // POST /v2/crawl: start the job
         new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
-        // GET /v2/crawl/job-1 — first poll, already completed
+        // GET /v2/crawl/job-1: first poll, already completed
         new Response(200, [], json_encode([
             'success' => true,
             'status' => 'completed',

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlCrawlTest.php
@@ -8,7 +8,7 @@ use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Tools\Request;
 
-it('crawls a site and returns pages as JSON', function (): void {
+it('crawls a site and returns status and pages as JSON', function (): void {
     $history = new ArrayObject();
     $client = fakeFirecrawlClient([
         new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
@@ -26,7 +26,12 @@ it('crawls a site and returns pages as JSON', function (): void {
     $result = (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
 
     expect(json_decode($result, true))->toBe([
-        ['url' => 'https://example.com/p1', 'markdown' => '# Page 1'],
+        'status' => 'completed',
+        'completed' => 1,
+        'total' => 1,
+        'pages' => [
+            ['url' => 'https://example.com/p1', 'markdown' => '# Page 1'],
+        ],
     ]);
 
     $body = json_decode((string) $history[0]['request']->getBody(), true);
@@ -34,6 +39,7 @@ it('crawls a site and returns pages as JSON', function (): void {
     expect($body['limit'])->toBe(5);
     expect($body['scrapeOptions']['formats'])->toBe(['markdown']);
     expect($body['integration'])->toBe('_laravel-ai');
+    expect($history[0]['request']->getHeaderLine('x-idempotency-key'))->toMatch('/^[0-9a-f]{32}$/');
 });
 
 it('clamps the page limit between 1 and 25', function (): void {
@@ -51,20 +57,78 @@ it('clamps the page limit between 1 and 25', function (): void {
     expect($body['limit'])->toBe(25);
 });
 
-it('reports crawls that finish without pages', function (): void {
+it('reuses the same idempotency key across HTTP retries of the start request', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(502, [], json_encode(['error' => 'bad gateway'])),
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'completed', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
+    ], $history);
+
+    (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
+
+    $firstKey = $history[0]['request']->getHeaderLine('x-idempotency-key');
+    $retryKey = $history[1]['request']->getHeaderLine('x-idempotency-key');
+    expect($history[0]['request']->getMethod())->toBe('POST');
+    expect($history[1]['request']->getMethod())->toBe('POST');
+    expect($firstKey)->toMatch('/^[0-9a-f]{32}$/');
+    expect($retryKey)->toBe($firstKey);
+});
+
+it('surfaces failed crawls with partial pages and does not follow pagination', function (): void {
+    $history = new ArrayObject();
     $client = fakeFirecrawlClient([
         new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
         new Response(200, [], json_encode([
-            'success' => true, 'status' => 'failed', 'total' => 0, 'completed' => 0, 'data' => [],
+            'success' => true,
+            'status' => 'failed',
+            'total' => 5,
+            'completed' => 2,
+            'next' => 'https://api.firecrawl.dev/v2/crawl/job-1?skip=1',
+            'data' => [
+                ['markdown' => '# Partial page', 'metadata' => ['sourceURL' => 'https://example.com/p1']],
+            ],
+        ])),
+    ], $history);
+
+    $result = (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
+    $decoded = json_decode($result, true);
+
+    expect($decoded['status'])->toBe('failed');
+    expect($decoded['pages'])->toHaveCount(1);
+    expect($decoded['note'])->toContain('More pages exist');
+    expect($history)->toHaveCount(2);
+});
+
+it('applies the whole-result budget across pages', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true,
+            'status' => 'completed',
+            'total' => 3,
+            'completed' => 3,
+            'data' => [
+                ['markdown' => str_repeat('a', 40), 'metadata' => ['sourceURL' => 'https://example.com/1']],
+                ['markdown' => str_repeat('b', 40), 'metadata' => ['sourceURL' => 'https://example.com/2']],
+                ['markdown' => str_repeat('c', 40), 'metadata' => ['sourceURL' => 'https://example.com/3']],
+            ],
         ])),
     ]);
 
-    $result = (new FirecrawlCrawl($client))->handle(new Request(['url' => 'https://example.com']));
+    $tool = new class ($client) extends FirecrawlCrawl {
+        protected int $outputCharacterBudget = 60;
+    };
 
-    expect($result)->toBe('Crawl finished with status [failed] but returned no pages.');
+    $decoded = json_decode($tool->handle(new Request(['url' => 'https://example.com'])), true);
+
+    expect($decoded['pages'])->toHaveCount(1);
+    expect($decoded['omittedPages'])->toBe(2);
 });
 
-it('reports a friendly message when the crawl exceeds its own timeout', function (): void {
+it('returns a timeout message when the crawl runs long', function (): void {
     $client = fakeFirecrawlClient([
         new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
         new Response(200, [], json_encode([
@@ -77,14 +141,13 @@ it('reports a friendly message when the crawl exceeds its own timeout', function
 
     $tool = new class ($client) extends FirecrawlCrawl {
         protected int $timeoutSeconds = 1;
+        protected int $pollIntervalSeconds = 1;
     };
 
     $result = $tool->handle(new Request(['url' => 'https://example.com']));
 
-    expect($result)->toBe(
-        'The crawl did not finish within 1 seconds. It may still complete on the server. '
-        . 'Use a smaller limit, or scrape key pages individually with firecrawl_scrape.',
-    );
+    expect($result)->toContain('did not finish within 1 seconds');
+    expect($result)->toContain('may still complete on the server');
 });
 
 it('returns API failures as readable strings instead of throwing', function (): void {

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
@@ -32,7 +32,7 @@ it('maps a site and returns discovered URLs as JSON', function (): void {
     $body = json_decode((string) $history[0]['request']->getBody(), true);
     expect($body['url'])->toBe('https://example.com');
     expect($body['limit'])->toBe(100);
-    expect($body['integration'])->toBe('laravel-ai');
+    expect($body['integration'])->toBe('_laravel-ai');
     expect($body)->not->toHaveKey('search');
 });
 

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
@@ -58,6 +58,19 @@ it('reports when no URLs were discovered', function (): void {
     expect($result)->toBe('No URLs discovered.');
 });
 
+it('surfaces a success:false envelope as an error instead of empty results', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => false,
+            'error' => 'DNS resolution failed for host: nosuchdomain.example',
+        ])),
+    ]);
+
+    $result = (new FirecrawlMap($client))->handle(new Request(['url' => 'https://nosuchdomain.example']));
+
+    expect($result)->toStartWith('Firecrawl request failed: DNS resolution failed');
+});
+
 it('exposes name and a schema with required url', function (): void {
     $tool = new FirecrawlMap(fakeFirecrawlClient([]));
 

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
@@ -116,3 +116,19 @@ it('drops tail links and reports the cut when output exceeds the budget', functi
     expect($decoded)->not->toHaveCount(4);
     expect(array_key_exists('omitted', end($decoded)))->toBeTrue();
 });
+
+it('reduces a single oversized item to an omitted marker', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['links' => [
+            ['url' => 'https://example.com/' . str_repeat('x', 400)],
+        ]]])),
+    ]);
+
+    $tool = new class ($client) extends FirecrawlMap {
+        protected int $outputCharacterBudget = 100;
+    };
+
+    $result = $tool->handle(new Request(['url' => 'https://example.com']));
+
+    expect(json_decode($result, true))->toBe([['omitted' => 1]]);
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
@@ -48,6 +48,18 @@ it('passes the search filter through when provided', function (): void {
     expect($body['search'])->toBe('docs');
 });
 
+it('clamps an explicit limit of 5000 down to 500', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['links' => []]])),
+    ], $history);
+
+    (new FirecrawlMap($client))->handle(new Request(['url' => 'https://example.com', 'limit' => 5000]));
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['limit'])->toBe(500);
+});
+
 it('reports when no URLs were discovered', function (): void {
     $client = fakeFirecrawlClient([
         new Response(200, [], json_encode(['success' => true, 'data' => ['links' => []]])),

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Firecrawl\Laravel\Tools\FirecrawlMap;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Tools\Request;
+
+it('maps a site and returns discovered URLs as JSON', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => true,
+            'data' => [
+                'links' => [
+                    ['url' => 'https://example.com/', 'title' => 'Home'],
+                    'https://example.com/pricing',
+                ],
+            ],
+        ])),
+    ], $history);
+
+    $result = (new FirecrawlMap($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect(json_decode($result, true))->toBe([
+        ['url' => 'https://example.com/', 'title' => 'Home'],
+        ['url' => 'https://example.com/pricing'],
+    ]);
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['url'])->toBe('https://example.com');
+    expect($body['limit'])->toBe(100);
+    expect($body['integration'])->toBe('laravel-ai');
+    expect($body)->not->toHaveKey('search');
+});
+
+it('passes the search filter through when provided', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['links' => []]])),
+    ], $history);
+
+    (new FirecrawlMap($client))->handle(new Request(['url' => 'https://example.com', 'search' => 'docs']));
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['search'])->toBe('docs');
+});
+
+it('reports when no URLs were discovered', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['links' => []]])),
+    ]);
+
+    $result = (new FirecrawlMap($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toBe('No URLs discovered.');
+});
+
+it('exposes name and a schema with required url', function (): void {
+    $tool = new FirecrawlMap(fakeFirecrawlClient([]));
+
+    expect($tool->name())->toBe('firecrawl_map');
+
+    $types = $tool->schema(new JsonSchemaTypeFactory());
+    expect($types)->toHaveKeys(['url', 'search', 'limit']);
+
+    $jsonSchema = (new ObjectSchema($types))->toSchema();
+    expect($jsonSchema['required'])->toContain('url');
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlMapTest.php
@@ -94,3 +94,25 @@ it('exposes name and a schema with required url', function (): void {
     $jsonSchema = (new ObjectSchema($types))->toSchema();
     expect($jsonSchema['required'])->toContain('url');
 });
+
+it('drops tail links and reports the cut when output exceeds the budget', function (): void {
+    $links = [];
+    for ($i = 1; $i <= 4; $i++) {
+        $links[] = ['url' => "https://example.com/page-{$i}"];
+    }
+
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['links' => $links]])),
+    ]);
+
+    $tool = new class ($client) extends FirecrawlMap {
+        protected int $outputCharacterBudget = 100;
+    };
+
+    $result = $tool->handle(new Request(['url' => 'https://example.com']));
+    $decoded = json_decode($result, true);
+
+    expect(mb_strlen($result))->toBeLessThanOrEqual(100);
+    expect($decoded)->not->toHaveCount(4);
+    expect(array_key_exists('omitted', end($decoded)))->toBeTrue();
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -85,7 +85,6 @@ it('converts non-SDK failures into readable strings instead of throwing', functi
     Container::setInstance(new Container());
 
     try {
-        // No FirecrawlClient binding — container resolution fails inside handle().
         $result = (new FirecrawlScrape())->handle(new Request(['url' => 'https://example.com']));
     } finally {
         Container::setInstance(null);

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Firecrawl\Laravel\Tools\FirecrawlScrape;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Tools\Request;
+
+it('scrapes a URL and returns markdown', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => true,
+            'data' => [
+                'markdown' => '# Example Page',
+                'metadata' => ['title' => 'Example', 'sourceURL' => 'https://example.com'],
+            ],
+        ])),
+    ], $history);
+
+    $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toBe('# Example Page');
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['url'])->toBe('https://example.com');
+    expect($body['formats'])->toBe(['markdown']);
+    expect($body['integration'])->toBe('laravel-ai');
+});
+
+it('prepends scrape warnings to the content', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => true,
+            'data' => ['markdown' => '# Partial', 'warning' => 'Page loaded partially'],
+        ])),
+    ]);
+
+    $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toBe("Warning: Page loaded partially\n\n# Partial");
+});
+
+it('reports empty documents instead of returning an empty string', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => []])),
+    ]);
+
+    $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toBe('No content was returned for this page.');
+});
+
+it('returns API failures as readable strings instead of throwing', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(401, [], json_encode(['error' => 'Unauthorized: invalid token'])),
+    ]);
+
+    $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toStartWith('Firecrawl request failed:');
+});
+
+it('exposes name, description, and a required url parameter', function (): void {
+    $tool = new FirecrawlScrape(fakeFirecrawlClient([]));
+
+    expect($tool->name())->toBe('firecrawl_scrape');
+    expect((string) $tool->description())->not->toBe('');
+
+    $types = $tool->schema(new JsonSchemaTypeFactory());
+    expect($types)->toHaveKey('url');
+
+    $jsonSchema = (new ObjectSchema($types))->toSchema();
+    expect($jsonSchema['required'])->toContain('url');
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -89,8 +89,9 @@ it('truncates markdown longer than 80000 characters', function (): void {
 
     $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
 
-    expect($result)->toStartWith($prefix);
-    expect($result)->toEndWith('[Truncated: showing the first 80000 of 80100 characters.]');
+    expect(mb_strlen($result))->toBeLessThanOrEqual(80000);
+    expect($result)->toStartWith(str_repeat('a', 1000));
+    expect($result)->toEndWith('[Truncated: 80100 characters total.]');
 });
 
 it('resolves the client from the container when none is injected', function (): void {

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -78,6 +78,21 @@ it('surfaces a success:false envelope as an error instead of empty content', fun
     expect($result)->toStartWith('Firecrawl request failed: DNS resolution failed');
 });
 
+it('truncates markdown longer than 80000 characters', function (): void {
+    $prefix = str_repeat('a', 80000);
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => true,
+            'data' => ['markdown' => $prefix . str_repeat('b', 100)],
+        ])),
+    ]);
+
+    $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
+
+    expect($result)->toStartWith($prefix);
+    expect($result)->toEndWith('[Truncated: showing the first 80000 of 80100 characters.]');
+});
+
 it('resolves the client from the container when none is injected', function (): void {
     $container = new Container();
     $container->instance(FirecrawlClient::class, fakeFirecrawlClient([

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -29,7 +29,7 @@ it('scrapes a URL and returns markdown', function (): void {
     $body = json_decode((string) $history[0]['request']->getBody(), true);
     expect($body['url'])->toBe('https://example.com');
     expect($body['formats'])->toBe(['markdown']);
-    expect($body['integration'])->toBe('laravel-ai');
+    expect($body['integration'])->toBe('_laravel-ai');
 });
 
 it('prepends scrape warnings to the content', function (): void {

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -65,6 +65,19 @@ it('returns API failures as readable strings instead of throwing', function (): 
     expect($result)->toStartWith('Firecrawl request failed:');
 });
 
+it('surfaces a success:false envelope as an error instead of empty content', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => false,
+            'error' => 'DNS resolution failed for host: nosuchdomain.example',
+        ])),
+    ]);
+
+    $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://nosuchdomain.example']));
+
+    expect($result)->toStartWith('Firecrawl request failed: DNS resolution failed');
+});
+
 it('resolves the client from the container when none is injected', function (): void {
     $container = new Container();
     $container->instance(FirecrawlClient::class, fakeFirecrawlClient([

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlScrapeTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Firecrawl\Client\FirecrawlClient;
 use Firecrawl\Laravel\Tools\FirecrawlScrape;
 use GuzzleHttp\Psr7\Response;
+use Illuminate\Container\Container;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Tools\Request;
@@ -61,6 +63,35 @@ it('returns API failures as readable strings instead of throwing', function (): 
     $result = (new FirecrawlScrape($client))->handle(new Request(['url' => 'https://example.com']));
 
     expect($result)->toStartWith('Firecrawl request failed:');
+});
+
+it('resolves the client from the container when none is injected', function (): void {
+    $container = new Container();
+    $container->instance(FirecrawlClient::class, fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['markdown' => '# Via Container']])),
+    ]));
+    Container::setInstance($container);
+
+    try {
+        $result = (new FirecrawlScrape())->handle(new Request(['url' => 'https://example.com']));
+    } finally {
+        Container::setInstance(null);
+    }
+
+    expect($result)->toBe('# Via Container');
+});
+
+it('converts non-SDK failures into readable strings instead of throwing', function (): void {
+    Container::setInstance(new Container());
+
+    try {
+        // No FirecrawlClient binding — container resolution fails inside handle().
+        $result = (new FirecrawlScrape())->handle(new Request(['url' => 'https://example.com']));
+    } finally {
+        Container::setInstance(null);
+    }
+
+    expect($result)->toStartWith('Tool execution failed:');
 });
 
 it('exposes name, description, and a required url parameter', function (): void {

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlSearchTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlSearchTest.php
@@ -55,6 +55,19 @@ it('reports when no results were found', function (): void {
     expect($result)->toBe('No results found.');
 });
 
+it('surfaces a success:false envelope as an error instead of empty results', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => false,
+            'error' => 'DNS resolution failed for host: nosuchdomain.example',
+        ])),
+    ]);
+
+    $result = (new FirecrawlSearch($client))->handle(new Request(['query' => 'nosuchdomain.example']));
+
+    expect($result)->toStartWith('Firecrawl request failed: DNS resolution failed');
+});
+
 it('exposes name and a schema with required query and optional limit', function (): void {
     $tool = new FirecrawlSearch(fakeFirecrawlClient([]));
 

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlSearchTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlSearchTest.php
@@ -30,7 +30,7 @@ it('searches the web and returns JSON results', function (): void {
     $body = json_decode((string) $history[0]['request']->getBody(), true);
     expect($body['query'])->toBe('firecrawl');
     expect($body['limit'])->toBe(5);
-    expect($body['integration'])->toBe('laravel-ai');
+    expect($body['integration'])->toBe('_laravel-ai');
 });
 
 it('clamps the limit between 1 and 20', function (): void {

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlSearchTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlSearchTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Firecrawl\Laravel\Tools\FirecrawlSearch;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Tools\Request;
+
+it('searches the web and returns JSON results', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode([
+            'success' => true,
+            'data' => [
+                'web' => [
+                    ['title' => 'Firecrawl', 'url' => 'https://firecrawl.dev', 'description' => 'Web data API', 'position' => 1],
+                ],
+            ],
+        ])),
+    ], $history);
+
+    $result = (new FirecrawlSearch($client))->handle(new Request(['query' => 'firecrawl']));
+
+    expect(json_decode($result, true))->toBe([
+        ['title' => 'Firecrawl', 'url' => 'https://firecrawl.dev', 'description' => 'Web data API'],
+    ]);
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['query'])->toBe('firecrawl');
+    expect($body['limit'])->toBe(5);
+    expect($body['integration'])->toBe('laravel-ai');
+});
+
+it('clamps the limit between 1 and 20', function (): void {
+    $history = new ArrayObject();
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['web' => []]])),
+    ], $history);
+
+    (new FirecrawlSearch($client))->handle(new Request(['query' => 'x', 'limit' => 99]));
+
+    $body = json_decode((string) $history[0]['request']->getBody(), true);
+    expect($body['limit'])->toBe(20);
+});
+
+it('reports when no results were found', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['web' => []]])),
+    ]);
+
+    $result = (new FirecrawlSearch($client))->handle(new Request(['query' => 'x']));
+
+    expect($result)->toBe('No results found.');
+});
+
+it('exposes name and a schema with required query and optional limit', function (): void {
+    $tool = new FirecrawlSearch(fakeFirecrawlClient([]));
+
+    expect($tool->name())->toBe('firecrawl_search');
+
+    $types = $tool->schema(new JsonSchemaTypeFactory());
+    expect($types)->toHaveKeys(['query', 'limit']);
+
+    $jsonSchema = (new ObjectSchema($types))->toSchema();
+    expect($jsonSchema['required'])->toContain('query');
+    expect($jsonSchema['required'])->not->toContain('limit');
+});

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlToolsTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlToolsTest.php
@@ -23,9 +23,23 @@ it('returns one instance of each core tool', function (): void {
 it('passes an explicit client through to every tool', function (): void {
     $client = fakeFirecrawlClient([
         new Response(200, [], json_encode(['success' => true, 'data' => ['markdown' => '# Hi']])),
+        new Response(200, [], json_encode(['success' => true, 'data' => [
+            'web' => [['title' => 'T', 'url' => 'https://a.com', 'description' => 'D']],
+        ]])),
+        new Response(200, [], json_encode(['success' => true, 'data' => [
+            'links' => [['url' => 'https://a.com']],
+        ]])),
+        new Response(200, [], json_encode(['success' => true, 'id' => 'job-1'])),
+        new Response(200, [], json_encode([
+            'success' => true, 'status' => 'completed', 'total' => 0, 'completed' => 0, 'data' => [],
+        ])),
     ]);
 
-    [$scrape] = FirecrawlTools::all($client);
+    [$scrape, $search, $map, $crawl] = FirecrawlTools::all($client);
 
     expect($scrape->handle(new Request(['url' => 'https://example.com'])))->toBe('# Hi');
+    expect($search->handle(new Request(['query' => 'hi'])))->toContain('https://a.com');
+    expect($map->handle(new Request(['url' => 'https://example.com'])))->toContain('https://a.com');
+    expect(json_decode($crawl->handle(new Request(['url' => 'https://example.com'])), true)['status'])
+        ->toBe('completed');
 });

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlToolsTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlToolsTest.php
@@ -27,6 +27,5 @@ it('passes an explicit client through to every tool', function (): void {
 
     [$scrape] = FirecrawlTools::all($client);
 
-    // Uses the injected client (no container involved) — would throw otherwise.
     expect($scrape->handle(new Request(['url' => 'https://example.com'])))->toBe('# Hi');
 });

--- a/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlToolsTest.php
+++ b/apps/php-sdk/tests/Unit/LaravelTools/FirecrawlToolsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Firecrawl\Laravel\Tools\FirecrawlCrawl;
+use Firecrawl\Laravel\Tools\FirecrawlMap;
+use Firecrawl\Laravel\Tools\FirecrawlScrape;
+use Firecrawl\Laravel\Tools\FirecrawlSearch;
+use Firecrawl\Laravel\Tools\FirecrawlTools;
+use GuzzleHttp\Psr7\Response;
+use Laravel\Ai\Tools\Request;
+
+it('returns one instance of each core tool', function (): void {
+    $tools = FirecrawlTools::all();
+
+    expect($tools)->toHaveCount(4);
+    expect($tools[0])->toBeInstanceOf(FirecrawlScrape::class);
+    expect($tools[1])->toBeInstanceOf(FirecrawlSearch::class);
+    expect($tools[2])->toBeInstanceOf(FirecrawlMap::class);
+    expect($tools[3])->toBeInstanceOf(FirecrawlCrawl::class);
+});
+
+it('passes an explicit client through to every tool', function (): void {
+    $client = fakeFirecrawlClient([
+        new Response(200, [], json_encode(['success' => true, 'data' => ['markdown' => '# Hi']])),
+    ]);
+
+    [$scrape] = FirecrawlTools::all($client);
+
+    // Uses the injected client (no container involved) — would throw otherwise.
+    expect($scrape->handle(new Request(['url' => 'https://example.com'])))->toBe('# Hi');
+});


### PR DESCRIPTION
## What

Laravel's first-party AI SDK ([laravel/ai](https://laravel.com/docs/13.x/ai-sdk)) is seeing heavy agent and tool-calling adoption, and Laravel developers currently reach Firecrawl through MCP or hand-rolled HTTP. This adds native tool classes to the PHP SDK that drop into any laravel/ai agent's tools() array:

- `Firecrawl\Laravel\Tools\FirecrawlScrape` (`firecrawl_scrape`)
- `FirecrawlSearch` (`firecrawl_search`)
- `FirecrawlMap` (`firecrawl_map`)
- `FirecrawlCrawl` (`firecrawl_crawl`)
- `FirecrawlTools::all()` to register all four at once

```php
public function tools(): iterable
{
    return [new FirecrawlScrape, new FirecrawlSearch];
}
```

Tool names match the MCP server, so the agent-facing vocabulary is the same across surfaces.

## How

- Tools implement `Laravel\Ai\Contracts\Tool` and resolve the existing `FirecrawlClient` singleton from the container, so config, auth, and retry behavior are reused as-is. A client can also be injected per tool.
- `laravel/ai` is a soft dependency (require-dev + suggest, `^0.9`). The classes only autoload when the consumer installs it; the SDK's PHP 8.1 floor is unchanged.
- Failures inside `handle()` (SDK exceptions, container misconfiguration, encoding errors) come back as readable strings, so a tool failure never aborts the consumer's agent run.
- Telemetry: every call sends `integration: "_laravel-ai"`. The underscore form passes the API's integration validator on every deployed version, including self-hosted.
- Tool outputs are budgeted so results stay model-sized: scrape truncates at 80k characters, crawl pages at 15k each under a 100k whole-result budget, and search/map drop tail items with an explicit omitted marker. This budgeting is new surface specific to model-facing tools; flagging it for conscious review.
- Crawl runs under one wall-clock deadline (55s default, overridable for queue workers), starts jobs with a UUID idempotency key that stays stable across HTTP retries, reports pagination cursors instead of following them, and returns a status-explicit object so failed or partial crawls are visible.
- Client-level fixes that benefit all PHP SDK users: `scrape()`, `search()`, and `map()` now throw when the API returns HTTP 200 with `success: false` (e.g. DNS failures) instead of hydrating empty results, matching the Python and JS SDKs; `CrawlOptions` gains `idempotencyKey`, mirroring batch scrape.
- Deliberately not wrapped in v1: extract and the agent endpoint.

## Testing

- 61 Pest unit tests over a Guzzle MockHandler asserting real request bodies on the wire (telemetry, nested options, idempotency key stability across retries), error strings, limit clamping, output budgets, failed-crawl surfacing, schema shapes, and container resolution. phpstan clean.
- Live verification against production: all four tools plus failure paths, and a booted Laravel application running laravel/ai's real generation loop end to end with only the LLM faked. The live pass caught and fixed a real bug (the API only accepts UUID-formatted idempotency keys).

## Release

Version 1.9.0, publish to Packagist per the usual process. Per review, this PR now also completes the release pipeline: `publish-php-sdk.yml` previously force-pushed the subtree to firecrawl-php but never created version tags, so Packagist only exposed `dev-main` and stable constraints like `^1.9` did not resolve. The workflow now pushes the split as `refs/tags/v{SDK_VERSION}` before notifying Packagist (with an already-exists guard for idempotent re-runs), so merging publishes `1.9.0` as the first stable Packagist version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
