### PR TITLE
feat(api): allow screenshots and pdf actions under zero data retention

### DIFF
--- a/apps/api/src/__tests__/snips/v2/zdr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/zdr.test.ts
@@ -8,7 +8,7 @@ import {
   idmux,
   searchRaw,
 } from "./lib";
-import { describeIf, TEST_PRODUCTION } from "../lib";
+import { describeIf, TEST_PRODUCTION, scrapeTimeout } from "../lib";
 import {
   getLogs,
   expectScrapeIsCleanedUp,
@@ -149,6 +149,63 @@ describeIf(TEST_PRODUCTION)("Zero Data Retention", () => {
       600000 + 20000,
     );
   });
+
+  it(
+    "should allow screenshots and clean them up",
+    async () => {
+      const identity = await idmux({
+        name: "zdr/screenshot",
+        credits: 10000,
+        flags: { scrapeZDR: "allowed" },
+      });
+
+      const scrape1 = await scrape(
+        {
+          url: "https://firecrawl.dev",
+          formats: ["screenshot"],
+          zeroDataRetention: true,
+        },
+        identity,
+      );
+
+      expect(scrape1.screenshot).toBeDefined();
+
+      const gcsJob = await getJobFromGCS(scrape1.metadata.scrapeId!);
+      expect(gcsJob).toBeNull();
+
+      await expectScrapeIsCleanedUp(scrape1.metadata.scrapeId!);
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "should allow pdf actions and clean them up",
+    async () => {
+      const identity = await idmux({
+        name: "zdr/pdf-action",
+        credits: 10000,
+        flags: { scrapeZDR: "allowed" },
+      });
+
+      const scrape1 = await scrape(
+        {
+          url: "https://firecrawl.dev",
+          actions: [{ type: "pdf" }],
+          zeroDataRetention: true,
+        },
+        identity,
+      );
+
+      expect(scrape1.actions?.pdfs).toBeDefined();
+      expect(scrape1.actions?.pdfs?.length).toBe(1);
+
+      const gcsJob = await getJobFromGCS(scrape1.metadata.scrapeId!);
+      expect(gcsJob).toBeNull();
+
+      await expectScrapeIsCleanedUp(scrape1.metadata.scrapeId!);
+    },
+    scrapeTimeout,
+  );
 
   it("should allow search when searchZDR is forced", async () => {
     const identity = await idmux({

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -43,7 +43,6 @@ import {
   NoCachedDataError,
   LockdownMissError,
   DNSResolutionError,
-  ZDRViolationError,
   PDFPrefetchFailed,
   DocumentPrefetchFailed,
   FEPageLoadFailed,
@@ -687,30 +686,6 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
       "engine.url": meta.rewrittenUrl ?? meta.url,
       "engine.features": Array.from(meta.featureFlags).join(","),
     });
-
-    if (meta.internalOptions.zeroDataRetention) {
-      if (meta.featureFlags.has("screenshot")) {
-        throw new ZDRViolationError("screenshot");
-      }
-
-      if (meta.featureFlags.has("screenshot@fullScreen")) {
-        throw new ZDRViolationError("screenshot@fullScreen");
-      }
-
-      if (
-        meta.options.actions &&
-        meta.options.actions.find(x => x.type === "screenshot")
-      ) {
-        throw new ZDRViolationError("screenshot action");
-      }
-
-      if (
-        meta.options.actions &&
-        meta.options.actions.find(x => x.type === "pdf")
-      ) {
-        throw new ZDRViolationError("pdf action");
-      }
-    }
 
     // TODO: handle sitemap data, see WebScraper/index.ts:280
     // TODO: ScrapeEvents


### PR DESCRIPTION
## Why

Fire-engine now supports ZDR screenshots and PDFs — the artifacts are written to a bucket with a 24h deletion policy. The API-side gate that threw `SCRAPE_ZDR_VIOLATION_ERROR` for screenshot formats, screenshot actions, and pdf actions on ZDR requests predates that support (from the original ZDR implementation in #1687) and is now obsolete.

## What

- Removed the ZDR screenshot/pdf-action gate in `scrapeURLLoop`. The API already passes `zeroDataRetention: true` in the fire-engine request payload, so fire-engine routes artifacts to the ZDR bucket on its own.
- Added two e2e tests to the ZDR suite: a ZDR scrape with `formats: ["screenshot"]` and one with `actions: [{ type: "pdf" }]`, asserting the artifact is returned, no job payload lands in the GCS jobs bucket, and the scrape DB record is scrubbed. The tests do not assert media deletion — the screenshot/pdf URLs intentionally remain live for up to 24h under the bucket lifecycle policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787934920&installation_model_id=11126&pr_number=4167&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4167&signature=51f0fa3ca043fa23c7faec572f560901f8630e8a28578fdc3a33633bd9652456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable screenshots and PDF actions for zero data retention scrapes by removing the obsolete API gate that threw `SCRAPE_ZDR_VIOLATION_ERROR`. Fire-engine now handles artifacts in a ZDR bucket with a 24h lifecycle.

- **New Features**
  - Removed the ZDR screenshot/PDF action block in `scrapeURLLoop`; `zeroDataRetention: true` is still sent to fire-engine, which routes artifacts to the ZDR bucket.
  - Added e2e tests for ZDR screenshot and PDF action that assert the artifact is returned, no GCS job is created, and the scrape record is scrubbed.

<sup>Written for commit a9868ecfe6edf58949d136dea3e760823d61b1fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

