### PR TITLE
fix(ui): support PgUp and PgDn in ingestion inputs

### DIFF
--- a/apps/ui/ingestion-ui/src/components/ingestion.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestion.tsx
@@ -16,6 +16,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { handleNumberInputPageKey } from "@/lib/utils";
 
 //! Hardcoded values (not recommended for production)
 //! Highly recommended to move all Firecrawl API calls to the backend (e.g. Next.js API route)
@@ -126,17 +127,12 @@ export default function FirecrawlComponent() {
   };
 
   const handleNumberKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key !== "PageUp" && e.key !== "PageDown") return;
-
-    e.preventDefault();
-    const currentValue = Number(e.currentTarget.value) || 0;
-    const value =
-      e.key === "PageUp" ? currentValue + 1 : Math.max(0, currentValue - 1);
-
-    setFormData((prevData) => ({
-      ...prevData,
-      [e.currentTarget.name]: value.toString(),
-    }));
+    handleNumberInputPageKey(e, (name, value) => {
+      setFormData((prevData) => ({
+        ...prevData,
+        [name]: value,
+      }));
+    });
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {

--- a/apps/ui/ingestion-ui/src/components/ingestion.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestion.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, FormEvent, useEffect } from "react";
+import { useState, ChangeEvent, FormEvent, KeyboardEvent, useEffect } from "react";
 import {
   Card,
   CardHeader,
@@ -122,6 +122,20 @@ export default function FirecrawlComponent() {
     setFormData((prevData) => ({
       ...prevData,
       [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleNumberKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "PageUp" && e.key !== "PageDown") return;
+
+    e.preventDefault();
+    const currentValue = Number(e.currentTarget.value) || 0;
+    const value =
+      e.key === "PageUp" ? currentValue + 1 : Math.max(0, currentValue - 1);
+
+    setFormData((prevData) => ({
+      ...prevData,
+      [e.currentTarget.name]: value.toString(),
     }));
   };
 
@@ -434,9 +448,12 @@ export default function FirecrawlComponent() {
                     <Input
                       id="limit"
                       name="limit"
+                      type="number"
+                      min={0}
                       placeholder="10"
                       value={formData.limit}
                       onChange={handleChange}
+                      onKeyDown={handleNumberKeyDown}
                     />
                   </div>
                   <div>
@@ -449,9 +466,12 @@ export default function FirecrawlComponent() {
                     <Input
                       id="maxDepth"
                       name="maxDepth"
+                      type="number"
+                      min={0}
                       placeholder="5"
                       value={formData.maxDepth}
                       onChange={handleChange}
+                      onKeyDown={handleNumberKeyDown}
                     />
                   </div>
                 </div>

--- a/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
@@ -16,6 +16,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { handleNumberInputPageKey } from "@/lib/utils";
 
 //! Hardcoded values (not recommended for production)
 //! Highly recommended to move all Firecrawl API calls to the backend (e.g. Next.js API route)
@@ -149,25 +150,19 @@ export default function FirecrawlComponentV1() {
   };
 
   const handleNumberKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key !== "PageUp" && e.key !== "PageDown") return;
+    handleNumberInputPageKey(e, (name, value) => {
+      setFormData((prevData) => {
+        const newData = {
+          ...prevData,
+          [name]: value,
+        };
 
-    e.preventDefault();
-    const currentValue = Number(e.currentTarget.value) || 0;
-    const value =
-      e.key === "PageUp" ? currentValue + 1 : Math.max(0, currentValue - 1);
-    const nextValue = value.toString();
+        if (name === "limit") {
+          newData.crawlSubPages = !!value || !!newData.search;
+        }
 
-    setFormData((prevData) => {
-      const newData = {
-        ...prevData,
-        [e.currentTarget.name]: nextValue,
-      };
-
-      if (e.currentTarget.name === "limit") {
-        newData.crawlSubPages = !!nextValue || !!newData.search;
-      }
-
-      return newData;
+        return newData;
+      });
     });
   };
 

--- a/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
@@ -155,11 +155,20 @@ export default function FirecrawlComponentV1() {
     const currentValue = Number(e.currentTarget.value) || 0;
     const value =
       e.key === "PageUp" ? currentValue + 1 : Math.max(0, currentValue - 1);
+    const nextValue = value.toString();
 
-    setFormData((prevData) => ({
-      ...prevData,
-      [e.currentTarget.name]: value.toString(),
-    }));
+    setFormData((prevData) => {
+      const newData = {
+        ...prevData,
+        [e.currentTarget.name]: nextValue,
+      };
+
+      if (e.currentTarget.name === "limit") {
+        newData.crawlSubPages = !!nextValue || !!newData.search;
+      }
+
+      return newData;
+    });
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {

--- a/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
+++ b/apps/ui/ingestion-ui/src/components/ingestionV1.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, FormEvent, useEffect } from "react";
+import { useState, ChangeEvent, FormEvent, KeyboardEvent, useEffect } from "react";
 import {
   Card,
   CardHeader,
@@ -146,6 +146,20 @@ export default function FirecrawlComponentV1() {
 
       return newData;
     });
+  };
+
+  const handleNumberKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "PageUp" && e.key !== "PageDown") return;
+
+    e.preventDefault();
+    const currentValue = Number(e.currentTarget.value) || 0;
+    const value =
+      e.key === "PageUp" ? currentValue + 1 : Math.max(0, currentValue - 1);
+
+    setFormData((prevData) => ({
+      ...prevData,
+      [e.currentTarget.name]: value.toString(),
+    }));
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -444,9 +458,12 @@ export default function FirecrawlComponentV1() {
                     <Input
                       id="limit"
                       name="limit"
+                      type="number"
+                      min={0}
                       placeholder="10"
                       value={formData.limit}
                       onChange={handleChange}
+                      onKeyDown={handleNumberKeyDown}
                     />
                   </div>
                 </div>

--- a/apps/ui/ingestion-ui/src/lib/utils.ts
+++ b/apps/ui/ingestion-ui/src/lib/utils.ts
@@ -1,6 +1,21 @@
 import { type ClassValue, clsx } from "clsx"
+import type { KeyboardEvent } from "react"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function handleNumberInputPageKey(
+  event: KeyboardEvent<HTMLInputElement>,
+  onValueChange: (name: string, value: string) => void,
+) {
+  if (event.key !== "PageUp" && event.key !== "PageDown") return
+
+  event.preventDefault()
+  const currentValue = Number(event.currentTarget.value) || 0
+  const value =
+    event.key === "PageUp" ? currentValue + 1 : Math.max(0, currentValue - 1)
+
+  onValueChange(event.currentTarget.name, value.toString())
 }


### PR DESCRIPTION
## Summary

Enable PageUp and PageDown on the ingestion UI numeric controls.

## Root cause

The Limit and Max depth controls were text inputs, so the browser had no numeric keyboard behavior. Changing the input type alone was not enough because PageUp/PageDown do not increment controlled number inputs automatically in Chromium.

## Changes

- Render V0 Limit, V0 Max depth, and V1 Limit as numeric inputs with a zero minimum.
- Handle PageUp and PageDown explicitly in the controlled form state.
- Clamp decrements at zero.

## Validation

- `pnpm run build`
- Built UI checked locally:
  - V1 Limit: PageUp changes `3` to `4`.
  - V1 Limit: PageDown changes `3` to `2`.
  - V1 Limit: PageDown at `0` remains `0`.
  - V0 Limit and Max depth render as numeric controls with `min=0`.

Fixes #3935

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PageUp/PageDown support for ingestion limits and max depth with number inputs clamped at 0. In V1, keyboard edits to limit keep crawl enabled; key handling is shared via a new utility.

- **Bug Fixes**
  - Converted V0 Limit, V0 Max depth, and V1 Limit to `type="number"` with `min=0` and explicit PageUp/PageDown handling to prevent negatives.
  - V1: when updating `limit` via keyboard, sync `crawlSubPages` so it stays enabled if `limit` or `search` is set.

- **Refactors**
  - Extracted PageUp/PageDown handling to `handleNumberInputPageKey` in `@/lib/utils` and used it in V0 and V1 inputs.

<sup>Written for commit 098b56497fca46924ade37a4e25a29e0457a7f6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

