### PR TITLE
fix(threat-protection): remove the zscaler-mode concurrency cap

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -105,10 +105,6 @@ const configSchema = z.object({
     .int()
     .positive()
     .default(500),
-  // Effective scrape concurrency cap for teams in "zscaler" mode, keeping URL
-  // demand near the classification budget (≤100 URLs/s burst, ~11 URLs/s
-  // sustained at 400 lookups/hour).
-  ZSCALER_MODE_CONCURRENCY_CAP: z.coerce.number().int().positive().default(15),
 
   // Organization SIEM logging delivery. The encryption key must decode to
   // exactly 32 bytes; validation happens when a secret is encrypted/decrypted

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -19,7 +19,6 @@ import {
   removeConcurrencyLimitActiveJob,
 } from "./concurrency-redis";
 import { autumnService } from "../services/autumn/autumn.service";
-import { getThreatProtectionConcurrencyCap } from "./threat-protection/store";
 
 // Fallback when Autumn can't give us a concurrency value.
 const DEFAULT_CONCURRENCY_LIMIT = 2;
@@ -29,22 +28,13 @@ const DEFAULT_CONCURRENCY_LIMIT = 2;
  * balance. Autumn is authoritative; when the entity is missing we fall back to
  * the low default of 2. When Autumn errors, getConcurrencyLimit already returns
  * a high fail-open value, so that carries through here.
- *
- * Threat protection can clamp the result: "zscaler" mode caps concurrency so
- * URL demand stays near the tenant's classification budget — otherwise a
- * large crawl outruns the 400-lookups/hour budget and every scrape resolves
- * through the failurePolicy instead of a verdict.
  */
 export async function getEffectiveConcurrencyLimit(
   teamId: string,
   orgId?: string | null,
 ): Promise<number> {
   const autumnValue = await autumnService.getConcurrencyLimit(teamId, orgId);
-  const limit = autumnValue ?? DEFAULT_CONCURRENCY_LIMIT;
-  const threatProtectionCap = await getThreatProtectionConcurrencyCap(teamId);
-  return threatProtectionCap !== null
-    ? Math.min(limit, threatProtectionCap)
-    : limit;
+  return autumnValue ?? DEFAULT_CONCURRENCY_LIMIT;
 }
 
 const constructKey = constructConcurrencyLimitKey;

--- a/apps/api/src/lib/threat-protection/providers/zscaler/lookup-queue.ts
+++ b/apps/api/src/lib/threat-protection/providers/zscaler/lookup-queue.ts
@@ -35,10 +35,10 @@ import {
 // sit in a line it cannot exit. Verdicts live only in the short-TTL reply
 // keys consumed moments later; there is no verdict cache (ZDR).
 //
-// Capacity note: the sustained ceiling is ~11 URLs/second per org (400
-// calls/hour × 100 URLs). The "zscaler"-mode concurrency cap (see
-// getThreatProtectionConcurrencyCap) keeps URL demand near this budget;
-// this queue only absorbs bursts.
+// Capacity note: the sustained ceiling is ~11 URLs/second per tenant (400
+// calls/hour × 100 URLs). Demand above that resolves through the fail-fast
+// paths below (queue depth cap, exhausted hourly budget) into the org's
+// failurePolicy — scrape concurrency is deliberately NOT throttled.
 
 const logger = _logger.child({ module: "threat-protection-zscaler-lookup" });
 

--- a/apps/api/src/lib/threat-protection/store.ts
+++ b/apps/api/src/lib/threat-protection/store.ts
@@ -1,6 +1,5 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { config as appConfig } from "../../config";
 import { db, dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { deleteKey, getValue, setValue } from "../../services/redis";
@@ -388,74 +387,4 @@ export async function getOrgZscalerCredentials(
     });
     return null;
   }
-}
-
-const concurrencyCapCacheKey = (teamId: string) =>
-  `threat-protection-concurrency-cap:${teamId}`;
-
-/**
- * Scrape-concurrency cap imposed by the team's threat protection mode, or
- * null when none applies. "zscaler" mode caps concurrency so URL demand
- * stays near the tenant's classification budget (POST /urlLookup allows 1
- * request/second × 100 URLs, 400 requests/hour) — without the cap, a large
- * crawl outruns the budget, every lookup times out, and the failurePolicy
- * fires for everything.
- *
- * The budget is org-scoped while concurrency admission is team-scoped, so
- * the org-level cap is split across the org's teams — otherwise an org with
- * N teams would run at N× the intended concurrency.
- *
- * Cached in Redis for 60s per team; fails open (null) so a Redis or DB
- * hiccup never blocks job admission.
- */
-export async function getThreatProtectionConcurrencyCap(
-  teamId: string,
-): Promise<number | null> {
-  // Self-hosted deployments have no org config database (and no enterprise
-  // threat protection) — skip the lookup instead of warning on every job.
-  if (!appConfig.USE_DB_AUTHENTICATION) return null;
-
-  const key = concurrencyCapCacheKey(teamId);
-  try {
-    const cached = await getValue(key);
-    if (cached === "none") return null;
-    if (cached !== null) {
-      const parsed = Number(cached);
-      // A malformed cache entry must not become a NaN/zero cap that breaks
-      // job admission — fall through and resolve from the source instead.
-      if (Number.isFinite(parsed) && parsed > 0) return parsed;
-    }
-  } catch (error) {
-    logger.warn("Failed to read the concurrency cap cache", { error, teamId });
-  }
-
-  let cap: number | null = null;
-  try {
-    const orgId = await getOrgIdForTeam(teamId);
-    const orgConfig = orgId ? await getOrgThreatProtectionConfig(orgId) : null;
-    if (orgId && orgConfig?.policy.mode === "zscaler") {
-      const teamRows = await dbRr
-        .select({ id: schema.teams.id })
-        .from(schema.teams)
-        .where(eq(schema.teams.org_id, orgId));
-      const teamCount = Math.max(teamRows.length, 1);
-      cap = Math.max(
-        1,
-        Math.floor(appConfig.ZSCALER_MODE_CONCURRENCY_CAP / teamCount),
-      );
-    }
-  } catch (error) {
-    logger.warn("Failed to resolve the threat protection concurrency cap", {
-      error,
-      teamId,
-    });
-    return null;
-  }
-
-  try {
-    await setValue(key, cap === null ? "none" : String(cap), 60);
-  } catch (error) {
-    logger.warn("Failed to write the concurrency cap cache", { error, teamId });
-  }
-  return cap;
 }


### PR DESCRIPTION
Follow-up to #4161. Zscaler mode capped the org's effective scrape concurrency to keep URL demand near the tenant's classification budget — but silently throttling paid concurrency is not an acceptable side effect of a security feature, so the cap is gone entirely (`getThreatProtectionConcurrencyCap`, its call in `getEffectiveConcurrencyLimit`, and the env knob).

What holds the line instead, unchanged from #4161: the lookup queue fails fast when the hourly budget is exhausted or the queue is too deep to drain before the wait timeout, and those requests resolve immediately through the org's failurePolicy. The practical consequence at sustained demand above ~11 URLs/s per tenant is failurePolicy outcomes (blocked pages when closed, unchecked pages when open) rather than reduced throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787855327&installation_model_id=11126&pr_number=4163&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4163&signature=722b56cd0ff54da239915167b5f4f7ba869544d827761e8647c2330f732b628d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the Zscaler-mode scrape concurrency cap so threat protection never throttles paid concurrency. Overload is handled by the fail-fast lookup queue and hourly budget limits, which resolve via the org’s failurePolicy.

- **Bug Fixes**
  - Removed cap logic: deleted `getThreatProtectionConcurrencyCap`, its use in `getEffectiveConcurrencyLimit`, and the `ZSCALER_MODE_CONCURRENCY_CAP` env.
  - Effective concurrency now only comes from Autumn (or the default of 2).
  - Kept fail-fast overload protection in the Zscaler lookup queue; above ~11 URLs/s per tenant, requests resolve via `failurePolicy` instead of reducing throughput.

<sup>Written for commit aed4acf58806648e0efbb848f865a9aee1d9ebb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

