### PR TITLE
refactor(api): confirm Exchange billing from the billing worker

### DIFF
--- a/apps/api/src/lib/exchange.test.ts
+++ b/apps/api/src/lib/exchange.test.ts
@@ -550,11 +550,13 @@ describe("Exchange routing", () => {
       status: 200,
     } as Awaited<ReturnType<typeof fetch>>);
 
-    await reportExchangeBilling({
-      accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
-      status: "confirmed",
-      billingReference: "bill-1",
-    });
+    await expect(
+      reportExchangeBilling({
+        accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
+        status: "confirmed",
+        billingReference: "bill-1",
+      }),
+    ).resolves.toBe(true);
 
     expect(fetch).toHaveBeenCalledWith(
       "https://exchange.example/v1/access-events/6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60/billing",
@@ -564,10 +566,12 @@ describe("Exchange routing", () => {
       }),
     );
 
-    await reportExchangeBilling({
-      accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
-      status: "void",
-    });
+    await expect(
+      reportExchangeBilling({
+        accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
+        status: "void",
+      }),
+    ).resolves.toBe(true);
 
     expect(fetch).toHaveBeenLastCalledWith(
       "https://exchange.example/v1/access-events/6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60/billing",
@@ -578,12 +582,58 @@ describe("Exchange routing", () => {
     );
 
     vi.mocked(fetch).mockRejectedValue(new Error("connect timeout"));
-    await expect(
-      reportExchangeBilling({
+    vi.useFakeTimers();
+    try {
+      const report = reportExchangeBilling({
         accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
         status: "confirmed",
         billingReference: "bill-1",
+      });
+      await vi.runAllTimersAsync();
+      await expect(report).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries transient billing report failures and stops on definitive rejections", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+      } as Awaited<ReturnType<typeof fetch>>)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      } as Awaited<ReturnType<typeof fetch>>);
+
+    vi.useFakeTimers();
+    try {
+      const report = reportExchangeBilling({
+        accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
+        status: "confirmed",
+      });
+      await vi.runAllTimersAsync();
+      await expect(report).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // A 4xx is the Exchange's final answer (conflict, unknown event):
+    // no retry, report failure to the caller.
+    vi.mocked(fetch).mockClear();
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 409,
+    } as Awaited<ReturnType<typeof fetch>>);
+
+    await expect(
+      reportExchangeBilling({
+        accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
+        status: "void",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/lib/exchange.test.ts
+++ b/apps/api/src/lib/exchange.test.ts
@@ -620,8 +620,34 @@ describe("Exchange routing", () => {
     }
     expect(fetch).toHaveBeenCalledTimes(2);
 
-    // A 4xx is the Exchange's final answer (conflict, unknown event):
-    // no retry, report failure to the caller.
+    // 429 is transient rate limiting, not a final answer: it retries.
+    vi.mocked(fetch).mockClear();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: new Headers({ "retry-after": "1" }),
+      } as Awaited<ReturnType<typeof fetch>>)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      } as Awaited<ReturnType<typeof fetch>>);
+
+    vi.useFakeTimers();
+    try {
+      const report = reportExchangeBilling({
+        accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
+        status: "confirmed",
+      });
+      await vi.runAllTimersAsync();
+      await expect(report).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // Any other 4xx is the Exchange's final answer (conflict, unknown
+    // event): no retry, report failure to the caller.
     vi.mocked(fetch).mockClear();
     vi.mocked(fetch).mockResolvedValue({
       ok: false,

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -547,53 +547,82 @@ export function getExchangeSuccessCredits(input: {
 }
 
 const EXCHANGE_BILLING_TIMEOUT_MS = 5_000;
+const EXCHANGE_BILLING_ATTEMPTS = 3;
+const EXCHANGE_BILLING_RETRY_DELAY_MS = 2_000;
 
 /**
  * Report the billing outcome of a delivered Exchange access so the service
  * can reconcile its ledger: "confirmed" once the customer was billed, "void"
  * when the delivered access was ultimately discarded and never billed.
- * Failures only log - the service flags unresolved events for follow-up.
+ * Retries transient failures with a short backoff; never throws. Returns
+ * whether the report was accepted - a sustained failure leaves the event
+ * pending on the Exchange, which flags unresolved events for follow-up.
  */
 export async function reportExchangeBilling(input: {
   accessEventId: string;
   status: "confirmed" | "void";
   billingReference?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const baseUrl = getExchangeBaseUrl();
   if (!baseUrl) {
-    return;
+    return false;
   }
 
-  try {
-    const response = await fetch(
-      `${baseUrl}/v1/access-events/${encodeURIComponent(input.accessEventId)}/billing`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          status: input.status,
-          ...(input.billingReference === undefined
-            ? {}
-            : { billingReference: input.billingReference }),
-        }),
-        signal: AbortSignal.timeout(EXCHANGE_BILLING_TIMEOUT_MS),
-      },
-    );
+  for (let attempt = 1; attempt <= EXCHANGE_BILLING_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(
+        `${baseUrl}/v1/access-events/${encodeURIComponent(input.accessEventId)}/billing`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            status: input.status,
+            ...(input.billingReference === undefined
+              ? {}
+              : { billingReference: input.billingReference }),
+          }),
+          signal: AbortSignal.timeout(EXCHANGE_BILLING_TIMEOUT_MS),
+        },
+      );
 
-    if (!response.ok) {
+      if (response.ok) {
+        return true;
+      }
+
+      // 4xx responses are definitive (conflict, unknown event) - the
+      // Exchange has spoken and a retry cannot change the answer.
+      if (response.status < 500) {
+        rootLogger.warn("Exchange billing report rejected", {
+          accessEventId: input.accessEventId,
+          status: input.status,
+          statusCode: response.status,
+        });
+        return false;
+      }
+
       rootLogger.warn("Exchange billing report failed", {
         accessEventId: input.accessEventId,
         status: input.status,
         statusCode: response.status,
+        attempt,
+      });
+    } catch (error) {
+      rootLogger.warn("Exchange billing report errored", {
+        accessEventId: input.accessEventId,
+        status: input.status,
+        attempt,
+        error,
       });
     }
-  } catch (error) {
-    rootLogger.warn("Exchange billing report errored", {
-      accessEventId: input.accessEventId,
-      status: input.status,
-      error,
-    });
+
+    if (attempt < EXCHANGE_BILLING_ATTEMPTS) {
+      await new Promise(resolve =>
+        setTimeout(resolve, EXCHANGE_BILLING_RETRY_DELAY_MS * attempt),
+      );
+    }
   }
+
+  return false;
 }
 
 /**

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -552,6 +552,7 @@ const EXCHANGE_BILLING_RETRY_DELAY_MS = 2_000;
 const EXCHANGE_BILLING_RETRY_MAX_DELAY_MS = 15_000;
 
 // Retry-After from a 429, in milliseconds, when present and sane.
+// Accepts both delta-seconds and HTTP-date forms.
 function getRetryAfterMs(response: {
   headers?: { get?: (name: string) => string | null };
 }): number | undefined {
@@ -559,11 +560,18 @@ function getRetryAfterMs(response: {
   if (!header) {
     return undefined;
   }
+
   const seconds = Number(header);
-  if (!Number.isFinite(seconds) || seconds <= 0) {
+  if (Number.isFinite(seconds)) {
+    return seconds > 0 ? seconds * 1_000 : undefined;
+  }
+
+  const resetAt = Date.parse(header);
+  if (Number.isNaN(resetAt)) {
     return undefined;
   }
-  return seconds * 1_000;
+  const delayMs = resetAt - Date.now();
+  return delayMs > 0 ? delayMs : undefined;
 }
 
 /**
@@ -641,9 +649,10 @@ export async function reportExchangeBilling(input: {
     if (attempt < EXCHANGE_BILLING_ATTEMPTS) {
       // Full jitter on the backoff so a batch of reports failing together
       // does not retry against a degraded Exchange in synchronized bursts.
+      // Retry-After, when given, is the lower bound.
       const backoff = EXCHANGE_BILLING_RETRY_DELAY_MS * attempt;
       const delay = Math.min(
-        Math.max(retryAfterMs ?? 0, backoff / 2 + Math.random() * backoff),
+        Math.max(retryAfterMs ?? 0, Math.random() * backoff),
         EXCHANGE_BILLING_RETRY_MAX_DELAY_MS,
       );
       await new Promise(resolve => setTimeout(resolve, delay));

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -549,6 +549,22 @@ export function getExchangeSuccessCredits(input: {
 const EXCHANGE_BILLING_TIMEOUT_MS = 5_000;
 const EXCHANGE_BILLING_ATTEMPTS = 3;
 const EXCHANGE_BILLING_RETRY_DELAY_MS = 2_000;
+const EXCHANGE_BILLING_RETRY_MAX_DELAY_MS = 15_000;
+
+// Retry-After from a 429, in milliseconds, when present and sane.
+function getRetryAfterMs(response: {
+  headers?: { get?: (name: string) => string | null };
+}): number | undefined {
+  const header = response.headers?.get?.("retry-after");
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return undefined;
+  }
+  return seconds * 1_000;
+}
 
 /**
  * Report the billing outcome of a delivered Exchange access so the service
@@ -569,6 +585,8 @@ export async function reportExchangeBilling(input: {
   }
 
   for (let attempt = 1; attempt <= EXCHANGE_BILLING_ATTEMPTS; attempt++) {
+    let retryAfterMs: number | undefined;
+
     try {
       const response = await fetch(
         `${baseUrl}/v1/access-events/${encodeURIComponent(input.accessEventId)}/billing`,
@@ -589,15 +607,20 @@ export async function reportExchangeBilling(input: {
         return true;
       }
 
-      // 4xx responses are definitive (conflict, unknown event) - the
-      // Exchange has spoken and a retry cannot change the answer.
-      if (response.status < 500) {
+      // 4xx responses other than 429 are definitive (conflict, unknown
+      // event) - the Exchange has spoken and a retry cannot change the
+      // answer. 429 is transient rate limiting and retries.
+      if (response.status < 500 && response.status !== 429) {
         rootLogger.warn("Exchange billing report rejected", {
           accessEventId: input.accessEventId,
           status: input.status,
           statusCode: response.status,
         });
         return false;
+      }
+
+      if (response.status === 429) {
+        retryAfterMs = getRetryAfterMs(response);
       }
 
       rootLogger.warn("Exchange billing report failed", {
@@ -616,9 +639,14 @@ export async function reportExchangeBilling(input: {
     }
 
     if (attempt < EXCHANGE_BILLING_ATTEMPTS) {
-      await new Promise(resolve =>
-        setTimeout(resolve, EXCHANGE_BILLING_RETRY_DELAY_MS * attempt),
+      // Full jitter on the backoff so a batch of reports failing together
+      // does not retry against a degraded Exchange in synchronized bursts.
+      const backoff = EXCHANGE_BILLING_RETRY_DELAY_MS * attempt;
+      const delay = Math.min(
+        Math.max(retryAfterMs ?? 0, backoff / 2 + Math.random() * backoff),
+        EXCHANGE_BILLING_RETRY_MAX_DELAY_MS,
       );
+      await new Promise(resolve => setTimeout(resolve, delay));
     }
   }
 

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -49,18 +49,33 @@ async function withExchangeConfirmSlot<T>(fn: () => Promise<T>): Promise<T> {
 async function confirmExchangeOutcomes(
   operations: BillingOperation[],
 ): Promise<void> {
+  // A small worker pool pulls operations one at a time, so a slow
+  // Exchange queues at most EXCHANGE_CONFIRM_CONCURRENCY waiters per
+  // invocation on the shared budget instead of one per operation.
+  let nextIndex = 0;
+  const workerCount = Math.min(
+    EXCHANGE_CONFIRM_CONCURRENCY,
+    operations.length,
+  );
   await Promise.all(
-    operations.map(op =>
-      withExchangeConfirmSlot(() =>
-        reportExchangeBilling({
-          accessEventId: op.exchange_access_event_id!,
-          status: "confirmed",
-          ...(op.billing_reference === undefined
-            ? {}
-            : { billingReference: op.billing_reference }),
-        }),
-      ),
-    ),
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex++;
+        if (index >= operations.length) {
+          return;
+        }
+        const op = operations[index];
+        await withExchangeConfirmSlot(() =>
+          reportExchangeBilling({
+            accessEventId: op.exchange_access_event_id!,
+            status: "confirmed",
+            ...(op.billing_reference === undefined
+              ? {}
+              : { billingReference: op.billing_reference }),
+          }),
+        );
+      }
+    }),
   );
 }
 

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -15,9 +15,30 @@ import {
 } from "./types";
 import { reportExchangeBilling } from "../../lib/exchange";
 
-// Upper bound on concurrent Exchange confirmation requests, so a full
-// batch never turns into a synchronized burst against the Exchange.
+// Upper bound on concurrent Exchange confirmation requests across the
+// whole worker, so slow or retrying deliveries from overlapping batch
+// runs never stack into a burst against the Exchange.
 const EXCHANGE_CONFIRM_CONCURRENCY = 16;
+let exchangeConfirmSlots = EXCHANGE_CONFIRM_CONCURRENCY;
+const exchangeConfirmWaiters: Array<() => void> = [];
+
+async function withExchangeConfirmSlot<T>(fn: () => Promise<T>): Promise<T> {
+  if (exchangeConfirmSlots > 0) {
+    exchangeConfirmSlots--;
+  } else {
+    await new Promise<void>(resolve => exchangeConfirmWaiters.push(resolve));
+  }
+  try {
+    return await fn();
+  } finally {
+    const next = exchangeConfirmWaiters.shift();
+    if (next !== undefined) {
+      next();
+    } else {
+      exchangeConfirmSlots++;
+    }
+  }
+}
 
 // Confirm the Exchange accesses behind a set of committed billing
 // operations. Runs after the batch lock is released so an Exchange outage
@@ -28,25 +49,19 @@ const EXCHANGE_CONFIRM_CONCURRENCY = 16;
 async function confirmExchangeOutcomes(
   operations: BillingOperation[],
 ): Promise<void> {
-  for (
-    let start = 0;
-    start < operations.length;
-    start += EXCHANGE_CONFIRM_CONCURRENCY
-  ) {
-    await Promise.all(
-      operations
-        .slice(start, start + EXCHANGE_CONFIRM_CONCURRENCY)
-        .map(op =>
-          reportExchangeBilling({
-            accessEventId: op.exchange_access_event_id!,
-            status: "confirmed",
-            ...(op.billing_reference === undefined
-              ? {}
-              : { billingReference: op.billing_reference }),
-          }),
-        ),
-    );
-  }
+  await Promise.all(
+    operations.map(op =>
+      withExchangeConfirmSlot(() =>
+        reportExchangeBilling({
+          accessEventId: op.exchange_access_event_id!,
+          status: "confirmed",
+          ...(op.billing_reference === undefined
+            ? {}
+            : { billingReference: op.billing_reference }),
+        }),
+      ),
+    ),
+  );
 }
 
 // Configuration constants

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -15,24 +15,24 @@ import {
 } from "./types";
 import { reportExchangeBilling } from "../../lib/exchange";
 
-// Report billing outcomes for the Exchange accesses in a group.
-// reportExchangeBilling never throws, so this cannot fail the batch.
-async function reportExchangeOutcomes(
-  group: GroupedBillingOperation,
-  status: "confirmed" | "void",
+// Confirm the Exchange accesses behind a set of committed billing
+// operations. Runs after the batch lock is released so an Exchange outage
+// can never stall the billing loop past its lease. reportExchangeBilling
+// retries internally and never throws; a sustained failure leaves the
+// event pending on the Exchange, which flags unresolved events for
+// reconciliation.
+async function confirmExchangeOutcomes(
+  operations: BillingOperation[],
 ): Promise<void> {
-  const exchangeOps = group.operations.filter(
-    op => op.exchange_access_event_id !== undefined,
-  );
-  if (exchangeOps.length === 0) {
+  if (operations.length === 0) {
     return;
   }
 
   await Promise.all(
-    exchangeOps.map(op =>
+    operations.map(op =>
       reportExchangeBilling({
         accessEventId: op.exchange_access_event_id!,
-        status,
+        status: "confirmed",
         ...(op.billing_reference === undefined
           ? {}
           : { billingReference: op.billing_reference }),
@@ -59,7 +59,8 @@ interface BillingOperation {
   api_key_id: number | null;
   autumnTrackInRequest: boolean;
   // Exchange access backing this operation, if any: its ledger event is
-  // confirmed once the debit commits and voided if the commit fails.
+  // confirmed once the debit commits. Failed or ambiguous commits leave
+  // the event pending for reconciliation rather than voiding it.
   exchange_access_event_id?: string;
   billing_reference?: string;
 }
@@ -140,6 +141,10 @@ export async function processBillingBatch() {
     return;
   }
 
+  // Exchange operations whose debit committed this run; their ledger
+  // confirmations are delivered after the lock is released.
+  const committedExchangeOps: BillingOperation[] = [];
+
   try {
     // Get all operations from Redis list
     const operations: BillingOperation[] = [];
@@ -219,7 +224,11 @@ export async function processBillingBatch() {
 
         if (!billingResult.success) {
           await refundRequestTrackedCredits(group);
-          await reportExchangeOutcomes(group, "void");
+          // Deliberately no Exchange outcome here: supaBillTeam maps thrown
+          // errors to success: false, and a transport error can occur after
+          // the debit committed, so voiding could erase a real debit. The
+          // events stay pending on the Exchange, which flags unresolved
+          // events for reconciliation.
           logger.warn(
             `⚠️ Billing returned success: false for team ${group.team_id}`,
             {
@@ -237,11 +246,17 @@ export async function processBillingBatch() {
 
         // Ledger commit only — usage is tracked to Autumn at request time, not here.
 
-        // The debit is committed: confirm the Exchange accesses it covered.
-        await reportExchangeOutcomes(group, "confirmed");
+        // The debit is committed: confirm the Exchange accesses it covered
+        // once the batch lock is released.
+        committedExchangeOps.push(
+          ...group.operations.filter(
+            op => op.exchange_access_event_id !== undefined,
+          ),
+        );
       } catch (error) {
         await refundRequestTrackedCredits(group);
-        await reportExchangeOutcomes(group, "void");
+        // No Exchange outcome here either — same ambiguity as the
+        // success: false branch above; the events stay pending.
         logger.error(`❌ Failed to bill team ${group.team_id}`, {
           error,
           group,
@@ -267,6 +282,8 @@ export async function processBillingBatch() {
   } finally {
     await releaseLock();
   }
+
+  await confirmExchangeOutcomes(committedExchangeOps);
 }
 
 // Start periodic batch processing

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -15,6 +15,10 @@ import {
 } from "./types";
 import { reportExchangeBilling } from "../../lib/exchange";
 
+// Upper bound on concurrent Exchange confirmation requests, so a full
+// batch never turns into a synchronized burst against the Exchange.
+const EXCHANGE_CONFIRM_CONCURRENCY = 16;
+
 // Confirm the Exchange accesses behind a set of committed billing
 // operations. Runs after the batch lock is released so an Exchange outage
 // can never stall the billing loop past its lease. reportExchangeBilling
@@ -24,21 +28,25 @@ import { reportExchangeBilling } from "../../lib/exchange";
 async function confirmExchangeOutcomes(
   operations: BillingOperation[],
 ): Promise<void> {
-  if (operations.length === 0) {
-    return;
+  for (
+    let start = 0;
+    start < operations.length;
+    start += EXCHANGE_CONFIRM_CONCURRENCY
+  ) {
+    await Promise.all(
+      operations
+        .slice(start, start + EXCHANGE_CONFIRM_CONCURRENCY)
+        .map(op =>
+          reportExchangeBilling({
+            accessEventId: op.exchange_access_event_id!,
+            status: "confirmed",
+            ...(op.billing_reference === undefined
+              ? {}
+              : { billingReference: op.billing_reference }),
+          }),
+        ),
+    );
   }
-
-  await Promise.all(
-    operations.map(op =>
-      reportExchangeBilling({
-        accessEventId: op.exchange_access_event_id!,
-        status: "confirmed",
-        ...(op.billing_reference === undefined
-          ? {}
-          : { billingReference: op.billing_reference }),
-      }),
-    ),
-  );
 }
 
 // Configuration constants

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -13,6 +13,33 @@ import {
   type BillingEndpoint,
   type BillingMetadata,
 } from "./types";
+import { reportExchangeBilling } from "../../lib/exchange";
+
+// Report billing outcomes for the Exchange accesses in a group.
+// reportExchangeBilling never throws, so this cannot fail the batch.
+async function reportExchangeOutcomes(
+  group: GroupedBillingOperation,
+  status: "confirmed" | "void",
+): Promise<void> {
+  const exchangeOps = group.operations.filter(
+    op => op.exchange_access_event_id !== undefined,
+  );
+  if (exchangeOps.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    exchangeOps.map(op =>
+      reportExchangeBilling({
+        accessEventId: op.exchange_access_event_id!,
+        status,
+        ...(op.billing_reference === undefined
+          ? {}
+          : { billingReference: op.billing_reference }),
+      }),
+    ),
+  );
+}
 
 // Configuration constants
 const BATCH_KEY = "billing_batch";
@@ -31,6 +58,10 @@ interface BillingOperation {
   timestamp: string;
   api_key_id: number | null;
   autumnTrackInRequest: boolean;
+  // Exchange access backing this operation, if any: its ledger event is
+  // confirmed once the debit commits and voided if the commit fails.
+  exchange_access_event_id?: string;
+  billing_reference?: string;
 }
 
 // Grouped billing operations for batch processing
@@ -188,6 +219,7 @@ export async function processBillingBatch() {
 
         if (!billingResult.success) {
           await refundRequestTrackedCredits(group);
+          await reportExchangeOutcomes(group, "void");
           logger.warn(
             `⚠️ Billing returned success: false for team ${group.team_id}`,
             {
@@ -204,8 +236,12 @@ export async function processBillingBatch() {
         );
 
         // Ledger commit only — usage is tracked to Autumn at request time, not here.
+
+        // The debit is committed: confirm the Exchange accesses it covered.
+        await reportExchangeOutcomes(group, "confirmed");
       } catch (error) {
         await refundRequestTrackedCredits(group);
+        await reportExchangeOutcomes(group, "void");
         logger.error(`❌ Failed to bill team ${group.team_id}`, {
           error,
           group,
@@ -262,6 +298,7 @@ export async function queueBillingOperation(
   billing: BillingMetadata,
   is_extract: boolean = false,
   autumnTrackInRequest: boolean = false,
+  exchange?: { accessEventId: string; billingReference?: string },
 ) {
   // Skip queuing for preview teams
   if (team_id === "preview" || team_id.startsWith("preview_")) {
@@ -285,6 +322,14 @@ export async function queueBillingOperation(
       timestamp: new Date().toISOString(),
       api_key_id,
       autumnTrackInRequest,
+      ...(exchange === undefined
+        ? {}
+        : {
+            exchange_access_event_id: exchange.accessEventId,
+            ...(exchange.billingReference === undefined
+              ? {}
+              : { billing_reference: exchange.billingReference }),
+          }),
     };
 
     // Add operation to Redis list

--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -108,7 +108,8 @@ const processBillingJobInternal = async (token: string, job: Job) => {
         }),
         is_extract,
         autumnTrackInRequest,
-        typeof exchangeAccessEventId === "string"
+        typeof exchangeAccessEventId === "string" &&
+          exchangeAccessEventId.length > 0
           ? {
               accessEventId: exchangeAccessEventId,
               billingReference: String(job.id),

--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -88,6 +88,7 @@ const processBillingJobInternal = async (token: string, job: Job) => {
         is_extract,
         api_key_id,
         autumnTrackInRequest,
+        exchangeAccessEventId,
       } = job.data;
 
       logger.info(`Adding team ${team_id} billing operation to batch queue`, {
@@ -107,6 +108,12 @@ const processBillingJobInternal = async (token: string, job: Job) => {
         }),
         is_extract,
         autumnTrackInRequest,
+        typeof exchangeAccessEventId === "string"
+          ? {
+              accessEventId: exchangeAccessEventId,
+              billingReference: String(job.id),
+            }
+          : undefined,
       );
     } else {
       logger.warn(`Unknown billing job type: ${job.name}`);

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -185,7 +185,9 @@ async function billScrapeJob(
           },
         );
 
-        // Add directly to the billing queue - the billing worker will handle the rest
+        // Add directly to the billing queue - the billing worker will handle
+        // the rest, including confirming the Exchange access event once the
+        // debit actually commits (and voiding it if the commit fails).
         await getBillingQueue().add(
           "bill_team",
           {
@@ -197,24 +199,15 @@ async function billScrapeJob(
             originating_job_id: job.id,
             api_key_id: job.data.apiKeyId,
             autumnTrackInRequest: trackedInRequest,
+            ...(exchange?.accessEventId === undefined
+              ? {}
+              : { exchangeAccessEventId: exchange.accessEventId }),
           },
           {
             jobId: billingJobId,
             priority: 10,
           },
         );
-
-        // Reconcile the Exchange ledger. Awaited so the confirmation lands
-        // before any later failure path could attempt to void this access -
-        // the service rejects confirmed->void, making the order decisive.
-        // reportExchangeBilling never throws and is bounded by its timeout.
-        if (exchange?.accessEventId !== undefined) {
-          await reportExchangeBilling({
-            accessEventId: exchange.accessEventId,
-            status: "confirmed",
-            billingReference: billingJobId,
-          });
-        }
 
         return creditsToBeBilled;
       } catch (error) {
@@ -982,10 +975,11 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
 
     // The Exchange delivered this access but the scrape ultimately failed,
     // so the customer was never billed for it - void the access event so
-    // the Exchange ledger reconciles. Fire-and-forget. If billing did
-    // happen before a later step failed, its confirmation was awaited
-    // above and the service rejects confirmed->void, so a paid access can
-    // never be marked void.
+    // the Exchange ledger reconciles. Fire-and-forget. If billing was in
+    // fact queued before a later step failed, the billing worker's
+    // confirmation authoritatively repairs this void (void -> confirmed is
+    // legal on the Exchange; confirmed -> void is not), so a paid access
+    // can never end up voided.
     if (pipeline?.success && pipeline.exchange?.accessEventId !== undefined) {
       void reportExchangeBilling({
         accessEventId: pipeline.exchange.accessEventId,

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -187,7 +187,8 @@ async function billScrapeJob(
 
         // Add directly to the billing queue - the billing worker will handle
         // the rest, including confirming the Exchange access event once the
-        // debit actually commits (and voiding it if the commit fails).
+        // debit actually commits. A failed commit leaves the event pending
+        // for reconciliation - it is never voided on an ambiguous outcome.
         await getBillingQueue().add(
           "bill_team",
           {
@@ -221,6 +222,18 @@ async function billScrapeJob(
             value: creditsToBeBilled,
             properties: autumnProperties,
             featureId,
+          });
+        }
+        // The billing operation never reached the queue, so no debit will
+        // commit and no confirmation will ever arrive: void the Exchange
+        // access event instead of leaving it dangling. If the enqueue
+        // actually succeeded and only the acknowledgement was lost, the
+        // eventual confirmation repairs the void (void -> confirmed is
+        // legal on the Exchange). Fire-and-forget.
+        if (exchange?.accessEventId !== undefined) {
+          void reportExchangeBilling({
+            accessEventId: exchange.accessEventId,
+            status: "void",
           });
         }
         captureExceptionWithZdrCheck(error, {


### PR DESCRIPTION
Follow-up to #4030, the agreed post-pilot refactor: the Exchange billing confirmation moves out of the scrape worker's hot path and into the billing pipeline, so **confirmed = the debit actually committed**, not merely queued.

## What changed

- `billScrapeJob` attaches `exchangeAccessEventId` to the `bill_team` job payload and drops its awaited confirmation call — the scrape worker no longer spends any time on Exchange accounting.
- The billing worker threads the event id + billing job id (as the audit reference) into the batch operation.
- `processBillingBatch` reports outcomes at the three points where the truth is known: **confirm** each covered access when the group's debit commits; **void** when the commit fails or is refunded. Reporting is parallel, never throws, and cannot affect billing.
- The failure-path void in the scrape worker can now race the async confirm; [exchange#18](https://github.com/firecrawl/exchange/pull/18) makes the confirmation authoritative (`void → confirmed` is a legal repair, `confirmed → void` stays rejected), so a paid access can never end up voided regardless of ordering.

## Why this is strictly better than the awaited call

Removes up to 5s of scrape-worker stall per Exchange-billed scrape under Exchange degradation; gains the billing queue's retry semantics for confirmations; closes the false-void double-failure window from #4030's review; and makes the ledger's "confirmed" state mean settled money, including the previously-unreported failed-commit → void case.

## Deploy note

Merge exchange#18 first (already green) — it's the ordering guarantee this relies on.

## Verification

- Clean typecheck; exchange, billing, and credit-billing suites pass.
- No provider-specific references in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Exchange billing confirmation into the billing pipeline so “confirmed” only happens after the debit commits. Adds jittered retries with a pull-based, worker-wide bounded concurrency and avoids voiding on ambiguous commits to keep the ledger authoritative.

- **Refactors**
  - `billScrapeJob` adds `exchangeAccessEventId` to `bill_team` jobs and drops the awaited confirm; enqueue failure now fire-and-forget voids the event.
  - Billing worker threads the event id + billing job id, confirms after the group’s debit commits and after the batch lock releases, and delivers via a pull-based worker pool capped at 16 across the worker; never voids on ambiguous/errored commits (events stay pending for reconciliation).
  - `reportExchangeBilling` retries transient failures (3 attempts) with full jittered backoff (0..backoff, capped at 15s) using `Retry-After` (delta-seconds or HTTP-date) as a lower bound, treats non-429 4xx as final, never throws, and returns a boolean.
  - Index worker ignores empty-string access event ids.

- **Dependencies**
  - Requires `exchange#18` for authoritative confirm/void semantics.

<sup>Written for commit 4aff6f0685b414b0e881d936967f47d4f9a86a1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

