### PR TITLE
fix(docker-compose): honor REDIS_RATE_LIMIT_URL instead of ignoring it

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ x-common-service: &common-service
 
 x-common-env: &common-env
   REDIS_URL: ${REDIS_URL:-redis://redis:6379}
-  REDIS_RATE_LIMIT_URL: ${REDIS_URL:-redis://redis:6379}
+  REDIS_RATE_LIMIT_URL: ${REDIS_RATE_LIMIT_URL:-${REDIS_URL:-redis://redis:6379}}
   PLAYWRIGHT_MICROSERVICE_URL: ${PLAYWRIGHT_MICROSERVICE_URL:-http://playwright-service:3000/scrape}
   POSTGRES_USER: ${POSTGRES_USER:-postgres}
   POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"


### PR DESCRIPTION
# Description

Fixes #4104

## Problem

In `docker-compose.yaml`, the shared environment block interpolated `REDIS_RATE_LIMIT_URL` from the wrong variable:

```yaml
REDIS_URL: ${REDIS_URL:-redis://redis:6379}
REDIS_RATE_LIMIT_URL: ${REDIS_URL:-redis://redis:6379} # interpolates ${REDIS_URL}
```

`.env.example` documents `REDIS_RATE_LIMIT_URL` as a separately configurable setting, and the API reads it as an independent configuration value in:

- `apps/api/src/services/rate-limiter.ts`
- `apps/api/src/services/redlock.ts`
- `apps/api/src/services/redis.ts` (where it also serves as the fallback for `REDIS_EVICT_URL`)

However, when running via Docker Compose, any value provided for `REDIS_RATE_LIMIT_URL` was silently ignored. As a result, the rate-limit Redis client, Redlock, and the `REDIS_EVICT_URL` fallback all connected to whatever `REDIS_URL` resolved to.

---

## Fix

Updated the Compose interpolation to use the correct variable while preserving backward compatibility:

```yaml
REDIS_RATE_LIMIT_URL: ${REDIS_RATE_LIMIT_URL:-${REDIS_URL:-redis://redis:6379}}
```

The nested fallback is intentional:

```
REDIS_RATE_LIMIT_URL
        ↓
    REDIS_URL
        ↓
redis://redis:6379
```

Because of the original bug, deployments that only define `REDIS_URL` currently receive that value for **both** variables. Using a simpler fallback such as:

```yaml
REDIS_RATE_LIMIT_URL: ${REDIS_RATE_LIMIT_URL:-redis://redis:6379}
```

would unintentionally change the behavior of those existing deployments by redirecting the rate limiter to the internal `redis` container.

The nested fallback fixes the bug while preserving the current behavior for deployments that rely only on `REDIS_URL`.

---

## Why This Works

- Allows `REDIS_RATE_LIMIT_URL` to be configured independently, as documented.
- Preserves existing behavior when only `REDIS_URL` is defined.
- Falls back to the default internal Redis container only when neither variable is set.
- Uses standard Compose variable interpolation syntax supported by Docker Compose v2 (which this repository already requires via the top-level `name:` field).

---

## Verification

Verified using `docker compose config`:

| Configuration | Result |
|---------------|--------|
| Nothing set | `REDIS_RATE_LIMIT_URL=redis://redis:6379` |
| `REDIS_URL=redis://external:6380` | `REDIS_RATE_LIMIT_URL=redis://external:6380` *(unchanged from previous behavior)* |
| `REDIS_RATE_LIMIT_URL=redis://ratelimit:7000` | `REDIS_RATE_LIMIT_URL=redis://ratelimit:7000` *(previously ignored, now respected)* |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker Compose so REDIS_RATE_LIMIT_URL is respected instead of being ignored, preventing rate limiter and Redlock from unintentionally using REDIS_URL. Uses a nested default to keep existing deployments working.

- **Bug Fixes**
  - Update docker-compose to read REDIS_RATE_LIMIT_URL with fallback to REDIS_URL, then redis://redis:6379.
  - Enables independent configuration for rate limiter and Redlock without breaking setups that only set REDIS_URL.

<sup>Written for commit 2ac9221ac5b45ca9f13393c7dac6dccb709afd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

