### PR TITLE
feat(rust-sdk): add search country/enterprise and crawl robots options

### DIFF
--- a/apps/rust-sdk/src/crawl.rs
+++ b/apps/rust-sdk/src/crawl.rs
@@ -42,6 +42,12 @@ pub struct CrawlOptions {
     /// Allow following links to subdomains.
     pub allow_subdomains: Option<bool>,
 
+    /// When true, skip robots.txt checks (enterprise feature on cloud).
+    pub ignore_robots_txt: Option<bool>,
+
+    /// User-agent string used when checking robots.txt.
+    pub robots_user_agent: Option<String>,
+
     /// Delay between requests in seconds.
     pub delay: Option<u32>,
 
@@ -607,5 +613,22 @@ mod tests {
         assert_eq!(result.data.len(), 1);
         start_mock.assert();
         status_mock.assert();
+    }
+
+    #[test]
+    fn serializes_robots_crawl_options() {
+        let options = CrawlOptions {
+            ignore_robots_txt: Some(true),
+            robots_user_agent: Some("MyBot/1.0".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(options).unwrap(),
+            json!({
+                "ignoreRobotsTxt": true,
+                "robotsUserAgent": "MyBot/1.0"
+            })
+        );
     }
 }

--- a/apps/rust-sdk/src/search.rs
+++ b/apps/rust-sdk/src/search.rs
@@ -35,6 +35,9 @@ pub struct SearchOptions {
     /// Geographic location string for local search results.
     pub location: Option<String>,
 
+    /// ISO country code for geo-targeted search results (e.g. "US", "DE").
+    pub country: Option<String>,
+
     /// Whether to ignore invalid URLs in results.
     pub ignore_invalid_urls: Option<bool>,
 
@@ -46,6 +49,10 @@ pub struct SearchOptions {
 
     /// Scrape options to apply to each search result.
     pub scrape_options: Option<ScrapeOptions>,
+
+    /// Enterprise search modes. Use `["zdr"]` for Zero Data Retention or
+    /// `["anon"]` for anonymized search (must be enabled for the team).
+    pub enterprise: Option<Vec<String>>,
 
     /// Integration identifier for tracking.
     pub integration: Option<String>,
@@ -278,6 +285,23 @@ mod tests {
         assert_eq!(
             serde_json::to_value(options).unwrap(),
             json!({ "highlights": false })
+        );
+    }
+
+    #[test]
+    fn serializes_country_and_enterprise_options() {
+        let options = SearchOptions {
+            country: Some("DE".to_string()),
+            enterprise: Some(vec!["zdr".to_string()]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(options).unwrap(),
+            json!({
+                "country": "DE",
+                "enterprise": ["zdr"]
+            })
         );
     }
 


### PR DESCRIPTION
## Summary

The Rust SDK was missing documented crawl and search options:

| Endpoint | Fields |
|----------|--------|
| Search | `country`, `enterprise` |
| Crawl | `ignore_robots_txt`, `robots_user_agent` |

These serialize via existing `#[serde(rename_all = "camelCase")]` on the option structs.

## Changes

- `SearchOptions::{country, enterprise}`
- `CrawlOptions::{ignore_robots_txt, robots_user_agent}`
- Unit tests for JSON serialization

## Test plan

- [ ] `cargo test serializes_` in `apps/rust-sdk` (CI � local Windows MinGW toolchain fails to link)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing search and crawl options to the Rust SDK for parity with the API and other SDKs. Serialization uses existing camelCase settings.

- New Features
  - `SearchOptions`: `country`, `enterprise`.
  - `CrawlOptions`: `ignore_robots_txt`, `robots_user_agent` (with unit tests for camelCase JSON).

<sup>Written for commit b9f8d699ccef3bb29cb5f16df11fe5db2803fdf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

