### PR TITLE
fix(branding): fall back to heuristic logo pick when the LLM call fails

### DIFF
--- a/apps/api/src/__tests__/lib/branding/llm-failure-fallback.test.ts
+++ b/apps/api/src/__tests__/lib/branding/llm-failure-fallback.test.ts
@@ -1,0 +1,90 @@
+import { vi, describe, it, expect } from "vitest";
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn().mockRejectedValue(new Error("connection reset")),
+}));
+vi.mock("../../../lib/generic-ai", () => ({
+  getModel: vi.fn().mockReturnValue({}),
+}));
+vi.mock("../../../services/sentry", () => ({
+  captureExceptionWithZdrCheck: vi.fn(),
+}));
+
+import { enhanceBrandingWithLLM } from "../../../lib/branding/llm";
+import { mergeBrandingResults } from "../../../lib/branding/merge";
+import { logger } from "../../../lib/logger";
+
+const CANDIDATES = [
+  {
+    src: "https://example.com/logo.svg",
+    alt: "Example logo",
+    isSvg: true,
+    isVisible: true,
+    location: "header" as const,
+    position: { top: 10, left: 10, width: 140, height: 40 },
+    indicators: {
+      inHeader: true,
+      altMatch: true,
+      srcMatch: true,
+      classMatch: false,
+      hrefMatch: true,
+    },
+    href: "/",
+    source: "header a img",
+  },
+];
+
+describe("LLM failure fallback", () => {
+  it("omits logoSelection, personality and designSystem on failure", async () => {
+    const result = await enhanceBrandingWithLLM({
+      jsAnalysis: {},
+      buttons: [],
+      logoCandidates: CANDIDATES,
+      url: "https://example.com",
+      logger,
+    });
+
+    expect(result.logoSelection).toBeUndefined();
+    expect(result.personality).toBeUndefined();
+    expect(result.designSystem).toBeUndefined();
+    expect(result.buttonClassification.primaryButtonReasoning).toBe(
+      "LLM failed",
+    );
+  });
+
+  it("merge keeps the heuristic logo pick and stamps no personality", () => {
+    // Shape the transformer produces when it restores the heuristic after an
+    // absent LLM logoSelection.
+    const merged = mergeBrandingResults(
+      { images: {} },
+      {
+        cleanedFonts: [],
+        buttonClassification: {
+          primaryButtonIndex: -1,
+          primaryButtonReasoning: "LLM failed",
+          secondaryButtonIndex: -1,
+          secondaryButtonReasoning: "LLM failed",
+          confidence: 0,
+        },
+        colorRoles: {
+          primaryColor: "",
+          accentColor: "",
+          backgroundColor: "",
+          textPrimary: "",
+          confidence: 0,
+        },
+        logoSelection: {
+          selectedLogoIndex: 0,
+          selectedLogoReasoning: "Heuristic fallback: strong indicators",
+          confidence: 0.8,
+        },
+      },
+      [],
+      CANDIDATES,
+    );
+
+    expect(merged.images?.logo).toBe("https://example.com/logo.svg");
+    expect((merged as any).personality).toBeUndefined();
+    expect((merged as any).designSystem).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/branding/llm.ts
+++ b/apps/api/src/lib/branding/llm.ts
@@ -216,6 +216,11 @@ export async function enhanceBrandingWithLLM(
       });
     }
 
+    // On LLM failure return only the fields that have honest fallback values.
+    // Omitting logoSelection lets the transformer restore the heuristic's
+    // pick (a failure object with confidence 0 used to override it and drop
+    // the logo entirely); omitting personality/designSystem avoids stamping
+    // fabricated values into the output.
     return {
       cleanedFonts: [],
       buttonClassification: {
@@ -230,20 +235,6 @@ export async function enhanceBrandingWithLLM(
         accentColor: "",
         backgroundColor: "",
         textPrimary: "",
-        confidence: 0,
-      },
-      personality: {
-        tone: "professional",
-        energy: "medium",
-        targetAudience: "unknown",
-      },
-      designSystem: {
-        framework: "unknown",
-        componentLibrary: "",
-      },
-      logoSelection: {
-        selectedLogoIndex: -1,
-        selectedLogoReasoning: "LLM failed",
         confidence: 0,
       },
     };

--- a/apps/api/src/lib/branding/schema.ts
+++ b/apps/api/src/lib/branding/schema.ts
@@ -137,12 +137,20 @@ export function getBrandingEnhancementSchema(hasLogoCandidates: boolean) {
     : baseBrandingEnhancementSchema;
 }
 
-// Type - logoSelection is optional in the type even though it's required in schema when candidates exist
+// Type - logoSelection is optional in the type even though it's required in
+// schema when candidates exist. personality/designSystem are optional so the
+// LLM-failure fallback can omit them instead of fabricating values.
 export type BrandingEnhancement = Omit<
   z.infer<typeof brandingEnhancementSchemaWithLogo>,
-  "logoSelection"
+  "logoSelection" | "personality" | "designSystem"
 > & {
   logoSelection?: z.infer<
     typeof brandingEnhancementSchemaWithLogo
   >["logoSelection"];
+  personality?: z.infer<
+    typeof brandingEnhancementSchemaWithLogo
+  >["personality"];
+  designSystem?: z.infer<
+    typeof brandingEnhancementSchemaWithLogo
+  >["designSystem"];
 };


### PR DESCRIPTION
## What

When `enhanceBrandingWithLLM` fails (network error, provider hiccup), its fallback object no longer includes a `logoSelection` with `confidence: 0` — which used to **override the heuristic's pick in the merge and drop the logo entirely**. With the field omitted, the transformer's existing restore path (`LLM didn't return logo selection → use heuristic`) promotes the heuristic selection with slightly discounted confidence, so a transient LLM failure degrades gracefully instead of erasing a logo we already found.

Also: the failure fallback no longer stamps fabricated `personality` ("professional/medium") and `designSystem` ("unknown") values into the output — those fields are now omitted when no model produced them.

## Evidence

Fresh 155-URL eval run (in the branding-evals app, Run 7/27/2026): one production page lost its logo exactly this way — 5 candidates collected, confident heuristic pick, LLM call failed, result rejected with reasoning `LLM failed`. This class of miss disappears with this change.

## Tests

- `enhanceBrandingWithLLM` failure path: asserts `logoSelection`/`personality`/`designSystem` are omitted (mocked provider rejection).
- `mergeBrandingResults`: asserts a heuristic-restored selection is honored and no personality is stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cx6pZQ6JaKSURsF2owpsFA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787761386&installation_model_id=11126&pr_number=4142&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4142&signature=2de4350de6a144d602a3206655add37a0cb5ebdf397736fe82c4da56413374a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle LLM failures in branding: preserve the heuristic logo pick instead of dropping it, and stop writing fabricated personality/designSystem values. This prevents transient errors from erasing a valid logo and keeps output honest.

- **Bug Fixes**
  - On LLM failure, `enhanceBrandingWithLLM` now omits `logoSelection` so merge restores the heuristic logo.
  - Stop stamping `personality`/`designSystem`; schema/types updated to make them optional, with tests covering failure and merge paths.

<sup>Written for commit d7187b238fbc35878c14ec804affad81495690aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

