### PR TITLE
feat(sdks): add search highlights option

### DIFF
--- a/apps/dot-net-sdk/Firecrawl.Tests/ModelsTests.cs
+++ b/apps/dot-net-sdk/Firecrawl.Tests/ModelsTests.cs
@@ -87,6 +87,7 @@ public class ModelsTests
             Limit = 5,
             Location = "US",
             Tbs = "qdr:w",
+            Highlights = false,
             IncludeDomains = new() { "firecrawl.dev" },
             ExcludeDomains = new() { "example.com" }
         };
@@ -95,6 +96,7 @@ public class ModelsTests
         Assert.Contains("\"limit\":5", json);
         Assert.Contains("\"location\":\"US\"", json);
         Assert.Contains("\"tbs\":\"qdr:w\"", json);
+        Assert.Contains("\"highlights\":false", json);
         Assert.Contains("\"includeDomains\":[\"firecrawl.dev\"]", json);
         Assert.Contains("\"excludeDomains\":[\"example.com\"]", json);
     }

--- a/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
+++ b/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>firecrawl-sdk</PackageId>
-    <Version>1.9.0</Version>
+    <Version>1.9.1</Version>
     <Authors>Firecrawl</Authors>
     <Company>Firecrawl</Company>
     <Description>.NET SDK for the Firecrawl API - web scraping, crawling, and data extraction</Description>

--- a/apps/dot-net-sdk/Firecrawl/Models/SearchOptions.cs
+++ b/apps/dot-net-sdk/Firecrawl/Models/SearchOptions.cs
@@ -43,6 +43,11 @@ public class SearchOptions
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Timeout { get; set; }
 
+    /// <summary>Generate query-relevant highlights for search results. Defaults to true.</summary>
+    [JsonPropertyName("highlights")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Highlights { get; set; }
+
     [JsonPropertyName("scrapeOptions")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ScrapeOptions? ScrapeOptions { get; set; }

--- a/apps/elixir-sdk/lib/firecrawl.ex
+++ b/apps/elixir-sdk/lib/firecrawl.ex
@@ -1150,6 +1150,7 @@ defmodule Firecrawl do
     enterprise: [type: {:list, :string}, doc: "Enterprise search options for Zero Data Retention (ZDR). Use `[\"zdr\"]` for end-to-end ZDR (10 credits / 10 results) or `[\"anon\"]` for anonymized ZDR (2 credits / 10 results). Must be enabled for your team."],
     exclude_domains: [type: {:list, :string}, doc: "Domains to exclude from search results."],
     ignore_invalid_urls: [type: :boolean, doc: "Excludes URLs from the search results that are invalid for other Firecrawl endpoints. This helps reduce errors if you are piping data from search into other Firecrawl API endpoints."],
+    highlights: [type: :boolean, doc: "Generate query-relevant highlights for search results. Defaults to true."],
     include_domains: [type: {:list, :string}, doc: "Domains to include in search results."],
     limit: [type: :integer, doc: "Maximum number of results to return"],
     location: [type: :string, doc: "Location parameter for search results (e.g. `San Francisco,California,United States`). For best results, set both this and the `country` parameter."],
@@ -1160,7 +1161,7 @@ defmodule Firecrawl do
     timeout: [type: :integer, doc: "Timeout in milliseconds"]
   ])
 
-  @search_and_scrape_key_mapping %{categories: "categories", country: "country", enterprise: "enterprise", exclude_domains: "excludeDomains", ignore_invalid_urls: "ignoreInvalidURLs", include_domains: "includeDomains", limit: "limit", location: "location", query: "query", scrape_options: "scrapeOptions", sources: "sources", tbs: "tbs", timeout: "timeout"}
+  @search_and_scrape_key_mapping %{categories: "categories", country: "country", enterprise: "enterprise", exclude_domains: "excludeDomains", highlights: "highlights", ignore_invalid_urls: "ignoreInvalidURLs", include_domains: "includeDomains", limit: "limit", location: "location", query: "query", scrape_options: "scrapeOptions", sources: "sources", tbs: "tbs", timeout: "timeout"}
 
   @doc """
   Search and optionally scrape search results

--- a/apps/elixir-sdk/mix.exs
+++ b/apps/elixir-sdk/mix.exs
@@ -1,7 +1,7 @@
 defmodule Firecrawl.MixProject do
   use Mix.Project
 
-  @version "1.8.0"
+  @version "1.8.1"
   @source_url "https://github.com/firecrawl/firecrawl/tree/main/apps/elixir-sdk"
 
   def project do

--- a/apps/elixir-sdk/test/firecrawl_test.exs
+++ b/apps/elixir-sdk/test/firecrawl_test.exs
@@ -317,6 +317,40 @@ defmodule FirecrawlTest do
     assert body["urls"] == ["https://example.com"]
   end
 
+  test "search maps highlights to highlights" do
+    parent = self()
+
+    adapter = fn request ->
+      send(parent, {:request, request})
+
+      resp = Req.Response.new(
+        status: 200,
+        headers: %{"content-type" => ["application/json"]},
+        body: Jason.encode!(%{"success" => true, "data" => %{}})
+      )
+
+      {request, resp}
+    end
+
+    assert {:ok, %Req.Response{status: 200}} =
+             Firecrawl.search_and_scrape(
+               [query: "firecrawl", highlights: false],
+               api_key: "test-key",
+               adapter: adapter
+             )
+
+    assert_receive {:request, request}
+
+    body =
+      cond do
+        is_binary(request.body) -> Jason.decode!(request.body)
+        is_map(request.body) -> request.body
+        true -> request.options[:json]
+      end
+
+    assert body["highlights"] == false
+  end
+
   test "all expected API functions are defined with bang variants" do
     functions = Firecrawl.__info__(:functions)
 

--- a/apps/go-sdk/options.go
+++ b/apps/go-sdk/options.go
@@ -171,6 +171,7 @@ type SearchOptions struct {
 	Location          *string        `json:"location,omitempty"`
 	IgnoreInvalidURLs *bool          `json:"ignoreInvalidURLs,omitempty"`
 	Timeout           *int           `json:"timeout,omitempty"`
+	Highlights        *bool          `json:"highlights,omitempty"`
 	ScrapeOptions     *ScrapeOptions `json:"scrapeOptions,omitempty"`
 	Integration       *string        `json:"integration,omitempty"`
 }

--- a/apps/go-sdk/options_test.go
+++ b/apps/go-sdk/options_test.go
@@ -76,3 +76,14 @@ func TestScrapeOptionsSerializesRedactPII(t *testing.T) {
 		t.Fatalf("serialized redactPII = %s", payload)
 	}
 }
+
+func TestSearchOptionsSerializesHighlights(t *testing.T) {
+	payload, err := json.Marshal(SearchOptions{Highlights: Bool(false)})
+	if err != nil {
+		t.Fatalf("Marshal SearchOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"highlights":false`) {
+		t.Fatalf("serialized search options = %s", payload)
+	}
+}

--- a/apps/go-sdk/version.go
+++ b/apps/go-sdk/version.go
@@ -9,4 +9,4 @@ package firecrawl
 // Bump this when preparing a new release. The publish-go-sdk GitHub workflow
 // reads this value and creates the corresponding monorepo-prefixed tag on
 // merge to main.
-const Version = "1.8.0"
+const Version = "1.8.1"

--- a/apps/java-sdk/build.gradle.kts
+++ b/apps/java-sdk/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.firecrawl"
-version = "1.11.0"
+version = "1.11.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java
@@ -18,6 +18,7 @@ public class SearchOptions {
     private String location;
     private Boolean ignoreInvalidURLs;
     private Integer timeout;
+    private Boolean highlights;
     private ScrapeOptions scrapeOptions;
     private String integration;
 
@@ -32,6 +33,7 @@ public class SearchOptions {
     public String getLocation() { return location; }
     public Boolean getIgnoreInvalidURLs() { return ignoreInvalidURLs; }
     public Integer getTimeout() { return timeout; }
+    public Boolean getHighlights() { return highlights; }
     public ScrapeOptions getScrapeOptions() { return scrapeOptions; }
     public String getIntegration() { return integration; }
 
@@ -47,6 +49,7 @@ public class SearchOptions {
         private String location;
         private Boolean ignoreInvalidURLs;
         private Integer timeout;
+        private Boolean highlights;
         private ScrapeOptions scrapeOptions;
         private String integration;
 
@@ -70,6 +73,8 @@ public class SearchOptions {
         public Builder ignoreInvalidURLs(Boolean ignoreInvalidURLs) { this.ignoreInvalidURLs = ignoreInvalidURLs; return this; }
         /** Timeout in milliseconds. */
         public Builder timeout(Integer timeout) { this.timeout = timeout; return this; }
+        /** Generate query-relevant highlights for search results. Defaults to true. */
+        public Builder highlights(Boolean highlights) { this.highlights = highlights; return this; }
         /** Scrape options applied to search result pages. */
         public Builder scrapeOptions(ScrapeOptions scrapeOptions) { this.scrapeOptions = scrapeOptions; return this; }
         /** Integration identifier. */
@@ -86,6 +91,7 @@ public class SearchOptions {
             o.location = this.location;
             o.ignoreInvalidURLs = this.ignoreInvalidURLs;
             o.timeout = this.timeout;
+            o.highlights = this.highlights;
             o.scrapeOptions = this.scrapeOptions;
             o.integration = this.integration;
             return o;

--- a/apps/java-sdk/src/test/java/com/firecrawl/SearchOptionsTest.java
+++ b/apps/java-sdk/src/test/java/com/firecrawl/SearchOptionsTest.java
@@ -1,15 +1,25 @@
 package com.firecrawl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.firecrawl.models.SearchOptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SearchOptionsTest {
     @Test
-    void exposesHighlightsOption() {
-        SearchOptions options = SearchOptions.builder().highlights(false).build();
+    void serializesHighlightsOption() {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode enabled = mapper.valueToTree(
+                SearchOptions.builder().highlights(true).build());
+        JsonNode disabled = mapper.valueToTree(
+                SearchOptions.builder().highlights(false).build());
+        JsonNode omitted = mapper.valueToTree(SearchOptions.builder().build());
 
-        assertFalse(options.getHighlights());
+        assertTrue(enabled.get("highlights").asBoolean());
+        assertFalse(disabled.get("highlights").asBoolean());
+        assertFalse(omitted.has("highlights"));
     }
 }

--- a/apps/java-sdk/src/test/java/com/firecrawl/SearchOptionsTest.java
+++ b/apps/java-sdk/src/test/java/com/firecrawl/SearchOptionsTest.java
@@ -1,0 +1,15 @@
+package com.firecrawl;
+
+import com.firecrawl.models.SearchOptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class SearchOptionsTest {
+    @Test
+    void exposesHighlightsOption() {
+        SearchOptions options = SearchOptions.builder().highlights(false).build();
+
+        assertFalse(options.getHighlights());
+    }
+}

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.30.0",
+  "version": "4.30.1",
   "description": "JavaScript SDK for Firecrawl API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-highlights.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-highlights.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { search } from "../../../v2/methods/search";
+
+describe("v2 search highlights", () => {
+  test("forwards the highlights option", async () => {
+    const http = {
+      post: jest.fn(async () => ({ status: 200, data: { success: true } })),
+    } as any;
+
+    await search(http, { query: "firecrawl", highlights: false });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/search",
+      { query: "firecrawl", highlights: false },
+      {},
+    );
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -37,6 +37,7 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.ignoreInvalidURLs != null)
     payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
   if (req.timeout != null) payload.timeout = req.timeout;
+  if (req.highlights != null) payload.highlights = req.highlights;
   if (req.integration && req.integration.trim())
     payload.integration = req.integration.trim();
   if (req.origin) payload.origin = req.origin;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -697,6 +697,8 @@ export interface SearchRequest {
   location?: string;
   ignoreInvalidURLs?: boolean;
   timeout?: number; // ms
+  /** Generate query-relevant highlights for search results. Defaults to true. */
+  highlights?: boolean;
   scrapeOptions?: ScrapeOptions;
   /**
    * Enterprise search options. Use `["zdr"]` for end-to-end Zero Data

--- a/apps/php-sdk/src/Models/SearchOptions.php
+++ b/apps/php-sdk/src/Models/SearchOptions.php
@@ -24,6 +24,7 @@ final class SearchOptions
         private readonly ?string $integration = null,
         private readonly ?array $includeDomains = null,
         private readonly ?array $excludeDomains = null,
+        private readonly ?bool $highlights = null,
     ) {}
 
     /**
@@ -44,10 +45,12 @@ final class SearchOptions
         ?string $integration = null,
         ?array $includeDomains = null,
         ?array $excludeDomains = null,
+        ?bool $highlights = null,
     ): self {
         return new self(
             $sources, $categories, $limit, $tbs, $location, $ignoreInvalidURLs,
             $timeout, $scrapeOptions, $integration, $includeDomains, $excludeDomains,
+            $highlights,
         );
     }
 
@@ -64,6 +67,7 @@ final class SearchOptions
             'location' => $this->location,
             'ignoreInvalidURLs' => $this->ignoreInvalidURLs,
             'timeout' => $this->timeout,
+            'highlights' => $this->highlights,
             'scrapeOptions' => $this->scrapeOptions?->toArray(),
             'integration' => $this->integration,
         ];

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.9.0';
+    public const SDK_VERSION = '1.9.1';
 }

--- a/apps/php-sdk/tests/Unit/ModelsTest.php
+++ b/apps/php-sdk/tests/Unit/ModelsTest.php
@@ -13,6 +13,7 @@ use Firecrawl\Models\HighlightsFormat;
 use Firecrawl\Models\QueryFormat;
 use Firecrawl\Models\QuestionFormat;
 use Firecrawl\Models\ScrapeOptions;
+use Firecrawl\Models\SearchOptions;
 use Firecrawl\Models\Monitor;
 use Firecrawl\Models\MonitorCheck;
 
@@ -257,6 +258,12 @@ it('returns null menu when absent in Document', function (): void {
     $doc = Document::fromArray(['markdown' => '# No menu']);
 
     expect($doc->getMenu())->toBeNull();
+});
+
+it('serializes the search highlights option', function (): void {
+    $options = SearchOptions::with(highlights: false);
+
+    expect($options->toArray())->toBe(['highlights' => false]);
 });
 
 it('coerces non-string scalar identity fields without a TypeError under strict_types', function (): void {

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -17,7 +17,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.32.0"
+__version__ = "4.32.1"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_request_preparation.py
@@ -44,6 +44,7 @@ class TestSearchRequestPreparation:
             location="US",
             ignore_invalid_urls=False,
             timeout=30000,
+            highlights=False,
             scrape_options=scrape_opts,
             integration="  _e2e-test  ",
         )
@@ -56,6 +57,7 @@ class TestSearchRequestPreparation:
         assert data["tbs"] == "qdr:w"
         assert data["location"] == "US"
         assert data["timeout"] == 30000
+        assert data["highlights"] is False
         
         # Check snake_case to camelCase conversions
         assert "ignoreInvalidURLs" in data

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -395,6 +395,7 @@ class FirecrawlClient:
         location: Optional[str] = None,
         ignore_invalid_urls: Optional[bool] = None,
         timeout: Optional[int] = None,
+        highlights: Optional[bool] = None,
         scrape_options: Optional[ScrapeOptions] = None,
         integration: Optional[str] = None,
         enterprise: Optional[List[str]] = None,
@@ -409,6 +410,8 @@ class FirecrawlClient:
             tbs: Time-based search filter
             location: Location string for search
             timeout: Request timeout in milliseconds (default: 300000)
+            highlights: Generate query-relevant highlights for search results
+                (default: true)
             page_options: Options for scraping individual pages
             enterprise: Enterprise search options. Use ["zdr"] for end-to-end
                 Zero Data Retention or ["anon"] for anonymized search. Must be
@@ -430,6 +433,7 @@ class FirecrawlClient:
             location=location,
             ignore_invalid_urls=ignore_invalid_urls,
             timeout=timeout,
+            highlights=highlights,
             scrape_options=scrape_options,
             integration=integration,
             enterprise=enterprise,

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1602,6 +1602,7 @@ class SearchRequest(BaseModel):
     location: Optional[str] = None
     ignore_invalid_urls: Optional[bool] = None
     timeout: Optional[int] = 300000
+    highlights: Optional[bool] = None
     scrape_options: Optional[ScrapeOptions] = None
     # Enterprise search options. Use ["zdr"] for end-to-end Zero Data
     # Retention or ["anon"] for anonymized search. Must be enabled for your team.

--- a/apps/ruby-sdk/lib/firecrawl/models/search_options.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/search_options.rb
@@ -6,7 +6,7 @@ module Firecrawl
     class SearchOptions
       FIELDS = %i[
         sources categories include_domains exclude_domains limit tbs location
-        ignore_invalid_urls timeout scrape_options integration enterprise
+        ignore_invalid_urls timeout highlights scrape_options integration enterprise
       ].freeze
 
       attr_reader(*FIELDS)
@@ -26,6 +26,7 @@ module Firecrawl
           "location" => location,
           "ignoreInvalidURLs" => ignore_invalid_urls,
           "timeout" => timeout,
+          "highlights" => highlights,
           "scrapeOptions" => scrape_options&.to_h,
           "integration" => integration,
           # Enterprise search options. Use ["zdr"] for end-to-end Zero Data

--- a/apps/ruby-sdk/lib/firecrawl/version.rb
+++ b/apps/ruby-sdk/lib/firecrawl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Firecrawl
-  VERSION = "1.10.0"
+  VERSION = "1.10.1"
 end

--- a/apps/ruby-sdk/test/firecrawl/client_test.rb
+++ b/apps/ruby-sdk/test/firecrawl/client_test.rb
@@ -742,6 +742,7 @@ class ClientTest < Minitest::Test
       limit: 10,
       location: "US",
       tbs: "qdr:w",
+      highlights: false,
       include_domains: ["firecrawl.dev"],
       exclude_domains: ["example.com"]
     )
@@ -749,6 +750,7 @@ class ClientTest < Minitest::Test
     assert_equal 10, h["limit"]
     assert_equal "US", h["location"]
     assert_equal "qdr:w", h["tbs"]
+    assert_equal false, h["highlights"]
     assert_equal ["firecrawl.dev"], h["includeDomains"]
     assert_equal ["example.com"], h["excludeDomains"]
   end

--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecrawl"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "mockito",
  "reqwest",

--- a/apps/rust-sdk/Cargo.toml
+++ b/apps/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecrawl"
-version = "2.11.0"
+version = "2.11.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://www.firecrawl.dev/"

--- a/apps/rust-sdk/src/search.rs
+++ b/apps/rust-sdk/src/search.rs
@@ -41,6 +41,9 @@ pub struct SearchOptions {
     /// Timeout in milliseconds.
     pub timeout: Option<u32>,
 
+    /// Whether to generate query-relevant highlights. Defaults to true.
+    pub highlights: Option<bool>,
+
     /// Scrape options to apply to each search result.
     pub scrape_options: Option<ScrapeOptions>,
 
@@ -264,6 +267,19 @@ impl Client {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn serializes_highlights_option() {
+        let options = SearchOptions {
+            highlights: Some(false),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(options).unwrap(),
+            json!({ "highlights": false })
+        );
+    }
 
     #[tokio::test]
     async fn test_search_with_mock() {


### PR DESCRIPTION
## Summary

- add the optional highlights search parameter to the JavaScript, Python, Go, Java, Rust, PHP, Ruby, .NET, and Elixir SDKs
- forward explicit true or false values without overriding the API default
- bump each SDK patch version for release
- add focused serialization coverage across the SDK implementations

## Validation

- JavaScript focused unit test and package build
- Python focused request-preparation tests: 6 passed
- Go test ./...
- Rust cargo test --lib: 62 passed
- Ruby syntax checks
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional search highlights flag across all SDKs. Clients can set true/false; if unset, we omit it so the API default applies.

- **New Features**
  - Added focused tests per SDK to verify serialization and request mapping, including a new Java test for highlights.

- **Dependencies**
  - Bumped patch versions for release across SDKs, including `@mendable/firecrawl-js`, Python, Go, Java, Rust, PHP, Ruby, .NET, and Elixir.

<sup>Written for commit 59f1c40ce0b4d098fd28d8e746b9a8ba8b2f324a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

