### PR TITLE
fix(api): merge adjacent DOCX formatting runs

### DIFF
--- a/apps/api/native/src/document/providers/docx.rs
+++ b/apps/api/native/src/document/providers/docx.rs
@@ -282,6 +282,120 @@ fn children<'a, 'b>(
     .filter(move |n| n.is_element() && n.tag_name().name() == local)
 }
 
+fn normalize_inline(inline: Inline) -> Inline {
+  match inline {
+    Inline::Link { href, children } => Inline::Link {
+      href,
+      children: normalize_inlines(children),
+    },
+    Inline::Strong(children) => Inline::Strong(normalize_inlines(children)),
+    Inline::Em(children) => Inline::Em(normalize_inlines(children)),
+    Inline::Del(children) => Inline::Del(normalize_inlines(children)),
+    Inline::Sup(children) => Inline::Sup(normalize_inlines(children)),
+    Inline::Sub(children) => Inline::Sub(normalize_inlines(children)),
+    inline => inline,
+  }
+}
+
+fn is_mergeable_format(inline: &Inline) -> bool {
+  matches!(
+    inline,
+    Inline::Strong(_) | Inline::Em(_) | Inline::Del(_) | Inline::Sup(_) | Inline::Sub(_)
+  )
+}
+
+fn has_same_mergeable_format(left: &Inline, right: &Inline) -> bool {
+  matches!(
+    (left, right),
+    (Inline::Strong(_), Inline::Strong(_))
+      | (Inline::Em(_), Inline::Em(_))
+      | (Inline::Del(_), Inline::Del(_))
+      | (Inline::Sup(_), Inline::Sup(_))
+      | (Inline::Sub(_), Inline::Sub(_))
+  )
+}
+
+fn merge_formatted_inlines(target: &mut Inline, source: Inline, separator: Option<String>) {
+  let (target_children, mut source_children) = match (target, source) {
+    (Inline::Strong(target), Inline::Strong(source)) => (target, source),
+    (Inline::Em(target), Inline::Em(source)) => (target, source),
+    (Inline::Del(target), Inline::Del(source)) => (target, source),
+    (Inline::Sup(target), Inline::Sup(source)) => (target, source),
+    (Inline::Sub(target), Inline::Sub(source)) => (target, source),
+    _ => unreachable!("formatted inline variants must match before merging"),
+  };
+
+  if let Some(separator) = separator {
+    target_children.push(Inline::Text(separator));
+  }
+  target_children.append(&mut source_children);
+
+  let children = std::mem::take(target_children);
+  *target_children = normalize_inlines(children);
+}
+
+fn normalize_inlines(inlines: Vec<Inline>) -> Vec<Inline> {
+  // Word may split visually identical formatting into arbitrary runs. Collapse
+  // those run boundaries before HTML rendering so Markdown does not emit
+  // adjacent delimiters such as `**10****th**`.
+  let mut output: Vec<Inline> = Vec::with_capacity(inlines.len());
+  let mut pending_whitespace: Option<String> = None;
+
+  for inline in inlines.into_iter().map(normalize_inline) {
+    let is_whitespace_after_format = match &inline {
+      Inline::Text(value) => {
+        !value.is_empty()
+          && value.chars().all(char::is_whitespace)
+          && output.last().map(is_mergeable_format).unwrap_or(false)
+      }
+      _ => false,
+    };
+
+    if is_whitespace_after_format {
+      let Inline::Text(value) = inline else {
+        unreachable!();
+      };
+      pending_whitespace
+        .get_or_insert_with(String::new)
+        .push_str(&value);
+      continue;
+    }
+
+    if let Some(separator) = pending_whitespace.take() {
+      let can_merge_across_whitespace = output
+        .last()
+        .map(|previous| has_same_mergeable_format(previous, &inline))
+        .unwrap_or(false);
+
+      if can_merge_across_whitespace {
+        let previous = output.last_mut().expect("checked above");
+        merge_formatted_inlines(previous, inline, Some(separator));
+        continue;
+      }
+
+      output.push(Inline::Text(separator));
+    }
+
+    let can_merge_directly = output
+      .last()
+      .map(|previous| has_same_mergeable_format(previous, &inline))
+      .unwrap_or(false);
+
+    if can_merge_directly {
+      let previous = output.last_mut().expect("checked above");
+      merge_formatted_inlines(previous, inline, None);
+    } else {
+      output.push(inline);
+    }
+  }
+
+  if let Some(whitespace) = pending_whitespace {
+    output.push(Inline::Text(whitespace));
+  }
+
+  output
+}
+
 fn parse_paragraph_with_listinfo(
   node: &Node,
   rels: &Relationships,
@@ -311,7 +425,13 @@ fn parse_paragraph_with_listinfo(
   }
 
   let list_info = paragraph_list_info(node, numbering);
-  Some((Paragraph { kind, inlines }, list_info))
+  Some((
+    Paragraph {
+      kind,
+      inlines: normalize_inlines(inlines),
+    },
+    list_info,
+  ))
 }
 
 fn paragraph_kind(
@@ -1071,4 +1191,153 @@ fn read_comments<R: Read + Seek>(
     });
   }
   out
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn text(value: &str) -> Inline {
+    Inline::Text(value.to_string())
+  }
+
+  fn strong(value: &str) -> Inline {
+    Inline::Strong(vec![text(value)])
+  }
+
+  fn inlines_text(inlines: &[Inline]) -> String {
+    let mut output = String::new();
+    for inline in inlines {
+      output.push_str(&inline_text(inline));
+    }
+    output
+  }
+
+  fn inline_text(inline: &Inline) -> String {
+    match inline {
+      Inline::Text(value) | Inline::Code(value) => value.clone(),
+      Inline::LineBreak => "\n".to_string(),
+      Inline::Link { children, .. }
+      | Inline::Strong(children)
+      | Inline::Em(children)
+      | Inline::Del(children)
+      | Inline::Sup(children)
+      | Inline::Sub(children) => inlines_text(children),
+      Inline::FootnoteRef(_)
+      | Inline::EndnoteRef(_)
+      | Inline::CommentRef(_)
+      | Inline::Bookmark(_) => String::new(),
+    }
+  }
+
+  #[test]
+  fn merges_adjacent_strong_runs_and_preserves_whitespace() {
+    let normalized = normalize_inlines(vec![
+      strong("Milton Keynes University Hospital - (10"),
+      strong("th"),
+      text(" "),
+      strong("June "),
+      strong("2024 - Present) Senior Specialist Diagnostic Radiographer"),
+    ]);
+
+    assert_eq!(normalized.len(), 1);
+    let Inline::Strong(children) = &normalized[0] else {
+      panic!("expected a single strong inline");
+    };
+    assert_eq!(
+      inlines_text(children),
+      "Milton Keynes University Hospital - (10th June 2024 - Present) Senior Specialist Diagnostic Radiographer",
+    );
+  }
+
+  #[test]
+  fn merges_fragmented_bold_runs_when_parsing_word_xml() {
+    let xml = XmlDoc::parse(
+      r#"
+        <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:t>10</w:t>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:t>th</w:t>
+          </w:r>
+          <w:r>
+            <w:t xml:space="preserve"> </w:t>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:t>June</w:t>
+          </w:r>
+        </w:p>
+      "#,
+    )
+    .expect("valid WordprocessingML fixture");
+    let size_buckets = std::collections::HashMap::new();
+    let (paragraph, _) = parse_paragraph_with_listinfo(
+      &xml.root_element(),
+      &Relationships::default(),
+      &StylesInfo::default(),
+      &size_buckets,
+      &NumberingInfo::default(),
+    )
+    .expect("paragraph should parse");
+
+    let [Inline::Strong(children)] = paragraph.inlines.as_slice() else {
+      panic!("expected fragmented Word runs to become one strong inline");
+    };
+    assert_eq!(inlines_text(children), "10th June");
+  }
+
+  #[test]
+  fn recursively_merges_matching_nested_formatting() {
+    let normalized = normalize_inlines(vec![
+      Inline::Strong(vec![Inline::Em(vec![text("frag")])]),
+      Inline::Strong(vec![Inline::Em(vec![text("mented")])]),
+    ]);
+
+    let [Inline::Strong(strong_children)] = normalized.as_slice() else {
+      panic!("expected a single strong inline");
+    };
+    let [Inline::Em(em_children)] = strong_children.as_slice() else {
+      panic!("expected nested emphasis to be merged");
+    };
+    assert_eq!(inlines_text(em_children), "fragmented");
+  }
+
+  #[test]
+  fn does_not_merge_across_semantic_boundaries() {
+    let normalized = normalize_inlines(vec![
+      strong("before"),
+      Inline::LineBreak,
+      strong("after"),
+      Inline::Link {
+        href: "https://example.com".to_string(),
+        children: vec![strong("linked")],
+      },
+      strong("tail"),
+    ]);
+
+    assert_eq!(normalized.len(), 5);
+    assert!(matches!(normalized[0], Inline::Strong(_)));
+    assert!(matches!(normalized[1], Inline::LineBreak));
+    assert!(matches!(normalized[2], Inline::Strong(_)));
+    assert!(matches!(normalized[3], Inline::Link { .. }));
+    assert!(matches!(normalized[4], Inline::Strong(_)));
+  }
+
+  #[test]
+  fn leaves_different_formatting_separate() {
+    let normalized = normalize_inlines(vec![
+      strong("bold"),
+      Inline::Em(vec![text("italic")]),
+      Inline::Del(vec![text("deleted")]),
+    ]);
+
+    assert_eq!(normalized.len(), 3);
+    assert!(matches!(normalized[0], Inline::Strong(_)));
+    assert!(matches!(normalized[1], Inline::Em(_)));
+    assert!(matches!(normalized[2], Inline::Del(_)));
+  }
 }

--- a/apps/api/native/src/document/providers/docx.rs
+++ b/apps/api/native/src/document/providers/docx.rs
@@ -282,118 +282,265 @@ fn children<'a, 'b>(
     .filter(move |n| n.is_element() && n.tag_name().name() == local)
 }
 
-fn normalize_inline(inline: Inline) -> Inline {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MergeableFormat {
+  Strong,
+  Em,
+  Del,
+  Sup,
+  Sub,
+}
+
+struct NormalizedInline {
+  inline: Inline,
+  has_merge_boundary: bool,
+}
+
+fn mergeable_format(inline: &Inline) -> Option<MergeableFormat> {
   match inline {
-    Inline::Link { href, children } => Inline::Link {
-      href,
-      children: normalize_inlines(children),
-    },
-    Inline::Strong(children) => Inline::Strong(normalize_inlines(children)),
-    Inline::Em(children) => Inline::Em(normalize_inlines(children)),
-    Inline::Del(children) => Inline::Del(normalize_inlines(children)),
-    Inline::Sup(children) => Inline::Sup(normalize_inlines(children)),
-    Inline::Sub(children) => Inline::Sub(normalize_inlines(children)),
-    inline => inline,
+    Inline::Strong(_) => Some(MergeableFormat::Strong),
+    Inline::Em(_) => Some(MergeableFormat::Em),
+    Inline::Del(_) => Some(MergeableFormat::Del),
+    Inline::Sup(_) => Some(MergeableFormat::Sup),
+    Inline::Sub(_) => Some(MergeableFormat::Sub),
+    _ => None,
   }
 }
 
-fn is_mergeable_format(inline: &Inline) -> bool {
-  matches!(
+fn normalized_mergeable_format(inline: &NormalizedInline) -> Option<MergeableFormat> {
+  if inline.has_merge_boundary {
+    None
+  } else {
+    mergeable_format(&inline.inline)
+  }
+}
+
+fn normalize_formatted_children(children: Vec<Inline>) -> (Vec<Inline>, bool) {
+  let normalized = normalize_inline_sequence(children);
+  let has_merge_boundary = normalized.iter().any(|inline| inline.has_merge_boundary);
+  let children = normalized.into_iter().map(|inline| inline.inline).collect();
+  (children, has_merge_boundary)
+}
+
+fn normalize_formatted_inline(format: MergeableFormat, children: Vec<Inline>) -> NormalizedInline {
+  let (children, has_merge_boundary) = normalize_formatted_children(children);
+  let inline = match format {
+    MergeableFormat::Strong => Inline::Strong(children),
+    MergeableFormat::Em => Inline::Em(children),
+    MergeableFormat::Del => Inline::Del(children),
+    MergeableFormat::Sup => Inline::Sup(children),
+    MergeableFormat::Sub => Inline::Sub(children),
+  };
+  NormalizedInline {
     inline,
-    Inline::Strong(_) | Inline::Em(_) | Inline::Del(_) | Inline::Sup(_) | Inline::Sub(_)
-  )
+    has_merge_boundary,
+  }
 }
 
-fn has_same_mergeable_format(left: &Inline, right: &Inline) -> bool {
-  matches!(
-    (left, right),
-    (Inline::Strong(_), Inline::Strong(_))
-      | (Inline::Em(_), Inline::Em(_))
-      | (Inline::Del(_), Inline::Del(_))
-      | (Inline::Sup(_), Inline::Sup(_))
-      | (Inline::Sub(_), Inline::Sub(_))
-  )
+fn normalize_inline(inline: Inline) -> NormalizedInline {
+  match inline {
+    Inline::Link { href, children } => NormalizedInline {
+      inline: Inline::Link {
+        href,
+        children: normalize_inlines(children),
+      },
+      has_merge_boundary: true,
+    },
+    Inline::Strong(children) => normalize_formatted_inline(MergeableFormat::Strong, children),
+    Inline::Em(children) => normalize_formatted_inline(MergeableFormat::Em, children),
+    Inline::Del(children) => normalize_formatted_inline(MergeableFormat::Del, children),
+    Inline::Sup(children) => normalize_formatted_inline(MergeableFormat::Sup, children),
+    Inline::Sub(children) => normalize_formatted_inline(MergeableFormat::Sub, children),
+    inline @ (Inline::LineBreak
+    | Inline::FootnoteRef(_)
+    | Inline::EndnoteRef(_)
+    | Inline::CommentRef(_)
+    | Inline::Bookmark(_)) => NormalizedInline {
+      inline,
+      has_merge_boundary: true,
+    },
+    inline => NormalizedInline {
+      inline,
+      has_merge_boundary: false,
+    },
+  }
 }
 
-fn merge_formatted_inlines(target: &mut Inline, source: Inline, separator: Option<String>) {
-  let (target_children, mut source_children) = match (target, source) {
+// Both sequences passed here have already been normalized and are known not
+// to contain semantic merge boundaries. Only their shared edge can require
+// more merging, which keeps fragmented-run normalization linear.
+fn append_boundary_free_inline(output: &mut Vec<Inline>, inline: Inline) {
+  let source_format = mergeable_format(&inline);
+
+  if source_format.is_some() && output.last().and_then(mergeable_format) == source_format {
+    let Some(target) = output.last_mut() else {
+      output.push(inline);
+      return;
+    };
+    match merge_formatted_inlines(target, inline, None) {
+      Ok(()) => return,
+      Err(inline) => {
+        output.push(inline);
+        return;
+      }
+    }
+  }
+
+  let previous_format = output
+    .get(output.len().saturating_sub(2))
+    .and_then(mergeable_format);
+  let has_whitespace_separator = matches!(
+    output.last(),
+    Some(Inline::Text(value))
+      if !value.is_empty() && value.chars().all(char::is_whitespace)
+  );
+
+  if source_format.is_some() && has_whitespace_separator && previous_format == source_format {
+    let Some(separator_inline) = output.pop() else {
+      output.push(inline);
+      return;
+    };
+    let Inline::Text(separator) = separator_inline else {
+      output.push(separator_inline);
+      output.push(inline);
+      return;
+    };
+    let Some(target) = output.last_mut() else {
+      output.push(Inline::Text(separator));
+      output.push(inline);
+      return;
+    };
+    match merge_formatted_inlines(target, inline, Some(separator.clone())) {
+      Ok(()) => return,
+      Err(inline) => {
+        output.push(Inline::Text(separator));
+        output.push(inline);
+        return;
+      }
+    }
+  }
+
+  output.push(inline);
+}
+
+fn merge_formatted_inlines(
+  target: &mut Inline,
+  source: Inline,
+  separator: Option<String>,
+) -> Result<(), Inline> {
+  let (target_children, source_children) = match (target, source) {
     (Inline::Strong(target), Inline::Strong(source)) => (target, source),
     (Inline::Em(target), Inline::Em(source)) => (target, source),
     (Inline::Del(target), Inline::Del(source)) => (target, source),
     (Inline::Sup(target), Inline::Sup(source)) => (target, source),
     (Inline::Sub(target), Inline::Sub(source)) => (target, source),
-    _ => unreachable!("formatted inline variants must match before merging"),
+    (_, source) => return Err(source),
   };
 
   if let Some(separator) = separator {
-    target_children.push(Inline::Text(separator));
+    append_boundary_free_inline(target_children, Inline::Text(separator));
   }
-  target_children.append(&mut source_children);
-
-  let children = std::mem::take(target_children);
-  *target_children = normalize_inlines(children);
+  for inline in source_children {
+    append_boundary_free_inline(target_children, inline);
+  }
+  Ok(())
 }
 
-fn normalize_inlines(inlines: Vec<Inline>) -> Vec<Inline> {
+fn try_merge_last(
+  output: &mut Vec<NormalizedInline>,
+  source: NormalizedInline,
+  separator: Option<String>,
+) -> Result<(), NormalizedInline> {
+  let source_format = normalized_mergeable_format(&source);
+  let target_format = output.last().and_then(normalized_mergeable_format);
+
+  if source_format.is_none() || source_format != target_format {
+    return Err(source);
+  }
+
+  let source_has_merge_boundary = source.has_merge_boundary;
+  let Some(target) = output.last_mut() else {
+    return Err(source);
+  };
+  match merge_formatted_inlines(&mut target.inline, source.inline, separator) {
+    Ok(()) => Ok(()),
+    Err(inline) => Err(NormalizedInline {
+      inline,
+      has_merge_boundary: source_has_merge_boundary,
+    }),
+  }
+}
+
+fn normalize_inline_sequence(inlines: Vec<Inline>) -> Vec<NormalizedInline> {
   // Word may split visually identical formatting into arbitrary runs. Collapse
   // those run boundaries before HTML rendering so Markdown does not emit
   // adjacent delimiters such as `**10****th**`.
-  let mut output: Vec<Inline> = Vec::with_capacity(inlines.len());
+  let mut output: Vec<NormalizedInline> = Vec::with_capacity(inlines.len());
   let mut pending_whitespace: Option<String> = None;
 
   for inline in inlines.into_iter().map(normalize_inline) {
-    let is_whitespace_after_format = match &inline {
-      Inline::Text(value) => {
-        !value.is_empty()
+    let is_whitespace_after_format = matches!(
+      &inline.inline,
+      Inline::Text(value)
+        if !value.is_empty()
           && value.chars().all(char::is_whitespace)
-          && output.last().map(is_mergeable_format).unwrap_or(false)
-      }
-      _ => false,
-    };
+          && output.last().and_then(normalized_mergeable_format).is_some()
+    );
 
     if is_whitespace_after_format {
-      let Inline::Text(value) = inline else {
-        unreachable!();
-      };
-      pending_whitespace
-        .get_or_insert_with(String::new)
-        .push_str(&value);
+      let has_merge_boundary = inline.has_merge_boundary;
+      match inline.inline {
+        Inline::Text(value) => {
+          pending_whitespace
+            .get_or_insert_with(String::new)
+            .push_str(&value);
+        }
+        inline => output.push(NormalizedInline {
+          inline,
+          has_merge_boundary,
+        }),
+      }
       continue;
     }
 
     if let Some(separator) = pending_whitespace.take() {
-      let can_merge_across_whitespace = output
-        .last()
-        .map(|previous| has_same_mergeable_format(previous, &inline))
-        .unwrap_or(false);
-
-      if can_merge_across_whitespace {
-        let previous = output.last_mut().expect("checked above");
-        merge_formatted_inlines(previous, inline, Some(separator));
-        continue;
+      match try_merge_last(&mut output, inline, Some(separator.clone())) {
+        Ok(()) => continue,
+        Err(inline) => {
+          output.push(NormalizedInline {
+            inline: Inline::Text(separator),
+            has_merge_boundary: false,
+          });
+          match try_merge_last(&mut output, inline, None) {
+            Ok(()) => continue,
+            Err(inline) => output.push(inline),
+          }
+        }
       }
-
-      output.push(Inline::Text(separator));
+      continue;
     }
 
-    let can_merge_directly = output
-      .last()
-      .map(|previous| has_same_mergeable_format(previous, &inline))
-      .unwrap_or(false);
-
-    if can_merge_directly {
-      let previous = output.last_mut().expect("checked above");
-      merge_formatted_inlines(previous, inline, None);
-    } else {
-      output.push(inline);
+    match try_merge_last(&mut output, inline, None) {
+      Ok(()) => {}
+      Err(inline) => output.push(inline),
     }
   }
 
   if let Some(whitespace) = pending_whitespace {
-    output.push(Inline::Text(whitespace));
+    output.push(NormalizedInline {
+      inline: Inline::Text(whitespace),
+      has_merge_boundary: false,
+    });
   }
 
   output
+}
+
+fn normalize_inlines(inlines: Vec<Inline>) -> Vec<Inline> {
+  normalize_inline_sequence(inlines)
+    .into_iter()
+    .map(|inline| inline.inline)
+    .collect()
 }
 
 fn parse_paragraph_with_listinfo(
@@ -1325,6 +1472,82 @@ mod tests {
     assert!(matches!(normalized[2], Inline::Strong(_)));
     assert!(matches!(normalized[3], Inline::Link { .. }));
     assert!(matches!(normalized[4], Inline::Strong(_)));
+  }
+
+  #[test]
+  fn does_not_merge_formatted_word_breaks_or_references() {
+    let xml = XmlDoc::parse(
+      r#"
+        <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:t>before</w:t>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:br/>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:footnoteReference w:id="1"/>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:endnoteReference w:id="2"/>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:commentReference w:id="3"/>
+          </w:r>
+          <w:r>
+            <w:rPr><w:b/></w:rPr>
+            <w:t>after</w:t>
+          </w:r>
+        </w:p>
+      "#,
+    )
+    .expect("valid WordprocessingML fixture");
+    let size_buckets = std::collections::HashMap::new();
+    let (paragraph, _) = parse_paragraph_with_listinfo(
+      &xml.root_element(),
+      &Relationships::default(),
+      &StylesInfo::default(),
+      &size_buckets,
+      &NumberingInfo::default(),
+    )
+    .expect("paragraph should parse");
+
+    let [Inline::Strong(before), Inline::Strong(line_break), Inline::Strong(footnote), Inline::Strong(endnote), Inline::Strong(comment), Inline::Strong(after)] =
+      paragraph.inlines.as_slice()
+    else {
+      panic!("expected formatted semantic boundaries to remain separate");
+    };
+    assert_eq!(inlines_text(before), "before");
+    assert!(matches!(line_break.as_slice(), [Inline::LineBreak]));
+    assert!(matches!(
+      footnote.as_slice(),
+      [Inline::FootnoteRef(NoteId(id))] if id == "1"
+    ));
+    assert!(matches!(
+      endnote.as_slice(),
+      [Inline::EndnoteRef(NoteId(id))] if id == "2"
+    ));
+    assert!(matches!(
+      comment.as_slice(),
+      [Inline::CommentRef(CommentId(id))] if id == "3"
+    ));
+    assert_eq!(inlines_text(after), "after");
+  }
+
+  #[test]
+  fn merges_heavily_fragmented_runs_incrementally() {
+    let normalized = normalize_inlines((0..10_000).map(|_| strong("x")).collect());
+
+    let [Inline::Strong(children)] = normalized.as_slice() else {
+      panic!("expected heavily fragmented runs to become one strong inline");
+    };
+    assert_eq!(children.len(), 10_000);
+    assert_eq!(inlines_text(children).len(), 10_000);
   }
 
   #[test]

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -20,8 +20,10 @@ import * as schema from "../../../db/schema";
 import { config } from "../../../config";
 import { getRedisConnection } from "../../../services/queue-service";
 
+// Minimal DOCX whose second paragraph is one bold heading split across five
+// Word formatting runs, including both mid-word and whitespace boundaries.
 const DOCX_FIXTURE_BASE64 =
-  "UEsDBBQAAAAIAKtlbVzXeYTq8QAAALgBAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbH2QzU7DMBCE730Ky9cqccoBIZSkB36OwKE8wMreJFb9J69b2rdn00KREOVozXwz62nXB+/EHjPZGDq5qhspMOhobBg7+b55ru6koALBgIsBO3lEkut+0W6OCUkwHKiTUynpXinSE3qgOiYMrAwxeyj8zKNKoLcworppmlulYygYSlXmDNkvhGgfcYCdK+LpwMr5loyOpHg4e+e6TkJKzmoorKt9ML+Kqq+SmsmThyabaMkGqa6VzOL1jh/0lSfK1qB4g1xewLNRfcRslIl65xmu/0/649o4DFbjhZ/TUo4aiXh77+qL4sGG71+06jR8/wlQSwMEFAAAAAgAq2VtXCAbhuqyAAAALgEAAAsAAABfcmVscy8ucmVsc43Puw6CMBQG4J2naM4uBQdjDIXFmLAafICmPZRGeklbL7y9HRzEODie23fyN93TzOSOIWpnGdRlBQStcFJbxeAynDZ7IDFxK/nsLDJYMELXFs0ZZ57yTZy0jyQjNjKYUvIHSqOY0PBYOo82T0YXDE+5DIp6Lq5cId1W1Y6GTwPagpAVS3rJIPSyBjIsHv/h3ThqgUcnbgZt+vHlayPLPChMDB4uSCrf7TKzQHNKuorZvgBQSwMEFAAAAAgAq2VtXCCNfXOwAAAA7AAAABEAAAB3b3JkL2RvY3VtZW50LnhtbDWOMQvCMBCFd3/FkV1THURKGwfFVQcF19icWmjuQi5a/fcmBZeP93jw3TXbjx/gjVF6plYtF5UCpI5dT49WXc6H+UaBJEvODkzYqi+K2ppZM9aOu5dHSpANJPXYqmdKodZauid6KwsOSHm7c/Q25RofeuToQuQORfIBP+hVVa21tz0pMwPI1hu7b4lTCSYjFiRzslEQ9sfdFS5hYOvgjJIaXbbCODFMGv33lPT/0/wAUEsBAhQDFAAAAAgAq2VtXNd5hOrxAAAAuAEAABMAAAAAAAAAAAAAAIABAAAAAFtDb250ZW50X1R5cGVzXS54bWxQSwECFAMUAAAACACrZW1cIBuG6rIAAAAuAQAACwAAAAAAAAAAAAAAgAEiAQAAX3JlbHMvLnJlbHNQSwECFAMUAAAACACrZW1cII19c7AAAADsAAAAEQAAAAAAAAAAAAAAgAH9AQAAd29yZC9kb2N1bWVudC54bWxQSwUGAAAAAAMAAwC5AAAA3AIAAAAA";
+  "UEsDBBQAAAAIAFWb/Fx5bjPX6AAAAK0BAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbH1QyU7DMBD9FWuuKHHggBCK0wPLETiUDxjZk8SqN3nc0v49Tlt6QIXjzFv1+tXeO7GjzDYGBbdtB4KCjsaGScHn+rV5AMEFg0EXAyk4EMNq6NeHRCyqNrCCuZT0KCXrmTxyGxOFiowxeyz1zJNMqDc4kbzrunupYygUSlMWDxj6Zxpx64p42df3qUcmxyCeTsQlSwGm5KzGUnG5C+ZXSnNOaKvyyOHZJr6pBJBXExbk74Cz7r0Ok60h8YG5vKGvLPkVs5Em6q2vyvZ/mys94zhaTRf94pZy1MRcF/euvSAebfjpL49zD99QSwMEFAAAAAgAVZv8XJv9N+qtAAAAKQEAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4KtE3mlaBoRQ0y4IqSsqB7ASN61oHkrCo7cnAwNFDIy2f3+W6/ZpZnanECdnBVRFCYysdGqyWsClP232wGJCq3B2lgQsFKFt6jPNmPJKHCcfWTZsFDCm5A+cRzmSwVg4TzZPBhcMplwGzT3KK2ri27Lc8fBpwNpknRIQOlUB6xdP/9huGCZJRydvhmz6ceIrkWUMmpKAhwuKq3e7yCzwpuarF5sXUEsDBBQAAAAIAFWb/FwJr8tEJQEAAHMCAAARAAAAd29yZC9kb2N1bWVudC54bWylUk1LA0EM/SthTnpoZ1tEZOluDxYRRVxsC16ns3F3YDczJNPW/nv34yCFIoqXFx5J3stMslh+tg0ckMV5ytRsmihAsr50VGVqu3mY3CmQaKg0jSfM1AlFLfPFMS293bdIEToBkvSYqTrGkGottsbWyNQHpC734bk1saNc6aPnMrC3KNLpt42eJ8mtbo0j1UvufHnqY+iBe4h5YVgQVq/377ANjTclbFDiQve5HnnAcN7GxRB2eiwZ2TBpKsHY7hmBUZAPqPIX10RP8IwnQoEtueEz4gkevQQXTQMTuJolZ44/2uSx/n3x5ZngaU8If7CcJ/Obf5tOoOgJxWtYIznPsA5onWmcRFg5U5GX6Cy8mdL5ik2okS8uQtDGgkfPcaf6+17yL1BLAQIUAxQAAAAIAFWb/Fx5bjPX6AAAAK0BAAATAAAAAAAAAAAAAACAAQAAAABbQ29udGVudF9UeXBlc10ueG1sUEsBAhQDFAAAAAgAVZv8XJv9N+qtAAAAKQEAAAsAAAAAAAAAAAAAAIABGQEAAF9yZWxzLy5yZWxzUEsBAhQDFAAAAAgAVZv8XAmvy0QlAQAAcwIAABEAAAAAAAAAAAAAAIAB7wEAAHdvcmQvZG9jdW1lbnQueG1sUEsFBgAAAAADAAMAuQAAAEMDAAAAAA==";
 
 const htmlFixture = `
 <!DOCTYPE html>
@@ -555,7 +557,7 @@ describe("/v2/parse", () => {
   );
 
   it(
-    "parses an uploaded DOCX file into markdown",
+    "parses DOCX uploads and merges adjacent formatting runs",
     async () => {
       const result = await parse(
         {
@@ -573,6 +575,9 @@ describe("/v2/parse", () => {
       );
 
       expect(result.markdown).toMatch(/Parse DOCX Upload Test/i);
+      expect(result.markdown).toContain(
+        "**Milton Keynes University Hospital - (10th June 2024 - Present) Senior Specialist Diagnostic Radiographer**",
+      );
       expect(result.metadata.creditsUsed).toBe(1);
     },
     scrapeTimeout,


### PR DESCRIPTION
## Summary

- normalize DOCX paragraph inlines before HTML rendering
- merge adjacent inline nodes with identical formatting while preserving whitespace
- add regression coverage for Word formatting runs split across word boundaries

## Problem

Microsoft Word may split visually continuous formatting into multiple `<w:r>` elements as a result of editing history. These run boundaries do not necessarily represent meaningful formatting changes.

The DOCX converter previously preserved each run as a separate inline formatting node. A visually continuous bold phrase could therefore produce HTML like:

```html
<strong>10</strong><strong>th</strong><strong> June </strong><strong>2024</strong>
```

which was converted into fragmented Markdown:

```markdown
**10****th** **June** **2024**
```

## Solution

Normalize paragraph inlines before rendering HTML.

The normalization:

- recursively processes nested inline nodes
- merges adjacent `Strong`, `Em`, `Del`, `Sup`, and `Sub` nodes when their formatting types match
- preserves whitespace between matching formatting nodes
- remains scoped to the current paragraph
- does not merge across links, line breaks, bookmarks, references, different formatting types, or block boundaries

The example above now produces:

```html
<strong>10th June 2024</strong>
```

and therefore:

```markdown
**10th June 2024**
```

## Test coverage

- added native regression tests for adjacent formatting runs and whitespace preservation
- added coverage for nested formatting and semantic boundaries
- added a valid minimal DOCX fixture to the `/v2/parse` upload tests
- verified that a heading split across multiple Word runs is emitted as one Markdown formatting span

Fixes #3951

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787835228&installation_model_id=11126&pr_number=4159&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4159&signature=8d8c00c2ba7d8026dd4a5d74c9dc1d37948bc9b9e749a087067ee2b00a777188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge adjacent identical DOCX formatting runs during parsing to prevent fragmented HTML/Markdown while preserving whitespace and semantic boundaries. Fixes #3951.

- **Bug Fixes**
  - Normalize paragraph inlines recursively before HTML rendering.
  - Merge adjacent identical formatting (bold, italic, strikethrough, superscript, subscript), including across whitespace and mid-word splits; handles heavily fragmented runs.
  - Do not merge across links, line breaks, bookmarks, footnote/endnote/comment references, or block boundaries; scope is per paragraph.
  - Added native tests and a `/v2/parse` DOCX upload fixture (bold heading split across five runs) to cover nested formatting, run merges, and whitespace preservation.

<sup>Written for commit 9fbad08fa7e6b99cebcb1743e6f17b31806b4e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

