### PR TITLE
fix(api): treat empty OPENAI_API_KEY/BASE_URL as unset

### DIFF
--- a/apps/api/src/__tests__/config.test.ts
+++ b/apps/api/src/__tests__/config.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// config.ts runs `configSchema.parse(process.env)` at import time, so each case
+// sets the env then imports the module fresh via vi.resetModules().
+describe("config emptyStringAsUndefined (OPENAI_API_KEY / OPENAI_BASE_URL)", () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  async function loadConfig() {
+    const mod = await import("../config");
+    return mod.config;
+  }
+
+  it("treats an empty string as undefined", async () => {
+    process.env.OPENAI_API_KEY = "";
+    process.env.OPENAI_BASE_URL = "";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBeUndefined();
+    expect(config.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("treats a whitespace-only string as undefined", async () => {
+    process.env.OPENAI_API_KEY = "   ";
+    process.env.OPENAI_BASE_URL = "\t\n ";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBeUndefined();
+    expect(config.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("passes a real value through unchanged", async () => {
+    process.env.OPENAI_API_KEY = "sk-real-key";
+    process.env.OPENAI_BASE_URL = "https://api.openai.com/v1";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBe("sk-real-key");
+    expect(config.OPENAI_BASE_URL).toBe("https://api.openai.com/v1");
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -10,7 +10,11 @@ const delimitedList = (separator = ",") => {
 };
 
 const emptyStringAsUndefined = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess(value => (value === "" ? undefined : value), schema.optional());
+  z.preprocess(
+    value =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    schema.optional(),
+  );
 
 const emptyStringAsDefault = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess(value => (value === "" ? undefined : value), schema);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -78,8 +78,10 @@ const configSchema = z.object({
 
   // API Keys & Authentication
   BULL_AUTH_KEY: z.string().optional(),
-  OPENAI_API_KEY: z.string().optional(),
-  OPENAI_BASE_URL: z.string().optional(),
+  // Empty strings from docker-compose ${VAR} passthrough must become undefined
+  // so loadApiKey / createOpenAI fall back correctly (see #4083).
+  OPENAI_API_KEY: emptyStringAsUndefined(z.string()),
+  OPENAI_BASE_URL: emptyStringAsUndefined(z.string()),
   OPENROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary
Self-hosted setups often get **present-but-empty** `OPENAI_API_KEY` / `OPENAI_BASE_URL` from docker-compose `${VAR}` expansion. Those were declared as plain `z.string().optional()`, so Zod kept `""` and:

1. `loadApiKey` accepted empty strings
2. `createOpenAI({ baseURL: "" })` did not fall back to the default API host

→ opaque `TypeError: Failed to parse URL from /responses` while still consuming credits on `json` scrapes.

## Change
Wrap both fields with the existing `emptyStringAsUndefined` helper (same pattern as `FDB_CLUSTER_FILE`, `NUQ_BACKEND`, etc.).

## Test plan
- [ ] `OPENAI_BASE_URL=` in `.env` + compose → config has `undefined`, default OpenAI base used when key is set
- [ ] Missing key surfaces the intended missing-key path instead of URL parse errors

Fixes #4083.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty and whitespace-only `OPENAI_API_KEY` and `OPENAI_BASE_URL` from docker-compose `${VAR}` as unset. This makes `loadApiKey` reject invalid keys and lets `createOpenAI` use the default base URL, avoiding URL parse errors and 401s.

- **Bug Fixes**
  - Trim whitespace-only env values to `undefined` in config.
  - Added tests for empty, whitespace-only, and valid values.

<sup>Written for commit bed234144ac429a76bf4d38db6eb4e7c28c07e23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

