### PR TITLE
Improve self-hosted search and scraper reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ _local/
 
 
 apps/api/src/lib/scrape-interact/*.md
+# Contains SearXNG secret_key and engine API keys
+searxng/settings.yml

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,7 +16,7 @@ RUN cd sharedLibs/go-html-to-md && \
     go mod download && \
     go build -o libhtml-to-markdown.so -buildmode=c-shared html-to-markdown.go
 
-FROM base AS build
+FROM base AS build-deps
 WORKDIR /app
 
 # Install system dependencies
@@ -65,6 +65,11 @@ ARG GIT_SHA=unknown
 RUN test -s dist/src/harness.js && \
     test -s dist/src/controllers/v0/crawl-status.js && \
     printf '%s\n' "$GIT_SHA" > BUILD_SHA
+
+# Keep a named layer with development dependencies so focused tests can run in
+# the same reproducible environment used by the production compile:
+#   docker build --target build-deps -t firecrawl-api-test apps/api
+FROM build-deps AS build
 
 # Remove dev dependencies
 RUN pnpm prune --prod --ignore-scripts

--- a/apps/api/src/__tests__/lib/search-profiles.test.ts
+++ b/apps/api/src/__tests__/lib/search-profiles.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSearchProfileRequests,
+  resolveSearchProfiles,
+} from "../../search/profiles";
+
+describe("search profiles", () => {
+  it("auto-routes developer, research, PDF, and general queries", () => {
+    expect(resolveSearchProfiles("firecrawl github sdk")[0].name).toBe(
+      "developer",
+    );
+    expect(
+      resolveSearchProfiles("weighted sampling research paper")[0].name,
+    ).toBe("research");
+    expect(resolveSearchProfiles("download the full text pdf")[0].name).toBe(
+      "pdf",
+    );
+    expect(resolveSearchProfiles("best restaurants in Montreal")[0].name).toBe(
+      "general",
+    );
+  });
+
+  it("lets explicit categories override automatic intent", () => {
+    expect(
+      resolveSearchProfiles("github implementation", ["research"]),
+    ).toEqual([{ name: "research", explicit: true, sites: undefined }]);
+  });
+
+  it("deduplicates mixed explicit profiles and preserves custom sites", () => {
+    expect(
+      resolveSearchProfiles("sampling", [
+        "research",
+        { type: "research", sites: ["example.edu"] },
+        "pdf",
+      ]),
+    ).toEqual([
+      { name: "research", explicit: true, sites: ["example.edu"] },
+      { name: "pdf", explicit: true, sites: undefined },
+    ]);
+  });
+
+  it("only adds ecosystem engines when the query asks for them", () => {
+    const profile = resolveSearchProfiles("firecrawl sdk github")[0];
+    const ordinary = buildSearchProfileRequests(
+      "firecrawl sdk github",
+      profile,
+    );
+    expect(ordinary[0].engines).toContain("github");
+    expect(ordinary[0].engines).not.toContain("docker hub");
+    expect(ordinary[0].engines).not.toContain("npm");
+
+    const packageSearch = buildSearchProfileRequests(
+      "firecrawl npm package",
+      profile,
+    );
+    expect(packageSearch[0].engines).toContain("npm");
+  });
+
+  it("keeps site operators away from specialist research APIs", () => {
+    const profile = resolveSearchProfiles("fairness paper", ["research"])[0];
+    const requests = buildSearchProfileRequests("fairness paper", profile);
+    expect(requests[0].query).toBe("fairness paper");
+    expect(requests[0].engines).toContain("crossref");
+    expect(requests[1].query).toContain("site:arxiv.org");
+    expect(requests[1].engines).toEqual(["braveapi"]);
+  });
+});

--- a/apps/api/src/__tests__/lib/search-quality.test.ts
+++ b/apps/api/src/__tests__/lib/search-quality.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalizeSearchUrl,
+  filterAndRankWebResults,
+  isArxivPdfUrl,
+  isPdfLikeUrl,
+  stripSearchDiagnostics,
+} from "../../search/quality";
+
+describe("search result quality", () => {
+  it("unwraps redirects and removes tracking parameters", () => {
+    expect(
+      canonicalizeSearchUrl(
+        "https://redirect.example/?url=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%3Futm_source%3Dtest",
+      ),
+    ).toBe("https://github.com/firecrawl/firecrawl");
+  });
+
+  it("recognizes extensionless arXiv PDF routes", () => {
+    expect(isArxivPdfUrl("https://arxiv.org/pdf/2307.04644")).toBe(true);
+    expect(isPdfLikeUrl("https://arxiv.org/pdf/2307.04644")).toBe(true);
+    expect(isArxivPdfUrl("https://arxiv.org/abs/2307.04644")).toBe(false);
+  });
+
+  it("rewrites arXiv abstract URLs for explicit PDF searches", () => {
+    expect(
+      canonicalizeSearchUrl("https://arxiv.org/abs/2307.04644", "pdf"),
+    ).toBe("https://arxiv.org/pdf/2307.04644");
+  });
+
+  it("hard-enforces GitHub and include-domain constraints", () => {
+    const results = filterAndRankWebResults(
+      [
+        {
+          url: "https://github.com/firecrawl/firecrawl",
+          title: "Firecrawl",
+          description: "developer API",
+        },
+        {
+          url: "https://example.com/firecrawl",
+          title: "Firecrawl mirror",
+          description: "developer API",
+        },
+      ],
+      {
+        query: "firecrawl",
+        profiles: ["developer"],
+        categories: ["github"],
+        includeDomains: ["github.com"],
+      },
+    );
+    expect(results.map(result => result.url)).toEqual([
+      "https://github.com/firecrawl/firecrawl",
+    ]);
+  });
+
+  it("deduplicates canonical URLs and ranks trusted exact matches first", () => {
+    const results = filterAndRankWebResults(
+      [
+        {
+          url: "https://example.com/unrelated",
+          title: "Unrelated",
+          description: "something else",
+          __search: { score: 1 },
+        },
+        {
+          url: "https://github.com/firecrawl/firecrawl?utm_source=x",
+          title: "Firecrawl repository",
+          description: "web scraping API",
+          __search: { score: 2, engine: "github" },
+        },
+        {
+          url: "https://github.com/firecrawl/firecrawl",
+          title: "Duplicate",
+          description: "",
+        },
+      ],
+      { query: "firecrawl web scraping", profiles: ["developer"] },
+    );
+    expect(results).toHaveLength(2);
+    expect(results[0].url).toBe("https://github.com/firecrawl/firecrawl");
+  });
+
+  it("removes internal engine diagnostics before returning results", () => {
+    expect(
+      stripSearchDiagnostics([
+        {
+          url: "https://example.com",
+          title: "Example",
+          description: "",
+          __search: { engine: "bing", score: 2 },
+        },
+      ]),
+    ).toEqual([
+      { url: "https://example.com", title: "Example", description: "" },
+    ]);
+  });
+});

--- a/apps/api/src/__tests__/snips/v2/search-feedback.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search-feedback.test.ts
@@ -1,4 +1,9 @@
-import { describeIf, TEST_PRODUCTION } from "../lib";
+import {
+  describeIf,
+  HAS_SEARCH,
+  TEST_PRODUCTION,
+  TEST_SELF_HOST,
+} from "../lib";
 import {
   searchRawFull,
   searchFeedback,
@@ -445,3 +450,51 @@ describeIf(TEST_PRODUCTION)("Search feedback tests", () => {
     90000,
   );
 });
+
+describeIf(TEST_SELF_HOST && HAS_SEARCH)(
+  "Self-hosted search feedback tests",
+  () => {
+    it("records feedback in Redis without database authentication and remains idempotent", async () => {
+      const raw = await searchRawFull(
+        { query: "firecrawl self-hosted feedback", limit: 3 },
+        identity,
+      );
+      expect(raw.statusCode).toBe(200);
+      expect(typeof raw.body.id).toBe("string");
+      expect((raw.body.data?.web ?? []).length).toBeGreaterThan(0);
+
+      const body = {
+        rating: "good" as const,
+        valuableSources: [{ url: raw.body.data.web[0].url }],
+      };
+      const first = await searchFeedbackRaw(raw.body.id, body, identity);
+      expect(first.statusCode).toBe(200);
+      expect(first.body.success).toBe(true);
+      expect(first.body.creditsRefunded).toBe(0);
+      expect(typeof first.body.feedbackId).toBe("string");
+      expect(first.body.feedbackId.length).toBeGreaterThan(0);
+      expect(String(first.body.warning)).toContain("Redis");
+
+      const second = await searchFeedbackRaw(raw.body.id, body, identity);
+      expect(second.statusCode).toBe(200);
+      expect(second.body.success).toBe(true);
+      expect(second.body.alreadySubmitted).toBe(true);
+      expect(second.body.feedbackId).toBe(first.body.feedbackId);
+    }, 90000);
+
+    it("rejects feedback for a search that is not in the self-hosted store", async () => {
+      const failed = await searchFeedbackRaw(
+        "00000000-0000-7000-8000-000000000000",
+        {
+          rating: "bad",
+          missingContent: [{ topic: "Any search results" }],
+        },
+        identity,
+      );
+
+      expect(failed.statusCode).toBe(404);
+      expect(failed.body.success).toBe(false);
+      expect(failed.body.feedbackErrorCode).toBe("SEARCH_NOT_FOUND");
+    }, 30000);
+  },
+);

--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -61,6 +61,92 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
   );
 
   it.concurrent(
+    "hard-enforces the GitHub category and does not expose engine diagnostics",
+    async () => {
+      const res = await search(
+        {
+          query: "firecrawl web scraping sdk",
+          categories: ["github"],
+          limit: 5,
+        },
+        identity,
+      );
+
+      expect(res.web?.length).toBeGreaterThan(0);
+      for (const result of res.web ?? []) {
+        const hostname = new URL(result.url).hostname;
+        expect(
+          hostname === "github.com" ||
+            hostname.endsWith(".github.com") ||
+            hostname.endsWith(".githubusercontent.com"),
+        ).toBe(true);
+        expect((result as any).__search).toBeUndefined();
+      }
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "routes research searches to scholarly domains",
+    async () => {
+      const res = await search(
+        {
+          query: "large language model context compression paper",
+          categories: ["research"],
+          limit: 5,
+        },
+        identity,
+      );
+
+      expect(res.web?.length).toBeGreaterThan(0);
+      for (const result of res.web ?? []) {
+        const hostname = new URL(result.url).hostname;
+        expect(
+          [
+            "arxiv.org",
+            "doi.org",
+            "semanticscholar.org",
+            "openalex.org",
+            "acm.org",
+            "ieee.org",
+            "springer.com",
+            "nature.com",
+          ].some(
+            domain => hostname === domain || hostname.endsWith(`.${domain}`),
+          ),
+        ).toBe(true);
+      }
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "returns PDF-like URLs for the PDF category",
+    async () => {
+      const res = await search(
+        {
+          query: "attention is all you need",
+          categories: ["pdf"],
+          limit: 3,
+        },
+        identity,
+      );
+
+      expect(res.web?.length).toBeGreaterThan(0);
+      for (const result of res.web ?? []) {
+        const parsed = new URL(result.url);
+        expect(
+          parsed.pathname.toLowerCase().endsWith(".pdf") ||
+            (parsed.hostname.endsWith("arxiv.org") &&
+              parsed.pathname.startsWith("/pdf/")) ||
+            parsed.searchParams.get("format")?.toLowerCase() === "pdf",
+        ).toBe(true);
+      }
+    },
+    60000,
+  );
+
+  it.concurrent(
     "rejects includeDomains with excludeDomains",
     async () => {
       const res = await searchWithFailure(

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -237,8 +237,58 @@ const configSchema = z.object({
   PROXY_USERNAME: z.string().optional(),
   PROXY_PASSWORD: z.string().optional(),
 
+  // Camoufox stealth fallback (self-hosted, no paid dependency).
+  // Off by default: the engine is only registered when the fallback is enabled
+  // AND a service URL is set, so an existing deployment is unaffected.
+  CAMOUFOX_FALLBACK_ENABLED: z.stringbool().default(false),
+  CAMOUFOX_SERVICE_URL: z.string().optional(),
+  CAMOUFOX_MAX_CONCURRENCY: z.coerce.number().int().positive().default(2),
+  CAMOUFOX_TIMEOUT_MS: z.coerce.number().int().positive().default(60000),
+  // Comma-separated hosts (matched exactly or as a parent domain). An empty
+  // allowlist means "any host"; the denylist always wins.
+  CAMOUFOX_DOMAIN_ALLOWLIST: delimitedList(",").optional(),
+  CAMOUFOX_DOMAIN_DENYLIST: delimitedList(",").optional(),
+  // "confirmed" restricts the fallback to responses carrying a known challenge
+  // fingerprint; "suspected" also allows bare 403/429 blocks.
+  CAMOUFOX_MIN_CONFIDENCE: z
+    .enum(["confirmed", "suspected"])
+    .default("suspected"),
+
+  // FlareSolverr challenge-solver fallback (self-hosted, no paid dependency).
+  // Off by default, same contract as Camoufox: registered only when enabled AND
+  // a URL is set. Sits *below* Camoufox in quality so it is the last resort --
+  // it is materially slower (measured 27-45s on a solve, and a full
+  // maxTimeout burn when it cannot).
+  FLARESOLVERR_ENABLED: z.stringbool().default(false),
+  FLARESOLVERR_URL: z.string().optional(),
+  FLARESOLVERR_TIMEOUT_MS: z.coerce.number().int().positive().default(120000),
+  FLARESOLVERR_MAX_RESPONSE_BYTES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(8 * 1024 * 1024),
+  // Comma-separated hosts (matched exactly or as a parent domain). An empty
+  // allowlist means "any host"; the denylist always wins.
+  FLARESOLVERR_DOMAIN_ALLOWLIST: delimitedList(",").optional(),
+  FLARESOLVERR_DOMAIN_DENYLIST: delimitedList(",").optional(),
+  FLARESOLVERR_MIN_CONFIDENCE: z
+    .enum(["confirmed", "suspected"])
+    .default("confirmed"),
+
+  // PMC official-source (BioC) adapter
+  PMC_BIOC_ADAPTER_ENABLED: z.stringbool().default(true),
+  PMC_BIOC_TIMEOUT_MS: z.coerce.number().int().positive().default(20000),
+  PMC_BIOC_MAX_RESPONSE_BYTES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(16 * 1024 * 1024),
+
   // External Services
   PLAYWRIGHT_MICROSERVICE_URL: z.string().optional(),
+  // Optional second Playwright service configured with a residential proxy.
+  // It is admitted only after `proxy:auto` observes a retryable block.
+  PLAYWRIGHT_PROXY_MICROSERVICE_URL: z.string().optional(),
   HTML_TO_MARKDOWN_SERVICE_URL: z.string().optional(),
   SMART_SCRAPE_API_URL: z.string().optional(),
 

--- a/apps/api/src/controllers/v2/feedback/record.ts
+++ b/apps/api/src/controllers/v2/feedback/record.ts
@@ -30,6 +30,11 @@ import {
   shouldSkipPersistenceForForcedZdr,
   shouldSkipPersistenceForJobZdr,
 } from "./zdr-persistence";
+import {
+  createSelfHostedSearchFeedbackSubmission,
+  getSelfHostedSearchFeedbackJob,
+  getSelfHostedSearchFeedbackSubmission,
+} from "../../../lib/search-feedback-redis";
 
 const PREVIEW_TEAM_ID = "3adefd26-77ec-5968-8dcf-c94b5630d1de";
 const POSTGRES_UNIQUE_VIOLATION = "23505";
@@ -76,6 +81,118 @@ function zdrFeedbackSuccess(
       dailyRefundCap: dailyCapFor(options),
     },
   };
+}
+
+function selfHostedFeedbackSuccess(
+  feedbackId: string,
+  alreadySubmitted = false,
+): FeedbackRecordResult {
+  return {
+    status: 200,
+    body: {
+      success: true,
+      feedbackId,
+      creditsRefunded: 0,
+      alreadySubmitted: alreadySubmitted || undefined,
+      creditsRefundedToday: 0,
+      dailyRefundCap: 0,
+      warning: alreadySubmitted
+        ? "Feedback was already submitted for this search; no additional submission was recorded."
+        : "Feedback was recorded in this deployment's Redis store. Credit refunds are unavailable when database authentication is disabled.",
+    },
+  };
+}
+
+async function recordSelfHostedSearchFeedback(
+  req: RequestWithAuth<any, any, any>,
+  options: FeedbackRecordOptions,
+  logger: FeedbackLogger,
+): Promise<FeedbackRecordResult> {
+  if (isPreviewTeam(req.auth.team_id)) {
+    return feedbackFailure(
+      403,
+      "PREVIEW_TEAM_NOT_ALLOWED",
+      "Feedback is not available for preview teams.",
+    );
+  }
+
+  if (req.acuc?.flags?.searchFeedbackOptOut === true) {
+    logger.info("Rejected self-hosted feedback: team opted out");
+    return feedbackFailure(
+      403,
+      "TEAM_OPTED_OUT",
+      "Feedback is disabled for this team.",
+    );
+  }
+
+  try {
+    let job = await getSelfHostedSearchFeedbackJob(options.jobId);
+    if (!job) {
+      await new Promise(resolve => setTimeout(resolve, LOOKUP_RACE_RETRY_MS));
+      job = await getSelfHostedSearchFeedbackJob(options.jobId);
+    }
+
+    if (!job || job.teamId !== req.auth.team_id) {
+      return feedbackFailure(
+        404,
+        options.notFoundCode ?? "SEARCH_NOT_FOUND",
+        "search job not found for this team.",
+      );
+    }
+
+    if (job.zeroDataRetention) {
+      logger.info("Skipping self-hosted feedback persistence for ZDR search");
+      return zdrFeedbackSuccess(options);
+    }
+
+    if (options.requireSuccessfulJob && !job.isSuccessful) {
+      return feedbackFailure(
+        409,
+        options.failedJobCode ?? "SEARCH_FAILED",
+        "Cannot submit feedback for a search job that did not succeed.",
+      );
+    }
+
+    const maxAgeSec = options.maxAgeSec ?? config.FEEDBACK_MAX_AGE_SEC;
+    if (Date.now() - job.createdAt > maxAgeSec * 1000) {
+      return feedbackFailure(
+        409,
+        "FEEDBACK_WINDOW_EXPIRED",
+        options.windowExpiredMessage ??
+          `Feedback must be submitted within ${maxAgeSec} seconds of the job.`,
+      );
+    }
+
+    const feedbackId = uuidv7();
+    const created = await createSelfHostedSearchFeedbackSubmission({
+      id: feedbackId,
+      jobId: options.jobId,
+      teamId: req.auth.team_id,
+      createdAt: Date.now(),
+      feedback: options.feedback,
+    });
+
+    if (!created) {
+      const existing = await getSelfHostedSearchFeedbackSubmission(
+        options.jobId,
+      );
+      return selfHostedFeedbackSuccess(existing?.id ?? "", true);
+    }
+
+    logger.info("Self-hosted search feedback recorded", {
+      feedbackId,
+      rating: options.feedback.rating,
+      issueTypes: options.feedback.issues ?? [],
+    });
+    return selfHostedFeedbackSuccess(feedbackId);
+  } catch (error) {
+    logger.error("Failed to record self-hosted search feedback", { error });
+    return feedbackFailure(
+      503,
+      "INTERNAL",
+      "The self-hosted feedback store is unavailable.",
+    );
+  }
 }
 
 function validateAccess(
@@ -250,6 +367,10 @@ export async function recordEndpointFeedback(
   if (shouldSkipPersistenceForForcedZdr(req, options)) {
     logger.info("Skipping feedback persistence for forced ZDR team");
     return zdrFeedbackSuccess(options);
+  }
+
+  if (config.USE_DB_AUTHENTICATION !== true && options.endpoint === "search") {
+    return recordSelfHostedSearchFeedback(req, options, logger);
   }
 
   const accessFailure = validateAccess(req, options, logger);

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -39,6 +39,10 @@ export async function searchController(
   req: RequestWithAuth<{}, SearchResponse, SearchRequest>,
   res: Response<SearchResponse>,
 ) {
+  const callerSpecifiedIgnoreInvalidURLs = Object.prototype.hasOwnProperty.call(
+    req.body,
+    "ignoreInvalidURLs",
+  );
   const middlewareStartTime =
     (req as any).requestTiming?.startTime || new Date().getTime();
   const controllerStartTime = new Date().getTime();
@@ -123,12 +127,17 @@ export async function searchController(
     const billing: BillingMetadata = req.body.__agentInterop
       ? { endpoint: "agent" as const, jobId }
       : { endpoint: "search" as const, jobId };
-
-    logger = logger.child({
-      version: "v2",
-      query: req.body.query,
-      origin: req.body.origin,
-    });
+    const agentLikeRequest =
+      req.body.__agentInterop !== undefined ||
+      /(?:^|[-_])(mcp|agent|codex|hermes|cli)(?:$|[-_])/i.test(
+        req.body.origin ?? "",
+      ) ||
+      ["hermes", "cli", "crewai", "langchain", "llamaindex"].includes(
+        req.body.integration ?? "",
+      );
+    const ignoreInvalidSearchResults = callerSpecifiedIgnoreInvalidURLs
+      ? req.body.ignoreInvalidURLs
+      : agentLikeRequest;
 
     // Inject the team-forced enterprise mode so downstream billing,
     // upstream routing, and ZDR cleanup all see it.
@@ -143,7 +152,12 @@ export async function searchController(
     const isAnon = req.body.enterprise?.includes("anon");
     const isZDROrAnon = isZDR || isAnon;
     zeroDataRetention = isZDROrAnon ?? false;
-    logger = logger.child({ zeroDataRetention });
+    logger = logger.child({
+      version: "v2",
+      origin: req.body.origin,
+      zeroDataRetention,
+      ...(zeroDataRetention ? {} : { query: req.body.query }),
+    });
     applyZdrScope(zeroDataRetention);
 
     // Verify the team has searchZDR enabled before allowing enterprise ZDR/anon
@@ -215,6 +229,7 @@ export async function searchController(
         scrapeOptions: req.body.scrapeOptions,
         highlights: req.body.highlights,
         timeout: req.body.timeout,
+        ignoreInvalidURLs: ignoreInvalidSearchResults,
       },
       {
         teamId: req.auth.team_id,

--- a/apps/api/src/lib/antibot-fallback-metrics.ts
+++ b/apps/api/src/lib/antibot-fallback-metrics.ts
@@ -1,0 +1,37 @@
+import { Counter } from "prom-client";
+
+export const scrapeEngineAttemptCounter = new Counter({
+  name: "firecrawl_scrape_engine_attempts_total",
+  help: "Normal-engine scrape attempts and their outcome",
+  labelNames: ["engine", "outcome"],
+});
+
+export const antibotFailureCounter = new Counter({
+  name: "firecrawl_antibot_failures_total",
+  help: "Responses classified as anti-bot blocks, by confidence and vendor",
+  labelNames: ["confidence", "vendor"],
+});
+
+export const camoufoxFallbackCounter = new Counter({
+  name: "firecrawl_camoufox_fallback_total",
+  help: "Camoufox stealth-fallback attempts by outcome",
+  labelNames: ["outcome"],
+});
+
+export const flaresolverrFallbackCounter = new Counter({
+  name: "firecrawl_flaresolverr_fallback_total",
+  help: "FlareSolverr challenge-solver fallback attempts by outcome",
+  labelNames: ["outcome"],
+});
+
+export const pmcBiocCounter = new Counter({
+  name: "firecrawl_pmc_bioc_total",
+  help: "PMC BioC official-source adapter attempts by outcome",
+  labelNames: ["outcome"],
+});
+
+export const terminalNotFoundCounter = new Counter({
+  name: "firecrawl_scrape_not_found_total",
+  help: "Scrapes that terminated on a 404/410 (not retryable by stealth)",
+  labelNames: ["status"],
+});

--- a/apps/api/src/lib/search-feedback-redis.test.ts
+++ b/apps/api/src/lib/search-feedback-redis.test.ts
@@ -1,0 +1,95 @@
+import { vi } from "vitest";
+import {
+  createSelfHostedSearchFeedbackSubmission,
+  getSelfHostedSearchFeedbackJob,
+  getSelfHostedSearchFeedbackSubmission,
+  saveSelfHostedSearchFeedbackJob,
+} from "./search-feedback-redis";
+import { redisEvictConnection } from "../services/redis";
+
+vi.mock("../services/redis", () => ({
+  redisEvictConnection: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+describe("self-hosted search feedback Redis store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores the minimal search job with an expiry", async () => {
+    vi.mocked(redisEvictConnection.set).mockResolvedValue("OK");
+    const job = {
+      id: "01933161-0000-7000-8000-000000000001",
+      requestId: "01933161-0000-7000-8000-000000000002",
+      teamId: "bypass",
+      creditsCost: 2,
+      createdAt: Date.now(),
+      isSuccessful: true,
+      zeroDataRetention: false,
+    };
+
+    await saveSelfHostedSearchFeedbackJob(job);
+
+    expect(redisEvictConnection.set).toHaveBeenCalledWith(
+      `search-feedback:job:${job.id}`,
+      JSON.stringify(job),
+      "EX",
+      expect.any(Number),
+    );
+  });
+
+  it("creates one idempotent submission and can read it back", async () => {
+    const submission = {
+      id: "01933161-0000-7000-8000-000000000003",
+      jobId: "01933161-0000-7000-8000-000000000001",
+      teamId: "bypass",
+      createdAt: Date.now(),
+      feedback: {
+        rating: "bad",
+        missingContent: [{ topic: "GitHub repositories" }],
+      },
+    };
+    vi.mocked(redisEvictConnection.set).mockResolvedValue("OK");
+    vi.mocked(redisEvictConnection.get).mockImplementation(async key => {
+      if (key === `search-feedback:submission:${submission.jobId}`) {
+        return JSON.stringify(submission);
+      }
+      return null;
+    });
+
+    await expect(
+      createSelfHostedSearchFeedbackSubmission(submission),
+    ).resolves.toBe(true);
+    await expect(
+      getSelfHostedSearchFeedbackSubmission(submission.jobId),
+    ).resolves.toEqual(submission);
+    await expect(
+      getSelfHostedSearchFeedbackJob(submission.jobId),
+    ).resolves.toBeNull();
+
+    expect(redisEvictConnection.set).toHaveBeenCalledWith(
+      `search-feedback:submission:${submission.jobId}`,
+      JSON.stringify(submission),
+      "EX",
+      expect.any(Number),
+      "NX",
+    );
+  });
+
+  it("reports a duplicate when Redis rejects the NX write", async () => {
+    vi.mocked(redisEvictConnection.set).mockResolvedValue(null);
+
+    await expect(
+      createSelfHostedSearchFeedbackSubmission({
+        id: "01933161-0000-7000-8000-000000000003",
+        jobId: "01933161-0000-7000-8000-000000000001",
+        teamId: "bypass",
+        createdAt: Date.now(),
+        feedback: { rating: "bad" },
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/lib/search-feedback-redis.ts
+++ b/apps/api/src/lib/search-feedback-redis.ts
@@ -1,0 +1,73 @@
+import { config } from "../config";
+import { redisEvictConnection } from "../services/redis";
+
+export type SelfHostedSearchFeedbackJob = {
+  id: string;
+  requestId: string;
+  teamId: string;
+  creditsCost: number;
+  createdAt: number;
+  isSuccessful: boolean;
+  zeroDataRetention: boolean;
+};
+
+export type SelfHostedSearchFeedbackSubmission = {
+  id: string;
+  jobId: string;
+  teamId: string;
+  createdAt: number;
+  feedback: unknown;
+};
+
+const jobKey = (jobId: string) => `search-feedback:job:${jobId}`;
+const submissionKey = (jobId: string) => `search-feedback:submission:${jobId}`;
+
+// Keep the job marker briefly after the submission window closes so the API
+// can distinguish an expired search from a search that never existed.
+const jobRetentionSeconds = () =>
+  Math.max(config.SEARCH_FEEDBACK_MAX_AGE_SEC + 60, 300);
+
+// Self-hosted feedback is operational data owned by the deployment. Redis is
+// already required by Firecrawl, so retain submissions there without adding a
+// second database requirement.
+const FEEDBACK_RETENTION_SECONDS = 30 * 24 * 60 * 60;
+
+export async function saveSelfHostedSearchFeedbackJob(
+  job: SelfHostedSearchFeedbackJob,
+): Promise<void> {
+  await redisEvictConnection.set(
+    jobKey(job.id),
+    JSON.stringify(job),
+    "EX",
+    jobRetentionSeconds(),
+  );
+}
+
+export async function getSelfHostedSearchFeedbackJob(
+  jobId: string,
+): Promise<SelfHostedSearchFeedbackJob | null> {
+  const stored = await redisEvictConnection.get(jobKey(jobId));
+  return stored ? (JSON.parse(stored) as SelfHostedSearchFeedbackJob) : null;
+}
+
+export async function createSelfHostedSearchFeedbackSubmission(
+  submission: SelfHostedSearchFeedbackSubmission,
+): Promise<boolean> {
+  const result = await redisEvictConnection.set(
+    submissionKey(submission.jobId),
+    JSON.stringify(submission),
+    "EX",
+    FEEDBACK_RETENTION_SECONDS,
+    "NX",
+  );
+  return result === "OK";
+}
+
+export async function getSelfHostedSearchFeedbackSubmission(
+  jobId: string,
+): Promise<SelfHostedSearchFeedbackSubmission | null> {
+  const stored = await redisEvictConnection.get(submissionKey(jobId));
+  return stored
+    ? (JSON.parse(stored) as SelfHostedSearchFeedbackSubmission)
+    : null;
+}

--- a/apps/api/src/scraper/scrapeURL/engines/camoufox/index.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/camoufox/index.test.ts
@@ -1,0 +1,283 @@
+import { config } from "../../../../config";
+import { createAntibotFallbackState } from "../../lib/antibot";
+import { EngineError } from "../../error";
+import type { Meta } from "../..";
+
+// vi.hoisted so the mock factory below (which is hoisted above the imports)
+// can reach the spy without a temporal-dead-zone error.
+const { robustFetchMock } = vi.hoisted(() => ({ robustFetchMock: vi.fn() }));
+
+vi.mock("../../lib/fetch", () => ({
+  robustFetch: (...args: unknown[]) => robustFetchMock(...args),
+}));
+vi.mock("@mendable/firecrawl-rs", () => ({
+  getInnerJson: async (x: string) => x,
+}));
+
+import {
+  isCamoufoxConfigured,
+  isDomainAllowedForCamoufox,
+  scrapeURLWithCamoufox,
+} from "./index";
+
+type ConfigSnapshot = Pick<
+  typeof config,
+  | "CAMOUFOX_FALLBACK_ENABLED"
+  | "CAMOUFOX_SERVICE_URL"
+  | "CAMOUFOX_MIN_CONFIDENCE"
+  | "CAMOUFOX_DOMAIN_ALLOWLIST"
+  | "CAMOUFOX_DOMAIN_DENYLIST"
+  | "CAMOUFOX_TIMEOUT_MS"
+>;
+
+let snapshot: ConfigSnapshot;
+
+beforeEach(() => {
+  snapshot = {
+    CAMOUFOX_FALLBACK_ENABLED: config.CAMOUFOX_FALLBACK_ENABLED,
+    CAMOUFOX_SERVICE_URL: config.CAMOUFOX_SERVICE_URL,
+    CAMOUFOX_MIN_CONFIDENCE: config.CAMOUFOX_MIN_CONFIDENCE,
+    CAMOUFOX_DOMAIN_ALLOWLIST: config.CAMOUFOX_DOMAIN_ALLOWLIST,
+    CAMOUFOX_DOMAIN_DENYLIST: config.CAMOUFOX_DOMAIN_DENYLIST,
+    CAMOUFOX_TIMEOUT_MS: config.CAMOUFOX_TIMEOUT_MS,
+  };
+  config.CAMOUFOX_FALLBACK_ENABLED = true;
+  config.CAMOUFOX_SERVICE_URL = "http://camoufox-service:3000/scrape";
+  config.CAMOUFOX_MIN_CONFIDENCE = "suspected";
+  config.CAMOUFOX_DOMAIN_ALLOWLIST = undefined;
+  config.CAMOUFOX_DOMAIN_DENYLIST = undefined;
+  config.CAMOUFOX_TIMEOUT_MS = 60000;
+  robustFetchMock.mockReset();
+});
+
+afterEach(() => {
+  Object.assign(config, snapshot);
+});
+
+function makeMeta(url = "https://academic.oup.com/jcr/article/1"): Meta {
+  const logger: any = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => logger,
+  };
+  return {
+    url,
+    logger,
+    options: { waitFor: 0, headers: undefined, skipTlsVerification: false },
+    abort: {
+      scrapeTimeout: () => 150000,
+      asSignal: () => new AbortController().signal,
+    },
+    mock: null,
+    antibot: createAntibotFallbackState(),
+  } as unknown as Meta;
+}
+
+/** The detection a Cloudflare-challenged 403 would have produced. */
+function confirmedBlock() {
+  return {
+    confidence: "confirmed" as const,
+    failureClass: "antibot_challenge:cloudflare",
+    vendor: "cloudflare",
+    statusCode: 403,
+  };
+}
+
+describe("isCamoufoxConfigured", () => {
+  it("is false unless both the flag and the URL are set", () => {
+    config.CAMOUFOX_FALLBACK_ENABLED = false;
+    expect(isCamoufoxConfigured()).toBe(false);
+
+    config.CAMOUFOX_FALLBACK_ENABLED = true;
+    config.CAMOUFOX_SERVICE_URL = "";
+    expect(isCamoufoxConfigured()).toBe(false);
+
+    config.CAMOUFOX_SERVICE_URL = "http://camoufox-service:3000/scrape";
+    expect(isCamoufoxConfigured()).toBe(true);
+  });
+});
+
+describe("isDomainAllowedForCamoufox", () => {
+  it("allows everything when no lists are configured", () => {
+    expect(isDomainAllowedForCamoufox("academic.oup.com")).toBe(true);
+  });
+
+  it("restricts to the allowlist, including subdomains", () => {
+    config.CAMOUFOX_DOMAIN_ALLOWLIST = ["oup.com", "mdpi.com"];
+    expect(isDomainAllowedForCamoufox("academic.oup.com")).toBe(true);
+    expect(isDomainAllowedForCamoufox("oup.com")).toBe(true);
+    expect(isDomainAllowedForCamoufox("www.mdpi.com")).toBe(true);
+    expect(isDomainAllowedForCamoufox("example.com")).toBe(false);
+    // Suffix matching must not match a lookalike registrable domain.
+    expect(isDomainAllowedForCamoufox("notoup.com")).toBe(false);
+  });
+
+  it("lets the denylist win over the allowlist", () => {
+    config.CAMOUFOX_DOMAIN_ALLOWLIST = ["oup.com"];
+    config.CAMOUFOX_DOMAIN_DENYLIST = ["academic.oup.com"];
+    expect(isDomainAllowedForCamoufox("academic.oup.com")).toBe(false);
+    expect(isDomainAllowedForCamoufox("other.oup.com")).toBe(true);
+  });
+});
+
+describe("scrapeURLWithCamoufox gating", () => {
+  it("runs once after a confirmed anti-bot block", async () => {
+    robustFetchMock.mockResolvedValue({
+      content: "<html><body>real article</body></html>",
+      pageStatusCode: 200,
+    });
+
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    const result = await scrapeURLWithCamoufox(meta);
+
+    expect(robustFetchMock).toHaveBeenCalledTimes(1);
+    expect(result.statusCode).toBe(200);
+    expect(result.proxyUsed).toBe("stealth");
+    expect(meta.antibot.camoufoxAttempts).toBe(1);
+    expect(meta.antibot.camoufoxOutcome).toBe("success");
+  });
+
+  it("declines a second time within the same job", async () => {
+    robustFetchMock.mockResolvedValue({
+      content: "<html></html>",
+      pageStatusCode: 200,
+    });
+
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    await scrapeURLWithCamoufox(meta);
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+
+    // The second call must not reach the service.
+    expect(robustFetchMock).toHaveBeenCalledTimes(1);
+    expect(meta.antibot.camoufoxAttempts).toBe(1);
+    expect(meta.antibot.camoufoxOutcome).toBe("skipped_already_attempted");
+  });
+
+  it("declines when nothing recorded an anti-bot block", async () => {
+    const meta = makeMeta();
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+    expect(robustFetchMock).not.toHaveBeenCalled();
+    expect(meta.antibot.camoufoxOutcome).toBe("skipped_not_applicable");
+  });
+
+  it.each([
+    ["404 not found", 404],
+    ["410 gone", 410],
+    ["401 unauthorized", 401],
+    ["500 server error", 500],
+    ["200 ordinary parse failure", 200],
+  ])("declines for %s", async (_label, statusCode) => {
+    const meta = makeMeta();
+    meta.antibot.detection = {
+      confidence: statusCode === 200 ? "none" : "suspected",
+      failureClass: `http_${statusCode}`,
+      statusCode,
+    };
+
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+    expect(robustFetchMock).not.toHaveBeenCalled();
+    expect(meta.antibot.camoufoxAttempts).toBe(0);
+  });
+
+  it("declines a suspected block when the minimum confidence is 'confirmed'", async () => {
+    config.CAMOUFOX_MIN_CONFIDENCE = "confirmed";
+    const meta = makeMeta();
+    meta.antibot.detection = {
+      confidence: "suspected",
+      failureClass: "http_403_blocked",
+      statusCode: 403,
+    };
+
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["cloud metadata", "http://169.254.169.254/latest/meta-data/"],
+    ["RFC1918 host", "http://192.168.0.107:3002/"],
+    ["loopback", "http://127.0.0.1:3002/v2/scrape"],
+    ["IPv6 loopback", "http://[::1]/"],
+  ])(
+    "never retries a literal private address (%s) even if it 403s",
+    async (_label, url) => {
+      // Our own SSRF controls surface a blocked target as HTTP 403, which by
+      // status alone looks exactly like an anti-bot block.
+      const meta = makeMeta(url);
+      meta.antibot.detection = {
+        confidence: "suspected",
+        failureClass: "http_403_blocked",
+        statusCode: 403,
+      };
+
+      await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+      expect(robustFetchMock).not.toHaveBeenCalled();
+      expect(meta.antibot.camoufoxAttempts).toBe(0);
+    },
+  );
+
+  it("declines a denylisted host", async () => {
+    config.CAMOUFOX_DOMAIN_DENYLIST = ["oup.com"];
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+    expect(robustFetchMock).not.toHaveBeenCalled();
+    expect(meta.antibot.camoufoxOutcome).toBe("skipped_domain_filter");
+  });
+
+  it("declines when the fallback is disabled", async () => {
+    config.CAMOUFOX_FALLBACK_ENABLED = false;
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("waterfalls rather than failing the scrape when the service is unreachable", async () => {
+    robustFetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    // EngineError is what makes the loop try the next engine instead of
+    // aborting the job.
+    await expect(scrapeURLWithCamoufox(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.camoufoxOutcome).toBe("service_unavailable");
+    expect(meta.antibot.camoufoxAttempts).toBe(1);
+  });
+
+  it("records a non-2xx stealth result as a failure but still returns it", async () => {
+    robustFetchMock.mockResolvedValue({
+      content: "<html>still blocked</html>",
+      pageStatusCode: 403,
+      pageError: "Forbidden",
+    });
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    const result = await scrapeURLWithCamoufox(meta);
+    expect(result.statusCode).toBe(403);
+    expect(meta.antibot.camoufoxOutcome).toBe("failure");
+  });
+
+  it("caps the service timeout at the remaining scrape budget", async () => {
+    config.CAMOUFOX_TIMEOUT_MS = 60000;
+    robustFetchMock.mockResolvedValue({
+      content: "<html></html>",
+      pageStatusCode: 200,
+    });
+
+    const meta = makeMeta();
+    meta.abort.scrapeTimeout = () => 10000;
+    meta.antibot.detection = confirmedBlock();
+
+    await scrapeURLWithCamoufox(meta);
+    expect(robustFetchMock.mock.calls[0][0].body.timeout).toBe(10000);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/camoufox/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/camoufox/index.ts
@@ -1,0 +1,233 @@
+/**
+ * Camoufox stealth fallback.
+ *
+ * Deliberately narrow: this engine only runs after an ordinary engine came back
+ * with anti-bot evidence, at most once per scrape job. Everything else — 404s,
+ * DNS/TLS failures, malformed URLs, unsupported downloads, ordinary parse
+ * failures — declines immediately with an `EngineError` so the waterfall moves
+ * on without paying for a stealth browser.
+ *
+ * The service speaks the same request/response contract as
+ * `apps/playwright-service-ts`, so the result shape needs no special handling
+ * downstream.
+ */
+
+import { z } from "zod";
+import { config } from "../../../../config";
+import { EngineScrapeResult } from "..";
+import { Meta } from "../..";
+import { robustFetch } from "../../lib/fetch";
+import { getInnerJson } from "@mendable/firecrawl-rs";
+import { EngineError } from "../../error";
+import { meetsConfidenceThreshold } from "../../lib/antibot";
+import { isIPPrivate } from "../utils/safeFetch";
+import { camoufoxFallbackCounter } from "../../../../lib/antibot-fallback-metrics";
+
+/**
+ * Statuses that a stealth browser can plausibly turn around. 401 is excluded on
+ * purpose: it means credentials are required, and no amount of fingerprint
+ * shaping fixes that.
+ */
+const RETRYABLE_BLOCK_STATUSES = [403, 429];
+
+export function isCamoufoxConfigured(): boolean {
+  return (
+    config.CAMOUFOX_FALLBACK_ENABLED === true &&
+    config.CAMOUFOX_SERVICE_URL !== undefined &&
+    config.CAMOUFOX_SERVICE_URL !== ""
+  );
+}
+
+/** Host matches `entry` exactly, or is a subdomain of it. */
+function hostMatches(hostname: string, entry: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  const target = entry.trim().toLowerCase().replace(/^\.+/, "");
+  if (target === "") return false;
+  return host === target || host.endsWith(`.${target}`);
+}
+
+export function isDomainAllowedForCamoufox(hostname: string): boolean {
+  const denylist = config.CAMOUFOX_DOMAIN_DENYLIST ?? [];
+  if (denylist.some(entry => hostMatches(hostname, entry))) return false;
+
+  const allowlist = (config.CAMOUFOX_DOMAIN_ALLOWLIST ?? []).filter(
+    x => x.trim() !== "",
+  );
+  if (allowlist.length === 0) return true;
+  return allowlist.some(entry => hostMatches(hostname, entry));
+}
+
+export async function scrapeURLWithCamoufox(
+  meta: Meta,
+): Promise<EngineScrapeResult> {
+  const state = meta.antibot;
+  const url = meta.rewrittenUrl ?? meta.url;
+
+  const decline = (
+    outcome: NonNullable<typeof state.camoufoxOutcome>,
+    detail: string,
+  ): never => {
+    state.camoufoxOutcome = outcome;
+    state.camoufoxDetail = detail;
+    camoufoxFallbackCounter.inc({ outcome });
+    throw new EngineError(`Camoufox fallback declined: ${detail}`);
+  };
+
+  if (!isCamoufoxConfigured()) {
+    decline("skipped_not_applicable", "camoufox fallback is not configured");
+  }
+
+  // One stealth attempt per scrape job. `meta.antibot` is a shared mutable
+  // holder, so this survives both the per-engine `{...meta}` copies and the
+  // outer feature-toggle retry loop that restarts the waterfall.
+  if (state.camoufoxAttempts >= 1) {
+    decline(
+      "skipped_already_attempted",
+      "camoufox already attempted once for this job",
+    );
+  }
+
+  const detection = state.detection;
+  if (detection === undefined) {
+    decline(
+      "skipped_not_applicable",
+      "no anti-bot evidence recorded for this job",
+    );
+  }
+
+  if (!RETRYABLE_BLOCK_STATUSES.includes(detection!.statusCode)) {
+    decline(
+      "skipped_not_applicable",
+      `initial failure status ${detection!.statusCode} is not stealth-retryable`,
+    );
+  }
+
+  if (!meetsConfidenceThreshold(detection!, config.CAMOUFOX_MIN_CONFIDENCE)) {
+    decline(
+      "skipped_not_applicable",
+      `anti-bot confidence "${detection!.confidence}" below configured minimum "${config.CAMOUFOX_MIN_CONFIDENCE}"`,
+    );
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    decline("skipped_not_applicable", "target URL is not parseable");
+    throw new Error("unreachable");
+  }
+
+  // Defence in depth. The Camoufox service enforces its own SSRF policy, but a
+  // literal private address should never even cost us a request: our own SSRF
+  // controls surface a blocked target as a 403, which is indistinguishable
+  // from an anti-bot 403 by status alone.
+  if (isIPPrivate(hostname.replace(/^\[|\]$/g, ""))) {
+    decline(
+      "skipped_not_applicable",
+      "target is a literal private/internal address",
+    );
+  }
+
+  if (!isDomainAllowedForCamoufox(hostname)) {
+    decline("skipped_domain_filter", "host excluded by allowlist/denylist");
+  }
+
+  state.camoufoxAttempts += 1;
+  camoufoxFallbackCounter.inc({ outcome: "attempt" });
+  const startedAt = Date.now();
+
+  meta.logger.info("Invoking Camoufox stealth fallback", {
+    host: hostname,
+    initialFailureClass: detection!.failureClass,
+    confidence: detection!.confidence,
+  });
+
+  // The scrape-level budget still wins; the Camoufox timeout only caps how long
+  // we are willing to wait on the stealth browser specifically.
+  const scrapeTimeout = meta.abort.scrapeTimeout();
+  const timeout =
+    scrapeTimeout !== undefined
+      ? Math.min(scrapeTimeout, config.CAMOUFOX_TIMEOUT_MS)
+      : config.CAMOUFOX_TIMEOUT_MS;
+
+  let response: {
+    content: string;
+    pageStatusCode: number;
+    pageError?: string;
+    contentType?: string;
+  };
+
+  try {
+    response = await robustFetch({
+      url: config.CAMOUFOX_SERVICE_URL!,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        url,
+        wait_after_load: meta.options.waitFor,
+        timeout,
+        headers: meta.options.headers,
+        skip_tls_verification: meta.options.skipTlsVerification,
+      },
+      method: "POST",
+      logger: meta.logger.child("scrapeURLWithCamoufox/robustFetch"),
+      schema: z.object({
+        content: z.string(),
+        pageStatusCode: z.number(),
+        pageError: z.string().optional(),
+        contentType: z.string().optional(),
+      }),
+      mock: meta.mock,
+      abort: meta.abort.asSignal(),
+    });
+  } catch (error) {
+    state.camoufoxOutcome = "service_unavailable";
+    state.camoufoxDetail =
+      error instanceof Error ? error.message : String(error);
+    state.camoufoxElapsedMs = Date.now() - startedAt;
+    camoufoxFallbackCounter.inc({ outcome: "service_unavailable" });
+    meta.logger.warn("Camoufox fallback service call failed", {
+      host: hostname,
+      elapsedMs: state.camoufoxElapsedMs,
+      error,
+    });
+    // Deliberately an EngineError: a stealth service that is down or slow must
+    // never take the scrape down with it, it just waterfalls to the next engine.
+    throw new EngineError(
+      `Camoufox service call failed: ${state.camoufoxDetail}`,
+    );
+  }
+
+  if (response.contentType?.includes("application/json")) {
+    response.content = await getInnerJson(response.content);
+  }
+
+  state.camoufoxElapsedMs = Date.now() - startedAt;
+  const succeeded =
+    response.pageStatusCode >= 200 && response.pageStatusCode < 300;
+  state.camoufoxOutcome = succeeded ? "success" : "failure";
+  camoufoxFallbackCounter.inc({ outcome: succeeded ? "success" : "failure" });
+
+  meta.logger.info("Camoufox stealth fallback completed", {
+    host: hostname,
+    pageStatusCode: response.pageStatusCode,
+    contentLength: response.content.length,
+    outcome: state.camoufoxOutcome,
+    elapsedMs: state.camoufoxElapsedMs,
+  });
+
+  return {
+    url,
+    html: response.content,
+    statusCode: response.pageStatusCode,
+    error: response.pageError,
+    contentType: response.contentType,
+
+    proxyUsed: "stealth",
+  };
+}
+
+export function camoufoxMaxReasonableTime(meta: Meta): number {
+  return (meta.options.waitFor ?? 0) + config.CAMOUFOX_TIMEOUT_MS;
+}

--- a/apps/api/src/scraper/scrapeURL/engines/flaresolverr/index.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/flaresolverr/index.test.ts
@@ -1,0 +1,334 @@
+import { config } from "../../../../config";
+import { createAntibotFallbackState } from "../../lib/antibot";
+import { EngineError } from "../../error";
+import type { Meta } from "../..";
+
+// vi.hoisted so the mock factory below (which is hoisted above the imports)
+// can reach the spy without a temporal-dead-zone error.
+const { robustFetchMock, axiosGetMock } = vi.hoisted(() => ({
+  robustFetchMock: vi.fn(),
+  axiosGetMock: vi.fn(),
+}));
+
+vi.mock("../../lib/fetch", () => ({
+  robustFetch: (...args: unknown[]) => robustFetchMock(...args),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    get: (...args: unknown[]) => axiosGetMock(...args),
+  },
+}));
+
+import {
+  isDomainAllowedForFlaresolverr,
+  isFlaresolverrConfigured,
+  scrapeURLWithFlaresolverr,
+} from "./index";
+
+// Bodies below are trimmed from responses FlareSolverr actually returned for
+// these hosts, so the "solver lied about success" tests exercise real evidence.
+// FlareSolverr reported `"Challenge not detected!"` with HTTP 200 for both.
+const AWS_WAF_INTERSTITIAL = `<html><head><script src="https://de5282c3ca0c.ca-central-1.token.awswaf.com/de5282c3ca0c/f321f3b23f09/challenge.js"></script></head><body><div id="challenge-container"></div><script>window.awsWafCookieDomainList = []; AwsWafIntegration.saveReferrer();</script></body></html>`;
+
+const JSTOR_ACCESS_CHECK = `<html><head><title>JSTOR: Access Check</title><style>.px-captcha-error-container{position:fixed;height:328px}</style><script src="https://www.gstatic.com/recaptcha/releases/A7KpaEASfhDcK0nXxgQEyyYv/recaptcha__en.js"></script></head><body><h2>Access Check</h2><p>Our systems have detected unusual traffic activity from your network.</p></body></html>`;
+
+const REAL_ARTICLE = `<!DOCTYPE html><html lang="en"><head><title>A beginner's guide to belief revision</title></head><body><article>${"<p>Real article body copy that runs on for a while. </p>".repeat(300)}</article></body></html>`;
+
+type ConfigSnapshot = Pick<
+  typeof config,
+  | "FLARESOLVERR_ENABLED"
+  | "FLARESOLVERR_URL"
+  | "FLARESOLVERR_MIN_CONFIDENCE"
+  | "FLARESOLVERR_DOMAIN_ALLOWLIST"
+  | "FLARESOLVERR_DOMAIN_DENYLIST"
+  | "FLARESOLVERR_TIMEOUT_MS"
+  | "FLARESOLVERR_MAX_RESPONSE_BYTES"
+>;
+
+let snapshot: ConfigSnapshot;
+
+beforeEach(() => {
+  snapshot = {
+    FLARESOLVERR_ENABLED: config.FLARESOLVERR_ENABLED,
+    FLARESOLVERR_URL: config.FLARESOLVERR_URL,
+    FLARESOLVERR_MIN_CONFIDENCE: config.FLARESOLVERR_MIN_CONFIDENCE,
+    FLARESOLVERR_DOMAIN_ALLOWLIST: config.FLARESOLVERR_DOMAIN_ALLOWLIST,
+    FLARESOLVERR_DOMAIN_DENYLIST: config.FLARESOLVERR_DOMAIN_DENYLIST,
+    FLARESOLVERR_TIMEOUT_MS: config.FLARESOLVERR_TIMEOUT_MS,
+    FLARESOLVERR_MAX_RESPONSE_BYTES: config.FLARESOLVERR_MAX_RESPONSE_BYTES,
+  };
+  config.FLARESOLVERR_ENABLED = true;
+  config.FLARESOLVERR_URL = "http://flaresolverr:8191/v1";
+  config.FLARESOLVERR_MIN_CONFIDENCE = "confirmed";
+  config.FLARESOLVERR_DOMAIN_ALLOWLIST = undefined;
+  config.FLARESOLVERR_DOMAIN_DENYLIST = undefined;
+  config.FLARESOLVERR_TIMEOUT_MS = 120000;
+  config.FLARESOLVERR_MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+  robustFetchMock.mockReset();
+  axiosGetMock.mockReset();
+  axiosGetMock.mockResolvedValue({ data: { status: "ok" } });
+});
+
+afterEach(() => {
+  Object.assign(config, snapshot);
+});
+
+function makeMeta(url = "https://www.researchgate.net/publication/24293777"): Meta {
+  const logger: any = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => logger,
+  };
+  return {
+    url,
+    logger,
+    options: { waitFor: 0, headers: undefined, skipTlsVerification: false },
+    abort: {
+      scrapeTimeout: () => 300000,
+      asSignal: () => new AbortController().signal,
+    },
+    mock: null,
+    antibot: createAntibotFallbackState(),
+  } as unknown as Meta;
+}
+
+/** The detection a DataDome-challenged 403 would have produced. */
+function confirmedBlock(statusCode = 403) {
+  return {
+    confidence: "confirmed" as const,
+    failureClass: "antibot_challenge:datadome",
+    vendor: "datadome",
+    statusCode,
+  };
+}
+
+function solved(html: string, status = 200) {
+  return {
+    status: "ok",
+    message: "Challenge solved!",
+    solution: { url: "https://www.researchgate.net/publication/24293777", status, response: html },
+  };
+}
+
+describe("isFlaresolverrConfigured", () => {
+  it("is false unless both the flag and the URL are set", () => {
+    config.FLARESOLVERR_ENABLED = false;
+    expect(isFlaresolverrConfigured()).toBe(false);
+
+    config.FLARESOLVERR_ENABLED = true;
+    config.FLARESOLVERR_URL = "";
+    expect(isFlaresolverrConfigured()).toBe(false);
+
+    config.FLARESOLVERR_URL = "http://flaresolverr:8191/v1";
+    expect(isFlaresolverrConfigured()).toBe(true);
+  });
+});
+
+describe("isDomainAllowedForFlaresolverr", () => {
+  it("allows everything when no lists are configured", () => {
+    expect(isDomainAllowedForFlaresolverr("www.researchgate.net")).toBe(true);
+  });
+
+  it("restricts to the allowlist, including subdomains", () => {
+    config.FLARESOLVERR_DOMAIN_ALLOWLIST = ["researchgate.net", "mdpi.com"];
+    expect(isDomainAllowedForFlaresolverr("www.researchgate.net")).toBe(true);
+    expect(isDomainAllowedForFlaresolverr("researchgate.net")).toBe(true);
+    expect(isDomainAllowedForFlaresolverr("example.com")).toBe(false);
+  });
+
+  it("lets the denylist win over the allowlist", () => {
+    config.FLARESOLVERR_DOMAIN_ALLOWLIST = ["researchgate.net"];
+    config.FLARESOLVERR_DOMAIN_DENYLIST = ["www.researchgate.net"];
+    expect(isDomainAllowedForFlaresolverr("www.researchgate.net")).toBe(false);
+  });
+});
+
+describe("scrapeURLWithFlaresolverr declines", () => {
+  it("when the fallback is not configured", async () => {
+    config.FLARESOLVERR_ENABLED = false;
+    const meta = makeMeta();
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_not_applicable");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("when no anti-bot evidence was recorded", async () => {
+    const meta = makeMeta();
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_not_applicable");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("only once per scrape job", async () => {
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+    meta.antibot.flaresolverrAttempts = 1;
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_already_attempted");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("on a status a solver cannot turn around", async () => {
+    const meta = makeMeta();
+    meta.antibot.detection = { ...confirmedBlock(), statusCode: 404 };
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_not_applicable");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("on a merely suspected block when `confirmed` is required", async () => {
+    const meta = makeMeta();
+    meta.antibot.detection = {
+      confidence: "suspected",
+      failureClass: "http_403_blocked",
+      statusCode: 403,
+    };
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_not_applicable");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("on a literal private address, before spending a request", async () => {
+    const meta = makeMeta("http://127.0.0.1:8080/admin");
+    meta.antibot.detection = confirmedBlock();
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_not_applicable");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("on a denylisted host", async () => {
+    config.FLARESOLVERR_DOMAIN_DENYLIST = ["researchgate.net"];
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("skipped_domain_filter");
+    expect(robustFetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("scrapeURLWithFlaresolverr accepts a real solve", () => {
+  it("returns the solved document", async () => {
+    robustFetchMock.mockResolvedValue(solved(REAL_ARTICLE));
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    const result = await scrapeURLWithFlaresolverr(meta);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.html).toBe(REAL_ARTICLE);
+    expect(result.proxyUsed).toBe("stealth");
+    expect(meta.antibot.flaresolverrOutcome).toBe("success");
+    expect(meta.antibot.flaresolverrAttempts).toBe(1);
+  });
+
+  it("is reachable for an AWS WAF challenge served under HTTP 202", async () => {
+    robustFetchMock.mockResolvedValue(solved(REAL_ARTICLE));
+    const meta = makeMeta("https://ieeexplore.ieee.org/document/9298885");
+    // ieeexplore really does answer 202 for its AWS WAF interstitial. An exact
+    // `=== 200` gate silently skipped it and the waterfall ran out of engines.
+    meta.antibot.detection = confirmedBlock(202);
+
+    const result = await scrapeURLWithFlaresolverr(meta);
+
+    expect(result.html).toBe(REAL_ARTICLE);
+    expect(meta.antibot.flaresolverrOutcome).toBe("success");
+  });
+
+  it("is reachable for an interstitial served under HTTP 200", async () => {
+    robustFetchMock.mockResolvedValue(solved(REAL_ARTICLE));
+    const meta = makeMeta();
+    // The PMC-shaped case: challenge fingerprint, ordinary 200 status. Camoufox
+    // declines this (403/429 only); FlareSolverr must not.
+    meta.antibot.detection = confirmedBlock(200);
+
+    const result = await scrapeURLWithFlaresolverr(meta);
+
+    expect(result.html).toBe(REAL_ARTICLE);
+    expect(meta.antibot.flaresolverrOutcome).toBe("success");
+  });
+});
+
+describe("scrapeURLWithFlaresolverr does not trust the solver's own verdict", () => {
+  // FlareSolverr only fingerprints Cloudflare, so it reports success on other
+  // vendors' interstitials. Passing those through would recreate the exact
+  // "challenge page marked successful" bug this work exists to fix.
+  it("rejects an AWS WAF interstitial reported as solved", async () => {
+    robustFetchMock.mockResolvedValue({
+      status: "ok",
+      message: "Challenge not detected!",
+      solution: { status: 200, response: AWS_WAF_INTERSTITIAL },
+    });
+    const meta = makeMeta("https://ieeexplore.ieee.org/document/9298885");
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("challenge_not_cleared");
+    expect(meta.antibot.flaresolverrDetail).toContain("awswaf");
+  });
+
+  it("rejects a JSTOR access check reported as solved", async () => {
+    robustFetchMock.mockResolvedValue({
+      status: "ok",
+      message: "Challenge not detected!",
+      solution: { status: 200, response: JSTOR_ACCESS_CHECK },
+    });
+    const meta = makeMeta("https://www.jstor.org/stable/2025464");
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("challenge_not_cleared");
+  });
+});
+
+describe("scrapeURLWithFlaresolverr failure handling", () => {
+  it("degrades to an EngineError when the service is unreachable", async () => {
+    robustFetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("service_unavailable");
+  });
+
+  it("degrades when the solver could not clear the challenge", async () => {
+    // FlareSolverr answers HTTP 500 for a solve timeout, which robustFetch
+    // surfaces as a rejection; a non-ok envelope is the other shape.
+    robustFetchMock.mockResolvedValue({
+      status: "error",
+      message: "Error solving the challenge. Timeout after 120.0 seconds.",
+    });
+    const meta = makeMeta("https://academic.oup.com/jcr/article/15/2/139/1841428");
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("failure");
+  });
+
+  it("refuses a response larger than the configured cap", async () => {
+    config.FLARESOLVERR_MAX_RESPONSE_BYTES = 1024;
+    robustFetchMock.mockResolvedValue(solved(REAL_ARTICLE));
+    const meta = makeMeta();
+    meta.antibot.detection = confirmedBlock();
+
+    await expect(scrapeURLWithFlaresolverr(meta)).rejects.toThrow(EngineError);
+    expect(meta.antibot.flaresolverrOutcome).toBe("failure");
+  });
+
+  it("caps maxTimeout at the remaining scrape budget", async () => {
+    robustFetchMock.mockResolvedValue(solved(REAL_ARTICLE));
+    const meta = makeMeta();
+    (meta.abort as any).scrapeTimeout = () => 5000;
+    meta.antibot.detection = confirmedBlock();
+
+    await scrapeURLWithFlaresolverr(meta);
+
+    expect(robustFetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ cmd: "request.get", maxTimeout: 5000 }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/flaresolverr/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/flaresolverr/index.ts
@@ -1,0 +1,326 @@
+/**
+ * FlareSolverr challenge-solver fallback.
+ *
+ * Last resort in the waterfall, and deliberately narrower than Camoufox: it
+ * only runs after an ordinary engine produced a *confirmed* challenge
+ * fingerprint, at most once per scrape job. Everything else declines
+ * immediately with an `EngineError` so the waterfall moves on.
+ *
+ * Why it exists alongside Camoufox: measured on the validation corpus,
+ * FlareSolverr cleared researchgate.net (DataDome, 551 KB of real article
+ * content, 45s) which Camoufox could not. It does NOT clear the interactive
+ * Cloudflare Turnstile on academic.oup.com or sciencedirect.com -- those burn
+ * the full timeout and fail, which is why this engine sits last and is capped.
+ *
+ * The one thing this module must not do is trust FlareSolverr's own verdict.
+ * FlareSolverr only fingerprints Cloudflare, so it reports
+ * `"Challenge not detected!"` with HTTP 200 while handing back an AWS WAF
+ * interstitial (observed: ieeexplore, 2 KB) or a PerimeterX/reCAPTCHA one
+ * (observed: jstor, 7.5 KB). Returning those verbatim would reintroduce exactly
+ * the "challenge page marked successful" bug this engine is meant to help fix,
+ * so every response is re-classified locally before it is accepted.
+ */
+
+import { z } from "zod";
+import { config } from "../../../../config";
+import { EngineScrapeResult } from "..";
+import { Meta } from "../..";
+import { robustFetch } from "../../lib/fetch";
+import { EngineError } from "../../error";
+import {
+  classifyAntibotResponse,
+  meetsConfidenceThreshold,
+} from "../../lib/antibot";
+import { isIPPrivate } from "../utils/safeFetch";
+import { flaresolverrFallbackCounter } from "../../../../lib/antibot-fallback-metrics";
+import axios from "axios";
+
+/**
+ * Statuses worth handing to a challenge solver. Unlike Camoufox (403/429 only)
+ * this admits the whole 2xx range, because the interstitial-under-a-success is
+ * the case it exists for: PMC serves its reCAPTCHA as 200 and ieeexplore serves
+ * its AWS WAF challenge as *202*, so an exact `=== 200` check would miss it.
+ * 401 stays out -- credentials are not a challenge.
+ */
+function isSolverRetryableStatus(statusCode: number): boolean {
+  if (statusCode >= 200 && statusCode < 300) return true;
+  return statusCode === 403 || statusCode === 429;
+}
+
+export function isFlaresolverrConfigured(): boolean {
+  return (
+    config.FLARESOLVERR_ENABLED === true &&
+    config.FLARESOLVERR_URL !== undefined &&
+    config.FLARESOLVERR_URL !== ""
+  );
+}
+
+/** Host matches `entry` exactly, or is a subdomain of it. */
+function hostMatches(hostname: string, entry: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  const target = entry.trim().toLowerCase().replace(/^\.+/, "");
+  if (target === "") return false;
+  return host === target || host.endsWith(`.${target}`);
+}
+
+export function isDomainAllowedForFlaresolverr(hostname: string): boolean {
+  const denylist = config.FLARESOLVERR_DOMAIN_DENYLIST ?? [];
+  if (denylist.some(entry => hostMatches(hostname, entry))) return false;
+
+  const allowlist = (config.FLARESOLVERR_DOMAIN_ALLOWLIST ?? []).filter(
+    x => x.trim() !== "",
+  );
+  if (allowlist.length === 0) return true;
+  return allowlist.some(entry => hostMatches(hostname, entry));
+}
+
+const flaresolverrResponseSchema = z.object({
+  status: z.string(),
+  message: z.string().optional(),
+  solution: z
+    .object({
+      url: z.string().optional(),
+      status: z.number().optional(),
+      response: z.string().optional(),
+      userAgent: z.string().optional(),
+    })
+    .optional(),
+});
+
+let healthCache:
+  | { checkedAt: number; healthy: boolean; detail?: string }
+  | undefined;
+
+async function checkFlaresolverrHealth(): Promise<{
+  healthy: boolean;
+  detail?: string;
+}> {
+  if (healthCache && Date.now() - healthCache.checkedAt < 30_000) {
+    return healthCache;
+  }
+  try {
+    const healthUrl = new URL("/health", config.FLARESOLVERR_URL!).toString();
+    await axios.get(healthUrl, { timeout: 2_000 });
+    healthCache = { checkedAt: Date.now(), healthy: true };
+  } catch (error) {
+    healthCache = {
+      checkedAt: Date.now(),
+      healthy: false,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return healthCache;
+}
+
+export async function scrapeURLWithFlaresolverr(
+  meta: Meta,
+): Promise<EngineScrapeResult> {
+  const state = meta.antibot;
+  const url = meta.rewrittenUrl ?? meta.url;
+
+  const decline = (
+    outcome: NonNullable<typeof state.flaresolverrOutcome>,
+    detail: string,
+  ): never => {
+    state.flaresolverrOutcome = outcome;
+    state.flaresolverrDetail = detail;
+    flaresolverrFallbackCounter.inc({ outcome });
+    throw new EngineError(`FlareSolverr fallback declined: ${detail}`);
+  };
+
+  if (!isFlaresolverrConfigured()) {
+    decline(
+      "skipped_not_applicable",
+      "flaresolverr fallback is not configured",
+    );
+  }
+
+  // One solve attempt per scrape job. `meta.antibot` is a shared mutable holder,
+  // so this survives the per-engine `{...meta}` copies and the outer
+  // feature-toggle retry loop that restarts the waterfall.
+  if (state.flaresolverrAttempts >= 1) {
+    decline(
+      "skipped_already_attempted",
+      "flaresolverr already attempted once for this job",
+    );
+  }
+
+  const detection = state.detection;
+  if (detection === undefined) {
+    decline(
+      "skipped_not_applicable",
+      "no anti-bot evidence recorded for this job",
+    );
+  }
+
+  if (!isSolverRetryableStatus(detection!.statusCode)) {
+    decline(
+      "skipped_not_applicable",
+      `initial failure status ${detection!.statusCode} is not solver-retryable`,
+    );
+  }
+
+  if (
+    !meetsConfidenceThreshold(detection!, config.FLARESOLVERR_MIN_CONFIDENCE)
+  ) {
+    decline(
+      "skipped_not_applicable",
+      `anti-bot confidence "${detection!.confidence}" below configured minimum "${config.FLARESOLVERR_MIN_CONFIDENCE}"`,
+    );
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    decline("skipped_not_applicable", "target URL is not parseable");
+    throw new Error("unreachable");
+  }
+
+  // Defence in depth. FlareSolverr has no SSRF policy of its own -- it will
+  // happily drive its browser at anything -- so a literal private address must
+  // be refused here, before it costs a request.
+  if (isIPPrivate(hostname.replace(/^\[|\]$/g, ""))) {
+    decline(
+      "skipped_not_applicable",
+      "target is a literal private/internal address",
+    );
+  }
+
+  if (!isDomainAllowedForFlaresolverr(hostname)) {
+    decline("skipped_domain_filter", "host excluded by allowlist/denylist");
+  }
+
+  const health = await checkFlaresolverrHealth();
+  if (!health.healthy) {
+    decline(
+      "service_unavailable",
+      `flaresolverr health check failed: ${health.detail ?? "unknown error"}`,
+    );
+  }
+
+  state.flaresolverrAttempts += 1;
+  flaresolverrFallbackCounter.inc({ outcome: "attempt" });
+  const startedAt = Date.now();
+
+  meta.logger.info("Invoking FlareSolverr challenge fallback", {
+    host: hostname,
+    initialFailureClass: detection!.failureClass,
+    confidence: detection!.confidence,
+  });
+
+  // The scrape-level budget still wins; the FlareSolverr timeout only caps how
+  // long we wait on the solver specifically.
+  const scrapeTimeout = meta.abort.scrapeTimeout();
+  const timeout =
+    scrapeTimeout !== undefined
+      ? Math.min(scrapeTimeout, config.FLARESOLVERR_TIMEOUT_MS)
+      : config.FLARESOLVERR_TIMEOUT_MS;
+
+  let response: z.infer<typeof flaresolverrResponseSchema>;
+  try {
+    response = await robustFetch({
+      url: config.FLARESOLVERR_URL!,
+      headers: { "Content-Type": "application/json" },
+      body: {
+        cmd: "request.get",
+        url,
+        maxTimeout: timeout,
+      },
+      method: "POST",
+      logger: meta.logger.child("scrapeURLWithFlaresolverr/robustFetch"),
+      schema: flaresolverrResponseSchema,
+      mock: meta.mock,
+      abort: meta.abort.asSignal(),
+    });
+  } catch (error) {
+    state.flaresolverrOutcome = "service_unavailable";
+    state.flaresolverrDetail =
+      error instanceof Error ? error.message : String(error);
+    state.flaresolverrElapsedMs = Date.now() - startedAt;
+    flaresolverrFallbackCounter.inc({ outcome: "service_unavailable" });
+    meta.logger.warn("FlareSolverr fallback service call failed", {
+      host: hostname,
+      elapsedMs: state.flaresolverrElapsedMs,
+      error,
+    });
+    // Deliberately an EngineError: a solver that is down, slow, or that failed
+    // to clear the challenge (FlareSolverr answers HTTP 500 for that) must never
+    // take the scrape down with it.
+    throw new EngineError(
+      `FlareSolverr service call failed: ${state.flaresolverrDetail}`,
+    );
+  }
+
+  state.flaresolverrElapsedMs = Date.now() - startedAt;
+  const html = response.solution?.response ?? "";
+  const pageStatusCode = response.solution?.status ?? 0;
+
+  if (response.status !== "ok" || html === "") {
+    state.flaresolverrOutcome = "failure";
+    state.flaresolverrDetail = response.message ?? "solver returned no content";
+    flaresolverrFallbackCounter.inc({ outcome: "failure" });
+    throw new EngineError(
+      `FlareSolverr did not return a solution: ${state.flaresolverrDetail}`,
+    );
+  }
+
+  if (html.length > config.FLARESOLVERR_MAX_RESPONSE_BYTES) {
+    state.flaresolverrOutcome = "failure";
+    state.flaresolverrDetail = `response ${html.length} bytes exceeds cap`;
+    flaresolverrFallbackCounter.inc({ outcome: "failure" });
+    throw new EngineError(
+      `FlareSolverr response too large: ${state.flaresolverrDetail}`,
+    );
+  }
+
+  // The load-bearing check. FlareSolverr's own "Challenge not detected!" is only
+  // a Cloudflare verdict, so a cleanly-reported 200 can still be an AWS WAF or
+  // PerimeterX interstitial. Re-classify locally and refuse to pass one on.
+  const postCheck = classifyAntibotResponse({
+    statusCode: pageStatusCode,
+    html,
+  });
+  if (postCheck.confidence === "confirmed") {
+    state.flaresolverrOutcome = "challenge_not_cleared";
+    state.flaresolverrDetail = postCheck.failureClass;
+    flaresolverrFallbackCounter.inc({ outcome: "challenge_not_cleared" });
+    meta.logger.warn(
+      "FlareSolverr reported success but returned a challenge page",
+      {
+        host: hostname,
+        solverMessage: response.message,
+        failureClass: postCheck.failureClass,
+        vendor: postCheck.vendor,
+        contentLength: html.length,
+        elapsedMs: state.flaresolverrElapsedMs,
+      },
+    );
+    throw new EngineError(
+      `FlareSolverr returned an unsolved challenge: ${postCheck.failureClass}`,
+    );
+  }
+
+  state.flaresolverrOutcome = "success";
+  flaresolverrFallbackCounter.inc({ outcome: "success" });
+  meta.logger.info("FlareSolverr challenge fallback completed", {
+    host: hostname,
+    pageStatusCode,
+    contentLength: html.length,
+    solverMessage: response.message,
+    elapsedMs: state.flaresolverrElapsedMs,
+  });
+
+  return {
+    url: response.solution?.url ?? url,
+    html,
+    statusCode: pageStatusCode,
+    contentType: "text/html",
+
+    proxyUsed: "stealth",
+  };
+}
+
+export function flaresolverrMaxReasonableTime(meta: Meta): number {
+  return (meta.options.waitFor ?? 0) + config.FLARESOLVERR_TIMEOUT_MS;
+}

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -14,6 +14,26 @@ import {
   playwrightMaxReasonableTime,
   scrapeURLWithPlaywright,
 } from "./playwright";
+import {
+  isPlaywrightProxyConfigured,
+  playwrightProxyMaxReasonableTime,
+  scrapeURLWithPlaywrightProxy,
+} from "./playwright-proxy";
+import {
+  camoufoxMaxReasonableTime,
+  isCamoufoxConfigured,
+  scrapeURLWithCamoufox,
+} from "./camoufox";
+import {
+  flaresolverrMaxReasonableTime,
+  isFlaresolverrConfigured,
+  scrapeURLWithFlaresolverr,
+} from "./flaresolverr";
+import {
+  isPmcArticleUrl,
+  pmcBiocMaxReasonableTime,
+  scrapeURLWithPmcBioc,
+} from "./pmc";
 import { indexMaxReasonableTime, scrapeURLWithIndex } from "./index/index";
 import {
   scrapeURLWithWikipedia,
@@ -46,13 +66,17 @@ export type Engine =
   | "fire-engine;tlsclient"
   | "fire-engine;tlsclient;stealth"
   | "playwright"
+  | "playwright-proxy"
+  | "camoufox"
+  | "flaresolverr"
   | "fetch"
   | "pdf"
   | "document"
   | "index"
   | "index;documents"
   | "wikipedia"
-  | "x-twitter";
+  | "x-twitter"
+  | "pmc-bioc";
 
 const useFireEngine =
   config.FIRE_ENGINE_BETA_URL !== "" &&
@@ -60,6 +84,7 @@ const useFireEngine =
 const usePlaywright =
   config.PLAYWRIGHT_MICROSERVICE_URL !== "" &&
   config.PLAYWRIGHT_MICROSERVICE_URL !== undefined;
+const usePlaywrightProxy = isPlaywrightProxyConfigured();
 const useWikipedia =
   config.WIKIPEDIA_ENTERPRISE_USERNAME !== undefined &&
   config.WIKIPEDIA_ENTERPRISE_USERNAME !== "" &&
@@ -69,9 +94,14 @@ const useXTwitter =
   (config.XAI_API_KEY !== undefined && config.XAI_API_KEY !== "") ||
   config.USE_DB_AUTHENTICATION === true;
 
+const useCamoufox = isCamoufoxConfigured();
+const useFlaresolverr = isFlaresolverrConfigured();
+const usePmcBioc = config.PMC_BIOC_ADAPTER_ENABLED === true;
+
 const engines: Engine[] = [
   ...(useXTwitter ? ["x-twitter" as const] : []),
   ...(useWikipedia ? ["wikipedia" as const] : []),
+  ...(usePmcBioc ? ["pmc-bioc" as const] : []),
   ...(useIndex ? ["index" as const, "index;documents" as const] : []),
   ...(useFireEngine
     ? [
@@ -84,6 +114,14 @@ const engines: Engine[] = [
       ]
     : []),
   ...(usePlaywright ? ["playwright" as const] : []),
+  ...(usePlaywrightProxy ? ["playwright-proxy" as const] : []),
+  // Negative quality keeps Camoufox out of the ordinary list entirely; it can
+  // only be selected once the stealthProxy flag is set, which happens after a
+  // blocking status.
+  ...(useCamoufox ? ["camoufox" as const] : []),
+  // Same negative-quality trick as Camoufox, one notch lower: FlareSolverr is
+  // the last resort, tried only if Camoufox is absent or also failed.
+  ...(useFlaresolverr ? ["flaresolverr" as const] : []),
   "fetch",
   "pdf",
   "document",
@@ -185,11 +223,15 @@ const engineHandlers: {
   "fire-engine;tlsclient": scrapeURLWithFireEngineTLSClient,
   "fire-engine;tlsclient;stealth": scrapeURLWithFireEngineTLSClient,
   playwright: scrapeURLWithPlaywright,
+  "playwright-proxy": scrapeURLWithPlaywrightProxy,
+  camoufox: scrapeURLWithCamoufox,
+  flaresolverr: scrapeURLWithFlaresolverr,
   fetch: scrapeURLWithFetch,
   pdf: scrapePDF,
   document: scrapeDocument,
   wikipedia: scrapeURLWithWikipedia,
   "x-twitter": scrapeURLWithXTwitter,
+  "pmc-bioc": scrapeURLWithPmcBioc,
 };
 
 const engineMRTs: {
@@ -211,11 +253,15 @@ const engineMRTs: {
   "fire-engine;tlsclient;stealth": meta =>
     fireEngineMaxReasonableTime(meta, "tlsclient"),
   playwright: playwrightMaxReasonableTime,
+  "playwright-proxy": playwrightProxyMaxReasonableTime,
+  camoufox: camoufoxMaxReasonableTime,
+  flaresolverr: flaresolverrMaxReasonableTime,
   fetch: fetchMaxReasonableTime,
   pdf: pdfMaxReasonableTime,
   document: documentMaxReasonableTime,
   wikipedia: wikipediaMaxReasonableTime,
   "x-twitter": xTwitterMaxReasonableTime,
+  "pmc-bioc": pmcBiocMaxReasonableTime,
 };
 
 const engineOptions: {
@@ -396,6 +442,87 @@ const engineOptions: {
     },
     quality: 20,
   },
+  "playwright-proxy": {
+    features: {
+      actions: false,
+      waitFor: true,
+      screenshot: false,
+      "screenshot@fullScreen": false,
+      pdf: false,
+      document: false,
+      audio: false,
+      video: false,
+      atsv: false,
+      location: false,
+      mobile: false,
+      skipTlsVerification: true,
+      useFastMode: false,
+      stealthProxy: true,
+      branding: false,
+      disableAdblock: false,
+    },
+    // First self-hosted anti-bot fallback: same browser behavior as the direct
+    // service, but with a residential exit. Camoufox and FlareSolverr follow.
+    quality: -2,
+  },
+  camoufox: {
+    features: {
+      actions: false,
+      waitFor: true,
+      screenshot: false,
+      "screenshot@fullScreen": false,
+      pdf: false,
+      document: false,
+      audio: false,
+      video: false,
+      atsv: false,
+      location: false,
+      mobile: false,
+      skipTlsVerification: true,
+      useFastMode: false,
+      // The whole point of the engine: it is the stealth-capable option in a
+      // self-hosted deployment that has no fire-engine.
+      stealthProxy: true,
+      branding: false,
+      disableAdblock: false,
+    },
+    // Negative, so the quality filter drops it from ordinary scrapes; above
+    // pdf/document (-20) so a confirmed anti-bot block tries stealth before
+    // falling into the document-prefetch path that produced the observed
+    // SCRAPE_RETRY_LIMIT(document_antibot) failures. Below fire-engine stealth
+    // (-2) so a cloud deployment still prefers fire-engine.
+    quality: -3,
+  },
+  flaresolverr: {
+    features: {
+      actions: false,
+      // FlareSolverr's request.get takes no post-load wait parameter, so a
+      // caller asking for one would silently not get it.
+      waitFor: false,
+      screenshot: false,
+      "screenshot@fullScreen": false,
+      pdf: false,
+      document: false,
+      audio: false,
+      video: false,
+      atsv: false,
+      location: false,
+      mobile: false,
+      // request.get exposes no TLS-verification switch.
+      skipTlsVerification: false,
+      useFastMode: false,
+      // The reason it is in the waterfall at all.
+      stealthProxy: true,
+      branding: false,
+      disableAdblock: false,
+    },
+    // One notch below Camoufox (-3): both are stealth-capable, but FlareSolverr
+    // is markedly slower (measured 27-45s on a solve, and a full timeout burn
+    // when it cannot clear the challenge), so it should only be reached when
+    // Camoufox is unavailable or has already failed. Still above pdf/document
+    // (-20) so it is preferred over the document-prefetch dead end.
+    quality: -4,
+  },
   "fire-engine;tlsclient": {
     features: {
       actions: false,
@@ -543,6 +670,30 @@ const engineOptions: {
     },
     quality: 1500,
   },
+  "pmc-bioc": {
+    features: {
+      actions: false,
+      waitFor: false,
+      screenshot: false,
+      "screenshot@fullScreen": false,
+      pdf: false,
+      document: false,
+      audio: false,
+      video: false,
+      atsv: false,
+      location: false,
+      mobile: false,
+      skipTlsVerification: true,
+      useFastMode: true,
+      stealthProxy: false,
+      branding: false,
+      disableAdblock: true,
+    },
+    // Below index (1000) so the cache is still consulted first, above every
+    // browser engine: for a PMC article the official machine-readable source
+    // beats automating the reCAPTCHA-gated HTML page.
+    quality: 900,
+  },
 };
 
 export function shouldUseIndex(meta: Meta) {
@@ -685,6 +836,15 @@ export async function buildFallbackList(meta: Meta): Promise<
     const indexDocumentsIndex = _engines.indexOf("index;documents");
     if (indexDocumentsIndex !== -1) {
       _engines.splice(indexDocumentsIndex, 1);
+    }
+  }
+
+  // The PMC adapter only understands PMC article URLs; drop it for anything
+  // else so it never occupies a slot in the waterfall.
+  if (!isPmcArticleUrl(meta.rewrittenUrl ?? meta.url)) {
+    const pmcIndex = _engines.indexOf("pmc-bioc");
+    if (pmcIndex !== -1) {
+      _engines.splice(pmcIndex, 1);
     }
   }
 

--- a/apps/api/src/scraper/scrapeURL/engines/playwright-proxy/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright-proxy/index.ts
@@ -1,0 +1,23 @@
+import { config } from "../../../../config";
+import type { EngineScrapeResult } from "..";
+import type { Meta } from "../..";
+import {
+  playwrightMaxReasonableTime,
+  scrapeURLWithPlaywrightEndpoint,
+} from "../playwright";
+
+export function isPlaywrightProxyConfigured(): boolean {
+  return Boolean(config.PLAYWRIGHT_PROXY_MICROSERVICE_URL);
+}
+
+export async function scrapeURLWithPlaywrightProxy(
+  meta: Meta,
+): Promise<EngineScrapeResult> {
+  return scrapeURLWithPlaywrightEndpoint(
+    meta,
+    config.PLAYWRIGHT_PROXY_MICROSERVICE_URL!,
+    "stealth",
+  );
+}
+
+export const playwrightProxyMaxReasonableTime = playwrightMaxReasonableTime;

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -8,8 +8,20 @@ import { getInnerJson } from "@mendable/firecrawl-rs";
 export async function scrapeURLWithPlaywright(
   meta: Meta,
 ): Promise<EngineScrapeResult> {
+  return scrapeURLWithPlaywrightEndpoint(
+    meta,
+    config.PLAYWRIGHT_MICROSERVICE_URL!,
+    "basic",
+  );
+}
+
+export async function scrapeURLWithPlaywrightEndpoint(
+  meta: Meta,
+  endpoint: string,
+  proxyUsed: "basic" | "stealth",
+): Promise<EngineScrapeResult> {
   const response = await robustFetch({
-    url: config.PLAYWRIGHT_MICROSERVICE_URL!,
+    url: endpoint,
     headers: {
       "Content-Type": "application/json",
     },
@@ -43,7 +55,7 @@ export async function scrapeURLWithPlaywright(
     error: response.pageError,
     contentType: response.contentType,
 
-    proxyUsed: "basic",
+    proxyUsed,
   };
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pmc/index.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pmc/index.test.ts
@@ -1,0 +1,249 @@
+import { convertBiocToHtml, extractPmcId, isPmcArticleUrl } from "./index";
+import { EngineError } from "../../error";
+
+const SOURCE_URL = "https://pmc.ncbi.nlm.nih.gov/articles/PMC5968224/";
+
+/** Shaped like a real BioC response, trimmed to the passages that matter. */
+function biocFixture(overrides: { passages?: unknown[] } = {}) {
+  return [
+    {
+      source: "PMC",
+      documents: [
+        {
+          id: "PMC5968224",
+          infons: { license: "CC BY" },
+          passages: overrides.passages ?? [
+            {
+              infons: {
+                "article-id_doi": "10.3352/jeehp.2018.15.7",
+                "article-id_pmc": "PMC5968224",
+                "article-id_pmid": "29575849",
+                kwd: "Algorithms Computers Computerized adaptive testing",
+                name_0: "surname:Han;given-names:Kyung (Chris) Tyek",
+                name_1: "surname:Huh;given-names:Sun",
+                section_type: "TITLE",
+                type: "front",
+                volume: "15",
+                year: "2018",
+              },
+              offset: 0,
+              text: "Components of the item selection algorithm in computerized adaptive testing",
+            },
+            {
+              infons: { section_type: "ABSTRACT", type: "abstract" },
+              offset: 76,
+              text: "Computerized adaptive testing greatly improves measurement efficiency in high-stakes testing operations through the selection and administration of test items with the difficulty matched to each examinee.",
+            },
+            {
+              infons: { section_type: "INTRO", type: "title_1" },
+              offset: 1891,
+              text: "Introduction",
+            },
+            {
+              infons: { section_type: "INTRO", type: "paragraph" },
+              offset: 1904,
+              text: "The emergence and advancement of modern test theory and the rapid deployment of new computing technologies have completely changed how educational measurement is carried out in practice today.",
+            },
+            {
+              infons: { section_type: "INTRO", type: "title_2" },
+              offset: 2600,
+              text: "Item selection",
+            },
+            {
+              infons: { section_type: "REF", type: "ref" },
+              offset: 9000,
+              text: "Han KT. Components of the item selection algorithm. J Educ Eval Health Prof. 2018.",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+describe("extractPmcId", () => {
+  it("extracts the id from a canonical PMC article URL", () => {
+    expect(extractPmcId(SOURCE_URL)).toBe("PMC5968224");
+    expect(
+      extractPmcId("https://pmc.ncbi.nlm.nih.gov/articles/PMC5968224"),
+    ).toBe("PMC5968224");
+  });
+
+  it("extracts the id from the legacy www.ncbi.nlm.nih.gov/pmc path", () => {
+    expect(
+      extractPmcId("https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234567/"),
+    ).toBe("PMC1234567");
+  });
+
+  it("normalises a lowercase id", () => {
+    expect(
+      extractPmcId("https://pmc.ncbi.nlm.nih.gov/articles/pmc5968224/"),
+    ).toBe("PMC5968224");
+  });
+
+  it("ignores query strings and fragments", () => {
+    expect(extractPmcId(`${SOURCE_URL}?report=classic#abstract`)).toBe(
+      "PMC5968224",
+    );
+  });
+
+  it("returns null for malformed or unsupported ids", () => {
+    for (const url of [
+      "https://pmc.ncbi.nlm.nih.gov/articles/PMCABCDEF/",
+      "https://pmc.ncbi.nlm.nih.gov/articles/12345/",
+      "https://pmc.ncbi.nlm.nih.gov/articles/",
+      "https://pmc.ncbi.nlm.nih.gov/",
+    ]) {
+      expect(extractPmcId(url)).toBeNull();
+    }
+  });
+
+  it("returns null for other hosts and non-article paths", () => {
+    for (const url of [
+      "https://example.com/articles/PMC5968224/",
+      "https://pmc.ncbi.nlm.nih.gov.evil.com/articles/PMC5968224/",
+      "https://www.mdpi.com/2308-3417/10/5/119",
+    ]) {
+      expect(extractPmcId(url)).toBeNull();
+    }
+  });
+
+  it("returns null for non-http(s) and unparseable URLs", () => {
+    for (const url of ["file:///articles/PMC1/", "not a url", ""]) {
+      expect(extractPmcId(url)).toBeNull();
+    }
+  });
+
+  it("isPmcArticleUrl mirrors extractPmcId", () => {
+    expect(isPmcArticleUrl(SOURCE_URL)).toBe(true);
+    expect(isPmcArticleUrl("https://www.mdpi.com/2308-3417/10/5/119")).toBe(
+      false,
+    );
+  });
+});
+
+describe("convertBiocToHtml", () => {
+  it("converts a full-text article, preserving title, headings and metadata", () => {
+    const { html, title } = convertBiocToHtml(
+      biocFixture(),
+      SOURCE_URL,
+      "PMC5968224",
+    );
+
+    expect(title).toBe(
+      "Components of the item selection algorithm in computerized adaptive testing",
+    );
+    expect(html).toContain(`<title>${title}</title>`);
+    expect(html).toContain(`<h1>${title}</h1>`);
+
+    // Section structure survives the conversion.
+    expect(html).toContain("<h2>Abstract</h2>");
+    expect(html).toContain("<h2>Introduction</h2>");
+    expect(html).toContain("<h3>Item selection</h3>");
+    expect(html).toContain("<h2>References</h2>");
+    expect(html).toContain("Computerized adaptive testing greatly improves");
+
+    // Useful bibliographic metadata is emitted where extractMetadata reads it.
+    expect(html).toContain(
+      'name="citation_doi" content="10.3352/jeehp.2018.15.7"',
+    );
+    expect(html).toContain('name="citation_pmid" content="29575849"');
+    expect(html).toContain('name="citation_pmcid" content="PMC5968224"');
+    expect(html).toContain('content="Kyung (Chris) Tyek Han"');
+    expect(html).toContain('content="Sun Huh"');
+    expect(html).toContain(`<link rel="canonical" href="${SOURCE_URL}">`);
+
+    // And it must be the article, not a challenge page.
+    expect(html.toLowerCase()).not.toContain("recaptcha");
+  });
+
+  it("escapes HTML in passage text", () => {
+    const fixture = biocFixture({
+      passages: [
+        {
+          infons: { type: "front", section_type: "TITLE" },
+          text: "Tags <script>alert(1)</script> & entities",
+        },
+        {
+          infons: { type: "paragraph", section_type: "INTRO" },
+          text: `${'Body copy with <b>markup</b> and "quotes". '.repeat(10)}`,
+        },
+      ],
+    });
+    const { html } = convertBiocToHtml(fixture, SOURCE_URL, "PMC5968224");
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&amp;");
+  });
+
+  describe("rejects payloads that are not usable full text", () => {
+    it("throws when the payload is not a collection array", () => {
+      for (const payload of [null, undefined, {}, [], "text", 42]) {
+        expect(() =>
+          convertBiocToHtml(payload, SOURCE_URL, "PMC5968224"),
+        ).toThrow(EngineError);
+      }
+    });
+
+    it("throws when there are no documents or passages", () => {
+      expect(() =>
+        convertBiocToHtml([{ documents: [] }], SOURCE_URL, "PMC5968224"),
+      ).toThrow(EngineError);
+      expect(() =>
+        convertBiocToHtml(
+          [{ documents: [{ id: "PMC1", passages: [] }] }],
+          SOURCE_URL,
+          "PMC5968224",
+        ),
+      ).toThrow(EngineError);
+    });
+
+    it("throws on a metadata-only record with no body text", () => {
+      // Non-open-access records come back as a title and nothing else. That is
+      // an unavailable article, not a successful scrape.
+      const fixture = biocFixture({
+        passages: [
+          {
+            infons: { type: "front", section_type: "TITLE" },
+            text: "A title but no licensed full text",
+          },
+        ],
+      });
+      expect(() =>
+        convertBiocToHtml(fixture, SOURCE_URL, "PMC5968224"),
+      ).toThrow(/no usable full text/);
+    });
+
+    it("throws when only references are present", () => {
+      const fixture = biocFixture({
+        passages: [
+          {
+            infons: { type: "front", section_type: "TITLE" },
+            text: "Title only",
+          },
+          {
+            infons: { type: "ref", section_type: "REF" },
+            text: "Some citation",
+          },
+        ],
+      });
+      expect(() =>
+        convertBiocToHtml(fixture, SOURCE_URL, "PMC5968224"),
+      ).toThrow(/no usable full text/);
+    });
+
+    it("throws when the title is missing", () => {
+      const fixture = biocFixture({
+        passages: [
+          {
+            infons: { type: "paragraph", section_type: "INTRO" },
+            text: "Body text without any title passage. ".repeat(20),
+          },
+        ],
+      });
+      expect(() =>
+        convertBiocToHtml(fixture, SOURCE_URL, "PMC5968224"),
+      ).toThrow(/no usable full text/);
+    });
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pmc/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pmc/index.ts
@@ -1,0 +1,397 @@
+/**
+ * PMC official-source adapter.
+ *
+ * pmc.ncbi.nlm.nih.gov fronts its rendered HTML with a reCAPTCHA interstitial
+ * that browser engines happily return as a 200, so scrapes "succeed" with
+ * "Checking your browser - reCAPTCHA" as the document. NCBI publishes the same
+ * articles as machine-readable BioC JSON, which needs no browser at all, so we
+ * take that route first and only fall through to the normal waterfall when the
+ * official source can't serve the article.
+ */
+
+import * as undici from "undici";
+import { EngineScrapeResult } from "..";
+import { Meta } from "../..";
+import { config } from "../../../../config";
+import { EngineError } from "../../error";
+import { getSecureDispatcher } from "../utils/safeFetch";
+import { pmcBiocCounter } from "../../../../lib/antibot-fallback-metrics";
+
+const BIOC_ENDPOINT =
+  "https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful/pmcoa.cgi/BioC_json";
+
+/** Hosts whose /articles/PMC…/ paths this adapter understands. */
+const PMC_HOSTS = new Set([
+  "pmc.ncbi.nlm.nih.gov",
+  "www.ncbi.nlm.nih.gov",
+  "ncbi.nlm.nih.gov",
+]);
+
+const PMCID_PATTERN = /^PMC\d{1,9}$/;
+
+/**
+ * Extracts the PMC identifier from a supported article URL, or null when the
+ * URL isn't a PMC article we can serve from the official API.
+ */
+export function extractPmcId(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+  if (!PMC_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+
+  // pmc.ncbi.nlm.nih.gov/articles/PMC5968224/
+  // www.ncbi.nlm.nih.gov/pmc/articles/PMC5968224/
+  const match = parsed.pathname.match(
+    /(?:^|\/)(?:pmc\/)?articles\/(PMC\d+)(?:\/|$)/i,
+  );
+  if (!match) return null;
+
+  const pmcId = match[1].toUpperCase();
+  if (!PMCID_PATTERN.test(pmcId)) return null;
+  return pmcId;
+}
+
+export function isPmcArticleUrl(url: string): boolean {
+  return extractPmcId(url) !== null;
+}
+
+type BiocPassage = {
+  infons?: Record<string, string>;
+  text?: string;
+};
+
+type BiocDocument = {
+  id?: string;
+  infons?: Record<string, string>;
+  passages?: BiocPassage[];
+};
+
+type BiocCollection = {
+  documents?: BiocDocument[];
+};
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Reads at most `maxBytes` from the response body. Anything larger is a
+ * malformed/hostile response as far as we're concerned — BioC articles are
+ * a few hundred KB.
+ */
+async function readBounded(
+  response: undici.Response,
+  maxBytes: number,
+): Promise<string> {
+  const body = response.body;
+  if (!body) return "";
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of body) {
+    const buf = Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      throw new EngineError(
+        `PMC BioC response exceeded ${maxBytes} bytes; refusing to buffer`,
+      );
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/** `surname:Han;given-names:Kyung (Chris) Tyek` -> `Kyung (Chris) Tyek Han` */
+function formatAuthor(raw: string): string | null {
+  const parts = Object.fromEntries(
+    raw
+      .split(";")
+      .map(pair => {
+        const idx = pair.indexOf(":");
+        return idx === -1
+          ? null
+          : ([pair.slice(0, idx).trim(), pair.slice(idx + 1).trim()] as const);
+      })
+      .filter((x): x is readonly [string, string] => x !== null),
+  );
+  const given = parts["given-names"] ?? "";
+  const surname = parts["surname"] ?? "";
+  const name = `${given} ${surname}`.trim();
+  return name.length > 0 ? name : null;
+}
+
+/**
+ * Heading level for a BioC passage type. `title_1` is a top-level section
+ * heading, `title_2` a subsection, and so on; they render below the `<h1>`
+ * article title.
+ */
+function headingLevelFor(passageType: string): number | null {
+  const match = passageType.match(/^title(?:_(\d+))?$/);
+  if (!match) return null;
+  const depth = match[1] ? Number.parseInt(match[1], 10) : 1;
+  return Math.min(1 + Math.max(depth, 1), 6);
+}
+
+type PmcConversion = {
+  html: string;
+  title: string;
+};
+
+/**
+ * Converts a BioC collection into an HTML document the normal transformer
+ * pipeline can turn into Markdown. Throws `EngineError` when the payload does
+ * not actually carry usable full text, so the caller falls back to the
+ * ordinary engines rather than reporting an empty success.
+ */
+export function convertBiocToHtml(
+  collections: unknown,
+  sourceUrl: string,
+  pmcId: string,
+): PmcConversion {
+  if (!Array.isArray(collections) || collections.length === 0) {
+    throw new EngineError("PMC BioC payload was not a collection array");
+  }
+
+  const document = (collections as BiocCollection[])
+    .flatMap(c => c?.documents ?? [])
+    .find(d => Array.isArray(d?.passages) && d.passages.length > 0);
+
+  if (!document) {
+    throw new EngineError("PMC BioC payload contained no document passages");
+  }
+
+  const passages = document.passages ?? [];
+  const frontInfons =
+    passages.find(p => (p.infons?.type ?? "") === "front")?.infons ?? {};
+
+  const title =
+    passages.find(p => (p.infons?.type ?? "") === "front")?.text?.trim() ||
+    passages
+      .find(p => (p.infons?.section_type ?? "") === "TITLE")
+      ?.text?.trim() ||
+    "";
+
+  const authors = Object.entries(frontInfons)
+    .filter(([key]) => /^name_\d+$/.test(key))
+    .sort(
+      ([a], [b]) =>
+        Number.parseInt(a.slice(5), 10) - Number.parseInt(b.slice(5), 10),
+    )
+    .map(([, value]) => formatAuthor(value))
+    .filter((x): x is string => x !== null);
+
+  const body: string[] = [];
+  const references: string[] = [];
+  let abstractHeadingEmitted = false;
+  let bodyTextLength = 0;
+
+  for (const passage of passages) {
+    const type = (passage.infons?.type ?? "").toLowerCase();
+    const text = (passage.text ?? "").trim();
+    if (text.length === 0) continue;
+
+    if (type === "front") continue; // rendered as <h1> below
+
+    if (type === "ref") {
+      references.push(`<li>${escapeHtml(text)}</li>`);
+      continue;
+    }
+
+    if (type === "abstract" || type.startsWith("abstract_")) {
+      if (!abstractHeadingEmitted) {
+        body.push("<h2>Abstract</h2>");
+        abstractHeadingEmitted = true;
+      }
+      body.push(`<p>${escapeHtml(text)}</p>`);
+      bodyTextLength += text.length;
+      continue;
+    }
+
+    const headingLevel = headingLevelFor(type);
+    if (headingLevel !== null) {
+      body.push(`<h${headingLevel}>${escapeHtml(text)}</h${headingLevel}>`);
+      continue;
+    }
+
+    if (type === "table") {
+      body.push(`<pre>${escapeHtml(text)}</pre>`);
+      bodyTextLength += text.length;
+      continue;
+    }
+
+    if (type.endsWith("caption") || type.endsWith("footnote")) {
+      body.push(`<p><em>${escapeHtml(text)}</em></p>`);
+      bodyTextLength += text.length;
+      continue;
+    }
+
+    body.push(`<p>${escapeHtml(text)}</p>`);
+    bodyTextLength += text.length;
+  }
+
+  // A payload with only a title (or only reference stubs) is not full text —
+  // treat it as unavailable so the waterfall gets a chance.
+  if (title.length === 0 || bodyTextLength < 200) {
+    throw new EngineError(
+      "PMC BioC payload carried no usable full text (non-open-access or metadata-only record)",
+    );
+  }
+
+  if (references.length > 0) {
+    body.push(`<h2>References</h2><ol>${references.join("")}</ol>`);
+  }
+
+  const metaTags: string[] = [
+    `<meta name="citation_pmcid" content="${escapeHtml(pmcId)}">`,
+    `<meta name="citation_title" content="${escapeHtml(title)}">`,
+    `<meta name="citation_public_url" content="${escapeHtml(sourceUrl)}">`,
+    `<meta name="firecrawl:source" content="pmc-bioc">`,
+  ];
+  const optionalMeta: [string, string | undefined][] = [
+    ["citation_doi", frontInfons["article-id_doi"]],
+    ["citation_pmid", frontInfons["article-id_pmid"]],
+    ["citation_journal_title", frontInfons["journal"]],
+    ["citation_volume", frontInfons["volume"]],
+    ["citation_date", frontInfons["year"]],
+    ["keywords", frontInfons["kwd"]],
+    ["license", frontInfons["license"] ?? document.infons?.license],
+  ];
+  for (const [name, value] of optionalMeta) {
+    if (value) {
+      metaTags.push(
+        `<meta name="${name}" content="${escapeHtml(String(value))}">`,
+      );
+    }
+  }
+  for (const author of authors) {
+    metaTags.push(
+      `<meta name="citation_author" content="${escapeHtml(author)}">`,
+    );
+  }
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(title)}</title>
+  <link rel="canonical" href="${escapeHtml(sourceUrl)}">
+  ${metaTags.join("\n  ")}
+</head>
+<body>
+  <article>
+    <h1>${escapeHtml(title)}</h1>
+    ${authors.length > 0 ? `<p>${escapeHtml(authors.join(", "))}</p>` : ""}
+    ${body.join("\n    ")}
+  </article>
+</body>
+</html>`;
+
+  return { html, title };
+}
+
+export async function scrapeURLWithPmcBioc(
+  meta: Meta,
+): Promise<EngineScrapeResult> {
+  const url = meta.rewrittenUrl ?? meta.url;
+  const pmcId = extractPmcId(url);
+
+  if (pmcId === null) {
+    throw new EngineError("URL is not a supported PMC article URL");
+  }
+
+  pmcBiocCounter.inc({ outcome: "attempt" });
+
+  const endpoint = `${BIOC_ENDPOINT}/${encodeURIComponent(pmcId)}/unicode`;
+  const signal = AbortSignal.any([
+    meta.abort.asSignal(),
+    AbortSignal.timeout(config.PMC_BIOC_TIMEOUT_MS),
+  ]);
+
+  let response: undici.Response;
+  try {
+    response = await undici.fetch(endpoint, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      dispatcher: getSecureDispatcher(),
+      signal,
+    });
+  } catch (error) {
+    pmcBiocCounter.inc({ outcome: "fallback" });
+    throw new EngineError(
+      `PMC BioC request failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.status !== 200) {
+    pmcBiocCounter.inc({ outcome: "fallback" });
+    throw new EngineError(
+      `PMC BioC returned HTTP ${response.status} for ${pmcId}`,
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = await readBounded(response, config.PMC_BIOC_MAX_RESPONSE_BYTES);
+  } catch (error) {
+    pmcBiocCounter.inc({ outcome: "fallback" });
+    throw error instanceof EngineError
+      ? error
+      : new EngineError(
+          `PMC BioC body read failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+  }
+
+  // The API answers unknown/non-open-access IDs with HTTP 200 and an HTML
+  // "[Error] : No result can be found." page, so status alone proves nothing.
+  const trimmed = raw.trimStart();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+    pmcBiocCounter.inc({ outcome: "fallback" });
+    throw new EngineError(
+      `PMC BioC has no open-access full text for ${pmcId} (non-JSON response)`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    pmcBiocCounter.inc({ outcome: "fallback" });
+    throw new EngineError(`PMC BioC returned malformed JSON for ${pmcId}`);
+  }
+
+  let converted: PmcConversion;
+  try {
+    converted = convertBiocToHtml(parsed, url, pmcId);
+  } catch (error) {
+    pmcBiocCounter.inc({ outcome: "fallback" });
+    throw error;
+  }
+
+  pmcBiocCounter.inc({ outcome: "success" });
+  meta.logger.info("Retrieved PMC article from official BioC API", {
+    pmcId,
+    title: converted.title,
+    htmlLength: converted.html.length,
+  });
+
+  return {
+    url,
+    html: converted.html,
+    statusCode: 200,
+    contentType: "text/html; charset=utf-8",
+    proxyUsed: "basic",
+  };
+}
+
+export function pmcBiocMaxReasonableTime(_meta: Meta): number {
+  return config.PMC_BIOC_TIMEOUT_MS;
+}

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -56,6 +56,17 @@ import {
   XTwitterConfigurationError,
 } from "./error";
 import { ScrapeRetryTracker } from "./retryTracker";
+import {
+  type AntibotFallbackState,
+  classifyAntibotResponse,
+  createAntibotFallbackState,
+} from "./lib/antibot";
+import {
+  antibotFailureCounter,
+  scrapeEngineAttemptCounter,
+  terminalNotFoundCounter,
+} from "../../lib/antibot-fallback-metrics";
+import { isArxivPdfUrl } from "../../search/quality";
 import { executeTransformers } from "./transformers";
 import { LLMRefusalError } from "./transformers/llmExtract";
 import { urlSpecificParams } from "./lib/urlSpecificParams";
@@ -170,6 +181,13 @@ export type Meta = {
     | null
     | undefined; // undefined: no prefetch yet, null: prefetch came back empty
   costTracking: CostTracking;
+  /**
+   * Anti-bot fallback bookkeeping. A shared mutable holder on purpose: engine
+   * attempts run against a shallow `{...meta}` copy, so a plain field would not
+   * survive back to the outer retry loop — and "one Camoufox attempt per job"
+   * depends on it doing exactly that.
+   */
+  antibot: AntibotFallbackState;
   winnerEngine?: Engine;
   abortHandle?: NodeJS.Timeout;
   audioCookies?: BrowserCookie[];
@@ -260,7 +278,11 @@ function buildFeatureFlags(
 
   if (isDocument) {
     flags.add("document");
-  } else if (lowerPath.endsWith(".pdf") || lowerPath.includes(".pdf/")) {
+  } else if (
+    lowerPath.endsWith(".pdf") ||
+    lowerPath.includes(".pdf/") ||
+    isArxivPdfUrl(url)
+  ) {
     // Only add PDF flag if it's not a document
     flags.add("pdf");
   }
@@ -469,6 +491,7 @@ async function buildMetaObject(
     documentPrefetch,
     fetchPrefetch,
     costTracking,
+    antibot: createAntibotFallbackState(),
     threatDecisions: [],
   };
 }
@@ -535,6 +558,56 @@ type EngineScrapeResultWithContext = {
 };
 
 const MAX_HTML_SIZE_FOR_MARKDOWN_CHECK = 300 * 1024; // 300KB
+
+/**
+ * One structured, secret-free line per scrape summarising the anti-bot path:
+ * what was asked for, which engine won, what blocked us first, whether the
+ * stealth fallback ran and how it went. Deliberately a single event so it can
+ * be aggregated without joining across log lines.
+ */
+function logAntibotSummary(
+  meta: Meta,
+  startTime: number,
+  finalFailureClass: string | null,
+): void {
+  const state = meta.antibot;
+  // Nothing interesting happened: no block was seen and no fallback ran.
+  if (state.detection === undefined && state.camoufoxAttempts === 0) {
+    return;
+  }
+
+  let host: string | null = null;
+  try {
+    host = new URL(meta.rewrittenUrl ?? meta.url).hostname;
+  } catch {
+    host = null;
+  }
+
+  // The console transport only serialises metadata for warn/error (see
+  // lib/logger.ts), so a summary that nobody can read is worse than useless
+  // for the cases that matter. Notable outcomes — the scrape failed, or the
+  // stealth fallback did not recover it — are logged at warn so the fields
+  // actually render; clean recoveries stay at info.
+  const isNotable =
+    finalFailureClass !== null ||
+    (state.camoufoxAttempts > 0 && state.camoufoxOutcome !== "success");
+
+  meta.logger[isNotable ? "warn" : "info"]("scrapeURL antibot summary", {
+    module: "scrapeURL/antibot-metrics",
+    url: meta.rewrittenUrl ?? meta.url,
+    host,
+    selectedEngine: meta.winnerEngine ?? null,
+    initialFailureClass: state.detection?.failureClass ?? null,
+    initialFailureConfidence: state.detection?.confidence ?? null,
+    antibotVendor: state.detection?.vendor ?? null,
+    camoufoxFallbackRan: state.camoufoxAttempts > 0,
+    camoufoxOutcome: state.camoufoxOutcome ?? null,
+    camoufoxDetail: state.camoufoxDetail ?? null,
+    camoufoxElapsedMs: state.camoufoxElapsedMs ?? null,
+    elapsedMs: Date.now() - startTime,
+    finalFailureClass,
+  });
+}
 
 async function scrapeURLLoopIter(
   meta: Meta,
@@ -627,6 +700,96 @@ async function scrapeURLLoopIter(
       engineResult.statusCode,
     );
 
+    // Record what actually blocked us before escalating, so the stealth
+    // fallback can decide on response evidence rather than on the status code
+    // alone.
+    //
+    // Classification is NOT gated on the status code. A challenge page does not
+    // have to arrive with a blocking status: pmc.ncbi.nlm.nih.gov serves its
+    // reCAPTCHA interstitial as a perfectly ordinary HTTP 200 carrying 185
+    // bytes of "Checking your browser...", and ieeexplore/jstor do the same
+    // with AWS WAF and PerimeterX. Gating on [401,403,429] meant
+    // `classifyAntibotResponse` was never even called for those, so a rule that
+    // matches the body (antibot.ts already carries reCAPTCHA, awswaf and
+    // perimeterx fingerprints) could never fire. The classifier is
+    // body-evidence-first and cheap on a miss, so run it whenever there is
+    // either a body to inspect or a blocking status to explain.
+    const detection =
+      isLikelyProxyError || engineResult.html !== undefined
+        ? classifyAntibotResponse({
+            statusCode: engineResult.statusCode,
+            html: engineResult.html,
+            contentType: engineResult.contentType,
+            pageError: engineResult.error,
+          })
+        : undefined;
+
+    // Only the first *meaningful* block is kept: that is the failure that
+    // characterises the job. `confidence: "none"` covers ordinary pages, so a
+    // successful 200 later in the waterfall cannot overwrite the real evidence.
+    if (
+      detection !== undefined &&
+      detection.confidence !== "none" &&
+      meta.antibot.detection === undefined
+    ) {
+      meta.antibot.detection = detection;
+      antibotFailureCounter.inc({
+        confidence: detection.confidence,
+        vendor: detection.vendor ?? "unknown",
+      });
+      meta.logger.info("Classified blocking response", {
+        engine,
+        statusCode: engineResult.statusCode,
+        failureClass: detection.failureClass,
+        confidence: detection.confidence,
+        vendor: detection.vendor,
+      });
+    }
+
+    // 404/410 are terminal: no amount of browser stealth conjures a page that
+    // is not there, and we track them separately so they never get counted as
+    // anti-bot failures.
+    if (engineResult.statusCode === 404 || engineResult.statusCode === 410) {
+      terminalNotFoundCounter.inc({ status: String(engineResult.statusCode) });
+    }
+
+    // A confirmed challenge fingerprint on an otherwise-successful status is a
+    // challenge page wearing a 200. Left alone it sails through the
+    // `isLongEnough` check below and is handed to the caller as a successful
+    // scrape -- observed on PMC, which returned 185 chars of reCAPTCHA text as
+    // `success: true`. That is worse than an error: it silently poisons the
+    // result with interstitial text instead of triggering a fallback.
+    //
+    // Deliberately scoped to `confirmed`. A bare "suspected" verdict is only a
+    // status-code guess, and 2xx responses never produce one, so this cannot
+    // fire on an ordinary page. The body-size ceiling in the classifier
+    // (400 KB) keeps a large real document that merely mentions a vendor string
+    // from being caught.
+    if (isGoodStatusCode && detection?.confidence === "confirmed") {
+      meta.logger.warn(
+        "Scrape via " + engine + " returned a challenge page under a 2xx status.",
+        {
+          statusCode: engineResult.statusCode,
+          failureClass: detection.failureClass,
+          vendor: detection.vendor,
+          length: engineResult.html?.trim().length ?? 0,
+        },
+      );
+      scrapeEngineAttemptCounter.inc({ engine, outcome: "failure" });
+
+      // Escalate the same way a 403/429 would. Without this the stealth engines
+      // are never even in the fallback list: they carry negative quality and are
+      // only admitted once `stealthProxy` is set, and that flag was previously
+      // reachable only via the isLikelyProxyError branch below. Observed on
+      // ieeexplore, which serves its AWS WAF challenge with HTTP *202* -- the
+      // page was correctly rejected but the waterfall then ran out of engines
+      // (fallbackList: [playwright, fetch]) instead of trying Camoufox.
+      if (meta.options.proxy === "auto" && !meta.featureFlags.has("stealthProxy")) {
+        throw new AddFeatureError(["stealthProxy"]);
+      }
+      throw new EngineUnsuccessfulError(engine);
+    }
+
     if (
       isLikelyProxyError &&
       meta.options.proxy === "auto" &&
@@ -652,12 +815,14 @@ async function scrapeURLLoopIter(
       meta.logger.info("Scrape via " + engine + " deemed successful.", {
         factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
       });
+      scrapeEngineAttemptCounter.inc({ engine, outcome: "success" });
       return engineResult;
     } else {
       meta.logger.warn("Scrape via " + engine + " deemed unsuccessful.", {
         factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
         length: engineResult.html?.trim().length ?? 0,
       });
+      scrapeEngineAttemptCounter.inc({ engine, outcome: "failure" });
       throw new EngineUnsuccessfulError(engine);
     }
   } finally {
@@ -1419,6 +1584,8 @@ export async function scrapeURL(
           result.success && result.document.metadata.cacheState === "hit",
       });
 
+      logAntibotSummary(meta, startTime, null);
+
       return meta.threatDecisions.length > 0
         ? { ...result, threatDecisions: meta.threatDecisions }
         : result;
@@ -1568,6 +1735,8 @@ export async function scrapeURL(
         "scrape.error_type": errorType,
         "scrape.duration_ms": Date.now() - startTime,
       });
+
+      logAntibotSummary(meta, startTime, errorType);
 
       return {
         success: false,

--- a/apps/api/src/scraper/scrapeURL/lib/antibot.test.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/antibot.test.ts
@@ -1,0 +1,239 @@
+import { classifyAntibotResponse, meetsConfidenceThreshold } from "./antibot";
+
+// Bodies below are trimmed from responses actually observed against the
+// self-hosted deployment, so the classifier is tested against real evidence
+// rather than invented markers.
+const CLOUDFLARE_CHALLENGE = `<!DOCTYPE html><html lang="en-US" dir="ltr"><head><title>Just a moment...</title><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="robots" content="noindex,nofollow"></head><body><div id="cf-wrapper"><script>window._cf_chl_opt={cvId:'3'};</script><div id="challenge-error-text">Enable JavaScript and cookies to continue</div><script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script></body></html>`;
+
+const AKAMAI_DENIED = `<html><head> <title>Access Denied</title> </head><body> <h1>Access Denied</h1> You don't have permission to access "http://www.mdpi.com/2308-3417/10/5/119" on this server.<p> Reference #18.967f3a17.1785290305.52b9950a </p><p>https://errors.edgesuite.net/18.967f3a17.1785290305.52b9950a</p> </body></html>`;
+
+const RECAPTCHA_INTERSTITIAL = `<!DOCTYPE html><html lang="en-US"><head><script src="https://www.gstatic.com/_/mss/boq-recaptcha/_/js/k=boq-recaptcha.RecaptchaChallengePageUi.en_US.js"></script><title>Checking your browser - reCAPTCHA</title></head><body><div class="g-recaptcha"></div></body></html>`;
+
+const LOVEHONEY_BLOCK = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Blocked request</title></head><body><nav></nav><main><section><p>Sorry, your request was blocked.</p></section></main></body></html>`;
+
+const REAL_ARTICLE = `<!DOCTYPE html><html lang="en-US"><head><title>8 Best Anal Masturbation Positions and Tips for Self-Love</title></head><body><article><h1>8 Best Positions</h1>${"<p>Real editorial body copy that goes on for a while. </p>".repeat(400)}</article></body></html>`;
+
+describe("classifyAntibotResponse", () => {
+  describe("confirmed challenge fingerprints", () => {
+    it("identifies a Cloudflare interstitial", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 403,
+        html: CLOUDFLARE_CHALLENGE,
+        contentType: "text/html; charset=UTF-8",
+      });
+      expect(result.confidence).toBe("confirmed");
+      expect(result.vendor).toBe("cloudflare");
+      expect(result.failureClass).toBe("antibot_challenge:cloudflare");
+    });
+
+    it("identifies an Akamai edge denial", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 403,
+        html: AKAMAI_DENIED,
+        contentType: "text/html",
+      });
+      expect(result.confidence).toBe("confirmed");
+      expect(result.vendor).toBe("akamai");
+    });
+
+    it("identifies a reCAPTCHA interstitial served with HTTP 200", () => {
+      // PMC answers 200 with this body, so status alone would call it a success.
+      const result = classifyAntibotResponse({
+        statusCode: 200,
+        html: RECAPTCHA_INTERSTITIAL,
+        contentType: "text/html; charset=utf-8",
+      });
+      expect(result.confidence).toBe("confirmed");
+      expect(result.vendor).toBe("recaptcha");
+    });
+  });
+
+  describe("suspected blocks without a fingerprint", () => {
+    it("marks a bare 403 block page as suspected, not confirmed", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 403,
+        html: LOVEHONEY_BLOCK,
+        contentType: "text/html",
+      });
+      expect(result.confidence).toBe("suspected");
+      expect(result.failureClass).toBe("http_403_blocked");
+      expect(result.vendor).toBeUndefined();
+    });
+
+    it("marks 429 as suspected", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 429,
+        html: "<html><body>Too many requests</body></html>",
+      });
+      expect(result.confidence).toBe("suspected");
+      expect(result.failureClass).toBe("http_429_blocked");
+    });
+  });
+
+  describe("non-anti-bot outcomes", () => {
+    it("never classifies a 404 as anti-bot", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 404,
+        html: "<html><body>Not Found</body></html>",
+      });
+      expect(result.confidence).toBe("none");
+      expect(result.failureClass).toBe("http_404");
+    });
+
+    it("never classifies a 410 as anti-bot", () => {
+      expect(
+        classifyAntibotResponse({ statusCode: 410, html: "<html></html>" })
+          .confidence,
+      ).toBe("none");
+    });
+
+    it("treats an ordinary 200 page as clean", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 200,
+        html: "<html><head><title>Docs</title></head><body><p>Hello</p></body></html>",
+        contentType: "text/html",
+      });
+      expect(result.confidence).toBe("none");
+    });
+
+    it("does not flag a large real article that merely happens to 403", () => {
+      // anesidoralove.com returns 403 with the full ~550 KB article. Calling
+      // that "anti-bot" would burn a stealth attempt on a page whose content
+      // already arrived.
+      const result = classifyAntibotResponse({
+        statusCode: 403,
+        html: REAL_ARTICLE,
+        contentType: "text/html",
+      });
+      expect(result.confidence).not.toBe("confirmed");
+    });
+
+    it("ignores markers in non-HTML payloads", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 403,
+        html: JSON.stringify({ note: "just a moment, __cf_chl" }),
+        contentType: "application/json",
+      });
+      expect(result.confidence).toBe("suspected");
+      expect(result.vendor).toBeUndefined();
+    });
+
+    it("never classifies our own SSRF block as anti-bot", () => {
+      // The browser microservices report a blocked internal target as HTTP 403
+      // with an explanatory pageError. Reading that as anti-bot would send the
+      // stealth browser off to retry an internal address.
+      for (const pageError of [
+        'Blocked insecure target URL "http://169.254.169.254/": resolves to a private/internal address',
+        'Blocked insecure target URL "http://192.168.0.107:3002/": port 3002 is not allowed',
+        "Connection violated security rules.",
+      ]) {
+        const result = classifyAntibotResponse({
+          statusCode: 403,
+          html: "",
+          pageError,
+        });
+        expect(result.confidence).toBe("none");
+        expect(result.failureClass).toBe("blocked_internal_target");
+      }
+    });
+
+    it("still classifies a genuine challenge that carries a pageError", () => {
+      const result = classifyAntibotResponse({
+        statusCode: 403,
+        html: CLOUDFLARE_CHALLENGE,
+        pageError: "Forbidden",
+      });
+      expect(result.confidence).toBe("confirmed");
+      expect(result.vendor).toBe("cloudflare");
+    });
+
+    it("handles a missing body without throwing", () => {
+      expect(classifyAntibotResponse({ statusCode: 403 }).confidence).toBe(
+        "suspected",
+      );
+      expect(classifyAntibotResponse({ statusCode: 200 }).confidence).toBe(
+        "none",
+      );
+    });
+  });
+});
+
+// Bodies FlareSolverr returned verbatim for these hosts while reporting
+// `"Challenge not detected!"` with HTTP 200. They are the reason the caller in
+// scrapeURL/index.ts classifies 2xx responses instead of only [401,403,429]:
+// the fingerprints below were always present, the classifier was simply never
+// invoked for them.
+const AWS_WAF_INTERSTITIAL = `<html><head><script src="https://de5282c3ca0c.ca-central-1.token.awswaf.com/de5282c3ca0c/challenge.js"></script></head><body><div id="challenge-container"></div><script>window.awsWafCookieDomainList = []; AwsWafIntegration.saveReferrer();</script></body></html>`;
+
+const JSTOR_ACCESS_CHECK = `<html><head><title>JSTOR: Access Check</title><style>.px-captcha-error-container{position:fixed;height:328px}</style></head><body><h2>Access Check</h2><p>Our systems have detected unusual traffic activity from your network.</p></body></html>`;
+
+describe("challenge pages served under a 2xx status", () => {
+  it("identifies an AWS WAF interstitial returned as HTTP 200", () => {
+    const result = classifyAntibotResponse({
+      statusCode: 200,
+      html: AWS_WAF_INTERSTITIAL,
+      contentType: "text/html",
+    });
+    expect(result.confidence).toBe("confirmed");
+    expect(result.vendor).toBe("awswaf");
+  });
+
+  it("identifies a JSTOR access check returned as HTTP 200", () => {
+    const result = classifyAntibotResponse({
+      statusCode: 200,
+      html: JSTOR_ACCESS_CHECK,
+      contentType: "text/html",
+    });
+    expect(result.confidence).toBe("confirmed");
+  });
+
+  it("still calls an ordinary 200 document clean", () => {
+    const result = classifyAntibotResponse({
+      statusCode: 200,
+      html: REAL_ARTICLE,
+      contentType: "text/html",
+    });
+    expect(result.confidence).toBe("none");
+  });
+
+  it("never returns `suspected` for a 2xx, so only body evidence can fail one", () => {
+    // The caller treats `confirmed` on a 2xx as an engine failure. If a bare
+    // 200 could ever come back `suspected`, that guard would misfire on real
+    // pages -- this pins the invariant it relies on.
+    for (const status of [200, 201, 204, 206, 304]) {
+      const result = classifyAntibotResponse({
+        statusCode: status,
+        html: "<html><body><p>ordinary</p></body></html>",
+        contentType: "text/html",
+      });
+      expect(result.confidence).toBe("none");
+    }
+  });
+});
+
+describe("meetsConfidenceThreshold", () => {
+  const confirmed = classifyAntibotResponse({
+    statusCode: 403,
+    html: CLOUDFLARE_CHALLENGE,
+  });
+  const suspected = classifyAntibotResponse({
+    statusCode: 403,
+    html: LOVEHONEY_BLOCK,
+  });
+  const none = classifyAntibotResponse({ statusCode: 404, html: "<html/>" });
+
+  it("never admits a non-anti-bot response", () => {
+    expect(meetsConfidenceThreshold(none, "suspected")).toBe(false);
+    expect(meetsConfidenceThreshold(none, "confirmed")).toBe(false);
+  });
+
+  it("admits suspected blocks only at the lower threshold", () => {
+    expect(meetsConfidenceThreshold(suspected, "suspected")).toBe(true);
+    expect(meetsConfidenceThreshold(suspected, "confirmed")).toBe(false);
+  });
+
+  it("admits confirmed challenges at either threshold", () => {
+    expect(meetsConfidenceThreshold(confirmed, "suspected")).toBe(true);
+    expect(meetsConfidenceThreshold(confirmed, "confirmed")).toBe(true);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/lib/antibot.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/antibot.ts
@@ -1,0 +1,199 @@
+/**
+ * Evidence-based anti-bot / challenge-page classification.
+ *
+ * A bare 4xx is NOT enough to call something anti-bot — plenty of sites return
+ * 403 while still serving the real document (observed on anesidoralove.com,
+ * which returns 403 with the full 550 KB article). Callers that spend real
+ * resources on a stealth retry need to look at the response body, so this
+ * module separates "we saw a challenge page" from "we saw a blocking status".
+ */
+
+/** Bounded prefix scanned for markers, so a huge document can't stall the loop. */
+const SCAN_PREFIX_BYTES = 256 * 1024;
+
+/**
+ * Bodies larger than this are not treated as challenge pages. Interstitials are
+ * small (observed: 308 B Akamai, 25 KB reCAPTCHA, 27 KB Cloudflare); a
+ * multi-hundred-KB document that happens to contain a marker string is far more
+ * likely to be real content than a challenge.
+ */
+const MAX_CHALLENGE_BODY_BYTES = 400 * 1024;
+
+/** Statuses that indicate the origin refused us, as opposed to a missing page. */
+const BLOCKING_STATUS_CODES = [403, 429];
+
+/**
+ * Challenge fingerprints. Every entry is a conjunction: all of its needles must
+ * appear (case-insensitively) in the scanned prefix. Single-needle entries are
+ * reserved for strings that essentially cannot appear outside a challenge page;
+ * anything that a normal page might legitimately embed (a reCAPTCHA widget on a
+ * contact form, for instance) is paired with a challenge-specific phrase.
+ */
+const CHALLENGE_SIGNATURES: { vendor: string; needles: string[] }[] = [
+  { vendor: "cloudflare", needles: ["__cf_chl"] },
+  { vendor: "cloudflare", needles: ["cf_chl_opt"] },
+  { vendor: "cloudflare", needles: ["/cdn-cgi/challenge-platform/"] },
+  { vendor: "cloudflare", needles: ["cf-browser-verification"] },
+  { vendor: "cloudflare", needles: ["<title>just a moment"] },
+  { vendor: "recaptcha", needles: ["boq-recaptcha"] },
+  { vendor: "recaptcha", needles: ["recaptcha", "checking your browser"] },
+  { vendor: "datadome", needles: ["geo.captcha-delivery.com"] },
+  { vendor: "datadome", needles: ["datadome", "captcha"] },
+  { vendor: "perimeterx", needles: ["px-captcha"] },
+  { vendor: "perimeterx", needles: ["perimeterx", "blocked"] },
+  { vendor: "imperva", needles: ["incapsula incident"] },
+  { vendor: "imperva", needles: ["_incapsula_resource"] },
+  { vendor: "akamai", needles: ["errors.edgesuite.net"] },
+  { vendor: "akamai", needles: ["access denied", "reference #"] },
+  { vendor: "awswaf", needles: ["awswafintegration"] },
+  { vendor: "awswaf", needles: ["token.awswaf.com"] },
+  { vendor: "sucuri", needles: ["sucuri website firewall"] },
+  { vendor: "hcaptcha", needles: ["hcaptcha", "verify you are human"] },
+  {
+    vendor: "generic",
+    needles: ["enable javascript and cookies to continue"],
+  },
+];
+
+type AntibotConfidence =
+  /** A known challenge/interstitial fingerprint was found in the body. */
+  | "confirmed"
+  /** The origin refused us (403/429) but the body carries no known fingerprint. */
+  | "suspected"
+  /** No anti-bot evidence — 404s, DNS/TLS errors, ordinary pages. */
+  | "none";
+
+export type AntibotDetection = {
+  confidence: AntibotConfidence;
+  /** Stable, secret-free label for logs and metrics. */
+  failureClass: string;
+  /** Vendor behind a `confirmed` verdict. */
+  vendor?: string;
+  statusCode: number;
+};
+
+/**
+ * Signatures of our *own* SSRF controls refusing a target.
+ *
+ * The browser microservices report a blocked internal address the same way a
+ * site reports a bot block — HTTP 403 — so status alone cannot tell them
+ * apart. Misreading one as anti-bot would send the stealth browser off to
+ * retry an internal address, which is both wasted work and precisely the
+ * behaviour the SSRF policy exists to prevent.
+ */
+const SSRF_BLOCK_SIGNATURES = [
+  "blocked insecure target url",
+  "connection violated security rules",
+  "private/internal address",
+  "target resolves to a private",
+  "violates ssrf policy",
+];
+
+export function classifyAntibotResponse({
+  statusCode,
+  html,
+  contentType,
+  pageError,
+}: {
+  statusCode: number;
+  html?: string;
+  contentType?: string;
+  /** Engine-reported error string, if any. */
+  pageError?: string;
+}): AntibotDetection {
+  if (pageError !== undefined) {
+    const lowered = pageError.toLowerCase();
+    if (SSRF_BLOCK_SIGNATURES.some(signature => lowered.includes(signature))) {
+      return {
+        confidence: "none",
+        failureClass: "blocked_internal_target",
+        statusCode,
+      };
+    }
+  }
+
+  const isHtmlish =
+    contentType === undefined ||
+    contentType.toLowerCase().includes("html") ||
+    contentType.toLowerCase().includes("text/plain");
+
+  if (
+    html !== undefined &&
+    isHtmlish &&
+    html.length <= MAX_CHALLENGE_BODY_BYTES
+  ) {
+    const haystack = html.slice(0, SCAN_PREFIX_BYTES).toLowerCase();
+    for (const signature of CHALLENGE_SIGNATURES) {
+      if (signature.needles.every(needle => haystack.includes(needle))) {
+        return {
+          confidence: "confirmed",
+          failureClass: `antibot_challenge:${signature.vendor}`,
+          vendor: signature.vendor,
+          statusCode,
+        };
+      }
+    }
+  }
+
+  if (BLOCKING_STATUS_CODES.includes(statusCode)) {
+    return {
+      confidence: "suspected",
+      failureClass: `http_${statusCode}_blocked`,
+      statusCode,
+    };
+  }
+
+  return {
+    confidence: "none",
+    failureClass: `http_${statusCode}`,
+    statusCode,
+  };
+}
+
+/** True when `detection` clears the configured minimum confidence bar. */
+export function meetsConfidenceThreshold(
+  detection: AntibotDetection,
+  minimum: "confirmed" | "suspected",
+): boolean {
+  if (detection.confidence === "none") return false;
+  if (minimum === "suspected") return true;
+  return detection.confidence === "confirmed";
+}
+
+/**
+ * Anti-bot fallback state, carried on `Meta` as a mutable holder so it survives
+ * the shallow `{...meta}` copies made per engine attempt and the outer
+ * feature-toggle retry loop. This is what enforces "one stealth attempt per
+ * scrape job" no matter how many times the waterfall restarts.
+ */
+export type AntibotFallbackState = {
+  /** Classification of the response that first blocked this job. */
+  detection?: AntibotDetection;
+  camoufoxAttempts: number;
+  camoufoxOutcome?:
+    | "success"
+    | "failure"
+    | "skipped_not_applicable"
+    | "skipped_already_attempted"
+    | "skipped_domain_filter"
+    | "service_unavailable";
+  /** Reason string for a skip/failure, safe to log. */
+  camoufoxDetail?: string;
+  camoufoxElapsedMs?: number;
+  flaresolverrAttempts: number;
+  flaresolverrOutcome?:
+    | "success"
+    | "failure"
+    | "skipped_not_applicable"
+    | "skipped_already_attempted"
+    | "skipped_domain_filter"
+    | "challenge_not_cleared"
+    | "service_unavailable";
+  /** Reason string for a skip/failure, safe to log. */
+  flaresolverrDetail?: string;
+  flaresolverrElapsedMs?: number;
+};
+
+export function createAntibotFallbackState(): AntibotFallbackState {
+  return { camoufoxAttempts: 0, flaresolverrAttempts: 0 };
+}

--- a/apps/api/src/search/execute.test.ts
+++ b/apps/api/src/search/execute.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isSuccessfulScrapedResult } from "./result-policy";
+
+describe("search scrape result policy", () => {
+  it("accepts successfully scraped content", () => {
+    expect(
+      isSuccessfulScrapedResult({
+        markdown: "# Result",
+        metadata: { statusCode: 200 },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([404, 410, 429, 500])("drops status %s", statusCode => {
+    expect(isSuccessfulScrapedResult({ metadata: { statusCode } })).toBe(false);
+  });
+
+  it("drops explicit scrape errors and empty un-scraped results", () => {
+    expect(
+      isSuccessfulScrapedResult({
+        metadata: { statusCode: 200, error: "challenge page" },
+      }),
+    ).toBe(false);
+    expect(isSuccessfulScrapedResult({})).toBe(false);
+  });
+});

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -25,6 +25,13 @@ import { checkUrlsAgainstThreatPolicy } from "../lib/threat-protection/request";
 import { calculateThreatScanCredits } from "../lib/scrape-billing";
 import { config } from "../config";
 import { logger as rootLogger } from "../lib/logger";
+import {
+  filterAndRankWebResults,
+  stripSearchDiagnostics,
+  type InternalWebSearchResult,
+} from "./quality";
+import { profileNames, resolveSearchProfiles } from "./profiles";
+import { isSuccessfulScrapedResult } from "./result-policy";
 
 interface SearchOptions {
   query: string;
@@ -42,6 +49,7 @@ interface SearchOptions {
   scrapeOptions?: ScrapeOptions;
   highlights?: boolean;
   timeout: number;
+  ignoreInvalidURLs?: boolean;
 }
 
 interface SearchContext {
@@ -90,11 +98,12 @@ export async function executeSearch(
     billing,
   } = context;
 
-  const num_results_buffer = Math.floor(limit * 2);
+  const num_results_buffer = Math.max(limit + 5, Math.floor(limit * 2));
 
   logger.info("Searching for results");
 
   const searchTypes = [...new Set(sources.map((s: any) => s.type))];
+  const profiles = resolveSearchProfiles(query, categories);
   const { query: searchQuery, categoryMap } = buildSearchQuery(
     query,
     categories,
@@ -116,7 +125,29 @@ export async function executeSearch(
     location: options.location,
     type: searchTypes,
     enterprise: options.enterprise,
+    routingQuery: query,
+    categories,
+    timeout: options.timeout,
   })) as SearchV2Response;
+
+  if (searchResponse.web && searchResponse.web.length > 0) {
+    const beforeCount = searchResponse.web.length;
+    searchResponse.web = filterAndRankWebResults(
+      searchResponse.web as InternalWebSearchResult[],
+      {
+        query,
+        profiles: profileNames(profiles),
+        categories,
+        includeDomains: options.includeDomains,
+        excludeDomains: options.excludeDomains,
+      },
+    );
+    logger.info("Search results normalized and ranked", {
+      profiles: profileNames(profiles),
+      beforeCount,
+      afterCount: searchResponse.web.length,
+    });
+  }
 
   // Threat protection: remove blocked results entirely — before
   // slicing/counting, before scraping, and before returning. Checks are
@@ -173,6 +204,11 @@ export async function executeSearch(
         : undefined,
     }));
   }
+
+  // Keep the ranked buffer for agent/MCP backfill. The public response is
+  // still sliced to `limit`; candidates beyond it are only scraped if an
+  // earlier result fails.
+  const webCandidates = [...(searchResponse.web ?? [])];
 
   let totalResultsCount = 0;
 
@@ -248,6 +284,77 @@ export async function executeSearch(
         allDocsWithCostTracking,
       );
       scrapeCredits = calculateScrapeCredits(allDocsWithCostTracking);
+
+      if (options.ignoreInvalidURLs) {
+        if (searchResponse.web) {
+          searchResponse.web = searchResponse.web.filter(
+            isSuccessfulScrapedResult,
+          );
+        }
+        if (searchResponse.news) {
+          searchResponse.news = searchResponse.news.filter(
+            isSuccessfulScrapedResult,
+          );
+        }
+        if (searchResponse.images) {
+          searchResponse.images = searchResponse.images.filter(
+            isSuccessfulScrapedResult,
+          );
+        }
+
+        let candidateOffset = Math.min(limit, webCandidates.length);
+        while (
+          (searchResponse.web?.length ?? 0) < limit &&
+          candidateOffset < webCandidates.length
+        ) {
+          const needed = limit - (searchResponse.web?.length ?? 0);
+          const replacements = webCandidates.slice(
+            candidateOffset,
+            candidateOffset + needed,
+          );
+          candidateOffset += replacements.length;
+
+          const replacementResponse: SearchV2Response = {
+            web: replacements,
+          };
+          const replacementItems = getItemsToScrape(
+            replacementResponse,
+            flags,
+            {
+              team_id: teamId,
+              org_id: orgId ?? null,
+              origin,
+            },
+          );
+          if (replacementItems.length === 0) continue;
+
+          const replacementDocs = await scrapeSearchResults(
+            replacementItems.map(item => item.scrapeInput),
+            scrapeOpts,
+            logger,
+            flags,
+          );
+          mergeScrapedContent(
+            replacementResponse,
+            replacementItems,
+            replacementDocs,
+          );
+          scrapeCredits += calculateScrapeCredits(replacementDocs);
+          const validReplacements = (replacementResponse.web ?? []).filter(
+            isSuccessfulScrapedResult,
+          );
+          searchResponse.web = [
+            ...(searchResponse.web ?? []),
+            ...validReplacements,
+          ].slice(0, limit);
+        }
+
+        logger.info("Invalid scraped search results removed and backfilled", {
+          requested: limit,
+          returnedWeb: searchResponse.web?.length ?? 0,
+          candidatesExamined: candidateOffset,
+        });
+      }
     }
   }
 
@@ -299,6 +406,12 @@ export async function executeSearch(
         typeof f === "string" ? f : f.type,
       )
     : [];
+
+  if (searchResponse.web) {
+    searchResponse.web = stripSearchDiagnostics(
+      searchResponse.web as InternalWebSearchResult[],
+    );
+  }
 
   trackSearchRequest({
     searchId: context.jobId,

--- a/apps/api/src/search/profiles.ts
+++ b/apps/api/src/search/profiles.ts
@@ -1,0 +1,186 @@
+import type { CategoryOption } from "../lib/search-query-builder";
+
+export type SearchProfileName = "general" | "developer" | "research" | "pdf";
+
+export interface SearchProfile {
+  name: SearchProfileName;
+  explicit: boolean;
+  sites?: string[];
+}
+
+export interface SearchProfileRequest {
+  profile: SearchProfileName;
+  query: string;
+  engines: string[];
+}
+
+const REPOSITORY_INTENT =
+  /\b(repo(?:sitory|sitories)?|source\s*code|github|gitlab|pull request|issue|readme)\b/i;
+const DOCKER_INTENT = /\b(docker|container|image|dockerfile|compose)\b/i;
+const NPM_INTENT =
+  /\b(npm|node(?:\.js)?|javascript|typescript|package\.json)\b/i;
+const PYPI_INTENT = /\b(pypi|python|pip|pyproject|poetry)\b/i;
+const CRATES_INTENT = /\b(crate|crates\.io|cargo|rust)\b/i;
+const HUGGINGFACE_INTENT =
+  /\b(hugging\s*face|huggingface|transformers|model weights|dataset)\b/i;
+const BIOMEDICAL_INTENT =
+  /\b(clinical|biomedical|medicine|medical|patient|disease|gene|protein|pubmed|pmc|trial)\b/i;
+const RESEARCH_INTENT =
+  /\b(paper|preprint|journal|citation|doi|arxiv|study|systematic review|literature review|research|scholar(?:ly)?|conference proceedings|weighted sampling|methodology)\b/i;
+const PDF_INTENT = /\b(pdf|filetype:pdf|downloadable paper|full[- ]text)\b/i;
+const DEVELOPER_INTENT =
+  /\b(api|sdk|cli|library|framework|plugin|package|dependency|code|coding|programming|implementation|bug|stack trace|typescript|javascript|python|rust|golang|docker|kubernetes)\b/i;
+
+function categoryType(category: CategoryOption): SearchProfileName {
+  const type = typeof category === "string" ? category : category.type;
+  if (type === "github") return "developer";
+  if (type === "research" || type === "pdf") return type;
+  return "general";
+}
+
+/**
+ * Resolve the caller's intent without an LLM. Explicit categories are always
+ * authoritative; otherwise the classifier deliberately picks one profile so a
+ * search cannot fan out across every configured engine.
+ */
+export function resolveSearchProfiles(
+  query: string,
+  categories?: CategoryOption[],
+): SearchProfile[] {
+  if (categories && categories.length > 0) {
+    const profiles = new Map<SearchProfileName, SearchProfile>();
+    for (const category of categories) {
+      const name = categoryType(category);
+      const sites =
+        typeof category === "object" && category.type === "research"
+          ? category.sites
+          : undefined;
+      const existing = profiles.get(name);
+      profiles.set(name, {
+        name,
+        explicit: true,
+        sites: sites ?? existing?.sites,
+      });
+    }
+    return [...profiles.values()];
+  }
+
+  if (PDF_INTENT.test(query)) {
+    return [{ name: "pdf", explicit: false }];
+  }
+  if (RESEARCH_INTENT.test(query)) {
+    return [{ name: "research", explicit: false }];
+  }
+  if (
+    DEVELOPER_INTENT.test(query) ||
+    REPOSITORY_INTENT.test(query) ||
+    DOCKER_INTENT.test(query) ||
+    NPM_INTENT.test(query) ||
+    PYPI_INTENT.test(query) ||
+    CRATES_INTENT.test(query) ||
+    HUGGINGFACE_INTENT.test(query)
+  ) {
+    return [{ name: "developer", explicit: false }];
+  }
+  return [{ name: "general", explicit: false }];
+}
+
+function siteExpression(sites: string[]): string {
+  return sites.map(site => `site:${site}`).join(" OR ");
+}
+
+const RESEARCH_WEB_SITES = [
+  "arxiv.org",
+  "doi.org",
+  "semanticscholar.org",
+  "openalex.org",
+  "pubmed.ncbi.nlm.nih.gov",
+  "pmc.ncbi.nlm.nih.gov",
+  "acm.org",
+  "ieee.org",
+  "springer.com",
+  "nature.com",
+  "science.org",
+];
+
+/**
+ * Split profiles into small engine groups. Search operators are only sent to
+ * general web engines; specialist APIs receive the user's unmodified query.
+ */
+export function buildSearchProfileRequests(
+  query: string,
+  profile: SearchProfile,
+): SearchProfileRequest[] {
+  switch (profile.name) {
+    case "developer": {
+      const specialistEngines = ["github"];
+      if (REPOSITORY_INTENT.test(query)) specialistEngines.push("gitlab");
+      if (DOCKER_INTENT.test(query)) specialistEngines.push("docker hub");
+      if (NPM_INTENT.test(query)) specialistEngines.push("npm");
+      if (PYPI_INTENT.test(query)) specialistEngines.push("pypi");
+      if (CRATES_INTENT.test(query)) specialistEngines.push("crates.io");
+      if (HUGGINGFACE_INTENT.test(query)) specialistEngines.push("huggingface");
+
+      return [
+        { profile: "developer", query, engines: specialistEngines },
+        {
+          profile: "developer",
+          query: `${query} (site:github.com OR site:gitlab.com OR site:stackoverflow.com)`,
+          engines: ["braveapi"],
+        },
+      ];
+    }
+    case "research": {
+      // The unauthenticated Semantic Scholar adapter returns non-JSON from
+      // this deployment, and the arXiv adapter repeatedly consumes the full
+      // SearXNG timeout. Brave's authenticated site search below still covers
+      // both domains without holding up the structured sources.
+      const engines = ["crossref", "openalex"];
+      if (BIOMEDICAL_INTENT.test(query)) engines.push("pubmed");
+      const sites =
+        profile.sites && profile.sites.length > 0
+          ? profile.sites
+          : RESEARCH_WEB_SITES;
+      return [
+        { profile: "research", query, engines },
+        {
+          profile: "research",
+          query: `${query} (${siteExpression(sites)})`,
+          engines: ["braveapi"],
+        },
+      ];
+    }
+    case "pdf":
+      return [
+        { profile: "pdf", query, engines: ["crossref", "openalex"] },
+        {
+          profile: "pdf",
+          query: `${query} filetype:pdf`,
+          engines: ["braveapi"],
+        },
+        {
+          profile: "pdf",
+          query: `${query} filetype:pdf`,
+          engines: ["bing"],
+        },
+      ];
+    case "general":
+    default:
+      return [
+        {
+          profile: "general",
+          query,
+          engines: ["braveapi"],
+        },
+        {
+          profile: "general",
+          query,
+          engines: ["bing", "dogpile", "seznam", "yandex", "fynd"],
+        },
+      ];
+  }
+}
+
+export function profileNames(profiles: SearchProfile[]): SearchProfileName[] {
+  return profiles.map(profile => profile.name);
+}

--- a/apps/api/src/search/quality.ts
+++ b/apps/api/src/search/quality.ts
@@ -1,0 +1,306 @@
+import type { WebSearchResult } from "../lib/entities";
+import {
+  getDefaultResearchSites,
+  type CategoryOption,
+} from "../lib/search-query-builder";
+import type { SearchProfileName } from "./profiles";
+
+export interface InternalSearchDiagnostics {
+  engine?: string;
+  engines?: string[];
+  score?: number;
+  publishedDate?: string;
+  profile?: SearchProfileName;
+}
+
+export type InternalWebSearchResult = WebSearchResult & {
+  __search?: InternalSearchDiagnostics;
+};
+
+const TRACKING_PARAMS = new Set([
+  "fbclid",
+  "gclid",
+  "mc_cid",
+  "mc_eid",
+  "ref",
+  "ref_src",
+]);
+
+const REDIRECT_PARAMS = [
+  "url",
+  "u",
+  "target",
+  "redirect",
+  "redirect_url",
+  "destination",
+];
+
+const RESEARCH_DOMAINS = new Set([
+  ...getDefaultResearchSites(),
+  "doi.org",
+  "semanticscholar.org",
+  "openalex.org",
+  "openreview.net",
+  "crossref.org",
+  "pmc.ncbi.nlm.nih.gov",
+  "ncbi.nlm.nih.gov",
+  "acm.org",
+  "dl.acm.org",
+  "ieee.org",
+  "ieeexplore.ieee.org",
+  "jstor.org",
+  "frontiersin.org",
+  "mdpi.com",
+  "tandfonline.com",
+  "sagepub.com",
+]);
+
+function hostMatches(hostname: string, domain: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  const target = domain
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .split("/")[0]
+    .replace(/\.$/, "");
+  return target !== "" && (host === target || host.endsWith(`.${target}`));
+}
+
+export function isArxivPdfUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      hostMatches(parsed.hostname, "arxiv.org") &&
+      /^\/pdf\/[^/]+(?:\.pdf)?$/i.test(parsed.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isPdfLikeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname.toLowerCase();
+    return (
+      path.endsWith(".pdf") ||
+      path.includes(".pdf/") ||
+      isArxivPdfUrl(url) ||
+      parsed.searchParams.get("format")?.toLowerCase() === "pdf"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function unwrapRedirect(parsed: URL): URL {
+  for (const name of REDIRECT_PARAMS) {
+    const value = parsed.searchParams.get(name);
+    if (!value) continue;
+    try {
+      const candidate = new URL(decodeURIComponent(value));
+      if (candidate.protocol === "http:" || candidate.protocol === "https:") {
+        return candidate;
+      }
+    } catch {
+      // A non-URL parameter named "url" is ordinary query data.
+    }
+  }
+  return parsed;
+}
+
+export function canonicalizeSearchUrl(
+  rawUrl: string,
+  profile?: SearchProfileName,
+): string | null {
+  try {
+    let parsed = unwrapRedirect(new URL(rawUrl));
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      return null;
+
+    parsed.hash = "";
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (key.toLowerCase().startsWith("utm_") || TRACKING_PARAMS.has(key)) {
+        parsed.searchParams.delete(key);
+      }
+    }
+
+    if (
+      profile === "pdf" &&
+      hostMatches(parsed.hostname, "arxiv.org") &&
+      parsed.pathname.startsWith("/abs/")
+    ) {
+      parsed = new URL(
+        `https://arxiv.org/pdf/${parsed.pathname.slice("/abs/".length)}`,
+      );
+    }
+
+    if (parsed.pathname !== "/" && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function categoryTypes(categories?: CategoryOption[]): Set<string> {
+  return new Set(
+    (categories ?? []).map(category =>
+      typeof category === "string" ? category : category.type,
+    ),
+  );
+}
+
+function requestedResearchSites(categories?: CategoryOption[]): string[] {
+  const sites: string[] = [];
+  for (const category of categories ?? []) {
+    if (
+      typeof category === "object" &&
+      category.type === "research" &&
+      category.sites
+    ) {
+      sites.push(...category.sites);
+    }
+  }
+  return sites;
+}
+
+function isGithubHost(hostname: string): boolean {
+  return [
+    "github.com",
+    "githubusercontent.com",
+    "raw.githubusercontent.com",
+  ].some(domain => hostMatches(hostname, domain));
+}
+
+function domainAllowed(
+  url: string,
+  includeDomains?: string[],
+  excludeDomains?: string[],
+): boolean {
+  const hostname = new URL(url).hostname;
+  if (excludeDomains?.some(domain => hostMatches(hostname, domain)) === true) {
+    return false;
+  }
+  return (
+    !includeDomains ||
+    includeDomains.length === 0 ||
+    includeDomains.some(domain => hostMatches(hostname, domain))
+  );
+}
+
+function categoryAllowed(url: string, categories?: CategoryOption[]): boolean {
+  const requested = categoryTypes(categories);
+  if (requested.size === 0) return true;
+  const parsed = new URL(url);
+  const customResearchSites = requestedResearchSites(categories);
+
+  return [...requested].some(category => {
+    if (category === "github") return isGithubHost(parsed.hostname);
+    if (category === "pdf") return isPdfLikeUrl(url);
+    if (category === "research") {
+      const domains =
+        customResearchSites.length > 0
+          ? customResearchSites
+          : [...RESEARCH_DOMAINS];
+      return domains.some(domain => hostMatches(parsed.hostname, domain));
+    }
+    return true;
+  });
+}
+
+function queryTokens(query: string): string[] {
+  return [
+    ...new Set(
+      query
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}._-]+/gu, " ")
+        .split(/\s+/)
+        .filter(token => token.length >= 3)
+        .filter(
+          token =>
+            !["site", "filetype", "with", "from", "that", "this"].includes(
+              token,
+            ),
+        ),
+    ),
+  ].slice(0, 20);
+}
+
+function trustScore(url: string): number {
+  const hostname = new URL(url).hostname;
+  if (isGithubHost(hostname)) return 5;
+  if ([...RESEARCH_DOMAINS].some(domain => hostMatches(hostname, domain))) {
+    return 4;
+  }
+  if (
+    hostname.startsWith("docs.") ||
+    hostname.startsWith("developer.") ||
+    hostname.startsWith("developers.")
+  ) {
+    return 3;
+  }
+  if (/resulthunter|resultsearch|redirect/i.test(hostname)) return -5;
+  return 0;
+}
+
+function resultScore(result: InternalWebSearchResult, query: string): number {
+  const haystack =
+    `${result.title} ${result.description} ${result.url}`.toLowerCase();
+  const tokens = queryTokens(query);
+  const overlap =
+    tokens.length === 0
+      ? 0
+      : tokens.filter(token => haystack.includes(token)).length / tokens.length;
+  const engineScore = Math.log1p(Math.max(0, result.__search?.score ?? 0));
+  const freshness = result.__search?.publishedDate ? 0.5 : 0;
+  return overlap * 10 + trustScore(result.url) + engineScore + freshness;
+}
+
+export function filterAndRankWebResults(
+  results: InternalWebSearchResult[],
+  options: {
+    query: string;
+    profiles: SearchProfileName[];
+    categories?: CategoryOption[];
+    includeDomains?: string[];
+    excludeDomains?: string[];
+  },
+): InternalWebSearchResult[] {
+  const seen = new Set<string>();
+  const normalized: InternalWebSearchResult[] = [];
+  const canonicalProfile =
+    options.profiles.length === 1 ? options.profiles[0] : undefined;
+
+  for (const result of results) {
+    const url = canonicalizeSearchUrl(result.url, canonicalProfile);
+    if (!url || seen.has(url)) continue;
+    if (
+      !domainAllowed(url, options.includeDomains, options.excludeDomains) ||
+      !categoryAllowed(url, options.categories)
+    ) {
+      continue;
+    }
+    seen.add(url);
+    normalized.push({ ...result, url });
+  }
+
+  return normalized
+    .map((result, index) => ({
+      result,
+      index,
+      score: resultScore(result, options.query),
+    }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map(({ result }, index) => ({ ...result, position: index + 1 }));
+}
+
+export function stripSearchDiagnostics(
+  results: InternalWebSearchResult[],
+): WebSearchResult[] {
+  return results.map(result => {
+    const { __search: _diagnostics, ...publicResult } = result;
+    return publicResult;
+  });
+}

--- a/apps/api/src/search/result-policy.ts
+++ b/apps/api/src/search/result-policy.ts
@@ -1,0 +1,14 @@
+export function isSuccessfulScrapedResult(result: any): boolean {
+  const statusCode = result.metadata?.statusCode;
+  if (
+    typeof statusCode === "number" &&
+    (statusCode < 200 || statusCode >= 400)
+  ) {
+    return false;
+  }
+  if (result.metadata?.error) return false;
+  return (
+    typeof statusCode === "number" ||
+    Boolean(result.markdown || result.html || result.rawHtml)
+  );
+}

--- a/apps/api/src/search/v2/index.ts
+++ b/apps/api/src/search/v2/index.ts
@@ -4,6 +4,13 @@ import { fire_engine_search_v2 } from "./fireEngine-v2";
 import { searxng_search } from "./searxng";
 import { ddgSearch } from "./ddgsearch";
 import { Logger } from "winston";
+import type { CategoryOption } from "../../lib/search-query-builder";
+import {
+  buildSearchProfileRequests,
+  profileNames,
+  resolveSearchProfiles,
+} from "../profiles";
+import type { InternalWebSearchResult } from "../quality";
 
 export async function search({
   query,
@@ -20,6 +27,8 @@ export async function search({
   timeout = 5000,
   type = undefined,
   enterprise = undefined,
+  routingQuery = undefined,
+  categories = undefined,
 }: {
   query: string;
   logger: Logger;
@@ -35,6 +44,8 @@ export async function search({
   timeout?: number;
   type?: SearchResultType | SearchResultType[];
   enterprise?: ("default" | "anon" | "zdr")[];
+  routingQuery?: string;
+  categories?: CategoryOption[];
 }): Promise<SearchV2Response> {
   try {
     if (config.FIRE_ENGINE_BETA_URL) {
@@ -54,16 +65,36 @@ export async function search({
     }
 
     if (config.SEARXNG_ENDPOINT) {
-      logger.info("Using searxng search");
-      const results = await searxng_search(query, {
-        num_results,
-        tbs,
-        filter,
-        lang,
-        country,
-        location,
+      const rawQuery = routingQuery ?? query;
+      const profiles = resolveSearchProfiles(rawQuery, categories);
+      const requests = profiles.flatMap(profile =>
+        buildSearchProfileRequests(rawQuery, profile),
+      );
+      logger.info("Using intent-routed SearXNG search", {
+        profiles: profileNames(profiles),
+        engineGroups: requests.map(request => request.engines),
       });
-      if (results.web && results.web.length > 0) return results;
+
+      const responses = await Promise.all(
+        requests.map(request =>
+          searxng_search(request.query, {
+            num_results,
+            tbs,
+            filter,
+            lang,
+            country,
+            location,
+            engines: request.engines,
+            profile: request.profile,
+            timeout,
+            logger,
+          }),
+        ),
+      );
+      const web = responses.flatMap(
+        response => (response.web ?? []) as InternalWebSearchResult[],
+      );
+      if (web.length > 0) return { web };
     }
 
     logger.info("Using DuckDuckGo search");

--- a/apps/api/src/search/v2/searxng.test.ts
+++ b/apps/api/src/search/v2/searxng.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import { config } from "../../config";
+import { searxng_search } from "./searxng";
+
+vi.mock("axios", () => ({
+  default: {
+    get: vi.fn(),
+    isAxiosError: (error: any) => error?.isAxiosError === true,
+  },
+}));
+
+const getMock = vi.mocked(axios.get);
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as any;
+
+describe("SearXNG adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    config.SEARXNG_ENDPOINT = "http://searxng.test";
+  });
+
+  it("passes the selected engine group and retains ranking diagnostics", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        results: [
+          {
+            url: "https://github.com/firecrawl/firecrawl",
+            title: "firecrawl/firecrawl",
+            content: "Web scraping API",
+            engine: "github",
+            engines: ["github"],
+            score: 4.2,
+            publishedDate: "2026-07-30T00:00:00Z",
+          },
+        ],
+        unresponsive_engines: [["gitlab", "timeout"]],
+      },
+    });
+
+    const result = await searxng_search("firecrawl", {
+      num_results: 5,
+      engines: ["github", "gitlab"],
+      profile: "developer",
+      logger,
+    });
+
+    expect(getMock).toHaveBeenCalledWith(
+      "http://searxng.test/search",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          q: "firecrawl",
+          engines: "github,gitlab",
+          categories: "",
+        }),
+        headers: expect.objectContaining({
+          "X-Forwarded-For": "127.0.0.1",
+        }),
+      }),
+    );
+    expect((result.web?.[0] as any).__search).toEqual({
+      engine: "github",
+      engines: ["github"],
+      score: 4.2,
+      publishedDate: "2026-07-30T00:00:00Z",
+      profile: "developer",
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      "SearXNG engine group completed",
+      expect.objectContaining({
+        unresponsiveEngines: [["gitlab", "timeout"]],
+      }),
+    );
+  });
+
+  it("retries one transient transport failure", async () => {
+    getMock
+      .mockRejectedValueOnce({ isAxiosError: true })
+      .mockResolvedValueOnce({ data: { results: [] } });
+
+    await searxng_search("firecrawl", {
+      num_results: 1,
+      engines: ["github"],
+      profile: "developer",
+      logger,
+    });
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Retrying transient SearXNG request failure",
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/api/src/search/v2/searxng.ts
+++ b/apps/api/src/search/v2/searxng.ts
@@ -1,7 +1,12 @@
 import axios from "axios";
 import { config } from "../../config";
-import { SearchV2Response, WebSearchResult } from "../../lib/entities";
-import { logger } from "../../lib/logger";
+import { SearchV2Response } from "../../lib/entities";
+import type { Logger } from "winston";
+import type {
+  InternalSearchDiagnostics,
+  InternalWebSearchResult,
+} from "../quality";
+import type { SearchProfileName } from "../profiles";
 
 interface SearchOptions {
   tbs?: string;
@@ -11,6 +16,53 @@ interface SearchOptions {
   location?: string;
   num_results: number;
   page?: number;
+  engines?: string[];
+  profile?: SearchProfileName;
+  timeout?: number;
+  logger: Logger;
+}
+
+interface SearxngResult {
+  url?: unknown;
+  title?: unknown;
+  content?: unknown;
+  engine?: unknown;
+  engines?: unknown;
+  score?: unknown;
+  publishedDate?: unknown;
+}
+
+interface SearxngResponse {
+  results?: SearxngResult[];
+  unresponsive_engines?: unknown;
+}
+
+function timeRangeFromTbs(tbs?: string): string | undefined {
+  if (!tbs) return undefined;
+  const value = tbs.toLowerCase();
+  if (value.includes("qdr:h") || value.includes("qdr:d")) return "day";
+  if (value.includes("qdr:w")) return "week";
+  if (value.includes("qdr:m")) return "month";
+  if (value.includes("qdr:y")) return "year";
+  return undefined;
+}
+
+function diagnosticsOf(
+  result: SearxngResult,
+  profile?: SearchProfileName,
+): InternalSearchDiagnostics {
+  return {
+    engine: typeof result.engine === "string" ? result.engine : undefined,
+    engines: Array.isArray(result.engines)
+      ? result.engines.filter((x): x is string => typeof x === "string")
+      : undefined,
+    score: typeof result.score === "number" ? result.score : undefined,
+    publishedDate:
+      typeof result.publishedDate === "string"
+        ? result.publishedDate
+        : undefined,
+    profile,
+  };
 }
 
 export async function searxng_search(
@@ -25,34 +77,85 @@ export async function searxng_search(
   const cleanedUrl = url.endsWith("/") ? url.slice(0, -1) : url;
   const finalUrl = cleanedUrl + "/search";
 
-  const fetchPage = async (page: number): Promise<WebSearchResult[]> => {
+  const fetchPage = async (
+    page: number,
+  ): Promise<InternalWebSearchResult[]> => {
     const params = {
       q: q,
       language: options.lang,
       // gl: options.country, //not possible with SearXNG
       // location: options.location, //not possible with SearXNG
       // num: options.num_results, //not possible with SearXNG
-      engines: config.SEARXNG_ENGINES ?? "",
-      categories: config.SEARXNG_CATEGORIES ?? "",
+      engines:
+        options.engines && options.engines.length > 0
+          ? options.engines.join(",")
+          : (config.SEARXNG_ENGINES ?? ""),
+      categories:
+        options.engines && options.engines.length > 0
+          ? ""
+          : (config.SEARXNG_CATEGORIES ?? ""),
+      time_range: timeRangeFromTbs(options.tbs),
       pageno: page,
       format: "json",
     };
 
-    const response = await axios.get(finalUrl, {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      params: params,
+    const startedAt = Date.now();
+    let response;
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        response = await axios.get(finalUrl, {
+          headers: {
+            "Content-Type": "application/json",
+            // SearXNG is private to the Compose network and its limiter is off,
+            // but the request parser still warns when neither forwarding
+            // header exists.
+            "X-Forwarded-For": "127.0.0.1",
+            "X-Real-IP": "127.0.0.1",
+          },
+          params: params,
+          timeout: Math.min(Math.max(options.timeout ?? 8000, 1000), 15000),
+        });
+        break;
+      } catch (error) {
+        const status = axios.isAxiosError(error)
+          ? error.response?.status
+          : undefined;
+        const transient =
+          status === undefined || status === 429 || status >= 500;
+        if (attempt >= 1 || !transient) throw error;
+        options.logger.warn("Retrying transient SearXNG request failure", {
+          profile: options.profile,
+          engines: options.engines,
+          status,
+        });
+      }
+    }
+
+    const data = response!.data as SearxngResponse;
+    const unresponsiveEngines = Array.isArray(data.unresponsive_engines)
+      ? data.unresponsive_engines
+      : [];
+
+    options.logger.info("SearXNG engine group completed", {
+      profile: options.profile,
+      engines: options.engines,
+      elapsedMs: Date.now() - startedAt,
+      resultCount: Array.isArray(data.results) ? data.results.length : 0,
+      unresponsiveEngines,
     });
 
-    const data = response.data;
-
     if (data && Array.isArray(data.results)) {
-      return data.results.map((a: any) => ({
-        url: a.url,
-        title: a.title,
-        description: a.content,
-      }));
+      return data.results.flatMap(a => {
+        if (typeof a.url !== "string" || typeof a.title !== "string") return [];
+        return [
+          {
+            url: a.url,
+            title: a.title,
+            description: typeof a.content === "string" ? a.content : "",
+            __search: diagnosticsOf(a, options.profile),
+          },
+        ];
+      });
     }
 
     return [];
@@ -67,7 +170,7 @@ export async function searxng_search(
       1,
       Math.ceil(requestedResults / resultsPerPage),
     );
-    let webResults: WebSearchResult[] = [];
+    let webResults: InternalWebSearchResult[] = [];
 
     for (let pageOffset = 0; pageOffset < pagesToFetch; pageOffset += 1) {
       const pageResults = await fetchPage(startPage + pageOffset);
@@ -86,7 +189,11 @@ export async function searxng_search(
         }
       : {};
   } catch (error) {
-    logger.error(`There was an error searching for content`, { error });
+    options.logger.error("SearXNG engine group failed", {
+      profile: options.profile,
+      engines: options.engines,
+      error,
+    });
     return {};
   }
 }

--- a/apps/api/src/services/logging/log_job.ts
+++ b/apps/api/src/services/logging/log_job.ts
@@ -22,6 +22,7 @@ import type { CostTracking } from "../../lib/cost-tracking";
 import type { Logger } from "winston";
 import { saveExtractResult } from "../../lib/extract/extract-redis";
 import { trackFirstSurfaceUse } from "../posthog";
+import { saveSelfHostedSearchFeedbackJob } from "../../lib/search-feedback-redis";
 configDotenv();
 
 const previewTeamId = "3adefd26-77ec-5968-8dcf-c94b5630d1de";
@@ -470,6 +471,24 @@ export async function logSearch(search: LoggedSearch, force: boolean = false) {
     search.zeroDataRetention || typeof search.options?.query !== "string"
       ? search.options
       : { ...search.options, query: sanitizeString(search.options.query) };
+
+  if (config.USE_DB_AUTHENTICATION !== true) {
+    try {
+      await saveSelfHostedSearchFeedbackJob({
+        id: search.id,
+        requestId: search.request_id,
+        teamId: search.team_id,
+        creditsCost: search.credits_cost,
+        createdAt: Date.now(),
+        isSuccessful: search.is_successful,
+        zeroDataRetention: search.zeroDataRetention,
+      });
+    } catch (error) {
+      logger.error("Failed to cache self-hosted search for feedback", {
+        error,
+      });
+    }
+  }
 
   await robustInsert(
     "searches",

--- a/apps/camoufox-service/Dockerfile
+++ b/apps/camoufox-service/Dockerfile
@@ -1,0 +1,71 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    DEBIAN_FRONTEND=noninteractive
+
+# Firefox runtime libraries, Xvfb for the virtual display, Mesa for software
+# WebGL, and a real font set. Fonts matter for the cloak: Camoufox picks a font
+# list matching the spoofed OS, and a container with almost no fonts installed
+# produces a measurably odd fingerprint.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      xvfb \
+      x11-utils \
+      libgtk-3-0 \
+      libx11-xcb1 \
+      libxt6 \
+      libxtst6 \
+      libxrandr2 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxcursor1 \
+      libxi6 \
+      libasound2 \
+      libdbus-glib-1-2 \
+      libpci3 \
+      libegl1 \
+      libgl1 \
+      libglx-mesa0 \
+      libgl1-mesa-dri \
+      libgbm1 \
+      libnss3 \
+      libnspr4 \
+      libpangocairo-1.0-0 \
+      fonts-liberation \
+      fonts-dejavu-core \
+      fonts-noto-core \
+      fonts-noto-color-emoji \
+      ca-certificates \
+      tzdata \
+      curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Pin the browser build too, not just the Python package. `camoufox fetch`
+# without a version follows a channel and would silently change the browser
+# (and its fingerprint) on any rebuild.
+ARG CAMOUFOX_BROWSER_VERSION=152.0.4-beta.28
+ENV CAMOUFOX_BROWSER_VERSION=${CAMOUFOX_BROWSER_VERSION}
+# `fetch` also pulls the MaxMind GeoLite2 databases that geoip=True needs, so
+# no separate download step is required.
+RUN python -m camoufox fetch "official/${CAMOUFOX_BROWSER_VERSION}" \
+    && python -m camoufox path
+
+COPY ssrf.py browser.py main.py entrypoint.sh ./
+COPY tests ./tests
+RUN chmod +x entrypoint.sh
+
+ENV PORT=3000 \
+    DISPLAY_NUM=99 \
+    SCREEN_GEOMETRY=1920x1080x24
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1
+
+CMD ["./entrypoint.sh"]

--- a/apps/camoufox-service/README.md
+++ b/apps/camoufox-service/README.md
@@ -1,0 +1,98 @@
+# Camoufox service
+
+A stealth browser-rendering service used as a **selective fallback**, not as a
+replacement for the Playwright/Chromium service.
+
+Firecrawl calls it only after an ordinary engine came back with anti-bot
+evidence, and at most once per scrape job. 404s, DNS failures, TLS errors,
+malformed URLs, unsupported downloads and ordinary parse failures never reach
+it. See `apps/api/src/scraper/scrapeURL/engines/camoufox/index.ts` for the gate
+and `apps/api/src/scraper/scrapeURL/lib/antibot.ts` for the classifier.
+
+## Contract
+
+Identical to `apps/playwright-service-ts`, so the scrape pipeline consumes both
+with the same code path:
+
+```
+POST /scrape
+  {url, wait_after_load?, timeout?, headers?, check_selector?, skip_tls_verification?}
+  -> {content, pageStatusCode, contentType?, pageError?}
+
+GET /health
+  -> {status, maxConcurrentPages, activePages, browserLaunches, pagesServed, connected}
+```
+
+One addition, which the Playwright contract has no field for:
+
+```
+POST /screenshot
+  {url, wait_after_load?, timeout?, full_page?}
+  -> {screenshot: <base64 PNG>, pageStatusCode, title, degraded?}
+```
+
+Nothing in the Firecrawl scrape path depends on `/screenshot`.
+
+## Pinned versions
+
+Both the Python package and the browser build are pinned. An unbounded
+`latest` would silently change the fingerprint — and therefore the detection
+profile — on every rebuild.
+
+| Component | Version | Where |
+|---|---|---|
+| `camoufox[geoip]` | `0.5.4` | `requirements.txt` |
+| `playwright` | `1.60.0` | `requirements.txt` (camoufox requires `<1.61`) |
+| `aiohttp` | `3.13.2` | `requirements.txt` |
+| Camoufox browser | `152.0.4-beta.28` | `Dockerfile` `ARG CAMOUFOX_BROWSER_VERSION` |
+
+To move the browser build:
+`docker compose build --build-arg CAMOUFOX_BROWSER_VERSION=<version> camoufox-service`
+
+## Cloak configuration
+
+Each setting answers a specific documented detection vector.
+
+| Setting | Default | Why |
+|---|---|---|
+| Own Xvfb at `1920x1080x24` | on | Camoufox's built-in `headless="virtual"` starts Xvfb with `-screen 0 1x1x24` ([camoufox#458](https://github.com/daijro/camoufox/issues/458)). A 1×1 screen is a blatant automation tell and a prime suspect in the "detected only inside Docker" reports ([camoufox#311](https://github.com/daijro/camoufox/issues/311)). We start our own display and hand Camoufox the number. |
+| Native headless | **never used** | The Camoufox docs state headless mode remains detectable and recommend a virtual display. |
+| Mesa software GL | installed | WebGL that returns *nothing* is a stronger signal than a spoofed renderer. |
+| `CAMOUFOX_OS` | `windows` | Windows dominates real desktop traffic; Camoufox keeps UA, platform, fonts and WebGL consistent with it. |
+| `CAMOUFOX_GEOIP` | `true` | Derives timezone/locale/geolocation from the real exit IP. An incoherent timezone-vs-IP pair is one of the cheapest checks a WAF runs. |
+| `CAMOUFOX_HUMANIZE` | `true` | Human-like cursor movement. Zero pointer/scroll activity is a documented reason to be escalated to an interactive challenge. |
+| `CAMOUFOX_FINGERPRINT_PRESET` | `true` | Uses real captured fingerprint presets instead of synthetic BrowserForge combinations. Camoufox's own stealth notes name internal *inconsistency* as the primary vulnerability. |
+| Caller `User-Agent` | ignored | Overriding just the UA reintroduces exactly the inconsistency that gets stealth browsers caught. Other headers are forwarded. |
+| Fresh `BrowserContext` per request | on | Per-job isolation of cookies and storage. The browser process is shared; contexts are not. |
+| WebRTC / WebGL blocking | off | Camoufox spoofs both; their conspicuous absence is easier to detect than a spoofed value. |
+
+## SSRF
+
+Two mandatory layers, in `ssrf.py`:
+
+1. `assert_safe_target_url` — runs before navigation and again for **every**
+   request the page makes, including redirects and subresources.
+2. `SsrfGuardProxy` — a loopback-only forward proxy the browser is pinned to.
+   The browser never resolves DNS or opens sockets itself. The proxy resolves
+   the name, refuses unless **every** returned address is globally routable,
+   then dials the exact address it validated. Pinning the dialled address is
+   what closes the DNS-rebinding window: there is no second lookup to poison.
+
+Blocked: loopback, link-local (incl. `169.254.169.254`), multicast, RFC1918,
+IPv6 unique-local, reserved, unspecified, CGNAT, and IPv4 addresses smuggled
+inside IPv6 (v4-mapped, 6to4, Teredo). Ports are limited to 80/443/8080/8443.
+
+**There is deliberately no `ALLOW_LOCAL_WEBHOOKS` escape hatch here.** That
+override exists on the Playwright service so the self-hosted test suite can
+scrape a local test site. Camoufox only ever runs against public sites that
+answered with an anti-bot challenge, so extending the override to this service
+would broaden it for no benefit.
+
+The container has no `ports:` mapping — it is reachable only from the API
+container on the Docker-internal `backend` network.
+
+## Tests
+
+```bash
+cd apps/camoufox-service && python -m unittest discover -s tests -v
+```

--- a/apps/camoufox-service/browser.py
+++ b/apps/camoufox-service/browser.py
@@ -1,0 +1,204 @@
+"""Camoufox browser lifecycle and cloak configuration.
+
+Cloak choices here are deliberate, and each one is answering a documented
+detection vector:
+
+* **Own Xvfb at 1920x1080, not ``headless="virtual"``.** Camoufox's bundled
+  virtual display hardcodes ``-screen 0 1x1x24`` (daijro/camoufox#458). A 1x1
+  screen is a blatant automation tell and is a prime suspect in the
+  "detected only inside Docker" reports (daijro/camoufox#311). We start our own
+  Xvfb at a normal desktop resolution and hand Camoufox the display number, so
+  the browser sees a plausible screen. Native headless mode is never used — the
+  Camoufox docs warn it stays detectable.
+* **Software GL present.** WebGL returning nothing is itself a signal; the
+  image ships Mesa so WebGL answers with a real (spoofed) renderer.
+* **``os="windows"`` by default.** Windows dominates real desktop traffic, and
+  Camoufox keeps UA, platform, fonts and WebGL internally consistent with it.
+* **``geoip=True``.** Locale/timezone/geolocation derived from the actual exit
+  IP. An incoherent timezone-vs-IP pair is one of the cheapest checks a WAF can
+  run.
+* **``humanize=True`` plus a short warm-up.** Zero mouse/scroll activity is a
+  documented reason for being forced into an interactive challenge.
+* **Fresh context per request, shared browser.** Contexts are cheap and give
+  per-job isolation (cookies, storage); relaunching the browser per job is not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from camoufox.async_api import AsyncCamoufox
+
+logger = logging.getLogger("camoufox.browser")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().upper() in ("1", "TRUE", "YES", "ON")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+MAX_CONCURRENT_PAGES = max(1, _env_int("MAX_CONCURRENT_PAGES", 2))
+NAVIGATION_TIMEOUT_MS = max(1000, _env_int("NAVIGATION_TIMEOUT_MS", 60000))
+BLOCK_MEDIA = _env_bool("BLOCK_MEDIA", False)
+HUMANIZE = _env_bool("CAMOUFOX_HUMANIZE", True)
+USE_GEOIP = _env_bool("CAMOUFOX_GEOIP", True)
+USE_FINGERPRINT_PRESET = _env_bool("CAMOUFOX_FINGERPRINT_PRESET", True)
+TARGET_OS = os.environ.get("CAMOUFOX_OS", "windows").strip() or "windows"
+VIRTUAL_DISPLAY = os.environ.get("DISPLAY", ":99")
+
+# Pages made per browser process before it is recycled. Bounds memory growth and
+# keeps a long-lived fingerprint from being reused indefinitely.
+MAX_PAGES_PER_BROWSER = max(1, _env_int("CAMOUFOX_MAX_PAGES_PER_BROWSER", 200))
+
+
+def build_launch_options() -> Dict[str, Any]:
+    """Assemble Camoufox launch options, dropping any this version lacks."""
+    options: Dict[str, Any] = {
+        # Never native headless: we supply a real X display instead.
+        "headless": False,
+        "virtual_display": VIRTUAL_DISPLAY,
+        "os": TARGET_OS,
+        "humanize": HUMANIZE,
+        "geoip": USE_GEOIP,
+        "block_images": BLOCK_MEDIA,
+        # Leave WebRTC and WebGL enabled: Camoufox spoofs both, and their
+        # conspicuous absence is easier to detect than a spoofed value.
+        "block_webrtc": False,
+        "block_webgl": False,
+        # No cross-job state.
+        "enable_cache": False,
+        "fingerprint_preset": USE_FINGERPRINT_PRESET,
+    }
+
+    # `fingerprint_preset` is recent; degrade gracefully on older packages
+    # rather than failing to launch.
+    try:
+        from camoufox.utils import launch_options as _camoufox_launch_options
+
+        supported = set(inspect.signature(_camoufox_launch_options).parameters)
+        unsupported = [k for k in options if k not in supported]
+        for key in unsupported:
+            logger.warning(
+                "Camoufox build does not support launch option %r; dropping it", key
+            )
+            options.pop(key)
+    except (ImportError, TypeError, ValueError) as exc:  # noqa: BLE001
+        logger.warning("Could not introspect Camoufox launch options: %s", exc)
+
+    return options
+
+
+class BrowserPool:
+    """Owns a single Camoufox browser, restarting it if it dies."""
+
+    def __init__(self, proxy_port: int) -> None:
+        self._proxy_port = proxy_port
+        self._manager: Optional[AsyncCamoufox] = None
+        self._browser: Any = None
+        self._lock = asyncio.Lock()
+        self._pages_served = 0
+        self.semaphore = asyncio.Semaphore(MAX_CONCURRENT_PAGES)
+        self.launches = 0
+
+    @property
+    def proxy_server(self) -> str:
+        return f"http://127.0.0.1:{self._proxy_port}"
+
+    async def _launch_locked(self) -> None:
+        options = build_launch_options()
+        # Pinning the browser to the loopback guard proxy is what keeps it from
+        # resolving DNS or opening sockets on its own.
+        options["proxy"] = {"server": self.proxy_server}
+        logger.info(
+            "Launching Camoufox (os=%s humanize=%s geoip=%s preset=%s display=%s)",
+            options.get("os"),
+            options.get("humanize"),
+            options.get("geoip"),
+            options.get("fingerprint_preset"),
+            options.get("virtual_display"),
+        )
+        manager = AsyncCamoufox(**options)
+        self._browser = await manager.__aenter__()
+        self._manager = manager
+        self._pages_served = 0
+        self.launches += 1
+
+    async def _shutdown_locked(self) -> None:
+        manager, self._manager, self._browser = self._manager, None, None
+        if manager is None:
+            return
+        try:
+            await manager.__aexit__(None, None, None)
+        except Exception as exc:  # noqa: BLE001 - teardown must not mask the real error
+            logger.warning("Error while shutting down Camoufox: %s", exc)
+
+    async def get_browser(self) -> Any:
+        async with self._lock:
+            # The caller already owns one semaphore slot. Recycle only when it
+            # is the sole active request; closing a browser with another live
+            # context is what produced pending-task and unretrieved-future
+            # warnings during fingerprint rotation.
+            active_requests = MAX_CONCURRENT_PAGES - self.semaphore._value  # noqa: SLF001
+            if (
+                self._browser is not None
+                and self._pages_served >= MAX_PAGES_PER_BROWSER
+                and active_requests <= 1
+            ):
+                logger.info(
+                    "Recycling Camoufox after %s pages", self._pages_served
+                )
+                await self._shutdown_locked()
+
+            if self._browser is not None and not self._browser.is_connected():
+                logger.warning("Camoufox browser disconnected; relaunching")
+                await self._shutdown_locked()
+
+            if self._browser is None:
+                await self._launch_locked()
+
+            self._pages_served += 1
+            return self._browser
+
+    async def ensure_healthy(self) -> bool:
+        """Launch if necessary and report transport health without a page.
+
+        Creating a randomized context in the health probe made liveness depend
+        on optional WebGL fingerprint data and raced active scrape contexts.
+        """
+        async with self._lock:
+            if self._browser is not None and not self._browser.is_connected():
+                await self._shutdown_locked()
+            if self._browser is None:
+                await self._launch_locked()
+            return bool(self._browser is not None and self._browser.is_connected())
+
+    async def restart(self) -> None:
+        """Force a clean relaunch after a crash."""
+        async with self._lock:
+            await self._shutdown_locked()
+
+    async def close(self) -> None:
+        async with self._lock:
+            await self._shutdown_locked()
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "maxConcurrentPages": MAX_CONCURRENT_PAGES,
+            "activePages": MAX_CONCURRENT_PAGES - self.semaphore._value,  # noqa: SLF001
+            "browserLaunches": self.launches,
+            "pagesServed": self._pages_served,
+            "connected": bool(self._browser is not None and self._browser.is_connected()),
+        }

--- a/apps/camoufox-service/entrypoint.sh
+++ b/apps/camoufox-service/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Start a real virtual display, then the service.
+#
+# Camoufox's own `headless="virtual"` mode spawns Xvfb with `-screen 0 1x1x24`
+# (daijro/camoufox#458). A 1x1 screen is an obvious automation tell and is the
+# leading suspect in the "Camoufox is detected only inside Docker" reports
+# (daijro/camoufox#311), so we run our own Xvfb at a normal desktop resolution
+# and hand Camoufox the display number instead.
+set -euo pipefail
+
+DISPLAY_NUM="${DISPLAY_NUM:-99}"
+SCREEN_GEOMETRY="${SCREEN_GEOMETRY:-1920x1080x24}"
+export DISPLAY=":${DISPLAY_NUM}"
+
+# Force Mesa software GL. WebGL that returns nothing at all is a stronger
+# signal than a spoofed renderer, so the container ships llvmpipe and Camoufox
+# spoofs the vendor/renderer strings on top of it.
+export __GLX_VENDOR_LIBRARY_NAME=mesa
+export LIBGL_ALWAYS_SOFTWARE=1
+export GDK_BACKEND=x11
+export MOZ_ENABLE_WAYLAND=0
+unset WAYLAND_DISPLAY || true
+
+cleanup() {
+  if [[ -n "${XVFB_PID:-}" ]] && kill -0 "$XVFB_PID" 2>/dev/null; then
+    kill "$XVFB_PID" 2>/dev/null || true
+    wait "$XVFB_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}" 2>/dev/null || true
+
+Xvfb "$DISPLAY" -screen 0 "$SCREEN_GEOMETRY" \
+  -ac -nolisten tcp \
+  +extension GLX +extension RANDR +extension RENDER \
+  >/dev/null 2>&1 &
+XVFB_PID=$!
+
+# Wait for the display socket rather than sleeping a fixed interval.
+for _ in $(seq 1 100); do
+  if [[ -S "/tmp/.X11-unix/X${DISPLAY_NUM}" ]]; then
+    break
+  fi
+  if ! kill -0 "$XVFB_PID" 2>/dev/null; then
+    echo "Xvfb exited before the display was ready" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if [[ ! -S "/tmp/.X11-unix/X${DISPLAY_NUM}" ]]; then
+  echo "Timed out waiting for Xvfb display ${DISPLAY}" >&2
+  exit 1
+fi
+
+echo "Xvfb ready on ${DISPLAY} (${SCREEN_GEOMETRY})"
+exec python -u main.py

--- a/apps/camoufox-service/main.py
+++ b/apps/camoufox-service/main.py
@@ -1,0 +1,556 @@
+"""Camoufox browser-rendering service.
+
+Speaks the same HTTP contract as ``apps/playwright-service-ts`` so the Firecrawl
+scrape pipeline can consume it with no extra parsing:
+
+    POST /scrape  {url, wait_after_load?, timeout?, headers?, check_selector?,
+                   skip_tls_verification?}
+              ->  {content, pageStatusCode, contentType?, pageError?}
+    GET  /health  -> {status, ...}
+
+Plus one endpoint the Playwright contract has no room for, since it cannot
+carry binary payloads:
+
+    POST /screenshot {url, wait_after_load?, timeout?, full_page?}
+              ->  {screenshot: <base64 PNG>, pageStatusCode, title, degraded?}
+
+It is a *fallback*: the API only calls it after an ordinary engine came back
+with anti-bot evidence, at most once per scrape job.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+from http import HTTPStatus
+from typing import Any, Dict, Optional
+from urllib.parse import urlsplit
+
+from aiohttp import web
+
+from browser import (
+    BLOCK_MEDIA,
+    NAVIGATION_TIMEOUT_MS,
+    BrowserPool,
+)
+from ssrf import InsecureConnectionError, SsrfGuardProxy, assert_safe_target_url
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger("camoufox.service")
+
+PORT = int(os.environ.get("PORT", "3000"))
+
+#: Navigation wait condition. `domcontentloaded` is the default deliberately —
+#: see the note in _scrape_page. Set to `load` or `networkidle` only if a target
+#: genuinely needs it.
+WAIT_UNTIL = os.environ.get("CAMOUFOX_WAIT_UNTIL", "domcontentloaded").strip()
+
+#: Settle delay after the wait condition, so client-rendered content lands.
+try:
+    SETTLE_MS = max(0, int(os.environ.get("CAMOUFOX_SETTLE_MS", "1200")))
+except ValueError:
+    SETTLE_MS = 1200
+
+MEDIA_EXTENSIONS = (
+    ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp",
+    ".mp3", ".mp4", ".avi", ".flac", ".ogg", ".wav", ".webm",
+)
+
+AD_SERVING_DOMAINS = (
+    "doubleclick.net",
+    "adservice.google.com",
+    "googlesyndication.com",
+    "googletagservices.com",
+    "googletagmanager.com",
+    "google-analytics.com",
+    "adsystem.com",
+    "adservice.com",
+    "adnxs.com",
+    "ads-twitter.com",
+    "facebook.net",
+    "fbcdn.net",
+    "amazon-adsystem.com",
+)
+
+STATUS_TEXT = {s.value: s.phrase for s in HTTPStatus}
+
+
+def get_error(status: Optional[int]) -> Optional[str]:
+    if status is None:
+        return "No response received"
+    if 200 <= status < 300:
+        return None
+    return STATUS_TEXT.get(status, f"HTTP {status}")
+
+
+class SecurityState:
+    """Records a navigation blocked by the route interceptor.
+
+    Playwright surfaces an aborted navigation as a generic ``page.goto`` failure,
+    so we stash the real reason here to report it accurately.
+    """
+
+    def __init__(self) -> None:
+        self.blocked_navigation_url: Optional[str] = None
+
+
+async def _install_route_guard(context: Any, state: SecurityState) -> None:
+    async def handler(route: Any, request: Any) -> None:
+        url = request.url
+        try:
+            # Cached: a single page can pull hundreds of subresources, and
+            # resolving each one inline blows the navigation deadline. The
+            # guard proxy still re-resolves for every real connection.
+            await assert_safe_target_url(url, use_cache=True)
+        except InsecureConnectionError as exc:
+            if request.is_navigation_request():
+                state.blocked_navigation_url = url
+            logger.warning("Blocked request: %s (%s)", url, exc.reason)
+            await route.abort("blockedbyclient")
+            return
+
+        host = (urlsplit(url).hostname or "").lower()
+        if any(domain in host for domain in AD_SERVING_DOMAINS):
+            await route.abort()
+            return
+
+        if BLOCK_MEDIA and any(
+            urlsplit(url).path.lower().endswith(ext) for ext in MEDIA_EXTENSIONS
+        ):
+            await route.abort()
+            return
+
+        await route.continue_()
+
+    await context.route("**/*", handler)
+
+
+async def _humanize_page(page: Any) -> None:
+    """Emit a little real-user activity.
+
+    A session with zero pointer or scroll events is a documented reason for bot
+    managers to escalate to an interactive challenge. Bounded and best-effort:
+    never let the warm-up fail a scrape.
+    """
+    try:
+        await page.mouse.move(360, 280)
+        await page.mouse.move(640, 420)
+        await page.evaluate("window.scrollBy(0, 320)")
+        await page.wait_for_timeout(180)
+        await page.evaluate("window.scrollTo(0, 0)")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Humanize warm-up skipped: %s", exc)
+
+
+def _cookie_domain(url: str) -> Optional[str]:
+    host = urlsplit(url).hostname
+    if not host:
+        return None
+    labels = host.split(".")
+    return ".".join(labels[-2:]) if len(labels) > 2 else host
+
+
+async def _scrape_page(
+    page: Any,
+    url: str,
+    wait_after_load: int,
+    timeout: int,
+    check_selector: Optional[str],
+    state: SecurityState,
+) -> Dict[str, Any]:
+    logger.info("Navigating to %s (timeout=%sms)", url, timeout)
+    salvaged = False
+    try:
+        # `domcontentloaded` rather than `load`. Waiting for `load` means
+        # waiting for every ad and tracker subresource; on commercial pages one
+        # of them routinely never settles, which burned the entire navigation
+        # budget and then left the DOM in a state `content()` could not
+        # serialise (observed: repeatable 90s timeouts on lovehoney.com).
+        # The settle delay below covers client-rendered content.
+        response = await page.goto(url, wait_until=WAIT_UNTIL, timeout=timeout)
+        if SETTLE_MS > 0:
+            await page.wait_for_timeout(SETTLE_MS)
+    except Exception:
+        if state.blocked_navigation_url:
+            raise InsecureConnectionError(
+                state.blocked_navigation_url,
+                "navigation to private/internal resource is not allowed",
+            )
+        # Ad-heavy commercial pages can keep the `load` event pending on a
+        # subresource that never settles. If navigation never committed that is
+        # a real failure; otherwise the document is already usable, and for a
+        # last-resort fallback a rendered page beats a timeout.
+        if page.url == "about:blank":
+            raise
+        logger.warning(
+            "Navigation did not reach 'load' for %s; using what rendered", url
+        )
+        # No Response object survives a goto timeout. The document committed,
+        # so report it as a normal 200 rather than "No response received".
+        response = None
+        salvaged = True
+
+    await _humanize_page(page)
+
+    if wait_after_load > 0:
+        await page.wait_for_timeout(wait_after_load)
+
+    if check_selector:
+        try:
+            await page.wait_for_selector(check_selector, timeout=timeout)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError("Required selector not found") from exc
+
+    # Bounded: serialising the DOM of a page that is still mutating can itself
+    # hang, and a wedged call here would pin a concurrency slot.
+    try:
+        content = await asyncio.wait_for(page.content(), timeout=30)
+    except Exception as exc:  # noqa: BLE001
+        # A late same-document/client redirect can briefly invalidate the
+        # execution context. Give navigation one bounded chance to settle.
+        message = str(exc).lower()
+        if not any(
+            marker in message
+            for marker in ("navigation", "execution context", "context was destroyed")
+        ):
+            raise
+        logger.info("DOM serialization raced navigation for %s; retrying once", url)
+        try:
+            await page.wait_for_load_state("domcontentloaded", timeout=3000)
+        except Exception:  # noqa: BLE001
+            await page.wait_for_timeout(250)
+        content = await asyncio.wait_for(page.content(), timeout=10)
+    content_type: Optional[str] = None
+    status: Optional[int] = None
+
+    if response is not None:
+        status = response.status
+        headers = await response.all_headers()
+        content_type = next(
+            (v for k, v in headers.items() if k.lower() == "content-type"), None
+        )
+        if content_type and (
+            "application/json" in content_type.lower()
+            or "text/plain" in content_type.lower()
+        ):
+            body = await response.body()
+            content = body.decode("utf-8", errors="replace")
+    elif salvaged:
+        status = 200
+
+    return {"content": content, "status": status, "contentType": content_type}
+
+
+async def handle_health(request: web.Request) -> web.Response:
+    pool: BrowserPool = request.app["pool"]
+    try:
+        if not await pool.ensure_healthy():
+            raise RuntimeError("browser transport is disconnected")
+        return web.json_response({"status": "healthy", **pool.stats()})
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Health check failed: %s", exc)
+        return web.json_response(
+            {"status": "unhealthy", "error": str(exc)}, status=503
+        )
+
+
+async def handle_scrape(request: web.Request) -> web.Response:
+    pool: BrowserPool = request.app["pool"]
+
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+    url = body.get("url")
+    wait_after_load = int(body.get("wait_after_load") or 0)
+    timeout = int(body.get("timeout") or NAVIGATION_TIMEOUT_MS)
+    timeout = max(1000, min(timeout, NAVIGATION_TIMEOUT_MS))
+    headers: Dict[str, str] = body.get("headers") or {}
+    check_selector = body.get("check_selector")
+    skip_tls_verification = bool(body.get("skip_tls_verification"))
+
+    if not url:
+        return web.json_response({"error": "URL is required"}, status=400)
+
+    logger.info("Scrape request: url=%s timeout=%s", url, timeout)
+
+    try:
+        await assert_safe_target_url(url)
+    except InsecureConnectionError as exc:
+        # Matches the Playwright service: a blocked target is a 403 page result,
+        # not a service error.
+        return web.json_response(
+            {"content": "", "pageStatusCode": 403, "pageError": str(exc)}
+        )
+
+    async with pool.semaphore:
+        context = None
+        page = None
+        try:
+            browser = await pool.get_browser()
+            state = SecurityState()
+            context = await browser.new_context(
+                ignore_https_errors=skip_tls_verification,
+                service_workers="block",
+            )
+            context.set_default_navigation_timeout(timeout)
+            await _install_route_guard(context, state)
+            page = await context.new_page()
+
+            # A caller-supplied User-Agent is deliberately ignored: Camoufox
+            # keeps UA, navigator, fonts and WebGL mutually consistent, and
+            # overriding just the UA reintroduces exactly the inconsistency
+            # that gets stealth browsers caught.
+            extra_headers = {
+                k: v
+                for k, v in headers.items()
+                if k.lower() not in ("user-agent", "cookie")
+            }
+            if "user-agent" in {k.lower() for k in headers}:
+                logger.info("Ignoring caller User-Agent to preserve fingerprint coherence")
+
+            cookie_header = next(
+                (v for k, v in headers.items() if k.lower() == "cookie"), None
+            )
+            if cookie_header:
+                domain = _cookie_domain(url)
+                cookies = []
+                for pair in cookie_header.split(";"):
+                    pair = pair.strip()
+                    if "=" not in pair:
+                        continue
+                    name, _, value = pair.partition("=")
+                    entry = {"name": name.strip(), "value": value.strip()}
+                    if domain:
+                        entry.update({"domain": f".{domain}", "path": "/"})
+                    else:
+                        entry["url"] = url
+                    cookies.append(entry)
+                if cookies:
+                    try:
+                        await context.add_cookies(cookies)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("Failed to seed cookies: %s", exc)
+
+            if extra_headers:
+                await page.set_extra_http_headers(extra_headers)
+
+            result = await asyncio.wait_for(
+                _scrape_page(
+                    page, url, wait_after_load, timeout, check_selector, state
+                ),
+                # Hard ceiling above the navigation timeout so a wedged page
+                # can never pin a concurrency slot indefinitely.
+                timeout=(timeout + wait_after_load) / 1000 + 30,
+            )
+
+            page_error = get_error(result["status"])
+            if page_error:
+                logger.info("Scrape returned status %s (%s)", result["status"], page_error)
+            else:
+                logger.info("Scrape successful (%s bytes)", len(result["content"]))
+
+            payload: Dict[str, Any] = {
+                "content": result["content"],
+                "pageStatusCode": result["status"],
+            }
+            if result["contentType"]:
+                payload["contentType"] = result["contentType"]
+            if page_error:
+                payload["pageError"] = page_error
+            return web.json_response(payload)
+
+        except InsecureConnectionError as exc:
+            return web.json_response(
+                {"content": "", "pageStatusCode": 403, "pageError": str(exc)}
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Scrape timed out for %s", url)
+            return web.json_response(
+                {"error": "Timed out while fetching the page."}, status=504
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Scrape error for %s: %s", url, exc)
+            # A dead browser process must not poison every later request.
+            message = str(exc).lower()
+            if any(
+                marker in message
+                for marker in ("target closed", "browser has been closed",
+                               "connection closed", "browser closed")
+            ):
+                logger.warning("Browser appears to have crashed; scheduling restart")
+                await pool.restart()
+            return web.json_response(
+                {"error": "An error occurred while fetching the page."}, status=500
+            )
+        finally:
+            # Contexts are the unit of isolation here; leaking one leaks a
+            # profile directory and its memory.
+            for closeable in (page, context):
+                if closeable is not None:
+                    try:
+                        await closeable.close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("Cleanup error: %s", exc)
+
+
+async def handle_screenshot(request: web.Request) -> web.Response:
+    """Capture a PNG of the target page.
+
+    Not part of the Playwright service contract — that response shape has no
+    field for binary data — so this is additive and nothing in the Firecrawl
+    scrape path depends on it. Same SSRF policy as /scrape.
+    """
+    pool: BrowserPool = request.app["pool"]
+
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+    url = body.get("url")
+    wait_after_load = int(body.get("wait_after_load") or 1000)
+    timeout = int(body.get("timeout") or NAVIGATION_TIMEOUT_MS)
+    timeout = max(1000, min(timeout, NAVIGATION_TIMEOUT_MS))
+    full_page = body.get("full_page")
+    full_page = True if full_page is None else bool(full_page)
+
+    if not url:
+        return web.json_response({"error": "URL is required"}, status=400)
+
+    try:
+        await assert_safe_target_url(url)
+    except InsecureConnectionError as exc:
+        return web.json_response(
+            {"error": str(exc), "pageStatusCode": 403}, status=403
+        )
+
+    async with pool.semaphore:
+        context = None
+        page = None
+        try:
+            browser = await pool.get_browser()
+            state = SecurityState()
+            context = await browser.new_context(service_workers="block")
+            context.set_default_navigation_timeout(timeout)
+            await _install_route_guard(context, state)
+            page = await context.new_page()
+
+            response = None
+            try:
+                # `domcontentloaded` rather than `load`: the load event can hang
+                # well past the timeout on ad/tracker subresources, and a
+                # settle delay after DOM ready is enough for a visual capture.
+                response = await page.goto(
+                    url, wait_until="domcontentloaded", timeout=timeout
+                )
+            except Exception:
+                if state.blocked_navigation_url:
+                    raise InsecureConnectionError(
+                        state.blocked_navigation_url,
+                        "navigation to private/internal resource is not allowed",
+                    )
+                # Still on about:blank means navigation never committed — a real
+                # failure. Otherwise the event simply never fired, so capture
+                # whatever did render.
+                if page.url == "about:blank":
+                    raise
+                logger.warning(
+                    "Navigation timed out but DOM committed for %s; capturing anyway",
+                    url,
+                )
+
+            await _humanize_page(page)
+            if wait_after_load > 0:
+                await page.wait_for_timeout(wait_after_load)
+
+            degraded = None
+            try:
+                image = await page.screenshot(
+                    full_page=full_page, type="png", timeout=timeout
+                )
+            except Exception as capture_error:  # noqa: BLE001
+                if not full_page:
+                    raise
+                # Full-page capture fails on very tall pages (Firefox surface
+                # size limits, or the capture timing out under memory
+                # pressure). A viewport shot beats a 500.
+                logger.warning(
+                    "Full-page capture failed for %s (%s); retrying viewport-only",
+                    url,
+                    capture_error,
+                )
+                image = await page.screenshot(
+                    full_page=False, type="png", timeout=min(timeout, 15000)
+                )
+                degraded = "full-page capture failed; captured viewport only"
+
+            payload: Dict[str, Any] = {
+                "screenshot": base64.b64encode(image).decode("ascii"),
+                "pageStatusCode": response.status if response is not None else 200,
+                "title": await page.title(),
+            }
+            if degraded:
+                payload["degraded"] = degraded
+            logger.info("Screenshot captured for %s (%s bytes)", url, len(image))
+            return web.json_response(payload)
+
+        except InsecureConnectionError as exc:
+            return web.json_response(
+                {"error": str(exc), "pageStatusCode": 403}, status=403
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Screenshot failed for %s: %s", url, exc)
+            message = str(exc).lower()
+            if any(
+                marker in message
+                for marker in ("target closed", "browser has been closed",
+                               "connection closed", "browser closed")
+            ):
+                await pool.restart()
+            return web.json_response(
+                {"error": "An error occurred while capturing the page."}, status=500
+            )
+        finally:
+            for closeable in (page, context):
+                if closeable is not None:
+                    try:
+                        await closeable.close()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("Cleanup error: %s", exc)
+
+
+async def _on_startup(app: web.Application) -> None:
+    proxy = SsrfGuardProxy()
+    port = await proxy.start()
+    app["proxy"] = proxy
+    app["pool"] = BrowserPool(proxy_port=port)
+
+
+async def _on_cleanup(app: web.Application) -> None:
+    pool: Optional[BrowserPool] = app.get("pool")
+    if pool is not None:
+        await pool.close()
+    proxy: Optional[SsrfGuardProxy] = app.get("proxy")
+    if proxy is not None:
+        await proxy.stop()
+
+
+def create_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", handle_health)
+    app.router.add_post("/scrape", handle_scrape)
+    app.router.add_post("/screenshot", handle_screenshot)
+    app.on_startup.append(_on_startup)
+    app.on_cleanup.append(_on_cleanup)
+    return app
+
+
+if __name__ == "__main__":
+    web.run_app(create_app(), host="0.0.0.0", port=PORT)  # noqa: S104

--- a/apps/camoufox-service/requirements.txt
+++ b/apps/camoufox-service/requirements.txt
@@ -1,0 +1,6 @@
+# Exact pins only — an unbounded `latest` here would silently change the
+# browser fingerprint (and therefore the detection profile) on every rebuild.
+camoufox[geoip]==0.5.4
+# camoufox requires playwright<1.61; pin the exact patch it was validated against.
+playwright==1.60.0
+aiohttp==3.13.2

--- a/apps/camoufox-service/ssrf.py
+++ b/apps/camoufox-service/ssrf.py
@@ -1,0 +1,419 @@
+"""SSRF controls for the Camoufox service.
+
+Two layers, both mandatory:
+
+1. ``assert_safe_target_url`` — checked before navigation and again for every
+   request the page makes (including redirects and subresources).
+2. ``SsrfGuardProxy`` — a loopback-only forward proxy the browser is pinned to.
+   Because the browser never resolves DNS or opens sockets itself, this is the
+   layer that actually enforces the policy: the proxy resolves the name, rejects
+   the connection unless *every* returned address is globally routable, and then
+   dials the exact address it validated. Pinning the dialled address is what
+   closes the DNS-rebinding window — there is no second lookup to poison.
+
+Unlike the Playwright service there is no ``ALLOW_LOCAL_WEBHOOKS`` escape hatch
+here. Camoufox exists to retry public sites that answered with an anti-bot
+challenge; it has no legitimate reason to reach a private address, so the
+override is deliberately not extended to this service.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+import time
+from typing import List, Optional, Tuple
+from urllib.parse import urlsplit
+
+logger = logging.getLogger("camoufox.ssrf")
+
+ALLOWED_SCHEMES = ("http", "https")
+
+# Only these ports may be tunnelled. Keeps the proxy from being used to reach
+# arbitrary TCP services even on a globally routable address.
+ALLOWED_PORTS = (80, 443, 8080, 8443)
+
+
+class InsecureConnectionError(Exception):
+    """Raised when a target fails the SSRF policy."""
+
+    def __init__(self, blocked_url: str, reason: str) -> None:
+        super().__init__(f'Blocked insecure target URL "{blocked_url}": {reason}')
+        self.blocked_url = blocked_url
+        self.reason = reason
+
+
+def is_global_address(raw: str) -> bool:
+    """True only for addresses that are safe to dial from inside the network.
+
+    Rejects loopback, link-local (including 169.254.169.254 cloud metadata),
+    multicast, private/RFC1918, unique-local, reserved, unspecified and
+    carrier-grade NAT space, in both IPv4 and IPv6. IPv6 forms that embed an
+    IPv4 address (v4-mapped, 6to4, Teredo) are unwrapped and re-checked so they
+    cannot be used to smuggle a private destination.
+    """
+    try:
+        addr = ipaddress.ip_address(raw)
+    except ValueError:
+        return False
+
+    if addr.version == 6:
+        mapped = addr.ipv4_mapped
+        if mapped is not None:
+            return is_global_address(str(mapped))
+        sixtofour = getattr(addr, "sixtofour", None)
+        if sixtofour is not None:
+            return is_global_address(str(sixtofour))
+        teredo = getattr(addr, "teredo", None)
+        if teredo is not None:
+            return all(is_global_address(str(part)) for part in teredo)
+
+    if (
+        addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_private
+        or addr.is_reserved
+        or addr.is_unspecified
+    ):
+        return False
+
+    # `is_global` also excludes shared address space (100.64.0.0/10) and the
+    # various IANA special-purpose ranges.
+    return bool(addr.is_global)
+
+
+async def resolve_global_addresses(hostname: str, port: int) -> List[Tuple[int, str]]:
+    """Resolve ``hostname`` and return ``(family, address)`` pairs.
+
+    Raises if the name does not resolve, or if *any* returned address is not
+    globally routable. Failing on any bad record — rather than filtering them
+    out — stops a hostile resolver from mixing one public answer in with a
+    private one to get past the check.
+    """
+    host = hostname.strip().strip("[]").lower().rstrip(".")
+    if not host:
+        raise InsecureConnectionError(hostname, "empty hostname")
+
+    # Literal IPs skip DNS entirely.
+    try:
+        ipaddress.ip_address(host)
+        if not is_global_address(host):
+            raise InsecureConnectionError(
+                hostname, "resolves to a private/internal address"
+            )
+        family = (
+            socket.AF_INET6 if ipaddress.ip_address(host).version == 6 else socket.AF_INET
+        )
+        return [(family, host)]
+    except ValueError:
+        pass
+
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise InsecureConnectionError(hostname, f"DNS resolution failed: {exc}") from exc
+
+    if not infos:
+        raise InsecureConnectionError(hostname, "DNS resolution returned no addresses")
+
+    resolved: List[Tuple[int, str]] = []
+    for family, _type, _proto, _canon, sockaddr in infos:
+        address = sockaddr[0]
+        if not is_global_address(address):
+            raise InsecureConnectionError(
+                hostname, "resolves to a private/internal address"
+            )
+        resolved.append((family, address))
+
+    return resolved
+
+
+#: Short-lived cache of (host, port) -> verdict for the *route interceptor*.
+#:
+#: A commercial page pulls hundreds of subresources, and resolving every one of
+#: them inline made navigation miss its deadline (a real 504 observed on
+#: lovehoney.com). Caching is safe here because the route guard is
+#: defence-in-depth, not the enforcing layer: SsrfGuardProxy re-resolves on
+#: every actual connection and pins the address it validated, so a stale
+#: positive here cannot turn into a connection to a private address.
+_VERDICT_TTL_SECONDS = 60.0
+_verdict_cache: dict[tuple[str, int], tuple[float, Optional[str]]] = {}
+
+
+def _cache_get(key: Tuple[str, int], now: float) -> Optional[Tuple[bool, Optional[str]]]:
+    entry = _verdict_cache.get(key)
+    if entry is None:
+        return None
+    expires_at, reason = entry
+    if expires_at < now:
+        _verdict_cache.pop(key, None)
+        return None
+    return (reason is None, reason)
+
+
+def _cache_put(key: Tuple[str, int], reason: Optional[str], now: float) -> None:
+    if len(_verdict_cache) > 4096:
+        _verdict_cache.clear()
+    _verdict_cache[key] = (now + _VERDICT_TTL_SECONDS, reason)
+
+
+async def assert_safe_target_url(url: str, *, use_cache: bool = False) -> None:
+    """Validate scheme, port and resolved addresses for ``url``.
+
+    ``use_cache`` is for the high-volume route interceptor only. The proxy and
+    the pre-navigation check always resolve for real.
+    """
+    # urlsplit itself raises on some malformed inputs (e.g. an unterminated
+    # IPv6 literal), so parsing has to be guarded too.
+    try:
+        parts = urlsplit(url)
+    except ValueError as exc:
+        raise InsecureConnectionError(url, f"URL is invalid: {exc}") from exc
+
+    if parts.scheme not in ALLOWED_SCHEMES:
+        raise InsecureConnectionError(url, f'unsupported protocol "{parts.scheme}:"')
+
+    try:
+        hostname = parts.hostname
+    except ValueError as exc:
+        raise InsecureConnectionError(url, f"URL is invalid: {exc}") from exc
+
+    if not hostname:
+        raise InsecureConnectionError(url, "URL is invalid")
+
+    try:
+        port = parts.port or (443 if parts.scheme == "https" else 80)
+    except ValueError as exc:
+        raise InsecureConnectionError(url, f"invalid port: {exc}") from exc
+
+    if port not in ALLOWED_PORTS:
+        raise InsecureConnectionError(url, f"port {port} is not allowed")
+
+    key = (hostname.strip().strip("[]").lower().rstrip("."), port)
+    now = time.monotonic()
+
+    if use_cache:
+        cached = _cache_get(key, now)
+        if cached is not None:
+            allowed, reason = cached
+            if allowed:
+                return
+            raise InsecureConnectionError(url, reason or "blocked by policy")
+
+    try:
+        await resolve_global_addresses(hostname, port)
+    except InsecureConnectionError as exc:
+        if use_cache:
+            _cache_put(key, exc.reason, now)
+        raise
+
+    if use_cache:
+        _cache_put(key, None, now)
+
+
+async def _pump(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            writer.write(chunk)
+            await writer.drain()
+    except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
+        pass
+    finally:
+        if not writer.is_closing():
+            try:
+                writer.write_eof()
+            except (OSError, RuntimeError):
+                pass
+
+
+class SsrfGuardProxy:
+    """Loopback HTTP/HTTPS forward proxy that enforces the SSRF policy."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 0) -> None:
+        self._host = host
+        self._requested_port = port
+        self._server: asyncio.AbstractServer | None = None
+        self.port: int = 0
+        self.blocked_count = 0
+        self._client_tasks: set[asyncio.Task[None]] = set()
+        self._client_writers: set[asyncio.StreamWriter] = set()
+
+    def _accept_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        task = asyncio.create_task(self._handle_client(reader, writer))
+        self._client_tasks.add(task)
+        task.add_done_callback(self._client_tasks.discard)
+
+    async def start(self) -> int:
+        self._server = await asyncio.start_server(
+            self._accept_client, self._host, self._requested_port
+        )
+        self.port = self._server.sockets[0].getsockname()[1]
+        logger.info("SSRF guard proxy listening on %s:%s", self._host, self.port)
+        return self.port
+
+    async def stop(self) -> None:
+        server, self._server = self._server, None
+        if server is not None:
+            server.close()
+        for writer in list(self._client_writers):
+            if not writer.is_closing():
+                writer.close()
+        tasks = list(self._client_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._client_tasks.clear()
+        if server is not None:
+            await server.wait_closed()
+        for writer in list(self._client_writers):
+            try:
+                await writer.wait_closed()
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                pass
+        self._client_writers.clear()
+
+    async def _deny(
+        self, writer: asyncio.StreamWriter, target: str, reason: str
+    ) -> None:
+        self.blocked_count += 1
+        logger.warning("SSRF guard blocked %s: %s", target, reason)
+        body = b"Blocked: target violates SSRF policy"
+        writer.write(
+            b"HTTP/1.1 403 Forbidden\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+            b"Connection: close\r\n\r\n" + body
+        )
+        try:
+            await writer.drain()
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+
+    async def _connect_validated(
+        self, hostname: str, port: int
+    ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        """Dial the exact address that passed validation (no re-resolution)."""
+        addresses = await resolve_global_addresses(hostname, port)
+        last_error: Exception | None = None
+        for _family, address in addresses:
+            try:
+                # Per-address, and deliberately short: a name with several A
+                # records would otherwise stack one full timeout per record and
+                # stall the page far past its navigation budget.
+                return await asyncio.wait_for(
+                    asyncio.open_connection(host=address, port=port), timeout=10
+                )
+            except (OSError, asyncio.TimeoutError) as exc:
+                last_error = exc
+        raise InsecureConnectionError(
+            hostname, f"could not connect to any validated address: {last_error}"
+        )
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self._client_writers.add(writer)
+        upstream_writer: asyncio.StreamWriter | None = None
+        try:
+            head = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=30)
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError,
+                asyncio.TimeoutError, ConnectionResetError):
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                pass
+            self._client_writers.discard(writer)
+            return
+
+        try:
+            request_line, _, header_block = head.partition(b"\r\n")
+            parts = request_line.decode("latin-1").split()
+            if len(parts) != 3:
+                await self._deny(writer, "<malformed>", "malformed request line")
+                return
+            method, target, version = parts
+
+            if method.upper() == "CONNECT":
+                host, _, raw_port = target.rpartition(":")
+                host = host.strip("[]")
+                try:
+                    port = int(raw_port)
+                except ValueError:
+                    await self._deny(writer, target, "malformed CONNECT target")
+                    return
+                if port not in ALLOWED_PORTS:
+                    await self._deny(writer, target, f"port {port} is not allowed")
+                    return
+
+                upstream_reader, upstream_writer = await self._connect_validated(
+                    host, port
+                )
+                writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                await writer.drain()
+                await asyncio.gather(
+                    _pump(reader, upstream_writer),
+                    _pump(upstream_reader, writer),
+                    return_exceptions=True,
+                )
+                return
+
+            # Plain HTTP arrives in absolute form: `GET http://host/path HTTP/1.1`
+            split = urlsplit(target)
+            if split.scheme not in ALLOWED_SCHEMES or not split.hostname:
+                await self._deny(writer, target, "unsupported or malformed absolute URI")
+                return
+            port = split.port or (443 if split.scheme == "https" else 80)
+            if port not in ALLOWED_PORTS:
+                await self._deny(writer, target, f"port {port} is not allowed")
+                return
+
+            upstream_reader, upstream_writer = await self._connect_validated(
+                split.hostname, port
+            )
+
+            origin_form = split.path or "/"
+            if split.query:
+                origin_form += "?" + split.query
+            rebuilt = f"{method} {origin_form} {version}\r\n".encode("latin-1")
+
+            # Drop hop-by-hop proxy headers before forwarding.
+            forwarded_headers = b"\r\n".join(
+                line
+                for line in header_block.split(b"\r\n")
+                if not line.lower().startswith(b"proxy-connection:")
+            )
+            upstream_writer.write(rebuilt + forwarded_headers)
+            await upstream_writer.drain()
+
+            await asyncio.gather(
+                _pump(reader, upstream_writer),
+                _pump(upstream_reader, writer),
+                return_exceptions=True,
+            )
+        except InsecureConnectionError as exc:
+            await self._deny(writer, exc.blocked_url, exc.reason)
+        except Exception as exc:  # noqa: BLE001 - proxy must never crash the service
+            logger.warning("SSRF guard proxy error: %s", exc)
+            try:
+                await self._deny(writer, "<error>", str(exc))
+            except Exception:  # noqa: BLE001
+                pass
+        finally:
+            for w in (upstream_writer, writer):
+                if w is not None and not w.is_closing():
+                    try:
+                        w.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+            self._client_writers.discard(writer)

--- a/apps/camoufox-service/tests/test_ssrf.py
+++ b/apps/camoufox-service/tests/test_ssrf.py
@@ -1,0 +1,227 @@
+"""SSRF policy tests for the Camoufox service.
+
+Run with:  python -m unittest discover -s tests -v
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ssrf import (  # noqa: E402
+    InsecureConnectionError,
+    SsrfGuardProxy,
+    assert_safe_target_url,
+    is_global_address,
+    resolve_global_addresses,
+)
+
+
+class TestAddressClassification(unittest.TestCase):
+    def test_blocks_loopback(self):
+        for addr in ("127.0.0.1", "127.1.2.3", "::1"):
+            self.assertFalse(is_global_address(addr), addr)
+
+    def test_blocks_cloud_metadata_and_link_local(self):
+        for addr in ("169.254.169.254", "169.254.0.1", "fe80::1", "fe80::a00:27ff:fe4e:66a1"):
+            self.assertFalse(is_global_address(addr), addr)
+
+    def test_blocks_rfc1918(self):
+        for addr in ("10.0.0.1", "10.255.255.255", "172.16.0.1", "172.31.255.254",
+                     "192.168.0.1", "192.168.0.107"):
+            self.assertFalse(is_global_address(addr), addr)
+
+    def test_blocks_ipv6_unique_local_and_unspecified(self):
+        for addr in ("fc00::1", "fd12:3456:789a::1", "::", "0.0.0.0"):
+            self.assertFalse(is_global_address(addr), addr)
+
+    def test_blocks_multicast_reserved_and_cgnat(self):
+        for addr in ("224.0.0.1", "239.255.255.255", "ff02::1",
+                     "240.0.0.1", "100.64.0.1"):
+            self.assertFalse(is_global_address(addr), addr)
+
+    def test_blocks_ipv4_embedded_in_ipv6(self):
+        # v4-mapped, 6to4 and Teredo must not smuggle a private destination past
+        # the check by wearing an IPv6 costume.
+        for addr in ("::ffff:127.0.0.1", "::ffff:169.254.169.254",
+                     "::ffff:192.168.1.1", "2002:c0a8:0101::1"):
+            self.assertFalse(is_global_address(addr), addr)
+
+    def test_allows_public(self):
+        for addr in ("1.1.1.1", "8.8.8.8", "93.184.216.34", "2606:4700:4700::1111"):
+            self.assertTrue(is_global_address(addr), addr)
+
+    def test_rejects_garbage(self):
+        for addr in ("", "not-an-ip", "999.999.999.999", "127.0.0.1.1"):
+            self.assertFalse(is_global_address(addr), addr)
+
+
+class TestAssertSafeTargetUrl(unittest.IsolatedAsyncioTestCase):
+    async def test_rejects_non_http_schemes(self):
+        for url in ("file:///etc/passwd", "gopher://x/", "ftp://example.com/",
+                    "data:text/html,hi", "javascript:alert(1)"):
+            with self.assertRaises(InsecureConnectionError, msg=url):
+                await assert_safe_target_url(url)
+
+    async def test_rejects_malformed(self):
+        for url in ("", "http://", "not a url", "http://[::"):
+            with self.assertRaises(InsecureConnectionError, msg=url):
+                await assert_safe_target_url(url)
+
+    async def test_rejects_literal_private_hosts(self):
+        for url in (
+            "http://127.0.0.1/",
+            "http://127.0.0.1:8080/admin",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://192.168.0.107:3002/v2/scrape",
+            "http://10.0.0.5/",
+            "http://172.17.0.1/",
+            "http://[::1]/",
+            "http://[fe80::1]/",
+        ):
+            with self.assertRaises(InsecureConnectionError, msg=url):
+                await assert_safe_target_url(url)
+
+    async def test_rejects_disallowed_port(self):
+        # Globally routable, but not a web port.
+        with self.assertRaises(InsecureConnectionError):
+            await assert_safe_target_url("http://1.1.1.1:22/")
+
+    async def test_public_name_resolving_to_private_ip_is_blocked(self):
+        """The classic bypass: a public hostname whose A record points inward."""
+
+        async def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("10.0.0.7", port))]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            with self.assertRaises(InsecureConnectionError) as ctx:
+                await assert_safe_target_url("https://totally-public.example.com/")
+        self.assertIn("private/internal", str(ctx.exception))
+
+    async def test_mixed_public_and_private_records_are_blocked(self):
+        """One private record poisons the whole name.
+
+        Rejecting the name outright — rather than filtering to the public
+        record — is what stops a hostile resolver from mixing a good answer in
+        with a bad one to win the race.
+        """
+
+        async def fake_getaddrinfo(host, port, **kwargs):
+            return [
+                (2, 1, 6, "", ("93.184.216.34", port)),
+                (2, 1, 6, "", ("127.0.0.1", port)),
+            ]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            with self.assertRaises(InsecureConnectionError):
+                await assert_safe_target_url("https://rebinding.example.com/")
+
+    async def test_dns_failure_is_blocked_not_allowed(self):
+        import socket
+
+        async def fake_getaddrinfo(host, port, **kwargs):
+            raise socket.gaierror("NXDOMAIN")
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            with self.assertRaises(InsecureConnectionError):
+                await assert_safe_target_url("https://nonexistent.invalid/")
+
+    async def test_allows_public_host(self):
+        async def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("93.184.216.34", port))]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            await assert_safe_target_url("https://example.com/some/path")
+
+    async def test_resolution_returns_validated_addresses(self):
+        async def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("93.184.216.34", port))]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            resolved = await resolve_global_addresses("example.com", 443)
+        self.assertEqual([addr for _f, addr in resolved], ["93.184.216.34"])
+
+
+class TestRouteGuardCache(unittest.IsolatedAsyncioTestCase):
+    """The cache is a latency fix for the route interceptor only."""
+
+    def setUp(self):
+        import ssrf
+
+        ssrf._verdict_cache.clear()
+
+    async def test_cache_avoids_repeat_resolution(self):
+        calls = 0
+
+        async def fake_getaddrinfo(host, port, **kwargs):
+            nonlocal calls
+            calls += 1
+            return [(2, 1, 6, "", ("93.184.216.34", port))]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            for _ in range(5):
+                await assert_safe_target_url(
+                    "https://example.com/asset.js", use_cache=True
+                )
+        self.assertEqual(calls, 1)
+
+    async def test_cache_is_off_by_default(self):
+        """Pre-navigation and proxy paths must always resolve for real."""
+        calls = 0
+
+        async def fake_getaddrinfo(host, port, **kwargs):
+            nonlocal calls
+            calls += 1
+            return [(2, 1, 6, "", ("93.184.216.34", port))]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            for _ in range(3):
+                await assert_safe_target_url("https://example.com/")
+        self.assertEqual(calls, 3)
+
+    async def test_blocked_verdicts_are_cached_as_blocked(self):
+        """A cached negative must keep blocking, never flip open."""
+
+        async def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("10.0.0.7", port))]
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(loop, "getaddrinfo", side_effect=fake_getaddrinfo):
+            with self.assertRaises(InsecureConnectionError):
+                await assert_safe_target_url("https://internal.example/", use_cache=True)
+            # Second call is served from cache and must still raise.
+            with self.assertRaises(InsecureConnectionError):
+                await assert_safe_target_url("https://internal.example/", use_cache=True)
+
+
+class TestProxyLifecycle(unittest.IsolatedAsyncioTestCase):
+    async def test_stop_closes_idle_clients_and_drains_handler_tasks(self):
+        proxy = SsrfGuardProxy()
+        await proxy.start()
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        await asyncio.sleep(0)
+
+        self.assertEqual(len(proxy._client_tasks), 1)
+        self.assertEqual(len(proxy._client_writers), 1)
+
+        await proxy.stop()
+
+        self.assertEqual(proxy._client_tasks, set())
+        self.assertEqual(proxy._client_writers, set())
+        self.assertEqual(await asyncio.wait_for(reader.read(1), timeout=1), b"")
+        writer.close()
+        await writer.wait_closed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,106 @@
+# Local self-host overrides.
+#
+# 1. Adds SearXNG as Firecrawl's /search backend (SEARXNG_ENDPOINT in .env).
+# 2. Parks the experimental FoundationDB services behind a profile so they
+#    don't start — upstream leaves them profile-less, so a plain
+#    `docker compose up` would boot a queue backend we aren't using
+#    (NUQ_BACKEND is unset, so the API talks to nuq-postgres).
+services:
+  searxng:
+    image: docker.io/searxng/searxng:latest
+    container_name: firecrawl-searxng
+    restart: unless-stopped
+    networks:
+      - backend
+    ports:
+      # 8080 on this host is taken by Bifrost; SearXNG's UI lands on 8999.
+      - "127.0.0.1:8999:8080"
+    volumes:
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+      - ./searxng/limiter.toml:/etc/searxng/limiter.toml:ro
+      - ./searxng/github_authenticated.py:/usr/local/searxng/searx/engines/github_authenticated.py:ro
+      - ./searxng/braveapi_authenticated.py:/usr/local/searxng/searx/engines/braveapi_authenticated.py:ro
+      - searxng-data:/var/cache/searxng:rw
+    environment:
+      SEARXNG_BASE_URL: http://localhost:8999/
+      SEARXNG_GITHUB_TOKEN: ${SEARXNG_GITHUB_TOKEN}
+      SEARXNG_BRAVE_API_KEY: ${SEARXNG_BRAVE_API_KEY:-}
+      SEARXNG_BRAVE_MIN_INTERVAL_SECONDS: ${SEARXNG_BRAVE_MIN_INTERVAL_SECONDS:-2.1}
+      SEARXNG_BRAVE_MAX_QUEUE_SECONDS: ${SEARXNG_BRAVE_MAX_QUEUE_SECONDS:-4.5}
+      BIND_ADDRESS: "[::]:8080"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- --header='X-Forwarded-For: 127.0.0.1' --header='X-Real-IP: 127.0.0.1' http://127.0.0.1:8080/config >/dev/null",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "2"
+
+  # 3. Restart policies. Upstream leaves these unset, so a container that dies
+  #    (or a host reboot) leaves the stack down until someone notices. This is a
+  #    long-running self-hosted deployment, so every service comes back on its
+  #    own; `unless-stopped` still respects a deliberate `docker compose stop`.
+  api:
+    restart: unless-stopped
+    depends_on:
+      searxng:
+        condition: service_healthy
+      # Upstream omits this, so the API races Postgres on a cold start and its
+      # nuq-prefetch-worker dies on `getaddrinfo ENOTFOUND nuq-postgres`,
+      # taking the whole harness down with it.
+      nuq-postgres:
+        condition: service_healthy
+
+  playwright-service:
+    restart: unless-stopped
+
+  camoufox-service:
+    restart: unless-stopped
+
+  playwright-proxy-service:
+    restart: unless-stopped
+
+  flaresolverr:
+    restart: unless-stopped
+
+  redis:
+    restart: unless-stopped
+
+  rabbitmq:
+    restart: unless-stopped
+
+  nuq-postgres:
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U $${POSTGRES_USER:-postgres} -d $${POSTGRES_DB:-postgres}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  foundationdb:
+    profiles: ["fdb"]
+
+  foundationdb-init:
+    profiles: ["fdb"]
+
+volumes:
+  searxng-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,9 +22,10 @@ x-common-service: &common-service
       compress: "true"
 
 x-common-env: &common-env
-  REDIS_URL: ${REDIS_URL:-redis://redis:6379}
-  REDIS_RATE_LIMIT_URL: ${REDIS_RATE_LIMIT_URL:-${REDIS_URL:-redis://redis:6379}}
+  REDIS_URL: ${REDIS_URL:-redis://:${REDIS_PASSWORD:-}@redis:6379}
+  REDIS_RATE_LIMIT_URL: ${REDIS_RATE_LIMIT_URL:-${REDIS_URL:-redis://:${REDIS_PASSWORD:-}@redis:6379}}
   PLAYWRIGHT_MICROSERVICE_URL: ${PLAYWRIGHT_MICROSERVICE_URL:-http://playwright-service:3000/scrape}
+  PLAYWRIGHT_PROXY_MICROSERVICE_URL: ${PLAYWRIGHT_PROXY_MICROSERVICE_URL:-}
   POSTGRES_USER: ${POSTGRES_USER:-postgres}
   POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
   POSTGRES_DB: ${POSTGRES_DB:-postgres}
@@ -35,29 +36,52 @@ x-common-env: &common-env
   CRAWL_CONCURRENT_REQUESTS: ${CRAWL_CONCURRENT_REQUESTS:-10}
   MAX_CONCURRENT_JOBS: ${MAX_CONCURRENT_JOBS:-5}
   BROWSER_POOL_SIZE: ${BROWSER_POOL_SIZE:-5}
-  OPENAI_API_KEY: ${OPENAI_API_KEY}
-  OPENAI_BASE_URL: ${OPENAI_BASE_URL}
-  MODEL_NAME: ${MODEL_NAME}
-  MODEL_EMBEDDING_NAME: ${MODEL_EMBEDDING_NAME}
-  OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
-  AUTUMN_SECRET_KEY: ${AUTUMN_SECRET_KEY}
-  SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
-  BULL_AUTH_KEY: ${BULL_AUTH_KEY}
-  TEST_API_KEY: ${TEST_API_KEY}
-  SUPABASE_ANON_TOKEN: ${SUPABASE_ANON_TOKEN}
-  SUPABASE_URL: ${SUPABASE_URL}
-  SUPABASE_SERVICE_TOKEN: ${SUPABASE_SERVICE_TOKEN}
-  SELF_HOSTED_WEBHOOK_URL: ${SELF_HOSTED_WEBHOOK_URL}
-  LOGGING_LEVEL: ${LOGGING_LEVEL}
-  PROXY_SERVER: ${PROXY_SERVER}
-  PROXY_USERNAME: ${PROXY_USERNAME}
-  PROXY_PASSWORD: ${PROXY_PASSWORD}
-  SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT}
-  SEARXNG_ENGINES: ${SEARXNG_ENGINES}
-  SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES}
+  OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+  OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+  MODEL_NAME: ${MODEL_NAME:-}
+  MODEL_EMBEDDING_NAME: ${MODEL_EMBEDDING_NAME:-}
+  OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+  AUTUMN_SECRET_KEY: ${AUTUMN_SECRET_KEY:-}
+  SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
+  BULL_AUTH_KEY: ${BULL_AUTH_KEY:-}
+  TEST_API_KEY: ${TEST_API_KEY:-}
+  SUPABASE_ANON_TOKEN: ${SUPABASE_ANON_TOKEN:-}
+  SUPABASE_URL: ${SUPABASE_URL:-}
+  SUPABASE_SERVICE_TOKEN: ${SUPABASE_SERVICE_TOKEN:-}
+  SELF_HOSTED_WEBHOOK_URL: ${SELF_HOSTED_WEBHOOK_URL:-}
+  LOGGING_LEVEL: ${LOGGING_LEVEL:-INFO}
+  SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT:-}
+  SEARXNG_ENGINES: ${SEARXNG_ENGINES:-}
+  SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES:-}
+  # Camoufox stealth fallback. Off unless BOTH the flag and the URL are set, so
+  # an existing deployment is unchanged by upgrading. Start the service with
+  # COMPOSE_PROFILES=camoufox.
+  CAMOUFOX_FALLBACK_ENABLED: ${CAMOUFOX_FALLBACK_ENABLED:-false}
+  CAMOUFOX_SERVICE_URL: ${CAMOUFOX_SERVICE_URL:-}
+  CAMOUFOX_MAX_CONCURRENCY: ${CAMOUFOX_MAX_CONCURRENCY:-2}
+  CAMOUFOX_TIMEOUT_MS: ${CAMOUFOX_TIMEOUT_MS:-60000}
+  CAMOUFOX_MIN_CONFIDENCE: ${CAMOUFOX_MIN_CONFIDENCE:-suspected}
+  CAMOUFOX_DOMAIN_ALLOWLIST: ${CAMOUFOX_DOMAIN_ALLOWLIST:-}
+  CAMOUFOX_DOMAIN_DENYLIST: ${CAMOUFOX_DOMAIN_DENYLIST:-}
+  # FlareSolverr challenge solver. Same off-unless-both-set contract as
+  # Camoufox, and it sits one quality notch below it, so this is only reached
+  # when Camoufox is absent or already failed. Not a compose service: it runs
+  # wherever FLARESOLVERR_URL points (a host process reached via
+  # host.docker.internal is fine).
+  FLARESOLVERR_ENABLED: ${FLARESOLVERR_ENABLED:-false}
+  FLARESOLVERR_URL: ${FLARESOLVERR_URL:-}
+  FLARESOLVERR_TIMEOUT_MS: ${FLARESOLVERR_TIMEOUT_MS:-120000}
+  FLARESOLVERR_MIN_CONFIDENCE: ${FLARESOLVERR_MIN_CONFIDENCE:-confirmed}
+  FLARESOLVERR_MAX_RESPONSE_BYTES: ${FLARESOLVERR_MAX_RESPONSE_BYTES:-8388608}
+  FLARESOLVERR_DOMAIN_ALLOWLIST: ${FLARESOLVERR_DOMAIN_ALLOWLIST:-}
+  FLARESOLVERR_DOMAIN_DENYLIST: ${FLARESOLVERR_DOMAIN_DENYLIST:-}
+  # PMC official-source (BioC) adapter. On by default: it only activates for
+  # pmc.ncbi.nlm.nih.gov article URLs and falls back to the normal engines.
+  PMC_BIOC_ADAPTER_ENABLED: ${PMC_BIOC_ADAPTER_ENABLED:-true}
+  PMC_BIOC_TIMEOUT_MS: ${PMC_BIOC_TIMEOUT_MS:-20000}
   # Set NUQ_BACKEND=fdb to run the queue on FoundationDB instead of Postgres
-  NUQ_BACKEND: ${NUQ_BACKEND}
-  FDB_CLUSTER_FILE: ${NUQ_BACKEND:+/var/fdb/fdb.cluster}
+  NUQ_BACKEND: ${NUQ_BACKEND:-}
+  FDB_CLUSTER_FILE: ${FDB_CLUSTER_FILE:-}
 
 services:
   playwright-service:
@@ -67,15 +91,26 @@ services:
     build: apps/playwright-service-ts
     environment:
       PORT: 3000
-      PROXY_SERVER: ${PROXY_SERVER}
-      PROXY_USERNAME: ${PROXY_USERNAME}
-      PROXY_PASSWORD: ${PROXY_PASSWORD}
-      ALLOW_LOCAL_WEBHOOKS: ${ALLOW_LOCAL_WEBHOOKS}
-      BLOCK_MEDIA: ${BLOCK_MEDIA}
+      # This service is intentionally direct. Residential credentials belong
+      # only to playwright-proxy-service so `proxy:auto` remains direct-first.
+      ALLOW_LOCAL_WEBHOOKS: ${ALLOW_LOCAL_WEBHOOKS:-false}
+      BLOCK_MEDIA: ${BLOCK_MEDIA:-false}
       # Configure maximum concurrent pages for Playwright browser instances
       MAX_CONCURRENT_PAGES: ${CRAWL_CONCURRENT_REQUESTS:-10}
     networks:
       - backend
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     # Resource limits for Docker Compose (not Swarm)
     cpus: 2.0
     mem_limit: 4G
@@ -88,6 +123,103 @@ services:
         compress: "true"
     tmpfs:
       - /tmp/.cache:noexec,nosuid,size=1g
+
+  playwright-proxy-service:
+    build: apps/playwright-service-ts
+    profiles: ["proxy"]
+    restart: unless-stopped
+    environment:
+      PORT: 3000
+      PROXY_SERVER: ${PROXY_SERVER:-}
+      PROXY_USERNAME: ${PROXY_USERNAME:-}
+      PROXY_PASSWORD: ${PROXY_PASSWORD:-}
+      ALLOW_LOCAL_WEBHOOKS: ${ALLOW_LOCAL_WEBHOOKS:-false}
+      BLOCK_MEDIA: ${BLOCK_MEDIA:-false}
+      MAX_CONCURRENT_PAGES: ${CAMOUFOX_MAX_CONCURRENCY:-2}
+    networks:
+      - backend
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    cpus: 2.0
+    mem_limit: 4G
+    memswap_limit: 4G
+    tmpfs:
+      - /tmp/.cache:noexec,nosuid,size=1g
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        compress: "true"
+
+  # Stealth fallback browser, invoked by the API only after an ordinary engine
+  # returned confirmed anti-bot evidence. Behind a profile so a plain
+  # `docker compose up` does not start it: enable with COMPOSE_PROFILES=camoufox.
+  camoufox-service:
+    build: apps/camoufox-service
+    profiles: ["camoufox"]
+    # The browser is long-lived and can die on a wedged page; come back
+    # automatically rather than leaving the fallback permanently unavailable.
+    restart: unless-stopped
+    environment:
+      PORT: 3000
+      MAX_CONCURRENT_PAGES: ${CAMOUFOX_MAX_CONCURRENCY:-2}
+      NAVIGATION_TIMEOUT_MS: ${CAMOUFOX_TIMEOUT_MS:-60000}
+      BLOCK_MEDIA: ${BLOCK_MEDIA:-false}
+      CAMOUFOX_OS: ${CAMOUFOX_OS:-windows}
+      CAMOUFOX_HUMANIZE: ${CAMOUFOX_HUMANIZE:-true}
+      CAMOUFOX_GEOIP: ${CAMOUFOX_GEOIP:-true}
+      CAMOUFOX_FINGERPRINT_PRESET: ${CAMOUFOX_FINGERPRINT_PRESET:-true}
+      CAMOUFOX_WAIT_UNTIL: ${CAMOUFOX_WAIT_UNTIL:-domcontentloaded}
+      CAMOUFOX_SETTLE_MS: ${CAMOUFOX_SETTLE_MS:-1200}
+      LOG_LEVEL: ${LOGGING_LEVEL:-INFO}
+    networks:
+      - backend
+    # No `ports:` on purpose — the service stays on the Docker-internal network
+    # and is only reachable from the API container.
+    cpus: 2.0
+    mem_limit: 4G
+    memswap_limit: 4G
+    # Firefox needs more than Docker's default 64 MB of shared memory.
+    shm_size: 2gb
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        compress: "true"
+
+  flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    profiles: ["flaresolverr"]
+    restart: unless-stopped
+    environment:
+      LOG_LEVEL: ${LOGGING_LEVEL:-info}
+      TZ: ${TZ:-UTC}
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8191/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        compress: "true"
 
   api:
     <<: *common-service
@@ -102,9 +234,9 @@ services:
       ENV: local
     depends_on:
       redis:
-        condition: service_started
+        condition: service_healthy
       playwright-service:
-        condition: service_started
+        condition: service_healthy
       rabbitmq:
         condition: service_healthy
     ports:
@@ -112,6 +244,16 @@ services:
     volumes:
       - fdb-cluster-file:/var/fdb:ro
     command: node dist/src/harness.js --start-docker
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'curl -fsS "http://127.0.0.1:$${INTERNAL_PORT:-3002}/" >/dev/null',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     # Resource limits for Docker Compose (not Swarm)
     # Increase if you have more CPU cores/RAM available
     cpus: 4.0
@@ -127,7 +269,24 @@ services:
 
     networks:
       - backend
-    command: redis-server --bind 0.0.0.0
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+    command:
+      [
+        "sh",
+        "-c",
+        'exec redis-server --bind 0.0.0.0 --requirepass "$$REDIS_PASSWORD"',
+      ]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'REDISCLI_AUTH="$$REDIS_PASSWORD" redis-cli --no-auth-warning ping | grep -q PONG',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
     logging:
       driver: "json-file"
       options:

--- a/searxng/SEARCH-PROFILES.md
+++ b/searxng/SEARCH-PROFILES.md
@@ -1,0 +1,96 @@
+# Search profiles
+
+Firecrawl now classifies each search into one deterministic profile in
+`apps/api/src/search/profiles.ts`. Explicit API categories always win; otherwise
+query intent selects `general`, `developer`, `research`, or `pdf`. Each profile
+runs a small set of SearXNG engine groups in parallel, then Firecrawl
+canonicalizes, filters, deduplicates, and ranks their combined results.
+
+For a new deployment, copy `settings.example.yml` to the ignored
+`settings.yml`, replace its placeholder secret, and put the GitHub and Brave
+tokens in `.env`. Compose passes those credentials to SearXNG without writing
+them into either settings file.
+
+SearXNG `!bang` prefixes remain useful for direct SearXNG clients, but Firecrawl
+callers should prefer the API categories because those also enforce result
+domains and PDF-like URLs.
+
+## Profiles
+
+Prefix the query. Multiple bangs union their engines.
+
+| API category | Structured engines | Web coverage |
+|---|---|---|
+| `github` | GitHub, plus ecosystem engines only when named by the query | Authenticated Brave site search for GitHub, GitLab, and Stack Overflow |
+| `research` | Crossref, OpenAlex, and PubMed for biomedical intent | Authenticated Brave search restricted to scholarly domains |
+| `pdf` | Crossref and OpenAlex | Separate Brave and Bing `filetype:pdf` groups |
+| omitted/general | Stable general-web engines | Brave is isolated from the other engines so quota pressure cannot discard their results |
+
+Bang shortcuts: `!pub` pubmed, `!cr` crossref, `!oa` openalex, `!oap`
+openairepublications, `!arx` arxiv, `!gos` google scholar, `!se` semantic
+scholar, `!gh` github, `!st` stackoverflow, `!hf` huggingface, `!mdn` mdn,
+`!bi` bing, `!wp` wikipedia. Full list at `http://127.0.0.1:8999/config`.
+
+Category bangs also work: `!science`, `!it`, `!general`.
+
+## Safesearch
+
+`safe_search: 0` is global in `settings.yml` and Firecrawl never sends a
+`safesearch` param, so nothing filters sexual-health or abuse-pattern queries.
+Measured on the same query: 64 results at level 0, 65 at 1, 56 at 2 — the
+engines in this set barely filter regardless, but 0 is what runs.
+
+Academic queries in this domain return exactly what they should — Frontiers,
+PMC, APA, CDC, Wiley, Taylor & Francis, ScienceDirect — with no bangs needed.
+
+## Engine health (measured 2026-07-31, from this IP)
+
+Working in the routed profiles: authenticated GitHub, PubMed, Crossref,
+OpenAlex, authenticated Brave API, Bing, Dogpile, Seznam, Yandex, Fynd, and
+conditional ecosystem indexes such as npm and PyPI.
+
+The academic engines are profile-only. A live ordinary Firecrawl search on
+2026-07-30 showed Google Scholar CAPTCHA and OpenAlex 429 errors because the
+client's explicit `SEARXNG_ENGINES` list forced them to run despite their
+non-general categories. They were removed from that default list; bangs still
+override the list when academic coverage is wanted.
+
+Broken, and why:
+
+- `semantic scholar` — JSONDecodeError on every call
+  (`semantic_scholar.py:108`); the unauthenticated endpoint returns non-JSON.
+  **Removed from the default set.** A free key re-enables it:
+  https://www.semanticscholar.org/product/api#api-key-form
+- `arxiv` — `export.arxiv.org` repeatedly consumed the full 10–15 second
+  engine timeout during the final live audit. It was removed from synchronous
+  structured groups. arXiv remains covered through Brave's `site:arxiv.org`
+  search, and PDF results are normalized to `arxiv.org/pdf/<id>`.
+- `reddit` — `access denied`, permanently suspended. Do not add; it is the
+  obvious pick for qualitative/lived-experience data and it does not work.
+- `google` — loads if you set `inactive: false`, but soft-blocks from this IP:
+  zero results, no error, nothing logged. Burns a request slot.
+- `google cse` — `too many requests`, because it is still on upstream's
+  hardcoded shared CX. Needs your own CX (not an API key), see `settings.yml`.
+- `duckduckgo`, `brave` (keyless HTML), `startpage`, `qwant`, `gmx`, and
+  `privacywall` — CAPTCHA, 429, or parser failures even through the configured
+  residential exits. Disabled after live validation on 2026-07-30; keeping
+  them enabled made every query look unhealthy without improving coverage.
+- `github` — the upstream engine timed out because it inherited HTTP/2. The
+  local `github_authenticated` wrapper uses the `gh` token from
+  `SEARXNG_GITHUB_TOKEN` and forces HTTP/1.1 for this engine only.
+
+## Brave budget and burst behavior
+
+The configured key has a low per-second ceiling. The local
+`braveapi_authenticated` wrapper spaces dispatches by 2.1 seconds, bounds its
+queue to 4.5 seconds, and shortens SearXNG's 429 suspension to two seconds.
+Brave is always a separate Firecrawl engine group, so a skipped or rate-limited
+Brave call cannot suppress results from GitHub, Crossref, OpenAlex, Bing, or
+the remaining general engines.
+
+Check remaining budget:
+
+```sh
+curl -sI 'https://api.search.brave.com/res/v1/web/search?q=test' \
+  -H "X-Subscription-Token: $BRAVE_KEY" | grep -i x-ratelimit
+```

--- a/searxng/braveapi_authenticated.py
+++ b/searxng/braveapi_authenticated.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Brave Search API engine with its key sourced from the environment."""
+
+import os
+import threading
+import time
+
+from searx.engines import braveapi as upstream
+from searx.exceptions import SearxEngineAPIException
+
+about = upstream.about
+categories = upstream.categories
+paging = upstream.paging
+safesearch = upstream.safesearch
+time_range_support = upstream.time_range_support
+results_per_page = upstream.results_per_page
+
+_rate_lock = threading.Lock()
+_last_request_at = 0.0
+
+
+def _pace_requests():
+    """Keep bursty traffic within Brave's ceiling without an unbounded queue."""
+    global _last_request_at
+
+    try:
+        minimum_interval = max(
+            0.0,
+            float(
+                os.environ.get(
+                    "SEARXNG_BRAVE_MIN_INTERVAL_SECONDS",
+                    "2.1",
+                )
+            ),
+        )
+    except ValueError:
+        minimum_interval = 2.1
+
+    try:
+        maximum_queue_seconds = max(
+            0.0,
+            float(
+                os.environ.get(
+                    "SEARXNG_BRAVE_MAX_QUEUE_SECONDS",
+                    "4.5",
+                )
+            ),
+        )
+    except ValueError:
+        maximum_queue_seconds = 4.5
+
+    if not _rate_lock.acquire(timeout=maximum_queue_seconds):
+        return False
+    try:
+        remaining = minimum_interval - (time.monotonic() - _last_request_at)
+        if remaining > 0:
+            time.sleep(remaining)
+        _last_request_at = time.monotonic()
+        return True
+    finally:
+        _rate_lock.release()
+
+
+def init(_):
+    token = os.environ.get("SEARXNG_BRAVE_API_KEY")
+    if not token:
+        raise SearxEngineAPIException("SEARXNG_BRAVE_API_KEY is not configured")
+    upstream.api_key = token
+
+
+def request(query, params):
+    if not _pace_requests():
+        # Empty URLs are intentionally ignored by SearXNG's online processor.
+        # Other profile groups can complete instead of this request waiting
+        # until Firecrawl's SearXNG client timeout and discarding their results.
+        params["url"] = ""
+        return
+    upstream.api_key = os.environ.get("SEARXNG_BRAVE_API_KEY", "")
+    return upstream.request(query, params)
+
+
+response = upstream.response

--- a/searxng/github_authenticated.py
+++ b/searxng/github_authenticated.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""SearXNG GitHub engine with optional token authentication.
+
+The upstream engine does not expose an API-token setting. This wrapper keeps
+its request/response behavior while sourcing the token from the container
+environment, so credentials never need to be committed to settings.yml.
+"""
+
+import os
+
+from searx.engines import github as upstream
+
+about = upstream.about
+categories = upstream.categories
+search_url = upstream.search_url
+accept_header = upstream.accept_header
+
+
+def request(query, params):
+    params = upstream.request(query, params)
+    token = os.environ.get("SEARXNG_GITHUB_TOKEN")
+    if token:
+        params["headers"]["Authorization"] = f"Bearer {token}"
+        params["headers"]["X-GitHub-Api-Version"] = "2022-11-28"
+    return params
+
+
+response = upstream.response

--- a/searxng/limiter.toml
+++ b/searxng/limiter.toml
@@ -1,0 +1,3 @@
+# The limiter is disabled in settings.yml because SearXNG is reachable only on
+# the private Compose network. Keeping a valid file suppresses the startup
+# warning emitted even when limiter=false.

--- a/searxng/settings.example.yml
+++ b/searxng/settings.example.yml
@@ -1,0 +1,74 @@
+# Copy this file to settings.yml and replace the secret before starting:
+#   cp searxng/settings.example.yml searxng/settings.yml
+#   sed -i "s/REPLACE_WITH_A_RANDOM_SECRET/$(openssl rand -hex 32)/" searxng/settings.yml
+#
+# settings.yml is ignored because it becomes deployment-specific and may
+# contain credentials. GitHub and Brave credentials stay in environment
+# variables and are loaded by the local engine wrappers.
+
+use_default_settings:
+  engines:
+    remove:
+      - ahmia
+      - torch
+      - wikidata
+
+server:
+  secret_key: "REPLACE_WITH_A_RANDOM_SECRET"
+  limiter: false
+  image_proxy: false
+
+search:
+  formats:
+    - html
+    - json
+  safe_search: 0
+  autocomplete: ""
+  suspended_times:
+    SearxEngineTooManyRequests: 2
+
+outgoing:
+  request_timeout: 10.0
+  max_request_timeout: 15.0
+  pool_connections: 100
+  pool_maxsize: 20
+
+engines:
+  - name: github
+    engine: github_authenticated
+    shortcut: gh
+    categories:
+      - it
+      - repos
+    disabled: false
+    enable_http2: false
+    timeout: 10.0
+
+  - name: braveapi
+    engine: braveapi_authenticated
+    shortcut: braveapi
+    categories:
+      - general
+      - web
+    disabled: false
+
+  - name: semantic scholar
+    disabled: true
+  - name: google scholar
+    disabled: true
+  - name: duckduckgo
+    disabled: true
+  - name: brave
+    disabled: true
+  - name: startpage
+    disabled: true
+  - name: qwant
+    disabled: true
+  - name: mojeek
+    disabled: true
+  - name: yep
+    disabled: true
+  - name: resulthunter
+    disabled: true
+  - name: naver
+    disabled: true


### PR DESCRIPTION
## Summary
- route searches by intent across curated SearXNG engine groups, then canonicalize, filter, deduplicate, and rank results
- authenticate and pace GitHub/Brave engines while keeping credentials in ignored environment files
- persist self-hosted search feedback in Redis with idempotent submissions
- add direct/proxy Playwright separation plus Camoufox, FlareSolverr, PMC, and anti-bot fallback handling
- harden Compose health checks, Redis authentication, and service startup ordering

## Validation
- API TypeScript build passed in the production Docker build
- 62 focused Vitest tests passed
- 5 focused live E2E search/feedback tests passed
- 21 Camoufox Python tests passed
- GitHub, research, PDF, arXiv PDF scrape, feedback, proxy egress, and five-search burst probes passed
- all nine Compose services healthy; post-ready severity log count was zero

## Notes
- local secrets remain in ignored .env and searxng/settings.yml files
- searxng/settings.example.yml documents fresh deployment setup

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788052982&installation_model_id=11126&pr_number=4188&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4188&signature=48dc1a2c5e01cd037d5f5a64306c75394e1ee9f1f5f197d10fddba187e13d552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves self-hosted search routing and scraper reliability with intent-based SearXNG profiles, anti-bot fallbacks, and Redis-backed feedback. Results are cleaner, more relevant, and more resilient to challenge pages.

- **New Features**
  - Intent-based search profiles (`general`, `developer`, `research`, `pdf`) route queries to curated SearXNG engine groups, then canonicalize, filter, dedupe, and rank combined results.
  - Enforces category domains (e.g., `github`) and strips internal diagnostics before returning results.
  - Adds anti-bot classification and selective fallbacks: Camoufox stealth browser, FlareSolverr challenge solver, and a PMC BioC adapter that fetches official article JSON to bypass reCAPTCHA.
  - Splits Playwright direct/proxy modes and adds outcome metrics counters.
  - Stores self-hosted search feedback in Redis with idempotent submissions and job markers when DB auth is disabled.
  - Hardens Docker Compose with Redis authentication, health checks, and service startup ordering; includes a `docker-compose.override.yaml` for local SearXNG and a new `apps/camoufox-service`.

- **Migration**
  - For SearXNG: copy `searxng/settings.example.yml` to `searxng/settings.yml`, set a random `secret_key`, and provide GitHub/Brave API tokens via environment variables (no secrets in `settings.yml`).
  - Enable fallbacks via env flags: `CAMOUFOX_*` and `FLARESOLVERR_*` (disabled by default). Set domain allow/deny lists if needed.
  - Set `REDIS_PASSWORD` and update `REDIS_URL`/`REDIS_RATE_LIMIT_URL` to include authentication.
  - Use the new build target for focused tests: `docker build --target build-deps -t firecrawl-api-test apps/api`.

<sup>Written for commit f1f7d3fc4a2aedbcb00613df0736d6d712f88b80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

