### PR TITLE
fix(scrapeURL): drop tlsclient/fetch from the waterfall when fire-engine is present

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -693,12 +693,15 @@ export async function buildFallbackList(meta: Meta): Promise<
   // HTTP client tends to produce bot-walled or otherwise low-quality content,
   // so we'd rather fail the scrape outright. They stay reachable when the
   // request asks for them: fastMode/atsv set feature flags that chrome-cdp
-  // can't satisfy (and are handled here), and forceEngine bypasses _engines
+  // can't satisfy (and are handled here), audio/video keep tlsclient as the
+  // avgrab fallback behind chrome-cdp, and forceEngine bypasses _engines
   // entirely, reading straight from internalOptions.
   if (
     useFireEngine &&
     !meta.featureFlags.has("useFastMode") &&
-    !meta.featureFlags.has("atsv")
+    !meta.featureFlags.has("atsv") &&
+    !meta.featureFlags.has("audio") &&
+    !meta.featureFlags.has("video")
   ) {
     for (const engine of ["fire-engine;tlsclient", "fetch"] as Engine[]) {
       const index = _engines.indexOf(engine);

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -688,6 +688,26 @@ export async function buildFallbackList(meta: Meta): Promise<
     }
   }
 
+  // When fire-engine is available, drop tlsclient and fetch from the general
+  // waterfall: once chrome-cdp (and its retry) fail, degrading to a plain
+  // HTTP client tends to produce bot-walled or otherwise low-quality content,
+  // so we'd rather fail the scrape outright. They stay reachable when the
+  // request asks for them: fastMode/atsv set feature flags that chrome-cdp
+  // can't satisfy (and are handled here), and forceEngine bypasses _engines
+  // entirely, reading straight from internalOptions.
+  if (
+    useFireEngine &&
+    !meta.featureFlags.has("useFastMode") &&
+    !meta.featureFlags.has("atsv")
+  ) {
+    for (const engine of ["fire-engine;tlsclient", "fetch"] as Engine[]) {
+      const index = _engines.indexOf(engine);
+      if (index !== -1) {
+        _engines.splice(index, 1);
+      }
+    }
+  }
+
   if (!isWikimediaUrl(meta.url) || Math.random() >= 0.5) {
     const wikiIndex = _engines.indexOf("wikipedia");
     if (wikiIndex !== -1) {


### PR DESCRIPTION
## What

When fire-engine is configured (`FIRE_ENGINE_BETA_URL` set), `fire-engine;tlsclient` and `fetch` are now spliced out of the general engine waterfall in `buildFallbackList`.

## Why

Once `fire-engine;chrome-cdp` and its retry variant have failed, falling back to a plain HTTP client mostly yields bot-walled or otherwise low-quality content. Failing the scrape outright is preferable — `stealthProxy` retries remain the recovery path for blocked sites.

## What still works

- **`forceEngine`**: unaffected — it bypasses `_engines` entirely and reads straight from `internalOptions`, and the handler/options maps keep their entries.
- **`fastMode` / `atsv`**: these set the `useFastMode`/`atsv` feature flags, which gate the splice, so tlsclient/fetch stay in the list for those requests (chrome-cdp can't satisfy either flag).
- **Self-hosted (no fire-engine)**: unaffected — the splice is gated on `useFireEngine`, so `fetch` remains the workhorse there.

## Behavioral consequence

On a plain scrape where CDP (and CDP-retry) fail and stealth retries don't recover, the request now returns an engine-exhaustion error instead of fetch's degraded output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787934976&installation_model_id=11126&pr_number=4168&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4168&signature=e76140bc662bd4dfc663234cfdc3fe28652144a125651bc660b38080d3e5a966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When `fire-engine` is enabled, remove `fire-engine;tlsclient` and `fetch` from the fallback waterfall in `buildFallbackList` to avoid degraded, bot-walled content, except for audio/video scrapes where `tlsclient` stays as the AV fallback. If `chrome-cdp` and its retry fail, we now fail fast.

- **Bug Fixes**
  - Gated on `FIRE_ENGINE_BETA_URL` (`useFireEngine`) and only when no `useFastMode`, `atsv`, `audio`, or `video` flags are set.
  - `forceEngine` unchanged; `fastMode`/`atsv` keep `tlsclient`/`fetch`; audio/video keep `tlsclient`; self-hosted without `fire-engine` unchanged.
  - On plain scrapes where `chrome-cdp` and retries fail and `stealthProxy` can’t recover, return an engine-exhaustion error instead of `fetch` output.

<sup>Written for commit 31175a98e0c2b474ae0a7ef61691cff6b0c929ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

