### PR TITLE
fix(api): forward screenshot/fullPage flags to Fire Engine (fixes #3384)

### DIFF
--- a/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
+++ b/apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts
@@ -1,4 +1,27 @@
-import { shouldForceNonRender } from "../../scraper/scrapeURL/engines/fire-engine";
+import {
+  shouldForceNonRender,
+  scrapeURLWithFireEngineChromeCDP,
+} from "../../scraper/scrapeURL/engines/fire-engine";
+import { fireEngineScrape } from "../../scraper/scrapeURL/engines/fire-engine/scrape";
+import { scrapeOptions } from "../../controllers/v2/types";
+import { AbortManager } from "../../scraper/scrapeURL/lib/abortManager";
+
+vi.mock("@mendable/firecrawl-rs", () => ({
+  getInnerJson: vi.fn((x: string) => x),
+}));
+
+vi.mock("../../scraper/scrapeURL/engines/fire-engine/scrape", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("../../scraper/scrapeURL/engines/fire-engine/scrape")>();
+  return {
+    ...actual,
+    fireEngineScrape: vi.fn(),
+  };
+});
+
+vi.mock("../../scraper/scrapeURL/engines/fire-engine/delete", () => ({
+  fireEngineDelete: vi.fn().mockResolvedValue(undefined),
+}));
 
 const fmt = (types: string[]) => types.map(type => ({ type })) as any;
 
@@ -107,5 +130,91 @@ describe("shouldForceNonRender", () => {
         youtubePostprocessorWillRun: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("fire-engine screenshot/fullPage forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fireEngineScrape as ReturnType<typeof vi.fn>).mockResolvedValue({
+      timeTaken: 1,
+      content: "<html><body>Hello</body></html>",
+      url: "https://example.com",
+      pageStatusCode: 200,
+      responseHeaders: { "content-type": "text/html" },
+      screenshots: [
+        "https://service.firecrawl.dev/storage/v1/object/public/media/test-screenshot",
+      ],
+    });
+  });
+
+  function buildMeta(options: any) {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(function () {
+        return logger;
+      }),
+    };
+
+    return {
+      id: "test-screenshot-fullpage",
+      url: "https://example.com",
+      options,
+      internalOptions: { teamId: "test", orgId: null },
+      logger,
+      abort: new AbortManager(),
+      featureFlags: new Set(),
+      mock: null,
+      pdfPrefetch: undefined,
+      documentPrefetch: undefined,
+      fetchPrefetch: undefined,
+      costTracking: {},
+      threatDecisions: [],
+    } as any;
+  }
+
+  it("sets screenshot and fullPage on the Fire Engine request for a full-page screenshot format", async () => {
+    const meta = buildMeta(
+      scrapeOptions.parse({
+        formats: [{ type: "screenshot" as const, fullPage: true }],
+      }),
+    );
+
+    await scrapeURLWithFireEngineChromeCDP(meta);
+
+    expect(fireEngineScrape).toHaveBeenCalledTimes(1);
+    const request = (fireEngineScrape as ReturnType<typeof vi.fn>).mock
+      .calls[0][2];
+    expect(request.screenshot).toBe(true);
+    expect(request.fullPage).toBe(true);
+    expect(request.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "screenshot", fullPage: true }),
+      ]),
+    );
+  });
+
+  it("sets screenshot and fullPage on the Fire Engine request for a screenshot action with fullPage", async () => {
+    const meta = buildMeta(
+      scrapeOptions.parse({
+        actions: [{ type: "screenshot" as const, fullPage: true }],
+      }),
+    );
+
+    await scrapeURLWithFireEngineChromeCDP(meta);
+
+    expect(fireEngineScrape).toHaveBeenCalledTimes(1);
+    const request = (fireEngineScrape as ReturnType<typeof vi.fn>).mock
+      .calls[0][2];
+    expect(request.screenshot).toBe(true);
+    expect(request.fullPage).toBe(true);
+    expect(request.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "screenshot", fullPage: true }),
+      ]),
+    );
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -76,8 +76,8 @@ async function performFireEngineScrape<
       "fire-engine.url": request.url,
       "fire-engine.priority": request.priority,
       "fire-engine.wait": (request as any).wait,
-      "fire-engine.screenshot": (request as any).screenshot,
-      "fire-engine.fullpage": (request as any).fullPage,
+      "fire-engine.screenshot": request.screenshot,
+      "fire-engine.fullpage": request.fullPage,
       "fire-engine.proxy": (request as any).proxy,
       "fire-engine.mobile": (request as any).mobile,
       "fire-engine.skip_tls": (request as any).skipTlsVerification,
@@ -331,6 +331,20 @@ export async function scrapeURLWithFireEngineChromeCDP(
         ? meta.options.waitFor
         : defaultWait;
 
+    const screenshotFormat = hasFormatOfType(
+      meta.options.formats,
+      "screenshot",
+    );
+    const screenshotFromAction = (meta.options.actions ?? []).some(
+      a => a.type === "screenshot",
+    );
+    const fullPageFromAction = (meta.options.actions ?? []).some(
+      a => a.type === "screenshot" && a.fullPage,
+    );
+    const isScreenshot =
+      screenshotFormat !== undefined || screenshotFromAction;
+    const isFullPage = !!screenshotFormat?.fullPage || fullPageFromAction;
+
     const actions: InternalAction[] = [
       // Transform waitFor option into an action (unsupported by chrome-cdp).
       // When branding is requested and user didn't set waitFor, use a default wait so the page is ready and we avoid JS errors.
@@ -350,19 +364,14 @@ export async function scrapeURLWithFireEngineChromeCDP(
       }),
 
       // Transform screenshot format into an action (unsupported by chrome-cdp)
-      ...(hasFormatOfType(meta.options.formats, "screenshot")
+      ...(screenshotFormat
         ? [
             {
               type: "screenshot" as const,
-              fullPage:
-                hasFormatOfType(meta.options.formats, "screenshot")?.fullPage ||
-                false,
-              ...(hasFormatOfType(meta.options.formats, "screenshot")?.viewport
+              fullPage: screenshotFormat.fullPage || false,
+              ...(screenshotFormat.viewport
                 ? {
-                    viewport: hasFormatOfType(
-                      meta.options.formats,
-                      "screenshot",
-                    )!.viewport,
+                    viewport: screenshotFormat.viewport,
                   }
                 : {}),
             },
@@ -426,6 +435,8 @@ export async function scrapeURLWithFireEngineChromeCDP(
         !meta.internalOptions.zeroDataRetention &&
         meta.internalOptions.saveScrapeResultToGCS,
       zeroDataRetention: meta.internalOptions.zeroDataRetention,
+      screenshot: isScreenshot,
+      fullPage: isFullPage,
       ...(shouldAllowMedia ? { blockMedia: false } : {}),
       ...(forceNonRender ? { forceNonRender: true } : {}),
       persistentStorage: meta.options.profile

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -54,6 +54,11 @@ export type FireEngineScrapeRequestCommon = {
   maxAge?: number;
   saveScrapeResultToGCS?: boolean;
   zeroDataRetention?: boolean;
+
+  /** Whether the scrape should capture a screenshot. */
+  screenshot?: boolean;
+  /** When screenshot is true, capture the full page instead of the viewport. */
+  fullPage?: boolean;
 };
 
 export type FireEngineScrapeRequestChromeCDP = {


### PR DESCRIPTION
This fixes #3384 by ensuring the `screenshot` and `fullPage` flags are sent as top-level fields in the JSON body posted to the Fire Engine `/scrape` endpoint.

Changes:
- Added `screenshot?: boolean` and `fullPage?: boolean` to `FireEngineScrapeRequestCommon` in `apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts`.
- In `apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts`, derive `isScreenshot` and `isFullPage` from the screenshot format and any screenshot action, then include them in the Fire Engine request body.
- Updated `apps/api/src/__tests__/lib/fire-engine-render-routing.test.ts` to assert the outgoing request body contains `screenshot: true` and `fullPage: true` when a full-page screenshot is requested.

Test note: the new unit tests pass (`vitest run src/__tests__/lib/fire-engine-render-routing.test.ts`). The Fire Engine remote itself is closed-source, so this fix only ensures the client sends the flags the remote expects.

Fixes #3384

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787552997&installation_model_id=11126&pr_number=4129&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4129&signature=09fc1195ffba2f1140862d1d23ba3ee6175899e04e0172cf8e80de23087a598d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards top‑level `screenshot` and `fullPage` flags to the Fire Engine `/scrape` request so full‑page screenshots work correctly. Fixes #3384.

- **Bug Fixes**
  - Added optional `screenshot` and `fullPage` to `FireEngineScrapeRequestCommon`.
  - Derived flags from screenshot format or actions and included them in the request body.
  - Added tests to verify both format- and action-based full‑page screenshots set `screenshot: true` and `fullPage: true`.

<sup>Written for commit b8c572e5bebc6b635d8ee29e5514107ce8ba9750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

