### PR TITLE
feat(siem): allow a test event against a disabled destination

### DIFF
--- a/apps/api/src/__tests__/snips/v2/team-siem-logging.test.ts
+++ b/apps/api/src/__tests__/snips/v2/team-siem-logging.test.ts
@@ -21,6 +21,12 @@ async function putConfig(identity: Identity, body: unknown) {
     .send(body as object);
 }
 
+async function testConfig(identity: Identity) {
+  return request(TEST_API_URL)
+    .post("/v2/team/siem/test")
+    .set("Authorization", `Bearer ${identity.apiKey}`);
+}
+
 describeIf(TEST_PRODUCTION)("Team SIEM logging config API", () => {
   it("rejects a team without the enterprise flag", async () => {
     const identity = await idmux({ name: "team-siem-logging/no-flag" });
@@ -83,6 +89,17 @@ describeIf(TEST_PRODUCTION)("Team SIEM logging config API", () => {
         expect(JSON.stringify(read.body)).not.toContain(
           "never-return-this-value",
         );
+      });
+
+      it("refuses a test event before a destination is saved", async () => {
+        const unconfigured = await idmux({
+          name: "team-siem-logging/untested",
+          flags: { siemLogging: true },
+        });
+        const response = await testConfig(unconfigured);
+
+        expect(response.statusCode).toBe(409);
+        expect(response.body.error).toContain("not configured");
       });
 
       it("rejects non-Azure ingestion endpoints", async () => {

--- a/apps/api/src/controllers/v2/team-siem-logging.ts
+++ b/apps/api/src/controllers/v2/team-siem-logging.ts
@@ -115,10 +115,14 @@ export async function testTeamSiemLoggingController(
   const orgId = await resolveOrgId(req, res);
   if (!orgId) return;
   const siemConfig = await getOrgSiemLoggingConfig(orgId);
-  if (!siemConfig?.enabled) {
+  // Deliberately does not require `enabled`: verifying a destination before
+  // turning it on is the point of this endpoint, and the dashboard gates the
+  // enable toggle on a passing test.
+  if (!siemConfig) {
     res.status(409).json({
       success: false,
-      error: "SIEM Logging is not configured and enabled.",
+      error:
+        "SIEM Logging is not configured. Save a destination before sending a test event.",
     });
     return;
   }


### PR DESCRIPTION
## Why

`POST /v2/team/siem/test` refuses with 409 unless the configuration is already **enabled**, which makes it useless for the one thing it exists to do — confirm a destination works before you start streaming to it.

That ordering matters because enabling an unreachable destination fails silently: every scrape enqueues an event, delivery fails, and the only signal is a metric nobody is watching yet. The dashboard is being changed to gate its enable toggle on a delivered test event (firecrawl-web#2958), which requires testing a saved-but-disabled config.

## What changed

The test endpoint now requires only that a destination is configured, not that it is enabled. When nothing is configured it still refuses, with a message that says what to do first rather than naming two conditions at once.

Nothing else moves: the endpoint still reads the destination and its decrypted secret at request time, still sends a single synthetic event, and still distinguishes bad credentials from a DCR schema rejection in its response.

## Testing

Added a snips case asserting the endpoint 409s with "not configured" for a flagged team that has never saved a destination. I deliberately did not add a snips case for the configured-but-disabled path — it would attempt real delivery to a non-resolving Azure host and burn three timeouts before failing. The delivery paths themselves are covered by the sender's unit tests.

`tsc`, `prettier` and `knip` clean.

## Note

This was originally committed onto the #4145 branch after that PR had already merged, so it never made it to main. Same change, moved onto a branch cut from current `main` — no content difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787774032&installation_model_id=11126&pr_number=4150&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4150&signature=84bae9a2f28077f9c58fdc6e109c1b14e10ade3f37e557501b4d42cbe86de5c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow SIEM test events against a saved but disabled destination to verify connectivity before enabling. Still returns 409 for unconfigured teams with a clearer message.

- **New Features**
  - `POST /v2/team/siem/test` accepts configured destinations even when disabled; returns 409 only when nothing is configured with guidance on saving a destination first.
  - Added a test that asserts unconfigured teams receive a 409 with "not configured".

<sup>Written for commit d254d397c0070373b2e4332159b3f0632710a7f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

