### PR TITLE
feat(api): send team concurrency with FirePDF async submits

### DIFF
--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -512,6 +512,7 @@ export async function parseController(
                       bypassBilling: isDirectToBullMQ || !shouldBill,
                       zeroDataRetention,
                       teamFlags: req.acuc?.flags ?? null,
+                      teamConcurrency: req.acuc?.concurrency ?? null,
                       uploadedFile: file,
                       forceEngine,
                       isParse: true,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -328,6 +328,7 @@ export async function scrapeController(
                       bypassBilling: isDirectToBullMQ || !shouldBill,
                       zeroDataRetention,
                       teamFlags: req.acuc?.flags ?? null,
+                      teamConcurrency: req.acuc?.concurrency ?? null,
                       agentIndexOnly: (req as any).agentIndexOnly ?? false,
                       threatProtection: threatProtection.policy ?? undefined,
                     },

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -7,6 +7,14 @@ vi.mock("../../../../../lib/gcs-pdf-cache", () => ({
   savePdfResultToCache: vi.fn(async () => null),
 }));
 
+// Stub the ACUC lookup: the async client reads the team's sold
+// concurrency (best-effort) to send as FirePDF account context. The
+// mock is swappable per-test via mockGetACUCTeam.
+const mockGetACUCTeam = vi.fn(async () => ({ concurrency: 12 }));
+vi.mock("../../../../../controllers/auth", () => ({
+  getACUCTeam: (...args: unknown[]) => mockGetACUCTeam(...args),
+}));
+
 import {
   FirePdfAsyncFailure,
   scrapePDFWithFirePDFAsync,
@@ -91,11 +99,18 @@ function makeFetchFromSequence(
     url: string;
     method: string;
     headers: Record<string, string> | undefined;
+    body: unknown;
   }> = [];
   const cursor = { idx: 0 };
   const fetchImpl: any = async (url: string, init: any) => {
     const method = (init?.method ?? "GET").toUpperCase();
-    calls.push({ url, method, headers: init?.headers });
+    let body: unknown;
+    try {
+      body = init?.body ? JSON.parse(init.body) : undefined;
+    } catch {
+      body = init?.body;
+    }
+    calls.push({ url, method, headers: init?.headers, body });
     const matcher = matchers[cursor.idx++];
     if (!matcher) {
       throw new Error(
@@ -241,6 +256,48 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect(result.pagesProcessed).toBe(12);
     expect(fallback).not.toHaveBeenCalled();
     expect(calls).toHaveLength(4);
+    // Account context rides the submit body (FirePDF ENG-5049).
+    expect((calls[0].body as { team_concurrency?: number }).team_concurrency).toBe(12);
+  });
+
+  it("submits without team context when the ACUC lookup fails", async () => {
+    mockGetACUCTeam.mockRejectedValueOnce(new Error("acuc unavailable"));
+    const { fetchImpl, calls } = makeFetchFromSequence([
+      {
+        matchUrl: /\/jobs$/,
+        matchMethod: "POST",
+        response: {
+          status: 200,
+          body: { scrape_id: "scrape-id-test", status: "done", lane: "fast", retry_after_ms: 0 },
+        },
+      },
+      {
+        matchUrl: /\/jobs\/scrape-id-test\/result$/,
+        matchMethod: "GET",
+        response: {
+          status: 200,
+          body: {
+            schema_version: 1,
+            markdown: "# No context",
+            pages_processed: 1,
+            failed_pages: null,
+            partial_pages: null,
+          },
+        },
+      },
+    ]);
+    const fallback = vi.fn();
+
+    const result = await scrapePDFWithFirePDFAsync(makeMeta(), "BASE64", undefined, undefined, undefined, {
+      fetchImpl,
+      fallbackImpl: fallback,
+      sleepImpl: noopSleep,
+    });
+
+    // Lookup failure must never block the scrape — field simply absent.
+    expect(result.markdown).toBe("# No context");
+    expect((calls[0].body as { team_concurrency?: number }).team_concurrency).toBeUndefined();
+    expect(fallback).not.toHaveBeenCalled();
   });
 
   it("cancels accepted work when polling is abandoned", async () => {
@@ -282,7 +339,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
 
     expect(error).toBeInstanceOf(FirePdfAsyncFailure);
     expect(error.reason).toBe("network_error");
-    expect(calls).toEqual([
+    expect(calls.map(({ url, method, headers }) => ({ url, method, ...(headers !== undefined && { headers }) }))).toEqual([
       {
         url: "http://fire-pdf.test/jobs",
         method: "POST",
@@ -401,7 +458,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect(err).toBeInstanceOf(FirePdfAsyncFailure);
     expect(err.reason).toBe("network_error");
     expect(fallback).not.toHaveBeenCalled();
-    expect(calls).toEqual([
+    expect(calls.map(({ url, method, headers }) => ({ url, method, ...(headers !== undefined && { headers }) }))).toEqual([
       { method: "POST", url: "http://fire-pdf.test/jobs" },
       {
         method: "DELETE",

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -7,13 +7,6 @@ vi.mock("../../../../../lib/gcs-pdf-cache", () => ({
   savePdfResultToCache: vi.fn(async () => null),
 }));
 
-// Stub the ACUC lookup: the async client reads the team's sold
-// concurrency (best-effort) to send as FirePDF account context. The
-// mock is swappable per-test via mockGetACUCTeam.
-const mockGetACUCTeam = vi.fn(async () => ({ concurrency: 12 }));
-vi.mock("../../../../../controllers/auth", () => ({
-  getACUCTeam: (...args: unknown[]) => mockGetACUCTeam(...args),
-}));
 
 import {
   FirePdfAsyncFailure,
@@ -79,6 +72,7 @@ function makeMeta(overrides: Record<string, unknown> = {}) {
     internalOptions: {
       zeroDataRetention: false,
       teamId: "team-x",
+      teamConcurrency: 12,
       crawlId: undefined,
     },
     options: {
@@ -151,6 +145,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
       internalOptions: {
         zeroDataRetention: true,
         teamId: "team-x",
+      teamConcurrency: 12,
         crawlId: undefined,
       },
     });
@@ -260,8 +255,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect((calls[0].body as { team_concurrency?: number }).team_concurrency).toBe(12);
   });
 
-  it("submits without team context when the ACUC lookup fails", async () => {
-    mockGetACUCTeam.mockRejectedValueOnce(new Error("acuc unavailable"));
+  it("submits without team context when the snapshot is absent", async () => {
     const { fetchImpl, calls } = makeFetchFromSequence([
       {
         matchUrl: /\/jobs$/,
@@ -288,13 +282,15 @@ describe("scrapePDFWithFirePDFAsync", () => {
     ]);
     const fallback = vi.fn();
 
-    const result = await scrapePDFWithFirePDFAsync(makeMeta(), "BASE64", undefined, undefined, undefined, {
+    const meta = makeMeta();
+    meta.internalOptions.teamConcurrency = null;
+    const result = await scrapePDFWithFirePDFAsync(meta, "BASE64", undefined, undefined, undefined, {
       fetchImpl,
       fallbackImpl: fallback,
       sleepImpl: noopSleep,
     });
 
-    // Lookup failure must never block the scrape — field simply absent.
+    // Missing snapshot must never block the scrape — field simply absent.
     expect(result.markdown).toBe("# No context");
     expect((calls[0].body as { team_concurrency?: number }).team_concurrency).toBeUndefined();
     expect(fallback).not.toHaveBeenCalled();
@@ -458,7 +454,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect(err).toBeInstanceOf(FirePdfAsyncFailure);
     expect(err.reason).toBe("network_error");
     expect(fallback).not.toHaveBeenCalled();
-    expect(calls.map(({ url, method, headers }) => ({ url, method, ...(headers !== undefined && { headers }) }))).toEqual([
+    expect(calls.map(({ url, method }) => ({ url, method }))).toEqual([
       { method: "POST", url: "http://fire-pdf.test/jobs" },
       {
         method: "DELETE",

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -8,7 +8,6 @@ import { scrapePDFWithFirePDF } from "../firePDF";
 import { cancelJob } from "./cancel";
 import { tryGetCached, maybeSaveResult } from "./cache";
 import { firePdfAsyncTotalDurationSeconds } from "./metrics";
-import { getACUCTeam } from "../../../../../controllers/auth";
 import { pollUntilTerminal } from "./poll";
 import { fetchResult } from "./result";
 import { FIRE_PDF_ASYNC_MIN_REMAINING_MS } from "./routing";
@@ -83,20 +82,15 @@ export async function scrapePDFWithFirePDFAsync(
   const deadlineAt = new Date(submitTime + deadlineFromNow).toISOString();
   const pollingDeadline = submitTime + deadlineFromNow + POLL_TIMEOUT_BUFFER_MS;
 
-  // Best-effort account context for FirePDF's per-team admission
-  // observation. Cached lookup; failure or absence must never block the
-  // scrape — FirePDF simply skips team observation for this submit.
-  let teamConcurrency: number | undefined;
-  if (meta.internalOptions.teamId) {
-    try {
-      const acuc = await getACUCTeam(meta.internalOptions.teamId, true);
-      if (typeof acuc?.concurrency === "number" && acuc.concurrency > 0) {
-        teamConcurrency = acuc.concurrency;
-      }
-    } catch (error) {
-      meta.logger.debug("FirePDF async: ACUC lookup failed, submitting without team context", { error });
-    }
-  }
+  // Account context for FirePDF's per-team admission observation,
+  // snapshotted from the request ACUC into internalOptions at
+  // acceptance (same pattern as teamFlags) — no re-fetch here. Absence
+  // means FirePDF skips team observation for this submit.
+  const rawConcurrency = meta.internalOptions.teamConcurrency;
+  const teamConcurrency =
+    typeof rawConcurrency === "number" && rawConcurrency > 0
+      ? rawConcurrency
+      : undefined;
 
   // ── Step 1: POST /jobs ────────────────────────────────────────────────
   let submissionAccepted = false;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -8,6 +8,7 @@ import { scrapePDFWithFirePDF } from "../firePDF";
 import { cancelJob } from "./cancel";
 import { tryGetCached, maybeSaveResult } from "./cache";
 import { firePdfAsyncTotalDurationSeconds } from "./metrics";
+import { getACUCTeam } from "../../../../../controllers/auth";
 import { pollUntilTerminal } from "./poll";
 import { fetchResult } from "./result";
 import { FIRE_PDF_ASYNC_MIN_REMAINING_MS } from "./routing";
@@ -82,6 +83,21 @@ export async function scrapePDFWithFirePDFAsync(
   const deadlineAt = new Date(submitTime + deadlineFromNow).toISOString();
   const pollingDeadline = submitTime + deadlineFromNow + POLL_TIMEOUT_BUFFER_MS;
 
+  // Best-effort account context for FirePDF's per-team admission
+  // observation. Cached lookup; failure or absence must never block the
+  // scrape — FirePDF simply skips team observation for this submit.
+  let teamConcurrency: number | undefined;
+  if (meta.internalOptions.teamId) {
+    try {
+      const acuc = await getACUCTeam(meta.internalOptions.teamId, true);
+      if (typeof acuc?.concurrency === "number" && acuc.concurrency > 0) {
+        teamConcurrency = acuc.concurrency;
+      }
+    } catch (error) {
+      meta.logger.debug("FirePDF async: ACUC lookup failed, submitting without team context", { error });
+    }
+  }
+
   // ── Step 1: POST /jobs ────────────────────────────────────────────────
   let submissionAccepted = false;
   let terminalReached = false;
@@ -96,6 +112,7 @@ export async function scrapePDFWithFirePDFAsync(
       pagesProcessed,
       mode,
       deadlineAt,
+      teamConcurrency,
       fetchImpl,
     });
     submissionAccepted = true;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
@@ -20,6 +20,9 @@ type SubmitArgs = {
   pagesProcessed: number | undefined;
   mode: PDFMode | undefined;
   deadlineAt: string;
+  /** Team's sold concurrency from the ACUC (ENG-5049 account context).
+   * Optional: entitlement lookup must never block or fail a scrape. */
+  teamConcurrency: number | undefined;
   fetchImpl: typeof undiciFetch;
 };
 
@@ -56,6 +59,7 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
     pagesProcessed,
     mode,
     deadlineAt,
+    teamConcurrency,
     fetchImpl,
   } = args;
   const scrapeId = meta.id;
@@ -71,6 +75,12 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
     }),
     ...(meta.internalOptions.crawlId && {
       crawl_id: meta.internalOptions.crawlId,
+    }),
+    // FirePDF per-team admission observation (its ENG-5049): sold
+    // concurrency from the account context. Absence means FirePDF
+    // skips team observation for this submit — never a rejection.
+    ...(teamConcurrency !== undefined && {
+      team_concurrency: teamConcurrency,
     }),
     options: {
       ...(pagesProcessed !== undefined && { pages_estimate: pagesProcessed }),

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -493,6 +493,10 @@ export type InternalOptions = {
   bypassBilling?: boolean;
   zeroDataRetention?: boolean;
   teamFlags?: TeamFlags;
+  /** Team's sold concurrency, snapshotted from the request ACUC at
+   * acceptance (same pattern as teamFlags). Rides the job payload so
+   * downstream engines (FirePDF async account context) never re-fetch. */
+  teamConcurrency?: number | null;
 
   /**
    * Effective threat protection policy for this scrape, resolved at the


### PR DESCRIPTION
## Summary

Companion to fire-pdf's per-team admission work (fire-pdf#473/#477/#481, its ENG-5049): FirePDF measures per-team quota decisions in observation mode, but sees no entitlement data until firecrawl sends it.

- **`internalOptions.teamConcurrency`**: snapshotted from `req.acuc?.concurrency` at the same two controller sites that snapshot `teamFlags` (v2 scrape + parse) — the ACUC is already in hand there, so no additional lookup anywhere. The snapshot rides the job payload like `teamId`/`teamFlags` and pins the entitlement to acceptance time.
- `submitJob` sends it as optional `team_concurrency`; absence (older payloads, flows that don't set it) means FirePDF skips team observation for that submit — never a rejection, and FirePDF-side enforcement is off regardless.
- `team_tier` is deliberately **not** sent: no plan/tier string exists in apps/api (ACUC carries only numeric `plan_priority`/`concurrency`). FirePDF defaults the tier for observation (fire-pdf#481); the authoritative tier source gets decided with the entitlement policy.

## Testing
- `firePDFAsync.test.ts`: fetch harness captures request bodies; happy path asserts `team_concurrency` rides the submit; absent-snapshot test proves clean degradation.
- All 70 pdf-engine tests pass. Remaining tsc noise is pre-existing (`firecrawl-rs` native module under --ignore-scripts; `document/index.ts` reproduces on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)