### PR TITLE
fix(scrape): bound avgrab metadata/download fetches so a slow call can't time out the scrape

### DIFF
--- a/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
@@ -12,7 +12,7 @@ describe("youtubePostprocessor /metadata fetch timeout", () => {
   });
 
   it("passes an abort signal so a slow /metadata call can't hang the scrape", async () => {
-    const spy = vi.fn(async () => ({
+    const spy = vi.fn(async (_url: string, _init?: RequestInit) => ({
       ok: true,
       json: async () => ({ uploaded_by: {}, transcript: "hi", title: "t" }),
     }));
@@ -34,10 +34,8 @@ describe("youtubePostprocessor /metadata fetch timeout", () => {
       } as any)
       .catch(() => {});
 
-    const call = spy.mock.calls.find(([u]: any[]) =>
-      String(u).endsWith("/metadata"),
-    );
-    expect(call![1].signal).toBeInstanceOf(AbortSignal);
+    const call = spy.mock.calls.find(([u]) => String(u).endsWith("/metadata"));
+    expect(call?.[1]?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("degrades gracefully: a rejected /metadata fetch returns the page unchanged", async () => {

--- a/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/youtube.test.ts
@@ -1,4 +1,69 @@
 import { youtubePostprocessor } from "../youtube";
+import { config } from "../../../../config";
+
+describe("youtubePostprocessor /metadata fetch timeout", () => {
+  const originalFetch = global.fetch;
+  const originalUrl = config.AVGRAB_SERVICE_URL;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    config.AVGRAB_SERVICE_URL = originalUrl;
+    vi.clearAllMocks();
+  });
+
+  it("passes an abort signal so a slow /metadata call can't hang the scrape", async () => {
+    const spy = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ uploaded_by: {}, transcript: "hi", title: "t" }),
+    }));
+    global.fetch = spy as any;
+    config.AVGRAB_SERVICE_URL = "https://avgrab.example";
+
+    const logger = { warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+    const meta: any = {
+      logger: { ...logger, child: () => logger },
+      url: "https://www.youtube.com/watch?v=H4fUJQCIV5E",
+      options: { lockdown: false, location: undefined },
+    };
+    // The mocked response fails later shape validation; we only assert the
+    // outgoing request carried a timeout signal.
+    await youtubePostprocessor
+      .run(meta, {
+        url: "https://www.youtube.com/watch?v=H4fUJQCIV5E",
+        markdown: "x",
+      } as any)
+      .catch(() => {});
+
+    const call = spy.mock.calls.find(([u]: any[]) =>
+      String(u).endsWith("/metadata"),
+    );
+    expect(call![1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("degrades gracefully: a rejected /metadata fetch returns the page unchanged", async () => {
+    global.fetch = vi.fn(async () => {
+      throw Object.assign(new Error("aborted"), { name: "TimeoutError" });
+    }) as any;
+    config.AVGRAB_SERVICE_URL = "https://avgrab.example";
+
+    const logger = { warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+    const engineResult: any = {
+      url: "https://www.youtube.com/watch?v=H4fUJQCIV5E",
+      markdown: "original page",
+    };
+    const meta: any = {
+      logger: { ...logger, child: () => logger },
+      url: engineResult.url,
+      options: { lockdown: false, location: undefined },
+    };
+    // The postprocessor itself throws; the pipeline's try/catch is what
+    // degrades. Here we assert getYouTubeMetadata rejects (so the caller can
+    // catch), rather than hanging.
+    await expect(
+      youtubePostprocessor.run(meta, engineResult),
+    ).rejects.toBeDefined();
+  });
+});
 
 describe("youtubePostprocessor.shouldRun", () => {
   const meta = {} as any;

--- a/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/youtube.ts
@@ -4,6 +4,13 @@ import type { Postprocessor } from ".";
 import type { EngineScrapeResult } from "../engines";
 import { throwIfMediaAccessDenied } from "../error";
 
+// Transcript enrichment is best-effort: the postprocessor loop swallows its
+// errors and returns the page without a transcript. But an unbounded fetch to
+// avgrab can hang on a slow extraction and silently consume the entire scrape
+// budget, turning "no transcript" into a scrape timeout (SCRAPE_TIMEOUT 500s).
+// A bound lets the graceful degradation actually fire.
+const METADATA_FETCH_TIMEOUT_MS = 45_000;
+
 type YouTubeMetadataResponse = {
   thumbnail_image: {
     url: string;
@@ -112,6 +119,7 @@ async function getYouTubeMetadata(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(requestBody),
+    signal: AbortSignal.timeout(METADATA_FETCH_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/apps/api/src/scraper/scrapeURL/transformers/audio.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/audio.ts
@@ -4,6 +4,11 @@ import { config } from "../../../config";
 import { hasFormatOfType } from "../../../lib/format-utils";
 import { AudioUnsupportedUrlError, throwIfMediaAccessDenied } from "../error";
 
+// Downloads can be large (long videos → hundreds of MB), so this is generous —
+// but an unbounded fetch that hangs would consume the whole scrape budget and
+// surface as an opaque timeout rather than a clean failure.
+const DOWNLOAD_FETCH_TIMEOUT_MS = 240_000;
+
 let cachedUrlRegex: RegExp | null = null;
 let cacheTimestamp = 0;
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -72,6 +77,7 @@ export async function fetchAudio(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(requestBody),
+    signal: AbortSignal.timeout(DOWNLOAD_FETCH_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/apps/api/src/scraper/scrapeURL/transformers/video.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/video.ts
@@ -4,6 +4,10 @@ import { config } from "../../../config";
 import { hasFormatOfType } from "../../../lib/format-utils";
 import { throwIfMediaAccessDenied } from "../error";
 
+// Video downloads can be large; generous but bounded so a hung fetch can't
+// silently consume the whole scrape budget.
+const DOWNLOAD_FETCH_TIMEOUT_MS = 240_000;
+
 let cachedUrlRegex: RegExp | null = null;
 let cacheTimestamp = 0;
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -171,6 +175,7 @@ async function fetchLegacyVideoIfSupported(meta: Meta, document: Document) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(requestBody),
+    signal: AbortSignal.timeout(DOWNLOAD_FETCH_TIMEOUT_MS),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Root cause (traced from a real customer failure)

A high-volume media customer's #1 failure bucket is "500 unexpected (exception ID)". Traced one end to end (2026-07-27 17:xx UTC):

- The **page scrape succeeded** in ~12s.
- The **media-metadata postprocessor** (the avgrab call that enriches the page) then **hung for ~4m48s** and the scrape hit its overall timeout → `SCRAPE_TIMEOUT`.
- avgrab was healthy at the time (no OOMs) — this was a single slow/hung call, amplified during the customer's batch bursts (~417 timeouts clustered at 17:00 UTC).

The bug: **the `fetch()` calls from the API to avgrab have no timeout.** Metadata enrichment is already best-effort — the postprocessor loop catches errors and returns the page unchanged — but an *unbounded* fetch **hangs** instead of erroring, so the graceful path never fires and the whole scrape 500s.

## Fix

Add `AbortSignal.timeout` to the avgrab calls:
- metadata postprocessor: **45s**. On timeout it throws → the existing try/catch degrades gracefully → the scrape returns the page **without** the enrichment instead of failing. This directly converts the customer's 500s into successful scrapes.
- audio/video download: **240s** — generous for large files, but bounded so a hung download can't silently consume the scrape budget.

Tests: assert the metadata request carries an abort signal and that a rejected fetch propagates (so the pipeline can degrade) rather than hanging.

Companion (separate): the avgrab metadata cache (fire-engine#529) + maxAge forwarding (#4147) make repeat lookups instant, removing the slow extraction that hangs in the first place.