### PR TITLE
docs: document FoundationDB client prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ First, start by installing dependencies:
 4. redis [instructions](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
 5. postgresql
 6. Docker (optional) (for running postgres)
+7. [FoundationDB client library](https://www.foundationdb.org/download/) (the API's native `foundationdb` dependency is built during `pnpm install`, even when using PostgreSQL for the queue). Install the client package for your platform and make sure its `foundationdb/fdb_c.h` header and `libfdb_c` library are available to the compiler and linker. The FoundationDB server is not required for the default PostgreSQL setup.
 
 You need to set up the PostgreSQL database by running the SQL file at `apps/nuq-postgres/nuq.sql`. Easiest way is to use the docker image inside `apps/nuq-postgres`. With Docker running, build the image:
 


### PR DESCRIPTION
Closes #4060.

## Summary

- document that `apps/api` builds the native `foundationdb` dependency during `pnpm install`, including when PostgreSQL is used for the queue
- point contributors to the FoundationDB client package and clarify that the FoundationDB server is not required for the default PostgreSQL path

## Reproduction and rationale

On macOS arm64 with Node 22.17.1 and the repository-pinned pnpm 11.4.0, a frozen dependency install reached the `foundationdb@2.0.1` native build and failed. After isolating an unrelated local Command Line Tools libc++ search-path issue, the generated build failed at the reported missing header:

```text
../src/utils.h:13:10: fatal error: 'foundationdb/fdb_c.h' file not found
```

The dependency's own README requires the FoundationDB client library, and the repository's server CI installs `foundationdb-clients` before the normal dependency install. The contributing guide did not list that prerequisite.

## Verification

- `git diff --check`
- targeted native build reproduces the missing `foundationdb/fdb_c.h` failure without the client package

This is a documentation-only change. I did not claim a successful post-change dependency install because installing the FoundationDB client would modify system-level software.

AI assistance disclosure: OpenAI Codex assisted with repository search, reproduction analysis, and drafting. I verified the issue state, reproduction, root cause, repository guidance, and final diff locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add FoundationDB client prerequisite to the contributing guide to prevent native `foundationdb` build failures during `pnpm install`. Clarifies that only the client library is needed; the FoundationDB server is not required for the default PostgreSQL setup.

<sup>Written for commit 67466212f3d0117b6f6d5f234830e3d9fe93f391. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

