### PR TITLE
feat(self-host): support mobile viewport emulation on playwright engine

### DIFF
--- a/apps/api/src/__tests__/snips/v2/mobile-routing.test.ts
+++ b/apps/api/src/__tests__/snips/v2/mobile-routing.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for mobile feature engine routing via buildFallbackList.
+ *
+ * Self-hosted deployments rely on the playwright engine (no fire-engine).
+ * If playwright does not advertise mobile support, mobile scrapes either
+ * fail with SCRAPE_ALL_ENGINES_FAILED or fall through to engines that ignore
+ * the flag. See #3744.
+ */
+
+describe("Mobile feature engine routing (buildFallbackList)", () => {
+  let buildFallbackList: typeof import("../../../scraper/scrapeURL/engines/index.js").buildFallbackList;
+  let clearExchangeProvidersForTest: typeof import("../../../lib/exchange.js").clearExchangeProvidersForTest;
+
+  const originalFireEngineUrl = process.env.FIRE_ENGINE_BETA_URL;
+  const originalIndexUrl = process.env.INDEX_DATABASE_URL;
+  const originalPlaywrightUrl = process.env.PLAYWRIGHT_MICROSERVICE_URL;
+  const originalExchangeUrl = process.env.FIRE_EXCHANGE_URL;
+
+  beforeAll(async () => {
+    // Self-hosted shape: playwright available, fire-engine / exchange / index not.
+    delete process.env.FIRE_ENGINE_BETA_URL;
+    delete process.env.FIRE_EXCHANGE_URL;
+    delete process.env.INDEX_DATABASE_URL;
+    process.env.PLAYWRIGHT_MICROSERVICE_URL = "http://playwright-service:3000/scrape";
+
+    vi.resetModules();
+    ({ buildFallbackList } = await import(
+      "../../../scraper/scrapeURL/engines/index.js"
+    ));
+    ({ clearExchangeProvidersForTest } = await import(
+      "../../../lib/exchange.js"
+    ));
+  });
+
+  afterEach(() => {
+    clearExchangeProvidersForTest();
+  });
+
+  afterAll(() => {
+    if (originalFireEngineUrl === undefined) {
+      delete process.env.FIRE_ENGINE_BETA_URL;
+    } else {
+      process.env.FIRE_ENGINE_BETA_URL = originalFireEngineUrl;
+    }
+    if (originalIndexUrl === undefined) {
+      delete process.env.INDEX_DATABASE_URL;
+    } else {
+      process.env.INDEX_DATABASE_URL = originalIndexUrl;
+    }
+    if (originalPlaywrightUrl === undefined) {
+      delete process.env.PLAYWRIGHT_MICROSERVICE_URL;
+    } else {
+      process.env.PLAYWRIGHT_MICROSERVICE_URL = originalPlaywrightUrl;
+    }
+    if (originalExchangeUrl === undefined) {
+      delete process.env.FIRE_EXCHANGE_URL;
+    } else {
+      process.env.FIRE_EXCHANGE_URL = originalExchangeUrl;
+    }
+  });
+
+  const buildStubMeta = (featureFlags: string[], opts: { mobile?: boolean } = {}) =>
+    ({
+      id: "test",
+      url: "https://example.com",
+      options: {
+        formats: [{ type: "markdown" }],
+        maxAge: 0,
+        mobile: opts.mobile ?? featureFlags.includes("mobile"),
+      },
+      internalOptions: { teamId: "test" },
+      featureFlags: new Set(featureFlags),
+      mock: null,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn().mockReturnThis(),
+      },
+    }) as any;
+
+  it("selects playwright for mobile scrapes on self-hosted (no fire-engine)", async () => {
+    const fallback = await buildFallbackList(
+      buildStubMeta(["mobile"], { mobile: true }),
+    );
+    const engines = fallback.map(f => f.engine);
+
+    expect(engines.length).toBeGreaterThan(0);
+    expect(engines).toContain("playwright");
+
+    const playwright = fallback.find(f => f.engine === "playwright");
+    expect(playwright).toBeDefined();
+    expect(playwright!.unsupportedFeatures.has("mobile")).toBe(false);
+  });
+
+  it("does not leave the mobile fallback list empty (regression for #3744)", async () => {
+    const fallback = await buildFallbackList(
+      buildStubMeta(["mobile"], { mobile: true }),
+    );
+
+    // Empty list used to surface as SCRAPE_ALL_ENGINES_FAILED with
+    // "Engines tried: []" on self-hosted mobile scrapes.
+    expect(fallback.length).toBeGreaterThan(0);
+  });
+
+  it("still allows playwright for non-mobile scrapes", async () => {
+    const fallback = await buildFallbackList(buildStubMeta([]));
+    const engines = fallback.map(f => f.engine);
+
+    expect(engines).toContain("playwright");
+    expect(engines).toContain("fetch");
+  });
+});

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -355,6 +355,49 @@ describe("Scrape tests", () => {
     scrapeTimeout,
   );
 
+  // Self-hosted mobile used to fail with SCRAPE_ALL_ENGINES_FAILED / partial
+  // scrapes because only fire-engine advertised mobile support (#3744).
+  concurrentIf(TEST_SELF_HOST && HAS_PLAYWRIGHT)(
+    "self-hosted mobile scrape succeeds without unsupported-feature warning",
+    async () => {
+      const response = await scrape(
+        {
+          url: "https://example.com",
+          formats: ["markdown"],
+          mobile: true,
+          maxAge: 0,
+        },
+        identity,
+      );
+
+      expect(response.markdown).toBeTruthy();
+      expect(response.markdown).toContain("Example Domain");
+      // playwright now emulates mobile; must not warn that mobile is unsupported
+      expect(response.warning ?? "").not.toMatch(/\bmobile\b/i);
+    },
+    scrapeTimeout,
+  );
+
+  concurrentIf(TEST_SELF_HOST && HAS_PLAYWRIGHT)(
+    "self-hosted desktop scrape is unchanged when mobile is false",
+    async () => {
+      const response = await scrape(
+        {
+          url: "https://example.com",
+          formats: ["markdown"],
+          mobile: false,
+          maxAge: 0,
+        },
+        identity,
+      );
+
+      expect(response.markdown).toBeTruthy();
+      expect(response.markdown).toContain("Example Domain");
+      expect(response.warning ?? "").not.toMatch(/\bmobile\b/i);
+    },
+    scrapeTimeout,
+  );
+
   itIf(TEST_SELF_HOST && !HAS_FIRE_ENGINE)(
     "rejects actions when fire-engine is not configured",
     async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -390,7 +390,8 @@ const engineOptions: {
       video: false,
       atsv: false,
       location: false,
-      mobile: false,
+      // Self-hosted playwright-service supports mobile viewport/UA emulation.
+      mobile: true,
       skipTlsVerification: true,
       useFastMode: false,
       stealthProxy: false,

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -19,6 +19,7 @@ export async function scrapeURLWithPlaywright(
       timeout: meta.abort.scrapeTimeout(),
       headers: meta.options.headers,
       skip_tls_verification: meta.options.skipTlsVerification,
+      mobile: meta.options.mobile,
     },
     method: "POST",
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -182,7 +182,17 @@ interface UrlModel {
   headers?: { [key: string]: string };
   check_selector?: string;
   skip_tls_verification?: boolean;
+  mobile?: boolean;
 }
+
+// Default mobile UA used when the caller asks for a mobile render but didn't
+// pass a mobile UA of its own. A desktop UA alongside isMobile makes the page
+// serve its desktop layout, defeating the point of mobile emulation.
+const MOBILE_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+const isMobileUserAgent = (ua?: string): boolean =>
+  !!ua && /Mobi|iPhone|iPod|Android/i.test(ua);
 
 let browser: Browser;
 
@@ -204,12 +214,19 @@ const initializeBrowser = async () => {
 const createContext = async (
   skipTlsVerification: boolean = false,
   userAgentOverride?: string,
+  mobile: boolean = false,
 ): Promise<{
   context: BrowserContext;
   securityState: ContextSecurityState;
 }> => {
-  const userAgent = userAgentOverride || new UserAgent().toString();
-  const viewport = { width: 1280, height: 800 };
+  const userAgent = mobile
+    ? isMobileUserAgent(userAgentOverride)
+      ? userAgentOverride!
+      : MOBILE_USER_AGENT
+    : userAgentOverride || new UserAgent().toString();
+  const viewport = mobile
+    ? { width: 390, height: 844 }
+    : { width: 1280, height: 800 };
   const securityState: ContextSecurityState = {
     blockedNavigationRequestUrl: null,
   };
@@ -219,6 +236,9 @@ const createContext = async (
     viewport,
     ignoreHTTPSErrors: skipTlsVerification,
     serviceWorkers: 'block',
+    ...(mobile
+      ? { isMobile: true, hasTouch: true, deviceScaleFactor: 3 }
+      : {}),
   };
 
   contextOptions.proxy = {
@@ -377,6 +397,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
     headers,
     check_selector,
     skip_tls_verification = false,
+    mobile = false,
   }: UrlModel = req.body;
 
   console.log(`================= Scrape Request =================`);
@@ -386,6 +407,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   console.log(`Headers: ${headers ? JSON.stringify(headers) : 'None'}`);
   console.log(`Check Selector: ${check_selector ? check_selector : 'None'}`);
   console.log(`Skip TLS Verification: ${skip_tls_verification}`);
+  console.log(`Mobile: ${mobile}`);
   console.log(`==================================================`);
 
   if (!url) {
@@ -438,6 +460,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
     const contextBundle = await createContext(
       skip_tls_verification,
       userAgentOverride,
+      mobile,
     );
     requestContext = contextBundle.context;
     securityState = contextBundle.securityState;


### PR DESCRIPTION
## Summary

Self-hosted deployments use the `playwright` engine (no fire-engine). The engine feature matrix only advertised `mobile: true` on fire-engine variants, so a `mobile: true` scrape either:

1. Failed with `SCRAPE_ALL_ENGINES_FAILED` (`Engines tried: []`), or
2. Fell through to playwright without emulation and returned a partial-scrape warning that mobile is unsupported.

This PR wires real mobile emulation through the self-hosted path.

Closes #3744

## Changes

- **`engines/index.ts`** — declare `mobile: true` on the `playwright` engine so it is selected for mobile scrapes
- **`engines/playwright/index.ts`** — forward `mobile` from the engine adapter to playwright-service
- **`playwright-service-ts/api.ts`** — apply mobile context when requested:
  - viewport `390×844`
  - `isMobile` / `hasTouch` / `deviceScaleFactor: 3`
  - default mobile UA when the caller did not pass a mobile User-Agent
- **Tests**
  - Unit: `mobile-routing.test.ts` — self-hosted fallback list includes playwright with full mobile support (regression for empty engines)
  - E2E snips (gated `TEST_SELF_HOST && HAS_PLAYWRIGHT`): mobile scrape succeeds without an unsupported-feature warning; desktop remains unchanged

## Verification

Rebuilt `api` + `playwright-service` images and confirmed against a local docker-compose stack:

**Before:** scrape succeeded but warned that mobile is unsupported (partial scrape).

**After:** scrape succeeds with no mobile warning; playwright-service logs show `Mobile: true`. Desktop scrapes are unchanged.

## Notes

- No new dependencies; Playwright already supports mobile emulation natively.
- Fire-engine mobile behavior is untouched.
- Existing open PR #3745 covers a similar change but is conflicting with main and lacks tests; this branch is based on current main with unit + snip coverage per the contribution guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables mobile viewport emulation for self-hosted scrapes using the `playwright` engine. Fixes #3744 by rendering mobile pages correctly instead of failing or warning.

- **New Features**
  - Advertise `mobile: true` for `playwright` so mobile scrapes route to it.
  - Forward the `mobile` flag from the engine adapter to `playwright-service`.
  - In `playwright-service`, apply mobile context: viewport 390×844, isMobile/hasTouch, deviceScaleFactor 3, and a default mobile UA when none is provided.
  - Add unit and E2E coverage for self-hosted routing and successful mobile scrapes.

<sup>Written for commit 48b4cf2a96f4638140d09375d81a875ff907ae55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

