### PR TITLE
(search/labs) Search Labs

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -32,6 +32,8 @@ const configSchema = z.object({
   SUPPORT_AGENT_URL: z.string().url().optional(),
   SUPPORT_AGENT_VERCEL_BYPASS_SECRET: z.string().optional(),
   RESEARCH_PROXY_URL: z.string().url().optional(),
+  LABS_SEARCH_URL: z.string().url().optional(),
+  LABS_SEARCH_SECRET: z.string().optional(),
 
   // Express
   EXPRESS_TRUST_PROXY: z.coerce.number().optional(),

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1306,6 +1306,7 @@ export type TeamFlags = {
   searchFeedbackOptOut?: boolean;
   researchBeta?: boolean;
   enrichBeta?: boolean;
+  labsSearch?: boolean;
   professionalProfileCompanyDataBeta?: boolean;
   organizationDataSourceAccess?: Record<
     string,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,6 +31,7 @@ import { v7 as uuidv7 } from "uuid";
 import { attachWsProxy } from "./services/agentLivecastWS";
 import { cacheableLookup } from "./scraper/scrapeURL/lib/cacheableLookup";
 import { v2Router } from "./routes/v2";
+import { labsRouter } from "./routes/labs";
 import { registerMcpActionLogIngestRoute } from "./routes/mcp-action-logs";
 import { startMcpActionLogRetentionWorkerIfEnabled } from "./services/mcp/action-logs";
 import { db } from "./db/connection";
@@ -131,6 +132,7 @@ app.get("/e2e-test", (_, res) => {
 app.use(v0Router);
 app.use("/v1", v1Router);
 app.use("/v2", v2Router);
+app.use("/labs", labsRouter);
 app.use(adminRouter);
 
 const DEFAULT_PORT = config.PORT;

--- a/apps/api/src/routes/labs.ts
+++ b/apps/api/src/routes/labs.ts
@@ -1,0 +1,200 @@
+import express, { Request, Response } from "express";
+import { Readable } from "node:stream";
+import { Agent, fetch } from "undici";
+import { config } from "../config";
+import { logger as rootLogger } from "../lib/logger";
+import type { RequestWithAuth } from "../controllers/v1/types";
+import { RateLimiterMode } from "../types";
+import { authMiddleware, wrap } from "./shared";
+
+const TIMEOUT_MS = 120_000;
+
+const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
+const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
+
+const dispatcher = new Agent({
+  connectTimeout: TIMEOUT_MS,
+  headersTimeout: TIMEOUT_MS,
+  bodyTimeout: TIMEOUT_MS,
+});
+
+function labsError(res: Response, status: number, error: string) {
+  return res.status(status).json({ success: false, error });
+}
+
+function upstreamBase(): string | null {
+  if (!config.LABS_SEARCH_URL || !config.LABS_SEARCH_SECRET) return null;
+  return config.LABS_SEARCH_URL.replace(/\/+$/, "");
+}
+
+function callerApiKey(req: Request): string | undefined {
+  const header = req.headers.authorization;
+  if (typeof header !== "string") return undefined;
+  return header.split(" ")[1];
+}
+
+function isMultipart(req: Request): boolean {
+  const contentType = req.headers["content-type"];
+  return (
+    typeof contentType === "string" &&
+    contentType.includes("multipart/form-data")
+  );
+}
+
+function hasJsonBody(req: Request): boolean {
+  return req.method !== "GET" && req.method !== "DELETE";
+}
+
+function upstreamHeaders(req: RequestWithAuth<any, any, any>) {
+  const headers: Record<string, string> = {};
+  for (const h of FORWARDED_REQUEST_HEADERS) {
+    const value = req.headers[h];
+    if (typeof value === "string") headers[h] = value;
+  }
+
+  headers["x-labs-search-secret"] = config.LABS_SEARCH_SECRET!;
+  headers["x-labs-search-team-id"] = req.auth.team_id;
+  const apiKey = callerApiKey(req);
+  if (apiKey) headers["x-labs-search-key"] = apiKey;
+
+  if (isMultipart(req)) {
+    // The body is piped through unparsed, so the multipart boundary and length
+    // have to travel with it.
+    for (const h of ["content-type", "content-length"]) {
+      const value = req.headers[h];
+      if (typeof value === "string") headers[h] = value;
+    }
+  } else if (hasJsonBody(req)) {
+    headers["content-type"] = "application/json";
+  }
+
+  return headers;
+}
+
+function upstreamBody(req: RequestWithAuth<any, any, any>) {
+  if (isMultipart(req)) {
+    return Readable.toWeb(req) as ReadableStream;
+  }
+  if (!hasJsonBody(req)) return undefined;
+  return JSON.stringify(req.body ?? {});
+}
+
+async function labsProxyController(req: Request, res: Response) {
+  const authedReq = req as RequestWithAuth<any, any, any>;
+  const logger = rootLogger.child({
+    module: "api/labs",
+    method: req.method,
+    path: req.path,
+    teamId: authedReq.auth.team_id,
+  });
+
+  const base = upstreamBase();
+  if (!base) {
+    return labsError(res, 503, "This endpoint is not available.");
+  }
+
+  if (!authedReq.acuc?.flags?.labsSearch) {
+    return labsError(res, 403, "This endpoint is not enabled for this team.");
+  }
+
+  try {
+    const upstream = await fetch(base + req.originalUrl, {
+      method: req.method,
+      headers: upstreamHeaders(authedReq),
+      body: upstreamBody(authedReq),
+      duplex: "half",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      dispatcher,
+    });
+
+    for (const h of FORWARDED_RESPONSE_HEADERS) {
+      const value = upstream.headers.get(h);
+      if (value) res.setHeader(h, value);
+    }
+
+    const text = await upstream.text();
+    let responseBody: any;
+    try {
+      responseBody = text ? JSON.parse(text) : null;
+    } catch {
+      responseBody = text;
+    }
+
+    if (responseBody === null || typeof responseBody === "string") {
+      return res.status(upstream.status).send(responseBody ?? "");
+    }
+    return res.status(upstream.status).json(responseBody);
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      logger.error("Labs proxy timed out");
+      return labsError(res, 504, "The request timed out.");
+    }
+    logger.error("Labs proxy error", { error });
+    return labsError(res, 502, "The request could not be completed.");
+  }
+}
+
+export const labsRouter = express.Router();
+
+// No credit check or billing here on purpose: the service behind this proxy
+// makes its own calls to the public API with the caller's own key, so usage is
+// billed on those existing paths instead.
+labsRouter.post(
+  "/search",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.post(
+  "/search/data/sites",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.post(
+  "/search/data/documents",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.get(
+  "/search/data",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.delete(
+  "/search/data/:sourceId",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.get(
+  "/search/providers",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.post(
+  "/search/configs",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.get(
+  "/search/configs",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.patch(
+  "/search/configs/:id",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.delete(
+  "/search/configs/:id",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);


### PR DESCRIPTION
Adds a pass-through router that authenticates the caller, gates on a team flag, and forwards to the service configured by LABS_SEARCH_URL. Credits are not checked or charged here because the downstream service calls the existing public endpoints with the caller's own key, which bills through those paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787887940&installation_model_id=11126&pr_number=4165&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4165&signature=e5fb78b6310e602e1243dd0bd0fbb14a421846aad9b92a4c35f04149065c2dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Labs Search proxy under `/labs` that authenticates callers, checks a team flag, and forwards requests to the service at `LABS_SEARCH_URL`. Billing is handled downstream with the caller’s key; the proxy does not charge credits.

- **New Features**
  - Adds `labsRouter` at `/labs` with search, data, and config endpoints.
  - Requires `labsSearch` team flag; uses auth and `RateLimiterMode.Search`.
  - Forwards headers and bodies (supports multipart), streams responses, and applies timeouts.
  - Sends `x-labs-search-secret`, `x-labs-search-team-id`, and optional `x-labs-search-key` to the upstream.

- **Migration**
  - Set `LABS_SEARCH_URL` and `LABS_SEARCH_SECRET`.
  - Enable the `labsSearch` flag for teams that should access this.

<sup>Written for commit 1180683ff6d34eea81d7e727243d8f9ca8bb4e92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

