### PR TITLE
fix(api): use stable drizzle-orm release

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -107,7 +107,7 @@
     "culori": "^4.0.2",
     "diff": "^8.0.3",
     "dotenv": "^16.3.1",
-    "drizzle-orm": "1.0.0-rc.3",
+    "drizzle-orm": "0.45.2",
     "esbuild": "^0.28.1",
     "escape-html": "^1.0.3",
     "express": "5.2.1",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^16.3.1
         version: 16.4.5
       drizzle-orm:
-        specifier: 1.0.0-rc.3
-        version: 1.0.0-rc.3(@opentelemetry/api@1.9.1)(@types/pg@8.15.5)(pg@8.16.3)(zod@4.1.12)
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.5)(pg@8.16.3)
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -2539,12 +2539,11 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
-  drizzle-orm@1.0.0-rc.3:
-    resolution: {integrity: sha512-akZOa5UxapFbdBG8IDkfBRpSZJpMHaOJtGgp7oi1oHaiU8S3KN92waHo2l5aRuv1D9tMGYpv3BQFOsiGcNjLTQ==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
-      '@effect/sql-pg': '>=4.0.0-beta.58 || >=4.0.0'
       '@electric-sql/pglite': '>=0.2.0'
       '@libsql/client': '>=0.10.0'
       '@libsql/client-wasm': '>=0.10.0'
@@ -2552,39 +2551,30 @@ packages:
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
       '@planetscale/database': '>=1.13'
-      '@sinclair/typebox': '>=0.34.8'
-      '@sqlitecloud/drivers': '>=1.0.653'
+      '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
-      '@tursodatabase/database': '>=0.2.1'
-      '@tursodatabase/database-common': '>=0.2.1'
-      '@tursodatabase/database-wasm': '>=0.2.1'
       '@types/better-sqlite3': '*'
-      '@types/mssql': ^9.1.4
       '@types/pg': '*'
       '@types/sql.js': '*'
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      arktype: '>=2.0.0'
-      better-sqlite3: '>=9.3.0'
+      better-sqlite3: '>=7'
       bun-types: '*'
-      effect: '>=4.0.0-beta.58 || >=4.0.0'
       expo-sqlite: '>=14.0.0'
-      mssql: ^11.0.1
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
+      prisma: '*'
       sql.js: '>=1'
       sqlite3: '>=5'
-      typebox: '>=1.0.0'
-      valibot: '>=1.0.0-beta.7'
-      zod: ^3.25.0 || ^4.0.0
     peerDependenciesMeta:
       '@aws-sdk/client-rds-data':
         optional: true
       '@cloudflare/workers-types':
-        optional: true
-      '@effect/sql-pg':
         optional: true
       '@electric-sql/pglite':
         optional: true
@@ -2600,21 +2590,11 @@ packages:
         optional: true
       '@planetscale/database':
         optional: true
-      '@sinclair/typebox':
-        optional: true
-      '@sqlitecloud/drivers':
+      '@prisma/client':
         optional: true
       '@tidbcloud/serverless':
         optional: true
-      '@tursodatabase/database':
-        optional: true
-      '@tursodatabase/database-common':
-        optional: true
-      '@tursodatabase/database-wasm':
-        optional: true
       '@types/better-sqlite3':
-        optional: true
-      '@types/mssql':
         optional: true
       '@types/pg':
         optional: true
@@ -2626,17 +2606,17 @@ packages:
         optional: true
       '@xata.io/client':
         optional: true
-      arktype:
-        optional: true
       better-sqlite3:
         optional: true
       bun-types:
         optional: true
-      effect:
-        optional: true
       expo-sqlite:
         optional: true
-      mssql:
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
         optional: true
       mysql2:
         optional: true
@@ -2644,15 +2624,11 @@ packages:
         optional: true
       postgres:
         optional: true
+      prisma:
+        optional: true
       sql.js:
         optional: true
       sqlite3:
-        optional: true
-      typebox:
-        optional: true
-      valibot:
-        optional: true
-      zod:
         optional: true
 
   dunder-proto@1.0.1:
@@ -6416,12 +6392,11 @@ snapshots:
 
   dotenv@16.4.5: {}
 
-  drizzle-orm@1.0.0-rc.3(@opentelemetry/api@1.9.1)(@types/pg@8.15.5)(pg@8.16.3)(zod@4.1.12):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.5)(pg@8.16.3):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.5
       pg: 8.16.3
-      zod: 4.1.12
 
   dunder-proto@1.0.1:
     dependencies:

--- a/apps/api/src/db/schema/columns.test.ts
+++ b/apps/api/src/db/schema/columns.test.ts
@@ -5,9 +5,9 @@ import { monitor_pages } from "./public";
 
 describe("bytea", () => {
   it.each([
-    getTableColumns(indexTable).url_hash,
-    getTableColumns(monitor_pages).url_hash,
-  ])("preserves Buffer values for %s", column => {
+    ["index.url_hash", getTableColumns(indexTable).url_hash],
+    ["monitor_pages.url_hash", getTableColumns(monitor_pages).url_hash],
+  ])("preserves Buffer values for %s", (_name, column) => {
     const value = Buffer.from("firecrawl");
 
     expect(column.getSQLType()).toBe("bytea");

--- a/apps/api/src/db/schema/columns.test.ts
+++ b/apps/api/src/db/schema/columns.test.ts
@@ -1,0 +1,17 @@
+import { getTableColumns } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { index as indexTable } from "./index-db";
+import { monitor_pages } from "./public";
+
+describe("bytea", () => {
+  it.each([
+    getTableColumns(indexTable).url_hash,
+    getTableColumns(monitor_pages).url_hash,
+  ])("preserves Buffer values for %s", column => {
+    const value = Buffer.from("firecrawl");
+
+    expect(column.getSQLType()).toBe("bytea");
+    expect(column.mapFromDriverValue(value)).toBe(value);
+    expect(column.mapToDriverValue(value)).toBe(value);
+  });
+});

--- a/apps/api/src/db/schema/columns.ts
+++ b/apps/api/src/db/schema/columns.ts
@@ -1,0 +1,7 @@
+import { customType } from "drizzle-orm/pg-core";
+
+export const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType() {
+    return "bytea";
+  },
+});

--- a/apps/api/src/db/schema/index-db.ts
+++ b/apps/api/src/db/schema/index-db.ts
@@ -5,10 +5,10 @@ import {
   integer,
   boolean,
   timestamp,
-  bytea,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import { bytea } from "./columns";
 
 // Tables in the separate index Postgres project (INDEX_DATABASE_URL).
 

--- a/apps/api/src/db/schema/public.ts
+++ b/apps/api/src/db/schema/public.ts
@@ -12,12 +12,12 @@ import {
   numeric,
   timestamp,
   date,
-  bytea,
   check,
   foreignKey,
   index,
   unique,
 } from "drizzle-orm/pg-core";
+import { bytea } from "./columns";
 
 const ts = (name: string) =>
   timestamp(name, { withTimezone: true, mode: "string" });


### PR DESCRIPTION
## Summary

- replace the `drizzle-orm` 1.0 release candidate with the latest stable release, `0.45.2`
- preserve the existing PostgreSQL `bytea` schemas with a Buffer-backed custom Drizzle type because the stable release does not export the first-class `bytea` helper
- add regression coverage for the SQL type and driver value mapping

## Why

The API was pinned to `1.0.0-rc.3`, leaving production code dependent on a prerelease package. This moves the Drizzle dependency back onto the stable release line while retaining the current schema behavior.

This addresses the `drizzle-orm` portion of #4050.

## Validation

- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/db/schema/columns.ts src/db/schema/columns.test.ts src/db/schema/index-db.ts src/db/schema/public.ts package.json`
- `pnpm exec vitest run src/db/schema/columns.test.ts src/services/mcp/action-logs.test.ts src/search/highlights.test.ts` (32 tests passed)
- `git diff --check`

The complete `pnpm test` suite was also attempted, but its E2E/snips cases require local API and Redis services, provider credentials, and external network access that are not available in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787843217&installation_model_id=11126&pr_number=4160&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4160&signature=e2b05f2dbf6534620c4ec87051b9033f98647150fdb633f01b2f4c47a9e9fbf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the API to stable `drizzle-orm@0.45.2` and replace the RC. Preserve PostgreSQL `bytea` columns with a Buffer-backed custom type and add labeled tests for both `url_hash` columns (part of #4050).

- **Dependencies**
  - Replace `drizzle-orm` `1.0.0-rc.3` with `0.45.2` (stable).

- **Bug Fixes**
  - Use a `customType`-based `bytea` to keep `Buffer` driver values and the `bytea` SQL type; update schema imports.
  - Add regression tests for `bytea` SQL type and mapTo/mapFrom on `index.url_hash` and `monitor_pages.url_hash`.

<sup>Written for commit d1a9c3253cd571ad52844de8be343e76b4a170e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

