### PR TITLE
fix(search): prefer the upstream title for developer results

### DIFF
--- a/apps/api/src/search/developer.test.ts
+++ b/apps/api/src/search/developer.test.ts
@@ -65,6 +65,7 @@ describe("searchDeveloperCategory", () => {
             id: "abc",
             type: "issue",
             url: "https://github.com/a/b/issues/1",
+            title: "Retries drop the backoff",
             passages: [{ text: "first passage" }],
           },
           { id: "def", type: "readme", url: "", passages: [] },
@@ -80,11 +81,43 @@ describe("searchDeveloperCategory", () => {
     expect(results).toEqual([
       {
         url: "https://github.com/a/b/issues/1",
-        title: "https://github.com/a/b/issues/1",
+        title: "Retries drop the backoff",
         description: "first passage",
         position: 1,
         category: "developer",
       },
+    ]);
+  });
+
+  it("falls back to the url when the upstream sends no usable title", async () => {
+    fetchMock.mockResolvedValue(
+      upstreamOk({
+        results: [
+          {
+            id: "abc",
+            type: "pull_request",
+            url: "https://github.com/a/b/pull/1",
+            passages: [{ text: "first passage" }],
+          },
+          {
+            id: "def",
+            type: "pull_request",
+            url: "https://github.com/a/b/pull/2",
+            title: "   ",
+            passages: [],
+          },
+        ],
+      }),
+    );
+
+    const results = await searchDeveloperCategory(
+      { query: "retries", limit: 5, teamId: "t1", timeout: 500 },
+      logger,
+    );
+
+    expect(results.map(result => result.title)).toEqual([
+      "https://github.com/a/b/pull/1",
+      "https://github.com/a/b/pull/2",
     ]);
   });
 

--- a/apps/api/src/search/developer.ts
+++ b/apps/api/src/search/developer.ts
@@ -42,7 +42,12 @@ export async function searchDeveloperCategory(
       .slice(0, options.limit)
       .map((result, index) => ({
         url: typeof result?.url === "string" ? result.url : "",
-        title: typeof result?.url === "string" ? result.url : "",
+        title:
+          typeof result?.title === "string" && result.title.trim().length > 0
+            ? result.title
+            : typeof result?.url === "string"
+              ? result.url
+              : "",
         description:
           typeof result?.passages?.[0]?.text === "string"
             ? result.passages[0].text


### PR DESCRIPTION
Developer results now use the upstream `title` from `/v2/code/search`, and fall back to the URL when no title arrives or the title is blank.

Upstream source per kind: doc → page title, issue and pull_request → the derived document title, readme → `repo_display`. The service omits a title it cannot vouch for, notably the "Conversation" and "Sponsor …" scrape artifacts, so those results keep the URL.

Depends on firecrawl/search#668. The mapping is inert until that deploys.

Tests: 6 pass, one new case for the missing and blank-title fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4vZ6XH65bUJDkLthyfmvC
