### PR TITLE
feat(api): route the two /labs/search/packs endpoints

### DIFF
--- a/apps/api/src/routes/labs.ts
+++ b/apps/api/src/routes/labs.ts
@@ -197,6 +197,18 @@ labsRouter.get(
   wrap(labsProxyController),
 );
 
+labsRouter.get(
+  "/search/packs",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
+labsRouter.patch(
+  "/search/packs/:packId",
+  authMiddleware(RateLimiterMode.Search),
+  wrap(labsProxyController),
+);
+
 labsRouter.post(
   "/search/configs",
   authMiddleware(RateLimiterMode.Search),
@@ -220,4 +232,3 @@ labsRouter.delete(
   authMiddleware(RateLimiterMode.Search),
   wrap(labsProxyController),
 );
-


### PR DESCRIPTION
## Summary

- The labs router is a pass-through proxy that enumerates every upstream path explicitly and has no catch-all, so an endpoint the service behind it grows returns this API's 404 until it is also listed here.
- The service is adding two paths for provider packs — `GET /labs/search/packs` and `PATCH /labs/search/packs/:packId` — and neither is reachable through the proxy until it enumerates them.
- List both next to the providers route, the catalog group they belong to, with the same auth, rate limiter and team flag gate as their neighbours. Nothing else changes.

## Test plan

- The proxy is forwarding-only: it adds no validation, no branching and no request or response shaping beyond the headers it already forwards for every other route. The behaviour of these two endpoints is defined and tested upstream, so there is nothing here to unit test beyond the route being registered.
- `prettier --write` then `--check` on `src/routes/labs.ts` — clean.
- `tsc` typecheck — no errors in `src/routes/labs.ts`. Two errors surface elsewhere in the tree (`src/lib/deterministicJson/pipeline/validate.ts` and `src/services/autumn/autumn.service.ts`) from a stale local install; both are in files this PR does not touch.
- The Server Test Suite runs on this PR and needs redis/postgres/rabbitmq, so it was not run locally and is left to CI.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788033141&installation_model_id=11126&pr_number=4184&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4184&signature=80d3d8313fdc26df4509dd0a6206255fd6dc1bdd76f4bd84706659660a8e278a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose provider pack endpoints through the labs proxy to stop 404s and allow teams to list and toggle packs. Adds GET and PATCH routes with the same auth and rate limits as existing catalog routes.

- **New Features**
  - Proxies GET /labs/search/packs.
  - Proxies PATCH /labs/search/packs/:packId.
  - Uses the same auth, rate limiter, and team gate as providers; no payload changes.

<sup>Written for commit 2adf7ba5f6a810eb6bfda5b42ec55a2a9fdbe68f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

