### PR TITLE
docs(contributing): update pnpm version requirement to 11.4.0+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ First, install the dependencies using pnpm.
 
 ```bash
 # cd apps/api # to make sure you're in the right folder
-pnpm install # make sure you have pnpm version 9+!
+pnpm install # make sure you have pnpm 11.4.0+!
 ```
 
 ### Running the project


### PR DESCRIPTION
## Summary
CONTRIBUTING.md still tells contributors to use "pnpm version 9+", but the repository has already migrated to pnpm 11.4.0.

## Evidence
`apps/api/package.json` pins the package manager to pnpm 11.4.0:

```json
"packageManager": "pnpm@11.4.0"
```

`git show upstream/main:CONTRIBUTING.md` still contains the stale marker:

```bash
pnpm install # make sure you have pnpm version 9+!
```

## Verification
- Fetched `upstream/main` and confirmed the bug marker is still present.
- `python3 scripts/preflight_ship.py --repo firecrawl/firecrawl --local firecrawl --branch main --file CONTRIBUTING.md --must-contain "pnpm version 9+"` passed.
- Searched open PRs and confirmed none update the install-line pnpm version requirement (e.g., #3881 and #4080 touch the test-command section, not this line).

## Scope
Single-line docs-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787548195&installation_model_id=11126&pr_number=4127&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4127&signature=d6fd90204d715122d70296caee4579d813677aa80a4e22772829ce2dfb12b12d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CONTRIBUTING.md to require `pnpm` 11.4.0+ instead of 9+. This matches the repo’s `packageManager: pnpm@11.4.0` and avoids setup issues.

<sup>Written for commit 22b334622e9b3a9be45a4b03fa8a07767b788d0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

