### PR TITLE
fix(python-sdk): stop forcing skipTlsVerification on every scrape

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -398,3 +398,38 @@ class TestPrepareScrapeOptions:
         assert result["minAge"] == 1000
         assert "min_age" not in result
         assert result["maxAge"] == 5000
+
+class TestSkipTlsVerificationDefault:
+    """The SDK must not send skipTlsVerification unless the caller set it.
+
+    The API decides the default itself: it turns certificate checking back on
+    when headers or actions are present, and only skips it for plain scrapes.
+    Sending a value from the SDK overrides that, so a scrape carrying
+    credentials in headers would silently stop verifying certificates.
+    """
+
+    def test_omitted_when_not_set(self):
+        """An unset option is left to the server."""
+        result = prepare_scrape_options(ScrapeOptions())
+
+        assert "skipTlsVerification" not in result
+
+    def test_omitted_when_headers_are_present(self):
+        """Headers are exactly the case the server wants to decide."""
+        result = prepare_scrape_options(
+            ScrapeOptions(headers={"Authorization": "Bearer token"})
+        )
+
+        assert "skipTlsVerification" not in result
+
+    def test_explicit_true_is_sent(self):
+        """Opting in is still honoured."""
+        result = prepare_scrape_options(ScrapeOptions(skip_tls_verification=True))
+
+        assert result["skipTlsVerification"] is True
+
+    def test_explicit_false_is_sent(self):
+        """Opting out is still honoured."""
+        result = prepare_scrape_options(ScrapeOptions(skip_tls_verification=False))
+
+        assert result["skipTlsVerification"] is False

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -531,11 +531,14 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
     if validated_options is None:
         return None
     
-    # Apply default values for None fields
+    # Apply default values for None fields.
+    # skip_tls_verification is deliberately absent: the API turns it off by
+    # itself when headers or actions are present, and sending an explicit
+    # value here would override that and disable certificate checks for
+    # authenticated scrapes.
     default_values = {
         "only_main_content": True,
         "mobile": False,
-        "skip_tls_verification": True,
         "remove_base64_images": True,
         "fast_mode": False,
         "block_ads": True,


### PR DESCRIPTION
`prepare_scrape_options` fills in a set of client-side defaults for any field the caller left unset, and `skip_tls_verification` is one of them:

```python
default_values = {
    ...
    "skip_tls_verification": True,
    ...
}
```

So the SDK sends `skipTlsVerification: true` on essentially every request, even though the user never asked for it. That defeats the API's own default logic in `applyScrapeOptionsDefaults` (`apps/api/src/controllers/v2/types.ts`):

```ts
skipTlsVerification:
  obj.skipTlsVerification ??
  ((obj.headers && Object.keys(obj.headers).length > 0) ||
   (obj.actions && obj.actions.length > 0)
    ? false
    : true),
```

The `??` only applies when the field is absent. Because the SDK always sends an explicit `true`, the branch that turns verification back **on** for requests with headers or actions can never run.

The practical case is an authenticated scrape:

```python
FirecrawlApp(...).scrape(url, headers={"Authorization": "Bearer <token>"})
```

The API would have used `skipTlsVerification: false` here, precisely because credentials are being sent. Instead the SDK's forced `true` disables certificate verification for that request. The JS SDK does not send the field at all, so the same call from JS keeps verification on; this is a Python-only divergence.

Reproduced against the current SDK:

```
headers (auth scrape)    -> skipTlsVerification sent = True     # server wanted False
plain scrape             -> skipTlsVerification sent = True
```

The fix removes `skip_tls_verification` from the client-side defaults so the field is omitted when unset and the API decides. An explicit value from the caller is still forwarded:

```
headers (auth scrape)    -> omitted, server decides (False)
plain scrape             -> omitted, server decides (True)
user set True            -> True
user set False           -> False
```

Plain scrapes are unaffected, since the server's default for them is `true`, which is what was being sent anyway. The only behaviour that changes is the case the server already intended to handle differently.

Added `TestSkipTlsVerificationDefault` to `firecrawl/__tests__/unit/v2/utils/test_validation.py`. Verified with `pytest firecrawl/__tests__/unit/v2/utils/test_validation.py`: 2 of the new tests fail against the current code and all 30 pass with the fix. The full unit suite is unchanged at 398 passed (`test_pagination.py`'s two `propagates_request_timeout` failures reproduce on a clean checkout and are unrelated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787831744&installation_model_id=11126&pr_number=4158&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4158&signature=2d1bbe4ca2a13d473126da2c172cf382e5131bd2da166817a01ef373a38fe718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Python SDK forcing `skipTlsVerification: true` on every scrape. The field is now omitted unless set by the user, so the API applies correct defaults and authenticated scrapes keep certificate checks on (matches JS SDK).

- **Bug Fixes**
  - Removed `skip_tls_verification` from defaults in `prepare_scrape_options`; omit when unset.
  - Let the server decide: verification on when headers/actions are present; skip only for plain scrapes.
  - Preserve explicit `True`/`False` from the caller; added `TestSkipTlsVerificationDefault` to cover this.

<sup>Written for commit d655fa4c8402100403f6253d0176e1ae66e40933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

