### PR TITLE
fix(api): route the three missing /labs/search/data endpoints

### DIFF
--- a/apps/api/src/routes/labs.ts
+++ b/apps/api/src/routes/labs.ts
@@ -139,6 +139,10 @@ export const labsRouter = express.Router();
 // No credit check or billing here on purpose: the service behind this proxy
 // makes its own calls to the public API with the caller's own key, so usage is
 // billed on those existing paths instead.
+//
+// This list mirrors the upstream service one route at a time; there is no
+// catch-all. An endpoint added upstream stays a 404 here until it is also
+// listed below, so keep the two in sync when the service grows.
 labsRouter.post(
   "/search",
   authMiddleware(RateLimiterMode.Search),
@@ -157,14 +161,32 @@ labsRouter.post(
   wrap(labsProxyController),
 );
 
+labsRouter.post(
+  "/search/data/pages",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
 labsRouter.get(
   "/search/data",
   authMiddleware(RateLimiterMode.Search),
   wrap(labsProxyController),
 );
 
+labsRouter.patch(
+  "/search/data/:sourceId",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
 labsRouter.delete(
   "/search/data/:sourceId",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.post(
+  "/search/data/:sourceId/refresh",
   authMiddleware(RateLimiterMode.Search),
   wrap(labsProxyController),
 );


### PR DESCRIPTION
## Summary

`apps/api/src/routes/labs.ts` is a pass-through proxy that enumerates every upstream path explicitly and has no catch-all, so an endpoint added to the service behind it falls through to the API's 404 handler until it is listed here too. Three had accumulated, and the dashboard already calls all three, so those features were broken end to end:

- `POST /labs/search/data/pages` — ingest a single URL rather than crawling a site
- `PATCH /labs/search/data/:sourceId` — rename a source / change its refresh policy
- `POST /labs/search/data/:sourceId/refresh` — re-read a source now

Each new route is registered next to its neighbours with the same `authMiddleware(RateLimiterMode.Search)` + `wrap(labsProxyController)` pairing, so the team flag gate, header forwarding and verbatim status/body pass-through are unchanged. No credit middleware, matching the rest of the file — billing still happens downstream.

The file now also carries a note that this list has to be kept in sync with the upstream service, since the enumeration is the reason the gap went unnoticed.

### Why not a catch-all

A scoped `/labs/search/*` catch-all would stop this recurring, but the proxy attaches a trusted shared secret to whatever upstream path it builds, so anything reachable through it is reachable with that secret. An explicit list keeps that surface auditable in review and makes new upstream endpoints opt-in rather than public by default. The competing argument — that enumerating here advertises the upstream shape — does not really hold, since the dashboard already calls these paths from the browser.

## Test plan

- [x] `npx tsc --noEmit` in `apps/api` reports only the two pre-existing errors (`src/lib/deterministicJson/pipeline/validate.ts`, `src/services/autumn/autumn.service.ts`); no new ones.
- [x] Traced all 13 routes through a router mounted at `/labs` on the repo's Express 5.2.1: each of the three new paths matches, and `req.originalUrl` still carries the full `/labs/search/...` prefix, including for the `:sourceId` variants and with a query string, so the upstream URL the controller composes is correct.
- [x] `PATCH` needed nothing special: it is already used by `/search/configs/:id`, the app-level `bodyParser.json` parses PATCH bodies, `hasJsonBody()` already returns true for it, and the default `cors()` allows the method.
- [ ] Confirm against the live service that the three endpoints return upstream responses rather than 404.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787947234&installation_model_id=11126&pr_number=4172&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4172&signature=d57579989c54b82821bec0887b052c93a8afb3b44f334aa7be299801182bb132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routed three missing Labs Search data endpoints through the API proxy to stop 404s in the dashboard. Uses existing auth/rate limiting and pass-through; billing remains downstream. Added a note to keep routes in sync with the upstream service.

- **Bug Fixes**
  - POST /labs/search/data/pages — ingest a single URL.
  - PATCH /labs/search/data/:sourceId — update source name or refresh policy.
  - POST /labs/search/data/:sourceId/refresh — trigger an immediate refresh.

<sup>Written for commit 533ab33f7e446e473549e39cac0f50107098a881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

