### PR TITLE
perf(branding): cut redundant DOM walks in the in-page script

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/branding-script/images.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/branding-script/images.ts
@@ -57,11 +57,18 @@ export const findImages = (): FindImagesResult => {
       seenRoots.add(root);
       roots.push(root);
       try {
+        // Push discovered roots in reverse so pop() visits siblings in
+        // document order — preserving the previous recursive (pre-order DFS)
+        // traversal, which candidate dedup depends on for first-seen ties.
+        const discovered: ShadowRoot[] = [];
         root.querySelectorAll("*").forEach(el => {
           const shadow = (el as Element & { shadowRoot?: ShadowRoot })
             .shadowRoot;
-          if (shadow) pending.push(shadow);
+          if (shadow) discovered.push(shadow);
         });
+        for (let i = discovered.length - 1; i >= 0; i--) {
+          pending.push(discovered[i]);
+        }
       } catch (_) {
         // Ignore errors
       }

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/branding-script/images.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/branding-script/images.ts
@@ -45,27 +45,41 @@ export const findImages = (): FindImagesResult => {
     if (src) imgs.push({ type, src });
   };
 
-  const querySelectorAllIncludingShadowRoots = (
-    selector: string,
-  ): Element[] => {
-    const results: Element[] = [];
+  // Discover shadow roots once — walking every element per selector query is
+  // O(selectors × DOM) and stalls the renderer on large pages.
+  const allQueryRoots: Array<Document | ShadowRoot> = (() => {
+    const roots: Array<Document | ShadowRoot> = [];
     const seenRoots = new Set<Document | ShadowRoot>();
-    function walk(root: Document | ShadowRoot): void {
-      if (!root || seenRoots.has(root)) return;
+    const pending: Array<Document | ShadowRoot> = [document];
+    while (pending.length > 0) {
+      const root = pending.pop()!;
+      if (!root || seenRoots.has(root)) continue;
       seenRoots.add(root);
+      roots.push(root);
       try {
-        const list = root.querySelectorAll(selector);
-        list.forEach(el => results.push(el));
         root.querySelectorAll("*").forEach(el => {
-          if ((el as Element & { shadowRoot?: ShadowRoot }).shadowRoot) {
-            walk((el as Element & { shadowRoot: ShadowRoot }).shadowRoot);
-          }
+          const shadow = (el as Element & { shadowRoot?: ShadowRoot })
+            .shadowRoot;
+          if (shadow) pending.push(shadow);
         });
       } catch (_) {
         // Ignore errors
       }
     }
-    walk(document);
+    return roots;
+  })();
+
+  const querySelectorAllIncludingShadowRoots = (
+    selector: string,
+  ): Element[] => {
+    const results: Element[] = [];
+    for (const root of allQueryRoots) {
+      try {
+        root.querySelectorAll(selector).forEach(el => results.push(el));
+      } catch (_) {
+        // Ignore errors
+      }
+    }
     return results;
   };
 
@@ -1031,12 +1045,9 @@ export const findImages = (): FindImagesResult => {
   const allElementsWithBg = Array.from(document.querySelectorAll("div, span"));
 
   const allDivsWithBgImage = allElementsWithBg.filter(el => {
-    const style = getComputedStyleCached(el);
-    const bgImage = style.getPropertyValue("background-image");
-    const bgImageUrl = extractBackgroundImageUrl(bgImage);
-
-    if (!bgImageUrl) return false;
-
+    // Cheap attribute/DOM checks first — reading computed style on every
+    // div/span forces style recalc across the page and stalls the renderer
+    // on style-heavy pages (e.g. lots of backdrop-filter).
     const className = el.className || "";
     const parentLink = el.closest("a");
 
@@ -1054,13 +1065,20 @@ export const findImages = (): FindImagesResult => {
     const inHeaderNavCheck =
       el.closest('header, nav, [role="banner"]') !== null;
 
-    return (
+    const hasLogoIndicators =
       hasLogoDataAttr ||
       hasLogoClass ||
       (hasLogoAriaLabel && hasHomeHrefCheck) ||
       (hasLogoAriaLabel && inHeaderNavCheck) ||
-      (hasHomeHrefCheck && inHeaderNavCheck)
-    );
+      (hasHomeHrefCheck && inHeaderNavCheck);
+
+    if (!hasLogoIndicators) return false;
+
+    const style = getComputedStyleCached(el);
+    const bgImage = style.getPropertyValue("background-image");
+    const bgImageUrl = extractBackgroundImageUrl(bgImage);
+
+    return !!bgImageUrl;
   });
 
   allDivsWithBgImage.forEach(el => {


### PR DESCRIPTION
## What

Two contained performance fixes in the branding extraction script (`branding-script/images.ts`):

1. **Shadow-root discovery is now done once per run.** `querySelectorAllIncludingShadowRoots` re-walked the entire DOM (`querySelectorAll('*')` per root) on every call — and it's called ~58 times (logo selectors + container selectors + img/svg/a sweeps). That's O(selectors × DOM) renderer work inside the scrape budget. The root list is now discovered once and reused for every selector query.

2. **The div/span background-image sweep does cheap checks first.** It previously forced a computed-style read on *every* div/span on the page before applying its cheap attribute/class/ancestry filters. On style-recalc-heavy pages (many `backdrop-filter` layers, common with Tailwind) each forced read is expensive. Attribute checks now run first; computed style is only read for elements that pass.

## Behavior

No output change — the final predicate and candidate collection are identical, only evaluation order/caching changed. Verified against a live production page: identical `logoCandidates` output from the old and new bundles, both via chrome-cdp `executeJavascript`.

## Context

Found while investigating slow branding scrapes on style-heavy pages (customer report of consistent `SCRAPE_TIMEOUT` on `formats: [branding]`). Companion fixes in fire-engine address the larger stalls; this removes the branding script's own worst-case DOM cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx6pZQ6JaKSURsF2owpsFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the branding in-page script by removing redundant DOM walks and avoiding unnecessary computed-style reads. This reduces stalls on style-heavy pages and helps prevent scrape timeouts; output is unchanged.

- **Refactors**
  - Cache shadow roots once and reuse them for all selector queries in `querySelectorAllIncludingShadowRoots`; preserve document-order traversal to keep first-seen dedup stable.
  - In the div/span background-image sweep, run cheap attribute/DOM checks first and only read computed style for likely candidates.

<sup>Written for commit a95b4767b6f196a86f1125b52f0434d2f75a6e90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

