### PR TITLE
docs(sdk): clarify maxAge and response metadata fields

### DIFF
--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -203,6 +203,13 @@ export interface ScrapeOptions {
   useMock?: string;
   blockAds?: boolean;
   proxy?: "basic" | "stealth" | "enhanced" | "auto" | string;
+  /**
+   * Maximum age, in milliseconds, of an indexed copy that may be returned
+   * instead of running the scrape path. If Firecrawl has indexed content
+   * younger than `maxAge`, it may be reused to cut latency and cost. When
+   * omitted, the common reuse window is 2 days and may be tuned by domain.
+   * Set to `0` to bypass index reuse.
+   */
   maxAge?: number;
   minAge?: number;
   storeInCache?: boolean;
@@ -553,6 +560,11 @@ export interface DocumentMetadata {
   // Common metadata fields
   title?: string;
   description?: string;
+  /**
+   * URL reported by the selected scrape engine. When it differs from
+   * `sourceURL` (the requested URL), it can indicate a redirect. Matching
+   * values do not prove that no redirect occurred.
+   */
   url?: string;
   language?: string;
   keywords?: string | string[];
@@ -589,7 +601,13 @@ export interface DocumentMetadata {
   articleSection?: string;
 
   // Response-level metadata
+  /** The URL that was requested. Compare with `url` for possible redirect evidence. */
   sourceURL?: string;
+  /**
+   * HTTP status code reported for the scrape response. A 200 does not confirm
+   * that the item described by the page (e.g. a job posting or listing) is
+   * still active.
+   */
   statusCode?: number;
   scrapeId?: string;
   numPages?: number;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -204,10 +204,7 @@ export interface ScrapeOptions {
   blockAds?: boolean;
   proxy?: "basic" | "stealth" | "enhanced" | "auto" | string;
   /**
-   * Maximum age, in milliseconds, of an indexed copy that may be returned
-   * instead of running the scrape path. If Firecrawl has indexed content
-   * younger than `maxAge`, it may be reused to cut latency and cost. When
-   * omitted, the common reuse window is 2 days and may be tuned by domain.
+   * Maximum age, in milliseconds, of indexed content that may be reused.
    * Set to `0` to bypass index reuse.
    */
   maxAge?: number;
@@ -560,11 +557,7 @@ export interface DocumentMetadata {
   // Common metadata fields
   title?: string;
   description?: string;
-  /**
-   * URL reported by the selected scrape engine. When it differs from
-   * `sourceURL` (the requested URL), it can indicate a redirect. Matching
-   * values do not prove that no redirect occurred.
-   */
+  /** URL reported by the selected scrape engine. */
   url?: string;
   language?: string;
   keywords?: string | string[];
@@ -601,13 +594,9 @@ export interface DocumentMetadata {
   articleSection?: string;
 
   // Response-level metadata
-  /** The URL that was requested. Compare with `url` for possible redirect evidence. */
+  /** URL requested for the scrape. */
   sourceURL?: string;
-  /**
-   * HTTP status code reported for the scrape response. A 200 does not confirm
-   * that the item described by the page (e.g. a job posting or listing) is
-   * still active.
-   */
+  /** HTTP status code reported for the scrape response. */
   statusCode?: number;
   scrapeId?: string;
   numPages?: number;

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -83,9 +83,7 @@ class DocumentMetadata(BaseModel):
     # Common metadata fields
     title: Optional[str] = None
     description: Optional[str] = None
-    # URL reported by the selected scrape engine. When it differs from source_url
-    # (the requested URL), it can indicate a redirect. Matching values do not
-    # prove that no redirect occurred.
+    # URL reported by the selected scrape engine.
     url: Optional[str] = None
     language: Optional[str] = None
     keywords: Optional[Union[str, List[str]]] = None
@@ -122,11 +120,9 @@ class DocumentMetadata(BaseModel):
     article_section: Optional[str] = None
 
     # Response-level metadata
-    # The URL that was requested. Compare with url for possible redirect evidence.
+    # URL requested for the scrape.
     source_url: Optional[str] = None
-    # HTTP status code reported for the scrape response. A 200 does not confirm
-    # that the item described by the page (e.g. a job posting or listing) is
-    # still active.
+    # HTTP status code reported for the scrape response.
     status_code: Optional[int] = None
     scrape_id: Optional[str] = None
     num_pages: Optional[int] = None
@@ -819,10 +815,7 @@ class ScrapeOptions(BaseModel):
     use_mock: Optional[str] = None
     block_ads: Optional[bool] = None
     proxy: Optional[Literal["basic", "stealth", "enhanced", "auto"]] = None
-    # Maximum age, in milliseconds, of an indexed copy that may be returned
-    # instead of running the scrape path. If Firecrawl has indexed content
-    # younger than max_age, it may be reused to cut latency and cost. When
-    # omitted, the common reuse window is 2 days and may be tuned by domain.
+    # Maximum age, in milliseconds, of indexed content that may be reused.
     # Set to 0 to bypass index reuse.
     max_age: Optional[int] = None
     min_age: Optional[int] = None

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -83,6 +83,9 @@ class DocumentMetadata(BaseModel):
     # Common metadata fields
     title: Optional[str] = None
     description: Optional[str] = None
+    # URL reported by the selected scrape engine. When it differs from source_url
+    # (the requested URL), it can indicate a redirect. Matching values do not
+    # prove that no redirect occurred.
     url: Optional[str] = None
     language: Optional[str] = None
     keywords: Optional[Union[str, List[str]]] = None
@@ -119,7 +122,11 @@ class DocumentMetadata(BaseModel):
     article_section: Optional[str] = None
 
     # Response-level metadata
+    # The URL that was requested. Compare with url for possible redirect evidence.
     source_url: Optional[str] = None
+    # HTTP status code reported for the scrape response. A 200 does not confirm
+    # that the item described by the page (e.g. a job posting or listing) is
+    # still active.
     status_code: Optional[int] = None
     scrape_id: Optional[str] = None
     num_pages: Optional[int] = None
@@ -812,6 +819,11 @@ class ScrapeOptions(BaseModel):
     use_mock: Optional[str] = None
     block_ads: Optional[bool] = None
     proxy: Optional[Literal["basic", "stealth", "enhanced", "auto"]] = None
+    # Maximum age, in milliseconds, of an indexed copy that may be returned
+    # instead of running the scrape path. If Firecrawl has indexed content
+    # younger than max_age, it may be reused to cut latency and cost. When
+    # omitted, the common reuse window is 2 days and may be tuned by domain.
+    # Set to 0 to bypass index reuse.
     max_age: Optional[int] = None
     min_age: Optional[int] = None
     store_in_cache: Optional[bool] = None


### PR DESCRIPTION
## Why

The JS and Python v2 SDKs already expose `maxAge`, `url`, `sourceURL`, and `statusCode` as typed fields, but their non-obvious semantics were not described in the type definitions.

## What changed

- Documented `maxAge` / `max_age` as milliseconds and clarified that `0` bypasses index reuse.
- Documented `sourceURL` / `source_url` as the URL requested for the scrape.
- Documented `url` as the URL reported by the selected scrape engine.
- Documented `statusCode` / `status_code` as the HTTP status reported for the scrape response.

The comments intentionally stay at field semantics. Guidance about freshness, redirects, and business-object liveness remains in the related skills, docs, and MCP changes.

Comments only: no runtime, type-shape, serialization, response-metadata, or cache-contract changes.

Related: firecrawl/skills#5, firecrawl/firecrawl-docs#1145, firecrawl/firecrawl-mcp-server#321.

## Validation

- JS SDK build and declaration generation pass.
- Python package compiles with `compileall`.
- `git diff --check` passes.
