### PR TITLE
fix(api): consume parse upload refs once

### DIFF
--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -281,6 +281,30 @@ describe("/v2/parse", () => {
   );
 
   it(
+    "allows an uploadRef to start only one parse",
+    async () => {
+      enableLocalUploadRefAdapter();
+      const init = await mintRequiredUploadRef(identity);
+      const upload = await uploadToMintedTarget(init, htmlFixture);
+      expect(upload.status).toBe(200);
+
+      const startParse = () =>
+        request(TEST_API_URL)
+          .post("/v2/parse")
+          .set("Authorization", `Bearer ${identity.apiKey}`)
+          .set("Content-Type", "application/json")
+          .send({ uploadRef: init.uploadRef, formats: ["markdown"] });
+
+      const responses = await Promise.all([startParse(), startParse()]);
+      expect(responses.map(response => response.statusCode).sort()).toEqual([
+        200,
+        409,
+      ]);
+    },
+    scrapeTimeout,
+  );
+
+  it(
     "rejects oversized declared upload-ref sizes before signing",
     async () => {
       enableLocalUploadRefAdapter();

--- a/apps/api/src/controllers/v2/parse-upload.ts
+++ b/apps/api/src/controllers/v2/parse-upload.ts
@@ -16,6 +16,7 @@ const PARSE_UPLOAD_TTL_MS = 10 * 60 * 1000;
 const PARSE_UPLOAD_UNPARSED_LIMIT = 10;
 const PARSE_UPLOAD_UNPARSED_WINDOW_MS = 24 * 60 * 60 * 1000;
 const PARSE_UPLOAD_UNPARSED_TTL_SECONDS = 25 * 60 * 60;
+const PARSE_UPLOAD_CONSUMED_KEY_PREFIX = "parse-upload-consumed:";
 const uploadInitSchema = z.strictObject({
   filename: z.string().min(1).max(512),
   contentType: z.string().min(1).max(255).optional(),
@@ -225,6 +226,24 @@ async function releaseUnparsedUploadRef(teamId: string, uploadId: string) {
     .zrem(key, uploadId)
     .expire(key, PARSE_UPLOAD_UNPARSED_TTL_SECONDS)
     .exec();
+}
+
+async function claimUploadRef(payload: ParseUploadRefPayload): Promise<boolean> {
+  const ttlMs = Math.max(1, payload.expiresAt - Date.now());
+  const result = await getRedisConnection().set(
+    `${PARSE_UPLOAD_CONSUMED_KEY_PREFIX}${payload.teamId}:${payload.uploadId}`,
+    "1",
+    "PX",
+    ttlMs,
+    "NX",
+  );
+  return result === "OK";
+}
+
+async function releaseUploadRefClaim(payload: ParseUploadRefPayload) {
+  await getRedisConnection().del(
+    `${PARSE_UPLOAD_CONSUMED_KEY_PREFIX}${payload.teamId}:${payload.uploadId}`,
+  );
 }
 
 async function reserveUnparsedUploadRefOrRespond(
@@ -578,6 +597,15 @@ export async function parseUploadRefPayloadMiddleware(
     return;
   }
 
+  if (!(await claimUploadRef(payload))) {
+    res.status(409).json({
+      success: false,
+      code: "UPLOAD_REF_ALREADY_USED",
+      error: "uploadRef has already been used.",
+    });
+    return;
+  }
+
   try {
     const resolved = await resolveUploadRef(payload);
     const { uploadRef: _uploadRef, ...options } = req.body;
@@ -598,6 +626,12 @@ export async function parseUploadRefPayloadMiddleware(
     });
     next();
   } catch (error) {
+    await releaseUploadRefClaim(payload).catch(releaseError => {
+      _logger.warn("Failed to release parse upload claim", {
+        error: releaseError,
+        uploadId: payload.uploadId,
+      });
+    });
     res.status(400).json({
       success: false,
       code: "BAD_REQUEST",


### PR DESCRIPTION
  Makes uploadRef consumption atomic with Redis. Concurrent attempts to parse the same uploaded file now
  allow one request to proceed and return 409 for duplicates.