### PR TITLE
fix(api): bump default timeout for branding format

### DIFF
--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1523,6 +1523,30 @@ describe("V2 Types Validation", () => {
       expect(result.waitFor).toBeGreaterThanOrEqual(5000); // Should be at least 5000
     });
 
+    it("should handle branding format timeout transformation", () => {
+      const input: ScrapeRequestInput = {
+        url: "https://example.com",
+        formats: [{ type: "branding" }],
+        timeout: 30000,
+        proxy: "basic", // Use basic proxy to avoid auto/stealth timeout transformation
+      };
+
+      const result = scrapeRequestSchema.parse(input);
+      expect(result.timeout).toBe(120000); // Should be transformed
+    });
+
+    it("should not override an explicit timeout for branding format", () => {
+      const input: ScrapeRequestInput = {
+        url: "https://example.com",
+        formats: [{ type: "branding" }],
+        timeout: 90000,
+        proxy: "basic",
+      };
+
+      const result = scrapeRequestSchema.parse(input);
+      expect(result.timeout).toBe(90000); // Explicit timeout is respected
+    });
+
     it("should handle json format timeout transformation", () => {
       const input: ScrapeRequestInput = {
         url: "https://example.com",

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -767,6 +767,16 @@ const extractTransformImpl = <T extends ScrapeOptionsBase | undefined>(
     result = { ...result, timeout: 60000 };
   }
 
+  // Branding always requires a full chrome-cdp render (no index cache), loads
+  // media, runs an in-page extraction script, and makes an LLM call — on heavy
+  // pages this routinely exceeds 30s, so give it the same headroom as stealth.
+  if (
+    obj.formats.find(x => typeof x === "object" && x.type === "branding") &&
+    obj.timeout === 30000
+  ) {
+    result = { ...result, timeout: 120000 };
+  }
+
   if (
     (obj.proxy === "stealth" ||
       obj.proxy === "enhanced" ||


### PR DESCRIPTION
## What

Bumps the default timeout to 120s when the `branding` format is requested and the user did not set an explicit timeout (same pattern as the existing `json`/`changeTracking` 60s bumps and the stealth-proxy 120s bump in `extractTransformImpl`).

## Why

Branding is the heaviest format we have, but it was the only heavy format with no timeout bump:

- the index cache is disabled for it, so it always does a full chrome-cdp render
- it sets `blockMedia: false` and injects a 2s settle wait
- it runs a large in-page extraction script
- it makes a synchronous LLM call inside the timeout budget

On JS-heavy pages a branding scrape routinely needs 100–120s (verified against production data for a customer report: branding scrapes of a heavy page consistently completed in 101–118s and always died at a 90s cap). With the 30s default it times out on exactly the sites customers most want branding from.

Explicit user-set timeouts are still respected — the bump only applies to the schema default.

## Tests

Added two cases to `snips/v2/types-validation.test.ts`: default is transformed to 120000, and an explicit 90000 is left untouched. Full file passes (116 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx6pZQ6JaKSURsF2owpsFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the default timeout to 120s for the `branding` format when no explicit timeout is set, matching existing bumps for `json`/`changeTracking` and stealth proxy. This reduces timeouts on heavy, JS-heavy pages while respecting user-set timeouts.

- **Bug Fixes**
  - In `extractTransformImpl`, if `branding` is requested and timeout is `30000`, set it to `120000`.
  - Added tests to verify the default transforms to `120000` and that an explicit timeout (e.g., `90000`) is preserved.

<sup>Written for commit 51a4640558cac842d2196eed8b7b9ca88355dd1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

