### PR TITLE
fix(threat-protection): no scan fee in zscaler mode

### DIFF
--- a/apps/api/src/lib/scrape-billing.test.ts
+++ b/apps/api/src/lib/scrape-billing.test.ts
@@ -245,6 +245,28 @@ describe("calculateThreatScanCredits", () => {
     ).toBe(0);
   });
 
+  it("never bills zscaler-mode decisions, consulted or not", () => {
+    const zscalerConsulted: ThreatDecision = {
+      ...consulted(false),
+      mode: "zscaler",
+      verdict: {
+        provider: "zscaler-zia",
+        riskScore: null,
+        categories: ["GAMBLING"],
+        fromCache: false,
+        raw: {},
+      },
+    };
+    expect(calculateThreatScanCredits([zscalerConsulted])).toBe(0);
+    // Mixed with a billable normal-mode decision, only that one bills.
+    expect(
+      calculateThreatScanCredits([
+        zscalerConsulted,
+        consulted(true, "http://a.example/"),
+      ]),
+    ).toBe(2);
+  });
+
   it("sums mixed decisions across URLs", () => {
     expect(
       calculateThreatScanCredits([

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -10,10 +10,7 @@ import { hasFormatOfType } from "./format-utils";
 import { TransportableError } from "./error";
 import { FeatureFlag } from "../scraper/scrapeURL/engines";
 import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";
-import {
-  ExchangeScrapeMetadata,
-  getExchangeSuccessCredits,
-} from "./exchange";
+import { ExchangeScrapeMetadata, getExchangeSuccessCredits } from "./exchange";
 import type { ThreatDecision } from "./threat-protection/types";
 import { UnsafeDomainBlockedError } from "./threat-protection/error";
 
@@ -38,6 +35,9 @@ const threatScanCost = 2;
  * Sums the scan fees for a set of threat protection decisions. Only decisions
  * that consulted the provider bill; the fee is +2 per unique scanned
  * canonical URL across the given decisions.
+ *
+ * "zscaler" mode is exempt: classification runs against the customer's own
+ * ZIA tenant (their credentials, their quota), so no scan fee applies.
  */
 export function calculateThreatScanCredits(
   decisions: Iterable<ThreatDecision>,
@@ -46,6 +46,7 @@ export function calculateThreatScanCredits(
   let credits = 0;
   for (const decision of decisions) {
     if (!decision.providerConsulted) continue;
+    if (decision.mode === "zscaler") continue;
     // Decisions serialized by a pre-URL-level deploy have no `url`; bill
     // them individually (the old per-decision behavior) rather than letting
     // them all collapse onto one `undefined` key.

--- a/apps/api/src/lib/threat-protection/types.ts
+++ b/apps/api/src/lib/threat-protection/types.ts
@@ -117,7 +117,11 @@ export interface ThreatDecision {
   url: string;
   /** Canonicalized host of the checked URL (for logs and error surfaces). */
   domain: string;
-  /** True if a provider verdict (fresh OR cached) was consulted — this drives billing (+2 per scanned URL). */
+  /**
+   * True if a provider verdict (fresh OR cached) was consulted — this drives
+   * billing (+2 per scanned URL; "zscaler" mode is exempt because the
+   * customer's own tenant does the classification).
+   */
   providerConsulted: boolean;
   verdict: RawVerdict | null;
   mode: ThreatProtectionMode;


### PR DESCRIPTION
# fix(threat-protection): no scan fee in zscaler mode

Follow-up to #4161.

Zscaler-mode classification runs against the customer's own ZIA tenant — their credentials, their API quota — so charging the +2 scan fee on top makes no sense. This exempts `mode: "zscaler"` decisions in `calculateThreatScanCredits`, which covers every billing surface at once (scrape, crawl, batch scrape, search, map, extract, agent all sum fees through it). Local-rule and synced-rule decisions were already free; lookup-backed decisions now are too. Normal mode (Google Web Risk) is unchanged at +2 per scanned URL.

`providerConsulted` keeps its meaning for SIEM and logging; only the fee changes. Unit test added for the exemption, including mixed normal+zscaler decision sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop charging the +2 threat scan fee when running in Zscaler mode. Normal mode billing is unchanged.

- **Bug Fixes**
  - Exempts `mode: "zscaler"` in `calculateThreatScanCredits`; fee is 0 even when `providerConsulted` is true.
  - Keeps normal mode at +2 per unique scanned URL; covers all billing surfaces that use this function.
  - Adds unit test, including mixed normal+zscaler decisions.
  - `providerConsulted` remains for SIEM/logging; only billing behavior changes.

<sup>Written for commit 96984b8d404cd646fd788eabe1c2000d802b142c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

