### PR TITLE
docs: fix CONTRIBUTING first-request and test commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,15 +105,40 @@ This will start the workers who are responsible for processing crawl jobs.
 
 Alright: now let’s send our first request.
 
-```curl
-curl -X GET http://localhost:3002/test
+```bash
+curl -X GET http://localhost:3002/
 ```
 
-This should return the response Hello, world!
+This should return JSON like:
 
-If you’d like to test the crawl endpoint, you can run this
+```json
+{
+  "message": "Firecrawl API",
+  "documentation_url": "https://docs.firecrawl.dev"
+}
+```
 
-```curl
+You can also hit the lightweight liveness probe:
+
+```bash
+curl -X GET http://localhost:3002/e2e-test
+```
+
+This should return `OK`.
+
+If you’d like to test the scrape endpoint (works without an API key when `USE_DB_AUTHENTICATION=false`):
+
+```bash
+curl -X POST http://localhost:3002/v1/scrape \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "url": "https://example.com"
+    }'
+```
+
+If you’d like to test the crawl endpoint, you can run this:
+
+```bash
 curl -X POST http://localhost:3002/v1/crawl \
     -H 'Content-Type: application/json' \
     -d '{
@@ -137,4 +162,10 @@ This will start Redis, the API server, and workers automatically in the correct 
 
 ## Tests:
 
-The best way to do this is run the test with `npm run test:snips`.
+From `apps/api`, the preferred way to run the snip (E2E) suite is:
+
+```bash
+pnpm harness vitest run src/__tests__/snips/v2
+```
+
+`pnpm harness` boots the API and workers for you — do not start them with a separate `pnpm start` while using harness. Run only the relevant test files locally when possible; let CI run the full suite.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` instructed new contributors to:

```bash
curl -X GET http://localhost:3002/test
```

and expected `Hello, world!`. That route is not registered � the API returns `Cannot GET /test`. Local setup verification then looks broken even when the stack is healthy.

## Changes

- Document the real root response (`GET /`) and `GET /e2e-test` (`OK`)
- Add a `POST /v1/scrape` example for `USE_DB_AUTHENTICATION=false`
- Keep the crawl example; mark curl fences as `bash`
- Update the test section to `pnpm harness vitest run ...` (Jest snips were migrated to Vitest)

## Test plan

- [x] Confirmed `GET /` and `GET /e2e-test` exist in `apps/api/src/index.ts`
- [x] Confirmed no `/test` route in the API


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken setup steps in CONTRIBUTING by pointing to real API endpoints and updating test commands. Makes first request and E2E test instructions accurate for local dev.

- **Bug Fixes**
  - Use correct endpoints for the first request: GET / (JSON) and GET /e2e-test (OK).
  - Add POST /v1/scrape example for `USE_DB_AUTHENTICATION=false`; keep crawl example.
  - Update tests to `pnpm harness vitest run src/__tests__/snips/v2` and note not to run servers separately while using harness.

<sup>Written for commit e15500cc1c629645e13227d1a7a3ea6bb8a73e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

