### PR TITLE
Reject whitespace-only HTML conversion input

### DIFF
--- a/apps/go-html-to-md-service/handler.go
+++ b/apps/go-html-to-md-service/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) ConvertHTML(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate input
-	if req.HTML == "" {
+	if strings.TrimSpace(req.HTML) == "" {
 		logger.Warn().Msg("Empty HTML field in request")
 		h.sendError(w, "HTML field is required", "The 'html' field cannot be empty", http.StatusBadRequest)
 		return

--- a/apps/go-html-to-md-service/handler_test.go
+++ b/apps/go-html-to-md-service/handler_test.go
@@ -201,6 +201,33 @@ func TestConvertHTML_EmptyHTML(t *testing.T) {
 	}
 }
 
+func TestConvertHTML_WhitespaceOnlyHTML(t *testing.T) {
+	converter := NewConverter()
+	handler := NewHandler(converter)
+
+	router := mux.NewRouter()
+	handler.RegisterRoutes(router)
+
+	reqBody := ConvertRequest{
+		HTML: " \n\t ",
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequest("POST", "/convert", bytes.NewBuffer(jsonBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+}
+
 func TestConvertHTML_InvalidJSON(t *testing.T) {
 	converter := NewConverter()
 	handler := NewHandler(converter)


### PR DESCRIPTION
## Summary
- treat whitespace-only html payloads as empty input in the Go HTML-to-Markdown service
- add a handler regression test for blank-but-not-empty HTML strings

## Validation
- git diff --check
- go test ./... was not run because Go is not installed in this local environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject whitespace-only HTML input in the `apps/go-html-to-md-service` conversion endpoint. Blank HTML now returns 400 Bad Request with a clear error, and a regression test ensures this behavior.

<sup>Written for commit 3046ebc399a4640757ceacc7c6be1c68ba0cbd2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

