### PR TITLE
test(billing): cover historical usage byApiKey=true e2e path

### DIFF
--- a/apps/api/src/__tests__/snips/v2/billing.test.ts
+++ b/apps/api/src/__tests__/snips/v2/billing.test.ts
@@ -669,6 +669,80 @@ describeIf(TEST_PRODUCTION)("Billing tests", () => {
     60000,
   );
 
+  // The `?byApiKey=true` path drives a grouped Autumn `events.aggregate` scan
+  // that used to time out against the 2s hot-path client and surface a 500.
+  // Assert it responds 200 with a well-formed (per-API-key) payload so a
+  // regression back onto the short-timeout client is caught.
+  it.concurrent(
+    "returns historical credit usage grouped by API key",
+    async () => {
+      const identity = await idmux({
+        name: "billing/returns historical credit usage byApiKey",
+        credits: 100,
+      });
+
+      const result = await creditUsageHistorical(identity, true);
+
+      expect(result.success).toBe(true);
+      expect(Array.isArray(result.periods)).toBe(true);
+
+      for (const period of result.periods) {
+        expect(typeof period.apiKey).toBe("string");
+        expect(typeof period.creditsUsed).toBe("number");
+        expect(period.creditsUsed).toBeGreaterThanOrEqual(0);
+      }
+
+      // Verify periods are sorted by startDate ascending (null dates last)
+      for (let i = 1; i < result.periods.length; i++) {
+        const prevRaw = result.periods[i - 1].startDate
+          ? Date.parse(result.periods[i - 1].startDate!)
+          : NaN;
+        const currRaw = result.periods[i].startDate
+          ? Date.parse(result.periods[i].startDate!)
+          : NaN;
+        if (!Number.isNaN(prevRaw) && !Number.isNaN(currRaw)) {
+          expect(currRaw).toBeGreaterThanOrEqual(prevRaw);
+        }
+      }
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "returns historical token usage grouped by API key",
+    async () => {
+      const identity = await idmux({
+        name: "billing/returns historical token usage byApiKey",
+        credits: 100,
+      });
+
+      const result = await tokenUsageHistorical(identity, true);
+
+      expect(result.success).toBe(true);
+      expect(Array.isArray(result.periods)).toBe(true);
+
+      for (const period of result.periods) {
+        expect(typeof period.apiKey).toBe("string");
+        expect(typeof period.tokensUsed).toBe("number");
+        expect(period.tokensUsed).toBeGreaterThanOrEqual(0);
+      }
+
+      // Verify periods are sorted by startDate ascending (null dates last)
+      for (let i = 1; i < result.periods.length; i++) {
+        const prevRaw = result.periods[i - 1].startDate
+          ? Date.parse(result.periods[i - 1].startDate!)
+          : NaN;
+        const currRaw = result.periods[i].startDate
+          ? Date.parse(result.periods[i].startDate!)
+          : NaN;
+        if (!Number.isNaN(prevRaw) && !Number.isNaN(currRaw)) {
+          expect(currRaw).toBeGreaterThanOrEqual(prevRaw);
+        }
+      }
+    },
+    60000,
+  );
+
   it.concurrent(
     "bills custom-cost ZDR scrape correctly",
     async () => {

--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -857,16 +857,21 @@ export async function creditUsage(
   return req.body.data;
 }
 
-export async function creditUsageHistorical(identity: Identity): Promise<{
+export async function creditUsageHistorical(
+  identity: Identity,
+  byApiKey: boolean = false,
+): Promise<{
   success: boolean;
   periods: {
     startDate: string | null;
     endDate: string | null;
+    apiKey?: string;
     creditsUsed: number;
   }[];
 }> {
   const req = await request(TEST_API_URL)
     .get("/v2/team/credit-usage/historical")
+    .query(byApiKey ? { byApiKey: "true" } : {})
     .set("Authorization", `Bearer ${identity.apiKey}`)
     .set("Content-Type", "application/json");
 
@@ -877,16 +882,21 @@ export async function creditUsageHistorical(identity: Identity): Promise<{
   return req.body;
 }
 
-export async function tokenUsageHistorical(identity: Identity): Promise<{
+export async function tokenUsageHistorical(
+  identity: Identity,
+  byApiKey: boolean = false,
+): Promise<{
   success: boolean;
   periods: {
     startDate: string | null;
     endDate: string | null;
+    apiKey?: string;
     tokensUsed: number;
   }[];
 }> {
   const req = await request(TEST_API_URL)
     .get("/v2/team/token-usage/historical")
+    .query(byApiKey ? { byApiKey: "true" } : {})
     .set("Authorization", `Bearer ${identity.apiKey}`)
     .set("Content-Type", "application/json");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds end-to-end (`snips`) coverage for the `?byApiKey=true` variant of the historical usage endpoints, which is the exact path that [PR #4179](https://github.com/firecrawl/firecrawl/pull/4179) fixes but which previously had **no e2e test**.

New tests in `apps/api/src/__tests__/snips/v2/billing.test.ts`:
- `returns historical credit usage grouped by API key` — `GET /v2/team/credit-usage/historical?byApiKey=true`
- `returns historical token usage grouped by API key` — `GET /v2/team/token-usage/historical?byApiKey=true`

Both assert a `200` response with a well-formed per-API-key payload (each period carries a string `apiKey`, a non-negative numeric usage value, and periods are sorted ascending by `startDate`).

The `byApiKey=true` path drives a grouped Autumn `events.aggregate` scan that used to time out against the 2s hot-path client and surface a `500`. #4179 routes it through a dedicated 15s `autumnHistoricalClient`; these tests guard against a regression back onto the short-timeout client.

`apps/api/src/__tests__/snips/v2/lib.ts` gains an optional `byApiKey` argument on the `creditUsageHistorical` / `tokenUsageHistorical` helpers.

## Why target the fix branch

Based on the PR branch so CI exercises the new e2e coverage against the fix, where the Autumn secret is available. The billing suite is gated by `describeIf(TEST_PRODUCTION)`.

## Testing done in-agent

The live harness could not run in the agent VM (no `AUTUMN_SECRET_KEY` / Firecrawl API key injected for the public repo, and the harness needs Supabase/Redis/FoundationDB/idmux). Offline validation performed:
- `vitest run src/services/autumn/__tests__/usage.test.ts` → **31/31 pass** (confirms both historical aggregations route through `autumnHistoricalClient`, not the hot-path client).
- `tsc --noEmit` → **clean** for all Autumn/usage/billing files and the edited test files (remaining project errors are solely the unbuilt native `@mendable/firecrawl-rs` module, unrelated to this change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-861fb3ad-1866-4c0a-a7f3-a3529c6400ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-861fb3ad-1866-4c0a-a7f3-a3529c6400ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788021869&installation_model_id=11126&pr_number=4180&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4180&signature=37e3e1b07cff76ed79511123a7e97735160df58daee136b41b75c0ac2f1840ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->