### PR TITLE
fix(api): forward all highlight shadow requests

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -164,7 +164,6 @@ const configSchema = z.object({
   HIGHLIGHT_MODEL_URL: z.string().optional(),
   HIGHLIGHT_MODEL_TOKEN: z.string().optional(),
   HIGHLIGHT_SHADOW_RATE: z.coerce.number().min(0).max(1).default(0),
-  HIGHLIGHT_SHADOW_MAX_INFLIGHT: z.coerce.number().int().positive().default(8),
 
   // Fire Engine
   FIRE_ENGINE_BETA_URL: z.string().optional(),

--- a/apps/api/src/search/highlight-model.ts
+++ b/apps/api/src/search/highlight-model.ts
@@ -160,6 +160,7 @@ interface HighlightBatchOptions {
   logPayload?: boolean;
   allowLegacyFallback?: boolean;
   requestId?: string;
+  timeoutMs?: number | null;
   onFailure?: (reason: HighlightFailureReason) => void;
 }
 
@@ -175,7 +176,12 @@ async function generateHighlightsBatchRequest(
   }
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const timeoutMs =
+    opts.timeoutMs === undefined ? REQUEST_TIMEOUT_MS : opts.timeoutMs;
+  const timer =
+    timeoutMs === null
+      ? undefined
+      : setTimeout(() => controller.abort(), timeoutMs);
   const start = Date.now();
   try {
     const baseUrl = config.HIGHLIGHT_MODEL_URL!.replace(/\/$/, "");
@@ -260,7 +266,9 @@ async function generateHighlightsBatchRequest(
     });
     return null;
   } finally {
-    clearTimeout(timer);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/apps/api/src/search/highlights-shadow.test.ts
+++ b/apps/api/src/search/highlights-shadow.test.ts
@@ -1,7 +1,6 @@
 vi.mock("../config", () => ({
   config: {
     HIGHLIGHT_SHADOW_RATE: 1,
-    HIGHLIGHT_SHADOW_MAX_INFLIGHT: 1,
   },
 }));
 
@@ -29,7 +28,6 @@ let runSearchHighlightsShadow = createSearchHighlightsShadowRunner(logger);
 afterEach(() => {
   vi.clearAllMocks();
   config.HIGHLIGHT_SHADOW_RATE = 1;
-  config.HIGHLIGHT_SHADOW_MAX_INFLIGHT = 1;
   vi.mocked(highlightsEnvReady).mockReturnValue(true);
   runSearchHighlightsShadow = createSearchHighlightsShadowRunner(logger);
 });
@@ -77,18 +75,13 @@ describe("runSearchHighlightsShadow", () => {
     expect(fields).not.toHaveProperty("highlights");
   });
 
-  it("drops excess work instead of creating a backlog", async () => {
-    let finish!: (value: {
-      attempted: number;
-      indexHits: number;
-      replaced: number;
-      succeeded: boolean;
-    }) => void;
-    vi.mocked(runIndexedSearchHighlightsShadow).mockReturnValue(
-      new Promise(resolve => {
-        finish = resolve;
-      }),
-    );
+  it("forwards concurrent shadow work without admission drops", async () => {
+    vi.mocked(runIndexedSearchHighlightsShadow).mockResolvedValue({
+      attempted: 1,
+      indexHits: 1,
+      replaced: 1,
+      succeeded: true,
+    });
 
     const input = {
       response: {} as any,
@@ -101,18 +94,9 @@ describe("runSearchHighlightsShadow", () => {
     ).toBe("started");
     expect(
       runSearchHighlightsShadow({ ...input, requestId: "request-2" }),
-    ).toBe("dropped");
-    expect(logger.info).toHaveBeenCalledWith(
-      "Search highlights shadow dropped",
-      expect.objectContaining({
-        canonicalLog: "search/highlights-shadow",
-        outcome: "dropped",
-        reason: "max_inflight",
-      }),
-    );
-
-    finish({ attempted: 1, indexHits: 1, replaced: 1, succeeded: true });
+    ).toBe("started");
     await new Promise(resolve => setImmediate(resolve));
+    expect(runIndexedSearchHighlightsShadow).toHaveBeenCalledTimes(2);
   });
 
   it("emits the content-free failure category", async () => {

--- a/apps/api/src/search/highlights-shadow.ts
+++ b/apps/api/src/search/highlights-shadow.ts
@@ -31,7 +31,7 @@ export function createSearchHighlightsShadowRunner(
   requestId: string;
   teamId: string;
   zeroDataRetention: boolean;
-}) => "skipped" | "dropped" | "started" {
+}) => "skipped" | "started" {
   let inFlight = 0;
 
   return options => {
@@ -41,20 +41,6 @@ export function createSearchHighlightsShadowRunner(
       !sampled(options.requestId, config.HIGHLIGHT_SHADOW_RATE)
     ) {
       return "skipped";
-    }
-
-    if (inFlight >= config.HIGHLIGHT_SHADOW_MAX_INFLIGHT) {
-      canonicalLogger.info("Search highlights shadow dropped", {
-        canonicalLog: CANONICAL_LOG,
-        outcome: "dropped",
-        reason: "max_inflight",
-        requestId: options.requestId,
-        teamId: options.teamId,
-        inFlight,
-        maxInFlight: config.HIGHLIGHT_SHADOW_MAX_INFLIGHT,
-        sampleRate: config.HIGHLIGHT_SHADOW_RATE,
-      });
-      return "dropped";
     }
 
     const urls = searchHighlightURLs(options.response);
@@ -74,7 +60,6 @@ export function createSearchHighlightsShadowRunner(
           failureReason: result.failureReason,
           timeTakenMs: Date.now() - startedAt,
           inFlight,
-          maxInFlight: config.HIGHLIGHT_SHADOW_MAX_INFLIGHT,
           sampleRate: config.HIGHLIGHT_SHADOW_RATE,
         });
       })
@@ -87,7 +72,6 @@ export function createSearchHighlightsShadowRunner(
           errorType: error instanceof Error ? error.name : "unknown",
           timeTakenMs: Date.now() - startedAt,
           inFlight,
-          maxInFlight: config.HIGHLIGHT_SHADOW_MAX_INFLIGHT,
           sampleRate: config.HIGHLIGHT_SHADOW_RATE,
         });
       })

--- a/apps/api/src/search/highlights.test.ts
+++ b/apps/api/src/search/highlights.test.ts
@@ -101,6 +101,7 @@ describe("runIndexedSearchHighlightsShadow", () => {
         logger,
         logPayload: false,
         requestId: "request-1",
+        timeoutMs: null,
         onFailure: expect.any(Function),
       },
     );

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -186,6 +186,7 @@ export async function runIndexedSearchHighlightsShadow(
     logger,
     logPayload: false,
     requestId,
+    timeoutMs: null,
     onFailure: reason => {
       failureReason = reason;
     },


### PR DESCRIPTION
Removes the local admission drop from indexed highlight shadowing and disables the batch request timer only for that background path. Regular highlight requests retain the existing timeout.

Verification:
- pnpm exec vitest run src/search/highlights-shadow.test.ts src/search/highlights.test.ts src/search/highlight-model.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward all highlight shadow requests by removing the local admission cap and disabling the batch timeout for the shadow path. Regular highlight requests keep the existing timeout.

- **Bug Fixes**
  - Removed `HIGHLIGHT_SHADOW_MAX_INFLIGHT` and the drop logic; shadow work is no longer skipped under load.
  - Added `timeoutMs` override to the highlight model; shadow calls pass `timeoutMs: null` to avoid aborts, non-shadow calls unchanged.
  - Cleaned up logs to remove “dropped” outcomes and max-inflight fields.
  - Updated tests to reflect always-forwarding behavior and the no-timeout shadow path.

<sup>Written for commit 516fb046ddba810797d8a4c5711bf4fb14bcb79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

