### PR TITLE
fix(search): route highlights beta through indexed chain

### DIFF
--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -13,7 +13,7 @@ import {
   mergeScrapedContent,
   calculateScrapeCredits,
 } from "./scrape";
-import { applySearchHighlights, highlightsEnvReady } from "./highlights";
+import { applyIndexedSearchHighlights, highlightsEnvReady } from "./highlights";
 import { runSearchHighlightsShadow } from "./highlights-shadow";
 import { trackSearchResults, trackSearchRequest } from "../lib/tracking";
 import type { BillingMetadata } from "../services/billing/types";
@@ -253,7 +253,12 @@ export async function executeSearch(
     flags?.highlightsBeta === true &&
     highlightsEnvReady();
   if (shouldApplyHighlights) {
-    await applySearchHighlights(searchResponse, query, logger);
+    await applyIndexedSearchHighlights(
+      searchResponse,
+      query,
+      logger,
+      context.requestId,
+    );
   } else {
     runSearchHighlightsShadow({
       response: searchResponse,

--- a/apps/api/src/search/highlights.test.ts
+++ b/apps/api/src/search/highlights.test.ts
@@ -45,6 +45,7 @@ import {
 import { config } from "../config";
 import { indexGetRecent5 } from "../db/rpc";
 import {
+  applyIndexedSearchHighlights,
   applySearchHighlights,
   highlightsEnvReady,
   runIndexedSearchHighlightsShadow,
@@ -110,6 +111,84 @@ describe("runIndexedSearchHighlightsShadow", () => {
       indexHits: 2,
       replaced: 1,
       succeeded: true,
+    });
+  });
+});
+
+describe("applyIndexedSearchHighlights", () => {
+  it("uses the shadow indexed request path and applies web and news responses by ID", async () => {
+    vi.mocked(generateHighlightsIndexedBatch).mockResolvedValue(
+      new Map([
+        ["0", { highlights: [], markdown: "first highlight" }],
+        ["1", { highlights: [], markdown: "second highlight" }],
+      ]),
+    );
+    const response = {
+      web: [{ url: "https://first.test", description: "first fallback" }],
+      news: [{ url: "https://second.test", snippet: "second fallback" }],
+    } as any;
+
+    const result = await applyIndexedSearchHighlights(
+      response,
+      "query",
+      logger,
+      "request-1",
+    );
+
+    expect(generateHighlightsIndexedBatch).toHaveBeenCalledWith(
+      "query",
+      [
+        {
+          id: "0",
+          url: "https://first.test",
+          indexObject: "index:https://first.test.json",
+        },
+        {
+          id: "1",
+          url: "https://second.test",
+          indexObject: "index:https://second.test.json",
+        },
+      ],
+      {
+        logger,
+        logPayload: false,
+        requestId: "request-1",
+        timeoutMs: null,
+        onFailure: expect.any(Function),
+      },
+    );
+    expect(generateHighlightsBatch).not.toHaveBeenCalled();
+    expect(response.web[0].description).toBe("first highlight");
+    expect(response.news[0].snippet).toBe("second highlight");
+    expect(result).toEqual({
+      attempted: 2,
+      indexHits: 2,
+      replaced: 2,
+      succeeded: true,
+    });
+  });
+
+  it("preserves provider snippets when the indexed Chain request fails", async () => {
+    vi.mocked(generateHighlightsIndexedBatch).mockResolvedValue(null);
+    const response = {
+      web: [{ url: "https://first.test", description: "first fallback" }],
+      news: [{ url: "https://second.test", snippet: "second fallback" }],
+    } as any;
+
+    const result = await applyIndexedSearchHighlights(
+      response,
+      "query",
+      logger,
+      "request-1",
+    );
+
+    expect(response.web[0].description).toBe("first fallback");
+    expect(response.news[0].snippet).toBe("second fallback");
+    expect(result).toEqual({
+      attempted: 2,
+      indexHits: 2,
+      replaced: 0,
+      succeeded: false,
     });
   });
 });

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -146,17 +146,42 @@ async function getIndexObjectForURL(
   }
 }
 
-export function searchHighlightURLs(response: SearchV2Response): string[] {
-  return [
-    ...(response.web ?? []).flatMap(result => (result.url ? [result.url] : [])),
-    ...(response.news ?? []).flatMap(result =>
-      result.url ? [result.url] : [],
-    ),
-  ];
+interface IndexedSearchHighlightTarget {
+  url: string;
+  apply?: (highlight: string) => void;
 }
 
-export async function runIndexedSearchHighlightsShadow(
-  urls: string[],
+function indexedSearchHighlightTargets(
+  response: SearchV2Response,
+): IndexedSearchHighlightTarget[] {
+  const targets: IndexedSearchHighlightTarget[] = [];
+  for (const result of response.web ?? []) {
+    if (!result.url) continue;
+    targets.push({
+      url: result.url,
+      apply: highlight => {
+        result.description = highlight;
+      },
+    });
+  }
+  for (const result of response.news ?? []) {
+    if (!result.url) continue;
+    targets.push({
+      url: result.url,
+      apply: highlight => {
+        result.snippet = highlight;
+      },
+    });
+  }
+  return targets;
+}
+
+export function searchHighlightURLs(response: SearchV2Response): string[] {
+  return indexedSearchHighlightTargets(response).map(target => target.url);
+}
+
+async function runIndexedSearchHighlights(
+  targets: IndexedSearchHighlightTarget[],
   query: string,
   logger: Logger,
   requestId: string,
@@ -167,16 +192,16 @@ export async function runIndexedSearchHighlightsShadow(
   succeeded: boolean;
   failureReason?: HighlightFailureReason;
 }> {
-  const attempted = urls.length;
+  const attempted = targets.length;
   const resolved = await Promise.all(
-    urls.map(url => getIndexObjectForURL(url, logger, false)),
+    targets.map(target => getIndexObjectForURL(target.url, logger, false)),
   );
   const pages: HighlightIndexedPage[] = [];
   resolved.forEach((indexRef, index) => {
     if (!indexRef) return;
     pages.push({
       id: String(index),
-      url: urls[index],
+      url: targets[index].url,
       indexObject: indexRef.name,
     });
   });
@@ -191,10 +216,15 @@ export async function runIndexedSearchHighlightsShadow(
       failureReason = reason;
     },
   });
-  const replaced = results
-    ? Array.from(results.values()).filter(result => result.markdown.trim())
-        .length
-    : 0;
+  let replaced = 0;
+  if (results) {
+    for (const page of pages) {
+      const highlight = results.get(page.id)?.markdown;
+      if (!highlight?.trim()) continue;
+      targets[Number(page.id)].apply?.(highlight);
+      replaced++;
+    }
+  }
 
   return {
     attempted,
@@ -203,6 +233,42 @@ export async function runIndexedSearchHighlightsShadow(
     succeeded: results !== null,
     ...(failureReason ? { failureReason } : {}),
   };
+}
+
+export async function applyIndexedSearchHighlights(
+  response: SearchV2Response,
+  query: string,
+  logger: Logger,
+  requestId: string,
+): ReturnType<typeof runIndexedSearchHighlights> {
+  const start = Date.now();
+  const result = await runIndexedSearchHighlights(
+    indexedSearchHighlightTargets(response),
+    query,
+    logger,
+    requestId,
+  );
+  logger.info("Search highlights applied", {
+    attempted: result.attempted,
+    indexHits: result.indexHits,
+    replaced: result.replaced,
+    timeTakenMs: Date.now() - start,
+  });
+  return result;
+}
+
+export function runIndexedSearchHighlightsShadow(
+  urls: string[],
+  query: string,
+  logger: Logger,
+  requestId: string,
+): ReturnType<typeof runIndexedSearchHighlights> {
+  return runIndexedSearchHighlights(
+    urls.map(url => ({ url })),
+    query,
+    logger,
+    requestId,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- route opted-in search highlights through the same indexed Chain request helper used by shadow traffic
- apply returned highlights to web and news results by stable page ID
- preserve provider snippets when the indexed request fails

## Tests
- `./node_modules/.bin/vitest run src/search/highlights.test.ts src/search/highlights-shadow.test.ts src/search/highlight-model.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- Prettier and staged-file Knip checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes highlights beta through the indexed Chain path and applies results to web and news by stable page ID. Falls back to provider snippets when the indexed request fails to avoid empty snippets.

- **Bug Fixes**
  - Call `applyIndexedSearchHighlights` in `execute` with `requestId`.
  - Apply returned highlights to `web.description` and `news.snippet` by ID; track `attempted`, `indexHits`, and `replaced`.
  - Preserve provider snippets when the indexed batch fails.

- **Refactors**
  - Introduce shared `runIndexedSearchHighlights` and wrapper `runIndexedSearchHighlightsShadow`; add `indexedSearchHighlightTargets` to map URLs to updaters.

<sup>Written for commit eec6ab0c8f8fc79cbb689e9263f63a7418d7b000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

