### PR TITLE
types(api): add firecrawl-rs type definitions

### DIFF
--- a/apps/api/src/types/firecrawl-rs.d.ts
+++ b/apps/api/src/types/firecrawl-rs.d.ts
@@ -1,0 +1,40 @@
+declare module '@mendable/firecrawl-rs' {
+  export function html_to_markdown(html: string | null | undefined): any;
+  export function html_transformer(html: string | null | undefined, options?: any): any;
+  export function html_transformer_with_links(html: string | null | undefined, options?: any): any;
+  export function extract_metadata(html: string | null | undefined, options?: any): any;
+  export function extractMetadata(html: string | null | undefined, options?: any): any;
+  export function parse_pdf(buffer: any, ...args: any[]): any;
+  export function getInnerJson(html: string | null | undefined, ...args: any[]): any;
+  export function processPdf(buffer: any, ...args: any[]): any;
+  export function detectPdf(buffer: any, ...args: any[]): any;
+  export function extractAttributes(html: string | null | undefined, ...args: any[]): any;
+  export function extractImages(html: string | null | undefined, ...args: any[]): any;
+  export function extractLinks(html: string | null | undefined, ...args: any[]): any;
+  export function transformHtml(html: any, ...args: any[]): any;
+  export function filterLinks(links: any, ...args: any[]): any;
+  export function filterUrl(url: any, ...args: any[]): any;
+  export function postProcessMarkdown(md: string | null | undefined): any;
+  export function extractBaseHref(html: string | null | undefined, ...args: any[]): any;
+  
+  export function processSitemap(...args: any[]): any;
+  export function parseSitemapXml(...args: any[]): any;
+  export function computeEngpickerVerdict(...args: any[]): any;
+
+  export enum DocumentType {
+    Docx = 1,
+    Doc,
+    Odt,
+    Rtf,
+    Xlsx
+  }
+  export class DocumentConverter {
+    constructor(...args: any[]);
+    convertBufferToHtml(...args: any[]): any;
+  }
+
+  export type TransformHtmlOptions = any;
+  export type EngpickerUrlResult = any;
+  export type ParsedSitemap = any;
+  export type SitemapProcessingResult = any;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add TypeScript module declarations for `@mendable/firecrawl-rs` in `apps/api`. This removes missing type errors and provides basic stubs for HTML/PDF utilities, sitemap helpers, `DocumentType`, and `DocumentConverter`.

<sup>Written for commit d21ef472b49b0754d05782bffc5d875b7422e37b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

