### PR TITLE
feat(scrape): forward maxAge to avgrab metadata cache

### DIFF
--- a/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
@@ -1,4 +1,69 @@
 import { youtubePostprocessor } from "../youtube";
+import { config } from "../../../../config";
+
+describe("youtubePostprocessor maxAge forwarding to avgrab", () => {
+  const originalFetch = global.fetch;
+  const originalUrl = config.AVGRAB_SERVICE_URL;
+  const engineResult: any = {
+    url: "https://www.youtube.com/watch?v=H4fUJQCIV5E",
+    markdown: "x",
+  };
+  const metaBase = {
+    logger: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      child: () => metaBase.logger,
+    },
+  };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    config.AVGRAB_SERVICE_URL = originalUrl;
+    vi.clearAllMocks();
+  });
+
+  function mockMetadata() {
+    const spy = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ uploaded_by: {}, transcript: "hi", title: "t" }),
+    }));
+    global.fetch = spy as any;
+    config.AVGRAB_SERVICE_URL = "https://avgrab.example";
+    return spy;
+  }
+
+  async function runWith(maxAge: number | undefined) {
+    const spy = mockMetadata();
+    const meta: any = {
+      ...metaBase,
+      url: engineResult.url,
+      options: { lockdown: false, maxAge, location: undefined },
+    };
+    // We only assert the outgoing request body; the mocked response may fail
+    // later shape validation, which is irrelevant here.
+    await youtubePostprocessor.run(meta, engineResult).catch(() => {});
+    const call = spy.mock.calls.find(([u]: any[]) =>
+      String(u).endsWith("/metadata"),
+    );
+    return JSON.parse(call![1].body as string);
+  }
+
+  it("forwards maxAge:0 as max_age_seconds:0 (probe cache bypass)", async () => {
+    const body = await runWith(0);
+    expect(body.max_age_seconds).toBe(0);
+  });
+
+  it("converts maxAge ms to seconds", async () => {
+    const body = await runWith(3_600_000);
+    expect(body.max_age_seconds).toBe(3600);
+  });
+
+  it("omits max_age_seconds when maxAge is unset (default TTL applies)", async () => {
+    const body = await runWith(undefined);
+    expect("max_age_seconds" in body).toBe(false);
+  });
+});
 
 describe("youtubePostprocessor.shouldRun", () => {
   const meta = {} as any;

--- a/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
@@ -30,6 +30,7 @@ type YouTubeMetadataRequest = {
   url: string;
   transcript_language: string;
   cookies?: BrowserCookie[];
+  max_age_seconds?: number;
 };
 
 function getTranscriptLanguage(meta: Meta): string {
@@ -102,10 +103,19 @@ async function getYouTubeMetadata(
   engineResult: EngineScrapeResult,
 ): Promise<YouTubeMetadataResponse> {
   const cookies = meta.audioCookies ?? engineResult.audioCookies;
+  // Forward the scrape's maxAge (ms) to avgrab's metadata cache as a seconds
+  // freshness bound. Only when explicitly set: unset leaves avgrab on its
+  // default TTL (so normal scrapes still benefit from the cache), while
+  // maxAge:0 forces a live extraction — which is how the E2E probe bypasses
+  // the cache so a stale hit can't mask a broken extraction path.
+  const maxAge = meta.options.maxAge;
   const requestBody: YouTubeMetadataRequest = {
     url: engineResult.url,
     transcript_language: getTranscriptLanguage(meta),
     ...(cookies && cookies.length > 0 ? { cookies } : {}),
+    ...(maxAge !== undefined
+      ? { max_age_seconds: Math.floor(maxAge / 1000) }
+      : {}),
   };
 
   const response = await fetch(`${config.AVGRAB_SERVICE_URL}/metadata`, {


### PR DESCRIPTION
## Why

Companion to the avgrab metadata cache (fire-engine#529). That cache is transparent to the API and needs no changes to *function* — but two things want maxAge threaded through:

1. **Customer control** — a scrape asking for fresh data (`maxAge` small/0) should get fresh metadata, not a cache hit.
2. **The E2E probe** — the probe must be able to **bypass** the metadata cache so a stale hit can't mask a broken extraction path (a cache-hit probe would stay green through an outage).

The video-metadata postprocessor now forwards `meta.options.maxAge` (ms) to avgrab as `max_age_seconds` (seconds), **only when explicitly set**:
- unset → omitted → avgrab uses its default TTL (normal scrapes keep the cache benefit)
- `maxAge: 0` → `max_age_seconds: 0` → avgrab forces a live extraction (the probe sets this)
- `maxAge: 3600000` → `max_age_seconds: 3600` (fresh-within-an-hour)

avgrab side: fire-engine#529 (adds the `max_age_seconds` request field + cache read honoring it). Merge that first.

Probe change (monitor config, no code): set `"maxAge": 0` in the request body.

Tests: request-body forwarding for all three cases (0 / set / unset).