### PR TITLE
fix(ai): force Chat Completions for self-hosted OpenAI-compatible servers

### DIFF
--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -62,6 +62,13 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   if (provider === "openai" && modelName.startsWith("o3-mini")) {
     return providerList.openai.chat(modelName);
   }
+  // Local / self-hosted OpenAI-compatible servers (LM Studio, llama.cpp,
+  // vLLM, etc.) implement /v1/chat/completions but not the newer /v1/responses
+  // API that this provider defaults to. When a custom OPENAI_BASE_URL is set,
+  // force Chat Completions so structured output works against those servers.
+  if (provider === "openai" && config.OPENAI_BASE_URL) {
+    return providerList.openai.chat(modelName);
+  }
   return providerList[provider](modelName);
 }
 


### PR DESCRIPTION
### Problem

The `@ai-sdk/openai` provider defaults to the **Responses API** (`/v1/responses`). Local, self-hosted OpenAI-compatible servers — **LM Studio**, **llama.cpp**, **vLLM**, etc. — only implement `/v1/chat/completions` and do not serve `/v1/responses`.

When a self-hosted model is configured via `OPENAI_BASE_URL` + `MODEL_NAME`, structured-output extraction (`json` / `extract` formats) **silently returns an empty result**: the scrape succeeds, but `data.json` is `null` and the logs show only `Request had format json, but there was no json field in the result.`

### Fix

When a custom `OPENAI_BASE_URL` is set, route the OpenAI provider through **Chat Completions** (via `providerList.openai.chat(...)`), mirroring the existing `o3-mini` workaround a few lines above. This makes `generateObject`-based structured output work against local OpenAI-compatible servers, while leaving the default (cloud OpenAI, no

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787530948&installation_model_id=11126&pr_number=4126&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4126&signature=2ed09222fff1dd8b5bf10eba13d8b1ffbc8074bbd415ae840dad2437a98bbb27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Chat Completions when a custom `OPENAI_BASE_URL` is set so self-hosted OpenAI-compatible servers work with structured output. Fixes empty `json`/`extract` results for LM Studio, llama.cpp, vLLM, etc., without changing behavior for cloud OpenAI.

- **Bug Fixes**
  - If `provider === "openai"` and `OPENAI_BASE_URL` is present, use `providerList.openai.chat(modelName)` to call `/v1/chat/completions` instead of the default `/v1/responses`.

<sup>Written for commit 596e5659fbdce516b1560771e2b4aad90301f469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

