### PR TITLE
fix(examples): replace retired and sunsetting OpenAI model IDs

### DIFF
--- a/examples/gpt-4.5-web-crawler/gpt-4.5-crawler.py
+++ b/examples/gpt-4.5-web-crawler/gpt-4.5-crawler.py
@@ -37,7 +37,7 @@ def find_relevant_page_via_map(objective, url, app, client):
 
         print(f"{Colors.YELLOW}Analyzing objective to determine optimal search parameter...{Colors.RESET}")
         completion = client.chat.completions.create(
-            model="gpt-4.5-preview",
+            model="gpt-4.1",
             messages=[
                 {
                     "role": "user",
@@ -112,7 +112,7 @@ def find_relevant_page_via_map(objective, url, app, client):
 
         print(f"{Colors.YELLOW}Ranking URLs by relevance to objective...{Colors.RESET}")
         completion = client.chat.completions.create(
-            model="gpt-4.5-preview",
+            model="gpt-4.1",
             messages=[
                 {
                     "role": "user", 
@@ -187,7 +187,7 @@ def find_objective_in_top_pages(map_website, objective, app, client):
             """
         
             completion = client.chat.completions.create(
-                model="gpt-4.5-preview",
+                model="gpt-4.1",
                 messages=[
                     {
                         "role": "user",

--- a/examples/job-resource-analyzer/job-resources-analyzer.py
+++ b/examples/job-resource-analyzer/job-resources-analyzer.py
@@ -118,7 +118,7 @@ def rank_and_summarize_resources(resources, skills):
         }}"""
 
         response = client.chat.completions.create(
-            model="o3-mini",
+            model="gpt-5-mini",
             messages=[
                 {"role": "system", "content": "You are a technical learning resource curator."},
                 {"role": "user", "content": prompt}

--- a/examples/o1_web_extractor/o1_web_extractor.py
+++ b/examples/o1_web_extractor/o1_web_extractor.py
@@ -39,7 +39,7 @@ def select_urls_with_o1(company, objective, serp_results):
                      for r in serp_results if r.get("link")]
 
         response = client.chat.completions.create(
-            model="o1-2024-12-17",
+            model="gpt-5",
             messages=[
                 {
                     "role": "developer",

--- a/examples/o3-mini-deal-finder/o3-mini-deal-finder.py
+++ b/examples/o3-mini-deal-finder/o3-mini-deal-finder.py
@@ -192,7 +192,7 @@ def display_comparison(data):
             
             try:
                 response = client.chat.completions.create(
-                    model="o3-mini",
+                    model="gpt-5-mini",
                     messages=[{"role": "user", "content": prompt }],
                 )
                 

--- a/examples/o3-mini_company_researcher/o3-mini_company_researcher.py
+++ b/examples/o3-mini_company_researcher/o3-mini_company_researcher.py
@@ -41,7 +41,7 @@ def select_urls_with_r1(company, objective, serp_results):
                      for r in serp_results if r.get("link")]
 
         response = client.chat.completions.create(
-            model="o3-mini",
+            model="gpt-5-mini",
             messages=[
                 {
                     "role": "system",

--- a/examples/o3-mini_web_crawler/o3-mini_web_crawler.py
+++ b/examples/o3-mini_web_crawler/o3-mini_web_crawler.py
@@ -37,7 +37,7 @@ def find_relevant_page_via_map(objective, url, app, client):
 
         print(f"{Colors.YELLOW}Analyzing objective to determine optimal search parameter...{Colors.RESET}")
         completion = client.chat.completions.create(
-            model="o3-mini",
+            model="gpt-5-mini",
             messages=[
                 {
                     "role": "user",
@@ -112,7 +112,7 @@ def find_relevant_page_via_map(objective, url, app, client):
 
         print(f"{Colors.YELLOW}Ranking URLs by relevance to objective...{Colors.RESET}")
         completion = client.chat.completions.create(
-            model="o3-mini",
+            model="gpt-5-mini",
             messages=[
                 {
                     "role": "user", 
@@ -187,7 +187,7 @@ def find_objective_in_top_pages(map_website, objective, app, client):
             """
         
             completion = client.chat.completions.create(
-                model="o3-mini",
+                model="gpt-5-mini",
                 messages=[
                     {
                         "role": "user",

--- a/examples/o4-mini-web-crawler/o4-mini-web-crawler.py
+++ b/examples/o4-mini-web-crawler/o4-mini-web-crawler.py
@@ -36,7 +36,7 @@ def find_relevant_page_via_map(objective, url, app, client):
 
         print(f"{Colors.YELLOW}Analyzing objective to determine optimal search parameter...{Colors.RESET}")
         completion = client.chat.completions.create(
-            model="o4-mini",
+            model="gpt-5-mini",
             messages=[
                 {
                     "role": "user",
@@ -109,7 +109,7 @@ def find_relevant_page_via_map(objective, url, app, client):
 
         print(f"{Colors.YELLOW}Ranking URLs by relevance to objective...{Colors.RESET}")
         completion = client.chat.completions.create(
-            model="o4-mini",
+            model="gpt-5-mini",
             messages=[
                 {
                     "role": "user", 
@@ -182,7 +182,7 @@ def find_objective_in_top_pages(map_website, objective, app, client):
             """
         
             completion = client.chat.completions.create(
-                model="o4-mini",
+                model="gpt-5-mini",
                 messages=[
                     {
                         "role": "user",


### PR DESCRIPTION
Several examples reference OpenAI models that no longer exist or have a shutdown date - which I happened to find with [arol](https://arol.ai/), a deprecation scanner I built:

- `gpt-4.5-preview` (gpt-4.5-web-crawler, ×3) was removed from the API on **July 14, 2025** — anyone copying this example today gets model-not-found errors.
- `o1-2024-12-17`, `o3-mini`, and `o4-mini` (o1_web_extractor, job-resource-analyzer, o3-mini-deal-finder, o3-mini_company_researcher, o3-mini_web_crawler, o4-mini-web-crawler) shut down **October 23, 2026** per https://platform.openai.com/docs/deprecations.

This PR is mechanical ID swaps only — every call site is a plain `chat.completions.create`, no parameter or logic changes: `gpt-4.5-preview` → `gpt-4.1` (where OpenAI's removal notice pointed), `o1-2024-12-17` → `gpt-5`, `o3-mini` / `o4-mini` → `gpt-5-mini`. Happy to change targets if maintainers prefer different models.

Deliberately not touched:
- the example directory *names* (o3-mini_web_crawler etc.) — your call on renames;
- `o3-mini` in production code (`apps/api/src/lib/generic-ai.ts:62`, `apps/api/src/lib/deep-research/research-manager.ts:346`) — flagging rather than changing, since model choice there has cost/eval tradeoffs;
- `model-prices.ts` — it's a price catalog, historical models belong there.

Found with [arol](https://arol.ai), a deprecation scanner I built after a vendor retirement broke our own production.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787965065&installation_model_id=11126&pr_number=4176&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4176&signature=0f10bccb4ca3c36082845a2ae115f57171719097722424f6bec5bf3656b2f921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced retired OpenAI model IDs in example scripts to stop model-not-found errors and keep examples working.

- **Bug Fixes**
  - `gpt-4.5-preview` → `gpt-4.1` (gpt-4.5-web-crawler)
  - `o1-2024-12-17` → `gpt-5` (o1_web_extractor)
  - `o3-mini`/`o4-mini` → `gpt-5-mini` (job-resource-analyzer, o3-mini-* examples, o4-mini-web-crawler)
  - Mechanical ID swaps only; no logic or parameter changes

<sup>Written for commit ee167ed6d29f1bf990accb580eee94ed6ac8c5c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

