### PR TITLE
chore(api): upgrade to pnpm 11

### DIFF
--- a/.github/workflows/npm-audit-claude-remediation.yml
+++ b/.github/workflows/npm-audit-claude-remediation.yml
@@ -32,10 +32,15 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 10
+          version: 11.4.0
 
       - name: Scan default branch audit failures
         id: scan

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 10
+          version: 11.4.0
       
       - name: Create audit output directory
         run: mkdir -p /tmp/audit-outputs

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -77,10 +77,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 10
-
-      - run: pnpm config set store-dir ~/.pnpm-store
-      - run: mkdir -p ~/.pnpm-store
+          version: 11.4.0
 
       - name: Install FoundationDB client library
         run: |
@@ -478,7 +475,7 @@ jobs:
 
   #     - uses: pnpm/action-setup@v4
   #       with:
-  #         version: 10
+  #         version: 11.4.0
 
   #     - run: pnpm config set store-dir ~/.pnpm-store
   #     - run: mkdir -p ~/.pnpm-store
@@ -589,10 +586,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 10
-
-      - run: pnpm config set store-dir ~/.pnpm-store
-      - run: mkdir -p ~/.pnpm-store
+          version: 11.4.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 11.4.0
+          version: 10
 
       - name: Install FoundationDB client library
         run: |
@@ -94,7 +94,7 @@ jobs:
             apps/test-site/pnpm-lock.yaml
             apps/playwright-service-ts/pnpm-lock.yaml
 
-      - run: pnpm fetch
+      - run: pnpm dlx pnpm@11.4.0 fetch
         working-directory: apps/api
       - run: pnpm fetch
         working-directory: apps/test-site
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build native lib
         if: steps.napi_restore.outputs.cache-hit != 'true'
-        run: pnpm install
+        run: pnpm dlx pnpm@11.4.0 install
         working-directory: apps/api/native
 
       - name: Cache native lib
@@ -213,7 +213,7 @@ jobs:
         working-directory: ./
 
       - name: Install API dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm dlx pnpm@11.4.0 install --frozen-lockfile --ignore-scripts
         working-directory: apps/api
         env:
           npm_config_ignore_scripts: 'true'
@@ -259,7 +259,7 @@ jobs:
           echo "docker:docker@127.0.0.1:4500" > /tmp/fdb.cluster
 
       - name: Run tests
-        run: pnpm harness pnpm test:snips
+        run: pnpm dlx pnpm@11.4.0 harness pnpm test:snips
         working-directory: apps/api
         env:
           npm_config_ignore_scripts: 'true' # required currently to prevent re-building cached native lib

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -5,7 +5,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV CI=true
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@11.4.0 --activate
 
 # Build Go shared library
 FROM golang:1.24 AS go-build

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -159,69 +159,8 @@
       "temp"
     ]
   },
-  "pnpm": {
-    "allowScripts": {
-      "oxc-resolver": true
-    },
-    "onlyBuiltDependencies": [
-      "@mendable/firecrawl-rs",
-      "@sentry-internal/node-cpu-profiler",
-      "@sentry/cli",
-      "bigint-buffer",
-      "bufferutil",
-      "esbuild",
-      "foundationdb",
-      "four-flap-bigint-buffer",
-      "keccak",
-      "koffi",
-      "libpq",
-      "msgpackr-extract",
-      "oxc-resolver",
-      "protobufjs",
-      "utf-8-validate",
-      "wordpos"
-    ],
-    "overrides": {
-      "bigint-buffer": "npm:four-flap-bigint-buffer@1.1.6",
-      "diff": "^8.0.3",
-      "ajv": "^8.18.0",
-      "fast-xml-builder": ">=1.1.6 <2.0.0",
-      "fast-xml-parser": "^5.7.0",
-      "fast-uri": ">=3.1.2 <4.0.0",
-      "glob@>=10.2.0 <10.5.0": ">=10.5.0",
-      "js-yaml@<3.14.2": "4.2.0",
-      "js-yaml@>=4.0.0 <4.2.0": "4.2.0",
-      "qs@<6.15.2": ">=6.15.2 <7.0.0",
-      "minimatch@<10.2.3": ">=10.2.3",
-      "bn.js@<5.2.3": ">=5.2.3",
-      "@tootallnate/once@<3.0.1": ">=3.0.1",
-      "yauzl": "^3.2.1",
-      "undici": "7.28.0",
-      "picomatch@<4.0.4": ">=4.0.4",
-      "yaml@<2.8.3": ">=2.8.3",
-      "smol-toml@<1.6.1": ">=1.6.1",
-      "handlebars": ">=4.7.9",
-      "path-to-regexp@~0.1.12": "0.1.13",
-      "brace-expansion": ">=5.0.6",
-      "ws@>=7.0.0 <7.5.11": "7.5.11",
-      "ws@>=8.0.0 <8.21.0": "8.21.0",
-      "form-data@>=2.0.0 <2.5.6": "2.5.6",
-      "form-data@>=3.0.0 <3.0.5": "3.0.5",
-      "form-data@>=4.0.0 <4.0.6": "4.0.6",
-      "@babel/core@>=7.0.0 <7.29.6": "7.29.7",
-      "follow-redirects@<1.16.0": ">=1.16.0 <2.0.0",
-      "uuid@<11.1.1": "11.1.1",
-      "js-cookie@<3.0.7": "3.0.7",
-      "shell-quote@<1.8.4": "1.8.4",
-      "esbuild@>=0.17.0 <0.28.1": "0.28.1",
-      "@opentelemetry/core@>=2.0.0 <2.8.0": "2.8.0"
-    },
-    "patchedDependencies": {
-      "node-fetch@2.7.0": "patches/node-fetch@2.7.0.patch"
-    }
-  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write"
   },
-  "packageManager": "pnpm@10.16.1"
+  "packageManager": "pnpm@11.4.0"
 }

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
   injectWorkspacePackages: true
 
 overrides:
+  '@types/express': ^5.0.6
   bigint-buffer: npm:four-flap-bigint-buffer@1.1.6
   diff: ^8.0.3
   ajv: ^8.18.0
@@ -41,9 +42,7 @@ overrides:
   '@opentelemetry/core@>=2.0.0 <2.8.0': 2.8.0
 
 patchedDependencies:
-  node-fetch@2.7.0:
-    hash: cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b
-    path: patches/node-fetch@2.7.0.patch
+  node-fetch@2.7.0: cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b
 
 importers:
 
@@ -87,7 +86,7 @@ importers:
         version: 1.0.22
       '@google-cloud/storage':
         specifier: ^7.21.0
-        version: 7.21.0(encoding@0.1.13)
+        version: 7.21.0
       '@mendable/firecrawl-rs':
         specifier: workspace:*
         version: link:native
@@ -96,7 +95,7 @@ importers:
         version: 2.9.1(ai@6.0.86(zod@4.1.12))(zod@4.1.12)
       '@sentry/cli':
         specifier: ^2.58.2
-        version: 2.58.2(encoding@0.1.13)
+        version: 2.58.2
       '@sentry/node':
         specifier: ^10.27.0
         version: 10.27.0
@@ -150,7 +149,7 @@ importers:
         version: 16.4.5
       drizzle-orm:
         specifier: 1.0.0-rc.3
-        version: 1.0.0-rc.3(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.41)(@types/pg@8.15.5)(pg@8.16.3(pg-native@3.5.2))(zod@4.1.12)
+        version: 1.0.0-rc.3(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(pg@8.16.3)(zod@4.1.12)
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -162,7 +161,7 @@ importers:
         version: 5.2.1
       express-ws:
         specifier: ^5.0.2
-        version: 5.0.2(bufferutil@4.0.9)(express@5.2.1)(utf-8-validate@5.0.10)
+        version: 5.0.2(express@5.2.1)
       foundationdb:
         specifier: ^2.0.1
         version: 2.0.1
@@ -195,7 +194,7 @@ importers:
         version: 2.9.0
       langsmith:
         specifier: ^0.6.0
-        version: 0.6.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@5.20.2(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.6.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(ws@8.21.0)
       lodash:
         specifier: ^4.18.0
         version: 4.18.1
@@ -216,7 +215,7 @@ importers:
         version: 1.1.1
       pg:
         specifier: ^8.16.3
-        version: 8.16.3(pg-native@3.5.2)
+        version: 8.16.3
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -273,7 +272,7 @@ importers:
         version: 3.14.2
       ws:
         specifier: ^8.21.0
-        version: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+        version: 8.21.0
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -1915,9 +1914,6 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0 || ^2.2.0
       '@opentelemetry/semantic-conventions': ^1.37.0
 
-  '@sinclair/typebox@0.34.41':
-    resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2359,9 +2355,6 @@ packages:
     resolution: {integrity: sha512-JocpCSOixzy5XFJi2ub6IMmV/G9i8Lrm2lZvwBv9xPdglmZM0ufDVBbjbrfU/zuLvBfD7Bv2eYxz9i+OHTgkew==}
     deprecated: pkg version number incorrect
 
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
@@ -2398,10 +2391,6 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
-  bufferutil@4.0.9:
-    resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
-    engines: {node: '>=6.14.2'}
 
   bullmq@5.56.7:
     resolution: {integrity: sha512-Aa4Y7rmkuZOuyHvitGd2rSETgQ0SMawPD0XVsU9gAUg9Q4bwNpSD9ZDVcWGhfAQAUZFJH82JUmLsm0B59Prmtg==}
@@ -2826,9 +2815,6 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2973,9 +2959,6 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -3374,9 +3357,6 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
-  libpq@1.10.0:
-    resolution: {integrity: sha512-PHY+JGD3+9X5b2emXLh+WJEnz1jhczO1xs25ZH0xbMWvQi+Hd9X/mTZOrGA99Rcw/DvNjsBRlegroqigpNfaJA==}
-
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -3627,9 +3607,6 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nan@2.23.1:
-    resolution: {integrity: sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==}
-
   nano-spawn@1.0.2:
     resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
     engines: {node: '>=20.17'}
@@ -3732,18 +3709,6 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openai@5.20.2:
-    resolution: {integrity: sha512-ZeBIEazj6W/XOulMw92L8iU5FblQeM5IxjPRCZNVArNXsoF+bLPnS7B2X4O0JSmpCM+F5Gdajr6bn4nAUj4LFQ==}
-    hasBin: true
-    peerDependencies:
-      ws: 8.21.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
   oxc-resolver@11.13.2:
     resolution: {integrity: sha512-1SXVyYQ9bqMX3uZo8Px81EG7jhZkO9PvvR5X9roY5TLYVm4ZA7pbPDNlYaDBBeF9U+YO3OeMNoHde52hrcCu8w==}
 
@@ -3832,9 +3797,6 @@ packages:
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
-
-  pg-native@3.5.2:
-    resolution: {integrity: sha512-3oi+KVil86Vngo4H0IlhBaYSJWdcu8t2f1Y4TkQoQi5oZ9bNeYECGqW3oSGx69mjSZYHoC3h+3jYtqzRgndn5A==}
 
   pg-pool@3.10.1:
     resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
@@ -4419,10 +4381,6 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  utf-8-validate@5.0.10:
-    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
-    engines: {node: '>=6.14.2'}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4987,7 +4945,7 @@ snapshots:
 
   '@google-cloud/promisify@4.0.0': {}
 
-  '@google-cloud/storage@7.21.0(encoding@0.1.13)':
+  '@google-cloud/storage@7.21.0':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
@@ -4996,13 +4954,13 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 5.7.1
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
       html-entities: 2.6.0
       mime: 3.0.0
       p-limit: 3.1.0
-      retry-request: 7.0.2(encoding@0.1.13)
-      teeny-request: 9.0.0(encoding@0.1.13)
+      retry-request: 7.0.2
+      teeny-request: 9.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5906,10 +5864,10 @@ snapshots:
   '@sentry/cli-win32-x64@2.58.2':
     optional: true
 
-  '@sentry/cli@2.58.2(encoding@0.1.13)':
+  '@sentry/cli@2.58.2':
     dependencies:
       https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)
       progress: 2.0.3
       proxy-from-env: 1.1.0
       which: 2.0.2
@@ -5994,9 +5952,6 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
       '@sentry/core': 10.27.0
-
-  '@sinclair/typebox@0.34.41':
-    optional: true
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -6391,11 +6346,6 @@ snapshots:
 
   bignumber.js@9.2.0: {}
 
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-    optional: true
-
   bintrees@1.0.2: {}
 
   body-parser@1.20.3:
@@ -6451,11 +6401,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  bufferutil@4.0.9:
-    dependencies:
-      node-gyp-build: 4.8.4
-    optional: true
 
   bullmq@5.56.7:
     dependencies:
@@ -6699,12 +6644,11 @@ snapshots:
 
   dotenv@16.4.5: {}
 
-  drizzle-orm@1.0.0-rc.3(@opentelemetry/api@1.9.0)(@sinclair/typebox@0.34.41)(@types/pg@8.15.5)(pg@8.16.3(pg-native@3.5.2))(zod@4.1.12):
+  drizzle-orm@1.0.0-rc.3(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(pg@8.16.3)(zod@4.1.12):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@sinclair/typebox': 0.34.41
       '@types/pg': 8.15.5
-      pg: 8.16.3(pg-native@3.5.2)
+      pg: 8.16.3
       zod: 4.1.12
 
   dunder-proto@1.0.1:
@@ -6748,11 +6692,6 @@ snapshots:
   enabled@2.0.0: {}
 
   encodeurl@2.0.0: {}
-
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6844,10 +6783,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-ws@5.0.2(bufferutil@4.0.9)(express@5.2.1)(utf-8-validate@5.0.10):
+  express-ws@5.0.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ws: 7.5.11(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6938,9 +6877,6 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  file-uri-to-path@1.0.0:
-    optional: true
-
   filelist@1.0.4:
     dependencies:
       minimatch: 10.2.4
@@ -7016,12 +6952,12 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  gaxios@6.7.1(encoding@0.1.13):
+  gaxios@6.7.1:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
-      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)
       uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
@@ -7036,9 +6972,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@6.1.1(encoding@0.1.13):
+  gcp-metadata@6.1.1:
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -7106,13 +7042,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1(encoding@0.1.13):
+  google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)
-      gcp-metadata: 6.1.1(encoding@0.1.13)
-      gtoken: 7.1.0(encoding@0.1.13)
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -7124,9 +7060,9 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  gtoken@7.1.0(encoding@0.1.13):
+  gtoken@7.1.0:
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -7403,22 +7339,15 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langsmith@0.6.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@5.20.2(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  langsmith@0.6.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      openai: 5.20.2(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
-      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.21.0
 
   leac@0.6.0: {}
-
-  libpq@1.10.0:
-    dependencies:
-      bindings: 1.5.0
-      nan: 2.23.1
-    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7633,9 +7562,6 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nan@2.23.1:
-    optional: true
-
   nano-spawn@1.0.2: {}
 
   nanoid@3.3.12: {}
@@ -7650,11 +7576,9 @@ snapshots:
 
   node-ensure@0.0.0: {}
 
-  node-fetch@2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13):
+  node-fetch@2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b):
     dependencies:
       whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
 
   node-fetch@3.3.2:
     dependencies:
@@ -7720,12 +7644,6 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
-
-  openai@5.20.2(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12):
-    optionalDependencies:
-      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      zod: 4.1.12
-    optional: true
 
   oxc-resolver@11.13.2:
     optionalDependencies:
@@ -7832,15 +7750,9 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-native@3.5.2:
+  pg-pool@3.10.1(pg@8.16.3):
     dependencies:
-      libpq: 1.10.0
-      pg-types: 2.2.0
-    optional: true
-
-  pg-pool@3.10.1(pg@8.16.3(pg-native@3.5.2)):
-    dependencies:
-      pg: 8.16.3(pg-native@3.5.2)
+      pg: 8.16.3
 
   pg-protocol@1.10.3: {}
 
@@ -7852,16 +7764,15 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  pg@8.16.3(pg-native@3.5.2):
+  pg@8.16.3:
     dependencies:
       pg-connection-string: 2.9.1
-      pg-pool: 3.10.1(pg@8.16.3(pg-native@3.5.2))
+      pg-pool: 3.10.1(pg@8.16.3)
       pg-protocol: 1.10.3
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.2.7
-      pg-native: 3.5.2
 
   pgpass@1.0.5:
     dependencies:
@@ -8030,11 +7941,11 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-request@7.0.2(encoding@0.1.13):
+  retry-request@7.0.2:
     dependencies:
       '@types/request': 2.48.13
       extend: 3.0.2
-      teeny-request: 9.0.0(encoding@0.1.13)
+      teeny-request: 9.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8302,11 +8213,11 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
-  teeny-request@9.0.0(encoding@0.1.13):
+  teeny-request@9.0.0:
     dependencies:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)(encoding@0.1.13)
+      node-fetch: 2.7.0(patch_hash=cf2058381802eaf328e1cb26b185762ba41e2157a5545e7ed9bba56b7de0c49b)
       stream-events: 1.0.5
       uuid: 11.1.1
     transitivePeerDependencies:
@@ -8449,11 +8360,6 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  utf-8-validate@5.0.10:
-    dependencies:
-      node-gyp-build: 4.8.4
-    optional: true
-
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
@@ -8580,15 +8486,9 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.11(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 5.0.10
+  ws@7.5.11: {}
 
-  ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 5.0.10
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/apps/api/pnpm-workspace.yaml
+++ b/apps/api/pnpm-workspace.yaml
@@ -13,22 +13,55 @@ minimumReleaseAgeExclude:
   - "@typescript/typescript-*"
 overrides:
   "@types/express": "^5.0.6"
+  bigint-buffer: "npm:four-flap-bigint-buffer@1.1.6"
+  diff: "^8.0.3"
+  ajv: "^8.18.0"
+  fast-xml-builder: ">=1.1.6 <2.0.0"
+  fast-xml-parser: "^5.7.0"
+  fast-uri: ">=3.1.2 <4.0.0"
+  "glob@>=10.2.0 <10.5.0": ">=10.5.0"
+  "js-yaml@<3.14.2": "4.2.0"
+  "js-yaml@>=4.0.0 <4.2.0": "4.2.0"
+  "qs@<6.15.2": ">=6.15.2 <7.0.0"
+  "minimatch@<10.2.3": ">=10.2.3"
+  "bn.js@<5.2.3": ">=5.2.3"
+  "@tootallnate/once@<3.0.1": ">=3.0.1"
+  yauzl: "^3.2.1"
+  undici: "7.28.0"
+  "picomatch@<4.0.4": ">=4.0.4"
+  "yaml@<2.8.3": ">=2.8.3"
+  "smol-toml@<1.6.1": ">=1.6.1"
+  handlebars: ">=4.7.9"
+  "path-to-regexp@~0.1.12": "0.1.13"
+  brace-expansion: ">=5.0.6"
+  "ws@>=7.0.0 <7.5.11": "7.5.11"
+  "ws@>=8.0.0 <8.21.0": "8.21.0"
+  "form-data@>=2.0.0 <2.5.6": "2.5.6"
+  "form-data@>=3.0.0 <3.0.5": "3.0.5"
+  "form-data@>=4.0.0 <4.0.6": "4.0.6"
+  "@babel/core@>=7.0.0 <7.29.6": "7.29.7"
+  "follow-redirects@<1.16.0": ">=1.16.0 <2.0.0"
+  "uuid@<11.1.1": "11.1.1"
+  "js-cookie@<3.0.7": "3.0.7"
+  "shell-quote@<1.8.4": "1.8.4"
+  "esbuild@>=0.17.0 <0.28.1": "0.28.1"
+  "@opentelemetry/core@>=2.0.0 <2.8.0": "2.8.0"
 patchedDependencies:
   "node-fetch@2.7.0": "patches/node-fetch@2.7.0.patch"
-onlyBuiltDependencies:
-  - "@mendable/firecrawl-rs"
-  - "@sentry-internal/node-cpu-profiler"
-  - "@sentry/cli"
-  - bigint-buffer
-  - bufferutil
-  - esbuild
-  - foundationdb
-  - four-flap-bigint-buffer
-  - keccak
-  - koffi
-  - libpq
-  - msgpackr-extract
-  - oxc-resolver
-  - protobufjs
-  - utf-8-validate
-  - wordpos
+allowBuilds:
+  "@mendable/firecrawl-rs": true
+  "@sentry-internal/node-cpu-profiler": true
+  "@sentry/cli": true
+  bigint-buffer: true
+  bufferutil: true
+  esbuild: true
+  foundationdb: true
+  four-flap-bigint-buffer: true
+  keccak: true
+  koffi: true
+  libpq: true
+  msgpackr-extract: true
+  oxc-resolver: true
+  protobufjs: true
+  utf-8-validate: true
+  wordpos: true


### PR DESCRIPTION
## Summary

Upgrade the API package, server CI workflow, audit workflows, and API container image to pnpm 11.4.0 with Node.js 22. Move API pnpm settings into the workspace configuration so overrides, patched dependencies, and native build policies remain effective under pnpm 11, while restoring API security audits through the supported bulk advisory endpoint.

This is the first stage of a staggered repository upgrade; SDKs, UI projects, test utilities, and standalone services remain on their existing package-manager versions.