### PR TITLE
fix(search): propagate highlight request IDs

### DIFF
--- a/apps/api/src/search/highlight-model.test.ts
+++ b/apps/api/src/search/highlight-model.test.ts
@@ -41,7 +41,7 @@ describe("generateHighlightsBatch", () => {
         { id: "0", markdown: "# First\n\nbody text" },
         { id: "1", markdown: "# Second\n\nmore text" },
       ],
-      { logger },
+      { logger, requestId: "request-1" },
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -49,6 +49,7 @@ describe("generateHighlightsBatch", () => {
     expect(url).toBe("https://highlight.test/batch_highlight");
     expect(init.method).toBe("POST");
     expect(init.headers.Authorization).toBe("Bearer secret-token");
+    expect(init.headers["X-Request-ID"]).toBe("request-1");
 
     const sent = JSON.parse(init.body);
     expect(sent).toEqual({

--- a/apps/api/src/search/highlight-model.ts
+++ b/apps/api/src/search/highlight-model.ts
@@ -47,10 +47,13 @@ interface HighlightResult {
   markdown: string;
 }
 
-function requestHeaders(): Record<string, string> {
+function requestHeaders(requestId?: string): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
+  if (requestId) {
+    headers["X-Request-ID"] = requestId;
+  }
   if (config.HIGHLIGHT_MODEL_TOKEN) {
     headers.Authorization = `Bearer ${config.HIGHLIGHT_MODEL_TOKEN}`;
   }
@@ -70,6 +73,7 @@ export async function generateHighlightsBatch(
     logger: Logger;
     logPayload?: boolean;
     allowLegacyFallback?: boolean;
+    requestId?: string;
   },
 ): Promise<Map<string, HighlightResult> | null> {
   if (pages.length === 0) {
@@ -83,7 +87,7 @@ export async function generateHighlightsBatch(
     const baseUrl = config.HIGHLIGHT_MODEL_URL!.replace(/\/$/, "");
     const res = await fetch(`${baseUrl}/batch_highlight`, {
       method: "POST",
-      headers: requestHeaders(),
+      headers: requestHeaders(opts.requestId),
       body: JSON.stringify({ query, pages }),
       signal: controller.signal,
     });
@@ -156,14 +160,14 @@ async function generateLegacyHighlightsBatch(
   query: string,
   pages: HighlightPage[],
   signal: AbortSignal,
-  opts: { logger: Logger },
+  opts: { logger: Logger; requestId?: string },
 ): Promise<Map<string, HighlightResult>> {
   const entries = await Promise.all(
     pages.map(async page => {
       try {
         const res = await fetch(`${baseUrl}/highlight`, {
           method: "POST",
-          headers: requestHeaders(),
+          headers: requestHeaders(opts.requestId),
           body: JSON.stringify({ query, markdown: page.markdown }),
           signal,
         });

--- a/apps/api/src/search/highlights-shadow.test.ts
+++ b/apps/api/src/search/highlights-shadow.test.ts
@@ -58,6 +58,7 @@ describe("runSearchHighlightsShadow", () => {
         suppressSummaryLog: true,
         suppressPayloadLog: true,
         allowLegacyFallback: false,
+        requestId: "request-1",
       },
     );
     expect(logger.info).toHaveBeenCalledWith(

--- a/apps/api/src/search/highlights-shadow.ts
+++ b/apps/api/src/search/highlights-shadow.ts
@@ -60,6 +60,7 @@ export function createSearchHighlightsShadowRunner(
       suppressSummaryLog: true,
       suppressPayloadLog: true,
       allowLegacyFallback: false,
+      requestId: options.requestId,
     })
       .then(result => {
         canonicalLogger.info("Search highlights shadow completed", {

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -135,6 +135,7 @@ export async function applySearchHighlights(
     suppressSummaryLog?: boolean;
     suppressPayloadLog?: boolean;
     allowLegacyFallback?: boolean;
+    requestId?: string;
   } = {},
 ): Promise<{
   attempted: number;
@@ -205,8 +206,9 @@ export async function applySearchHighlights(
             logger,
             logPayload: !options.suppressPayloadLog,
             allowLegacyFallback: options.allowLegacyFallback,
+            requestId: options.requestId,
           }
-        : { logger },
+        : { logger, requestId: options.requestId },
     );
     succeeded = results !== null;
     if (results) {


### PR DESCRIPTION
Forward the existing search request ID to the configured highlight service so failures can be correlated across service boundaries.

No query, markdown, or highlight content is added to canonical logs.

Validated with targeted highlight tests, TypeScript build, and knip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward search request IDs to the highlight service via the `X-Request-ID` header to improve cross-service error tracing. IDs now flow from `applySearchHighlights` and the shadow runner down to model requests.

- **Bug Fixes**
  - Added optional `requestId` to `applySearchHighlights`, shadow runner, and `generateHighlightsBatch` (including legacy path).
  - Set `X-Request-ID` in request headers when provided; existing auth headers remain unchanged.
  - Updated tests to assert header propagation in batch and shadow paths.

<sup>Written for commit 8dcea8aa93447e9a6132271e74a99a51e811cbcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/3999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

