### PR TITLE
fix(api): bill all /search/research endpoints against search credits

### DIFF
--- a/apps/api/src/controllers/v2/research-proxy.test.ts
+++ b/apps/api/src/controllers/v2/research-proxy.test.ts
@@ -2,21 +2,15 @@ import { vi } from "vitest";
 import express from "express";
 import request from "supertest";
 
-// ---------------------------------------------------------------------------
-// Mocks — hoisted above imports by Vitest. The research controller is billed
-// fire-and-forget through billTeam and reaches an upstream service over undici;
-// stub both so the route-level tests can assert the billing metadata without a
-// live proxy or real Autumn/DB calls.
-// ---------------------------------------------------------------------------
-
+// Stub billing and the upstream fetch so route tests can assert billing
+// metadata without a live proxy or real Autumn/DB calls.
 const billTeamMock = vi.fn().mockResolvedValue({ success: true });
 vi.mock("../../services/billing/credit_billing", () => ({
   billTeam: (...args: any[]) => billTeamMock(...args),
 }));
 
 const fetchMock = vi.fn();
-// Only stub `fetch`; keep the real Agent/interceptors so other modules in the
-// import graph (e.g. safeFetch) that rely on `Agent.compose` still work.
+// Stub only `fetch`; keep the real Agent/interceptors that other modules need.
 vi.mock("undici", async () => {
   const actual = await vi.importActual<typeof import("undici")>("undici");
   return { ...actual, fetch: (...args: any[]) => fetchMock(...args) };
@@ -44,8 +38,7 @@ import {
 } from "./research-proxy";
 import type { RequestWithAuth } from "../v1/types";
 
-// The research proxy only reads `costModel` off the endpoint config when
-// computing credits, so a partial cast keeps these fixtures focused.
+// computeResearchCredits only reads `costModel`, so a partial cast suffices.
 const flatEndpoint = { costModel: "flat" } as any;
 const perResultEndpoint = { costModel: "perResult" } as any;
 
@@ -59,8 +52,6 @@ function reqWithFlags(flags?: Record<string, unknown>) {
 
 describe("research proxy billing", () => {
   it("bills the shared research billing endpoint against the search-credits pool", () => {
-    // The billing endpoint must resolve to SEARCH_CREDITS so search credits
-    // pay for the special search endpoints.
     expect(featureIdForBillingEndpoint(RESEARCH_BILLING_ENDPOINT)).toBe(
       SEARCH_CREDITS_FEATURE_ID,
     );
@@ -69,8 +60,7 @@ describe("research proxy billing", () => {
     );
   });
 
-  it("charges a flat scrape-like credit for read/inspect endpoints", () => {
-    // The flat cost model is independent of any returned results.
+  it("charges a flat credit for read/inspect regardless of results", () => {
     expect(computeResearchCredits(flatEndpoint, {}, reqWithFlags())).toBe(1);
     expect(
       computeResearchCredits(
@@ -106,11 +96,7 @@ describe("research proxy billing", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Route-level coverage: exercise every mounted endpoint through the real
-// router and assert each one submits the search-credits billing endpoint.
-// ---------------------------------------------------------------------------
-
+// Drive every mounted route and assert each submits the search-credits endpoint.
 describe("research proxy routes bill against search credits", () => {
   let originalProxyUrl: string | undefined;
 
@@ -146,8 +132,6 @@ describe("research proxy routes bill against search credits", () => {
     billTeamMock.mockResolvedValue({ success: true });
   });
 
-  // Each case returns at least one result so the per-result endpoints incur a
-  // charge; the flat read endpoint charges regardless of the body shape.
   const cases: Array<{ name: string; path: string; query: Record<string, string> }> = [
     { name: "papers search", path: "/search/research/papers", query: { query: "rag" } },
     {

--- a/apps/api/src/controllers/v2/research-proxy.test.ts
+++ b/apps/api/src/controllers/v2/research-proxy.test.ts
@@ -1,3 +1,37 @@
+import { vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted above imports by Vitest. The research controller is billed
+// fire-and-forget through billTeam and reaches an upstream service over undici;
+// stub both so the route-level tests can assert the billing metadata without a
+// live proxy or real Autumn/DB calls.
+// ---------------------------------------------------------------------------
+
+const billTeamMock = vi.fn().mockResolvedValue({ success: true });
+vi.mock("../../services/billing/credit_billing", () => ({
+  billTeam: (...args: any[]) => billTeamMock(...args),
+}));
+
+const fetchMock = vi.fn();
+// Only stub `fetch`; keep the real Agent/interceptors so other modules in the
+// import graph (e.g. safeFetch) that rely on `Agent.compose` still work.
+vi.mock("undici", async () => {
+  const actual = await vi.importActual<typeof import("undici")>("undici");
+  return { ...actual, fetch: (...args: any[]) => fetchMock(...args) };
+});
+
+vi.mock("../../services/logging/log_job", () => ({
+  logRequest: vi.fn().mockResolvedValue(undefined),
+  logResearchEndpoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../lib/keyless", () => ({
+  chargeKeylessCredits: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { config } from "../../config";
 import {
   featureIdForBillingEndpoint,
   SEARCH_CREDITS_FEATURE_ID,
@@ -6,6 +40,7 @@ import {
 import {
   RESEARCH_BILLING_ENDPOINT,
   computeResearchCredits,
+  createResearchRouter,
 } from "./research-proxy";
 import type { RequestWithAuth } from "../v1/types";
 
@@ -23,9 +58,9 @@ function reqWithFlags(flags?: Record<string, unknown>) {
 }
 
 describe("research proxy billing", () => {
-  it("bills every /search/research endpoint against the search-credits pool", () => {
-    // All research endpoints share this billing endpoint, and it must resolve
-    // to SEARCH_CREDITS so search credits pay for the special search endpoints.
+  it("bills the shared research billing endpoint against the search-credits pool", () => {
+    // The billing endpoint must resolve to SEARCH_CREDITS so search credits
+    // pay for the special search endpoints.
     expect(featureIdForBillingEndpoint(RESEARCH_BILLING_ENDPOINT)).toBe(
       SEARCH_CREDITS_FEATURE_ID,
     );
@@ -69,4 +104,79 @@ describe("research proxy billing", () => {
       ),
     ).toBe(20);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Route-level coverage: exercise every mounted endpoint through the real
+// router and assert each one submits the search-credits billing endpoint.
+// ---------------------------------------------------------------------------
+
+describe("research proxy routes bill against search credits", () => {
+  let originalProxyUrl: string | undefined;
+
+  const buildApp = () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).auth = { team_id: "team-123" };
+      (req as any).acuc = { api_key_id: 42, flags: null };
+      next();
+    });
+    app.use("/search/research", createResearchRouter());
+    return app;
+  };
+
+  const upstreamResponse = (body: unknown) => ({
+    status: 200,
+    ok: true,
+    headers: { get: () => null },
+    text: async () => JSON.stringify(body),
+  });
+
+  beforeAll(() => {
+    originalProxyUrl = config.RESEARCH_PROXY_URL;
+    config.RESEARCH_PROXY_URL = "http://research.test";
+  });
+
+  afterAll(() => {
+    config.RESEARCH_PROXY_URL = originalProxyUrl;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    billTeamMock.mockResolvedValue({ success: true });
+  });
+
+  // Each case returns at least one result so the per-result endpoints incur a
+  // charge; the flat read endpoint charges regardless of the body shape.
+  const cases: Array<{ name: string; path: string; query: Record<string, string> }> = [
+    { name: "papers search", path: "/search/research/papers", query: { query: "rag" } },
+    {
+      name: "similar papers",
+      path: "/search/research/papers/1706.03762/similar",
+      query: { intent: "attention" },
+    },
+    {
+      name: "paper read",
+      path: "/search/research/papers/1706.03762",
+      query: { query: "attention" },
+    },
+    { name: "github search", path: "/search/research/github", query: { query: "firecrawl" } },
+  ];
+
+  it.each(cases)(
+    "$name bills the search-credits endpoint",
+    async ({ path, query }) => {
+      fetchMock.mockResolvedValue(upstreamResponse({ results: [{ id: 1 }] }));
+
+      const res = await request(buildApp()).get(path).query(query);
+
+      expect(res.statusCode).toBe(200);
+      expect(billTeamMock).toHaveBeenCalledTimes(1);
+      const billing = billTeamMock.mock.calls[0][3];
+      expect(billing.endpoint).toBe(RESEARCH_BILLING_ENDPOINT);
+      expect(featureIdForBillingEndpoint(billing.endpoint)).toBe(
+        SEARCH_CREDITS_FEATURE_ID,
+      );
+    },
+  );
 });

--- a/apps/api/src/controllers/v2/research-proxy.test.ts
+++ b/apps/api/src/controllers/v2/research-proxy.test.ts
@@ -1,0 +1,72 @@
+import {
+  featureIdForBillingEndpoint,
+  SEARCH_CREDITS_FEATURE_ID,
+  CREDITS_FEATURE_ID,
+} from "../../services/autumn/autumn.service";
+import {
+  RESEARCH_BILLING_ENDPOINT,
+  computeResearchCredits,
+} from "./research-proxy";
+import type { RequestWithAuth } from "../v1/types";
+
+// The research proxy only reads `costModel` off the endpoint config when
+// computing credits, so a partial cast keeps these fixtures focused.
+const flatEndpoint = { costModel: "flat" } as any;
+const perResultEndpoint = { costModel: "perResult" } as any;
+
+function reqWithFlags(flags?: Record<string, unknown>) {
+  return { acuc: flags ? { flags } : undefined } as unknown as RequestWithAuth<
+    any,
+    any,
+    any
+  >;
+}
+
+describe("research proxy billing", () => {
+  it("bills every /search/research endpoint against the search-credits pool", () => {
+    // All research endpoints share this billing endpoint, and it must resolve
+    // to SEARCH_CREDITS so search credits pay for the special search endpoints.
+    expect(featureIdForBillingEndpoint(RESEARCH_BILLING_ENDPOINT)).toBe(
+      SEARCH_CREDITS_FEATURE_ID,
+    );
+    expect(featureIdForBillingEndpoint(RESEARCH_BILLING_ENDPOINT)).not.toBe(
+      CREDITS_FEATURE_ID,
+    );
+  });
+
+  it("charges a flat scrape-like credit for read/inspect endpoints", () => {
+    // The flat cost model is independent of any returned results.
+    expect(computeResearchCredits(flatEndpoint, {}, reqWithFlags())).toBe(1);
+    expect(
+      computeResearchCredits(
+        flatEndpoint,
+        { results: [1, 2, 3, 4, 5] },
+        reqWithFlags(),
+      ),
+    ).toBe(1);
+  });
+
+  it("scales per-result endpoints by returned result count", () => {
+    const body = { results: new Array(11).fill({}) };
+    // ceil(11 / 10) * 2 = 4
+    expect(computeResearchCredits(perResultEndpoint, body, reqWithFlags())).toBe(
+      4,
+    );
+    // No results → no charge.
+    expect(
+      computeResearchCredits(perResultEndpoint, { results: [] }, reqWithFlags()),
+    ).toBe(0);
+  });
+
+  it("applies the ZDR search-credit rate for forced-zdr teams", () => {
+    const body = { results: new Array(11).fill({}) };
+    // ceil(11 / 10) * 10 = 20
+    expect(
+      computeResearchCredits(
+        perResultEndpoint,
+        body,
+        reqWithFlags({ searchZDR: "forced-zdr" }),
+      ),
+    ).toBe(20);
+  });
+});

--- a/apps/api/src/controllers/v2/research-proxy.test.ts
+++ b/apps/api/src/controllers/v2/research-proxy.test.ts
@@ -29,82 +29,18 @@ import { config } from "../../config";
 import {
   featureIdForBillingEndpoint,
   SEARCH_CREDITS_FEATURE_ID,
-  CREDITS_FEATURE_ID,
 } from "../../services/autumn/autumn.service";
-import {
-  RESEARCH_BILLING_ENDPOINT,
-  computeResearchCredits,
-  createResearchRouter,
-} from "./research-proxy";
-import type { RequestWithAuth } from "../v1/types";
+import { createResearchRouter } from "./research-proxy";
 
-// computeResearchCredits only reads `costModel`, so a partial cast suffices.
-const flatEndpoint = { costModel: "flat" } as any;
-const perResultEndpoint = { costModel: "perResult" } as any;
-
-function reqWithFlags(flags?: Record<string, unknown>) {
-  return { acuc: flags ? { flags } : undefined } as unknown as RequestWithAuth<
-    any,
-    any,
-    any
-  >;
-}
-
+// Drive every mounted route and assert each bills against search credits.
 describe("research proxy billing", () => {
-  it("bills the shared research billing endpoint against the search-credits pool", () => {
-    expect(featureIdForBillingEndpoint(RESEARCH_BILLING_ENDPOINT)).toBe(
-      SEARCH_CREDITS_FEATURE_ID,
-    );
-    expect(featureIdForBillingEndpoint(RESEARCH_BILLING_ENDPOINT)).not.toBe(
-      CREDITS_FEATURE_ID,
-    );
-  });
-
-  it("charges a flat credit for read/inspect regardless of results", () => {
-    expect(computeResearchCredits(flatEndpoint, {}, reqWithFlags())).toBe(1);
-    expect(
-      computeResearchCredits(
-        flatEndpoint,
-        { results: [1, 2, 3, 4, 5] },
-        reqWithFlags(),
-      ),
-    ).toBe(1);
-  });
-
-  it("scales per-result endpoints by returned result count", () => {
-    const body = { results: new Array(11).fill({}) };
-    // ceil(11 / 10) * 2 = 4
-    expect(computeResearchCredits(perResultEndpoint, body, reqWithFlags())).toBe(
-      4,
-    );
-    // No results → no charge.
-    expect(
-      computeResearchCredits(perResultEndpoint, { results: [] }, reqWithFlags()),
-    ).toBe(0);
-  });
-
-  it("applies the ZDR search-credit rate for forced-zdr teams", () => {
-    const body = { results: new Array(11).fill({}) };
-    // ceil(11 / 10) * 10 = 20
-    expect(
-      computeResearchCredits(
-        perResultEndpoint,
-        body,
-        reqWithFlags({ searchZDR: "forced-zdr" }),
-      ),
-    ).toBe(20);
-  });
-});
-
-// Drive every mounted route and assert each submits the search-credits endpoint.
-describe("research proxy routes bill against search credits", () => {
   let originalProxyUrl: string | undefined;
 
-  const buildApp = () => {
+  const buildApp = (flags: unknown = null) => {
     const app = express();
     app.use((req, _res, next) => {
       (req as any).auth = { team_id: "team-123" };
-      (req as any).acuc = { api_key_id: 42, flags: null };
+      (req as any).acuc = { api_key_id: 42, flags };
       next();
     });
     app.use("/search/research", createResearchRouter());
@@ -132,35 +68,62 @@ describe("research proxy routes bill against search credits", () => {
     billTeamMock.mockResolvedValue({ success: true });
   });
 
-  const cases: Array<{ name: string; path: string; query: Record<string, string> }> = [
+  const billingOf = () => billTeamMock.mock.calls[0][3];
+  const creditsOf = () => billTeamMock.mock.calls[0][1];
+
+  const searchCases = [
     { name: "papers search", path: "/search/research/papers", query: { query: "rag" } },
     {
       name: "similar papers",
       path: "/search/research/papers/1706.03762/similar",
       query: { intent: "attention" },
     },
-    {
-      name: "paper read",
-      path: "/search/research/papers/1706.03762",
-      query: { query: "attention" },
-    },
     { name: "github search", path: "/search/research/github", query: { query: "firecrawl" } },
   ];
 
-  it.each(cases)(
-    "$name bills the search-credits endpoint",
+  it.each(searchCases)(
+    "$name bills search credits, scaled by result count",
     async ({ path, query }) => {
-      fetchMock.mockResolvedValue(upstreamResponse({ results: [{ id: 1 }] }));
+      fetchMock.mockResolvedValue(
+        upstreamResponse({ results: new Array(11).fill({}) }),
+      );
 
       const res = await request(buildApp()).get(path).query(query);
 
       expect(res.statusCode).toBe(200);
       expect(billTeamMock).toHaveBeenCalledTimes(1);
-      const billing = billTeamMock.mock.calls[0][3];
-      expect(billing.endpoint).toBe(RESEARCH_BILLING_ENDPOINT);
-      expect(featureIdForBillingEndpoint(billing.endpoint)).toBe(
+      expect(billingOf().endpoint).toBe("search");
+      expect(featureIdForBillingEndpoint(billingOf().endpoint)).toBe(
         SEARCH_CREDITS_FEATURE_ID,
       );
+      expect(creditsOf()).toBe(4); // ceil(11 / 10) * 2
     },
   );
+
+  it("paper read bills search credits at a flat 1 credit", async () => {
+    fetchMock.mockResolvedValue(upstreamResponse({ paperId: "1706.03762" }));
+
+    const res = await request(buildApp())
+      .get("/search/research/papers/1706.03762")
+      .query({ query: "attention" });
+
+    expect(res.statusCode).toBe(200);
+    expect(billTeamMock).toHaveBeenCalledTimes(1);
+    expect(billingOf().endpoint).toBe("search");
+    expect(creditsOf()).toBe(1);
+  });
+
+  it("applies the ZDR search-credit rate for forced-zdr teams", async () => {
+    fetchMock.mockResolvedValue(
+      upstreamResponse({ results: new Array(11).fill({}) }),
+    );
+
+    const res = await request(buildApp({ searchZDR: "forced-zdr" }))
+      .get("/search/research/papers")
+      .query({ query: "rag" });
+
+    expect(res.statusCode).toBe(200);
+    expect(billingOf().endpoint).toBe("search");
+    expect(creditsOf()).toBe(20); // ceil(11 / 10) * 10
+  });
 });

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -104,19 +104,13 @@ type ResearchEndpointConfig = {
     params: Record<string, any>,
     req: RequestWithAuth<any, any, any>,
   ) => string;
-  // How the credit cost is computed. "flat" charges a single scrape-like
-  // credit (paper reads/inspects fetch one document); "perResult" scales the
-  // charge with the number of returned results (search-style endpoints).
-  // This governs the *amount* only — the billing pool is always search
-  // credits (see RESEARCH_BILLING_ENDPOINT).
+  // Credit amount only: "flat" charges 1 (reads/inspects), "perResult" scales
+  // with returned results (searches). The pool is always search credits.
   costModel: "flat" | "perResult";
 };
 
-// Every endpoint mounted under /search/research is part of the search family
-// and draws from the shared SEARCH_CREDITS pool, so they all bill under the
-// "search" billing endpoint regardless of their cost model. The pool is
-// selected from this label by featureIdForBillingEndpoint, so keeping every
-// research endpoint on "search" is what routes them to SEARCH_CREDITS.
+// All research endpoints bill under "search" so featureIdForBillingEndpoint
+// routes them to SEARCH_CREDITS.
 export const RESEARCH_BILLING_ENDPOINT = "search" as const;
 
 type ResearchController = (req: Request, res: Response) => Promise<any>;

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -104,14 +104,8 @@ type ResearchEndpointConfig = {
     params: Record<string, any>,
     req: RequestWithAuth<any, any, any>,
   ) => string;
-  // Credit amount only: "flat" charges 1 (reads/inspects), "perResult" scales
-  // with returned results (searches). The pool is always search credits.
-  costModel: "flat" | "perResult";
+  billAs: "scrape" | "search";
 };
-
-// All research endpoints bill under "search" so featureIdForBillingEndpoint
-// routes them to SEARCH_CREDITS.
-export const RESEARCH_BILLING_ENDPOINT = "search" as const;
 
 type ResearchController = (req: Request, res: Response) => Promise<any>;
 type ResearchQueryParams = Record<string, any> & {
@@ -194,12 +188,12 @@ function requestOrigin(params: ResearchQueryParams, req: Request) {
   return params.origin ?? firstHeaderValue(req, "x-origin") ?? "api";
 }
 
-export function computeResearchCredits(
-  endpoint: ResearchEndpointConfig,
+function creditsFor(
+  config: ResearchEndpointConfig,
   body: any,
   req: RequestWithAuth<any, any, any>,
 ) {
-  if (endpoint.costModel === "flat") return 1;
+  if (config.billAs === "scrape") return 1;
   const forcedKind = getSearchForcedKind(req.acuc?.flags);
   const perTen =
     forcedKind === "zdr"
@@ -322,14 +316,16 @@ function createResearchController(
       }
 
       if (upstream.ok) {
-        credits = computeResearchCredits(endpoint, responseBody, authedReq);
+        credits = creditsFor(endpoint, responseBody, authedReq);
         if (credits > 0) {
           billTeam(
             authedReq.auth.team_id,
             credits,
             authedReq.acuc?.api_key_id ?? null,
             {
-              endpoint: RESEARCH_BILLING_ENDPOINT,
+              // All /search/research endpoints draw from SEARCH_CREDITS, even
+              // read/inspect (billAs "scrape" sets the amount, not the pool).
+              endpoint: "search",
               jobId,
             },
           ).catch(billingError => {
@@ -416,7 +412,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
           action: "searchPapers",
           targetHint: params => String(params.query),
           upstreamPath: () => "/v2/research/papers",
-          costModel: "perResult",
+          billAs: "search",
         },
         options,
       ),
@@ -437,7 +433,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
             `${req.params.id}: ${String(params.intent)}`,
           upstreamPath: (_params, req) =>
             `/v2/research/papers/${encodeURIComponent(req.params.id)}/similar`,
-          costModel: "perResult",
+          billAs: "search",
         },
         options,
       ),
@@ -460,7 +456,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
           targetHint: (_params, request) => request.params.id,
           upstreamPath: (_params, request) =>
             `/v2/research/papers/${encodeURIComponent(request.params.id)}`,
-          costModel: "flat",
+          billAs: "scrape",
         },
         options,
       );
@@ -480,7 +476,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
           action: "searchGithub",
           targetHint: params => String(params.query),
           upstreamPath: () => "/v2/research/github",
-          costModel: "perResult",
+          billAs: "search",
         },
         options,
       ),

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -104,8 +104,20 @@ type ResearchEndpointConfig = {
     params: Record<string, any>,
     req: RequestWithAuth<any, any, any>,
   ) => string;
-  billAs: "scrape" | "search";
+  // How the credit cost is computed. "flat" charges a single scrape-like
+  // credit (paper reads/inspects fetch one document); "perResult" scales the
+  // charge with the number of returned results (search-style endpoints).
+  // This governs the *amount* only — the billing pool is always search
+  // credits (see RESEARCH_BILLING_ENDPOINT).
+  costModel: "flat" | "perResult";
 };
+
+// Every endpoint mounted under /search/research is part of the search family
+// and draws from the shared SEARCH_CREDITS pool, so they all bill under the
+// "search" billing endpoint regardless of their cost model. The pool is
+// selected from this label by featureIdForBillingEndpoint, so keeping every
+// research endpoint on "search" is what routes them to SEARCH_CREDITS.
+export const RESEARCH_BILLING_ENDPOINT = "search" as const;
 
 type ResearchController = (req: Request, res: Response) => Promise<any>;
 type ResearchQueryParams = Record<string, any> & {
@@ -188,12 +200,12 @@ function requestOrigin(params: ResearchQueryParams, req: Request) {
   return params.origin ?? firstHeaderValue(req, "x-origin") ?? "api";
 }
 
-function creditsFor(
-  config: ResearchEndpointConfig,
+export function computeResearchCredits(
+  endpoint: ResearchEndpointConfig,
   body: any,
   req: RequestWithAuth<any, any, any>,
 ) {
-  if (config.billAs === "scrape") return 1;
+  if (endpoint.costModel === "flat") return 1;
   const forcedKind = getSearchForcedKind(req.acuc?.flags);
   const perTen =
     forcedKind === "zdr"
@@ -316,14 +328,14 @@ function createResearchController(
       }
 
       if (upstream.ok) {
-        credits = creditsFor(endpoint, responseBody, authedReq);
+        credits = computeResearchCredits(endpoint, responseBody, authedReq);
         if (credits > 0) {
           billTeam(
             authedReq.auth.team_id,
             credits,
             authedReq.acuc?.api_key_id ?? null,
             {
-              endpoint: endpoint.billAs === "scrape" ? "scrape" : "search",
+              endpoint: RESEARCH_BILLING_ENDPOINT,
               jobId,
             },
           ).catch(billingError => {
@@ -410,7 +422,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
           action: "searchPapers",
           targetHint: params => String(params.query),
           upstreamPath: () => "/v2/research/papers",
-          billAs: "search",
+          costModel: "perResult",
         },
         options,
       ),
@@ -431,7 +443,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
             `${req.params.id}: ${String(params.intent)}`,
           upstreamPath: (_params, req) =>
             `/v2/research/papers/${encodeURIComponent(req.params.id)}/similar`,
-          billAs: "search",
+          costModel: "perResult",
         },
         options,
       ),
@@ -454,7 +466,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
           targetHint: (_params, request) => request.params.id,
           upstreamPath: (_params, request) =>
             `/v2/research/papers/${encodeURIComponent(request.params.id)}`,
-          billAs: "scrape",
+          costModel: "flat",
         },
         options,
       );
@@ -474,7 +486,7 @@ export function createResearchRouter(options: { legacy?: boolean } = {}) {
           action: "searchGithub",
           targetHint: params => String(params.query),
           upstreamPath: () => "/v2/research/github",
-          billAs: "search",
+          costModel: "perResult",
         },
         options,
       ),


### PR DESCRIPTION
## What & why

Follow-up to the search-credits experiment discussion in #team-engineering-reviews: make sure the **special search endpoints** (the research family served by `createResearchRouter`) all draw from the `SEARCH_CREDITS` pool.

The billing pool is selected purely from the `endpoint` label via `featureIdForBillingEndpoint` (`endpoint === "search"` → `SEARCH_CREDITS`, else `CREDITS`). In `research-proxy.ts` the pool was driven by a single `billAs: "scrape" | "search"` field that conflated two separate concerns:

1. the **credit cost model** — flat 1 credit vs. per-result, and
2. the **billing pool** — `CREDITS` vs. `SEARCH_CREDITS`.

Because of that coupling, paper read/inspect (`GET .../papers/:id`) billed under the `"scrape"` endpoint and drew from the **main `CREDITS` pool**, even though it's part of the research search family. The papers-search, similar-papers, and github-search endpoints already billed `"search"` → `SEARCH_CREDITS`.

Note we can't simply flip `billAs: "scrape"` → `"search"` on the read endpoint: that field also switches the cost model to per-result, and a read returns no `results` array, so the charge would collapse to 0 (free reads).

## Change

- Split the coupled field into `costModel: "flat" | "perResult"`, which governs the **amount only**.
- Introduce `RESEARCH_BILLING_ENDPOINT = "search"` and bill **every** research endpoint under it, so the whole research family routes to `SEARCH_CREDITS` regardless of cost model.
- Per-request credit **amounts are unchanged** (reads/inspects still cost a flat 1 credit; searches still scale by result count, including the forced-ZDR rate) — only the pool the credits are drawn from changes.

### Mount scope

`createResearchRouter` backs **both** mounts — the canonical `/search/research/*` and the deprecated legacy `/research/*` alias — so this change covers both, intentionally. It's the same set of endpoints either way, and before this PR 3 of the legacy alias's 4 endpoints (papers/similar/github) already billed search credits; only legacy read/inspect diverged onto `CREDITS`. Keeping the two mounts consistent avoids the same operation debiting a different pool based on which URL alias was used. There's no failure risk from the shift: Autumn tracks with `overflow`, so once a team's search credits are exhausted, usage overflows to the general `CREDITS` balance.

Legacy `deep-research` is a separate product on its own `"deep_research"` endpoint (not part of the research search family), so it's intentionally left on `CREDITS`.

## Tests

`research-proxy.test.ts`:
- unit: `RESEARCH_BILLING_ENDPOINT` resolves to `SEARCH_CREDITS_FEATURE_ID` (and not `CREDITS`); the flat model always charges 1; the per-result model scales by count, charges 0 on empty results, and applies the forced-ZDR rate;
- route-level: drives all four endpoints (papers search, similar papers, paper read, github search) through the real router with `billTeam` and the upstream `fetch` mocked, asserting each submits `RESEARCH_BILLING_ENDPOINT` → `SEARCH_CREDITS`.

The existing `research.test.ts` billing snips still hold: they assert the combined balance decrements by the same amount, which the preserved cost model guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)