### PR TITLE
fix(python-sdk): expose search country option for geo-targeting

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_search_request_preparation.py
@@ -19,6 +19,16 @@ class TestSearchRequestPreparation:
         # Check that snake_case fields are not present
         assert "ignore_invalid_urls" not in data
         assert "scrape_options" not in data
+        assert "country" not in data
+
+    def test_country_forwarded_to_payload(self):
+        """country is a documented /v2/search field and must reach the API."""
+        request = SearchRequest(query="restaurants", country="DE", limit=5)
+        data = _prepare_search_request(request)
+
+        assert data["country"] == "DE"
+        assert data["query"] == "restaurants"
+        assert data["limit"] == 5
 
     def test_all_fields_conversion(self):
         """Test request preparation with all possible fields."""

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -393,6 +393,7 @@ class FirecrawlClient:
         limit: Optional[int] = None,
         tbs: Optional[str] = None,
         location: Optional[str] = None,
+        country: Optional[str] = None,
         ignore_invalid_urls: Optional[bool] = None,
         timeout: Optional[int] = None,
         highlights: Optional[bool] = None,
@@ -409,6 +410,7 @@ class FirecrawlClient:
             limit: Maximum number of results to return (default: 5)
             tbs: Time-based search filter
             location: Location string for search
+            country: ISO country code for geo-targeted results (e.g. "US", "DE")
             timeout: Request timeout in milliseconds (default: 300000)
             highlights: Generate query-relevant highlights for search results
                 (default: true)
@@ -431,6 +433,7 @@ class FirecrawlClient:
             limit=limit,
             tbs=tbs,
             location=location,
+            country=country,
             ignore_invalid_urls=ignore_invalid_urls,
             timeout=timeout,
             highlights=highlights,

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1600,6 +1600,8 @@ class SearchRequest(BaseModel):
     limit: Optional[int] = 5
     tbs: Optional[str] = None
     location: Optional[str] = None
+    # ISO country code for geo-targeted search (e.g. "US", "DE"). Documented on /v2/search.
+    country: Optional[str] = None
     ignore_invalid_urls: Optional[bool] = None
     timeout: Optional[int] = 300000
     highlights: Optional[bool] = None


### PR DESCRIPTION
## Summary

`/v2/search` documents a top-level `country` parameter for geo-targeted results. The Python SDK already exposed `enterprise` but not `country` on `SearchRequest` or `client.search()`, so callers could not send it without raw HTTP.

## Changes

- Add `country` to `SearchRequest`
- Add `country` keyword arg to `FirecrawlClient.search()`
- Async client already accepts kwargs into `SearchRequest`, so it picks up the field automatically
- Unit test that `_prepare_search_request` includes `country` in the payload

## Test plan

- [x] `pytest -k country` on search request preparation � pass


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `country` for geo-targeted `/v2/search` results in the Python SDK. This lets callers set an ISO country code without using raw HTTP.

- **Bug Fixes**
  - Add `country` to `SearchRequest`.
  - Add `country` kwarg to `FirecrawlClient.search()` and include it in the payload.
  - Unit test ensures `_prepare_search_request` forwards `country`.

<sup>Written for commit 869aa49872040c70edc604559c2a61d4502b3940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

