### PR TITLE
chore(playwright-service): run chromium as non-root

### DIFF
--- a/apps/playwright-service-ts/Dockerfile
+++ b/apps/playwright-service-ts/Dockerfile
@@ -19,9 +19,14 @@ RUN pnpm exec playwright install chromium --with-deps
 
 RUN pnpm run build
 
+RUN chown -R node:node /usr/src/app \
+  && chmod -R a+rX /usr/local/share/playwright
+
 ARG PORT
 ENV PORT=${PORT}
 
 EXPOSE ${PORT}
+
+USER node
 
 CMD [ "pnpm", "start" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,10 @@ services:
       MAX_CONCURRENT_PAGES: ${CRAWL_CONCURRENT_REQUESTS:-10}
     networks:
       - backend
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     # Resource limits for Docker Compose (not Swarm)
     cpus: 2.0
     mem_limit: 4G

--- a/examples/kubernetes/cluster-install/playwright-service.yaml
+++ b/examples/kubernetes/cluster-install/playwright-service.yaml
@@ -22,10 +22,21 @@ spec:
     spec:
       imagePullSecrets:
         - name: docker-registry-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: playwright-service
           image: ghcr.io/firecrawl/playwright-service:latest
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: 3000
           envFrom:


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787941154&installation_model_id=11126&pr_number=4171&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4171&signature=870324116863eaf3d4c4e7d1c89cde8ced6aedae4f1b7c16c00e90b02eca954b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Chromium in the Playwright service as a non-root user and harden container security for Docker Compose and Kubernetes. Lowers privileges by default without changing behavior.

- **Refactors**
  - Dockerfile: chown app dir, chmod Playwright files, set USER `node`.
  - Docker Compose: add `security_opt: no-new-privileges:true`, drop all caps.
  - Kubernetes: enforce non-root (uid/gid 1000), `seccompProfile: RuntimeDefault`, disable privilege escalation, drop all caps.

<sup>Written for commit e7a3d17921648af42a82ac3169ecc0b5c05fcf1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

