### PR TITLE
chore(api): remove dead maxAge forwarding to Fire Engine scrape requests

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -379,7 +379,6 @@ export async function scrapeURLWithFireEngineChromeCDP(
       timeout: meta.abort.scrapeTimeout() ?? 300000,
       disableSmartWaitCache: meta.internalOptions.disableSmartWaitCache,
       mobileProxy: meta.featureFlags.has("stealthProxy"),
-      maxAge: meta.options.maxAge,
       saveScrapeResultToGCS:
         !meta.internalOptions.zeroDataRetention &&
         meta.internalOptions.saveScrapeResultToGCS,
@@ -522,7 +521,6 @@ export async function scrapeURLWithFireEngineTLSClient(
       mobileProxy: meta.featureFlags.has("stealthProxy"),
 
       timeout: meta.abort.scrapeTimeout() ?? 300000,
-      maxAge: meta.options.maxAge,
       saveScrapeResultToGCS:
         !meta.internalOptions.zeroDataRetention &&
         meta.internalOptions.saveScrapeResultToGCS,

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -51,7 +51,6 @@ export type FireEngineScrapeRequestCommon = {
   mobileProxy?: boolean; // leave it undefined if user doesn't specify
 
   timeout?: number;
-  maxAge?: number;
   saveScrapeResultToGCS?: boolean;
   zeroDataRetention?: boolean;
 };


### PR DESCRIPTION

## What

Removes the `maxAge` field from the Fire Engine scrape request path in
`apps/api/src/scraper/scrapeURL/engines/fire-engine/`:

- Drops `maxAge?: number;` from the `FireEngineScrapeRequestCommon` type (`scrape.ts`).
- Drops `maxAge: meta.options.maxAge,` from the `chrome-cdp` request payload (`index.ts`).
- Drops `maxAge: meta.options.maxAge,` from the `tlsclient` request payload (`index.ts`).

No behavior change. This only stops sending a field that Fire Engine never reads.

**Important:** `maxAge` remains fully meaningful on the API side — it still controls
Firecrawl's own index cache reuse (index-engine eligibility / `cacheState`). That
behavior is deliberately untouched. The `/v2/scrape` A/B mirror in
`services/ab-test.ts` (`SCRAPEURL_AB_EXTEND_MAXAGE` → `maxAge: 900000000`) is also
untouched — it sets the API-level request param, not the Fire Engine type field.

## Evidence

Fire Engine's scrape controller (`api/src/controllers/scrape.ts` in the fire-engine
repo) never consumes `maxAge`. The only `maxAge` references in fire-engine live in
the `enrich/`, `data-layer/`, `gcs-cache`, and browser-warmup paths — none of which
are on the normal scrape request path. So the field forwarded from the API scrape
engines was dead on arrival.

An earlier claim that Fire Engine caches normal scrape responses via this `maxAge`
was incorrect: it conflated normal scraping with the removed data-layer/enrichment
path.

Post-change verification (in a clean worktree off `origin/main`):
- `grep` confirms no remaining `maxAge` references in the `fire-engine/` engine dir.
- All `FireEngineScrapeRequestCommon` consumers (`index.ts`, `scrape.ts`,
  `services/ab-test.ts`) compile without referencing the removed field.
- `tsc --noEmit`: 0 errors.
- `knip`: 0 findings.
- The behavioral contract to protect (scrapes with `maxAge` still reuse the
  Firecrawl index as before) is covered by the existing snips tests
  `snips/v2/scrape-cache.test.ts` and `snips/v2/index-cache-variants.test.ts`;
  they are env-gated locally (no test-website/fire-engine credentials), so CI is
  the verification path for them.

## Related finding — cache-provenance contract (decision needed, NOT resolved here)

While in this area, a pre-existing correctness/observability concern surfaced that
this PR deliberately does **not** touch:

The legacy `cacheState: "miss"` emitted at response assembly
(`apps/api/src/scraper/scrapeURL/index.ts`, the `fallbackList` index-eligibility
block around the `document.metadata` construction) is **not an attested cache miss**.
It is emitted whenever the index engine was in the eligible fallback list *and* the
winning result lacked index `cacheInfo` — which conflates:

- (a) a genuine index miss,
- (b) an index error, and
- (c) the index losing the staggered engine race even when it held the entry.

These three are indistinguishable at assembly time. Note that truly index-ineligible
requests already omit `cacheState` entirely, so the "miss" population is actually
"index-eligible-but-unresolved", not "ineligible".

`cacheState: "hit"` + `cachedAt` (derived from `engineResult.cacheInfo`) remains a
valid, attested positive signal.

Scraper owners should decide between:

1. Keep current behavior, but document "miss" as ambiguous.
2. Emit only attested `"hit"`, and omit `cacheState` otherwise.
3. Add internal outcome tracking first (distinguish miss / error / race-loss) with no
   public contract change.

This PR implements **none** of these — it is flagged for a follow-up decision.

## Non-goal

This is **not** a fix for the customer liveness report. A fresh scrape is not the
same as business-object liveness; that concern is handled separately via
skills/onboarding guidance (see firecrawl/skills#5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
