### PR TITLE
feat(go-sdk): add Profile, robots crawl flags, and search country/enterprise

### DIFF
--- a/apps/go-sdk/README.md
+++ b/apps/go-sdk/README.md
@@ -140,6 +140,27 @@ if err != nil {
 fmt.Println(doc.Menu)
 ```
 
+### Persistent Browser Profile
+
+Pass a `Profile` to preserve browser state (cookies, `localStorage`, session data)
+across scrapes. Scrapes that reuse the same profile name share that state, which is
+useful for staying logged in between requests without scripting interactions.
+
+```go
+doc, err := client.Scrape(ctx, "https://example.com/dashboard", &firecrawl.ScrapeOptions{
+	Formats: []string{"markdown"},
+	Profile: &firecrawl.ProfileConfig{Name: "my-profile"},
+})
+```
+
+`SaveChanges` controls whether browser state changed during the scrape is persisted
+back to the profile; it defaults to `true`. Since it is a `*bool`, use the
+`firecrawl.Bool` helper to load an existing profile without saving any changes:
+
+```go
+Profile: &firecrawl.ProfileConfig{Name: "my-profile", SaveChanges: firecrawl.Bool(false)},
+```
+
 #### Interactive Browser
 
 Execute code in a scrape-bound browser session:

--- a/apps/go-sdk/options.go
+++ b/apps/go-sdk/options.go
@@ -88,9 +88,15 @@ type ScrapeOptions struct {
 	BlockAds            *bool                    `json:"blockAds,omitempty"`
 	Proxy               *string                  `json:"proxy,omitempty"`
 	MaxAge              *int64                   `json:"maxAge,omitempty"`
+	// MinAge, when set, only checks the cache and never triggers a fresh scrape.
+	// Value is milliseconds; set to 1 to accept any cached data regardless of age.
+	MinAge              *int64                   `json:"minAge,omitempty"`
 	StoreInCache        *bool                    `json:"storeInCache,omitempty"`
 	Lockdown            *bool                    `json:"lockdown,omitempty"`
 	RedactPII           *bool                    `json:"redactPII,omitempty"`
+	// Profile enables a persistent browser profile (cookies, localStorage, etc.)
+	// shared across scrapes that use the same name. See ProfileConfig.
+	Profile             *ProfileConfig           `json:"profile,omitempty"`
 	Integration         *string                  `json:"integration,omitempty"`
 	JsonOptions         *JsonOptions             `json:"jsonOptions,omitempty"`
 }
@@ -127,6 +133,10 @@ type CrawlOptions struct {
 	CrawlEntireDomain      *bool          `json:"crawlEntireDomain,omitempty"`
 	AllowExternalLinks     *bool          `json:"allowExternalLinks,omitempty"`
 	AllowSubdomains        *bool          `json:"allowSubdomains,omitempty"`
+	// IgnoreRobotsTxt skips robots.txt checks when true. Enterprise feature on cloud.
+	IgnoreRobotsTxt        *bool          `json:"ignoreRobotsTxt,omitempty"`
+	// RobotsUserAgent is the user-agent string used when checking robots.txt.
+	RobotsUserAgent        *string        `json:"robotsUserAgent,omitempty"`
 	Delay                  *int           `json:"delay,omitempty"`
 	MaxConcurrency         *int           `json:"maxConcurrency,omitempty"`
 	Webhook                interface{}    `json:"webhook,omitempty"`
@@ -169,9 +179,14 @@ type SearchOptions struct {
 	Limit             *int           `json:"limit,omitempty"`
 	TBS               *string        `json:"tbs,omitempty"`
 	Location          *string        `json:"location,omitempty"`
+	// Country is an ISO country code for geo-targeted search (e.g. "US", "DE").
+	Country           *string        `json:"country,omitempty"`
 	IgnoreInvalidURLs *bool          `json:"ignoreInvalidURLs,omitempty"`
 	Timeout           *int           `json:"timeout,omitempty"`
 	Highlights        *bool          `json:"highlights,omitempty"`
+	// Enterprise search modes. Use []string{"zdr"} for Zero Data Retention or
+	// []string{"anon"} for anonymized search (must be enabled for the team).
+	Enterprise        []string       `json:"enterprise,omitempty"`
 	ScrapeOptions     *ScrapeOptions `json:"scrapeOptions,omitempty"`
 	Integration       *string        `json:"integration,omitempty"`
 }
@@ -192,6 +207,17 @@ type AgentOptions struct {
 type LocationConfig struct {
 	Country   string   `json:"country,omitempty"`
 	Languages []string `json:"languages,omitempty"`
+}
+
+// ProfileConfig enables a persistent browser profile for a scrape. Scrapes that
+// reuse the same profile name share browser state such as cookies, localStorage,
+// and session data, which is useful for staying logged in across requests.
+type ProfileConfig struct {
+	// Name identifies the profile. Required (1-128 characters).
+	Name string `json:"name"`
+	// SaveChanges controls whether browser state changed during the scrape is
+	// persisted back to the profile. Defaults to true on the server when omitted.
+	SaveChanges *bool `json:"saveChanges,omitempty"`
 }
 
 // WebhookConfig configures webhook notifications.

--- a/apps/go-sdk/options_test.go
+++ b/apps/go-sdk/options_test.go
@@ -87,3 +87,81 @@ func TestSearchOptionsSerializesHighlights(t *testing.T) {
 		t.Fatalf("serialized search options = %s", payload)
 	}
 }
+
+func TestScrapeOptionsSerializesProfile(t *testing.T) {
+	payload, err := json.Marshal(ScrapeOptions{
+		Profile: &ProfileConfig{Name: "my-profile"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal ScrapeOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"profile":{"name":"my-profile"}`) {
+		t.Fatalf("serialized profile = %s, want to contain %s", payload, `"profile":{"name":"my-profile"}`)
+	}
+}
+
+func TestScrapeOptionsSerializesProfileSaveChanges(t *testing.T) {
+	payload, err := json.Marshal(ScrapeOptions{
+		Profile: &ProfileConfig{Name: "my-profile", SaveChanges: Bool(false)},
+	})
+	if err != nil {
+		t.Fatalf("Marshal ScrapeOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"profile":{"name":"my-profile","saveChanges":false}`) {
+		t.Fatalf("serialized profile = %s, want to contain %s", payload, `"profile":{"name":"my-profile","saveChanges":false}`)
+	}
+}
+
+func TestScrapeOptionsSerializesMinAge(t *testing.T) {
+	minAge := int64(1000)
+	payload, err := json.Marshal(ScrapeOptions{MinAge: &minAge})
+	if err != nil {
+		t.Fatalf("Marshal ScrapeOptions: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"minAge":1000`) {
+		t.Fatalf("serialized minAge = %s", payload)
+	}
+}
+
+func TestCrawlOptionsSerializesRobotsFields(t *testing.T) {
+	payload, err := json.Marshal(CrawlOptions{
+		IgnoreRobotsTxt: Bool(true),
+		RobotsUserAgent: String("MyBot/1.0"),
+	})
+	if err != nil {
+		t.Fatalf("Marshal CrawlOptions: %v", err)
+	}
+
+	jsonBody := string(payload)
+	for _, want := range []string{
+		`"ignoreRobotsTxt":true`,
+		`"robotsUserAgent":"MyBot/1.0"`,
+	} {
+		if !strings.Contains(jsonBody, want) {
+			t.Fatalf("serialized crawl options = %s, want to contain %s", jsonBody, want)
+		}
+	}
+}
+
+func TestSearchOptionsSerializesCountryAndEnterprise(t *testing.T) {
+	payload, err := json.Marshal(SearchOptions{
+		Country:    String("DE"),
+		Enterprise: []string{"zdr"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal SearchOptions: %v", err)
+	}
+
+	jsonBody := string(payload)
+	for _, want := range []string{
+		`"country":"DE"`,
+		`"enterprise":["zdr"]`,
+	} {
+		if !strings.Contains(jsonBody, want) {
+			t.Fatalf("serialized search options = %s, want to contain %s", jsonBody, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The Go SDK was missing several options that the API and other SDKs already support:

| Area | Field | Issue / context |
|------|-------|-----------------|
| Scrape | `Profile` | #3458 � persistent browser state between scrapes |
| Scrape | `MinAge` | cache-only scrape hint (parity with JS/Python) |
| Crawl | `IgnoreRobotsTxt`, `RobotsUserAgent` | same gap as JS #3940 |
| Search | `Country`, `Enterprise` | geo-targeting + ZDR/anon modes |

Structs use `json` tags, so values serialize into request bodies automatically via the existing option-merge path.

Closes #3458

## Changes

- `ProfileConfig` + `ScrapeOptions.Profile` / `MinAge`
- `CrawlOptions.IgnoreRobotsTxt` / `RobotsUserAgent`
- `SearchOptions.Country` / `Enterprise`
- Unit tests for serialization
- README: Persistent Browser Profile section

## Test plan

- [x] `go test ./...` in `apps/go-sdk` � pass
- [ ] CI Go checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent browser profiles, robots.txt crawl flags, and country/enterprise search options in the Go SDK to match the API and other SDKs. This enables stateful scrapes, finer robots control, and geo/enterprise search modes.

- **New Features**
  - Scrape: `Profile` (with `ProfileConfig`) and `MinAge` (cache-only).
  - Crawl: `IgnoreRobotsTxt` and `RobotsUserAgent`.
  - Search: `Country` and `Enterprise` (e.g., "zdr", "anon").
  - Added JSON serialization tests and README example for profiles.

<sup>Written for commit d44deeb9a8323c082125f87aa9a69f3905fd2421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

