### PR TITLE
fix(api): accept scrapeOptions.zeroDataRetention on /v2/search

### DIFF
--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1127,6 +1127,33 @@ describe("V2 Types Validation", () => {
       ]);
     });
 
+    it("should accept scrapeOptions.zeroDataRetention for search (#3441)", () => {
+      const input: SearchRequestInput = {
+        query: "sensitive topic",
+        enterprise: ["zdr"],
+        scrapeOptions: {
+          formats: [{ type: "markdown" }],
+          zeroDataRetention: true,
+        },
+      };
+
+      const result = searchRequestSchema.parse(input);
+      expect(result.scrapeOptions?.zeroDataRetention).toBe(true);
+      expect(result.enterprise).toEqual(["zdr"]);
+    });
+
+    it("should reject unknown fields under search scrapeOptions (strict)", () => {
+      const input = {
+        query: "test",
+        scrapeOptions: {
+          formats: [{ type: "markdown" }],
+          notARealField: true,
+        },
+      };
+
+      expect(() => searchRequestSchema.parse(input)).toThrow();
+    });
+
     it("should accept search scrapeOptions with question and highlights formats", () => {
       const input: SearchRequestInput = {
         query: "test",

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -142,7 +142,10 @@ export async function searchController(
     const isZDR = req.body.enterprise?.includes("zdr");
     const isAnon = req.body.enterprise?.includes("anon");
     const isZDROrAnon = isZDR || isAnon;
-    zeroDataRetention = isZDROrAnon ?? false;
+    // Docs allow scrape-side ZDR via scrapeOptions.zeroDataRetention while
+    // top-level enterprise: ["zdr"] covers the search portion (#3441).
+    const scrapeOptionsZDR = req.body.scrapeOptions?.zeroDataRetention === true;
+    zeroDataRetention = Boolean(isZDROrAnon) || scrapeOptionsZDR;
     logger = logger.child({ zeroDataRetention });
     applyZdrScope(zeroDataRetention);
 

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -2002,6 +2002,9 @@ export const searchRequestSchema = z
           .refine(x => {
             return x.filter(f => f.type === "screenshot").length <= 1;
           }, "You may only specify one screenshot format"),
+        // Search docs document scrape-side ZDR via scrapeOptions.zeroDataRetention
+        // (alongside top-level enterprise: ["zdr"] for the search portion).
+        zeroDataRetention: z.boolean().optional(),
       })
       .optional(),
     __agentInterop: z


### PR DESCRIPTION
## Summary

Docs for Search ZDR describe combining:

```json
{
  "enterprise": ["zdr"],
  "scrapeOptions": {
    "formats": ["markdown"],
    "zeroDataRetention": true
  }
}
```

The live `/v2/search` schema rejected `scrapeOptions.zeroDataRetention` because the nested scrape options schema never allowed that field (strict object).

Closes #3441

## Changes

- Allow `zeroDataRetention` under `searchRequestSchema.scrapeOptions`
- OR scrape-side ZDR into the search job `zeroDataRetention` flag (billing / logging / cleanup)
- Schema unit tests: accept documented shape; still reject unknown nested fields

## Test plan

- [x] `vitest run types-validation.test.ts -t scrapeOptions.zeroDataRetention` � pass
- [ ] CI snips


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables zero data retention in `/v2/search` when clients send `scrapeOptions.zeroDataRetention`, matching the docs. The flag is OR’d with `enterprise: ["zdr"]` or `["anon"]` to apply ZDR across scraping and search.

- **Bug Fixes**
  - Accept `scrapeOptions.zeroDataRetention` in `searchRequestSchema`; still reject unknown nested fields.
  - OR `scrapeOptions.zeroDataRetention` with enterprise ZDR/anon to set job-level `zeroDataRetention` (billing, logging, cleanup).
  - Added schema tests for acceptance and strictness.

<sup>Written for commit e6edb4d8532f60d7ce3cbdb7cb60b49820beb620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

