### PR TITLE
docs(readme): replace stale mendableai GitHub org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,7 @@ print_r($results);
 **Agents & AI Tools**
 - [Firecrawl Skills Catalog](https://github.com/firecrawl/skills) — install with `npx skills add firecrawl/skills`
 - [Firecrawl CLI](https://docs.firecrawl.dev/sdks/cli)
-- [Firecrawl MCP](https://github.com/mendableai/firecrawl-mcp-server)
+- [Firecrawl MCP](https://github.com/firecrawl/firecrawl-mcp-server)
 
 The build skills (integrating Firecrawl into product code) are authored in this repo under [`skills/`](./skills) and mirrored into the catalog by CI. Contributing skills? CLI skills (including the research/developer index skills) → PR [`firecrawl/cli`](https://github.com/firecrawl/cli). Build/SDK skills → PR this repo (`skills/`). Workflow skills → PR [`firecrawl/firecrawl-workflows`](https://github.com/firecrawl/firecrawl-workflows). The catalog ([`firecrawl/skills`](https://github.com/firecrawl/skills)) is read-only — never PR it directly.
 
@@ -866,7 +866,7 @@ The build skills (integrating Firecrawl into product code) are authored in this 
 
 [View all integrations →](https://www.firecrawl.dev/integrations)
 
-**Missing your favorite tool?** [Open an issue](https://github.com/mendableai/firecrawl/issues) and let us know!
+**Missing your favorite tool?** [Open an issue](https://github.com/firecrawl/firecrawl/issues) and let us know!
 
 ---
 


### PR DESCRIPTION
## Problem

`README.md` still pointed two links at the legacy `mendableai/` GitHub org:
- `Firecrawl MCP` linked to `https://github.com/mendableai/firecrawl-mcp-server`
- `Open an issue` linked to `https://github.com/mendableai/firecrawl/issues`

Both now 301-redirect to the `firecrawl/` org. The rest of the README (and the earlier MCP link at line 310) already uses `firecrawl/`, so these two links were stale and inconsistent.

## Triage / Root cause

The repository migrated from the `mendableai` GitHub org to `firecrawl`. Most references were updated in #2987, but the two links in the Integrations section and the issue footer were missed.

## Fix

- `Firecrawl MCP` → `https://github.com/firecrawl/firecrawl-mcp-server`
- `Open an issue` → `https://github.com/firecrawl/firecrawl/issues`

No functional code changed.

## Verification

```bash
# 1. Confirm the stale markers are still on upstream/main
$ git show upstream/main:README.md | grep -n 'mendableai'
859:  [Firecrawl MCP](https://github.com/mendableai/firecrawl-mcp-server)
868:  [Open an issue](https://github.com/mendableai/firecrawl/issues)

# 2. Confirm the old URLs 301-redirect to firecrawl/
$ curl -sI https://github.com/mendableai/firecrawl-mcp-server | grep -i '^location'
location: https://github.com/firecrawl/firecrawl-mcp-server

$ curl -sI https://github.com/mendableai/firecrawl/issues | grep -i '^location'
location: https://github.com/firecrawl/firecrawl/issues

# 3. Confirm no other mendableai links remain in README after the fix
$ grep -i 'mendableai' README.md
(no output)
```

## Notes / Risks

- Self-sourced; no open issue.
- Searched open/merged PRs for related link fixes; #4080 fixes CONTRIBUTING first-request commands, not these README org links. PR #2987 updated `mendableai` links in the test-site content but left these two in `README.md`.
- The Ruby SDK gemspec (`apps/ruby-sdk/firecrawl-sdk.gemspec`) still contains `mendableai` URLs; that is a separate code-metadata file and is left for a follow-up SDK PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787548228&installation_model_id=11126&pr_number=4128&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4128&signature=0fe0041c0b33c090b74658dfb2a8e11998a79b0eef67f9254f6574a5dcd37f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace two stale README links from the legacy `mendableai/` org to the canonical `firecrawl/` org to remove 301 redirects and keep docs consistent. Previously, “Firecrawl MCP” and “Open an issue” pointed to `mendableai/...`; they now point to `firecrawl/firecrawl-mcp-server` and `firecrawl/firecrawl/issues` respectively.

<sup>Written for commit fb80de8f4b30c5d666d8e42920b8aa1d0c5137ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

