### PR TITLE
fix(js-sdk): forward documented country field on v2 search

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-country.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/search-country.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { search } from "../../../v2/methods/search";
+
+describe("v2 search country", () => {
+  test("forwards the country option to /v2/search", async () => {
+    const http = {
+      post: jest.fn(async () => ({
+        status: 200,
+        data: { success: true, data: { web: [] } },
+      })),
+    } as any;
+
+    await search(http, { query: "restaurants", country: "DE", limit: 5 });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/search",
+      { query: "restaurants", country: "DE", limit: 5 },
+      {},
+    );
+  });
+
+  test("omits country when undefined", async () => {
+    const http = {
+      post: jest.fn(async () => ({
+        status: 200,
+        data: { success: true, data: { web: [] } },
+      })),
+    } as any;
+
+    await search(http, { query: "firecrawl" });
+
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).toEqual({ query: "firecrawl" });
+    expect(payload).not.toHaveProperty("country");
+  });
+
+  test("forwards country alongside enterprise", async () => {
+    const http = {
+      post: jest.fn(async () => ({
+        status: 200,
+        data: { success: true, data: { web: [] } },
+      })),
+    } as any;
+
+    await search(http, {
+      query: "sensitive topic",
+      country: "US",
+      enterprise: ["zdr"],
+    });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/search",
+      {
+        query: "sensitive topic",
+        country: "US",
+        enterprise: ["zdr"],
+      },
+      {},
+    );
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/search.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/search.ts
@@ -34,6 +34,7 @@ function prepareSearchPayload(req: SearchRequest): Record<string, unknown> {
   if (req.limit != null) payload.limit = req.limit;
   if (req.tbs != null) payload.tbs = req.tbs;
   if (req.location != null) payload.location = req.location;
+  if (req.country != null) payload.country = req.country;
   if (req.ignoreInvalidURLs != null)
     payload.ignoreInvalidURLs = req.ignoreInvalidURLs;
   if (req.timeout != null) payload.timeout = req.timeout;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -695,6 +695,11 @@ export interface SearchRequest {
   limit?: number;
   tbs?: string;
   location?: string;
+  /**
+   * ISO country code for geo-targeted search results (e.g. `"US"`, `"DE"`).
+   * Documented on `/v2/search`; forwarded to the API when set.
+   */
+  country?: string;
   ignoreInvalidURLs?: boolean;
   timeout?: number; // ms
   /** Generate query-relevant highlights for search results. Defaults to true. */


### PR DESCRIPTION
## Summary

The public `/v2/search` API documents a top-level `country` parameter for geo-targeted results. The JS SDK already forwards `enterprise` (from #3919) but still dropped `country`:

- not on `SearchRequest`
- not copied in `prepareSearchPayload`

So TypeScript rejected valid options, and even a cast would not send the field.

Closes #3437

## Changes

- Add `country?: string` to `SearchRequest`
- Forward `country` in `prepareSearchPayload`
- Unit tests for present / omitted / alongside enterprise

## Test plan

- [x] `jest src/__tests__/unit/v2/search-country.unit.test.ts` � 3 tests passed
- [ ] CI unit suite


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the JS SDK v2 search to accept and pass through the country option for geo-targeted results. TypeScript now allows `country`, and the SDK sends it to the API. Closes #3437.

- **Bug Fixes**
  - Add `country?: string` to `SearchRequest`.
  - Forward `country` in `prepareSearchPayload`.
  - Add unit tests for present, omitted, and with `enterprise`.

<sup>Written for commit 94109914fa7085d29cac8c9a233e1c548781b5cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

