### PR TITLE
fix(js-sdk): forward ignoreRobotsTxt in crawl payload; fix README community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Pst. Hey, you, join our stargazers :)_
 - **Agent ready**: Connect Firecrawl to any AI agent or MCP client with a single command
 - **Media parsing**: Parse and extract content from web-hosted PDFs, DOCX, and more
 - **Actions**: Click, scroll, write, wait, and press before extracting content
-- **Open source**: Developed transparently and collaboratively — [join our community](https://github.com/firecrawl/firecrawl)
+- **Open source**: Developed transparently and collaboratively — [join our community](https://discord.gg/firecrawl)
 
 ---
 

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,6 +28,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;


### PR DESCRIPTION
## Summary

Two small fixes:

### Fix 1: Forward `ignoreRobotsTxt` in JS SDK crawl payload (closes #3940)

The `ignoreRobotsTxt` option is declared in `CrawlOptions` (v2/types.ts) but `prepareCrawlPayload` in crawl.ts never included it in the POST body sent to the API. This adds the field forwarding with a `!= null` guard, consistent with all other boolean options in the same function.

### Fix 2: Fix "join our community" link in README (closes #3887)

The "join our community" hyperlink at the bottom of the feature list pointed to the GitHub repository rather than the Discord community. Updated to `https://discord.gg/firecrawl`.

## Testing

- The `ignoreRobotsTxt` change follows the identical pattern used by all other boolean fields in `prepareCrawlPayload`
- README link change is a simple URL swap to the canonical Discord invite used elsewhere in the same file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards `ignoreRobotsTxt` in the JS SDK crawl payload so the API respects this option. Updates the README “join our community” link to Discord.

- **Bug Fixes**
  - Add `ignoreRobotsTxt` to `prepareCrawlPayload` when set.
  - Update community link to https://discord.gg/firecrawl.

<sup>Written for commit c4275c5220fd9c9b596e1e05a7d4281d282c4e1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

