### PR TITLE
chore(ci): upgrade support services to pnpm 11

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 10
+          version: 11.4.0
 
       - name: Install FoundationDB client library
         run: |
@@ -94,7 +94,7 @@ jobs:
             apps/test-site/pnpm-lock.yaml
             apps/playwright-service-ts/pnpm-lock.yaml
 
-      - run: pnpm dlx pnpm@11.4.0 fetch
+      - run: pnpm fetch
         working-directory: apps/api
       - run: pnpm fetch
         working-directory: apps/test-site
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build native lib
         if: steps.napi_restore.outputs.cache-hit != 'true'
-        run: pnpm dlx pnpm@11.4.0 install
+        run: pnpm install
         working-directory: apps/api/native
 
       - name: Cache native lib
@@ -213,7 +213,7 @@ jobs:
         working-directory: ./
 
       - name: Install API dependencies
-        run: pnpm dlx pnpm@11.4.0 install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: apps/api
         env:
           npm_config_ignore_scripts: 'true'
@@ -259,7 +259,7 @@ jobs:
           echo "docker:docker@127.0.0.1:4500" > /tmp/fdb.cluster
 
       - name: Run tests
-        run: pnpm dlx pnpm@11.4.0 harness pnpm test:snips
+        run: pnpm harness pnpm test:snips
         working-directory: apps/api
         env:
           npm_config_ignore_scripts: 'true' # required currently to prevent re-building cached native lib

--- a/apps/playwright-service-ts/Dockerfile
+++ b/apps/playwright-service-ts/Dockerfile
@@ -1,21 +1,27 @@
-FROM node:18-slim
+FROM node:22-slim
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+ENV CI=true
+
+RUN corepack enable && corepack prepare pnpm@11.4.0 --activate
 
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm install
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
 
 COPY . .
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/share/playwright
 
 # Install Playwright dependencies
-RUN npx playwright install chromium --with-deps
+RUN pnpm exec playwright install chromium --with-deps
 
-RUN npm run build
+RUN pnpm run build
 
 ARG PORT
 ENV PORT=${PORT}
 
 EXPOSE ${PORT}
 
-CMD [ "npm", "start" ]
+CMD [ "pnpm", "start" ]

--- a/apps/playwright-service-ts/package.json
+++ b/apps/playwright-service-ts/package.json
@@ -11,6 +11,9 @@
   "keywords": [],
   "author": "Jeff Pereira",
   "license": "ISC",
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^5.2.1",
@@ -26,11 +29,5 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
-  "pnpm": {
-    "overrides": {
-      "path-to-regexp@<8.4.0": ">=8.4.0",
-      "qs@<6.15.2": ">=6.15.2 <7.0.0",
-      "esbuild@>=0.17.0 <0.28.1": "0.28.1"
-    }
-  }
+  "packageManager": "pnpm@11.4.0"
 }

--- a/apps/playwright-service-ts/pnpm-workspace.yaml
+++ b/apps/playwright-service-ts/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  esbuild: true
+overrides:
+  "path-to-regexp@<8.4.0": ">=8.4.0"
+  "qs@<6.15.2": ">=6.15.2 <7.0.0"
+  "esbuild@>=0.17.0 <0.28.1": "0.28.1"

--- a/apps/test-site/package.json
+++ b/apps/test-site/package.json
@@ -2,6 +2,9 @@
   "name": "firecrawl-test-site",
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
@@ -20,23 +23,5 @@
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ],
-    "overrides": {
-      "fast-xml-builder": ">=1.1.6 <2.0.0",
-      "fast-xml-parser": "^5.7.0",
-      "devalue": ">=5.8.1 <6.0.0",
-      "h3": ">=1.15.9",
-      "picomatch@<4.0.4": ">=4.0.4",
-      "smol-toml@<1.6.1": ">=1.6.1",
-      "defu": ">=6.1.5",
-      "vite@>=7.0.0 <7.3.5": "7.3.5",
-      "js-yaml@>=4.0.0 <4.2.0": "4.2.0",
-      "postcss@<8.5.10": ">=8.5.10 <9.0.0",
-      "esbuild@>=0.17.0 <0.28.1": "0.28.1"
-    }
-  }
+  "packageManager": "pnpm@11.4.0"
 }

--- a/apps/test-site/pnpm-workspace.yaml
+++ b/apps/test-site/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+overrides:
+  fast-xml-builder: ">=1.1.6 <2.0.0"
+  fast-xml-parser: "^5.7.0"
+  devalue: ">=5.8.1 <6.0.0"
+  h3: ">=1.15.9"
+  "picomatch@<4.0.4": ">=4.0.4"
+  "smol-toml@<1.6.1": ">=1.6.1"
+  defu: ">=6.1.5"
+  "vite@>=7.0.0 <7.3.5": "7.3.5"
+  "js-yaml@>=4.0.0 <4.2.0": "4.2.0"
+  "postcss@<8.5.10": ">=8.5.10 <9.0.0"
+  "esbuild@>=0.17.0 <0.28.1": "0.28.1"


### PR DESCRIPTION
## Summary

Upgrade the Playwright service and test-site to pnpm 11.4.0 and Node.js 22, migrating their pnpm overrides and native build policies into workspace configuration. Update the shared server workflow to use pnpm 11 directly now that all workspaces exercised by that matrix support it.

This is the second stage of the repository rollout after the API upgrade; SDKs, ingestion UI, and the standalone test-suite remain on their existing package-manager versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Playwright service and test-site to `pnpm@11.4.0` and Node.js 22. CI now uses `pnpm` v11 directly with overrides/build policies moved into per-app workspace configs.

- **Dependencies**
  - CI: set `pnpm/action-setup` to 11.4.0 and replace `pnpm dlx pnpm@11.4.0` calls with plain `pnpm` (`fetch`, `install`, `harness`).
  - Playwright service: switch to `node:22-slim`, enable Corepack and `pnpm@11.4.0`, use `pnpm` for install/build/start, use `pnpm exec` for Playwright, add `engines` (Node ≥22.13.0) and `packageManager`, move overrides to `pnpm-workspace.yaml` (allow `esbuild` builds).
  - Test-site: add `engines` (Node ≥22.13.0) and `packageManager`, move overrides and build allowances to `pnpm-workspace.yaml` (allow `esbuild` and `sharp`).

<sup>Written for commit 7e02ac4833cac88026083f9b9d37f7c18aaed096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

