### PR TITLE
fix(python-sdk): map min_age to minAge in scrape options

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_parse_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_parse_request_preparation.py
@@ -87,3 +87,17 @@ class TestParseRequestPreparation:
 
         payload = json.loads(fields["options"])
         assert "lockdown" not in payload
+
+    def test_prepare_parse_request_strips_min_age(self):
+        """Parse is always uncached; minAge must be stripped once mapped to camelCase."""
+        options = ParseOptions(formats=["markdown"], min_age=1000)
+        fields, _ = _prepare_parse_request(
+            b"<html><body><h1>Parse</h1></body></html>",
+            options,
+            filename="upload.html",
+            content_type="text/html",
+        )
+
+        payload = json.loads(fields["options"])
+        assert "minAge" not in payload
+        assert "min_age" not in payload

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -388,3 +388,13 @@ class TestPrepareScrapeOptions:
         result = prepare_scrape_options(options)
 
         assert result["parsers"][0]["maxPages"] == 5
+
+    def test_prepare_min_age_maps_to_camel_case(self):
+        """min_age must be sent as minAge; the server drops the snake_case key."""
+        options = ScrapeOptions(min_age=1000, max_age=5000)
+
+        result = prepare_scrape_options(options)
+
+        assert result["minAge"] == 1000
+        assert "min_age" not in result
+        assert result["maxAge"] == 5000

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -566,6 +566,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
         "block_ads": "blockAds",
         "store_in_cache": "storeInCache",
         "max_age": "maxAge",
+        "min_age": "minAge",
         "redact_pii": "redactPII",
         "threat_protection": "threatProtection",
     }


### PR DESCRIPTION
## Summary

`prepare_scrape_options` maps snake_case scrape options to camelCase for the API. Every field had a mapping except `min_age`, so the payload still contained `min_age`. The v2 backend drops unknown keys, so the min-age cache window was never applied.

This also fixes parse: `opts.pop("minAge")` never matched the unmapped snake_case key.

Closes #4001

## Changes

- Add `"min_age": "minAge"` next to `"max_age": "maxAge"` in `field_mappings`
- Unit test that `minAge` is present and `min_age` is not
- Parse unit test that minAge is stripped from parse payloads

## Test plan

- [x] `pytest -k min_age` � 2 passed
- [ ] CI Python SDK tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps `min_age` to `minAge` in the Python SDK scrape options so the v2 API applies the cache window, and ensures parse requests strip `minAge`.

- **Bug Fixes**
  - Added `"min_age": "minAge"` mapping in `prepare_scrape_options`.
  - Parse requests now strip `minAge`/`min_age` from options.
  - Added unit tests for mapping and parse payload stripping.

<sup>Written for commit 265af82004fd162504485f1cf827f3ed35c9c4a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

