### PR TITLE
fix: disable auto-pagination in batch status polling

### DIFF
--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -531,7 +531,10 @@ class AsyncFirecrawlClient:
     async def wait_batch_scrape(self, job_id: str, poll_interval: int = 2, timeout: Optional[int] = None) -> Any:
         start = asyncio.get_event_loop().time()
         while True:
-            status = await async_batch.get_batch_scrape_status(self.async_http_client, job_id)
+            status = await async_batch.get_batch_scrape_status(
+                self.async_http_client, job_id,
+                pagination_config=PaginationConfig(auto_paginate=False)
+            )
             if status.status in ["completed", "failed", "cancelled"]:
                 return status
             if timeout and (asyncio.get_event_loop().time() - start) > timeout:

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -316,7 +316,10 @@ def wait_for_batch_completion(
     start_time = time.monotonic()
     
     while True:
-        status_job = get_batch_scrape_status(client, job_id)
+        status_job = get_batch_scrape_status(
+            client, job_id,
+            pagination_config=PaginationConfig(auto_paginate=False)
+        )
         
         # Check if job is complete
         if status_job.status in ["completed", "failed", "cancelled"]:


### PR DESCRIPTION
wait_for_batch_completion and wait_batch_scrape call get_batch_scrape_status
without passing a pagination_config. When pagination_config is None, the
default auto_paginate=True kicks in, causing every page of results to be
fetched and materialized in memory — only to be discarded (the waiter only
checks status.status).

Pass PaginationConfig(auto_paginate=False) to avoid unnecessary pagination
during status polling.

Fixes #4107


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable auto-pagination while polling batch status to avoid fetching all pages and loading them into memory. This reduces unnecessary requests and memory use. Fixes #4107.

- **Bug Fixes**
  - Updated `wait_for_batch_completion` and `wait_batch_scrape` to call `get_batch_scrape_status` with `pagination_config=PaginationConfig(auto_paginate=False)` so only the status is fetched.

<sup>Written for commit 62bf78d61ea296807229bf7150b8173b07b530c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

