### PR TITLE
fix(docker): add default fallback to PORT build arg in playwright-service-ts

### DIFF
--- a/apps/playwright-service-ts/Dockerfile
+++ b/apps/playwright-service-ts/Dockerfile
@@ -19,7 +19,9 @@ RUN pnpm exec playwright install chromium --with-deps
 
 RUN pnpm run build
 
-ARG PORT
+# Default fallback to prevent build crashes in podman-compose and other builders that drop .env args
+ARG PORT=3000
+
 ENV PORT=${PORT}
 
 EXPOSE ${PORT}


### PR DESCRIPTION
### Description
When building with alternative container engines like `podman-compose`, environment variables from `.env` are not automatically injected into the image build context. This causes `ARG PORT` in `apps/playwright-service-ts/Dockerfile` to remain empty, which subsequently causes `EXPOSE ${PORT}` to crash the build with `EXPOSE requires at least one argument`.

Adding a comment and `ARG PORT=3000` provides a sane default fallback so the build succeeds regardless of compose builder quirks or missing `.env` flags.

### Why 3000?
* **It matches the existing config:** The `playwright-service` in `docker-compose.yaml` already sets the environment variable `PORT: 3000`.
* **No host conflicts:** Because this service does not map ports to the host machine in the compose file (it only communicates internally over the `backend` network), defaulting to `3000` inside the container will not clash with any services running on the user's host machine.
* **It is strictly a fallback:** If a user or build system explicitly passes `--build-arg PORT=4000`, it will still successfully override this default. 

Closes #4137

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787950140&installation_model_id=11126&pr_number=4173&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4173&signature=35ebfaac7caf7139be902c2f2073d6e3201db4ee6e8ecc5f38112169f0f99433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a default `ARG PORT=3000` in `apps/playwright-service-ts/Dockerfile` to prevent `EXPOSE` build failures when `.env` values aren’t injected by builders like `podman-compose`. `PORT` now always has a value while still allowing overrides via `--build-arg PORT`.

<sup>Written for commit def41d58414329bc3b24c15781e03a5643c04359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

