### PR TITLE
fix(siem): take the workspace resource ID, and document the real setup order

### DIFF
--- a/apps/siem/azure-sentinel/README.md
+++ b/apps/siem/azure-sentinel/README.md
@@ -5,14 +5,59 @@ Sentinel through the Azure Monitor Logs Ingestion API.
 
 ## Files
 
-- `azuredeploy.json` creates the data collection endpoint and rule.
-- `DCR.json` contains the CCF data collection rule and ASIM transform.
+- `azuredeploy.json` creates the data collection endpoint and rule. This is the
+  only artifact needed to make ingestion work, and the only one the dashboard's
+  "Deploy to Azure" button uses.
+- `DCR.json` contains the CCF data collection rule and ASim transform. It is a
+  fragment of a Sentinel solution package — it references variables defined by
+  its container, so it is not independently deployable.
 - `connectorDefinition.json` and `dataConnector.json` define the CCF Push
-  connector.
+  connector, which only affects how the integration appears in Sentinel's data
+  connector gallery. Ingestion does not depend on them.
 - `sample-event.json` is a valid input-stream event.
 
 The database schema is maintained as a migration in the Firecrawl database
 repository, not in this package.
+
+## Customer setup
+
+Three steps, in this order — the credential step needs the rule's resource ID,
+which only exists after the deployment.
+
+1. **Deploy the resources.** Use the dashboard's "Deploy to Azure" button, or
+   deploy `azuredeploy.json` directly. It asks for the full resource ID of the
+   Log Analytics workspace that should receive the events (workspace →
+   Properties → Resource ID). It takes an ID rather than a name so the workspace
+   does not have to live in the same resource group as the deployment.
+
+2. **Create the identity and grant it access.** One command creates the app
+   registration and the role assignment together, scoped to the rule that was
+   just deployed:
+
+   ```
+   az ad sp create-for-rbac \
+     --name firecrawl-siem \
+     --role "Monitoring Metrics Publisher" \
+     --scopes <dataCollectionRuleResourceId from the deployment outputs>
+   ```
+
+   It prints `tenant`, `appId` and `password`, which are the Tenant ID, Client ID
+   and Client secret the dashboard asks for. Granting that role is not optional:
+   without it the token is valid but ingestion returns 403, which surfaces as
+   `invalid_credentials` and looks like a wrong secret.
+
+3. **Paste and verify.** Enter the deployment outputs and the credentials in the
+   dashboard, then save. The stream is only enabled after a test event is
+   actually accepted.
+
+### Deployment outputs
+
+| Output | Used for |
+| --- | --- |
+| `dataCollectionEndpoint` | Data collection endpoint URL |
+| `dataCollectionRuleImmutableId` | DCR immutable ID |
+| `streamName` | Stream name |
+| `dataCollectionRuleResourceId` | `--scopes` value in step 2 |
 
 ## Severity
 

--- a/apps/siem/azure-sentinel/azuredeploy.json
+++ b/apps/siem/azure-sentinel/azuredeploy.json
@@ -6,8 +6,12 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "workspaceName": {
-      "type": "string"
+    "workspaceResourceId": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Full resource ID of the Log Analytics workspace that receives these events, e.g. /subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<name>. Copy it from the workspace's Properties blade. A full ID rather than a name so the workspace does not have to live in the resource group this template is deployed into."
+      }
     },
     "dataCollectionEndpointName": {
       "type": "string",
@@ -19,7 +23,6 @@
     }
   },
   "variables": {
-    "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
     "streamName": "Custom-FirecrawlScrapeActivity"
   },
   "resources": [
@@ -136,7 +139,7 @@
         "destinations": {
           "logAnalytics": [
             {
-              "workspaceResourceId": "[variables('workspaceResourceId')]",
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
               "name": "firecrawlWorkspace"
             }
           ]


### PR DESCRIPTION
## Why

Two things stood between the dashboard's new guided setup and a customer actually completing it unaided.

**The workspace had to be in the resource group they deployed into.** The template built its destination as `resourceId('Microsoft.OperationalInsights/workspaces', workspaceName)`, and the two-argument form of `resourceId()` resolves in the deployment's *own* resource group. Sentinel workspaces routinely sit in a dedicated resource group, and the portal's template blade lets you pick any group, so a customer choosing the wrong one got either a validation failure or — if a same-named workspace happened to exist alongside — a rule silently pointed at the wrong workspace. Nothing in the template, the deploy button, or the form said so.

**The setup order was never written down, and the load-bearing step was invisible.** The credential step needs the rule's resource ID, so it can only come after the deployment — but nothing said that. And the role assignment isn't optional: without Monitoring Metrics Publisher on the rule, the token is perfectly valid and ingestion returns 403, which our sender classifies as `invalid_credentials`. A customer then re-checks a secret that was never the problem.

## What changed

**`workspaceName` becomes `workspaceResourceId`.** Taking the full ID removes the resource-group constraint rather than documenting it, and the parameter carries a description saying where to copy it from. No other resource in the template referenced the old variable.

**The README now states the three steps in dependency order**, with the one command that replaces the manual portal walk:

```
az ad sp create-for-rbac \
  --name firecrawl-siem \
  --role "Monitoring Metrics Publisher" \
  --scopes <dataCollectionRuleResourceId from the deployment outputs>
```

That creates the app registration *and* the role assignment together, scoped to the rule just deployed, and prints exactly the three credentials the dashboard asks for. The template already emitted `dataCollectionRuleResourceId` as an output, so nothing new was needed to make this work — which is why this replaces the `principalId` parameter I'd originally floated. Fewer moving parts, same guarantee.

There's also a table mapping each deployment output to the field it fills.

**Clarified what the other artifacts are for**, since a customer reading this directory would reasonably assume they all need deploying: `DCR.json` is a Sentinel solution-package fragment that references variables from its container and isn't independently deployable, and the connector definitions only affect how the integration appears in Sentinel's data-connector gallery. Ingestion needs neither.

## Testing

`jq` validates the template and there are no dangling references to the removed variable. I have no Azure subscription to deploy against, so the template change is verified by inspection only — worth a real deployment before this goes to a customer, since a bad `workspaceResourceId` reference would fail at deploy time rather than in review.

## Related

- firecrawl-web#2958 — the dashboard flow this supports; its step 2 now shows the command above behind a copy button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787775455&installation_model_id=11126&pr_number=4151&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4151&signature=f112861417f2d4ba77074086d8607c21a09aec48ea5fea44517f3dfe28847b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the SIEM template to use a full Log Analytics workspace resource ID and documents the correct setup order. This prevents wrong-workspace deployments and 403s that looked like invalid credentials.

- **Bug Fixes**
  - Template now takes `workspaceResourceId` instead of `workspaceName`, removing the same-resource-group constraint and avoiding silent misrouting.
  - README adds the 3-step flow with a single `az ad sp create-for-rbac` command (creates the app registration and Monitoring Metrics Publisher role on the DCR), explains required artifacts only, and maps deployment outputs to dashboard fields.

- **Migration**
  - If you deploy `azuredeploy.json` manually, provide `workspaceResourceId` instead of `workspaceName`.

<sup>Written for commit c97c5122e5d54249be45ba223d9eee2779ca67ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

