### PR TITLE
fix(api): make readiness probe check Redis health

### DIFF
--- a/apps/api/src/__tests__/snips/health.test.ts
+++ b/apps/api/src/__tests__/snips/health.test.ts
@@ -1,0 +1,33 @@
+import request from "supertest";
+import { TEST_API_URL } from "./lib";
+
+beforeAll(async () => {
+  const deadline = Date.now() + 10_000;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await request(TEST_API_URL).get("/v0/health/liveness");
+      if (response.statusCode === 200) return;
+    } catch {}
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  throw new Error("API did not become live within 10 seconds");
+});
+
+describe("health probes", () => {
+  it("keeps liveness dependency-independent", async () => {
+    const response = await request(TEST_API_URL).get("/v0/health/liveness");
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ status: "ok" });
+  });
+
+  it("reports ready when both shared Redis clients are healthy", async () => {
+    const response = await request(TEST_API_URL).get("/v0/health/readiness");
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ status: "ok" });
+  });
+});

--- a/apps/api/src/controllers/__tests__/health.test.ts
+++ b/apps/api/src/controllers/__tests__/health.test.ts
@@ -31,7 +31,7 @@ const {
 
   return {
     getRedisConnection: vi.fn(() => queueRedis),
-    logger: { warn: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn() },
     queueRedis,
     queueRedisProbe,
     redisRateLimitClient,
@@ -92,6 +92,11 @@ describe("livenessController", () => {
 });
 
 describe("readinessController", () => {
+  beforeEach(async () => {
+    await readinessController({} as Request, makeResponse());
+    vi.clearAllMocks();
+  });
+
   it("preserves the existing response when both Redis clients are healthy", async () => {
     const res = makeResponse();
 
@@ -101,6 +106,7 @@ describe("readinessController", () => {
     expect(res.json).toHaveBeenCalledWith({ status: "ok" });
     expect(queueRedisProbe.ping).toHaveBeenCalledTimes(1);
     expect(redisRateLimitProbe.ping).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
@@ -116,8 +122,8 @@ describe("readinessController", () => {
     expect(queueRedisProbe.disconnect).toHaveBeenCalledTimes(1);
     expect(redisRateLimitProbe.ping).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
-      "Readiness Redis dependency check failed",
-      { dependency: "queueRedis", error },
+      "Readiness Redis dependency is unhealthy",
+      { dependency: "queueRedis", reason: "error", error },
     );
   });
 
@@ -132,9 +138,10 @@ describe("readinessController", () => {
     expect(queueRedisProbe.ping).toHaveBeenCalledTimes(1);
     expect(redisRateLimitProbe.ping).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
-      "Readiness Redis dependency is not ready",
+      "Readiness Redis dependency is unhealthy",
       {
         dependency: "redisRateLimitClient",
+        reason: "not_ready",
         status: "reconnecting",
         probeStatus: "ready",
       },
@@ -157,13 +164,41 @@ describe("readinessController", () => {
     });
     expect(redisRateLimitProbe.ping).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
-      "Readiness Redis dependency check failed",
+      "Readiness Redis dependency is unhealthy",
       {
         dependency: "queueRedis",
+        reason: "error",
         error: expect.objectContaining({
           message: "Command timed out",
         }),
       },
+    );
+  });
+
+  it("logs Redis health transitions instead of every probe", async () => {
+    redisRateLimitClient.status = "reconnecting";
+
+    await readinessController({} as Request, makeResponse());
+    await readinessController({} as Request, makeResponse());
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Readiness Redis dependency is unhealthy",
+      {
+        dependency: "redisRateLimitClient",
+        reason: "not_ready",
+        status: "reconnecting",
+        probeStatus: "ready",
+      },
+    );
+
+    redisRateLimitClient.status = "ready";
+    await readinessController({} as Request, makeResponse());
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Readiness Redis dependency recovered",
+      { dependency: "redisRateLimitClient" },
     );
   });
 });

--- a/apps/api/src/controllers/__tests__/health.test.ts
+++ b/apps/api/src/controllers/__tests__/health.test.ts
@@ -1,0 +1,142 @@
+import type { Request, Response } from "express";
+import { vi } from "vitest";
+
+const { getRedisConnection, logger, queueRedis, redisRateLimitClient } =
+  vi.hoisted(() => {
+    const queueRedis = {
+      status: "ready",
+      ping: vi.fn<() => Promise<unknown>>(),
+    };
+    const redisRateLimitClient = {
+      status: "ready",
+      ping: vi.fn<() => Promise<unknown>>(),
+    };
+
+    return {
+      getRedisConnection: vi.fn(() => queueRedis),
+      logger: { warn: vi.fn() },
+      queueRedis,
+      redisRateLimitClient,
+    };
+  });
+
+vi.mock("../../services/queue-service", () => ({ getRedisConnection }));
+vi.mock("../../services/rate-limiter", () => ({ redisRateLimitClient }));
+vi.mock("../../lib/logger", () => ({ logger }));
+
+import { livenessController } from "../v0/liveness";
+import {
+  readinessController,
+  READINESS_CHECK_TIMEOUT_MS,
+} from "../v0/readiness";
+
+function makeResponse() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response & {
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  queueRedis.status = "ready";
+  redisRateLimitClient.status = "ready";
+  queueRedis.ping.mockResolvedValue("PONG");
+  redisRateLimitClient.ping.mockResolvedValue("PONG");
+  getRedisConnection.mockReturnValue(queueRedis);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("livenessController", () => {
+  it("stays dependency-independent", async () => {
+    const res = makeResponse();
+
+    await livenessController({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    expect(getRedisConnection).not.toHaveBeenCalled();
+    expect(queueRedis.ping).not.toHaveBeenCalled();
+    expect(redisRateLimitClient.ping).not.toHaveBeenCalled();
+  });
+});
+
+describe("readinessController", () => {
+  it("preserves the existing response when both Redis clients are healthy", async () => {
+    const res = makeResponse();
+
+    await readinessController({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    expect(getRedisConnection).toHaveBeenCalledTimes(1);
+    expect(queueRedis.ping).toHaveBeenCalledTimes(1);
+    expect(redisRateLimitClient.ping).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns unavailable when a shared Redis client rejects", async () => {
+    const error = new Error("connection refused");
+    queueRedis.ping.mockRejectedValue(error);
+    const res = makeResponse();
+
+    await readinessController({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({ status: "unhealthy" });
+    expect(redisRateLimitClient.ping).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Readiness Redis dependency check failed",
+      { dependency: "queueRedis", error },
+    );
+  });
+
+  it("does not queue a ping while a shared Redis client is reconnecting", async () => {
+    redisRateLimitClient.status = "reconnecting";
+    const res = makeResponse();
+
+    await readinessController({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({ status: "unhealthy" });
+    expect(queueRedis.ping).toHaveBeenCalledTimes(1);
+    expect(redisRateLimitClient.ping).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Readiness Redis dependency is not ready",
+      {
+        dependency: "redisRateLimitClient",
+        status: "reconnecting",
+      },
+    );
+  });
+
+  it("returns unavailable when a shared Redis client times out", async () => {
+    vi.useFakeTimers();
+    queueRedis.ping.mockImplementation(() => new Promise(() => {}));
+    const res = makeResponse();
+
+    const response = readinessController({} as Request, res);
+    await vi.advanceTimersByTimeAsync(READINESS_CHECK_TIMEOUT_MS);
+    await response;
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({ status: "unhealthy" });
+    expect(redisRateLimitClient.ping).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Readiness Redis dependency check failed",
+      {
+        dependency: "queueRedis",
+        error: expect.objectContaining({
+          message: "Redis readiness check timed out",
+        }),
+      },
+    );
+  });
+});

--- a/apps/api/src/controllers/__tests__/health.test.ts
+++ b/apps/api/src/controllers/__tests__/health.test.ts
@@ -1,24 +1,43 @@
 import type { Request, Response } from "express";
 import { vi } from "vitest";
 
-const { getRedisConnection, logger, queueRedis, redisRateLimitClient } =
-  vi.hoisted(() => {
-    const queueRedis = {
-      status: "ready",
-      ping: vi.fn<() => Promise<unknown>>(),
-    };
-    const redisRateLimitClient = {
-      status: "ready",
-      ping: vi.fn<() => Promise<unknown>>(),
-    };
-
+const {
+  getRedisConnection,
+  logger,
+  queueRedis,
+  queueRedisProbe,
+  redisRateLimitClient,
+  redisRateLimitProbe,
+} = vi.hoisted(() => {
+  function makeProbe() {
     return {
-      getRedisConnection: vi.fn(() => queueRedis),
-      logger: { warn: vi.fn() },
-      queueRedis,
-      redisRateLimitClient,
+      status: "ready",
+      ping: vi.fn<() => Promise<unknown>>(),
+      disconnect: vi.fn(),
     };
-  });
+  }
+
+  function makeClient(probe: ReturnType<typeof makeProbe>) {
+    return {
+      status: "ready",
+      duplicate: vi.fn(() => probe),
+    };
+  }
+
+  const queueRedisProbe = makeProbe();
+  const redisRateLimitProbe = makeProbe();
+  const queueRedis = makeClient(queueRedisProbe);
+  const redisRateLimitClient = makeClient(redisRateLimitProbe);
+
+  return {
+    getRedisConnection: vi.fn(() => queueRedis),
+    logger: { warn: vi.fn() },
+    queueRedis,
+    queueRedisProbe,
+    redisRateLimitClient,
+    redisRateLimitProbe,
+  };
+});
 
 vi.mock("../../services/queue-service", () => ({ getRedisConnection }));
 vi.mock("../../services/rate-limiter", () => ({ redisRateLimitClient }));
@@ -44,9 +63,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.useRealTimers();
   queueRedis.status = "ready";
+  queueRedisProbe.status = "ready";
   redisRateLimitClient.status = "ready";
-  queueRedis.ping.mockResolvedValue("PONG");
-  redisRateLimitClient.ping.mockResolvedValue("PONG");
+  redisRateLimitProbe.status = "ready";
+  queueRedisProbe.ping.mockResolvedValue("PONG");
+  redisRateLimitProbe.ping.mockResolvedValue("PONG");
+  queueRedis.duplicate.mockReturnValue(queueRedisProbe);
+  redisRateLimitClient.duplicate.mockReturnValue(redisRateLimitProbe);
   getRedisConnection.mockReturnValue(queueRedis);
 });
 
@@ -63,8 +86,8 @@ describe("livenessController", () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ status: "ok" });
     expect(getRedisConnection).not.toHaveBeenCalled();
-    expect(queueRedis.ping).not.toHaveBeenCalled();
-    expect(redisRateLimitClient.ping).not.toHaveBeenCalled();
+    expect(queueRedisProbe.ping).not.toHaveBeenCalled();
+    expect(redisRateLimitProbe.ping).not.toHaveBeenCalled();
   });
 });
 
@@ -76,22 +99,22 @@ describe("readinessController", () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ status: "ok" });
-    expect(getRedisConnection).toHaveBeenCalledTimes(1);
-    expect(queueRedis.ping).toHaveBeenCalledTimes(1);
-    expect(redisRateLimitClient.ping).toHaveBeenCalledTimes(1);
+    expect(queueRedisProbe.ping).toHaveBeenCalledTimes(1);
+    expect(redisRateLimitProbe.ping).toHaveBeenCalledTimes(1);
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("returns unavailable when a shared Redis client rejects", async () => {
     const error = new Error("connection refused");
-    queueRedis.ping.mockRejectedValue(error);
+    queueRedisProbe.ping.mockRejectedValue(error);
     const res = makeResponse();
 
     await readinessController({} as Request, res);
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.json).toHaveBeenCalledWith({ status: "unhealthy" });
-    expect(redisRateLimitClient.ping).toHaveBeenCalledTimes(1);
+    expect(queueRedisProbe.disconnect).toHaveBeenCalledTimes(1);
+    expect(redisRateLimitProbe.ping).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
       "Readiness Redis dependency check failed",
       { dependency: "queueRedis", error },
@@ -106,35 +129,39 @@ describe("readinessController", () => {
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.json).toHaveBeenCalledWith({ status: "unhealthy" });
-    expect(queueRedis.ping).toHaveBeenCalledTimes(1);
-    expect(redisRateLimitClient.ping).not.toHaveBeenCalled();
+    expect(queueRedisProbe.ping).toHaveBeenCalledTimes(1);
+    expect(redisRateLimitProbe.ping).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
       "Readiness Redis dependency is not ready",
       {
         dependency: "redisRateLimitClient",
         status: "reconnecting",
+        probeStatus: "ready",
       },
     );
   });
 
-  it("returns unavailable when a shared Redis client times out", async () => {
-    vi.useFakeTimers();
-    queueRedis.ping.mockImplementation(() => new Promise(() => {}));
+  it("resets a dedicated probe connection when a command times out", async () => {
+    queueRedisProbe.ping.mockRejectedValue(new Error("Command timed out"));
     const res = makeResponse();
 
-    const response = readinessController({} as Request, res);
-    await vi.advanceTimersByTimeAsync(READINESS_CHECK_TIMEOUT_MS);
-    await response;
+    await readinessController({} as Request, res);
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.json).toHaveBeenCalledWith({ status: "unhealthy" });
-    expect(redisRateLimitClient.ping).toHaveBeenCalledTimes(1);
+    expect(queueRedisProbe.disconnect).toHaveBeenCalledTimes(1);
+    expect(queueRedis.duplicate).toHaveBeenCalledWith({
+      commandTimeout: READINESS_CHECK_TIMEOUT_MS,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 0,
+    });
+    expect(redisRateLimitProbe.ping).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
       "Readiness Redis dependency check failed",
       {
         dependency: "queueRedis",
         error: expect.objectContaining({
-          message: "Redis readiness check timed out",
+          message: "Command timed out",
         }),
       },
     );

--- a/apps/api/src/controllers/v0/liveness.ts
+++ b/apps/api/src/controllers/v0/liveness.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 
 export async function livenessController(req: Request, res: Response) {
-  //TODO: add checks if the application is live and healthy like checking the redis connection
+  // Liveness is intentionally dependency-independent: serving this handler proves
+  // the process can accept work, while readiness reports dependency health.
   res.status(200).json({ status: "ok" });
 }

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -1,6 +1,79 @@
 import { Request, Response } from "express";
+import type Redis from "ioredis";
+import { logger } from "../../lib/logger";
+import { getRedisConnection } from "../../services/queue-service";
+import { redisRateLimitClient } from "../../services/rate-limiter";
+
+export const READINESS_CHECK_TIMEOUT_MS = 1000;
+
+type RedisDependency = "queueRedis" | "redisRateLimitClient";
+type RedisPingClient = Pick<Redis, "ping" | "status">;
+
+async function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Redis readiness check timed out")),
+          READINESS_CHECK_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function checkRedis(
+  dependency: RedisDependency,
+  getClient: () => RedisPingClient,
+): Promise<boolean> {
+  try {
+    const client = getClient();
+
+    // The queue client has an unbounded offline queue. Do not add a PING while
+    // it is already reconnecting; the timeout covers a command that stalls
+    // after the client was observed in the ready state.
+    if (client.status !== "ready") {
+      logger.warn("Readiness Redis dependency is not ready", {
+        dependency,
+        status: client.status,
+      });
+      return false;
+    }
+
+    if ((await withTimeout(client.ping())) !== "PONG") {
+      logger.warn(
+        "Readiness Redis dependency returned an unexpected response",
+        {
+          dependency,
+        },
+      );
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    logger.warn("Readiness Redis dependency check failed", {
+      dependency,
+      error,
+    });
+    return false;
+  }
+}
 
 export async function readinessController(req: Request, res: Response) {
-  // TODO: add checks when the application is ready to serve traffic
-  res.status(200).json({ status: "ok" });
+  const [queueRedisHealthy, redisRateLimitClientHealthy] = await Promise.all([
+    checkRedis("queueRedis", getRedisConnection),
+    checkRedis("redisRateLimitClient", () => redisRateLimitClient),
+  ]);
+
+  if (!queueRedisHealthy || !redisRateLimitClientHealthy) {
+    return res.status(503).json({ status: "unhealthy" });
+  }
+
+  return res.status(200).json({ status: "ok" });
 }

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -7,6 +7,37 @@ import { redisRateLimitClient } from "../../services/rate-limiter";
 export const READINESS_CHECK_TIMEOUT_MS = 1000;
 
 type RedisDependency = "queueRedis" | "redisRateLimitClient";
+type RedisReadinessState =
+  | "ready"
+  | "not_ready"
+  | "unexpected_response"
+  | "error";
+
+const redisReadinessStates = new Map<RedisDependency, RedisReadinessState>();
+
+function recordReadinessState(
+  dependency: RedisDependency,
+  state: RedisReadinessState,
+  details: Record<string, unknown> = {},
+) {
+  const previousState = redisReadinessStates.get(dependency);
+  if (previousState === state) return;
+
+  redisReadinessStates.set(dependency, state);
+
+  if (state === "ready") {
+    if (previousState && previousState !== "ready") {
+      logger.info("Readiness Redis dependency recovered", { dependency });
+    }
+    return;
+  }
+
+  logger.warn("Readiness Redis dependency is unhealthy", {
+    dependency,
+    reason: state,
+    ...details,
+  });
+}
 
 const redisClients: Record<RedisDependency, Redis> = {
   queueRedis: getRedisConnection(),
@@ -37,8 +68,7 @@ async function checkRedis(dependency: RedisDependency): Promise<boolean> {
     const probeClient = probeClients[dependency];
 
     if (client.status !== "ready" || probeClient.status !== "ready") {
-      logger.warn("Readiness Redis dependency is not ready", {
-        dependency,
+      recordReadinessState(dependency, "not_ready", {
         status: client.status,
         probeStatus: probeClient.status,
       });
@@ -46,22 +76,17 @@ async function checkRedis(dependency: RedisDependency): Promise<boolean> {
     }
 
     if ((await probeClient.ping()) !== "PONG") {
-      logger.warn(
-        "Readiness Redis dependency returned an unexpected response",
-        {
-          dependency,
-        },
-      );
+      recordReadinessState(dependency, "unexpected_response");
       return false;
     }
 
+    recordReadinessState(dependency, "ready");
     return true;
   } catch (error) {
     // A timed-out ioredis command remains queued internally. Closing this
     // dedicated connection discards it without affecting application clients.
     resetProbeClient(dependency);
-    logger.warn("Readiness Redis dependency check failed", {
-      dependency,
+    recordReadinessState(dependency, "error", {
       error,
     });
     return false;

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -7,45 +7,45 @@ import { redisRateLimitClient } from "../../services/rate-limiter";
 export const READINESS_CHECK_TIMEOUT_MS = 1000;
 
 type RedisDependency = "queueRedis" | "redisRateLimitClient";
-type RedisPingClient = Pick<Redis, "ping" | "status">;
 
-async function withTimeout<T>(promise: Promise<T>): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
+const redisClients: Record<RedisDependency, Redis> = {
+  queueRedis: getRedisConnection(),
+  redisRateLimitClient,
+};
 
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error("Redis readiness check timed out")),
-          READINESS_CHECK_TIMEOUT_MS,
-        );
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+function createProbeClient(client: Redis): Redis {
+  return client.duplicate({
+    commandTimeout: READINESS_CHECK_TIMEOUT_MS,
+    enableOfflineQueue: false,
+    maxRetriesPerRequest: 0,
+  });
 }
 
-async function checkRedis(
-  dependency: RedisDependency,
-  getClient: () => RedisPingClient,
-): Promise<boolean> {
-  try {
-    const client = getClient();
+const probeClients: Record<RedisDependency, Redis> = {
+  queueRedis: createProbeClient(redisClients.queueRedis),
+  redisRateLimitClient: createProbeClient(redisClients.redisRateLimitClient),
+};
 
-    // The queue client has an unbounded offline queue. Do not add a PING while
-    // it is already reconnecting; the timeout covers a command that stalls
-    // after the client was observed in the ready state.
-    if (client.status !== "ready") {
+function resetProbeClient(dependency: RedisDependency) {
+  probeClients[dependency].disconnect();
+  probeClients[dependency] = createProbeClient(redisClients[dependency]);
+}
+
+async function checkRedis(dependency: RedisDependency): Promise<boolean> {
+  try {
+    const client = redisClients[dependency];
+    const probeClient = probeClients[dependency];
+
+    if (client.status !== "ready" || probeClient.status !== "ready") {
       logger.warn("Readiness Redis dependency is not ready", {
         dependency,
         status: client.status,
+        probeStatus: probeClient.status,
       });
       return false;
     }
 
-    if ((await withTimeout(client.ping())) !== "PONG") {
+    if ((await probeClient.ping()) !== "PONG") {
       logger.warn(
         "Readiness Redis dependency returned an unexpected response",
         {
@@ -57,6 +57,9 @@ async function checkRedis(
 
     return true;
   } catch (error) {
+    // A timed-out ioredis command remains queued internally. Closing this
+    // dedicated connection discards it without affecting application clients.
+    resetProbeClient(dependency);
     logger.warn("Readiness Redis dependency check failed", {
       dependency,
       error,
@@ -67,8 +70,8 @@ async function checkRedis(
 
 export async function readinessController(req: Request, res: Response) {
   const [queueRedisHealthy, redisRateLimitClientHealthy] = await Promise.all([
-    checkRedis("queueRedis", getRedisConnection),
-    checkRedis("redisRateLimitClient", () => redisRateLimitClient),
+    checkRedis("queueRedis"),
+    checkRedis("redisRateLimitClient"),
   ]);
 
   if (!queueRedisHealthy || !redisRateLimitClientHealthy) {


### PR DESCRIPTION
## Summary

- make readiness verify the shared queue and rate-limit Redis clients with concurrent `PING` checks
- return `503` when either client is not ready, rejects, times out, or returns an unexpected response
- bound each dependency check to one second and avoid adding commands to the queue client offline queue while it reconnects
- keep liveness dependency-independent and preserve the existing `200 {"status":"ok"}` response contract

Fixes #4045.

## Testing

- `pnpm vitest run src/controllers/__tests__/health.test.ts` (6 passed)
- `pnpm harness pnpm vitest run src/__tests__/snips/health.test.ts` (2 passed)
- `pnpm build`
- Prettier, `lint-staged`, and `git diff --check`

`pnpm knip --cache` remains blocked by the two pre-existing unused exported types in `src/lib/exchange.ts` (`ExchangeTerms` and `ExchangeProvider`); this change does not touch that file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Readiness now checks `queueRedis` and `redisRateLimitClient` with concurrent PINGs using isolated probe connections and a 1s timeout, returning 503 if either is unhealthy. Liveness stays dependency-independent and continues to return 200 with `{ status: "ok" }`. Addresses Linear issue #4045.

- **Bug Fixes**
  - Isolate checks with dedicated Redis probe connections (`duplicate`) using 1s timeouts, offline queue disabled, and 0 retries; reset probes on timeout.
  - Skip PING when client/probe isn’t ready; return 503 on error/timeout/non-PONG; log only health state transitions (warn on unhealthy, info on recovery); add unit and harness tests.

<sup>Written for commit 8ff8e15805265f3da385907e4102fa646ad7aeba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->