### PR TITLE
fix(readme): update 'join our community' link to point to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Pst. Hey, you, join our stargazers :)_
 - **Agent ready**: Connect Firecrawl to any AI agent or MCP client with a single command
 - **Media parsing**: Parse and extract content from web-hosted PDFs, DOCX, and more
 - **Actions**: Click, scroll, write, wait, and press before extracting content
-- **Open source**: Developed transparently and collaboratively — [join our community](https://github.com/firecrawl/firecrawl)
+- **Open source**: Developed transparently and collaboratively — [join our community](https://discord.gg/firecrawl)
 
 ---
 

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,7 +28,6 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
-  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,6 +28,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;


### PR DESCRIPTION
## Problem

The 'join our community' link in the README's 'Why Firecrawl?' section points to `https://github.com/firecrawl/firecrawl` (the repo itself) instead of the community/Discord page.

Closes #3887.

## Fix

Update the link to `https://discord.gg/firecrawl` — the same Discord invite already used by the Discord badge at the top of the README.

## Checklist

- [x] Single-file change to `README.md`
- [x] No new dependencies
- [x] Commit references the issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the "join our community" link in the README to point to our Discord (`https://discord.gg/firecrawl`) instead of the repo, so readers land on the correct community page.

<sup>Written for commit 5d21f1c5f7dd44b6e7e85724a967e5e0acc1bf94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

