### PR TITLE
feat(scrape): forward scrape maxAge to avgrab's metadata cache

### DIFF
--- a/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
@@ -29,6 +29,11 @@ type YouTubeMetadataRequest = {
   url: string;
   transcript_language: string;
   cookies?: BrowserCookie[];
+  /**
+   * Cache freshness we'll accept from avgrab's metadata cache, in ms.
+   * 0 forces a live extraction; omitted means avgrab's server default TTL.
+   */
+  max_age_ms?: number;
 };
 
 function getTranscriptLanguage(meta: Meta): string {
@@ -105,6 +110,9 @@ async function getYouTubeMetadata(
     url: engineResult.url,
     transcript_language: getTranscriptLanguage(meta),
     ...(cookies && cookies.length > 0 ? { cookies } : {}),
+    ...(meta.options.maxAge !== undefined
+      ? { max_age_ms: meta.options.maxAge }
+      : {}),
   };
 
   const response = await fetch(`${config.AVGRAB_SERVICE_URL}/metadata`, {


### PR DESCRIPTION
avgrab is growing a GCS-backed cache for `/metadata` responses ([firecrawl/fire-engine#529](https://github.com/firecrawl/fire-engine/pull/529)) with an optional `max_age_ms` request field. This forwards the scrape's `maxAge` from the YouTube postprocessor so freshness composes end-to-end:

- `maxAge: 0` scrapes force a live yt-dlp extraction (today's behavior, no surprise for users forcing a re-scrape)
- explicit `maxAge` values carry over, capped by avgrab's server-side TTL
- unset `maxAge` omits the field, deferring to avgrab's default TTL (4h)

Safe to land in either order with the fire-engine PR: avgrab ignores unknown request fields today, and the field is optional on the avgrab side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward the scrape `maxAge` from the YouTube postprocessor to `avgrab`’s `/metadata` as `max_age_ms` so cache freshness is respected end-to-end. Safe to deploy before the `fire-engine` cache work; unknown fields are ignored by `avgrab`.

- **New Features**
  - `maxAge: 0` forces a live yt-dlp extraction.
  - Explicit `maxAge` is sent as `max_age_ms` (capped by server TTL).
  - Unset `maxAge` omits the field; `avgrab` uses its default TTL.

<sup>Written for commit 4b95f8ab8474b6aa8f804a36aad790b435705663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

