### PR TITLE
fix: add min_age to camelCase field mapping for Python SDK scrape options

### DIFF
--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -566,6 +566,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
         "block_ads": "blockAds",
         "store_in_cache": "storeInCache",
         "max_age": "maxAge",
+        "min_age": "minAge",
         "redact_pii": "redactPII",
         "threat_protection": "threatProtection",
     }


### PR DESCRIPTION
## Summary

The `field_mappings` dict in `prepare_scrape_options()` was missing the `min_age` → `minAge` mapping. This caused `min_age` to leak through as snake_case to the API, preventing the v2 backend from applying cache-control for Python SDK users.

## Changes

- Added `"min_age": "minAge"` to the `field_mappings` dict in `apps/python-sdk/firecrawl/v2/utils/validation.py`

## Side-effect fix

The existing `opts.pop("minAge", None)` in `apps/python-sdk/firecrawl/v2/methods/parse.py` (line 73) previously never fired because `minAge` was never set in the payload. After this fix, the pop works correctly — Parse operations will correctly strip cache-related hints.

## Testing

- Verified locally: `ScrapeOptions(min_age=3600)` → `prepare_scrape_options()` correctly produces `minAge: 3600` in the output dict
- All existing tests continue to pass (no regressions)

Fixes #4001


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `min_age` → `minAge` mapping in the Python SDK scrape options so v2 backend cache-control works and parse operations strip cache hints. Fixes #4001.

- **Bug Fixes**
  - Added mapping in `prepare_scrape_options()`; `parse` now correctly `pop`s `minAge` from the payload.

<sup>Written for commit bdcc2d0cc5c1953ecdda8bcf6e53d8cc1dd5b532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->