### PR TITLE
docs(self-host): OpenAI-compatible LLM gateway example (DaoXE)

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -58,9 +58,20 @@ USE_DB_AUTHENTICATION=false
 # MODEL_NAME=deepseek-r1:7b
 # MODEL_EMBEDDING_NAME=nomic-embed-text
 
-# Experimental: Use any OpenAI-compatible API
+# Experimental: Use any OpenAI-compatible API (custom base URL).
+# Firecrawl's OpenAI provider path honors OPENAI_BASE_URL for JSON-format
+# scrape fields and the /extract API (see apps/api/src/lib/generic-ai.ts).
 # OPENAI_BASE_URL=https://example.com/v1
 # OPENAI_API_KEY=
+# MODEL_NAME=your_exact_model_id
+
+# Example: DaoXE multi-model multi-protocol gateway (OpenAI-compatible Chat Completions)
+# DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients;
+# self-hosted Firecrawl uses the OpenAI-compatible path below.
+# Copy an exact model ID from your DaoXE account (account-scoped availability).
+# OPENAI_BASE_URL=https://daoxe.com/v1
+# OPENAI_API_KEY=your_daoxe_api_key
+# MODEL_NAME=your_exact_account_model_id
 
 ## === Proxy ===
 # PROXY_SERVER can be a full URL (e.g. http://0.1.2.3:1234) or just an IP and port combo (e.g. 0.1.2.3:1234)
@@ -121,6 +132,21 @@ BULL_AUTH_KEY=CHANGEME
 # Set if you'd like to allow local webhooks to be sent to your self-hosted instance
 # ALLOW_LOCAL_WEBHOOKS=true
 ```
+
+### AI features with an OpenAI-compatible gateway
+
+Self-hosted Firecrawl can drive JSON-format scrape fields and the `/extract` API through any OpenAI-compatible Chat Completions endpoint by setting `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and optionally `MODEL_NAME` / `MODEL_EMBEDDING_NAME`.
+
+Example with [DaoXE](https://daoxe.com) (multi-model multi-protocol API gateway; not a built-in Firecrawl provider):
+
+```bash
+# In your root .env (do not commit real keys)
+OPENAI_BASE_URL=https://daoxe.com/v1
+OPENAI_API_KEY=your_daoxe_api_key
+MODEL_NAME=your_exact_account_model_id
+```
+
+Use an exact model ID currently available to your DaoXE account (for example from the DaoXE dashboard or `GET https://daoxe.com/v1/models` with your key). Do not hard-code a public model list from a blog post—availability is account-scoped. Requests may be billed by the gateway. Examples: https://github.com/seven7763/DaoXE-AI
 
 ### Security considerations
 


### PR DESCRIPTION
## Summary
- Clarify that self-hosted Firecrawl's AI features (JSON-format scrape fields and `/extract`) already honor `OPENAI_BASE_URL` + `OPENAI_API_KEY` (+ optional `MODEL_NAME`) for any OpenAI-compatible Chat Completions endpoint (`apps/api/src/lib/generic-ai.ts`).
- Add a concrete [DaoXE](https://daoxe.com) example: base URL `https://daoxe.com/v1`, account-scoped model IDs (no hardcoded public model list), with a short multi-protocol note (OpenAI Chat Completions / Responses / Anthropic Messages). DaoXE is documented as a gateway option, **not** a built-in Firecrawl provider.

Docs-only. No code or env schema changes.

I maintain DaoXE. Examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [x] Diff limited to `SELF_HOST.md`
- [x] Env example uses placeholders only (no secrets)
- [x] Model IDs described as account-scoped (`your_exact_account_model_id`)
- [ ] Maintainers: confirm wording matches self-host AI feature scope

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that self-hosted Firecrawl’s JSON-format scrape fields and `/extract` can use any OpenAI-compatible Chat Completions endpoint via `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and optional `MODEL_NAME`. Adds a DaoXE gateway example in `SELF_HOST.md` using `https://daoxe.com/v1` with account-scoped model IDs; DaoXE is documented as an option, not a built-in provider.

<sup>Written for commit b40a25b8172e4c689b6ac4df931930c2506aafd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

