### PR TITLE
test: add regression, crawl testing, and safe cherry-pick scripts

### DIFF
--- a/regression_test.py
+++ b/regression_test.py
@@ -1,0 +1,81 @@
+import httpx
+import asyncio
+import json
+import re
+import sys
+
+URLS = [
+    # HTML
+    "https://example.com",
+    "https://en.wikipedia.org/wiki/Web_scraping",
+    "https://news.ycombinator.com/",
+    # PDFs
+    "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+    "https://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
+    "https://pdfobject.com/pdf/sample-3pp.pdf"
+]
+
+def analyze_markdown(md, url):
+    if not md:
+        print(f"  [!] No markdown returned for {url}")
+        return False
+
+    headings = len(re.findall(r'^#{1,6}\s', md, re.MULTILINE))
+    links = len(re.findall(r'\[.*?\]\(.*?\)', md))
+    tables = len(re.findall(r'\|.*\|.*\|', md))
+    chars = len(md)
+
+    print(f"  - Markdown length: {chars} chars")
+    print(f"  - Headings: {headings}")
+    print(f"  - Links: {links}")
+    print(f"  - Tables lines: {tables}")
+    
+    if chars < 10:
+        print(f"  [!] Markdown too short for {url}")
+        return False
+    return True
+
+async def run():
+    success = True
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        print("Checking API Health...")
+        try:
+            resp = await client.get("http://localhost:3002/test")
+            print("API:", resp.status_code, resp.text)
+        except Exception as e:
+            print("Health check failed:", e)
+            sys.exit(1)
+
+        for url in URLS:
+            print(f"\nScraping {url} ...")
+            payload = {
+                "url": url,
+                "formats": ["markdown", "html"]
+            }
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test"
+            }
+            try:
+                resp = await client.post("http://localhost:3002/v1/scrape", json=payload, headers=headers)
+                print(f"HTTP {resp.status_code}")
+                if resp.status_code == 200:
+                    data = resp.json()
+                    md = data.get("data", {}).get("markdown", "")
+                    if not analyze_markdown(md, url):
+                        success = False
+                else:
+                    print("Error:", resp.text)
+                    success = False
+            except Exception as e:
+                print(f"Failed to scrape {url}: {e}")
+                success = False
+                
+    if success:
+        print("\nAll regression tests PASSED.")
+    else:
+        print("\nSome regression tests FAILED.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/safe_cherry_pick.py
+++ b/safe_cherry_pick.py
@@ -1,0 +1,116 @@
+import subprocess
+import sys
+
+LOCKED_FILES = [
+    "scrape-worker.ts",
+    "nuq.ts",
+    "crawl-redis.ts",
+    "queue-jobs.ts",
+    "auth.ts",
+    "supabase-"
+]
+
+BOUNDARY_FILES = [
+    "apps/api/src/__tests__/snips/v2/document-converter.test.ts",
+    "apps/api/src/lib/__tests__/html-transformer.test.ts",
+    "apps/api/src/lib/engpicker.ts",
+    "apps/api/src/lib/html-to-markdown.ts",
+    "apps/api/src/lib/native-logging.ts",
+    "apps/api/src/scraper/WebScraper/crawler.ts",
+    "apps/api/src/scraper/WebScraper/sitemap.ts",
+    "apps/api/src/scraper/crawler/sitemap.ts",
+    "apps/api/src/scraper/scrapeURL/engines/document/index.ts",
+    "apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts",
+    "apps/api/src/scraper/scrapeURL/engines/pdf/index.ts",
+    "apps/api/src/scraper/scrapeURL/engines/playwright/index.ts",
+    "apps/api/src/scraper/scrapeURL/lib/extractAttributes.ts",
+    "apps/api/src/scraper/scrapeURL/lib/extractImages.ts",
+    "apps/api/src/scraper/scrapeURL/lib/extractLinks.ts",
+    "apps/api/src/scraper/scrapeURL/lib/extractMetadata.ts",
+    "apps/api/src/scraper/scrapeURL/lib/removeUnwantedElements.ts"
+]
+
+def run(cmd, cwd=None):
+    print(f"RUNNING: {cmd}")
+    res = subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=cwd)
+    if res.returncode != 0:
+        print(f"FAILED: {cmd}\n{res.stdout}\n{res.stderr}")
+    return res
+
+commits = sys.argv[1:]
+
+for commit in commits:
+    print(f"\n--- Processing {commit} ---")
+    res = run(f"git cherry-pick {commit}")
+    auto_resolved = False
+    if res.returncode != 0:
+        status_res = run("git diff --name-only --diff-filter=U")
+        conflicted_files = status_res.stdout.strip().split('\n')
+        
+        if conflicted_files == ["apps/js-sdk/firecrawl/package.json"]:
+            with open("apps/js-sdk/firecrawl/package.json", "r") as f:
+                content = f.read()
+            if content.count("<<<<<<< HEAD") == 1 and "<<<<<<< HEAD\n  \"version\":" in content:
+                import re
+                resolved_content = re.sub(r'<<<<<<< HEAD\n  "version": "[^"]+",\n=======\n  "version": "[^"]+",\n>>>>>>> [^\n]+\n',
+                                          r'  "version": "4.25.2",\n', content)
+                with open("apps/js-sdk/firecrawl/package.json", "w") as f:
+                    f.write(resolved_content)
+                run("git add apps/js-sdk/firecrawl/package.json")
+                run("pnpm install")
+                run("git add -u")
+                run("git commit --no-edit")
+                auto_resolved = True
+                print(f"Auto-resolved: version-field-only conflict in package.json for {commit}.")
+            else:
+                print("Conflict is not just version field. Aborting.")
+                run("git cherry-pick --abort")
+                sys.exit(1)
+        else:
+            print(f"Conflicts in unapproved files: {conflicted_files}. Aborting.")
+            run("git cherry-pick --abort")
+            sys.exit(1)
+        
+    res = run("git diff HEAD~1..HEAD --name-only")
+    files = res.stdout.strip().split('\n')
+    
+    # Check locked files
+    dropped_for_locked = False
+    for f in files:
+        if dropped_for_locked: break
+        for locked in LOCKED_FILES:
+            if locked in f:
+                print(f"LOCKED FILE VIOLATION: {f} matches {locked}. Dropping commit.")
+                run("git reset --hard HEAD~1")
+                dropped_for_locked = True
+                break
+
+    if dropped_for_locked:
+        continue # skip to next commit
+        
+    # Check boundary
+    touches_boundary = False
+    for f in files:
+        if f in BOUNDARY_FILES or f.startswith("apps/api/native/src/"):
+            print(f"RUST BOUNDARY TOUCHED: {f}")
+            touches_boundary = True
+            
+    # Check TSC
+    print("Running TSC...")
+    res = run("npx tsc --noEmit", cwd="apps/api")
+    if res.returncode != 0:
+        print("TSC FAILED. Dropping commit and halting.")
+        run("git reset --hard HEAD~1")
+        sys.exit(1)
+        
+    if touches_boundary:
+        print("Running full Docker build for boundary check...")
+        res = run("docker compose build api")
+        if res.returncode != 0:
+            print("DOCKER BUILD FAILED. Dropping commit and halting.")
+            run("git reset --hard HEAD~1")
+            sys.exit(1)
+            
+    print(f"Commit {commit} passed all checks.")
+
+print("All commits processed successfully!")

--- a/test_crawl.py
+++ b/test_crawl.py
@@ -1,0 +1,71 @@
+"""Real-topology trigger: KS/Firecrawl -> IC receiver.
+
+Submits a small real crawl and points Firecrawl's signed webhook at the IC
+receiver. Firecrawl runs in Docker; the IC receiver runs on the host, so the
+webhook URL must use host.docker.internal (already mapped via extra_hosts in
+docker-compose.yaml), NOT localhost/127.0.0.1.
+
+Config via env (all optional, sane defaults for a local test):
+  FIRECRAWL_URL   default http://localhost:3002
+  FIRECRAWL_KEY   default "offline-local" (auth is bypassed in self-hosted mode)
+  CRAWL_TARGET    default https://httpbin.org/html
+  CRAWL_LIMIT     default 2
+  IC_WEBHOOK_URL  default http://host.docker.internal:8009/webhook/firecrawl
+"""
+import asyncio
+import os
+
+import httpx
+
+FIRECRAWL_URL = os.environ.get("FIRECRAWL_URL", "http://localhost:3002")
+FIRECRAWL_KEY = os.environ.get("FIRECRAWL_KEY", "offline-local")
+CRAWL_TARGET = os.environ.get("CRAWL_TARGET", "https://httpbin.org/html")
+CRAWL_LIMIT = int(os.environ.get("CRAWL_LIMIT", "2"))
+IC_WEBHOOK_URL = os.environ.get(
+    "IC_WEBHOOK_URL", "http://host.docker.internal:8009/webhook/firecrawl"
+)
+
+
+async def run():
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        r = await client.get(f"{FIRECRAWL_URL}/")
+        print(f"[health] GET / -> {r.status_code}")
+
+        payload = {
+            "url": CRAWL_TARGET,
+            "limit": CRAWL_LIMIT,
+            "webhook": IC_WEBHOOK_URL,
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {FIRECRAWL_KEY}",
+        }
+        print(f"[crawl] target={CRAWL_TARGET} limit={CRAWL_LIMIT}")
+        print(f"[crawl] webhook -> {IC_WEBHOOK_URL}")
+        r = await client.post(
+            f"{FIRECRAWL_URL}/v1/crawl", json=payload, headers=headers
+        )
+        print(f"[crawl] POST /v1/crawl -> {r.status_code}: {r.text[:200]}")
+        if r.status_code != 200:
+            return
+
+        crawl_id = r.json()["id"]
+        print(f"[crawl] id = {crawl_id}")
+
+        for i in range(30):
+            await asyncio.sleep(5)
+            r = await client.get(
+                f"{FIRECRAWL_URL}/v1/crawl/{crawl_id}", headers=headers
+            )
+            body = r.json()
+            print(
+                f"[poll {i}] status={body.get('status')} "
+                f"completed={body.get('completed')}/{body.get('total')}"
+            )
+            if body.get("status") in ("completed", "failed"):
+                print(f"[done] final crawl status = {body.get('status')}")
+                return
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
### Summary
Introduces standalone Python utility scripts for developer testing and branch maintenance:
- `regression_test.py`: Quick regression testing against local or hosted endpoints.
- `test_crawl.py`: Scripted testing verification for batch scrape/crawl flows.
- `safe_cherry_pick.py`: Helper script to cleanly cherry-pick upstream commits with automated conflict verification.

### Why
Provides contributors and maintainers with lightweight, scriptable tooling to rapidly verify local API behavior and safely port patches across forks or maintenance branches without requiring full Jest harness spin-up for quick smoke checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three developer scripts for quick regression checks, end-to-end crawl testing, and safer cherry-picks. Speeds up local testing and reduces risk when porting commits.

- **New Features**
  - regression_test.py: Runs smoke tests against /test and /v1/scrape for sample HTML/PDF URLs; validates markdown; fails fast.
  - test_crawl.py: Triggers a small crawl with a signed webhook to host (host.docker.internal); polls status; env-configurable.
  - safe_cherry_pick.py: Cherry-picks with guardrails; blocks locked files; auto-resolves version-only conflicts in `apps/js-sdk/firecrawl/package.json`; runs TypeScript check and Docker build when boundary files change.

<sup>Written for commit 3d1b20f391b66d11a5328eeb951aaf7c00b3f3c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

