### PR TITLE
fix(python-sdk): map min_age to minAge in scrape options

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_parse_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_parse_request_preparation.py
@@ -87,3 +87,16 @@ class TestParseRequestPreparation:
 
         payload = json.loads(fields["options"])
         assert "lockdown" not in payload
+
+    def test_prepare_parse_request_strips_min_age(self):
+        options = ParseOptions(formats=["markdown"], min_age=1000)
+        fields, _ = _prepare_parse_request(
+            b"<html><body><h1>Parse</h1></body></html>",
+            options,
+            filename="upload.html",
+            content_type="text/html",
+        )
+
+        payload = json.loads(fields["options"])
+        assert "minAge" not in payload
+        assert "min_age" not in payload

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -388,3 +388,13 @@ class TestPrepareScrapeOptions:
         result = prepare_scrape_options(options)
 
         assert result["parsers"][0]["maxPages"] == 5
+
+    def test_prepare_min_age_maps_to_camel_case(self):
+        """min_age must be sent as minAge; the server drops the snake_case key."""
+        options = ScrapeOptions(min_age=1000, max_age=5000)
+
+        result = prepare_scrape_options(options)
+
+        assert result["minAge"] == 1000
+        assert "min_age" not in result
+        assert result["maxAge"] == 5000

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -566,6 +566,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
         "block_ads": "blockAds",
         "store_in_cache": "storeInCache",
         "max_age": "maxAge",
+        "min_age": "minAge",
         "redact_pii": "redactPII",
         "threat_protection": "threatProtection",
     }


### PR DESCRIPTION
## What and why

`prepare_scrape_options` camelCases every snake_case scrape option through `field_mappings`, but `min_age` had no entry, so it was sent verbatim as `min_age`. The v2 backend strips unknown keys, so the value was dropped and the min-age cache window never applied. It also leaked into the `/v2/parse` body, because parse strips the field by its camelCase name (`minAge`), which never matched the emitted `min_age`.

## Change

- Add `"min_age": "minAge"` to `field_mappings` in `prepare_scrape_options`. The single mapping fixes both the scrape and the parse paths.
- `test_prepare_min_age_maps_to_camel_case` (validation) asserts `minAge` is emitted and the snake_case key is gone.
- `test_prepare_parse_request_strips_min_age` (parse) asserts neither `minAge` nor `min_age` reaches the parse body.

Both tests fail on the current code (validation raises `KeyError: minAge`, parse leaks `min_age`) and pass with the fix. The full python-sdk unit suite (397 tests) passes.

Fixes #4001

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps `min_age` to `minAge` in the Python SDK scrape options so v2 applies the min-age cache window, and strips the field from `/v2/parse` payloads.

- **Bug Fixes**
  - Added `"min_age": "minAge"` to `field_mappings` in `prepare_scrape_options`, fixing both scrape and parse paths.
  - Added tests verifying scrape emits `minAge` (and removes `min_age`), parse payload excludes both keys, and `max_age` continues to map to `maxAge`.

<sup>Written for commit 295d993545a84c3ac9eb1e9e7466cd358b98c0d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

