### PR TITLE
feat(ruby-sdk): add search country, crawl robots, scrape min_age/profile

### DIFF
--- a/apps/ruby-sdk/lib/firecrawl/models/crawl_options.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/crawl_options.rb
@@ -8,6 +8,7 @@ module Firecrawl
         prompt exclude_paths include_paths max_discovery_depth sitemap
         ignore_query_parameters deduplicate_similar_urls limit
         crawl_entire_domain allow_external_links allow_subdomains
+        ignore_robots_txt robots_user_agent
         delay max_concurrency webhook scrape_options regex_on_full_url
         zero_data_retention integration
       ].freeze
@@ -31,6 +32,8 @@ module Firecrawl
           "crawlEntireDomain" => crawl_entire_domain,
           "allowExternalLinks" => allow_external_links,
           "allowSubdomains" => allow_subdomains,
+          "ignoreRobotsTxt" => ignore_robots_txt,
+          "robotsUserAgent" => robots_user_agent,
           "delay" => delay,
           "maxConcurrency" => max_concurrency,
           "webhook" => serialize_webhook,

--- a/apps/ruby-sdk/lib/firecrawl/models/scrape_options.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/scrape_options.rb
@@ -8,7 +8,7 @@ module Firecrawl
         formats headers include_tags exclude_tags only_main_content
         timeout wait_for mobile parsers actions location
         skip_tls_verification remove_base64_images block_ads proxy
-        max_age store_in_cache lockdown redact_pii integration
+        max_age min_age store_in_cache lockdown redact_pii profile integration
       ].freeze
 
       attr_reader(*FIELDS)
@@ -36,9 +36,11 @@ module Firecrawl
           "blockAds" => block_ads,
           "proxy" => proxy,
           "maxAge" => max_age,
+          "minAge" => min_age,
           "storeInCache" => store_in_cache,
           "lockdown" => lockdown,
           "redactPII" => redact_pii,
+          "profile" => serialize_profile,
           "integration" => integration,
         }.compact
       end
@@ -47,6 +49,11 @@ module Firecrawl
 
       def format_value(fmt)
         fmt.respond_to?(:to_h) ? fmt.to_h : fmt
+      end
+
+      def serialize_profile
+        return profile if profile.is_a?(Hash)
+        profile&.to_h
       end
     end
   end

--- a/apps/ruby-sdk/lib/firecrawl/models/search_options.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/search_options.rb
@@ -6,7 +6,8 @@ module Firecrawl
     class SearchOptions
       FIELDS = %i[
         sources categories include_domains exclude_domains limit tbs location
-        ignore_invalid_urls timeout highlights scrape_options integration enterprise
+        country ignore_invalid_urls timeout highlights scrape_options integration
+        enterprise
       ].freeze
 
       attr_reader(*FIELDS)
@@ -24,6 +25,8 @@ module Firecrawl
           "limit" => limit,
           "tbs" => tbs,
           "location" => location,
+          # ISO country code for geo-targeted search (e.g. "US", "DE")
+          "country" => country,
           "ignoreInvalidURLs" => ignore_invalid_urls,
           "timeout" => timeout,
           "highlights" => highlights,

--- a/apps/ruby-sdk/test/firecrawl/options_serialization_test.rb
+++ b/apps/ruby-sdk/test/firecrawl/options_serialization_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class OptionsSerializationTest < Minitest::Test
+  def test_search_options_include_country
+    opts = Firecrawl::Models::SearchOptions.new(country: "DE", enterprise: ["zdr"])
+    payload = opts.to_h
+
+    assert_equal "DE", payload["country"]
+    assert_equal ["zdr"], payload["enterprise"]
+  end
+
+  def test_crawl_options_include_robots_fields
+    opts = Firecrawl::Models::CrawlOptions.new(
+      ignore_robots_txt: true,
+      robots_user_agent: "MyBot/1.0"
+    )
+    payload = opts.to_h
+
+    assert_equal true, payload["ignoreRobotsTxt"]
+    assert_equal "MyBot/1.0", payload["robotsUserAgent"]
+  end
+
+  def test_scrape_options_include_min_age_and_profile
+    opts = Firecrawl::Models::ScrapeOptions.new(
+      min_age: 1000,
+      profile: { "name" => "my-profile", "saveChanges" => false }
+    )
+    payload = opts.to_h
+
+    assert_equal 1000, payload["minAge"]
+    assert_equal({ "name" => "my-profile", "saveChanges" => false }, payload["profile"])
+  end
+
+  def test_omits_unset_optional_fields
+    search = Firecrawl::Models::SearchOptions.new(limit: 5).to_h
+    crawl = Firecrawl::Models::CrawlOptions.new(limit: 10).to_h
+    scrape = Firecrawl::Models::ScrapeOptions.new(timeout: 5000).to_h
+
+    refute search.key?("country")
+    refute crawl.key?("ignoreRobotsTxt")
+    refute scrape.key?("minAge")
+    refute scrape.key?("profile")
+  end
+end


### PR DESCRIPTION
## Summary

The Ruby SDK was missing several documented v2 options that JS/Python already support:

| Area | Fields |
|------|--------|
| Search | `country` (geo-targeting) |
| Crawl | `ignore_robots_txt`, `robots_user_agent` |
| Scrape | `min_age`, `profile` |

## Changes

- Wire fields into model `FIELDS` lists and `to_h` camelCase payloads
- Unit tests for serialization / omission of unset fields

## Test plan

- [ ] `ruby -Ilib:test test/firecrawl/options_serialization_test.rb` (CI)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing v2 options to the Ruby SDK for search, crawl, and scrape. Also updates payload serialization (camelCase) and adds tests to ensure unset fields are omitted.

- New Features
  - Search: add country (geo-targeting).
  - Crawl: add ignore_robots_txt and robots_user_agent.
  - Scrape: add min_age and profile (hash or object).

<sup>Written for commit 15fcad0a1b287eb67b824f0db443fe5618cd1128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

