### PR TITLE
feat(api): switch ACUC to v56

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -19,9 +19,7 @@ import { checkIpRestriction } from "../lib/ip-restriction";
 import { checkKeyEndpointRestriction } from "../lib/key-restriction";
 import { deleteKey, getValue, setValue } from "../services/redis";
 import { redlock } from "../services/redlock";
-import { eq } from "drizzle-orm";
 import { db, dbRr } from "../db/connection";
-import * as schema from "../db/schema";
 import {
   authCreditUsageChunk,
   authCreditUsageChunkFromTeam,
@@ -614,44 +612,6 @@ export async function authenticateUser(
   })(req, res, mode, options);
 }
 
-/**
- * Backfills org_id for stale cached auth chunks so Autumn check gating can run.
- */
-async function ensureChunkOrgId(
-  apiKey: string,
-  chunk: AuthCreditUsageChunk | null,
-): Promise<AuthCreditUsageChunk | null> {
-  if (!chunk || chunk.org_id || config.USE_DB_AUTHENTICATION !== true) {
-    return chunk;
-  }
-
-  let data: { org_id: string | null } | undefined;
-  try {
-    [data] = await dbRr
-      .select({ org_id: schema.teams.org_id })
-      .from(schema.teams)
-      .where(eq(schema.teams.id, chunk.team_id))
-      .limit(1);
-  } catch (error) {
-    logger.warn("Failed to backfill org_id for auth chunk", {
-      teamId: chunk.team_id,
-      error,
-    });
-    return chunk;
-  }
-
-  if (!data?.org_id) {
-    logger.warn("Failed to backfill org_id for auth chunk", {
-      teamId: chunk.team_id,
-    });
-    return chunk;
-  }
-
-  chunk.org_id = data.org_id;
-  await setCachedACUC(apiKey, !!chunk.is_extract, chunk);
-  return chunk;
-}
-
 async function supaAuthenticateUser(
   req,
   res,
@@ -714,7 +674,6 @@ async function supaAuthenticateUser(
     // Use the resolved fc- API key to get the normal ACUC chunk
     const resolvedApi = parseApi(introspection.api_key);
     chunk = await getACUC(resolvedApi, false, true, RateLimiterMode.Scrape);
-    chunk = await ensureChunkOrgId(resolvedApi, chunk);
 
     if (chunk === null) {
       return {
@@ -744,7 +703,6 @@ async function supaAuthenticateUser(
     }
 
     chunk = await getACUC(normalizedApi, false, true, RateLimiterMode.Scrape);
-    chunk = await ensureChunkOrgId(normalizedApi, chunk);
 
     if (chunk === null) {
       return {

--- a/apps/api/src/db/rpc.ts
+++ b/apps/api/src/db/rpc.ts
@@ -34,7 +34,7 @@ export async function authCreditUsageChunk(
 ): Promise<AuthCreditUsageChunkRow[]> {
   const rows = await execRows<AuthCreditUsageChunkRow>(
     database,
-    sql`select * from auth_credit_usage_chunk_55(input_key => ${input_key})`,
+    sql`select * from auth_credit_usage_chunk_56(input_key => ${input_key})`,
   );
   // api_key_id is a bigint column, so the pg driver hands it back as a string.
   for (const row of rows) {
@@ -51,7 +51,7 @@ export function authCreditUsageChunkFromTeam(
 ): Promise<AuthCreditUsageChunkRow[]> {
   return execRows(
     database,
-    sql`select * from auth_credit_usage_chunk_55_from_team(input_team => ${input_team})`,
+    sql`select * from auth_credit_usage_chunk_56_from_team(input_team => ${input_team})`,
   );
 }
 


### PR DESCRIPTION
Switches the ACUC RPC calls from `auth_credit_usage_chunk_55`/`_55_from_team` to the v56 variants, which additionally return `org_id`, and removes the now-redundant `ensureChunkOrgId` backfill (the extra `teams` query that patched `org_id` onto chunks).

- Chunks now carry the team's org directly from the RPC.
- Transition window: Redis-cached v55 chunks (10-minute TTL) briefly lack `org_id` after deploy; all readers already tolerate a missing value.
- Depends on the v56 DB functions existing (deployed separately); v55 remains in place, so the RPC switch itself is safe to roll back.
- Merge order: DB function first, then this, then #4064 (which makes `org_id` a required field on the chunk type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)