### PR TITLE
fix(py-sdk): don't send the API key to cross-host next URLs in the async client

### DIFF
--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -10,6 +10,37 @@ from .get_version import get_version
 
 version = get_version()
 
+
+def build_url(api_url: str, endpoint: str) -> str:
+    """Resolve ``endpoint`` against ``api_url``, never leaving the configured host.
+
+    Absolute URLs pointing at a different host (e.g. a ``next`` pagination URL
+    returned by a proxied or self-hosted deployment) are rewritten onto the
+    configured ``api_url`` host/scheme so credentials are never sent to a
+    foreign host.
+    """
+    base = urlparse(api_url)
+    ep = urlparse(endpoint)
+
+    # Absolute or protocol-relative (has netloc)
+    if ep.netloc:
+        # Different host: keep path/query but force base host/scheme (no token leakage)
+        path = ep.path or "/"
+        if (ep.hostname or "") != (base.hostname or ""):
+            return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
+        # Same host: normalize scheme to base
+        return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
+
+    # Relative (including leading slash or not)
+    base_str = api_url if api_url.endswith("/") else f"{api_url}/"
+    # Guard protocol-relative like //host/path slipping through as “relative”
+    if endpoint.startswith("//"):
+        ep2 = urlparse(f"https:{endpoint}")
+        path = ep2.path or "/"
+        return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
+    return urljoin(base_str, endpoint)
+
+
 class HttpClient:
     """HTTP client with retry logic and error handling."""
 
@@ -28,26 +59,7 @@ class HttpClient:
         self.backoff_factor = backoff_factor
 
     def _build_url(self, endpoint: str) -> str:
-        base = urlparse(self.api_url)
-        ep = urlparse(endpoint)
-
-        # Absolute or protocol-relative (has netloc)
-        if ep.netloc:
-            # Different host: keep path/query but force base host/scheme (no token leakage)
-            path = ep.path or "/"
-            if (ep.hostname or "") != (base.hostname or ""):
-                return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
-            # Same host: normalize scheme to base
-            return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
-
-        # Relative (including leading slash or not)
-        base_str = self.api_url if self.api_url.endswith("/") else f"{self.api_url}/"
-        # Guard protocol-relative like //host/path slipping through as “relative”
-        if endpoint.startswith("//"):
-            ep2 = urlparse(f"https:{endpoint}")
-            path = ep2.path or "/"
-            return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
-        return urljoin(base_str, endpoint)
+        return build_url(self.api_url, endpoint)
     
     def _prepare_headers(
         self,

--- a/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
@@ -2,6 +2,7 @@ import asyncio
 import httpx
 from typing import Optional, Dict, Any
 from .get_version import get_version
+from .http_client import build_url
 
 version = get_version()
 
@@ -35,6 +36,16 @@ class AsyncHttpClient:
     async def close(self) -> None:
         await self._client.aclose()
 
+    def _build_url(self, endpoint: str) -> str:
+        """Resolve ``endpoint`` against ``api_url``, pinning it to the configured host.
+
+        httpx ignores ``base_url`` for absolute URLs, so without this an
+        absolute cross-host endpoint (e.g. a ``next`` pagination URL from a
+        proxied deployment) would be requested as-is — with the client-level
+        Authorization header attached. Mirrors the sync ``HttpClient``.
+        """
+        return build_url(self.api_url, endpoint)
+
     def _headers(self, idempotency_key: Optional[str] = None) -> Dict[str, str]:
         headers: Dict[str, str] = {}
         if idempotency_key:
@@ -66,7 +77,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.post(
-                    endpoint,
+                    self._build_url(endpoint),
                     json=payload,
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,
@@ -107,7 +118,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.post(
-                    endpoint,
+                    self._build_url(endpoint),
                     data=data,
                     files=files,
                     headers={**self._headers(), **(headers or {})},
@@ -147,7 +158,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.get(
-                    endpoint,
+                    self._build_url(endpoint),
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,
                 )
@@ -185,7 +196,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.delete(
-                    endpoint,
+                    self._build_url(endpoint),
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,
                 )
@@ -227,7 +238,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.patch(
-                    endpoint,
+                    self._build_url(endpoint),
                     json=payload,
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,

--- a/apps/python-sdk/tests/test_cross_host_url_rewrite.py
+++ b/apps/python-sdk/tests/test_cross_host_url_rewrite.py
@@ -1,0 +1,162 @@
+"""Regression tests for cross-host URL rewriting (GH issue #4139).
+
+The async client must never send the Authorization header to a host other
+than the configured ``api_url`` host. Crawl/batch auto-pagination feeds the
+server-provided ``next`` URL straight back into the HTTP client, so an
+absolute cross-host URL has to be rewritten onto the configured base, exactly
+like the sync ``HttpClient._build_url`` already does.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+
+from firecrawl.v2.utils.http_client import HttpClient, build_url
+from firecrawl.v2.utils.http_client_async import AsyncHttpClient
+
+API_URL = "https://api.firecrawl.dev"
+
+
+class TestBuildUrl:
+    def test_cross_host_absolute_url_is_pinned_to_base(self):
+        url = build_url(API_URL, "https://evil.example.com/v2/crawl/job-1?skip=10")
+        assert url == "https://api.firecrawl.dev/v2/crawl/job-1?skip=10"
+
+    def test_same_host_absolute_url_keeps_path_and_query(self):
+        url = build_url(API_URL, "https://api.firecrawl.dev/v2/crawl/job-1?skip=10")
+        assert url == "https://api.firecrawl.dev/v2/crawl/job-1?skip=10"
+
+    def test_same_host_scheme_is_normalized_to_base(self):
+        url = build_url(API_URL, "http://api.firecrawl.dev/v2/crawl/job-1")
+        assert url == "https://api.firecrawl.dev/v2/crawl/job-1"
+
+    def test_relative_endpoint_is_joined(self):
+        assert build_url(API_URL, "/v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+        assert build_url(API_URL, "v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+
+    def test_protocol_relative_url_is_pinned_to_base(self):
+        url = build_url(API_URL, "//evil.example.com/v2/crawl/job-1?skip=5")
+        assert url == "https://api.firecrawl.dev/v2/crawl/job-1?skip=5"
+
+    def test_userinfo_and_fragment_are_dropped(self):
+        url = build_url(API_URL, "https://user:pass@evil.example.com/v2/x?a=1#frag")
+        assert url == "https://api.firecrawl.dev/v2/x?a=1"
+
+
+class TestSyncAsyncParity:
+    """The two clients must resolve URLs identically so they never drift again."""
+
+    CASES = [
+        "https://evil.example.com/v2/crawl/job-1?skip=10",
+        "https://api.firecrawl.dev/v2/crawl/job-1?skip=10",
+        "http://api.firecrawl.dev/v2/crawl/job-1",
+        "//evil.example.com/v2/crawl/job-1",
+        "/v2/scrape",
+        "v2/scrape",
+    ]
+
+    def test_async_build_url_matches_sync(self):
+        sync_client = HttpClient(api_key="fc-test", api_url=API_URL)
+        async_client = AsyncHttpClient(api_key="fc-test", api_url=API_URL)
+        try:
+            for endpoint in self.CASES:
+                assert async_client._build_url(endpoint) == sync_client._build_url(endpoint), endpoint
+        finally:
+            asyncio.run(async_client.close())
+
+
+def _install_mock_transport(client: AsyncHttpClient, requests_seen: list) -> None:
+    """Swap the client's httpx transport for one that records every request."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(request)
+        return httpx.Response(200, json={"success": True})
+
+    old = client._client
+    client._client = httpx.AsyncClient(
+        base_url=str(old.base_url),
+        headers=old.headers,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.parametrize("verb", ["get", "delete", "post", "patch"])
+def test_async_client_never_sends_api_key_cross_host(verb):
+    client = AsyncHttpClient(api_key="fc-PROBE-SECRET-KEY", api_url=API_URL)
+    seen: list = []
+    _install_mock_transport(client, seen)
+
+    async def run():
+        method = getattr(client, verb)
+        cross_host = "https://evil.example.com/v2/crawl/job-1?skip=10"
+        if verb in ("post", "patch"):
+            await method(cross_host, data={})
+        else:
+            await method(cross_host)
+        await client.close()
+
+    asyncio.run(run())
+
+    assert len(seen) == 1
+    request = seen[0]
+    # The request must be pinned to the configured host, path/query preserved.
+    assert request.url.host == "api.firecrawl.dev"
+    assert request.url.path == "/v2/crawl/job-1"
+    assert request.url.params.get("skip") == "10"
+
+
+def test_async_client_post_multipart_never_sends_api_key_cross_host():
+    client = AsyncHttpClient(api_key="fc-PROBE-SECRET-KEY", api_url=API_URL)
+    seen: list = []
+    _install_mock_transport(client, seen)
+
+    async def run():
+        await client.post_multipart(
+            "https://evil.example.com/v2/upload",
+            data={"k": "v"},
+            files={"file": ("f.txt", b"data")},
+        )
+        await client.close()
+
+    asyncio.run(run())
+
+    assert len(seen) == 1
+    assert seen[0].url.host == "api.firecrawl.dev"
+    assert seen[0].url.path == "/v2/upload"
+
+
+def test_async_client_same_host_pagination_still_works():
+    """A same-host absolute ``next`` URL must keep working (normal pagination)."""
+    client = AsyncHttpClient(api_key="fc-test", api_url=API_URL)
+    seen: list = []
+    _install_mock_transport(client, seen)
+
+    async def run():
+        await client.get("https://api.firecrawl.dev/v2/crawl/job-1?skip=10")
+        await client.close()
+
+    asyncio.run(run())
+
+    assert len(seen) == 1
+    request = seen[0]
+    assert request.url.host == "api.firecrawl.dev"
+    assert request.url.path == "/v2/crawl/job-1"
+    assert request.url.params.get("skip") == "10"
+    assert request.headers.get("Authorization") == "Bearer fc-test"
+
+
+def test_async_client_relative_endpoint_still_works():
+    client = AsyncHttpClient(api_key="fc-test", api_url=API_URL)
+    seen: list = []
+    _install_mock_transport(client, seen)
+
+    async def run():
+        await client.get("/v2/crawl/job-1")
+        await client.close()
+
+    asyncio.run(run())
+
+    assert len(seen) == 1
+    assert seen[0].url.host == "api.firecrawl.dev"
+    assert seen[0].url.path == "/v2/crawl/job-1"


### PR DESCRIPTION
Fixes #4139

## What

The async client passed endpoints straight to httpx. httpx ignores `base_url` when the endpoint is an absolute URL, and the Authorization header is set on the client, so a cross-host `next` URL from crawl/batch auto-pagination was followed as-is with the API key attached.

The sync client already neutralizes this in `_build_url`. This PR extracts that logic into a shared `build_url()` helper in `http_client.py` and routes all five `AsyncHttpClient` verbs (`post`, `post_multipart`, `get`, `delete`, `patch`) through it, so the two clients resolve URLs identically and can't drift again.

## Tests

Added `tests/test_cross_host_url_rewrite.py`:

- unit tests for `build_url` (cross-host, same-host, relative, protocol-relative, userinfo/fragment stripping)
- a sync/async parity test over the same endpoint set
- MockTransport wire tests asserting a cross-host URL is pinned to the configured host on every verb, and that same-host pagination and relative endpoints still work

Without the fix the wire tests fail (the request goes to the foreign host). With it, all 14 pass. Full suite shows no new failures; the 13 failures in `tests/test_timeout_conversion.py` and friends reference removed private APIs and fail on main too.

Credit to @toolshedlabs-hash for the detailed report and root cause analysis in #4139.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787803652&installation_model_id=11126&pr_number=4155&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4155&signature=a65f809739ef823711700ff6fac3b3587b1310dc1f9b23a4781fb13f69723750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Python SDK async client from sending the API key to cross-host absolute endpoints by rewriting them onto the configured api host. The async client now resolves URLs like the sync client to block credential leakage via `httpx`.

- **Bug Fixes**
  - Added a shared `build_url()` helper to pin endpoints to the configured host and normalize scheme (handles absolute, relative, and protocol-relative URLs).
  - Routed all async verbs through `build_url()` (`post`, `post_multipart`, `get`, `delete`, `patch`); added tests for cross-host rewrite, same-host pagination, and sync/async parity.

<sup>Written for commit 64846b7d95c1f1055dcb3f86893379ea90d9d440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

