### PR TITLE
ci: phase 0 cleanup — timeouts, path filters, dead code removal

### DIFF
--- a/.github/scripts/audit-ci-vuln-scan.mjs
+++ b/.github/scripts/audit-ci-vuln-scan.mjs
@@ -359,8 +359,7 @@ You are fixing CI security audit failures in this monorepo and must mirror this 
 
 Source of truth:
 - Workflow file: \`.github/workflows/npm-audit.yml\`
-- Job: \`audit\`
-- Failure reporter step: \`Report audit failures\`
+- Job: \`audit\` — a matrix with one \`Audit <name>\` job per package directory; each failed matrix job's log contains the audit-ci output for that package.
 - Reproduce using the same \`audit-ci\` commands/flags used in that workflow.
 
 Current uncovered audit failures on main:

--- a/.github/workflows/deploy-go-service.yaml
+++ b/.github/workflows/deploy-go-service.yaml
@@ -20,7 +20,7 @@ jobs:
         working-directory: "./apps/go-html-to-md-service"
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/.github/workflows/deploy-playwright.yml
+++ b/.github/workflows/deploy-playwright.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: './apps/playwright-service-ts'
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1

--- a/.github/workflows/deploy-redis.yml
+++ b/.github/workflows/deploy-redis.yml
@@ -19,7 +19,7 @@ jobs:
             working-directory: './apps/redis'
         steps:
           - name: 'Checkout GitHub Action'
-            uses: actions/checkout@main
+            uses: actions/checkout@v5
 
           - name: 'Login to GitHub Container Registry'
             uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -4,13 +4,38 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '**/package.json'
+      - '**/pnpm-lock.yaml'
+      - '**/audit-ci.jsonc'
+      - .github/workflows/npm-audit.yml
   schedule:
     - cron: "0 17 * * *"  # 9am PST / 10am PDT
   workflow_dispatch:
 
 jobs:
   audit:
+    name: Audit ${{ matrix.name }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: API
+            directory: apps/api
+          - name: Playwright Service
+            directory: apps/playwright-service-ts
+          - name: JavaScript SDK
+            directory: apps/js-sdk
+          - name: JavaScript SDK Firecrawl
+            directory: apps/js-sdk/firecrawl
+          - name: Test Suite
+            directory: apps/test-suite
+          - name: Ingestion UI
+            directory: apps/ui/ingestion-ui
+          - name: Test Site
+            directory: apps/test-site
     steps:
       - uses: actions/checkout@v5
       - name: Install Node.js
@@ -21,99 +46,6 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 11.4.0
-      
-      - name: Create audit output directory
-        run: mkdir -p /tmp/audit-outputs
 
-      - name: Audit API Packages
-        id: audit-api
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/api --config apps/api/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/api.txt
-
-      - name: Audit Playwright Service Packages
-        id: audit-playwright-service
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/playwright-service-ts --config apps/playwright-service-ts/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/playwright-service.txt
-
-      - name: Audit JavaScript SDK Packages
-        id: audit-js-sdk
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/js-sdk --config apps/js-sdk/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/js-sdk.txt
-
-      - name: Audit JavaScript SDK Firecrawl Packages
-        id: audit-js-sdk-firecrawl
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/js-sdk/firecrawl --config apps/js-sdk/firecrawl/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/js-sdk-firecrawl.txt
-
-      - name: Audit Test Suite Packages
-        id: audit-test-suite
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/test-suite --config apps/test-suite/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/test-suite.txt
-
-      - name: Audit Ingestion UI Packages
-        id: audit-ingestion-ui
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/ui/ingestion-ui --config apps/ui/ingestion-ui/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/ingestion-ui.txt
-
-      - name: Audit Test Site Packages
-        id: audit-test-site
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          pnpm dlx audit-ci@^7 --directory apps/test-site --config apps/test-site/audit-ci.jsonc 2>&1 | tee /tmp/audit-outputs/test-site.txt
-
-      - name: Report audit failures
-        if: always()
-        run: |
-          declare -A AUDIT_FILES=(
-            ["API"]="api.txt"
-            ["Playwright Service"]="playwright-service.txt"
-            ["JavaScript SDK"]="js-sdk.txt"
-            ["JavaScript SDK Firecrawl"]="js-sdk-firecrawl.txt"
-            ["Test Suite"]="test-suite.txt"
-            ["Ingestion UI"]="ingestion-ui.txt"
-            ["Test Site"]="test-site.txt"
-          )
-
-          declare -A AUDIT_OUTCOMES=(
-            ["API"]="${{ steps.audit-api.outcome }}"
-            ["Playwright Service"]="${{ steps.audit-playwright-service.outcome }}"
-            ["JavaScript SDK"]="${{ steps.audit-js-sdk.outcome }}"
-            ["JavaScript SDK Firecrawl"]="${{ steps.audit-js-sdk-firecrawl.outcome }}"
-            ["Test Suite"]="${{ steps.audit-test-suite.outcome }}"
-            ["Ingestion UI"]="${{ steps.audit-ingestion-ui.outcome }}"
-            ["Test Site"]="${{ steps.audit-test-site.outcome }}"
-          )
-
-          FAILED=false
-          for name in "API" "Playwright Service" "JavaScript SDK" "JavaScript SDK Firecrawl" "Test Suite" "Ingestion UI" "Test Site"; do
-            if [ "${AUDIT_OUTCOMES[$name]}" == "failure" ]; then
-              FAILED=true
-              echo ""
-              echo "=========================================="
-              echo "❌ $name audit failed"
-              echo "=========================================="
-              if [ -f "/tmp/audit-outputs/${AUDIT_FILES[$name]}" ]; then
-                # Extract only the summary (from "Found vulnerable advisory paths:" to end)
-                sed -n '/Found vulnerable advisory paths:/,$p' "/tmp/audit-outputs/${AUDIT_FILES[$name]}" | sed 's/\x1b\[[0-9;]*m//g'
-              fi
-            fi
-          done
-
-          if [ "$FAILED" == "true" ]; then
-            exit 1
-          else
-            echo "✅ All audits passed"
-          fi
+      - name: Audit ${{ matrix.name }}
+        run: pnpm dlx audit-ci@^7 --directory ${{ matrix.directory }} --config ${{ matrix.directory }}/audit-ci.jsonc

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '**/package.json'
       - '**/pnpm-lock.yaml'
+      - '**/pnpm-workspace.yaml'
       - '**/audit-ci.jsonc'
       - .github/workflows/npm-audit.yml
   schedule:

--- a/.github/workflows/scrape-evals.yml
+++ b/.github/workflows/scrape-evals.yml
@@ -6,78 +6,21 @@ on:
     types: [opened]
 
 jobs:
-  quality-eval:
+  dispatch-evals:
     if: |
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        (contains(github.event.comment.body, '#scrape-quality-eval') ||
-        contains(github.event.issue.title, '#scrape-quality-eval'))) ||
-      (github.event_name == 'pull_request' &&
-       (contains(github.event.pull_request.body, '#scrape-quality-eval') ||
-        contains(github.event.pull_request.title, '#scrape-quality-eval')))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check org membership
-        id: check-member
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.SCRAPE_EVALS_PAT }}
-          script: |
-            try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: 'firecrawl',
-                username: context.actor,
-              });
-              return true;
-            } catch {
-              return false;
-            }
-
-      - name: Dispatch quality eval
-        if: steps.check-member.outputs.result == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.SCRAPE_EVALS_PAT }}
-          script: |
-            let prNumber, prBranch, commitSha, headRepo;
-            if (context.eventName === 'pull_request') {
-              prNumber = context.payload.pull_request.number;
-              prBranch = context.payload.pull_request.head.ref;
-              commitSha = context.payload.pull_request.head.sha;
-              headRepo = context.payload.pull_request.head.repo.full_name;
-            } else {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-              });
-              prNumber = pr.data.number;
-              prBranch = pr.data.head.ref;
-              commitSha = pr.data.head.sha;
-              headRepo = pr.data.head.repo.full_name;
-            }
-            await github.rest.repos.createDispatchEvent({
-              owner: 'firecrawl',
-              repo: 'scrape-evals',
-              event_type: 'firecrawl-pr-eval',
-              client_payload: {
-                pr_number: prNumber,
-                pr_branch: prBranch,
-                commit_sha: commitSha,
-                repo: headRepo,
-              },
-            });
-
-  ocr-eval:
-    if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       (contains(github.event.comment.body, '#scrape-ocr-eval') ||
+        contains(github.event.comment.body, '#scrape-ocr-eval') ||
+        contains(github.event.issue.title, '#scrape-quality-eval') ||
         contains(github.event.issue.title, '#scrape-ocr-eval'))) ||
       (github.event_name == 'pull_request' &&
-       (contains(github.event.pull_request.body, '#scrape-ocr-eval') ||
+       (contains(github.event.pull_request.body, '#scrape-quality-eval') ||
+        contains(github.event.pull_request.body, '#scrape-ocr-eval') ||
+        contains(github.event.pull_request.title, '#scrape-quality-eval') ||
         contains(github.event.pull_request.title, '#scrape-ocr-eval')))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check org membership
         id: check-member
@@ -95,18 +38,20 @@ jobs:
               return false;
             }
 
-      - name: Dispatch OCR eval
+      - name: Dispatch requested evals
         if: steps.check-member.outputs.result == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.SCRAPE_EVALS_PAT }}
           script: |
-            let prNumber, prBranch, commitSha, headRepo;
+            let prNumber, prBranch, commitSha, headRepo, text;
             if (context.eventName === 'pull_request') {
-              prNumber = context.payload.pull_request.number;
-              prBranch = context.payload.pull_request.head.ref;
-              commitSha = context.payload.pull_request.head.sha;
-              headRepo = context.payload.pull_request.head.repo.full_name;
+              const pr = context.payload.pull_request;
+              prNumber = pr.number;
+              prBranch = pr.head.ref;
+              commitSha = pr.head.sha;
+              headRepo = pr.head.repo.full_name;
+              text = `${pr.title}\n${pr.body ?? ''}`;
             } else {
               const pr = await github.rest.pulls.get({
                 owner: context.repo.owner,
@@ -117,15 +62,26 @@ jobs:
               prBranch = pr.data.head.ref;
               commitSha = pr.data.head.sha;
               headRepo = pr.data.head.repo.full_name;
+              text = `${context.payload.issue.title}\n${context.payload.comment.body}`;
             }
-            await github.rest.repos.createDispatchEvent({
-              owner: 'firecrawl',
-              repo: 'scrape-evals',
-              event_type: 'firecrawl-ocr-eval',
-              client_payload: {
-                pr_number: prNumber,
-                pr_branch: prBranch,
-                commit_sha: commitSha,
-                repo: headRepo,
-              },
-            });
+
+            const evals = [
+              { tag: '#scrape-quality-eval', eventType: 'firecrawl-pr-eval' },
+              { tag: '#scrape-ocr-eval', eventType: 'firecrawl-ocr-eval' },
+            ];
+
+            for (const { tag, eventType } of evals) {
+              if (!text.includes(tag)) continue;
+              await github.rest.repos.createDispatchEvent({
+                owner: 'firecrawl',
+                repo: 'scrape-evals',
+                event_type: eventType,
+                client_payload: {
+                  pr_number: prNumber,
+                  pr_branch: prBranch,
+                  commit_sha: commitSha,
+                  repo: headRepo,
+                },
+              });
+              core.info(`Dispatched ${eventType} for PR #${prNumber} (${commitSha})`);
+            }

--- a/.github/workflows/scrape-evals.yml
+++ b/.github/workflows/scrape-evals.yml
@@ -70,18 +70,28 @@ jobs:
               { tag: '#scrape-ocr-eval', eventType: 'firecrawl-ocr-eval' },
             ];
 
+            // Match case-insensitively, like the workflow-level contains() gate.
+            const lowerText = text.toLowerCase();
+            const failures = [];
             for (const { tag, eventType } of evals) {
-              if (!text.includes(tag)) continue;
-              await github.rest.repos.createDispatchEvent({
-                owner: 'firecrawl',
-                repo: 'scrape-evals',
-                event_type: eventType,
-                client_payload: {
-                  pr_number: prNumber,
-                  pr_branch: prBranch,
-                  commit_sha: commitSha,
-                  repo: headRepo,
-                },
-              });
-              core.info(`Dispatched ${eventType} for PR #${prNumber} (${commitSha})`);
+              if (!lowerText.includes(tag)) continue;
+              try {
+                await github.rest.repos.createDispatchEvent({
+                  owner: 'firecrawl',
+                  repo: 'scrape-evals',
+                  event_type: eventType,
+                  client_payload: {
+                    pr_number: prNumber,
+                    pr_branch: prBranch,
+                    commit_sha: commitSha,
+                    repo: headRepo,
+                  },
+                });
+                core.info(`Dispatched ${eventType} for PR #${prNumber} (${commitSha})`);
+              } catch (error) {
+                failures.push(`${eventType}: ${error.message}`);
+              }
+            }
+            if (failures.length > 0) {
+              core.setFailed(`Failed to dispatch: ${failures.join('; ')}`);
             }

--- a/.github/workflows/test-dotnet-sdk.yml
+++ b/.github/workflows/test-dotnet-sdk.yml
@@ -18,6 +18,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||

--- a/.github/workflows/test-go-html-to-md-service.yml
+++ b/.github/workflows/test-go-html-to-md-service.yml
@@ -18,6 +18,7 @@ jobs:
   build-vet-test:
     name: Build, Vet and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||

--- a/.github/workflows/test-go-sdk.yml
+++ b/.github/workflows/test-go-sdk.yml
@@ -18,6 +18,7 @@ jobs:
   build-and-vet:
     name: Build and Vet
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||

--- a/.github/workflows/test-java-sdk.yml
+++ b/.github/workflows/test-java-sdk.yml
@@ -18,6 +18,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||

--- a/.github/workflows/test-js-sdk.yml
+++ b/.github/workflows/test-js-sdk.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Run tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
@@ -39,6 +40,10 @@ jobs:
       - name: Build
         run: pnpm run build
         working-directory: ./apps/js-sdk/firecrawl
-      - name: Run tests
+      # The live e2e suite runs against a deployed API, so failures may reflect
+      # the deployment rather than this PR. Reported, but not blocking until the
+      # suite is stably green (see CI redesign plan).
+      - name: Run e2e tests (non-blocking)
+        continue-on-error: true
         run: pnpm run test
         working-directory: ./apps/js-sdk/firecrawl

--- a/.github/workflows/test-php-sdk.yml
+++ b/.github/workflows/test-php-sdk.yml
@@ -18,6 +18,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     env:
       HAS_API_KEY: ${{ secrets.FIRECRAWL_API_KEY != '' }}
     if: >-

--- a/.github/workflows/test-ruby-sdk.yml
+++ b/.github/workflows/test-ruby-sdk.yml
@@ -18,6 +18,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Build and Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -4,9 +4,16 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - apps/api/**
+      - apps/playwright-service-ts/**
+      - apps/nuq-postgres/**
+      - apps/test-site/**
+      - apps/go-html-to-md-service/**
+      - .github/workflows/test-server.yml
 
 concurrency:
-  group: ci=${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -35,6 +42,7 @@ jobs:
         # search: ["searxng", "google"]
         # ai: ["openai", "no-ai"]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     services:
       redis:
         image: redis
@@ -132,18 +140,6 @@ jobs:
         with:
           go-version: 1.24
           cache-dependency-path: apps/api/sharedLibs/go-html-to-md/go.sum
-
-      - name: Verify go.sum is up to date (sharedLibs/go-html-to-md)
-        run: |
-          cd apps/api/sharedLibs/go-html-to-md
-          go mod tidy
-          git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum is out of sync -- run 'go mod tidy' and commit" && exit 1)
-
-      - name: Verify go.sum is up to date (go-html-to-md-service)
-        run: |
-          cd apps/go-html-to-md-service
-          go mod tidy
-          git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum is out of sync -- run 'go mod tidy' and commit" && exit 1)
 
       - name: Restore Go lib
         id: golib_restore
@@ -409,176 +405,38 @@ jobs:
           name: Logs (kubernetes, ${{ matrix.ai }}, ${{ matrix.search }}, ${{ matrix.engine }}, ${{ matrix.proxy }}, ${{ matrix.nuq }})
           path: logs/logs.zip
 
-  # temp disabled
-  # prod-test:
-  #   name: Production environment tests
-  #   runs-on: big-runner
-  #   services:
-  #     redis:
-  #       image: redis
-  #       ports:
-  #         - 6379:6379
-  #     rabbitmq:
-  #       image: rabbitmq
-  #       ports:
-  #         - 5672:5672
-  #   env:
-  #     BULL_AUTH_KEY: ${{ secrets.BULL_AUTH_KEY }}
-  #     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  #     REDIS_URL: ${{ secrets.REDIS_URL }}
-  #     SUPABASE_ANON_TOKEN: ${{ secrets.SUPABASE_ANON_TOKEN }}
-  #     SUPABASE_SERVICE_TOKEN: ${{ secrets.SUPABASE_SERVICE_TOKEN }}
-  #     SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-  #     SUPABASE_REPLICA_URL: ${{ secrets.SUPABASE_REPLICA_URL }}
-  #     INDEX_SUPABASE_SERVICE_TOKEN: ${{ secrets.INDEX_SUPABASE_SERVICE_TOKEN }}
-  #     INDEX_SUPABASE_ANON_TOKEN: ${{ secrets.INDEX_SUPABASE_ANON_TOKEN }}
-  #     INDEX_SUPABASE_URL: ${{ secrets.INDEX_SUPABASE_URL }}
-  #     TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
-  #     TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
-  #     TEST_API_KEY_CONCURRENCY: ${{ secrets.TEST_API_KEY_CONCURRENCY }}
-  #     TEST_TEAM_ID_CONCURRENCY: ${{ secrets.TEST_TEAM_ID_CONCURRENCY }}
-  #     TEST_API_KEY_ZDR: ${{ secrets.TEST_API_KEY_ZDR }}
-  #     TEST_TEAM_ID_ZDR: ${{ secrets.TEST_TEAM_ID_ZDR }}
-  #     FIRE_ENGINE_BETA_URL: ${{ secrets.FIRE_ENGINE_BETA_URL }}
-  #     FIRE_ENGINE_STAGING_URL: ${{ secrets.FIRE_ENGINE_STAGING_URL }}
-  #     USE_DB_AUTHENTICATION: true
-  #     ENV: ${{ secrets.ENV }}
-  #     RUNPOD_MU_POD_ID: ${{ secrets.RUNPOD_MU_POD_ID }}
-  #     RUNPOD_MUV2_POD_ID: ${{ secrets.RUNPOD_MUV2_POD_ID }}
-  #     RUNPOD_MU_API_KEY: ${{ secrets.RUNPOD_MU_API_KEY }}
-  #     GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
-  #     GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
-  #     GCS_INDEX_BUCKET_NAME: ${{ secrets.GCS_INDEX_BUCKET_NAME }}
-  #     GCS_MEDIA_BUCKET_NAME: ${{ secrets.GCS_MEDIA_BUCKET_NAME }}
-  #     GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-  #     GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-  #     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  #     VERTEX_CREDENTIALS: ${{ secrets.VERTEX_CREDENTIALS }}
-  #     USE_GO_MARKDOWN_PARSER: true
-  #     SENTRY_ENVIRONMENT: dev
-  #     IDMUX_URL: ${{ secrets.IDMUX_URL }}
-  #     LOG_ENCRYPTION_KEY: ${{ secrets.LOG_ENCRYPTION_KEY }}
-  #     TEST_SUITE_WEBSITE: ${{ secrets.TEST_SUITE_WEBSITE }}
-  #     NUQ_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-  #     NUQ_RABBITMQ_URL: amqp://localhost:5672
-  #     HOST: 0.0.0.0
-  #   steps:
-  #     - uses: actions/checkout@v5
+  # The old prod-test job (fire-engine / Supabase / GCS against live infra) was
+  # removed here after sitting disabled for a long time; see git history for the
+  # full wiring. Cloud-path coverage is being rebuilt per the CI redesign plan.
 
-  #     - name: Tailscale
-  #       uses: tailscale/github-action@v4
-  #       with:
-  #         oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-  #         oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-  #         tags: tag:ci
-  #         use-cache: 'true'
+  go-mod-tidy:
+    name: Verify go.mod/go.sum are tidy
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
 
-  #     - uses: pnpm/action-setup@v4
-  #       with:
-  #         version: 11.4.0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.24
+          cache-dependency-path: apps/api/sharedLibs/go-html-to-md/go.sum
 
-  #     - run: pnpm config set store-dir ~/.pnpm-store
-  #     - run: mkdir -p ~/.pnpm-store
+      - name: Verify go.sum is up to date (sharedLibs/go-html-to-md)
+        run: |
+          cd apps/api/sharedLibs/go-html-to-md
+          go mod tidy
+          git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum is out of sync -- run 'go mod tidy' and commit" && exit 1)
 
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 22
-  #         cache: pnpm
-  #         cache-dependency-path: |
-  #           apps/api/pnpm-lock.yaml
-
-  #     - run: pnpm fetch
-  #       working-directory: apps/api
-
-  #     - name: Restore native lib
-  #       id: napi_restore
-  #       uses: actions/cache/restore@v4
-  #       with:
-  #         path: |
-  #           apps/api/native/*.node
-  #           apps/api/native/index.js
-  #           apps/api/native/index.d.ts
-  #         # note: this key is not ideal, need to find a better solution
-  #         key: ${{ runner.os }}-napi-${{ hashFiles('apps/api/native/Cargo.toml', 'apps/api/native/package.json', 'apps/api/native/src/**') }}
-
-  #     - name: Build native lib
-  #       if: steps.napi_restore.outputs.cache-hit != 'true'
-  #       run: pnpm install
-  #       working-directory: apps/api/native
-
-  #     - name: Cache native lib
-  #       if: steps.napi_restore.outputs.cache-hit != 'true'
-  #       uses: actions/cache/save@v4
-  #       with:
-  #         path: |
-  #           apps/api/native/*.node
-  #           apps/api/native/index.js
-  #           apps/api/native/index.d.ts
-  #         key: ${{ steps.napi_restore.outputs.cache-primary-key }}
-
-  #     - uses: actions/setup-go@v6
-  #       with:
-  #         go-version: 1.24
-  #         cache-dependency-path: apps/api/sharedLibs/go-html-to-md/go.sum
-
-  #     - name: Restore Go lib
-  #       id: golib_restore
-  #       uses: actions/cache/restore@v4
-  #       with:
-  #         path: apps/api/sharedLibs/go-html-to-md/libhtml-to-markdown.so
-  #         key: ${{ runner.os }}-golib-${{ hashFiles('apps/api/sharedLibs/go-html-to-md/go.sum', 'apps/api/sharedLibs/go-html-to-md/*.go') }}
-
-  #     - name: Build go-html-to-md
-  #       if: steps.golib_restore.outputs.cache-hit != 'true'
-  #       run: |
-  #         cd apps/api/sharedLibs/go-html-to-md
-  #         go mod tidy
-  #         go build -o libhtml-to-markdown.so -buildmode=c-shared html-to-markdown.go
-
-  #     - name: Cache Go lib
-  #       if: steps.golib_restore.outputs.cache-hit != 'true'
-  #       uses: actions/cache/save@v4
-  #       with:
-  #         path: apps/api/sharedLibs/go-html-to-md/libhtml-to-markdown.so
-  #         key: ${{ steps.golib_restore.outputs.cache-primary-key }}
-
-  #     - name: Install API dependencies
-  #       run: pnpm install --frozen-lockfile --ignore-scripts
-  #       working-directory: apps/api
-  #       env:
-  #         npm_config_ignore_scripts: "true"
-
-  #     - name: Run Docker Postgres
-  #       run: |
-  #         docker build -t firecrawl/nuq-postgres:latest ./apps/nuq-postgres
-  #         docker run -d -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres --name postgres firecrawl/nuq-postgres:latest
-
-  #     - name: Run tests
-  #       run: pnpm harness pnpm test:snips
-  #       working-directory: apps/api
-  #       env:
-  #         npm_config_ignore_scripts: "true" # required currently to prevent re-building cached native lib
-
-  #     - name: Create logs directory
-  #       if: always()
-  #       run: |
-  #         mkdir -p logs
-  #         cp ./apps/api/firecrawl.log logs/firecrawl.log
-  #         cd logs
-  #         zip -r logs.zip ./*
-  #         echo "${{ secrets.LOG_ENCRYPTION_KEY }}" | gpg --batch --yes --passphrase-fd 0 -c logs.zip
-  #         rm logs.zip
-
-  #     - uses: actions/upload-artifact@v4
-  #       if: always()
-  #       with:
-  #         name: Encrypted Logs
-  #         path: logs/logs.zip.gpg
-  #         retention-days: 5
+      - name: Verify go.sum is up to date (go-html-to-md-service)
+        run: |
+          cd apps/go-html-to-md-service
+          go mod tidy
+          git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum is out of sync -- run 'go mod tidy' and commit" && exit 1)
 
   nuq-fdb-core:
     name: NuQ FoundationDB core tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     env:
       FDB_VERSION: 7.3.63
     steps:

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -419,7 +419,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: 1.24
-          cache-dependency-path: apps/api/sharedLibs/go-html-to-md/go.sum
+          cache-dependency-path: |
+            apps/api/sharedLibs/go-html-to-md/go.sum
+            apps/go-html-to-md-service/go.sum
 
       - name: Verify go.sum is up to date (sharedLibs/go-html-to-md)
         run: |

--- a/.github/workflows/validate-lockfiles.yml
+++ b/.github/workflows/validate-lockfiles.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   validate:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm


### PR DESCRIPTION
Phase 0 of the CI redesign: hygiene-only changes, no new coverage yet. All changes are workflow YAML.

## What changed

- **`timeout-minutes` on every test job** — previously none existed anywhere, so a hung scrape could burn the 6-hour default per matrix cell. Values are ~2× the observed p95 per workflow.
- **Path filters on the two most expensive unfiltered workflows** — `test-server.yml` now triggers only on `apps/api`, `apps/playwright-service-ts`, `apps/nuq-postgres`, `apps/test-site`, `apps/go-html-to-md-service`, and itself; `npm-audit.yml` on manifests/lockfiles/audit configs. Docs- and SDK-only PRs no longer pay for the full 6-job server suite. (Safe: `main` has no required status checks, so a skipped workflow can't block a merge.)
- **Deleted the disabled `prod-test` job** (165 commented lines in `test-server.yml`). It was the only record of the old fire-engine/Supabase/GCS wiring — it remains in git history, and cloud-path coverage is being rebuilt in later phases of the redesign.
- **Moved the two `go mod tidy` drift checks out of the 5-cell matrix** into a standalone `go-mod-tidy` job — they were running 5× per PR inside the most expensive job.
- **`npm-audit`: 7 sequential `pnpm dlx audit-ci` steps → parallel matrix**, one job per package dir. Failures now point directly at the failing package instead of an aggregate log. The `workflow_run` trigger for the Claude remediation workflow is unaffected (any failed matrix leg still fails the run).
- **Demoted the js-sdk live e2e step to `continue-on-error`** — it runs against a deployed API over Tailscale and is currently red on every PR (13 failing extract tests), which is training everyone to ignore it. It still runs and reports. Its unit suite also has 13/110 failures locally, so making that blocking is deferred to phase 1 alongside fixing it.
- **Deduped `scrape-evals.yml`** — two ~95%-identical jobs merged into one dispatch job that handles both `#scrape-quality-eval` and `#scrape-ocr-eval` (including both tags on one PR).
- **Pinned `actions/checkout@main` → `@v5`** in `deploy-playwright`, `deploy-redis`, `deploy-go-service`.
- **Fixed the malformed concurrency group** in `test-server.yml` (`ci=${{ ... }}` prefix).

## Verification

- All 30 workflow files parse as valid YAML.
- This PR touches `.github/workflows/test-server.yml`, which is in its own path filter, so the server suite runs here and validates the restructured workflow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018edKYuep3MHnqjLZJdk9tC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787767895&installation_model_id=11126&pr_number=4146&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4146&signature=bbbdc8a354d84a8bb4e3644657f0f2f654cd02060aad2333a6e1455cc23e6882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 0 CI cleanup to cut wasted minutes and make failures clearer. Adds timeouts and path filters, parallelizes `npm-audit`, strengthens eval dispatch, removes dead jobs, and fixes a concurrency config.

- **Refactors**
  - Added `timeout-minutes` across test workflows (SDKs, server) and `validate-lockfiles` to prevent hangs.
  - Path-filtered `test-server.yml` to `apps/api`, `apps/playwright-service-ts`, `apps/nuq-postgres`, `apps/test-site`, `apps/go-html-to-md-service`, and itself; filtered `npm-audit.yml` to manifests/lockfiles/configs plus `pnpm-workspace.yaml`.
  - Removed the long-disabled prod test job from `test-server.yml`.
  - Moved both `go mod tidy` drift checks into a standalone `go-mod-tidy` job and included both `go.sum` files in the `setup-go` cache key.
  - `npm-audit`: converted 7 sequential runs into a parallel matrix (one per package dir) with a 10‑min timeout.
  - `test-js-sdk`: made the live e2e step `continue-on-error` (still runs and reports).
  - `scrape-evals.yml`: merged into a single dispatcher, matched tags case-insensitively, and dispatched each requested eval independently; 10‑min timeout.
  - Fixed malformed `concurrency.group` in `test-server.yml`.
  - Updated `.github/scripts/audit-ci-vuln-scan.mjs` to reflect matrix audit jobs and per‑package logs.

- **Dependencies**
  - Pinned `actions/checkout@main` to `actions/checkout@v5` in `deploy-playwright`, `deploy-redis`, and `deploy-go-service`.

<sup>Written for commit c8354158ae476aabf7a72e1869674e3d7e692b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

