### PR TITLE
fix(js-sdk): forward ignoreRobotsTxt in v2 crawl payload

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { startCrawl } from "../../../v2/methods/crawl";
+
+describe("v2 crawl payload", () => {
+  test("forwards ignoreRobotsTxt when set", async () => {
+    const http = {
+      post: jest.fn(async () => ({
+        status: 200,
+        data: { success: true, id: "crawl-1", url: "https://api.example/v2/crawl/crawl-1" },
+      })),
+    } as any;
+
+    await startCrawl(http, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+
+    expect(http.post).toHaveBeenCalledWith("/v2/crawl", {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+  });
+
+  test("forwards robotsUserAgent alongside ignoreRobotsTxt", async () => {
+    const http = {
+      post: jest.fn(async () => ({
+        status: 200,
+        data: { success: true, id: "crawl-2", url: "https://api.example/v2/crawl/crawl-2" },
+      })),
+    } as any;
+
+    await startCrawl(http, {
+      url: "https://example.com",
+      ignoreRobotsTxt: false,
+      robotsUserAgent: "MyBot/1.0",
+    });
+
+    expect(http.post).toHaveBeenCalledWith("/v2/crawl", {
+      url: "https://example.com",
+      ignoreRobotsTxt: false,
+      robotsUserAgent: "MyBot/1.0",
+    });
+  });
+
+  test("omits ignoreRobotsTxt when undefined", async () => {
+    const http = {
+      post: jest.fn(async () => ({
+        status: 200,
+        data: { success: true, id: "crawl-3", url: "https://api.example/v2/crawl/crawl-3" },
+      })),
+    } as any;
+
+    await startCrawl(http, { url: "https://example.com" });
+
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).toEqual({ url: "https://example.com" });
+    expect(payload).not.toHaveProperty("ignoreRobotsTxt");
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -27,6 +27,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.includePaths) data.includePaths = request.includePaths;
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;


### PR DESCRIPTION
## Summary

`CrawlOptions.ignoreRobotsTxt` is declared in the JS SDK v2 types but was never forwarded to `POST /v2/crawl`. Callers passing `ignoreRobotsTxt: true` got silent no-ops — crawls kept respecting robots.txt.

Same class of bug as `robotsUserAgent` (fixed in #3403): declared next to it in `CrawlOptions`, wired into `prepareCrawlPayload` for user-agent only.

Closes #3940

## Changes

- Forward `ignoreRobotsTxt` in `prepareCrawlPayload` when set
- Unit tests asserting the field is present when true/false and omitted when undefined

## Test plan

- [x] `jest src/__tests__/unit/v2/crawl.unit.test.ts` — 3 tests passed
- [ ] CI unit suite


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the JS SDK v2 crawl payload to forward ignoreRobotsTxt to POST /v2/crawl, so setting ignoreRobotsTxt works as expected. Crawls can now bypass robots.txt when requested.

- **Bug Fixes**
  - Omit ignoreRobotsTxt when undefined to preserve API defaults.
  - Added unit tests for true, false, and omission. Closes #3940.

<sup>Written for commit 16ff69f0268772304daa729e982df301ee4e2f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

