### PR TITLE
fix(api): add company group to api_surface_first_used

### DIFF
--- a/apps/api/src/services/posthog.ts
+++ b/apps/api/src/services/posthog.ts
@@ -118,6 +118,20 @@ async function resolveDistinctId(
   }
 }
 
+/** The org a team belongs to, for the PostHog `company` ($group_0) group. */
+async function resolveOrgId(teamId: string): Promise<string | null> {
+  try {
+    const rows = await dbRr
+      .select({ orgId: schema.teams.org_id })
+      .from(schema.teams)
+      .where(eq(schema.teams.id, teamId))
+      .limit(1);
+    return rows[0]?.orgId ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Emit a one-time `api_surface_first_used` event the first time a team makes a
  * request from a given surface (playground / sdk / mcp / cli / api / ...).
@@ -162,7 +176,10 @@ export function trackFirstSurfaceUse(args: {
 
       // Key to the person (api-key owner email) so the event attributes to the
       // same PostHog person the dashboard identifies, e.g. for experiments.
-      const distinctId = await resolveDistinctId(teamId, apiKeyId);
+      const [distinctId, orgId] = await Promise.all([
+        resolveDistinctId(teamId, apiKeyId),
+        resolveOrgId(teamId),
+      ]);
 
       capturePostHog("api_surface_first_used", distinctId, {
         surface,
@@ -171,8 +188,9 @@ export function trackFirstSurfaceUse(args: {
         kind,
         api_version: apiVersion,
         team_id: teamId,
-        // Associate with the PostHog `team` group for team-level analysis.
-        $groups: { team: teamId },
+        // Associate with the PostHog `team` ($group_1) and, when resolvable, the
+        // `company` ($group_0) groups for group-level analysis.
+        $groups: { team: teamId, ...(orgId ? { company: orgId } : {}) },
       });
     } catch (error) {
       _logger.debug("trackFirstSurfaceUse failed", {


### PR DESCRIPTION
## What

The `api_surface_first_used` PostHog event (`apps/api/src/services/posthog.ts` → `trackFirstSurfaceUse`) only associated the `team` (`$group_1`) group. This adds the `company` (`$group_0`) group by resolving the team's org via `teams.org_id`.

## How

- Add a `resolveOrgId(teamId)` helper next to `resolveDistinctId`, reading `teams.org_id` through the same `dbRr` connection the file already uses. Best-effort: returns `null` on any error.
- Resolve it alongside `distinctId` in a single `Promise.all`, and include `company` in `$groups` only when the org resolves.

## Verification

- Confirmed `schema.teams` exists in the API's drizzle schema (`apps/api/src/db/schema/public.ts:645`) with an `org_id` column (`uuid`, `notNull`, line 657).
- Mirrors the existing `resolveDistinctId` pattern (same `eq` / `dbRr` / `schema` imports).

## Caveat

Forward-only. The 100k+ historical `api_surface_first_used` events cannot be backfilled with a group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach the PostHog `company` ($group_0) group to `api_surface_first_used` events by resolving a team’s org via `teams.org_id`. This enables company-level analysis; existing events are unchanged.

- **Bug Fixes**
  - Added `resolveOrgId(teamId)` to read `schema.teams.org_id` and return `null` on errors.
  - Resolve `distinctId` and `orgId` together, and include `company` in `$groups` only when available (keeps `team`).
  - Forward-only change; historical events are not backfilled.

<sup>Written for commit 9a8d7b3ef077e9f0fa07763496feacedb97a7334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

