### PR TITLE
fix(api): add a timeout to the html-to-markdown conversion

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -230,6 +230,11 @@ const configSchema = z.object({
   // External Services
   PLAYWRIGHT_MICROSERVICE_URL: z.string().optional(),
   HTML_TO_MARKDOWN_SERVICE_URL: z.string().optional(),
+  HTML_TO_MARKDOWN_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(60000),
   SMART_SCRAPE_API_URL: z.string().optional(),
 
   // PDF Processing

--- a/apps/api/src/lib/__tests__/html-to-markdown.test.ts
+++ b/apps/api/src/lib/__tests__/html-to-markdown.test.ts
@@ -48,3 +48,70 @@ describe("parseMarkdown", () => {
     }
   });
 });
+
+describe("parseMarkdown Go parser timeout", () => {
+  afterEach(() => {
+    vi.doUnmock("koffi");
+    vi.doUnmock("fs/promises");
+    vi.doUnmock("../../config");
+    vi.resetModules();
+  });
+
+  // Re-imports the module with the Go parser enabled and its FFI call replaced.
+  async function loadWithGoParser(
+    timeoutMs: number,
+    goAsync: (
+      html: string,
+      cb: (err: Error | null, res?: string) => void,
+    ) => void,
+  ) {
+    vi.resetModules();
+    vi.doMock("koffi", () => ({
+      default: {
+        load: () => ({
+          func: () => ({ async: goAsync }),
+        }),
+        disposable: () => "CString:mock",
+      },
+    }));
+    vi.doMock("fs/promises", async importOriginal => {
+      const orig = await importOriginal<typeof import("fs/promises")>();
+      return { ...orig, stat: async () => ({}) as any };
+    });
+    vi.doMock("../../config", async importOriginal => {
+      const orig = await importOriginal<typeof import("../../config")>();
+      return {
+        ...orig,
+        config: {
+          ...orig.config,
+          USE_GO_MARKDOWN_PARSER: true,
+          HTML_TO_MARKDOWN_SERVICE_URL: undefined,
+          HTML_TO_MARKDOWN_TIMEOUT_MS: timeoutMs,
+        },
+      };
+    });
+    return await import("../html-to-markdown.js");
+  }
+
+  it("falls back to turndown instead of hanging when the Go conversion never completes", async () => {
+    const { parseMarkdown: parseWithHangingGo } = await loadWithGoParser(
+      200,
+      () => {
+        // never invoke the callback, simulating a hung native conversion
+      },
+    );
+    await expect(parseWithHangingGo("<p>Hello, world!</p>")).resolves.toBe(
+      "Hello, world!",
+    );
+  });
+
+  it("returns the Go parser result when conversion completes within the timeout", async () => {
+    const { parseMarkdown: parseWithFastGo } = await loadWithGoParser(
+      5000,
+      (_html, cb) => cb(null, "go parser output"),
+    );
+    await expect(parseWithFastGo("<p>Hello, world!</p>")).resolves.toBe(
+      "go parser output",
+    );
+  });
+});

--- a/apps/api/src/lib/html-to-markdown-client.ts
+++ b/apps/api/src/lib/html-to-markdown-client.ts
@@ -72,7 +72,7 @@ export async function convertHTMLToMarkdownWithHttpService(
       `${url}/convert`,
       request,
       {
-        timeout: 60_000,
+        timeout: config.HTML_TO_MARKDOWN_TIMEOUT_MS,
         headers,
       },
     );

--- a/apps/api/src/lib/html-to-markdown.ts
+++ b/apps/api/src/lib/html-to-markdown.ts
@@ -9,7 +9,12 @@ import { HTML_TO_MARKDOWN_PATH } from "../natives";
 import { convertHTMLToMarkdownWithHttpService } from "./html-to-markdown-client";
 import { postProcessMarkdown } from "@mendable/firecrawl-rs";
 
-// TODO: add a timeout to the Go parser
+class ConversionTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`HTML to Markdown conversion timed out after ${timeoutMs}ms`);
+    this.name = "ConversionTimeoutError";
+  }
+}
 
 class GoMarkdownConverter {
   private static instance: GoMarkdownConverter;
@@ -39,7 +44,12 @@ class GoMarkdownConverter {
   }
 
   public async convertHTMLToMarkdown(html: string): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
+    const timeoutMs = config.HTML_TO_MARKDOWN_TIMEOUT_MS;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+
+    // The native call cannot be cancelled once started; the race only unblocks
+    // the caller so the scrape can fall back instead of stalling the worker.
+    const conversion = new Promise<string>((resolve, reject) => {
       this.convert.async(html, (err: Error, res: string) => {
         if (err) {
           reject(err);
@@ -48,6 +58,19 @@ class GoMarkdownConverter {
         }
       });
     });
+
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () => reject(new ConversionTimeoutError(timeoutMs)),
+        timeoutMs,
+      );
+    });
+
+    try {
+      return await Promise.race([conversion, timeout]);
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
   }
 }
 
@@ -99,7 +122,22 @@ export async function parseMarkdown(
       return markdownContent;
     }
   } catch (error) {
-    if (
+    if (error instanceof ConversionTimeoutError) {
+      contextLogger.warn(
+        "HTML to Markdown conversion timed out, falling back",
+        {
+          timeout_ms: config.HTML_TO_MARKDOWN_TIMEOUT_MS,
+          ...(zeroDataRetention ? {} : { input_size: html.length }),
+          ...(requestId && !zeroDataRetention ? { request_id: requestId } : {}),
+        },
+      );
+      Sentry.captureException(error, {
+        tags: {
+          conversion_timeout: "true",
+          ...(requestId && !zeroDataRetention ? { request_id: requestId } : {}),
+        },
+      });
+    } else if (
       !(error instanceof Error) ||
       error.message !== "Go shared library not found"
     ) {


### PR DESCRIPTION
Fixes #4046

The Go converter call in `apps/api/src/lib/html-to-markdown.ts` had no deadline (the `// TODO: add a timeout to the Go parser` at the top of the file), so a conversion that never returns would block the calling scrape worker indefinitely. This adds an `HTML_TO_MARKDOWN_TIMEOUT_MS` config (default 60000, the same value the HTTP service path already used as a hardcoded axios timeout), races the FFI call against it, and emits a warn log plus a tagged Sentry event when a conversion times out. On timeout the scrape falls through to the existing Turndown fallback instead of stalling. The HTTP service path now reads the same config instead of its hardcoded 60s, so its behavior is unchanged at the default.

One limitation worth stating: the native call itself cannot be cancelled once started, so a hung conversion still occupies its thread until it returns. The timeout unblocks the worker and makes the failure visible (log + Sentry tag), which is what the issue asks for; making the in-process Go path fully hang-proof is what the out-of-process HTTP service path is for.

Tests: two new cases in `src/lib/__tests__/html-to-markdown.test.ts`. The regression test mocks the FFI call to never invoke its callback: on main it hangs until the runner kills it, with this change it falls back and passes in about 400ms. I could not express this as a snip because there is no way to force a hung native conversion through the public API, but I ran the v2 scrape snips locally against the full self-hosted stack with `USE_GO_MARKDOWN_PARSER=true` (so the changed path runs on every scrape) and they pass, and `pnpm build` is green.

quick note: I'm a college freshman trying my best to contribute for the greater good :) I put this together with Claude Code's help (we worked through the logic together and I ran the build, unit tests, and self-hosted scrape snips locally), so apologies in advance if anything looks off. if there are mistakes I would genuinely love to learn from them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a timeout to the in-process Go HTML-to-Markdown converter so hung conversions no longer stall scrape workers. On timeout we log, tag Sentry, and fall back to Turndown; the HTTP service now shares the same configurable timeout.

- **Bug Fixes**
  - Added `HTML_TO_MARKDOWN_TIMEOUT_MS` (default 60s) and use it in both the Go FFI path and the HTTP service client.
  - Race the Go conversion against the timeout; on timeout emit a warn log, tag Sentry (`conversion_timeout: true`), and fall back to Turndown.
  - Known limitation: the native call isn’t cancellable; it may keep a thread busy until it returns.
  - New tests cover a never-resolving Go call (falls back) and a fast call (returns result).

<sup>Written for commit a01afd1b8663b361c23c6e86ee8d6597d9d83cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

