### PR TITLE
fix(api): keep branding-only scrapes off the render engine

### DIFF
--- a/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
+++ b/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
@@ -31,6 +31,34 @@ describe("shouldForceNonRender", () => {
     ).toBe(false);
   });
 
+  it("still opts out with DOM-only user actions", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding"]),
+        actions: [
+          { type: "wait" },
+          { type: "click" },
+          { type: "scroll" },
+          { type: "write" },
+          { type: "press" },
+          { type: "scrape" },
+          { type: "executeJavascript" },
+        ],
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps render routing for unknown/future action types (fail safe)", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding"]),
+        actions: [{ type: "someFutureVisualAction" }],
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+  });
+
   it("keeps render routing when a pdf action is requested", () => {
     expect(
       shouldForceNonRender({

--- a/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
+++ b/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
@@ -31,6 +31,16 @@ describe("shouldForceNonRender", () => {
     ).toBe(false);
   });
 
+  it("keeps render routing when a pdf action is requested", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding"]),
+        actions: [{ type: "pdf" }],
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+  });
+
   it("keeps render routing for audio/video formats", () => {
     expect(
       shouldForceNonRender({

--- a/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
+++ b/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
@@ -1,0 +1,73 @@
+import { shouldForceNonRender } from "../../scraper/scrapeURL/engines/fire-engine";
+
+const fmt = (types: string[]) => types.map(type => ({ type })) as any;
+
+describe("shouldForceNonRender", () => {
+  it("opts branding-only scrapes out of render routing", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding"]),
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps render routing when a screenshot format is requested", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding", "screenshot"]),
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps render routing when a screenshot action is requested", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding"]),
+        actions: [{ type: "wait" }, { type: "screenshot" }],
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps render routing for audio/video formats", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding", "audio"]),
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding", "video"]),
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps render routing when the media postprocessor will run", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["branding"]),
+        youtubePostprocessorWillRun: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does nothing for non-branding scrapes", () => {
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["markdown"]),
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldForceNonRender({
+        formats: fmt(["markdown"]),
+        actions: [{ type: "wait" }],
+        youtubePostprocessorWillRun: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -288,7 +288,9 @@ export function shouldForceNonRender(input: {
 
   const needsVisualRendering =
     hasFormatOfType(input.formats, "screenshot") !== undefined ||
-    (input.actions ?? []).some(a => a.type === "screenshot") ||
+    (input.actions ?? []).some(
+      a => a.type === "screenshot" || a.type === "pdf",
+    ) ||
     hasFormatOfType(input.formats, "audio") !== undefined ||
     hasFormatOfType(input.formats, "video") !== undefined ||
     input.youtubePostprocessorWillRun;

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -273,6 +273,29 @@ async function performFireEngineScrape<
   });
 }
 
+// Branding needs media *loaded* (real image dimensions in the DOM), not
+// *rendered* — but blockMedia: false routes to the render engine, where
+// visually heavy pages can stall the renderer. Opt out of render routing
+// unless something actually needs visual output.
+export function shouldForceNonRender(input: {
+  formats: Meta["options"]["formats"];
+  actions?: Array<{ type: string }>;
+  youtubePostprocessorWillRun: boolean;
+}): boolean {
+  if (!hasFormatOfType(input.formats, "branding")) {
+    return false;
+  }
+
+  const needsVisualRendering =
+    hasFormatOfType(input.formats, "screenshot") !== undefined ||
+    (input.actions ?? []).some(a => a.type === "screenshot") ||
+    hasFormatOfType(input.formats, "audio") !== undefined ||
+    hasFormatOfType(input.formats, "video") !== undefined ||
+    input.youtubePostprocessorWillRun;
+
+  return !needsVisualRendering;
+}
+
 export async function scrapeURLWithFireEngineChromeCDP(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
@@ -360,18 +383,11 @@ export async function scrapeURLWithFireEngineChromeCDP(
       hasFormatOfType(meta.options.formats, "branding") ||
       shouldRunYoutubePostprocessor;
 
-    // Branding needs media *loaded* (real image dimensions in the DOM), not
-    // *rendered* — but blockMedia: false routes to the render engine, where
-    // visually heavy pages can stall the renderer. Opt out of render routing
-    // unless something actually needs visual output.
-    const needsVisualRendering =
-      hasFormatOfType(meta.options.formats, "screenshot") !== undefined ||
-      (meta.options.actions ?? []).some(a => a.type === "screenshot") ||
-      hasAudio ||
-      hasVideo ||
-      shouldRunYoutubePostprocessor;
-    const forceNonRender =
-      hasBranding && shouldAllowMedia && !needsVisualRendering;
+    const forceNonRender = shouldForceNonRender({
+      formats: meta.options.formats,
+      actions: meta.options.actions ?? undefined,
+      youtubePostprocessorWillRun: shouldRunYoutubePostprocessor,
+    });
 
     const request: FireEngineScrapeRequestCommon &
       FireEngineScrapeRequestChromeCDP = {

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -273,6 +273,19 @@ async function performFireEngineScrape<
   });
 }
 
+// Action types that only read or drive the DOM and don't depend on rendered
+// output. Anything not listed here (screenshot, pdf, and any future visual
+// action) keeps render-engine routing — fail safe, not open.
+const DOM_SAFE_ACTION_TYPES: ReadonlySet<string> = new Set([
+  "wait",
+  "click",
+  "write",
+  "press",
+  "scroll",
+  "scrape",
+  "executeJavascript",
+]);
+
 // Branding needs media *loaded* (real image dimensions in the DOM), not
 // *rendered* — but blockMedia: false routes to the render engine, where
 // visually heavy pages can stall the renderer. Opt out of render routing
@@ -288,9 +301,7 @@ export function shouldForceNonRender(input: {
 
   const needsVisualRendering =
     hasFormatOfType(input.formats, "screenshot") !== undefined ||
-    (input.actions ?? []).some(
-      a => a.type === "screenshot" || a.type === "pdf",
-    ) ||
+    (input.actions ?? []).some(a => !DOM_SAFE_ACTION_TYPES.has(a.type)) ||
     hasFormatOfType(input.formats, "audio") !== undefined ||
     hasFormatOfType(input.formats, "video") !== undefined ||
     input.youtubePostprocessorWillRun;

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -360,6 +360,19 @@ export async function scrapeURLWithFireEngineChromeCDP(
       hasFormatOfType(meta.options.formats, "branding") ||
       shouldRunYoutubePostprocessor;
 
+    // Branding needs media *loaded* (real image dimensions in the DOM), not
+    // *rendered* — but blockMedia: false routes to the render engine, where
+    // visually heavy pages can stall the renderer. Opt out of render routing
+    // unless something actually needs visual output.
+    const needsVisualRendering =
+      hasFormatOfType(meta.options.formats, "screenshot") !== undefined ||
+      (meta.options.actions ?? []).some(a => a.type === "screenshot") ||
+      hasAudio ||
+      hasVideo ||
+      shouldRunYoutubePostprocessor;
+    const forceNonRender =
+      hasBranding && shouldAllowMedia && !needsVisualRendering;
+
     const request: FireEngineScrapeRequestCommon &
       FireEngineScrapeRequestChromeCDP = {
       url: meta.rewrittenUrl ?? meta.url,
@@ -385,6 +398,7 @@ export async function scrapeURLWithFireEngineChromeCDP(
         meta.internalOptions.saveScrapeResultToGCS,
       zeroDataRetention: meta.internalOptions.zeroDataRetention,
       ...(shouldAllowMedia ? { blockMedia: false } : {}),
+      ...(forceNonRender ? { forceNonRender: true } : {}),
       persistentStorage: meta.options.profile
         ? {
             uniqueId: `${createHash("sha256").update(meta.internalOptions.teamId).digest("hex").slice(0, 16)}_${meta.options.profile.name}`,

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -61,6 +61,8 @@ export type FireEngineScrapeRequestChromeCDP = {
   skipTlsVerification?: boolean;
   actions?: InternalAction[];
   blockMedia?: boolean;
+  /** Opt out of render-engine routing (blockMedia: false normally forces it). */
+  forceNonRender?: boolean;
   mobile?: boolean;
   disableSmartWaitCache?: boolean;
   persistentStorage?: { uniqueId: string };


### PR DESCRIPTION
## What

When the `branding` format is the only reason media is unblocked (`blockMedia: false`), pass a `forceNonRender` hint so the scrape stays on the standard browser engine. Anything that actually needs visual output — screenshot format or action, audio/video, media postprocessing — keeps its current routing.

Until the upstream side of the flag deploys, the extra field is ignored (no behavior change), so merge order is safe in either direction.

## Why

Branding needs media **loaded** so logo candidates have real image dimensions in the DOM — it never reads pixels. But media loading is currently treated as a signal that visual rendering is wanted, which routes branding scrapes to a rendering-focused engine. On visually heavy pages (large animated/filtered surfaces), real rendering can block the page's main thread for extended periods, which stalls the in-page branding script and times out the scrape.

An in-page event-loop probe run simultaneously on both engines against such a page: 362 event-loop ticks per 1.5s on the standard engine vs 2 on the rendering engine, with a single main-thread task lasting ~90s — the difference between a ~6s scrape and a timeout. The branding script itself runs in single-digit milliseconds with identical output on the standard engine (validated over a 155-URL eval corpus, results on #4101).

## Tests

Schema/type tests pass; tsc/prettier clean. Will post before/after timings once the upstream flag is deployed to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx6pZQ6JaKSURsF2owpsFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route branding-only scrapes to the standard engine by sending a `forceNonRender` hint when media is unblocked but no visual output is needed. Now uses an allow-list of DOM-safe actions so unknown/future visual actions stay on the render engine.

- **Bug Fixes**
  - Added `forceNonRender` to the Chrome CDP request; exported `shouldForceNonRender` with unit tests.
  - Opt out only with a DOM-safe action allow-list: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`. Any other action, `pdf`/`screenshot`, audio/video formats, or the YouTube postprocessor keep render routing.
  - Set `forceNonRender: true` only for branding-only scrapes with media allowed. No-op until the upstream router supports the flag.

<sup>Written for commit 5c49cfc5e63f4e728e3163bdbb17a545a19600a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

