### PR TITLE
fix(api): log errors swallowed by empty catch blocks

### DIFF
--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -243,7 +243,13 @@ export async function crawlController(req: Request, res: Response) {
 
     try {
       sc.robots = await crawler.getRobotsTxt();
-    } catch (_) {}
+    } catch (error) {
+      logger.warn("Failed to get robots.txt for crawl, proceeding without it", {
+        error,
+        crawlId: id,
+        teamId: team_id,
+      });
+    }
 
     sc.queueBackend = await resolveNewGroupBackend(sc.team_id);
     await crawlGroup.addGroup(

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -156,7 +156,13 @@ export async function getMapResults({
   try {
     sc.robots = await crawler.getRobotsTxt(false, abort);
     crawler.importRobotsTxt(sc.robots);
-  } catch (_) {}
+  } catch (error) {
+    logger.warn("Failed to get robots.txt for map, proceeding without it", {
+      error,
+      crawlId: id,
+      teamId,
+    });
+  }
 
   // If sitemapOnly is true, only get links from sitemap
   if (crawlerOptions.sitemapOnly) {

--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -641,7 +641,15 @@ export function crawlToCrawler(
   if (sc.robots !== undefined) {
     try {
       crawler.importRobotsTxt(sc.robots);
-    } catch (_) {}
+    } catch (error) {
+      _logger.warn(
+        "Failed to import robots.txt for crawl, proceeding without it",
+        {
+          error,
+          crawlId: id,
+        },
+      );
+    }
   }
 
   return crawler;

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -483,7 +483,7 @@ export async function extractData({
   } catch (error) {
     console.error(">>>>>>>extractSmartScrape.ts error>>>>>\n", error);
     if (error instanceof Error && error.message === "Cost limit exceeded") {
-      costLimitExceededTokenUsage = (error as any).cause.tokenUsage;
+      costLimitExceededTokenUsage = (error as any).cause?.tokenUsage ?? null;
       warning =
         "Smart scrape cost limit exceeded." + (warning ? " " + warning : "");
     } else {

--- a/apps/api/src/scraper/scrapeURL/lib/smartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/smartScrape.ts
@@ -206,7 +206,14 @@ export async function smartScrape({
         if (json.error === "Cost limit exceeded") {
           throw new CostLimitExceededError();
         }
-      } catch (e) {}
+      } catch (e) {
+        if (e instanceof CostLimitExceededError) {
+          throw e;
+        }
+        logger.debug("Failed to parse smart scrape error response", {
+          error: e,
+        });
+      }
     }
 
     // Safely extract error information without circular references

--- a/apps/api/src/services/redis.ts
+++ b/apps/api/src/services/redis.ts
@@ -11,7 +11,10 @@ redisRateLimitClient.on("error", error => {
     } else if (error.message === "ECONNREFUSED") {
       logger.error("Connection to Redis Session Rate Limit Store refused!");
     } else logger.error(error);
-  } catch (error) {}
+  } catch (error) {
+    // last resort if the logger itself throws; never let the handler crash
+    console.error("Failed to log Redis connection error", error);
+  }
 });
 
 // Listen to 'reconnecting' event to Redis
@@ -20,14 +23,18 @@ redisRateLimitClient.on("reconnecting", err => {
     if (redisRateLimitClient.status === "reconnecting")
       logger.info("Reconnecting to Redis Session Rate Limit Store...");
     else logger.error("Error reconnecting to Redis Session Rate Limit Store.");
-  } catch (error) {}
+  } catch (error) {
+    console.error("Failed to log Redis reconnecting state", error);
+  }
 });
 
 // Listen to the 'connect' event to Redis
 redisRateLimitClient.on("connect", err => {
   try {
     if (!err) logger.info("Connected to Redis Session Rate Limit Store!");
-  } catch (error) {}
+  } catch (error) {
+    console.error("Failed to log Redis connect state", error);
+  }
 });
 
 /**

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1629,7 +1629,11 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
                 logger.debug("Job succeeded -- putting result in Redis");
                 return result.document;
               }
-            } catch (e) {}
+            } catch (e) {
+              logger.warn("Failed to return completed job document", {
+                error: e,
+              });
+            }
           } else {
             throw (result as any).error;
           }


### PR DESCRIPTION
Fixes #4048

Adds logging to the six empty catch sites from the issue so degradation is visible. The three Redis connection-state handlers in `services/redis.ts` get a `console.error` last resort (those try blocks guard the logger itself, so logging the failure via the logger would be circular). The robots.txt paths in v1 map, v0 crawl and `crawl-redis.ts` get warn logs with crawl context, since behavior changes when the fetch fails (rules not applied). The completed-job return path in `scrape-worker.ts` gets a warn matching the sibling catch right above it.

One of the six was hiding an actual bug: in `smartScrape.ts` the empty catch was also swallowing the `CostLimitExceededError` thrown two lines above it inside the same try, so the cost limit never propagated (the outer catch at line 177 already rethrows exactly this error type, which is pretty clearly the intended path). The catch now rethrows `CostLimitExceededError` and debug-logs JSON parse failures. Propagating it surfaced a latent crash in `extractSmartScrape.ts` line 486, which reads `.cause.tokenUsage` off an error that never carries a `cause`, so that read is now optional-chained with a null fallback and the graceful "Smart scrape cost limit exceeded" warning path works as written (the value itself is only destructured by the caller and not used further).

Testing: the logging additions are behavior-preserving and covered by the existing suite. I ran the v2 map snips (which go through the changed robots.txt path) and the v2 scrape snips locally against the full self-hosted stack and they pass (6/6 and 4/4), plus `pnpm build`. The smart-scrape lane needs the hosted service so I could not exercise it locally; the rethrow mirrors the outer catch's existing handling and the crash fix is a two-character optional chain.

small note: freshman in college here, contributing for the greater good as best I can :) Claude Code helped me work through this one, I read every line and ran the self-hosted snips and build locally. apologies if anything seems off, and if there are mistakes I would honestly love to learn from them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds logging to six previously empty catch blocks so errors surface in production. Also fixes smart scrape cost limit handling by rethrowing `CostLimitExceededError` and guarding optional `tokenUsage`. Fixes #4048.

- **Bug Fixes**
  - Robots.txt: warn and continue on fetch/import failures in v1 map, v0 crawl, and `crawl-redis.ts` (includes crawl context).
  - Redis client: add `console.error` fallbacks in error/reconnecting/connect handlers if the logger fails.
  - Smart scrape: rethrow `CostLimitExceededError`; debug-log JSON parse failures.
  - Smart scrape extraction: avoid crash by using `cause?.tokenUsage ?? null`.
  - Scrape worker: warn if returning the completed job document fails.

<sup>Written for commit e2e42e5ad03d2fef201e368efb98c5bf873b1063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

