### PR TITLE
fix(search): isolate shadow canonical log context

### DIFF
--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -261,7 +261,6 @@ export async function executeSearch(
       requestId: context.requestId,
       teamId,
       zeroDataRetention: zeroDataRetention === true || isZDR === true,
-      logger,
     });
   }
 

--- a/apps/api/src/search/highlights-shadow.test.ts
+++ b/apps/api/src/search/highlights-shadow.test.ts
@@ -19,14 +19,14 @@ const logger = {
   warn: vi.fn(),
 } as any;
 
-let runSearchHighlightsShadow = createSearchHighlightsShadowRunner();
+let runSearchHighlightsShadow = createSearchHighlightsShadowRunner(logger);
 
 afterEach(() => {
   vi.clearAllMocks();
   config.HIGHLIGHT_SHADOW_RATE = 1;
   config.HIGHLIGHT_SHADOW_MAX_INFLIGHT = 1;
   vi.mocked(highlightsEnvReady).mockReturnValue(true);
-  runSearchHighlightsShadow = createSearchHighlightsShadowRunner();
+  runSearchHighlightsShadow = createSearchHighlightsShadowRunner(logger);
 });
 
 describe("runSearchHighlightsShadow", () => {
@@ -45,7 +45,6 @@ describe("runSearchHighlightsShadow", () => {
         requestId: "request-1",
         teamId: "team-1",
         zeroDataRetention: false,
-        logger,
       }),
     ).toBe("started");
     await new Promise(resolve => setImmediate(resolve));
@@ -95,7 +94,6 @@ describe("runSearchHighlightsShadow", () => {
       query: "query",
       teamId: "team-1",
       zeroDataRetention: false,
-      logger,
     };
     expect(
       runSearchHighlightsShadow({ ...input, requestId: "request-1" }),
@@ -122,7 +120,6 @@ describe("runSearchHighlightsShadow", () => {
       query: "query",
       requestId: "request-1",
       teamId: "team-1",
-      logger,
     };
 
     expect(

--- a/apps/api/src/search/highlights-shadow.ts
+++ b/apps/api/src/search/highlights-shadow.ts
@@ -1,6 +1,7 @@
 import { createLogger, type Logger } from "winston";
 import type { SearchV2Response } from "../lib/entities";
 import { config } from "../config";
+import { logger as rootLogger } from "../lib/logger";
 import { applySearchHighlights, highlightsEnvReady } from "./highlights";
 
 const CANONICAL_LOG = "search/highlights-shadow";
@@ -18,13 +19,14 @@ function sampled(requestId: string, rate: number): boolean {
   return (hash >>> 0) / 0x1_0000_0000 < rate;
 }
 
-export function createSearchHighlightsShadowRunner(): (options: {
+export function createSearchHighlightsShadowRunner(
+  canonicalLogger: Pick<Logger, "info" | "warn"> = rootLogger,
+): (options: {
   response: SearchV2Response;
   query: string;
   requestId: string;
   teamId: string;
   zeroDataRetention: boolean;
-  logger: Logger;
 }) => "skipped" | "dropped" | "started" {
   let inFlight = 0;
 
@@ -38,7 +40,7 @@ export function createSearchHighlightsShadowRunner(): (options: {
     }
 
     if (inFlight >= config.HIGHLIGHT_SHADOW_MAX_INFLIGHT) {
-      options.logger.info("Search highlights shadow dropped", {
+      canonicalLogger.info("Search highlights shadow dropped", {
         canonicalLog: CANONICAL_LOG,
         outcome: "dropped",
         reason: "max_inflight",
@@ -60,7 +62,7 @@ export function createSearchHighlightsShadowRunner(): (options: {
       allowLegacyFallback: false,
     })
       .then(result => {
-        options.logger.info("Search highlights shadow completed", {
+        canonicalLogger.info("Search highlights shadow completed", {
           canonicalLog: CANONICAL_LOG,
           outcome: result.succeeded ? "completed" : "failed",
           requestId: options.requestId,
@@ -75,7 +77,7 @@ export function createSearchHighlightsShadowRunner(): (options: {
         });
       })
       .catch(error => {
-        options.logger.warn("Search highlights shadow failed", {
+        canonicalLogger.warn("Search highlights shadow failed", {
           canonicalLog: CANONICAL_LOG,
           outcome: "failed",
           requestId: options.requestId,


### PR DESCRIPTION
## Summary

- emit shadow aggregate events through a context-free root logger
- keep request identifiers and aggregate counters explicit
- prevent inherited request fields from entering the canonical shadow record

## Validation

- 18 focused highlight tests
- TypeScript build
- Knip
- Prettier
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the highlights shadow canonical logging by emitting through a root, context-free `logger`. This prevents request-scoped fields from leaking into the canonical shadow log and keeps identifiers explicit.

- **Bug Fixes**
  - `createSearchHighlightsShadowRunner` now takes an optional canonical logger (defaults to root `logger`) and uses it for shadow events.
  - Removed per-request `logger` from runner options and from `executeSearch` to avoid context inheritance.
  - Canonical events now include only `canonicalLog`, `outcome`, `requestId`, `teamId`, `zeroDataRetention`, and counters; tests updated accordingly.

<sup>Written for commit 5e5d5044684db806fbdc151fc2c288366124268a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

