### PR TITLE
fix(api): reject empty local parse uploads

### DIFF
--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -302,6 +302,23 @@ describe("/v2/parse", () => {
   );
 
   it(
+    "rejects empty local upload-ref files",
+    async () => {
+      enableLocalUploadRefAdapter();
+      const init = await mintRequiredUploadRef(identity);
+
+      const upload = await uploadToMintedTarget(init, "");
+      expect(upload.status).toBe(400);
+      expect(await upload.json()).toMatchObject({
+        success: false,
+        code: "BAD_REQUEST",
+        error: "Uploaded file must not be empty.",
+      });
+    },
+    scrapeTimeout,
+  );
+
+  it(
     "limits each team to 10 unparsed upload refs from the last 24 hours",
     async () => {
       enableLocalUploadRefAdapter();

--- a/apps/api/src/controllers/v2/parse-upload.ts
+++ b/apps/api/src/controllers/v2/parse-upload.ts
@@ -436,11 +436,14 @@ export async function parseLocalUploadController(req: Request, res: Response) {
   const body = Buffer.isBuffer(req.body)
     ? req.body
     : Buffer.from(req.body ?? "");
-  if (body.length > record.maxBytes) {
+  if (body.length === 0 || body.length > record.maxBytes) {
     return res.status(400).json({
       success: false,
       code: "BAD_REQUEST",
-      error: "Uploaded file exceeds maximum size of 50MB.",
+      error:
+        body.length === 0
+          ? "Uploaded file must not be empty."
+          : "Uploaded file exceeds maximum size of 50MB.",
     });
   }
 


### PR DESCRIPTION
  Rejects zero-byte local parse uploads with a clear 400 error, matching the minimum-size requirement
  already enforced for GCS uploads.

