### PR TITLE
feat(api): thread org context through the scrape pipeline

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -79,6 +79,7 @@ const mockPreviewACUC: (
   api_key: "preview",
   api_key_id: 0,
   team_id,
+  org_id: "preview",
   rate_limits: {
     crawl: 2,
     scrape: 10,
@@ -104,6 +105,7 @@ const mockACUC: () => AuthCreditUsageChunk = () => ({
   api_key: "bypass",
   api_key_id: 0,
   team_id: "bypass",
+  org_id: "bypass",
   rate_limits: {
     crawl: 99999999,
     scrape: 99999999,

--- a/apps/api/src/controllers/v0/admin/crawl-monitor.ts
+++ b/apps/api/src/controllers/v0/admin/crawl-monitor.ts
@@ -61,6 +61,7 @@ export async function crawlMonitorController(
     internalOptions: {
       disableSmartWaitCache: true,
       teamId: req.auth.team_id,
+      orgId: req.acuc?.org_id ?? null,
       saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
       zeroDataRetention: false,
     },

--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -225,6 +225,7 @@ export async function crawlController(req: Request, res: Response) {
       team_id,
     );
     internalOptions.disableSmartWaitCache = true; // NOTE: smart wait disabled for crawls to ensure contentful scrape, speed does not matter
+    internalOptions.orgId = auth.chunk?.org_id ?? null;
     internalOptions.saveScrapeResultToGCS = process.env
       .GCS_FIRE_ENGINE_BUCKET_NAME
       ? true

--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -180,6 +180,7 @@ export async function crawlController(req: Request, res: Response) {
     if (
       isUrlBlocked(url, auth.chunk?.flags ?? null, {
         team_id: auth.chunk?.team_id ?? team_id,
+        org_id: auth.chunk?.org_id ?? null,
         origin: req.body?.origin ?? null,
       })
     ) {

--- a/apps/api/src/controllers/v0/scrape.ts
+++ b/apps/api/src/controllers/v0/scrape.ts
@@ -90,6 +90,7 @@ async function scrapeHelper(
     team_id,
   );
 
+  internalOptions.orgId = org_id;
   internalOptions.saveScrapeResultToGCS = process.env
     .GCS_FIRE_ENGINE_BUCKET_NAME
     ? true

--- a/apps/api/src/controllers/v0/scrape.ts
+++ b/apps/api/src/controllers/v0/scrape.ts
@@ -41,6 +41,7 @@ async function scrapeHelper(
   extractorOptions: ExtractorOptions,
   timeout: number,
   flags: TeamFlags,
+  org_id: string | null,
   apiKeyId: number | null,
 ): Promise<{
   success: boolean;
@@ -70,6 +71,7 @@ async function scrapeHelper(
   if (
     isUrlBlocked(url, flags, {
       team_id,
+      org_id,
       origin: req.body?.origin ?? null,
     })
   ) {
@@ -299,6 +301,7 @@ export async function scrapeController(req: Request, res: Response) {
       extractorOptions,
       timeout,
       chunk?.flags ?? null,
+      chunk?.org_id ?? null,
       chunk?.api_key_id ?? null,
     );
 

--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -37,6 +37,7 @@ async function searchHelper(
   pageOptions: PageOptions,
   searchOptions: SearchOptions,
   flags: TeamFlags,
+  org_id: string | null,
   api_key_id: number | null,
 ): Promise<{
   success: boolean;
@@ -103,6 +104,7 @@ async function searchHelper(
     r =>
       !isUrlBlocked(r.url, flags, {
         team_id,
+        org_id,
         origin: req.body?.origin ?? null,
       }),
   );
@@ -269,6 +271,7 @@ export async function searchController(req: Request, res: Response) {
       pageOptions,
       searchOptions,
       chunk?.flags ?? null,
+      chunk?.org_id ?? null,
       chunk?.api_key_id ?? null,
     );
     const endTime = new Date().getTime();

--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -82,6 +82,7 @@ async function searchHelper(
     crawlerOptions,
     team_id,
   );
+  internalOptions.orgId = org_id;
 
   if (justSearch) {
     const searchCredits = Math.ceil(res.length / 10) * 2;

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -252,6 +252,7 @@ export async function batchScrapeController(
           ...internalOptions,
           disableSmartWaitCache: true,
           teamId: req.auth.team_id,
+          orgId: req.acuc?.org_id ?? null,
           saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME
             ? true
             : false,

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -121,6 +121,7 @@ export async function batchScrapeController(
         if (
           !isUrlBlocked(nu, req.acuc?.flags ?? null, {
             team_id: req.auth.team_id,
+            org_id: req.acuc?.org_id ?? null,
             origin: req.body.origin ?? null,
           })
         ) {
@@ -138,6 +139,7 @@ export async function batchScrapeController(
       req.body.urls?.some((url: string) =>
         isUrlBlocked(url, req.acuc?.flags ?? null, {
           team_id: req.auth.team_id,
+          org_id: req.acuc?.org_id ?? null,
           origin: req.body.origin ?? null,
         }),
       )

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -201,6 +201,7 @@ export async function crawlController(
       ...internalOptions,
       disableSmartWaitCache: true,
       teamId: req.auth.team_id,
+      orgId: req.acuc?.org_id ?? null,
       saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
       zeroDataRetention,
       agentIndexOnly: (req as any).agentIndexOnly ?? false,

--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -124,6 +124,7 @@ export async function extractController(
     req.body.urls?.filter((url: string) =>
       isUrlBlocked(url, req.acuc?.flags ?? null, {
         team_id: req.auth.team_id,
+        org_id: req.acuc?.org_id ?? null,
         origin: req.body.origin ?? null,
       }),
     ) ?? [];

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -93,6 +93,7 @@ export async function getMapResults({
   includeSubdomains = true,
   crawlerOptions = {},
   teamId,
+  orgId,
   origin,
   includeMetadata = false,
   allowExternalLinks,
@@ -114,6 +115,7 @@ export async function getMapResults({
   includeSubdomains?: boolean;
   crawlerOptions?: any;
   teamId: string;
+  orgId?: string | null;
   origin?: string;
   includeMetadata?: boolean;
   allowExternalLinks?: boolean;
@@ -146,7 +148,7 @@ export async function getMapResults({
       ...(location ? { location } : {}),
       ...(headers ? { headers } : {}),
     }),
-    internalOptions: { teamId },
+    internalOptions: { teamId, orgId: orgId ?? null },
     team_id: teamId,
     createdAt: Date.now(),
   };
@@ -445,6 +447,7 @@ export async function mapController(
         crawlerOptions: req.body,
         origin: req.body.origin,
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
         abort: abort.signal,
         mock: req.body.useMock,
         filterByPath: req.body.filterByPath !== false,

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -227,6 +227,7 @@ export async function scrapeController(
               bypassBilling: isDirectToBullMQ,
               zeroDataRetention,
               teamFlags: req.acuc?.flags ?? null,
+              orgId: req.acuc?.org_id ?? null,
               agentIndexOnly: (req as any).agentIndexOnly ?? false,
               threatProtection: threatProtection.policy ?? undefined,
             },

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -22,7 +22,6 @@ import { ScrapeJobTimeoutError } from "../../lib/error";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
 import { z } from "zod";
 import { executeSearch } from "../../search/execute";
-import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { resolveThreatProtection } from "../../lib/threat-protection/request";
 import {
   DocumentWithCostTracking,
@@ -65,15 +64,6 @@ export async function searchAndScrapeSearchResult(
       num_results: 5,
     });
 
-    const allowedResults = searchResults.filter(
-      r =>
-        !isUrlBlocked(r.url, flags, {
-          team_id: options.teamId,
-          org_id: options.orgId ?? null,
-          origin: options.origin,
-        }),
-    );
-
     const { scrapeOptions } = fromV1ScrapeOptions(
       options.scrapeOptions,
       options.timeout,
@@ -81,7 +71,7 @@ export async function searchAndScrapeSearchResult(
     );
 
     return await scrapeSearchResults(
-      allowedResults.map(r => ({
+      searchResults.map(r => ({
         url: r.url,
         title: r.title,
         description: r.description,

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -22,6 +22,7 @@ import { ScrapeJobTimeoutError } from "../../lib/error";
 import { captureExceptionWithZdrCheck } from "../../services/sentry";
 import { z } from "zod";
 import { executeSearch } from "../../search/execute";
+import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { resolveThreatProtection } from "../../lib/threat-protection/request";
 import {
   DocumentWithCostTracking,
@@ -64,6 +65,15 @@ export async function searchAndScrapeSearchResult(
       num_results: 5,
     });
 
+    const allowedResults = searchResults.filter(
+      r =>
+        !isUrlBlocked(r.url, flags, {
+          team_id: options.teamId,
+          org_id: options.orgId ?? null,
+          origin: options.origin,
+        }),
+    );
+
     const { scrapeOptions } = fromV1ScrapeOptions(
       options.scrapeOptions,
       options.timeout,
@@ -71,7 +81,7 @@ export async function searchAndScrapeSearchResult(
     );
 
     return await scrapeSearchResults(
-      searchResults.map(r => ({
+      allowedResults.map(r => ({
         url: r.url,
         title: r.title,
         description: r.description,

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -47,6 +47,7 @@ export async function searchAndScrapeSearchResult(
   query: string,
   options: {
     teamId: string;
+    orgId?: string | null;
     origin: string;
     timeout: number;
     scrapeOptions: any;
@@ -77,6 +78,7 @@ export async function searchAndScrapeSearchResult(
       })),
       {
         teamId: options.teamId,
+        orgId: options.orgId ?? null,
         origin: options.origin,
         timeout: options.timeout,
         scrapeOptions,
@@ -235,6 +237,7 @@ export async function searchController(
       },
       {
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
         origin: req.body.origin,
         apiKeyId: req.acuc?.api_key_id ?? null,
         flags: req.acuc?.flags ?? null,

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1453,7 +1453,6 @@ function fromLegacyCrawlerOptions(
     internalOptions: {
       v0CrawlOnlyUrls: x.returnOnlyUrls,
       teamId,
-      // Conversion helpers have no ACUC; entry-point builders override this.
       orgId: null,
     },
   };
@@ -1520,7 +1519,6 @@ export function fromLegacyScrapeOptions(
       atsv: pageOptions.atsv,
       v0DisableJsDom: pageOptions.disableJsDom,
       teamId,
-      // Conversion helpers have no ACUC; entry-point builders override this.
       orgId: null,
     },
     // TODO: fallback, fetchPageContent, replaceAllPathsWithAbsolutePaths, includeLinks

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1256,7 +1256,7 @@ export type AuthCreditUsageChunk = {
   api_key: string;
   api_key_id: number;
   team_id: string;
-  org_id?: string | null;
+  org_id: string;
   plan_priority: {
     bucketLimit: number;
     planModifier: number;

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1453,6 +1453,8 @@ function fromLegacyCrawlerOptions(
     internalOptions: {
       v0CrawlOnlyUrls: x.returnOnlyUrls,
       teamId,
+      // Conversion helpers have no ACUC; entry-point builders override this.
+      orgId: null,
     },
   };
 }
@@ -1518,6 +1520,8 @@ export function fromLegacyScrapeOptions(
       atsv: pageOptions.atsv,
       v0DisableJsDom: pageOptions.disableJsDom,
       teamId,
+      // Conversion helpers have no ACUC; entry-point builders override this.
+      orgId: null,
     },
     // TODO: fallback, fetchPageContent, replaceAllPathsWithAbsolutePaths, includeLinks
   };

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -273,6 +273,7 @@ export async function batchScrapeController(
         internalOptions: {
           disableSmartWaitCache: true,
           teamId: req.auth.team_id,
+          orgId: req.acuc?.org_id ?? null,
           saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME
             ? true
             : false,

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -142,6 +142,7 @@ export async function batchScrapeController(
         if (
           !isUrlBlocked(nu, req.acuc?.flags ?? null, {
             team_id: req.auth.team_id,
+            org_id: req.acuc?.org_id ?? null,
             origin: req.body.origin ?? null,
           })
         ) {
@@ -159,6 +160,7 @@ export async function batchScrapeController(
       req.body.urls?.some((url: string) =>
         isUrlBlocked(url, req.acuc?.flags ?? null, {
           team_id: req.auth.team_id,
+          org_id: req.acuc?.org_id ?? null,
           origin: req.body.origin ?? null,
         }),
       )

--- a/apps/api/src/controllers/v2/crawl-cancel.ts
+++ b/apps/api/src/controllers/v2/crawl-cancel.ts
@@ -41,6 +41,7 @@ export async function crawlCancelController(
       scrapeOptions: scrapeOptions.parse({}),
       internalOptions: {
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
       },
     };
 

--- a/apps/api/src/controllers/v2/crawl-params-preview.ts
+++ b/apps/api/src/controllers/v2/crawl-params-preview.ts
@@ -67,6 +67,7 @@ export async function crawlParamsPreviewController(
         basePrompt: parsedBody.prompt,
         url: parsedBody.url,
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
         flags: req.acuc?.flags ?? null,
         logger,
         limit: 50,

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -262,6 +262,7 @@ export async function crawlController(
     internalOptions: {
       disableSmartWaitCache: true,
       teamId: req.auth.team_id,
+      orgId: req.acuc?.org_id ?? null,
       saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME ? true : false,
       zeroDataRetention,
       agentIndexOnly: (req as any).agentIndexOnly ?? false,

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -170,6 +170,7 @@ export async function crawlController(
         basePrompt: req.body.prompt,
         url: req.body.url,
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
         flags: req.acuc?.flags ?? null,
         logger,
         limit: 50,

--- a/apps/api/src/controllers/v2/extract.ts
+++ b/apps/api/src/controllers/v2/extract.ts
@@ -67,6 +67,7 @@ export async function extractController(
     req.body.urls?.filter((url: string) =>
       isUrlBlocked(url, req.acuc?.flags ?? null, {
         team_id: req.auth.team_id,
+        org_id: req.acuc?.org_id ?? null,
         origin: req.body.origin ?? null,
       }),
     ) ?? [];

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -167,6 +167,7 @@ export async function mapController(
         },
         origin: req.body.origin,
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
         allowExternalLinks: req.body.allowExternalLinks,
         abort: abort.signal,
         mock: req.body.useMock,

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -512,6 +512,7 @@ export async function parseController(
                       bypassBilling: isDirectToBullMQ || !shouldBill,
                       zeroDataRetention,
                       teamFlags: req.acuc?.flags ?? null,
+                      orgId: req.acuc?.org_id ?? null,
                       teamConcurrency: req.acuc?.concurrency ?? null,
                       uploadedFile: file,
                       forceEngine,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -328,6 +328,7 @@ export async function scrapeController(
                       bypassBilling: isDirectToBullMQ || !shouldBill,
                       zeroDataRetention,
                       teamFlags: req.acuc?.flags ?? null,
+                      orgId: req.acuc?.org_id ?? null,
                       teamConcurrency: req.acuc?.concurrency ?? null,
                       agentIndexOnly: (req as any).agentIndexOnly ?? false,
                       threatProtection: threatProtection.policy ?? undefined,

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -218,6 +218,7 @@ export async function searchController(
       },
       {
         teamId: req.auth.team_id,
+        orgId: req.acuc?.org_id ?? null,
         origin: req.body.origin,
         apiKeyId: req.acuc?.api_key_id ?? null,
         flags: req.acuc?.flags ?? null,

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1664,7 +1664,6 @@ function fromV0CrawlerOptions(
     internalOptions: {
       v0CrawlOnlyUrls: x.returnOnlyUrls,
       teamId,
-      // Conversion helpers have no ACUC; entry-point builders override this.
       orgId: null,
     },
   };
@@ -1730,7 +1729,6 @@ export function fromV0ScrapeOptions(
       atsv: pageOptions.atsv,
       v0DisableJsDom: pageOptions.disableJsDom,
       teamId,
-      // Conversion helpers have no ACUC; entry-point builders override this.
       orgId: null,
       ...(extractorOptions !== undefined &&
       extractorOptions.mode.includes("llm-extraction")
@@ -1844,7 +1842,6 @@ export function fromV1ScrapeOptions(
     }),
     internalOptions: {
       teamId,
-      // Conversion helpers have no ACUC; entry-point builders override this.
       orgId: null,
       v1Agent: v1ScrapeOptions.agent,
       v1JSONSystemPrompt: (

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1664,6 +1664,8 @@ function fromV0CrawlerOptions(
     internalOptions: {
       v0CrawlOnlyUrls: x.returnOnlyUrls,
       teamId,
+      // Conversion helpers have no ACUC; entry-point builders override this.
+      orgId: null,
     },
   };
 }
@@ -1728,6 +1730,8 @@ export function fromV0ScrapeOptions(
       atsv: pageOptions.atsv,
       v0DisableJsDom: pageOptions.disableJsDom,
       teamId,
+      // Conversion helpers have no ACUC; entry-point builders override this.
+      orgId: null,
       ...(extractorOptions !== undefined &&
       extractorOptions.mode.includes("llm-extraction")
         ? {
@@ -1840,6 +1844,8 @@ export function fromV1ScrapeOptions(
     }),
     internalOptions: {
       teamId,
+      // Conversion helpers have no ACUC; entry-point builders override this.
+      orgId: null,
       v1Agent: v1ScrapeOptions.agent,
       v1JSONSystemPrompt: (
         v1ScrapeOptions.jsonOptions || v1ScrapeOptions.extract

--- a/apps/api/src/db/schema/public.ts
+++ b/apps/api/src/db/schema/public.ts
@@ -96,6 +96,8 @@ export const batch_scrapes = pgTable("batch_scrapes", {
 export const blocklist = pgTable("blocklist", {
   id: bigintNum("id").notNull().generatedByDefaultAsIdentity(),
   data: jsonb("data").notNull(),
+  // NULL = the row's entries block globally; set = they block only that org.
+  org_id: uuid("org_id"),
 });
 
 export const blocklist_hits = pgTable("blocklist_hits", {

--- a/apps/api/src/db/schema/public.ts
+++ b/apps/api/src/db/schema/public.ts
@@ -96,7 +96,6 @@ export const batch_scrapes = pgTable("batch_scrapes", {
 export const blocklist = pgTable("blocklist", {
   id: bigintNum("id").notNull().generatedByDefaultAsIdentity(),
   data: jsonb("data").notNull(),
-  // NULL = the row's entries block globally; set = they block only that org.
   org_id: uuid("org_id"),
 });
 

--- a/apps/api/src/lib/deep-research/deep-research-service.ts
+++ b/apps/api/src/lib/deep-research/deep-research-service.ts
@@ -133,6 +133,7 @@ export async function performDeepResearch(options: DeepResearchServiceOptions) {
           searchQuery.query,
           {
             teamId: options.teamId,
+            orgId: acuc?.org_id ?? null,
             origin: "deep-research",
             timeout: 10000,
             scrapeOptions: {

--- a/apps/api/src/lib/engpicker.ts
+++ b/apps/api/src/lib/engpicker.ts
@@ -48,6 +48,7 @@ async function evaluateURL(
     {
       forceEngine: engine,
       teamId: "engpicker",
+      orgId: null,
     },
     new CostTracking(),
   );

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -50,12 +50,12 @@ export type ExchangeScrapeMetadata = {
   integrationId?: string;
 };
 
-export type ExchangeTerms = {
+type ExchangeTerms = {
   key: string;
   version: string;
 };
 
-export type ExchangeProvider = {
+type ExchangeProvider = {
   id: string;
   creditsCost: number;
   terms?: ExchangeTerms;
@@ -227,7 +227,10 @@ async function getExchangeProviders(): Promise<ExchangeProvider[] | null> {
   return providersRequest;
 }
 
-function providerMatchesUrl(provider: ExchangeProvider, inputUrl: string): boolean {
+function providerMatchesUrl(
+  provider: ExchangeProvider,
+  inputUrl: string,
+): boolean {
   let parsed: URL;
   try {
     parsed = new URL(inputUrl);
@@ -265,7 +268,9 @@ export async function resolveExchangeProvider(
     return null;
   }
 
-  return providers.find(provider => providerMatchesUrl(provider, inputUrl)) ?? null;
+  return (
+    providers.find(provider => providerMatchesUrl(provider, inputUrl)) ?? null
+  );
 }
 
 export function getExchangeRequestLogContext(inputUrl: string):
@@ -365,7 +370,9 @@ function getProviderAccessDecision(
   const entry = typeof access === "object" && access !== null ? access : null;
 
   if (provider.terms === undefined) {
-    return entry !== null && entry.status !== "enabled" ? "not_enabled" : "allowed";
+    return entry !== null && entry.status !== "enabled"
+      ? "not_enabled"
+      : "allowed";
   }
 
   if (entry === null) {

--- a/apps/api/src/lib/extract/document-scraper.ts
+++ b/apps/api/src/lib/extract/document-scraper.ts
@@ -17,6 +17,7 @@ import { scrapeQueue } from "../../services/worker/nuq-router";
 interface ScrapeDocumentOptions {
   url: string;
   teamId: string;
+  orgId?: string | null;
   origin: string;
   timeout: number;
   isSingleUrl?: boolean;
@@ -40,6 +41,7 @@ export async function scrapeDocument(
   if (
     isUrlBlocked(options.url, options.flags ?? null, {
       team_id: options.teamId,
+      org_id: options.orgId ?? null,
       origin: options.origin,
     })
   ) {
@@ -64,6 +66,7 @@ export async function scrapeDocument(
         }),
         internalOptions: {
           teamId: options.teamId,
+          orgId: options.orgId ?? null,
           saveScrapeResultToGCS: config.GCS_FIRE_ENGINE_BUCKET_NAME
             ? true
             : false,

--- a/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
@@ -17,6 +17,7 @@ import type { ThreatProtectionPolicy } from "../../threat-protection/types";
 interface ScrapeDocumentOptions {
   url: string;
   teamId: string;
+  orgId?: string | null;
   origin: string;
   timeout: number;
   isSingleUrl?: boolean;
@@ -42,6 +43,7 @@ export async function scrapeDocument_F0(
   if (
     isUrlBlocked(options.url, options.flags ?? null, {
       team_id: options.teamId,
+      org_id: options.orgId ?? null,
       origin: options.origin,
     })
   ) {
@@ -68,6 +70,7 @@ export async function scrapeDocument_F0(
         scrapeOptions,
         internalOptions: {
           teamId: options.teamId,
+          orgId: options.orgId ?? null,
           bypassBilling: true,
           threatProtection: options.threatProtectionPolicy ?? undefined,
         },

--- a/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
@@ -180,6 +180,7 @@ export async function performExtraction_F0(
         url,
         prompt: request.prompt,
         teamId,
+        orgId: acuc?.org_id ?? null,
         allowExternalLinks: request.allowExternalLinks,
         origin: request.origin,
         limit: request.limit,
@@ -348,6 +349,7 @@ export async function performExtraction_F0(
           {
             url,
             teamId,
+            orgId: acuc?.org_id ?? null,
             origin: "extract",
             timeout,
             flags: acuc?.flags ?? null,
@@ -644,6 +646,7 @@ export async function performExtraction_F0(
           {
             url,
             teamId,
+            orgId: acuc?.org_id ?? null,
             origin: "extract",
             timeout,
             flags: acuc?.flags ?? null,

--- a/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
@@ -119,6 +119,7 @@ export async function processUrl_F0(
       url: baseUrl,
       search: searchQuery,
       teamId: options.teamId,
+      orgId: options.orgId ?? null,
       allowExternalLinks: options.allowExternalLinks,
       origin: options.origin,
       limit: options.limit,

--- a/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
@@ -157,6 +157,7 @@ export async function processUrl_F0(
       const retryMapResults = await getMapResults({
         url: baseUrl,
         teamId: options.teamId,
+        orgId: options.orgId ?? null,
         allowExternalLinks: options.allowExternalLinks,
         origin: options.origin,
         limit: options.limit,

--- a/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/url-processor-f0.ts
@@ -53,6 +53,7 @@ interface ProcessUrlOptions {
   prompt?: string;
   schema?: any;
   teamId: string;
+  orgId?: string | null;
   allowExternalLinks?: boolean;
   origin?: string;
   limit?: number;
@@ -80,6 +81,7 @@ export async function processUrl_F0(
     if (
       !isUrlBlocked(options.url, teamFlags, {
         team_id: options.teamId,
+        org_id: options.orgId ?? null,
         origin: options.origin ?? null,
       })
     ) {

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -149,6 +149,7 @@ export async function performGenerateLlmsTxt(
     const mapResult = await getMapResults({
       url,
       teamId,
+      orgId: acuc?.org_id ?? null,
       limit: effectiveMaxUrls,
       includeSubdomains: false,
       ignoreSitemap: false,

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -159,6 +159,7 @@ export async function performGenerateLlmsTxt(
               {
                 url,
                 teamId,
+                orgId: acuc?.org_id ?? null,
                 origin: "llmstxt",
                 timeout: 30000,
                 isSingleUrl: true,

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -3,7 +3,10 @@ import { updateGeneratedLlmsTxt } from "./generate-llmstxt-redis";
 import { getMapResults } from "../../controllers/v1/map";
 import { z } from "zod";
 import { scrapeDocument } from "../extract/document-scraper";
-import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
+import {
+  hasOrgScopedBlocklist,
+  isUrlBlocked,
+} from "../../scraper/WebScraper/utils/blocklist";
 import {
   getLlmsTextFromCache,
   saveLlmsTextToCache,
@@ -88,14 +91,19 @@ export async function performGenerateLlmsTxt(
     // Enforce max URL limit
     const effectiveMaxUrls = Math.min(maxUrls, 5000);
 
-    // The cache is shared across teams, so a requester whose org blocks this
-    // URL must neither read cached content for it nor seed the cache with
-    // their (blocklist-filtered) generation.
-    const urlBlockedForRequester = isUrlBlocked(url, acuc?.flags ?? null, {
-      team_id: teamId,
-      org_id: acuc?.org_id ?? null,
-      origin: "llmstxt",
-    });
+    // The cache is shared across teams, so a requester under org-scoped
+    // blocklist rules must not touch it at all: even when the origin URL
+    // itself is exempt, mapped child URLs may still be blocked, so a cached
+    // generation could hand them blocked content and their filtered output
+    // would poison the cache for everyone else. A blocked origin likewise
+    // skips both read and write.
+    const urlBlockedForRequester =
+      hasOrgScopedBlocklist(acuc?.org_id) ||
+      isUrlBlocked(url, acuc?.flags ?? null, {
+        team_id: teamId,
+        org_id: acuc?.org_id ?? null,
+        origin: "llmstxt",
+      });
 
     // Check cache first, unless cache is set to false
     const cachedResult =

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -3,10 +3,7 @@ import { updateGeneratedLlmsTxt } from "./generate-llmstxt-redis";
 import { getMapResults } from "../../controllers/v1/map";
 import { z } from "zod";
 import { scrapeDocument } from "../extract/document-scraper";
-import {
-  hasOrgScopedBlocklist,
-  isUrlBlocked,
-} from "../../scraper/WebScraper/utils/blocklist";
+import { hasOrgScopedBlocklist } from "../../scraper/WebScraper/utils/blocklist";
 import {
   getLlmsTextFromCache,
   saveLlmsTextToCache,
@@ -17,7 +14,6 @@ import { getModel } from "../generic-ai";
 import { generateCompletions } from "../../scraper/scrapeURL/transformers/llmExtract";
 import { CostTracking } from "../cost-tracking";
 import { getACUCTeam } from "../../controllers/auth";
-import { UNSUPPORTED_SITE_MESSAGE } from "../strings";
 interface GenerateLLMsTextServiceOptions {
   generationId: string;
   teamId: string;
@@ -92,21 +88,6 @@ export async function performGenerateLlmsTxt(
     // Enforce max URL limit
     const effectiveMaxUrls = Math.min(maxUrls, 5000);
 
-    // A blocked origin fails outright — before the cache, and before mapping
-    // would fire sitemap/discovery requests at the blocked site.
-    const originBlocked = isUrlBlocked(url, acuc?.flags ?? null, {
-      team_id: teamId,
-      org_id: acuc?.org_id ?? null,
-      origin: "llmstxt",
-    });
-    if (originBlocked) {
-      await updateGeneratedLlmsTxt(generationId, {
-        status: "failed",
-        error: UNSUPPORTED_SITE_MESSAGE,
-      });
-      return { success: false as const, error: UNSUPPORTED_SITE_MESSAGE };
-    }
-
     // The cache is shared across teams, so a requester under org-scoped
     // blocklist rules must not touch it at all: even with the origin URL
     // itself unblocked, mapped child URLs may still be blocked, so a cached
@@ -144,7 +125,7 @@ export async function performGenerateLlmsTxt(
       });
 
       return {
-        success: true as const,
+        success: true,
         data: {
           generatedText: limitedLlmsTxt,
           fullText: cleanFullText,
@@ -312,7 +293,7 @@ export async function performGenerateLlmsTxt(
     });
 
     return {
-      success: true as const,
+      success: true,
       data: {
         generatedText: llmstxt,
         fullText: cleanFullText,

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -3,6 +3,7 @@ import { updateGeneratedLlmsTxt } from "./generate-llmstxt-redis";
 import { getMapResults } from "../../controllers/v1/map";
 import { z } from "zod";
 import { scrapeDocument } from "../extract/document-scraper";
+import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import {
   getLlmsTextFromCache,
   saveLlmsTextToCache,
@@ -87,10 +88,20 @@ export async function performGenerateLlmsTxt(
     // Enforce max URL limit
     const effectiveMaxUrls = Math.min(maxUrls, 5000);
 
+    // The cache is shared across teams, so a requester whose org blocks this
+    // URL must neither read cached content for it nor seed the cache with
+    // their (blocklist-filtered) generation.
+    const urlBlockedForRequester = isUrlBlocked(url, acuc?.flags ?? null, {
+      team_id: teamId,
+      org_id: acuc?.org_id ?? null,
+      origin: "llmstxt",
+    });
+
     // Check cache first, unless cache is set to false
-    const cachedResult = cache
-      ? await getLlmsTextFromCache(url, effectiveMaxUrls)
-      : null;
+    const cachedResult =
+      cache && !urlBlockedForRequester
+        ? await getLlmsTextFromCache(url, effectiveMaxUrls)
+        : null;
     if (cachedResult) {
       logger.info("Found cached LLMs text", { url });
 
@@ -234,7 +245,9 @@ export async function performGenerateLlmsTxt(
     }
 
     // After successful generation, save to cache
-    await saveLlmsTextToCache(url, llmstxt, llmsFulltxt, effectiveMaxUrls);
+    if (!urlBlockedForRequester) {
+      await saveLlmsTextToCache(url, llmstxt, llmsFulltxt, effectiveMaxUrls);
+    }
 
     // Limit pages and remove separators before final update
     const limitedFullText = limitPages(llmsFulltxt, effectiveMaxUrls);

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -17,6 +17,7 @@ import { getModel } from "../generic-ai";
 import { generateCompletions } from "../../scraper/scrapeURL/transformers/llmExtract";
 import { CostTracking } from "../cost-tracking";
 import { getACUCTeam } from "../../controllers/auth";
+import { UNSUPPORTED_SITE_MESSAGE } from "../strings";
 interface GenerateLLMsTextServiceOptions {
   generationId: string;
   teamId: string;
@@ -91,23 +92,31 @@ export async function performGenerateLlmsTxt(
     // Enforce max URL limit
     const effectiveMaxUrls = Math.min(maxUrls, 5000);
 
-    // The cache is shared across teams, so a requester under org-scoped
-    // blocklist rules must not touch it at all: even when the origin URL
-    // itself is exempt, mapped child URLs may still be blocked, so a cached
-    // generation could hand them blocked content and their filtered output
-    // would poison the cache for everyone else. A blocked origin likewise
-    // skips both read and write.
-    const urlBlockedForRequester =
-      hasOrgScopedBlocklist(acuc?.org_id) ||
-      isUrlBlocked(url, acuc?.flags ?? null, {
-        team_id: teamId,
-        org_id: acuc?.org_id ?? null,
-        origin: "llmstxt",
+    // A blocked origin fails outright — before the cache, and before mapping
+    // would fire sitemap/discovery requests at the blocked site.
+    const originBlocked = isUrlBlocked(url, acuc?.flags ?? null, {
+      team_id: teamId,
+      org_id: acuc?.org_id ?? null,
+      origin: "llmstxt",
+    });
+    if (originBlocked) {
+      await updateGeneratedLlmsTxt(generationId, {
+        status: "failed",
+        error: UNSUPPORTED_SITE_MESSAGE,
       });
+      return { success: false as const, error: UNSUPPORTED_SITE_MESSAGE };
+    }
+
+    // The cache is shared across teams, so a requester under org-scoped
+    // blocklist rules must not touch it at all: even with the origin URL
+    // itself unblocked, mapped child URLs may still be blocked, so a cached
+    // generation could hand them blocked content and their filtered output
+    // would poison the cache for everyone else.
+    const skipSharedCache = hasOrgScopedBlocklist(acuc?.org_id);
 
     // Check cache first, unless cache is set to false
     const cachedResult =
-      cache && !urlBlockedForRequester
+      cache && !skipSharedCache
         ? await getLlmsTextFromCache(url, effectiveMaxUrls)
         : null;
     if (cachedResult) {
@@ -135,7 +144,7 @@ export async function performGenerateLlmsTxt(
       });
 
       return {
-        success: true,
+        success: true as const,
         data: {
           generatedText: limitedLlmsTxt,
           fullText: cleanFullText,
@@ -254,7 +263,7 @@ export async function performGenerateLlmsTxt(
     }
 
     // After successful generation, save to cache
-    if (!urlBlockedForRequester) {
+    if (!skipSharedCache) {
       await saveLlmsTextToCache(url, llmstxt, llmsFulltxt, effectiveMaxUrls);
     }
 
@@ -303,7 +312,7 @@ export async function performGenerateLlmsTxt(
     });
 
     return {
-      success: true,
+      success: true as const,
       data: {
         generatedText: llmstxt,
         fullText: cleanFullText,

--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -372,6 +372,7 @@ export async function buildPromptWithWebsiteStructure({
   basePrompt,
   url,
   teamId,
+  orgId,
   flags,
   logger,
   limit = 50,
@@ -383,6 +384,7 @@ export async function buildPromptWithWebsiteStructure({
   basePrompt: string;
   url: string;
   teamId: string;
+  orgId?: string | null;
   flags: TeamFlags | null;
   logger: Logger;
   limit?: number;
@@ -399,6 +401,7 @@ export async function buildPromptWithWebsiteStructure({
       includeSubdomains,
       crawlerOptions: { sitemap: "include" },
       teamId,
+      orgId: orgId ?? null,
       flags,
       allowExternalLinks,
       filterByPath: false,

--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -86,6 +86,7 @@ export async function getMapResults({
   includeSubdomains = true,
   crawlerOptions = {},
   teamId,
+  orgId,
   allowExternalLinks,
   abort = new AbortController().signal,
   filterByPath = true,
@@ -103,6 +104,7 @@ export async function getMapResults({
   includeSubdomains?: boolean;
   crawlerOptions?: any;
   teamId: string;
+  orgId?: string | null;
   origin?: string;
   includeMetadata?: boolean;
   allowExternalLinks?: boolean;
@@ -144,7 +146,7 @@ export async function getMapResults({
       ...(location ? { location } : {}),
       ...(headers ? { headers } : {}),
     }),
-    internalOptions: { teamId },
+    internalOptions: { teamId, orgId: orgId ?? null },
     team_id: teamId,
     createdAt: Date.now(),
     zeroDataRetention,

--- a/apps/api/src/lib/robots-txt.ts
+++ b/apps/api/src/lib/robots-txt.ts
@@ -79,6 +79,7 @@ export async function fetchRobotsTxt(
     {
       forceEngine,
       v0DisableJsDom: true,
+      orgId: null,
       externalAbort: abort
         ? {
             signal: abort,

--- a/apps/api/src/lib/scrape-billing.test.ts
+++ b/apps/api/src/lib/scrape-billing.test.ts
@@ -13,6 +13,7 @@ describe("calculateCreditsToBeBilled", () => {
       } as any,
       {
         teamId: "team-id",
+        orgId: null,
       },
       {
         metadata: {
@@ -40,6 +41,7 @@ describe("calculateCreditsToBeBilled", () => {
       } as any,
       {
         teamId: "team-id",
+        orgId: null,
       },
       {
         metadata: {
@@ -64,6 +66,7 @@ describe("calculateCreditsToBeBilled", () => {
       } as any,
       {
         teamId: "team-id",
+        orgId: null,
       },
       {
         metadata: {
@@ -95,6 +98,7 @@ describe("calculateCreditsToBeBilled", () => {
       } as any,
       {
         teamId: "team-id",
+        orgId: null,
       },
       {
         metadata: {
@@ -163,7 +167,7 @@ const billWithDecisions = (args: {
 }) =>
   calculateCreditsToBeBilled(
     { formats: [{ type: "markdown" }] } as any,
-    { teamId: "team-id" },
+    { teamId: "team-id", orgId: null },
     args.document as any,
     { totalCost: 0 } as any,
     {} as any,

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -29,6 +29,8 @@ export async function startWebScraperPipeline({
       crawlId: job.data.crawl_id,
       teamId: job.data.team_id,
       ...job.data.internalOptions,
+      // In-flight jobs enqueued before orgId existed may omit it.
+      orgId: job.data.internalOptions?.orgId ?? null,
     },
     team_id: job.data.team_id,
     bull_job_id: job.id,
@@ -89,6 +91,7 @@ async function runWebScraper({
           ...internalOptions,
           urlInvisibleInCurrentCrawl,
           teamId: internalOptions?.teamId ?? team_id,
+          orgId: internalOptions?.orgId ?? null,
         },
         costTracking,
       );

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -341,6 +341,7 @@ function blocklistGate(
       !canUseExchange &&
       isUrlBlocked(req.body.url, req.acuc?.flags ?? null, {
         team_id: req.acuc?.team_id ?? null,
+        org_id: req.acuc?.org_id ?? null,
         origin: typeof req.body.origin === "string" ? req.body.origin : null,
       })
     ) {

--- a/apps/api/src/scraper/WebScraper/sitemap.ts
+++ b/apps/api/src/scraper/WebScraper/sitemap.ts
@@ -115,6 +115,7 @@ export async function getLinksFromSitemap(
           {
             forceEngine,
             v0DisableJsDom: true,
+            orgId: null,
             externalAbort: abort
               ? {
                   signal: abort,

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
@@ -172,12 +172,19 @@ describe("isUrlBlocked", () => {
       expect(isUrlBlocked("https://example.com", null, ctx(ORG_B))).toBe(false);
     });
 
-    it("throws when no global row exists", async () => {
+    it("throws when the table is empty", async () => {
+      dbState.rows = [];
+      await expect(initializeBlocklist()).rejects.toThrow(
+        "No data returned from database",
+      );
+    });
+
+    it("throws when rows exist but none is global", async () => {
       dbState.rows = [
         { org_id: ORG_A, data: { blocklist: [], allowedKeywords: [] } },
       ];
       await expect(initializeBlocklist()).rejects.toThrow(
-        "No data returned from database",
+        "No global blocklist row",
       );
     });
   });

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
@@ -145,6 +145,15 @@ describe("isUrlBlocked", () => {
       expect(hasOrgScopedBlocklist(null)).toBe(false);
       expect(hasOrgScopedBlocklist(undefined)).toBe(false);
     });
+
+    it("does not count an org whose rows hold no blockable entries", async () => {
+      dbState.rows = [
+        GLOBAL_ROW,
+        { org_id: ORG_B, data: { blocklist: [], allowedKeywords: ["/x"] } },
+      ];
+      await initializeBlocklist();
+      expect(hasOrgScopedBlocklist(ORG_B)).toBe(false);
+    });
   });
 
   describe("row loading", () => {

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
@@ -154,6 +154,18 @@ describe("isUrlBlocked", () => {
       await initializeBlocklist();
       expect(hasOrgScopedBlocklist(ORG_B)).toBe(false);
     });
+
+    it("does not count an org whose entries are all blank strings", async () => {
+      dbState.rows = [
+        GLOBAL_ROW,
+        {
+          org_id: ORG_B,
+          data: { blocklist: ["", "   "], allowedKeywords: [] },
+        },
+      ];
+      await initializeBlocklist();
+      expect(hasOrgScopedBlocklist(ORG_B)).toBe(false);
+    });
   });
 
   describe("row loading", () => {

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
@@ -1,0 +1,184 @@
+import type { TeamFlags } from "../../../controllers/v1/types";
+import { initializeBlocklist, isUrlBlocked } from "./blocklist";
+
+const dbState = vi.hoisted(() => ({
+  rows: [] as { data: unknown; org_id: string | null }[],
+}));
+
+vi.mock("../../../config", () => ({
+  config: {
+    USE_DB_AUTHENTICATION: true,
+    DISABLE_BLOCKLIST: false,
+  },
+}));
+
+vi.mock("../../../db/connection", () => ({
+  db: {
+    insert: vi.fn(() => ({ values: vi.fn(async () => {}) })),
+  },
+  dbRr: {
+    select: vi.fn(() => ({
+      from: vi.fn(async () => dbState.rows),
+    })),
+  },
+}));
+
+const ORG_A = "00000000-0000-0000-0000-00000000000a";
+const ORG_B = "00000000-0000-0000-0000-00000000000b";
+const TEAM = "00000000-0000-0000-0000-000000000001";
+
+// NOTE: the matcher also blocks other TLDs of the same base domain, so
+// placeholder domains here must not share a base name across lists unless
+// the test is exercising exactly that rule.
+const GLOBAL_ROW = {
+  org_id: null,
+  data: {
+    blocklist: ["facebook.com"],
+    allowedKeywords: ["/legal"],
+  },
+};
+
+function ctx(org_id: string | null) {
+  return { team_id: TEAM, org_id, origin: "test" };
+}
+
+describe("isUrlBlocked", () => {
+  describe("global entries", () => {
+    beforeAll(async () => {
+      dbState.rows = [GLOBAL_ROW];
+      await initializeBlocklist();
+    });
+
+    it("blocks a global entry with no context", () => {
+      expect(isUrlBlocked("https://facebook.com/profile", null)).toBe(true);
+    });
+
+    it("blocks a global entry for any org", () => {
+      expect(
+        isUrlBlocked("https://facebook.com/profile", null, ctx(ORG_A)),
+      ).toBe(true);
+      expect(
+        isUrlBlocked("https://facebook.com/profile", null, ctx(null)),
+      ).toBe(true);
+    });
+
+    it("does not block unlisted domains", () => {
+      expect(isUrlBlocked("https://example.com", null, ctx(ORG_A))).toBe(false);
+    });
+
+    it("respects global allowedKeywords", () => {
+      expect(isUrlBlocked("https://facebook.com/legal", null)).toBe(false);
+    });
+
+    it("unblocks a global entry via flags.unblockedDomains", () => {
+      const flags = { unblockedDomains: ["facebook.com"] } as TeamFlags;
+      expect(isUrlBlocked("https://facebook.com/profile", flags)).toBe(false);
+    });
+  });
+
+  describe("org-scoped entries", () => {
+    beforeAll(async () => {
+      dbState.rows = [
+        GLOBAL_ROW,
+        {
+          org_id: ORG_A,
+          data: {
+            blocklist: ["example.com", "org-blocked.com"],
+            allowedKeywords: ["/allowed-path"],
+          },
+        },
+      ];
+      await initializeBlocklist();
+    });
+
+    it("blocks the org's entry for that org only", () => {
+      expect(isUrlBlocked("https://example.com", null, ctx(ORG_A))).toBe(true);
+      expect(isUrlBlocked("https://example.com", null, ctx(ORG_B))).toBe(false);
+      expect(isUrlBlocked("https://example.com", null, ctx(null))).toBe(false);
+      expect(isUrlBlocked("https://example.com", null)).toBe(false);
+    });
+
+    it("keeps blocking global entries for the org", () => {
+      expect(
+        isUrlBlocked("https://facebook.com/profile", null, ctx(ORG_A)),
+      ).toBe(true);
+    });
+
+    it("blocks subdomains of an org-scoped entry", () => {
+      expect(
+        isUrlBlocked("https://sub.example.com/page", null, ctx(ORG_A)),
+      ).toBe(true);
+    });
+
+    it("blocks different TLDs of an org-scoped entry", () => {
+      expect(isUrlBlocked("https://example.de", null, ctx(ORG_A))).toBe(true);
+    });
+
+    it("unblocks org-scoped entries via flags.unblockedDomains", () => {
+      const flags = { unblockedDomains: ["example.com"] } as TeamFlags;
+      expect(isUrlBlocked("https://example.com", flags, ctx(ORG_A))).toBe(
+        false,
+      );
+      // Only the listed domain is unblocked, not the org's other entries.
+      expect(isUrlBlocked("https://org-blocked.com", flags, ctx(ORG_A))).toBe(
+        true,
+      );
+    });
+
+    it("respects the org blob's own allowedKeywords for its list only", () => {
+      expect(
+        isUrlBlocked("https://example.com/allowed-path", null, ctx(ORG_A)),
+      ).toBe(false);
+      // The org's allowedKeywords do not exempt globally-blocked URLs.
+      expect(
+        isUrlBlocked("https://facebook.com/allowed-path", null, ctx(ORG_A)),
+      ).toBe(true);
+    });
+  });
+
+  describe("row loading", () => {
+    it("merges multiple rows for the same org", async () => {
+      dbState.rows = [
+        GLOBAL_ROW,
+        {
+          org_id: ORG_A,
+          data: { blocklist: ["example-one.com"], allowedKeywords: [] },
+        },
+        {
+          org_id: ORG_A,
+          data: { blocklist: ["example-two.com"], allowedKeywords: [] },
+        },
+      ];
+      await initializeBlocklist();
+
+      expect(isUrlBlocked("https://example-one.com", null, ctx(ORG_A))).toBe(
+        true,
+      );
+      expect(isUrlBlocked("https://example-two.com", null, ctx(ORG_A))).toBe(
+        true,
+      );
+    });
+
+    it("tolerates malformed org row data without breaking loading", async () => {
+      dbState.rows = [
+        GLOBAL_ROW,
+        { org_id: ORG_A, data: null },
+        { org_id: ORG_B, data: { blocklist: "not-an-array" } },
+      ];
+      await initializeBlocklist();
+
+      expect(isUrlBlocked("https://facebook.com/profile", null)).toBe(true);
+      expect(isUrlBlocked("https://example.com", null, ctx(ORG_A))).toBe(false);
+      expect(isUrlBlocked("https://example.com", null, ctx(ORG_B))).toBe(false);
+    });
+
+    it("throws when no global row exists", async () => {
+      dbState.rows = [
+        { org_id: ORG_A, data: { blocklist: [], allowedKeywords: [] } },
+      ];
+      await expect(initializeBlocklist()).rejects.toThrow(
+        "No data returned from database",
+      );
+    });
+  });
+});

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.test.ts
@@ -1,5 +1,9 @@
 import type { TeamFlags } from "../../../controllers/v1/types";
-import { initializeBlocklist, isUrlBlocked } from "./blocklist";
+import {
+  hasOrgScopedBlocklist,
+  initializeBlocklist,
+  isUrlBlocked,
+} from "./blocklist";
 
 const dbState = vi.hoisted(() => ({
   rows: [] as { data: unknown; org_id: string | null }[],
@@ -133,6 +137,13 @@ describe("isUrlBlocked", () => {
       expect(
         isUrlBlocked("https://facebook.com/allowed-path", null, ctx(ORG_A)),
       ).toBe(true);
+    });
+
+    it("reports which orgs have org-scoped entries", () => {
+      expect(hasOrgScopedBlocklist(ORG_A)).toBe(true);
+      expect(hasOrgScopedBlocklist(ORG_B)).toBe(false);
+      expect(hasOrgScopedBlocklist(null)).toBe(false);
+      expect(hasOrgScopedBlocklist(undefined)).toBe(false);
     });
   });
 

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -239,6 +239,20 @@ function findBlockedMatch(
   return null;
 }
 
+/**
+ * Whether the org has any org-scoped blocklist entries at all. Lets shared
+ * caches opt such requesters out entirely: a per-URL check is not enough
+ * when the cached artifact covers other URLs than the one checked.
+ */
+export function hasOrgScopedBlocklist(
+  orgId: string | null | undefined,
+): boolean {
+  if (blob === null) {
+    throw new Error("Blocklist not initialized");
+  }
+  return typeof orgId === "string" && orgBlobs.has(orgId);
+}
+
 export function isUrlBlocked(
   url: string,
   flags: TeamFlags,

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -106,16 +106,21 @@ let blob: BlocklistBlob | null = null;
 let orgBlobs: Map<string, BlocklistBlob> = new Map();
 
 // Rows are written by ops directly, so reads must survive a missing or
-// partial document — a bad row must never take down startup.
+// partial document — a bad row must never take down startup. Blank entries
+// can never match and would make an org register as scoped, so drop them.
+function parseStringEntries(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (x): x is string => typeof x === "string" && x.trim().length > 0,
+      )
+    : [];
+}
+
 function parseBlob(data: unknown): BlocklistBlob {
   const doc = (data ?? {}) as Record<string, unknown>;
   return {
-    blocklist: Array.isArray(doc.blocklist)
-      ? doc.blocklist.filter((x): x is string => typeof x === "string")
-      : [],
-    allowedKeywords: Array.isArray(doc.allowedKeywords)
-      ? doc.allowedKeywords.filter((x): x is string => typeof x === "string")
-      : [],
+    blocklist: parseStringEntries(doc.blocklist),
+    allowedKeywords: parseStringEntries(doc.allowedKeywords),
   };
 }
 

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -177,7 +177,15 @@ export async function initializeBlocklist() {
     }
   }
   for (const [orgId, orgBlob] of perOrg) {
-    perOrg.set(orgId, dedupeBlob(orgBlob));
+    const deduped = dedupeBlob(orgBlob);
+    // An org whose rows hold no blockable entries must not register as
+    // org-scoped at all — hasOrgScopedBlocklist consumers would otherwise
+    // pay cache opt-outs for an org that can never block anything.
+    if (deduped.blocklist.length === 0) {
+      perOrg.delete(orgId);
+    } else {
+      perOrg.set(orgId, deduped);
+    }
   }
   blob = dedupeBlob(globalBlob);
   orgBlobs = perOrg;

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -15,6 +15,7 @@ type BlocklistBlob = {
 
 type BlockContext = {
   team_id?: string | null;
+  org_id?: string | null;
   origin?: string | null;
 };
 
@@ -102,6 +103,26 @@ function allowedKeywordMatches(url: string, allowedKeyword: string): boolean {
 }
 
 let blob: BlocklistBlob | null = null;
+let orgBlobs: Map<string, BlocklistBlob> = new Map();
+
+// Rows are written by ops directly, so reads must survive a missing or
+// partial document — a bad row must never take down startup.
+function parseBlob(data: unknown): BlocklistBlob {
+  const doc = (data ?? {}) as Record<string, unknown>;
+  return {
+    blocklist: Array.isArray(doc.blocklist)
+      ? doc.blocklist.filter((x): x is string => typeof x === "string")
+      : [],
+    allowedKeywords: Array.isArray(doc.allowedKeywords)
+      ? doc.allowedKeywords.filter((x): x is string => typeof x === "string")
+      : [],
+  };
+}
+
+function mergeBlob(target: BlocklistBlob, source: BlocklistBlob): void {
+  target.blocklist.push(...source.blocklist);
+  target.allowedKeywords.push(...source.allowedKeywords);
+}
 
 export async function initializeBlocklist() {
   if (config.USE_DB_AUTHENTICATION !== true || config.DISABLE_BLOCKLIST) {
@@ -109,22 +130,95 @@ export async function initializeBlocklist() {
       blocklist: [],
       allowedKeywords: [],
     };
+    orgBlobs = new Map();
     return;
   }
 
-  let data: { data: any } | undefined;
+  let rows: { data: any; org_id: string | null }[];
   try {
-    [data] = await dbRr.select().from(schema.blocklist).limit(1);
+    rows = await dbRr.select().from(schema.blocklist);
   } catch (error) {
     throw new Error(
       `Error getting blocklist: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
     );
   }
 
-  if (!data) {
+  if (!rows.some(row => row.org_id === null)) {
     throw new Error("Error getting blocklist: No data returned from database");
   }
-  blob = data.data;
+
+  const globalBlob: BlocklistBlob = { blocklist: [], allowedKeywords: [] };
+  const perOrg = new Map<string, BlocklistBlob>();
+  for (const row of rows) {
+    if (row.org_id === null) {
+      mergeBlob(globalBlob, parseBlob(row.data));
+    } else {
+      const existing = perOrg.get(row.org_id);
+      if (existing) {
+        mergeBlob(existing, parseBlob(row.data));
+      } else {
+        perOrg.set(row.org_id, parseBlob(row.data));
+      }
+    }
+  }
+  blob = globalBlob;
+  orgBlobs = perOrg;
+}
+
+function findBlockedMatch(
+  url: string,
+  lowerCaseUrl: string,
+  blockedlist: string[],
+  allowedKeywords: string[],
+): string | null {
+  const decryptedUrl =
+    blockedlist.find(decrypted => lowerCaseUrl === decrypted) || lowerCaseUrl;
+
+  // If the URL is empty or invalid, return no match
+  let parsedUrl: any;
+  try {
+    parsedUrl = parse(decryptedUrl);
+  } catch {
+    console.log("Error parsing URL:", url);
+    return null;
+  }
+
+  const domain = parsedUrl.domain;
+  const publicSuffix = parsedUrl.publicSuffix;
+
+  if (!domain) {
+    return null;
+  }
+
+  // Check if URL contains any allowed keyword
+  if (allowedKeywords.some(keyword => allowedKeywordMatches(url, keyword))) {
+    return null;
+  }
+
+  // Block exact matches
+  if (blockedlist.includes(domain)) {
+    return domain;
+  }
+
+  // Block subdomains
+  if (blockedlist.some(blocked => domain.endsWith(`.${blocked}`))) {
+    return domain;
+  }
+
+  // Block different TLDs of the same base domain
+  const baseDomain = domain.split(".")[0]; // Extract the base domain (e.g., "facebook" from "facebook.com")
+
+  if (
+    publicSuffix &&
+    baseDomain.length > 2 &&
+    blockedlist.some(
+      blocked => blocked.startsWith(baseDomain + ".") && blocked !== domain,
+    )
+  ) {
+    return domain;
+  }
+
+  return null;
 }
 
 export function isUrlBlocked(
@@ -146,56 +240,36 @@ export function isUrlBlocked(
     );
   }
 
-  const decryptedUrl =
-    blockedlist.find(decrypted => lowerCaseUrl === decrypted) || lowerCaseUrl;
-
-  // If the URL is empty or invalid, return false
-  let parsedUrl: any;
-  try {
-    parsedUrl = parse(decryptedUrl);
-  } catch {
-    console.log("Error parsing URL:", url);
-    return false;
-  }
-
-  const domain = parsedUrl.domain;
-  const publicSuffix = parsedUrl.publicSuffix;
-
-  if (!domain) {
-    return false;
-  }
-
-  // Check if URL contains any allowed keyword
-  if (
-    blob.allowedKeywords.some(keyword => allowedKeywordMatches(url, keyword))
-  ) {
-    return false;
-  }
-
-  // Block exact matches
-  if (blockedlist.includes(domain)) {
-    recordHit(url, domain, context);
+  const globalMatch = findBlockedMatch(
+    url,
+    lowerCaseUrl,
+    blockedlist,
+    blob.allowedKeywords,
+  );
+  if (globalMatch !== null) {
+    recordHit(url, globalMatch, context);
     return true;
   }
 
-  // Block subdomains
-  if (blockedlist.some(blocked => domain.endsWith(`.${blocked}`))) {
-    recordHit(url, domain, context);
-    return true;
-  }
-
-  // Block different TLDs of the same base domain
-  const baseDomain = domain.split(".")[0]; // Extract the base domain (e.g., "facebook" from "facebook.com")
-
-  if (
-    publicSuffix &&
-    baseDomain.length > 2 &&
-    blockedlist.some(
-      blocked => blocked.startsWith(baseDomain + ".") && blocked !== domain,
-    )
-  ) {
-    recordHit(url, domain, context);
-    return true;
+  // The org blob's own allowedKeywords exempt URLs from the org list only.
+  const orgBlob = context?.org_id ? orgBlobs.get(context.org_id) : undefined;
+  if (orgBlob) {
+    let orgBlockedlist = orgBlob.blocklist;
+    if (flags?.unblockedDomains) {
+      orgBlockedlist = orgBlockedlist.filter(
+        blocked => !flags.unblockedDomains!.includes(blocked),
+      );
+    }
+    const orgMatch = findBlockedMatch(
+      url,
+      lowerCaseUrl,
+      orgBlockedlist,
+      orgBlob.allowedKeywords,
+    );
+    if (orgMatch !== null) {
+      recordHit(url, orgMatch, context);
+      return true;
+    }
   }
 
   return false;

--- a/apps/api/src/scraper/WebScraper/utils/blocklist.ts
+++ b/apps/api/src/scraper/WebScraper/utils/blocklist.ts
@@ -124,6 +124,15 @@ function mergeBlob(target: BlocklistBlob, source: BlocklistBlob): void {
   target.allowedKeywords.push(...source.allowedKeywords);
 }
 
+// Rows may repeat entries; the match loops scan linearly, so dedupe once at
+// load instead of paying for duplicates on every check.
+function dedupeBlob(blob: BlocklistBlob): BlocklistBlob {
+  return {
+    blocklist: [...new Set(blob.blocklist)],
+    allowedKeywords: [...new Set(blob.allowedKeywords)],
+  };
+}
+
 export async function initializeBlocklist() {
   if (config.USE_DB_AUTHENTICATION !== true || config.DISABLE_BLOCKLIST) {
     blob = {
@@ -143,8 +152,14 @@ export async function initializeBlocklist() {
     );
   }
 
-  if (!rows.some(row => row.org_id === null)) {
+  if (rows.length === 0) {
     throw new Error("Error getting blocklist: No data returned from database");
+  }
+
+  if (!rows.some(row => row.org_id === null)) {
+    throw new Error(
+      "Error getting blocklist: No global blocklist row (org_id IS NULL) found",
+    );
   }
 
   const globalBlob: BlocklistBlob = { blocklist: [], allowedKeywords: [] };
@@ -161,7 +176,10 @@ export async function initializeBlocklist() {
       }
     }
   }
-  blob = globalBlob;
+  for (const [orgId, orgBlob] of perOrg) {
+    perOrg.set(orgId, dedupeBlob(orgBlob));
+  }
+  blob = dedupeBlob(globalBlob);
   orgBlobs = perOrg;
 }
 

--- a/apps/api/src/scraper/crawler/sitemap.ts
+++ b/apps/api/src/scraper/crawler/sitemap.ts
@@ -88,6 +88,7 @@ async function getSitemapXML(options: SitemapScrapeOptions): Promise<string> {
       v0DisableJsDom: true,
       // externalAbort: options.abort,
       teamId: "sitemap",
+      orgId: null,
       zeroDataRetention: options.zeroDataRetention,
       crawlId: options.crawlId,
       isPreCrawl: options.isPreCrawl,

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -7,10 +7,7 @@ import {
   scrapeURLWithFireEngineChromeCDP,
   scrapeURLWithFireEngineTLSClient,
 } from "./fire-engine";
-import {
-  exchangeMaxReasonableTime,
-  scrapeURLWithExchange,
-} from "./exchange";
+import { exchangeMaxReasonableTime, scrapeURLWithExchange } from "./exchange";
 import { pdfMaxReasonableTime, scrapePDF } from "./pdf";
 import { fetchMaxReasonableTime, scrapeURLWithFetch } from "./fetch";
 import {
@@ -178,7 +175,7 @@ export type EngineScrapeResult = {
 const engineHandlers: {
   [E in Engine]: (meta: Meta) => Promise<EngineScrapeResult>;
 } = {
-  "exchange": scrapeURLWithExchange,
+  exchange: scrapeURLWithExchange,
   index: scrapeURLWithIndex,
   "index;documents": scrapeURLWithIndex,
   "fire-engine;chrome-cdp": scrapeURLWithFireEngineChromeCDP,
@@ -198,7 +195,7 @@ const engineHandlers: {
 const engineMRTs: {
   [E in Engine]: (meta: Meta) => number;
 } = {
-  "exchange": exchangeMaxReasonableTime,
+  exchange: exchangeMaxReasonableTime,
   index: indexMaxReasonableTime,
   "index;documents": indexMaxReasonableTime,
   "fire-engine;chrome-cdp": meta =>
@@ -231,7 +228,7 @@ const engineOptions: {
     quality: number;
   };
 } = {
-  "exchange": {
+  exchange: {
     features: {
       actions: false,
       waitFor: false,
@@ -632,6 +629,7 @@ export async function buildFallbackList(meta: Meta): Promise<
             meta.internalOptions.teamFlags ?? null,
             {
               team_id: meta.internalOptions.teamId ?? null,
+              org_id: meta.internalOptions.orgId ?? null,
               origin: null,
             },
           )
@@ -639,10 +637,9 @@ export async function buildFallbackList(meta: Meta): Promise<
           return [];
         }
       } catch (error) {
-        meta.logger.warn(
-          "Exchange blocklist re-check failed; failing closed",
-          { error },
-        );
+        meta.logger.warn("Exchange blocklist re-check failed; failing closed", {
+          error,
+        });
         return [];
       }
     }

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -495,8 +495,10 @@ export type InternalOptions = {
   teamFlags?: TeamFlags;
   /** Team's org, snapshotted from the request ACUC at acceptance (same
    * pattern as teamFlags). Rides the job payload so org-scoped blocklist
-   * checks work without re-fetching the chunk. */
-  orgId?: string | null;
+   * checks work without re-fetching the chunk. Required so a payload
+   * builder cannot silently omit the org and skip org-scoped enforcement;
+   * pass null when the caller genuinely has no org (internal/system work). */
+  orgId: string | null;
   /** Team's sold concurrency, snapshotted from the request ACUC at
    * acceptance (same pattern as teamFlags). Rides the job payload so
    * downstream engines (FirePDF async account context) never re-fetch. */

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -493,6 +493,10 @@ export type InternalOptions = {
   bypassBilling?: boolean;
   zeroDataRetention?: boolean;
   teamFlags?: TeamFlags;
+  /** Team's org, snapshotted from the request ACUC at acceptance (same
+   * pattern as teamFlags). Rides the job payload so org-scoped blocklist
+   * checks work without re-fetching the chunk. */
+  orgId?: string | null;
   /** Team's sold concurrency, snapshotted from the request ACUC at
    * acceptance (same pattern as teamFlags). Rides the job payload so
    * downstream engines (FirePDF async account context) never re-fetch. */

--- a/apps/api/src/scraper/scrapeURL/scrapeURL.test.ts
+++ b/apps/api/src/scraper/scrapeURL/scrapeURL.test.ts
@@ -10,7 +10,7 @@ import { Engine } from "./engines";
 import { CostTracking } from "../../lib/cost-tracking";
 
 // Mock parseMarkdown but delegate to real implementation for other tests
-vi.mock("../../lib/html-to-markdown", async (importOriginal) => {
+vi.mock("../../lib/html-to-markdown", async importOriginal => {
   const actual =
     await importOriginal<typeof import("../../lib/html-to-markdown")>();
   return {
@@ -40,7 +40,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-basic",
         "https://firecrawl-test-site.vercel.app",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -79,7 +79,7 @@ describe("Standalone scrapeURL tests", () => {
         scrapeOptions.parse({
           formats: ["markdown", "html"],
         }),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -104,7 +104,7 @@ describe("Standalone scrapeURL tests", () => {
         scrapeOptions.parse({
           onlyMainContent: false,
         }),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -128,7 +128,7 @@ describe("Standalone scrapeURL tests", () => {
           onlyMainContent: false,
           excludeTags: [".nav", "#footer", "strong"],
         }),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -149,7 +149,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-400",
         "https://httpstat.us/400",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -168,7 +168,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-401",
         "https://httpstat.us/401",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -187,7 +187,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-403",
         "https://httpstat.us/403",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -206,7 +206,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-404",
         "https://httpstat.us/404",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -225,7 +225,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-405",
         "https://httpstat.us/405",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -244,7 +244,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-500",
         "https://httpstat.us/500",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -263,7 +263,7 @@ describe("Standalone scrapeURL tests", () => {
         "test:scrape-redirect",
         "https://scrapethissite.com/",
         scrapeOptions.parse({}),
-        { forceEngine, teamId: "test" },
+        { forceEngine, teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -296,7 +296,7 @@ describe("Standalone scrapeURL tests", () => {
           scrapeOptions.parse({
             formats: ["screenshot"],
           }),
-          { forceEngine, teamId: "test" },
+          { forceEngine, teamId: "test", orgId: null },
           new CostTracking(),
         );
 
@@ -325,7 +325,7 @@ describe("Standalone scrapeURL tests", () => {
           scrapeOptions.parse({
             formats: ["screenshot@fullPage"],
           }),
-          { forceEngine, teamId: "test" },
+          { forceEngine, teamId: "test", orgId: null },
           new CostTracking(),
         );
 
@@ -354,7 +354,7 @@ describe("Standalone scrapeURL tests", () => {
       "test:scrape-pdf",
       "https://arxiv.org/pdf/astro-ph/9301001.pdf",
       scrapeOptions.parse({}),
-      { teamId: "test" },
+      { teamId: "test", orgId: null },
       new CostTracking(),
     );
 
@@ -374,7 +374,7 @@ describe("Standalone scrapeURL tests", () => {
       "test:scrape-docx",
       "https://nvca.org/wp-content/uploads/2019/06/NVCA-Model-Document-Stock-Purchase-Agreement.docx",
       scrapeOptions.parse({}),
-      { teamId: "test" },
+      { teamId: "test", orgId: null },
       new CostTracking(),
     );
 
@@ -396,7 +396,7 @@ describe("Standalone scrapeURL tests", () => {
       "test:scrape-xlsx",
       "https://download.microsoft.com/download/1/4/E/14EDED28-6C58-4055-A65C-23B4DA81C4DE/Financial%20Sample.xlsx",
       scrapeOptions.parse({}),
-      { teamId: "test" },
+      { teamId: "test", orgId: null },
       new CostTracking(),
     );
 
@@ -437,7 +437,7 @@ describe("Standalone scrapeURL tests", () => {
           },
         },
       }),
-      { teamId: "test" },
+      { teamId: "test", orgId: null },
       new CostTracking(),
     );
 
@@ -474,7 +474,7 @@ describe("Standalone scrapeURL tests", () => {
           },
         },
       }),
-      { teamId: "test" },
+      { teamId: "test", orgId: null },
       new CostTracking(),
     );
 
@@ -501,7 +501,7 @@ describe("Standalone scrapeURL tests", () => {
         id,
         url,
         scrapeOptions.parse({}),
-        { teamId: "test" },
+        { teamId: "test", orgId: null },
         new CostTracking(),
       );
 
@@ -545,7 +545,7 @@ describe("Standalone scrapeURL tests", () => {
       scrapeOptions.parse({
         formats: ["rawHtml"],
       }),
-      { teamId: "sitemap" },
+      { teamId: "sitemap", orgId: null },
       new CostTracking(),
     );
 

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -41,6 +41,7 @@ interface SearchOptions {
 
 interface SearchContext {
   teamId: string;
+  orgId?: string | null;
   origin: string;
   apiKeyId: number | null;
   flags: TeamFlags;
@@ -73,6 +74,7 @@ export async function executeSearch(
   const { query, limit, sources, categories, scrapeOptions } = options;
   const {
     teamId,
+    orgId,
     origin,
     apiKeyId,
     flags,
@@ -206,12 +208,14 @@ export async function executeSearch(
   if (shouldScrape && scrapeOptions) {
     const itemsToScrape = getItemsToScrape(searchResponse, flags, {
       team_id: teamId,
+      org_id: orgId ?? null,
       origin,
     });
 
     if (itemsToScrape.length > 0) {
       const scrapeOpts = {
         teamId,
+        orgId: orgId ?? null,
         origin,
         timeout: options.timeout,
         scrapeOptions,

--- a/apps/api/src/search/scrape.ts
+++ b/apps/api/src/search/scrape.ts
@@ -31,6 +31,7 @@ interface ScrapeItem {
 
 interface ScrapeSearchOptions {
   teamId: string;
+  orgId?: string | null;
   origin: string;
   timeout: number;
   scrapeOptions: ScrapeOptions;
@@ -79,6 +80,7 @@ async function scrapeSearchResultDirect(
         },
         internalOptions: {
           teamId: options.teamId,
+          orgId: options.orgId ?? null,
           bypassBilling: options.bypassBilling ?? true,
           zeroDataRetention,
           teamFlags: flags,
@@ -147,7 +149,11 @@ async function scrapeSearchResultDirect(
 export function getItemsToScrape(
   searchResponse: SearchV2Response,
   flags: TeamFlags,
-  context?: { team_id?: string | null; origin?: string | null },
+  context?: {
+    team_id?: string | null;
+    org_id?: string | null;
+    origin?: string | null;
+  },
 ): ScrapeItem[] {
   const items: ScrapeItem[] = [];
 

--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -503,6 +503,7 @@ const processPrecrawlJob = async (token: string, job: Job) => {
               internalOptions: {
                 disableSmartWaitCache: true, // NOTE: smart wait disabled for crawls to ensure contentful scrape, speed does not matter
                 teamId,
+                orgId: null, // internal pre-crawl team, no org applies
                 saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
                 zeroDataRetention: false,
                 isPreCrawl: true, // NOTE: must be added to internal options for indexing, if not it will be treated as a normal scrape in the index

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -264,7 +264,6 @@ export function estimateActualCredits(doc: any, options?: any): number {
 // per-page — search monitors bill flat at the check level.
 async function scrapeSearchMonitorPage(params: {
   teamId: string;
-  orgId?: string | null;
   checkId: string;
   url: string;
   judgePrompt: string;
@@ -304,7 +303,9 @@ async function scrapeSearchMonitorPage(params: {
       scrapeOptions,
       internalOptions: {
         teamId: params.teamId,
-        orgId: params.orgId ?? null,
+        // Monitors do no in-pipeline blocklist enforcement (business rule);
+        // search results are filtered via isBlocked before scraping.
+        orgId: null,
         saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
         bypassBilling: true,
         zeroDataRetention: false,
@@ -509,8 +510,6 @@ async function enqueueMonitorScrapeTarget(params: {
     throw new Error("Expected scrape target");
   }
 
-  const acuc = await getACUCTeam(params.monitor.team_id);
-
   for (const [index, url] of params.target.urls.entries()) {
     const scrapeId = params.targetRun.expectedJobs[index];
     const scrapeOptions = scrapeRequestSchema.parse({
@@ -539,7 +538,8 @@ async function enqueueMonitorScrapeTarget(params: {
         scrapeOptions,
         internalOptions: {
           teamId: params.monitor.team_id,
-          orgId: acuc?.org_id ?? null,
+          // Monitors do no in-pipeline blocklist enforcement (business rule).
+          orgId: null,
           saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
           bypassBilling: true,
           zeroDataRetention: false,
@@ -575,7 +575,6 @@ async function enqueueMonitorCrawlTarget(params: {
   }
 
   const crawlId = params.targetRun.crawlId;
-  const acuc = await getACUCTeam(params.monitor.team_id);
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
@@ -609,7 +608,8 @@ async function enqueueMonitorCrawlTarget(params: {
     internalOptions: {
       disableSmartWaitCache: true,
       teamId: params.monitor.team_id,
-      orgId: acuc?.org_id ?? null,
+      // Monitors do no in-pipeline blocklist enforcement (business rule).
+      orgId: null,
       saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
       zeroDataRetention: false,
       bypassBilling: true,
@@ -778,7 +778,6 @@ async function runMonitorSearchTarget(params: {
     scrapePage: ({ url, judgePrompt }) =>
       scrapeSearchMonitorPage({
         teamId: monitor.team_id,
-        orgId: acuc?.org_id ?? null,
         checkId: check.id,
         url,
         judgePrompt,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -11,7 +11,6 @@ import {
   resolveNewGroupBackend,
 } from "../worker/nuq-router";
 import { ScrapeJobData } from "../../types";
-import type { TeamFlags } from "../../controllers/v1/types";
 import { includesFormat } from "../../lib/format-utils";
 import { normalizeMonitorFormats } from "./diff";
 import { autumnService } from "../autumn/autumn.service";
@@ -266,7 +265,6 @@ export function estimateActualCredits(doc: any, options?: any): number {
 async function scrapeSearchMonitorPage(params: {
   teamId: string;
   orgId?: string | null;
-  teamFlags?: TeamFlags | null;
   checkId: string;
   url: string;
   judgePrompt: string;
@@ -307,7 +305,6 @@ async function scrapeSearchMonitorPage(params: {
       internalOptions: {
         teamId: params.teamId,
         orgId: params.orgId ?? null,
-        teamFlags: params.teamFlags ?? null,
         saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
         bypassBilling: true,
         zeroDataRetention: false,
@@ -543,7 +540,6 @@ async function enqueueMonitorScrapeTarget(params: {
         internalOptions: {
           teamId: params.monitor.team_id,
           orgId: acuc?.org_id ?? null,
-          teamFlags: acuc?.flags ?? null,
           saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
           bypassBilling: true,
           zeroDataRetention: false,
@@ -614,7 +610,6 @@ async function enqueueMonitorCrawlTarget(params: {
       disableSmartWaitCache: true,
       teamId: params.monitor.team_id,
       orgId: acuc?.org_id ?? null,
-      teamFlags: acuc?.flags ?? null,
       saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
       zeroDataRetention: false,
       bypassBilling: true,
@@ -784,7 +779,6 @@ async function runMonitorSearchTarget(params: {
       scrapeSearchMonitorPage({
         teamId: monitor.team_id,
         orgId: acuc?.org_id ?? null,
-        teamFlags,
         checkId: check.id,
         url,
         judgePrompt,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -11,6 +11,7 @@ import {
   resolveNewGroupBackend,
 } from "../worker/nuq-router";
 import { ScrapeJobData } from "../../types";
+import type { TeamFlags } from "../../controllers/v1/types";
 import { includesFormat } from "../../lib/format-utils";
 import { normalizeMonitorFormats } from "./diff";
 import { autumnService } from "../autumn/autumn.service";
@@ -265,6 +266,7 @@ export function estimateActualCredits(doc: any, options?: any): number {
 async function scrapeSearchMonitorPage(params: {
   teamId: string;
   orgId?: string | null;
+  teamFlags?: TeamFlags | null;
   checkId: string;
   url: string;
   judgePrompt: string;
@@ -305,6 +307,7 @@ async function scrapeSearchMonitorPage(params: {
       internalOptions: {
         teamId: params.teamId,
         orgId: params.orgId ?? null,
+        teamFlags: params.teamFlags ?? null,
         saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
         bypassBilling: true,
         zeroDataRetention: false,
@@ -540,6 +543,7 @@ async function enqueueMonitorScrapeTarget(params: {
         internalOptions: {
           teamId: params.monitor.team_id,
           orgId: acuc?.org_id ?? null,
+          teamFlags: acuc?.flags ?? null,
           saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
           bypassBilling: true,
           zeroDataRetention: false,
@@ -610,6 +614,7 @@ async function enqueueMonitorCrawlTarget(params: {
       disableSmartWaitCache: true,
       teamId: params.monitor.team_id,
       orgId: acuc?.org_id ?? null,
+      teamFlags: acuc?.flags ?? null,
       saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
       zeroDataRetention: false,
       bypassBilling: true,
@@ -779,6 +784,7 @@ async function runMonitorSearchTarget(params: {
       scrapeSearchMonitorPage({
         teamId: monitor.team_id,
         orgId: acuc?.org_id ?? null,
+        teamFlags,
         checkId: check.id,
         url,
         judgePrompt,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -264,6 +264,7 @@ export function estimateActualCredits(doc: any, options?: any): number {
 // per-page — search monitors bill flat at the check level.
 async function scrapeSearchMonitorPage(params: {
   teamId: string;
+  orgId?: string | null;
   checkId: string;
   url: string;
   judgePrompt: string;
@@ -303,6 +304,7 @@ async function scrapeSearchMonitorPage(params: {
       scrapeOptions,
       internalOptions: {
         teamId: params.teamId,
+        orgId: params.orgId ?? null,
         saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
         bypassBilling: true,
         zeroDataRetention: false,
@@ -507,6 +509,8 @@ async function enqueueMonitorScrapeTarget(params: {
     throw new Error("Expected scrape target");
   }
 
+  const acuc = await getACUCTeam(params.monitor.team_id);
+
   for (const [index, url] of params.target.urls.entries()) {
     const scrapeId = params.targetRun.expectedJobs[index];
     const scrapeOptions = scrapeRequestSchema.parse({
@@ -535,6 +539,7 @@ async function enqueueMonitorScrapeTarget(params: {
         scrapeOptions,
         internalOptions: {
           teamId: params.monitor.team_id,
+          orgId: acuc?.org_id ?? null,
           saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
           bypassBilling: true,
           zeroDataRetention: false,
@@ -570,6 +575,7 @@ async function enqueueMonitorCrawlTarget(params: {
   }
 
   const crawlId = params.targetRun.crawlId;
+  const acuc = await getACUCTeam(params.monitor.team_id);
   const body = crawlRequestSchema.parse({
     url: params.target.url,
     ...(params.target.crawlOptions ?? {}),
@@ -603,6 +609,7 @@ async function enqueueMonitorCrawlTarget(params: {
     internalOptions: {
       disableSmartWaitCache: true,
       teamId: params.monitor.team_id,
+      orgId: acuc?.org_id ?? null,
       saveScrapeResultToGCS: !!config.GCS_FIRE_ENGINE_BUCKET_NAME,
       zeroDataRetention: false,
       bypassBilling: true,
@@ -771,6 +778,7 @@ async function runMonitorSearchTarget(params: {
     scrapePage: ({ url, judgePrompt }) =>
       scrapeSearchMonitorPage({
         teamId: monitor.team_id,
+        orgId: acuc?.org_id ?? null,
         checkId: check.id,
         url,
         judgePrompt,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -778,6 +778,7 @@ async function runMonitorSearchTarget(params: {
     isBlocked: url =>
       isUrlBlocked(url, teamFlags, {
         team_id: monitor.team_id,
+        org_id: acuc?.org_id ?? null,
         origin: "monitor.search",
       }),
     goalVersion,

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -165,7 +165,7 @@ const processGenerateLlmsTxtJobInternal = async (
       return result;
     } else {
       const error = new Error(
-        result.error ?? "LLMs text generation failed without specific error",
+        "LLMs text generation failed without specific error",
       );
       await job.moveToFailed(error, token, false);
       await updateGeneratedLlmsTxt(job.data.generateId, {

--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -165,7 +165,7 @@ const processGenerateLlmsTxtJobInternal = async (
       return result;
     } else {
       const error = new Error(
-        "LLMs text generation failed without specific error",
+        result.error ?? "LLMs text generation failed without specific error",
       );
       await job.moveToFailed(error, token, false);
       await updateGeneratedLlmsTxt(job.data.generateId, {

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -464,15 +464,13 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
           await saveCrawl(job.data.crawl_id, sc);
         }
 
+        const teamChunk = await getACUCTeam(job.data.team_id);
         if (
-          isUrlBlocked(
-            doc.metadata.url,
-            (await getACUCTeam(job.data.team_id))?.flags ?? null,
-            {
-              team_id: job.data.team_id,
-              origin: job.data.origin,
-            },
-          )
+          isUrlBlocked(doc.metadata.url, teamChunk?.flags ?? null, {
+            team_id: job.data.team_id,
+            org_id: teamChunk?.org_id ?? null,
+            origin: job.data.origin,
+          })
         ) {
           throw new CrawlDenialError(UNSUPPORTED_SITE_MESSAGE); // TODO: make this its own error type that is ignored by error tracking
         }


### PR DESCRIPTION
## What

Makes the requester's organization available end-to-end in the scrape pipeline, and adds support for org-scoped rows in internal configuration (`org_id IS NULL` rows keep the current behavior; rows with an `org_id` apply only to that org's teams).

## How

- `org_id` comes from data already in hand (`req.acuc.org_id` at controllers, the already-fetched team chunk in workers) and rides `InternalOptions`/job payloads the same way `teamFlags` does — no new queries.
- `orgId` is a required field on `InternalOptions`, so a payload builder cannot silently omit it; internal/system builders pass `null` explicitly.
- Config rows load at process startup with tolerant jsonb parsing (a bad row degrades to empty instead of failing startup) and per-scope merging/dedup of multiple rows.
- Org-scoped requesters skip the shared llms.txt cache in both directions, since cached artifacts can't be shared across differing org configurations.

## Rollout

An additive nullable column must be applied to the relevant table **before** deploy (the loader selects it explicitly and fails fast at startup if it's missing). DDL shared internally.

## Tests

Unit tests cover scoping (global vs org rows), matching, precedence with team flags, multi-row merging, and malformed-row tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)