### PR TITLE
chore(threat-protection): hardcode zscaler limits, drop the env knobs

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -86,25 +86,6 @@ const configSchema = z.object({
   // real endpoints derived from the org's vanity domain and cloud name.
   ZSCALER_TOKEN_URL_OVERRIDE: z.string().url().optional(),
   ZSCALER_API_URL_OVERRIDE: z.string().url().optional(),
-  // Per-org hourly budget for POST /urlLookup calls. ZIA allows 400/hour;
-  // the default keeps headroom for connection tests.
-  ZSCALER_LOOKUP_HOURLY_BUDGET: z.coerce.number().int().positive().default(380),
-  // Per-org hourly budget for GET /urlCategories calls (ZIA allows 1,000/hour).
-  ZSCALER_CATEGORIES_HOURLY_BUDGET: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(900),
-  // How long one queued urlLookup may wait for its batched verdict before the
-  // org's failurePolicy decides.
-  ZSCALER_LOOKUP_TIMEOUT_MS: z.coerce.number().int().positive().default(15000),
-  // Queued-URL depth per org above which new lookups fail fast into the
-  // failurePolicy instead of waiting in a line they cannot exit.
-  ZSCALER_LOOKUP_MAX_QUEUE_DEPTH: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(500),
 
   // Organization SIEM logging delivery. The encryption key must decode to
   // exactly 32 bytes; validation happens when a secret is encrypted/decrypted

--- a/apps/api/src/lib/threat-protection/index.ts
+++ b/apps/api/src/lib/threat-protection/index.ts
@@ -1,8 +1,8 @@
-import { config } from "../../config";
 import { logger } from "../logger";
 import { fetchGoogleWebRiskVerdict } from "./providers/google-web-risk";
 import { canonicalizeUrl } from "./providers/web-risk/canonicalize";
 import { fetchZscalerVerdict } from "./providers/zscaler";
+import { ZSCALER_LOOKUP_TIMEOUT_MS } from "./providers/zscaler/lookup-queue";
 import { evaluateZscalerSyncedRules } from "./providers/zscaler/sync";
 import type {
   RawVerdict,
@@ -102,7 +102,7 @@ async function fetchProviderVerdict(
 ): Promise<RawVerdict> {
   const attempts = mode === "zscaler" ? 1 : PROVIDER_ATTEMPTS;
   const timeoutMs =
-    mode === "zscaler" ? config.ZSCALER_LOOKUP_TIMEOUT_MS : PROVIDER_TIMEOUT_MS;
+    mode === "zscaler" ? ZSCALER_LOOKUP_TIMEOUT_MS : PROVIDER_TIMEOUT_MS;
 
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt++) {

--- a/apps/api/src/lib/threat-protection/providers/zscaler/lookup-queue.ts
+++ b/apps/api/src/lib/threat-protection/providers/zscaler/lookup-queue.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "crypto";
 import { RateLimiterRedis, RateLimiterRes } from "rate-limiter-flexible";
-import { config } from "../../../../config";
 import { logger as _logger } from "../../../logger";
 import { redisRateLimitClient } from "../../../../services/rate-limiter";
 import { redlock } from "../../../../services/redlock";
@@ -49,6 +48,15 @@ const drainLockKey = (orgId: string) =>
   `threat-protection:zscaler:drain-lock:${orgId}`;
 
 const BATCH_SIZE = 100;
+// ZIA's published urlLookup quota is 400 calls/hour per tenant; keep headroom
+// for connection tests.
+const LOOKUP_HOURLY_BUDGET = 380;
+// How long one queued lookup may wait for its batched verdict before the
+// org's failurePolicy decides.
+export const ZSCALER_LOOKUP_TIMEOUT_MS = 15_000;
+// Queued-URL depth per org above which new lookups fail fast into the
+// failurePolicy instead of waiting in a line they cannot exit.
+const MAX_QUEUE_DEPTH = 500;
 const REPLY_TTL_SECONDS = 120;
 const REPLY_POLL_INTERVAL_MS = 150;
 /** Re-attempt to become the drainer this often while waiting (drainer death recovery). */
@@ -91,7 +99,7 @@ function getHourlyBudget(): RateLimiterRedis {
     hourlyBudget = new RateLimiterRedis({
       storeClient: redisRateLimitClient,
       keyPrefix: "threat-protection:zscaler:lookup-budget",
-      points: config.ZSCALER_LOOKUP_HOURLY_BUDGET,
+      points: LOOKUP_HOURLY_BUDGET,
       duration: 3600,
     });
   }
@@ -158,7 +166,7 @@ export async function enqueueZscalerLookup(
   // heuristic, and a brief overshoot from concurrent enqueuers is bounded
   // by their count and harmless.
   const depth = await redisRateLimitClient.llen(queueKey(orgId));
-  if (depth >= config.ZSCALER_LOOKUP_MAX_QUEUE_DEPTH) {
+  if (depth >= MAX_QUEUE_DEPTH) {
     throw new ZscalerError(
       "quota",
       `Zscaler lookup queue is over capacity (${depth} URLs waiting)`,
@@ -173,10 +181,7 @@ export async function enqueueZscalerLookup(
     const budgetState = await getHourlyBudget()
       .get(zscalerBudgetKey(credentials))
       .catch(() => null);
-    if (
-      budgetState &&
-      budgetState.consumedPoints >= config.ZSCALER_LOOKUP_HOURLY_BUDGET
-    ) {
+    if (budgetState && budgetState.consumedPoints >= LOOKUP_HOURLY_BUDGET) {
       throw new ZscalerError(
         "quota",
         "Zscaler urlLookup hourly budget is exhausted",
@@ -301,8 +306,7 @@ const ENTRY_EXPIRY_GRACE_MS = 2000;
 
 function isExpired(entry: QueueEntry): boolean {
   return (
-    Date.now() - entry.at >
-    config.ZSCALER_LOOKUP_TIMEOUT_MS + ENTRY_EXPIRY_GRACE_MS
+    Date.now() - entry.at > ZSCALER_LOOKUP_TIMEOUT_MS + ENTRY_EXPIRY_GRACE_MS
   );
 }
 

--- a/apps/api/src/lib/threat-protection/providers/zscaler/sync.ts
+++ b/apps/api/src/lib/threat-protection/providers/zscaler/sync.ts
@@ -1,6 +1,5 @@
 import { RateLimiterRedis, RateLimiterRes } from "rate-limiter-flexible";
 import { z } from "zod";
-import { config } from "../../../../config";
 import { logger as _logger } from "../../../logger";
 import { redisRateLimitClient } from "../../../../services/rate-limiter";
 import { redlock } from "../../../../services/redlock";
@@ -175,7 +174,8 @@ function getCategoriesBudget(): RateLimiterRedis {
     categoriesBudget = new RateLimiterRedis({
       storeClient: redisRateLimitClient,
       keyPrefix: "threat-protection:zscaler:categories-budget",
-      points: config.ZSCALER_CATEGORIES_HOURLY_BUDGET,
+      // ZIA's published urlCategories quota is 1,000 calls/hour per tenant.
+      points: 900,
       duration: 3600,
     });
   }


### PR DESCRIPTION
Follow-up to #4161. Four env vars (`ZSCALER_LOOKUP_HOURLY_BUDGET`, `ZSCALER_CATEGORIES_HOURLY_BUDGET`, `ZSCALER_LOOKUP_TIMEOUT_MS`, `ZSCALER_LOOKUP_MAX_QUEUE_DEPTH`) were unrequested configuration surface: the budgets encode ZIA's published per-tenant quotas (400/h lookups, 1,000/h categories, with headroom for connection tests) and the timeout/depth values are design constants. They are now module constants where they are used. Behavior is unchanged at the defaults.

The two test-only base-URL overrides (`ZSCALER_TOKEN_URL_OVERRIDE`, `ZSCALER_API_URL_OVERRIDE`) stay: they are what points the mock-gated E2E snips at the mock ZIA server, mirroring the existing `GOOGLE_WEB_RISK_API_URL` pattern for the sibling provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787855629&installation_model_id=11126&pr_number=4164&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4164&signature=43554a6d73d22ada18d3453dd7190e1da85d1d693b8bc4023124379a99419ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcoded Zscaler quotas and queue settings in threat-protection and removed the related env vars. Behavior is unchanged at the previous defaults; only the test URL overrides remain.

- **Refactors**
  - Removed `ZSCALER_LOOKUP_HOURLY_BUDGET`, `ZSCALER_CATEGORIES_HOURLY_BUDGET`, `ZSCALER_LOOKUP_TIMEOUT_MS`, `ZSCALER_LOOKUP_MAX_QUEUE_DEPTH` from `config`.
  - Added module constants: lookup budget 380/h, categories budget 900/h, timeout 15s, max queue depth 500.
  - Updated lookup queue and sync to use these constants; exported `ZSCALER_LOOKUP_TIMEOUT_MS` for the fetch path.
  - Kept `ZSCALER_TOKEN_URL_OVERRIDE` and `ZSCALER_API_URL_OVERRIDE` for tests.

- **Migration**
  - Remove the four deleted env vars from deployments; no other changes needed.

<sup>Written for commit 41e3e28b1ee0a205dc7c3a69a1a5320a2249b82b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

