### PR TITLE
fix(billing): serve historical usage from a precomputed per-month rollup

### DIFF
--- a/apps/api/src/__tests__/snips/v2/billing.test.ts
+++ b/apps/api/src/__tests__/snips/v2/billing.test.ts
@@ -669,6 +669,80 @@ describeIf(TEST_PRODUCTION)("Billing tests", () => {
     60000,
   );
 
+  // The `?byApiKey=true` path drives a grouped Autumn `events.aggregate` scan
+  // that used to time out against the 2s hot-path client and surface a 500.
+  // Assert it responds 200 with a well-formed (per-API-key) payload so a
+  // regression back onto the short-timeout client is caught.
+  it.concurrent(
+    "returns historical credit usage grouped by API key",
+    async () => {
+      const identity = await idmux({
+        name: "billing/returns historical credit usage byApiKey",
+        credits: 100,
+      });
+
+      const result = await creditUsageHistorical(identity, true);
+
+      expect(result.success).toBe(true);
+      expect(Array.isArray(result.periods)).toBe(true);
+
+      for (const period of result.periods) {
+        expect(typeof period.apiKey).toBe("string");
+        expect(typeof period.creditsUsed).toBe("number");
+        expect(period.creditsUsed).toBeGreaterThanOrEqual(0);
+      }
+
+      // Verify periods are sorted by startDate ascending (null dates last)
+      for (let i = 1; i < result.periods.length; i++) {
+        const prevRaw = result.periods[i - 1].startDate
+          ? Date.parse(result.periods[i - 1].startDate!)
+          : NaN;
+        const currRaw = result.periods[i].startDate
+          ? Date.parse(result.periods[i].startDate!)
+          : NaN;
+        if (!Number.isNaN(prevRaw) && !Number.isNaN(currRaw)) {
+          expect(currRaw).toBeGreaterThanOrEqual(prevRaw);
+        }
+      }
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "returns historical token usage grouped by API key",
+    async () => {
+      const identity = await idmux({
+        name: "billing/returns historical token usage byApiKey",
+        credits: 100,
+      });
+
+      const result = await tokenUsageHistorical(identity, true);
+
+      expect(result.success).toBe(true);
+      expect(Array.isArray(result.periods)).toBe(true);
+
+      for (const period of result.periods) {
+        expect(typeof period.apiKey).toBe("string");
+        expect(typeof period.tokensUsed).toBe("number");
+        expect(period.tokensUsed).toBeGreaterThanOrEqual(0);
+      }
+
+      // Verify periods are sorted by startDate ascending (null dates last)
+      for (let i = 1; i < result.periods.length; i++) {
+        const prevRaw = result.periods[i - 1].startDate
+          ? Date.parse(result.periods[i - 1].startDate!)
+          : NaN;
+        const currRaw = result.periods[i].startDate
+          ? Date.parse(result.periods[i].startDate!)
+          : NaN;
+        if (!Number.isNaN(prevRaw) && !Number.isNaN(currRaw)) {
+          expect(currRaw).toBeGreaterThanOrEqual(prevRaw);
+        }
+      }
+    },
+    60000,
+  );
+
   it.concurrent(
     "bills custom-cost ZDR scrape correctly",
     async () => {

--- a/apps/api/src/__tests__/snips/v2/lib.ts
+++ b/apps/api/src/__tests__/snips/v2/lib.ts
@@ -871,16 +871,21 @@ export async function creditUsage(
   return req.body.data;
 }
 
-export async function creditUsageHistorical(identity: Identity): Promise<{
+export async function creditUsageHistorical(
+  identity: Identity,
+  byApiKey: boolean = false,
+): Promise<{
   success: boolean;
   periods: {
     startDate: string | null;
     endDate: string | null;
+    apiKey?: string;
     creditsUsed: number;
   }[];
 }> {
   const req = await request(TEST_API_URL)
     .get("/v2/team/credit-usage/historical")
+    .query(byApiKey ? { byApiKey: "true" } : {})
     .set("Authorization", `Bearer ${identity.apiKey}`)
     .set("Content-Type", "application/json");
 
@@ -891,16 +896,21 @@ export async function creditUsageHistorical(identity: Identity): Promise<{
   return req.body;
 }
 
-export async function tokenUsageHistorical(identity: Identity): Promise<{
+export async function tokenUsageHistorical(
+  identity: Identity,
+  byApiKey: boolean = false,
+): Promise<{
   success: boolean;
   periods: {
     startDate: string | null;
     endDate: string | null;
+    apiKey?: string;
     tokensUsed: number;
   }[];
 }> {
   const req = await request(TEST_API_URL)
     .get("/v2/team/token-usage/historical")
+    .query(byApiKey ? { byApiKey: "true" } : {})
     .set("Authorization", `Bearer ${identity.apiKey}`)
     .set("Content-Type", "application/json");
 

--- a/apps/api/src/lib/research-upstream.ts
+++ b/apps/api/src/lib/research-upstream.ts
@@ -9,7 +9,7 @@ const dispatcher = new Agent({
   bodyTimeout: TIMEOUT_MS,
 });
 
-export function appendQuery(
+function appendQuery(
   url: URL,
   params: Record<string, unknown>,
   allowed: string[],

--- a/apps/api/src/services/autumn/__tests__/usage-timeout.test.ts
+++ b/apps/api/src/services/autumn/__tests__/usage-timeout.test.ts
@@ -1,0 +1,126 @@
+import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
+
+// Exercises the REAL Autumn clients from `../client` (no SDK mocking) against a
+// stubbed transport that answers slower than the hot-path client's 2s budget.
+//
+// The mock-based tests in usage.test.ts can only assert which client a call is
+// routed to; they cannot catch the actual defect, which is a timeout. This file
+// covers it: the grouped `?byApiKey=true` aggregate takes several seconds
+// against real Autumn, and the SDK's TimeoutFixHook intersects the client-level
+// timeout with the request signal via `AbortSignal.any` — so a per-call
+// `timeoutMs` can only ever shorten it. A 15s per-call override on the 2s
+// hot-path client is a no-op, which is why historical usage needs its own
+// client.
+vi.hoisted(() => {
+  process.env.AUTUMN_SECRET_KEY ??= "sk_test_usage_timeout";
+});
+
+const RESPONSE_DELAY_MS = 4000;
+
+// One daily bin, one API key, so the grouped path has something to roll up.
+const AGGREGATE_BODY = {
+  list: [
+    {
+      period: Date.parse("2026-07-15T00:00:00.000Z"),
+      values: { CREDITS: 12 },
+      grouped_values: { CREDITS: { "101": 12 } },
+    },
+  ],
+  total: { CREDITS: { count: 1, sum: 12 } },
+};
+
+vi.mock("../../../db/connection", () => ({
+  get dbRr() {
+    return {
+      select: () => ({
+        from: () => ({
+          where: () =>
+            // api_keys lookup awaits the builder; teams lookup calls .limit(1)
+            Object.assign(Promise.resolve([{ id: 101, name: "Default" }]), {
+              limit: () => Promise.resolve([{ org_id: "org-1" }]),
+            }),
+        }),
+      }),
+    };
+  },
+}));
+
+// No Redis in unit tests: every rollup read is a miss, so each call goes
+// through to the (stubbed) Autumn transport, which is what we want to time.
+vi.mock("../../redis", () => ({
+  getValue: async () => null,
+  setValue: async () => undefined,
+}));
+
+import { getTeamHistoricalUsageByApiKey } from "../usage";
+import { autumnClient } from "../client";
+
+const realFetch = globalThis.fetch;
+
+/** Answers after RESPONSE_DELAY_MS, honouring whatever signal the SDK attached. */
+function slowFetch(input: any): Promise<Response> {
+  const signal: AbortSignal | undefined = input?.signal;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      resolve(
+        new Response(JSON.stringify(AGGREGATE_BODY), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }, RESPONSE_DELAY_MS);
+
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    });
+  });
+}
+
+beforeEach(() => {
+  globalThis.fetch = slowFetch as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("historical usage against a slow Autumn", () => {
+  it("resolves byApiKey usage that takes longer than the hot-path budget", async () => {
+    const periods = await getTeamHistoricalUsageByApiKey("team-1");
+
+    // The stub answers every window with the same July bin, so the closed and
+    // current slices both land in July — the assertion that matters here is
+    // that the call completed at all rather than aborting at 2s.
+    expect(periods.length).toBeGreaterThan(0);
+    for (const period of periods) {
+      expect(period.apiKey).toBe("Default");
+      expect(period.creditsUsed).toBeGreaterThan(0);
+    }
+  }, 20000);
+
+  // Guards the reason the dedicated client exists: on the hot-path client the
+  // same call dies at ~2s even with a 15s per-call override, which is what
+  // surfaced as a 500 on /team/credit-usage/historical?byApiKey=true.
+  it("fails on the hot-path client even with a longer per-call timeout", async () => {
+    const started = Date.now();
+    await expect(
+      autumnClient!.events.aggregate(
+        {
+          customerId: "org-1",
+          entityId: "team-1",
+          featureId: "CREDITS",
+          binSize: "day",
+          groupBy: "properties.apiKeyId",
+          customRange: {
+            start: Date.parse("2026-07-01T00:00:00.000Z"),
+            end: Date.parse("2026-07-31T00:00:00.000Z"),
+          },
+        },
+        { timeoutMs: 15000 },
+      ),
+    ).rejects.toThrow();
+
+    expect(Date.now() - started).toBeLessThan(RESPONSE_DELAY_MS);
+  }, 20000);
+});

--- a/apps/api/src/services/autumn/__tests__/usage-timeout.test.ts
+++ b/apps/api/src/services/autumn/__tests__/usage-timeout.test.ts
@@ -57,9 +57,16 @@ import { autumnClient } from "../client";
 
 const realFetch = globalThis.fetch;
 
-/** Answers after RESPONSE_DELAY_MS, honouring whatever signal the SDK attached. */
-function slowFetch(input: any): Promise<Response> {
-  const signal: AbortSignal | undefined = input?.signal;
+/**
+ * Answers after RESPONSE_DELAY_MS, honouring whatever signal the SDK attached.
+ *
+ * The SDK currently calls `fetch(request)` with the signal on the Request, but
+ * read it from the init argument too: if that ever changes, this stub must
+ * still abort, or the timeout tests below would pass for the wrong reason (the
+ * response arriving rather than the budget expiring).
+ */
+function slowFetch(input: any, init?: any): Promise<Response> {
+  const signal: AbortSignal | undefined = input?.signal ?? init?.signal;
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       resolve(
@@ -80,6 +87,28 @@ function slowFetch(input: any): Promise<Response> {
 beforeEach(() => {
   globalThis.fetch = slowFetch as unknown as typeof fetch;
 });
+
+it("the stub actually sees the SDK's abort signal", async () => {
+  // Guards the two timeout tests: if the stub could not observe a signal, they
+  // would pass because the response arrived, not because the budget expired.
+  let sawSignal = false;
+  globalThis.fetch = ((input: any, init?: any) => {
+    sawSignal = Boolean(input?.signal ?? init?.signal);
+    return slowFetch(input, init);
+  }) as unknown as typeof fetch;
+
+  await expect(
+    autumnClient!.events.aggregate({
+      customerId: "org-1",
+      entityId: "team-1",
+      featureId: "CREDITS",
+      binSize: "day",
+      customRange: { start: 0, end: 1 },
+    }),
+  ).rejects.toThrow();
+
+  expect(sawSignal).toBe(true);
+}, 20000);
 
 afterAll(() => {
   globalThis.fetch = realFetch;

--- a/apps/api/src/services/autumn/__tests__/usage.test.ts
+++ b/apps/api/src/services/autumn/__tests__/usage.test.ts
@@ -1193,7 +1193,10 @@ describe("getTeamHistoricalUsageByApiKey", () => {
 
     await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
       expect.objectContaining({ apiKey: "Default", creditsUsed: 5 }),
-      expect.objectContaining({ apiKey: "Other", creditsUsed: 40 }),
+      expect.objectContaining({
+        apiKey: "Other (unattributed)",
+        creditsUsed: 40,
+      }),
       expect.objectContaining({ apiKey: "Unknown", creditsUsed: 2 }),
     ]);
   });

--- a/apps/api/src/services/autumn/__tests__/usage.test.ts
+++ b/apps/api/src/services/autumn/__tests__/usage.test.ts
@@ -1,4 +1,4 @@
-import { vi, beforeEach } from "vitest";
+import { vi, beforeEach, afterEach } from "vitest";
 
 // Historical aggregations run on the dedicated `autumnHistoricalClient` (which
 // carries a longer client-level timeout), NOT the hot-path `autumnClient`.
@@ -59,14 +59,43 @@ vi.mock("../../../db/connection", () => ({
   },
 }));
 
+// In-memory stand-in for the rollup cache. `redisSets` records the TTL each
+// slice was written with, which is what the closed-vs-current caching contract
+// is asserted on.
+const redisStore = new Map<string, string>();
+const redisSets: Array<{ key: string; ttl?: number }> = [];
+let redisEnabled = true;
+
+vi.mock("../../redis", () => ({
+  getValue: async (key: string) => {
+    if (!redisEnabled) throw new Error("redis down");
+    return redisStore.get(key) ?? null;
+  },
+  setValue: async (key: string, value: string, ttl?: number) => {
+    if (!redisEnabled) throw new Error("redis down");
+    redisStore.set(key, value);
+    redisSets.push({ key, ttl });
+  },
+}));
+
 import {
   getTeamBalance,
   getTeamHistoricalUsage,
   getTeamHistoricalUsageByApiKey,
 } from "../usage";
 
+// Fixed clock so the calendar-month windows the rollup derives are
+// deterministic. With HISTORICAL_MONTHS = 3 this makes the reported window
+// [2026-05-01, 2026-07-20) and the current-month boundary 2026-07-01.
+const NOW = new Date("2026-07-20T12:00:00.000Z");
+const CURRENT_MONTH_START = Date.parse("2026-07-01T00:00:00.000Z");
+const TODAY_START = Date.parse("2026-07-20T00:00:00.000Z");
+const WINDOW_START = Date.parse("2026-05-01T00:00:00.000Z");
+
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
   autumnClientRef = {
     events: { aggregate: mockHotPathAggregate },
     entities: { get: mockEntitiesGet },
@@ -77,7 +106,30 @@ beforeEach(() => {
   };
   teamLookup = { data: { org_id: "org-1" }, error: null };
   apiKeysData = [];
+  redisStore.clear();
+  redisSets.length = 0;
+  redisEnabled = true;
 });
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/**
+ * Serves `bins` from Autumn, honouring the half-open [start, end) window each
+ * call asks for. The rollup queries closed months and the current month
+ * separately, so this both feeds the tests and asserts the windowing is real:
+ * a bin outside a window is not returned for it.
+ */
+function serveBins(bins: any[]) {
+  mockAggregate.mockImplementation(async (args: any) => ({
+    list: bins.filter(
+      b =>
+        b.period >= args.customRange.start && b.period < args.customRange.end,
+    ),
+    total: {},
+  }));
+}
 
 // ---------------------------------------------------------------------------
 // getTeamBalance — covers all four billing-period / planCredits bug fixes
@@ -752,188 +804,366 @@ describe("getTeamBalance", () => {
 });
 
 // ---------------------------------------------------------------------------
-// getTeamHistoricalUsage
+// Monthly rollup windowing
 // ---------------------------------------------------------------------------
 
-describe("getTeamHistoricalUsage", () => {
-  it("aggregates 90 days of daily usage into calendar-month buckets", async () => {
-    mockAggregate.mockResolvedValue({
-      list: [
+// The endpoints no longer ask Autumn for a rolling 90-day span on every
+// request. The reported window is split at the start of the current calendar
+// month: closed months are immutable and cached until the month rolls over,
+// and only the current month is re-queried. That is what takes this endpoint's
+// cost off the team's total event volume — the grouped `byApiKey` variant used
+// to make Autumn walk ~90 days of raw events per group per daily bin, which is
+// what timed out for high-volume teams.
+describe("historical usage rollup windows", () => {
+  it("queries each closed month, the month to date, and today separately", async () => {
+    serveBins([]);
+
+    await getTeamHistoricalUsage("team-1");
+
+    // 2 closed months + month-to-date + today
+    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    const ranges = mockAggregate.mock.calls.map(
+      ([args]: any[]) => args.customRange,
+    );
+    expect(ranges).toEqual(
+      expect.arrayContaining([
+        { start: WINDOW_START, end: Date.parse("2026-06-01T00:00:00.000Z") },
         {
-          period: Date.parse("2026-03-30T00:00:00.000Z"),
-          values: { CREDITS: 20 },
+          start: Date.parse("2026-06-01T00:00:00.000Z"),
+          end: CURRENT_MONTH_START,
         },
-        {
-          period: Date.parse("2026-03-31T00:00:00.000Z"),
-          values: { CREDITS: 333 },
-        },
-        {
-          period: Date.parse("2026-04-01T00:00:00.000Z"),
-          values: { CREDITS: 1 },
-        },
-      ],
-    });
+        { start: CURRENT_MONTH_START, end: TODAY_START },
+        { start: TODAY_START, end: NOW.getTime() },
+      ]),
+    );
+    // The rolling window is gone; nothing may fall back to `range`.
+    for (const [args] of mockAggregate.mock.calls as any[][]) {
+      expect(args.range).toBeUndefined();
+      expect(args.customerId).toBe("org-1");
+      expect(args.entityId).toBe("team-1");
+      expect(args.binSize).toBe("day");
+    }
+  });
+
+  it("stitches closed-month and current-month slices into one series", async () => {
+    serveBins([
+      {
+        period: Date.parse("2026-05-31T00:00:00.000Z"),
+        values: { CREDITS: 20 },
+      },
+      {
+        period: Date.parse("2026-06-01T00:00:00.000Z"),
+        values: { CREDITS: 333 },
+      },
+      {
+        period: Date.parse("2026-06-30T00:00:00.000Z"),
+        values: { CREDITS: 7 },
+      },
+      {
+        period: Date.parse("2026-07-02T00:00:00.000Z"),
+        values: { CREDITS: 1 },
+      },
+    ]);
 
     await expect(getTeamHistoricalUsage("team-1")).resolves.toEqual([
       {
-        startDate: "2026-03-01T00:00:00.000Z",
-        endDate: "2026-04-01T00:00:00.000Z",
-        creditsUsed: 353,
+        startDate: "2026-05-01T00:00:00.000Z",
+        endDate: "2026-06-01T00:00:00.000Z",
+        creditsUsed: 20,
       },
       {
-        startDate: "2026-04-01T00:00:00.000Z",
+        startDate: "2026-06-01T00:00:00.000Z",
+        endDate: "2026-07-01T00:00:00.000Z",
+        creditsUsed: 340,
+      },
+      {
+        startDate: "2026-07-01T00:00:00.000Z",
         endDate: null,
         creditsUsed: 1,
       },
     ]);
+  });
 
-    expect(mockAggregate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        customerId: "org-1",
-        entityId: "team-1",
-        featureId: "CREDITS",
-        range: "90d",
-        binSize: "day",
-      }),
-    );
+  it("uses the next calendar month as endDate when a month has zero usage", async () => {
+    serveBins([
+      {
+        period: Date.parse("2026-05-31T00:00:00.000Z"),
+        values: { CREDITS: 12 },
+      },
+      {
+        period: Date.parse("2026-07-01T00:00:00.000Z"),
+        values: { CREDITS: 7 },
+      },
+    ]);
+
+    await expect(getTeamHistoricalUsage("team-1")).resolves.toEqual([
+      {
+        startDate: "2026-05-01T00:00:00.000Z",
+        endDate: "2026-06-01T00:00:00.000Z",
+        creditsUsed: 12,
+      },
+      {
+        startDate: "2026-07-01T00:00:00.000Z",
+        endDate: null,
+        creditsUsed: 7,
+      },
+    ]);
   });
 
   // The aggregate is scoped strictly to the team's entity. When the entity is
   // missing the team simply has no usage of its own — we return an empty
   // history rather than falling back to the org-wide total.
   it("returns an empty history (no org fallback) when the entity is missing", async () => {
-    mockAggregate.mockRejectedValueOnce(
+    mockAggregate.mockRejectedValue(
       Object.assign(new Error("not found"), { statusCode: 404 }),
     );
 
     await expect(getTeamHistoricalUsage("team-1")).resolves.toEqual([]);
 
-    // Only the entity-scoped call is made; no customer-level retry.
-    expect(mockAggregate).toHaveBeenCalledTimes(1);
-    expect(mockAggregate).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        customerId: "org-1",
-        entityId: "team-1",
-        range: "90d",
-        binSize: "day",
-      }),
-    );
+    // Only entity-scoped calls are made; no customer-level retry.
+    for (const [args] of mockAggregate.mock.calls as any[][]) {
+      expect(args.entityId).toBe("team-1");
+    }
   });
 
   it("rethrows non-404 aggregate errors", async () => {
-    mockAggregate.mockRejectedValueOnce(
+    mockAggregate.mockRejectedValue(
       Object.assign(new Error("boom"), { statusCode: 500 }),
     );
     await expect(getTeamHistoricalUsage("team-1")).rejects.toThrow("boom");
   });
+});
 
-  it("uses the next calendar month as endDate when a month has zero usage", async () => {
-    mockAggregate.mockResolvedValue({
-      list: [
-        {
-          period: Date.parse("2026-01-31T00:00:00.000Z"),
-          values: { CREDITS: 12 },
-        },
-        {
-          period: Date.parse("2026-03-01T00:00:00.000Z"),
-          values: { CREDITS: 7 },
-        },
-      ],
+// ---------------------------------------------------------------------------
+// Rollup caching
+// ---------------------------------------------------------------------------
+
+describe("historical usage rollup caching", () => {
+  it("serves a repeat request entirely from cache", async () => {
+    serveBins([
+      {
+        period: Date.parse("2026-06-10T00:00:00.000Z"),
+        values: { CREDITS: 5 },
+      },
+      {
+        period: Date.parse("2026-07-10T00:00:00.000Z"),
+        values: { CREDITS: 9 },
+      },
+    ]);
+
+    const first = await getTeamHistoricalUsage("team-1");
+    expect(mockAggregate).toHaveBeenCalledTimes(4);
+
+    const second = await getTeamHistoricalUsage("team-1");
+    expect(second).toEqual(first);
+    // No further Autumn work for the second request.
+    expect(mockAggregate).toHaveBeenCalledTimes(4);
+  });
+
+  // Closed months can never change, so they are cached until the month rolls
+  // over; the current month is still accruing and gets a short TTL.
+  // Correctness comes from the key naming its own window, not from the TTL: a
+  // stale entry can never be served for a different day or month.
+  it("keys each slice by the window it covers", async () => {
+    serveBins([]);
+
+    await getTeamHistoricalUsage("team-1");
+
+    const keys = redisSets.map(s => s.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(":m:2026-05"),
+        expect.stringContaining(":m:2026-06"),
+        expect.stringContaining(":mtd:2026-07:2026-07-20"),
+        expect.stringContaining(":d:2026-07-20"),
+      ]),
+    );
+
+    // Only today is short-lived; the immutable windows are held much longer.
+    const today = redisSets.find(s => s.key.includes(":d:2026-07-20"))!;
+    const closedMonth = redisSets.find(s => s.key.includes(":m:2026-05"))!;
+    expect(today.ttl).toBe(60);
+    expect(closedMonth.ttl).toBeGreaterThan(today.ttl!);
+  });
+
+  // The steady-state cost: with the immutable windows already cached, a request
+  // during the day re-queries one day of events, not ~90.
+  it("re-queries only today once the immutable windows are cached", async () => {
+    serveBins([]);
+
+    await getTeamHistoricalUsage("team-1");
+    mockAggregate.mockClear();
+
+    // Drop only today's entry, as its 60s TTL would.
+    for (const key of [...redisStore.keys()]) {
+      if (key.includes(":d:")) redisStore.delete(key);
+    }
+
+    await getTeamHistoricalUsage("team-1");
+
+    expect(mockAggregate).toHaveBeenCalledTimes(1);
+    expect(mockAggregate.mock.calls[0][0].customRange).toEqual({
+      start: TODAY_START,
+      end: NOW.getTime(),
     });
+  });
+
+  it("keys the grouped and ungrouped rollups separately", async () => {
+    apiKeysData = [{ id: 101, name: "Default" }];
+    serveBins([
+      {
+        period: Date.parse("2026-07-10T00:00:00.000Z"),
+        values: { CREDITS: 9 },
+        grouped_values: { CREDITS: { "101": 9 } },
+      },
+    ]);
+
+    await getTeamHistoricalUsage("team-1");
+    const afterUngrouped = mockAggregate.mock.calls.length;
+
+    // Must not be served the ungrouped entry, which carries no per-key data.
+    await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
+      {
+        startDate: "2026-07-01T00:00:00.000Z",
+        endDate: null,
+        apiKey: "Default",
+        creditsUsed: 9,
+      },
+    ]);
+    expect(mockAggregate.mock.calls.length).toBeGreaterThan(afterUngrouped);
+  });
+
+  it("coalesces concurrent cold-cache requests into one Autumn call per window", async () => {
+    serveBins([
+      {
+        period: Date.parse("2026-07-10T00:00:00.000Z"),
+        values: { CREDITS: 9 },
+      },
+    ]);
+
+    const [a, b, c] = await Promise.all([
+      getTeamHistoricalUsage("team-1"),
+      getTeamHistoricalUsage("team-1"),
+      getTeamHistoricalUsage("team-1"),
+    ]);
+
+    expect(b).toEqual(a);
+    expect(c).toEqual(a);
+    // One call per window, not one per request (3 requests × 4 windows = 12).
+    expect(mockAggregate).toHaveBeenCalledTimes(4);
+  });
+
+  it("still answers when the cache is unavailable", async () => {
+    redisEnabled = false;
+    serveBins([
+      {
+        period: Date.parse("2026-07-10T00:00:00.000Z"),
+        values: { CREDITS: 9 },
+      },
+    ]);
 
     await expect(getTeamHistoricalUsage("team-1")).resolves.toEqual([
       {
-        startDate: "2026-01-01T00:00:00.000Z",
-        endDate: "2026-02-01T00:00:00.000Z",
-        creditsUsed: 12,
-      },
-      {
-        startDate: "2026-03-01T00:00:00.000Z",
+        startDate: "2026-07-01T00:00:00.000Z",
         endDate: null,
-        creditsUsed: 7,
+        creditsUsed: 9,
       },
     ]);
   });
 });
 
+// ---------------------------------------------------------------------------
+// getTeamHistoricalUsageByApiKey
+// ---------------------------------------------------------------------------
+
 describe("getTeamHistoricalUsageByApiKey", () => {
-  it("aggregates daily grouped usage into calendar-month buckets", async () => {
+  it("aggregates grouped usage into calendar-month buckets across windows", async () => {
     apiKeysData = [
       { id: 101, name: "Default" },
       { id: 202, name: "postman" },
     ];
 
-    mockAggregate.mockResolvedValue({
-      list: [
-        {
-          period: Date.parse("2026-03-30T00:00:00.000Z"),
-          grouped_values: { CREDITS: { "101": 10, "202": 3 } },
-        },
-        {
-          period: Date.parse("2026-03-31T00:00:00.000Z"),
-          grouped_values: { CREDITS: { "101": 26 } },
-        },
-        {
-          period: Date.parse("2026-04-02T00:00:00.000Z"),
-          grouped_values: { CREDITS: { "202": 5 } },
-        },
-      ],
-    });
+    serveBins([
+      {
+        period: Date.parse("2026-06-30T00:00:00.000Z"),
+        grouped_values: { CREDITS: { "101": 10, "202": 3 } },
+      },
+      {
+        period: Date.parse("2026-06-29T00:00:00.000Z"),
+        grouped_values: { CREDITS: { "101": 26 } },
+      },
+      {
+        period: Date.parse("2026-07-02T00:00:00.000Z"),
+        grouped_values: { CREDITS: { "202": 5 } },
+      },
+    ]);
 
     await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
       {
-        startDate: "2026-03-01T00:00:00.000Z",
-        endDate: "2026-04-01T00:00:00.000Z",
+        startDate: "2026-06-01T00:00:00.000Z",
+        endDate: "2026-07-01T00:00:00.000Z",
         apiKey: "Default",
         creditsUsed: 36,
       },
       {
-        startDate: "2026-03-01T00:00:00.000Z",
-        endDate: "2026-04-01T00:00:00.000Z",
+        startDate: "2026-06-01T00:00:00.000Z",
+        endDate: "2026-07-01T00:00:00.000Z",
         apiKey: "postman",
         creditsUsed: 3,
       },
       {
-        startDate: "2026-04-01T00:00:00.000Z",
+        startDate: "2026-07-01T00:00:00.000Z",
         endDate: null,
         apiKey: "postman",
         creditsUsed: 5,
       },
     ]);
+  });
 
-    expect(mockAggregate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        customerId: "org-1",
-        entityId: "team-1",
-        featureId: "CREDITS",
-        range: "90d",
-        binSize: "day",
-        groupBy: "properties.apiKeyId",
-      }),
-    );
+  // Autumn's default `maxGroups` is 9 and applies per bin, so with per-day bins
+  // the top-9 keys differ day to day and per-key monthly totals get silently
+  // scrambled into "Other". Ask for a ceiling no real team reaches.
+  it("requests a group ceiling well above the Autumn default", async () => {
+    serveBins([]);
+
+    await getTeamHistoricalUsageByApiKey("team-1");
+
+    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    for (const [args] of mockAggregate.mock.calls as any[][]) {
+      expect(args.groupBy).toBe("properties.apiKeyId");
+      expect(args.maxGroups).toBeGreaterThanOrEqual(100);
+    }
+  });
+
+  it("does not send groupBy on the ungrouped path", async () => {
+    serveBins([]);
+
+    await getTeamHistoricalUsage("team-1");
+
+    for (const [args] of mockAggregate.mock.calls as any[][]) {
+      expect(args.groupBy).toBeUndefined();
+      expect(args.maxGroups).toBeUndefined();
+    }
   });
 
   it("labels unresolvable apiKeyIds as 'Unknown' instead of echoing raw values", async () => {
     apiKeysData = [];
 
-    mockAggregate.mockResolvedValue({
-      list: [
-        {
-          period: Date.parse("2026-04-15T00:00:00.000Z"),
-          grouped_values: {
-            CREDITS: {
-              ba9045fffbd34fc8aabc2597df6ba044: 11,
-              "99999999": 7,
-            },
+    serveBins([
+      {
+        period: Date.parse("2026-07-15T00:00:00.000Z"),
+        grouped_values: {
+          CREDITS: {
+            ba9045fffbd34fc8aabc2597df6ba044: 11,
+            "99999999": 7,
           },
         },
-      ],
-    });
+      },
+    ]);
 
     await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
       {
-        startDate: "2026-04-01T00:00:00.000Z",
+        startDate: "2026-07-01T00:00:00.000Z",
         endDate: null,
         apiKey: "Unknown",
         creditsUsed: 18,
@@ -941,54 +1171,34 @@ describe("getTeamHistoricalUsageByApiKey", () => {
     ]);
   });
 
-  it("uses the next calendar month as endDate for grouped data when a month has zero usage", async () => {
+  // Names are resolved on read, not baked into the cache, so renaming a key is
+  // reflected immediately instead of being frozen for the rest of the month.
+  it("reflects an API key rename without waiting for the cache to expire", async () => {
     apiKeysData = [{ id: 101, name: "Default" }];
-
-    mockAggregate.mockResolvedValue({
-      list: [
-        {
-          period: Date.parse("2026-01-31T00:00:00.000Z"),
-          grouped_values: { CREDITS: { "101": 12 } },
-        },
-        {
-          period: Date.parse("2026-03-01T00:00:00.000Z"),
-          grouped_values: { CREDITS: { "101": 7 } },
-        },
-      ],
-    });
+    serveBins([
+      {
+        period: Date.parse("2026-07-10T00:00:00.000Z"),
+        grouped_values: { CREDITS: { "101": 9 } },
+      },
+    ]);
 
     await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
-      {
-        startDate: "2026-01-01T00:00:00.000Z",
-        endDate: "2026-02-01T00:00:00.000Z",
-        apiKey: "Default",
-        creditsUsed: 12,
-      },
-      {
-        startDate: "2026-03-01T00:00:00.000Z",
-        endDate: null,
-        apiKey: "Default",
-        creditsUsed: 7,
-      },
+      expect.objectContaining({ apiKey: "Default", creditsUsed: 9 }),
+    ]);
+
+    apiKeysData = [{ id: 101, name: "renamed" }];
+
+    await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
+      expect.objectContaining({ apiKey: "renamed", creditsUsed: 9 }),
     ]);
   });
 
   it("returns an empty history (no org fallback) when the entity is missing", async () => {
-    mockAggregate.mockRejectedValueOnce(
+    mockAggregate.mockRejectedValue(
       Object.assign(new Error("not found"), { statusCode: 404 }),
     );
 
     await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([]);
-
-    expect(mockAggregate).toHaveBeenCalledTimes(1);
-    expect(mockAggregate).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        customerId: "org-1",
-        entityId: "team-1",
-        groupBy: "properties.apiKeyId",
-      }),
-    );
   });
 });
 
@@ -996,30 +1206,27 @@ describe("getTeamHistoricalUsageByApiKey", () => {
 // Historical aggregations run on the dedicated (longer-timeout) client
 // ---------------------------------------------------------------------------
 
-// These aggregations bin by day (and optionally group by API key), so Autumn
-// walks raw events and the call cost scales with the team's event volume —
-// routinely several seconds. The Autumn SDK only honors a timeout set at the
-// client level (a per-call timeoutMs/signal does NOT override a lower client
-// default), so historical calls must go through `autumnHistoricalClient`, not
-// the hot-path `autumnClient` whose 2s budget is sized for balance checks. If
-// they regressed to the hot-path client, high-volume teams would time out and
-// surface a 500.
+// The Autumn SDK only honors a timeout set at the client level (a per-call
+// timeoutMs/signal does NOT override a lower client default), so historical
+// calls must go through `autumnHistoricalClient`, not the hot-path
+// `autumnClient` whose 2s budget is sized for balance checks. If they regressed
+// to the hot-path client, slow teams would time out and surface a 500.
 describe("historical usage routes through the dedicated Autumn client", () => {
   it("uses autumnHistoricalClient, not the hot-path client, for the ungrouped aggregate", async () => {
-    mockAggregate.mockResolvedValue({ list: [] });
+    serveBins([]);
 
     await getTeamHistoricalUsage("team-1");
 
-    expect(mockAggregate).toHaveBeenCalledTimes(1);
+    expect(mockAggregate).toHaveBeenCalled();
     expect(mockHotPathAggregate).not.toHaveBeenCalled();
   });
 
   it("uses autumnHistoricalClient, not the hot-path client, for the grouped byApiKey aggregate", async () => {
-    mockAggregate.mockResolvedValue({ list: [] });
+    serveBins([]);
 
     await getTeamHistoricalUsageByApiKey("team-1");
 
-    expect(mockAggregate).toHaveBeenCalledTimes(1);
+    expect(mockAggregate).toHaveBeenCalled();
     expect(mockHotPathAggregate).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/autumn/__tests__/usage.test.ts
+++ b/apps/api/src/services/autumn/__tests__/usage.test.ts
@@ -84,13 +84,13 @@ import {
   getTeamHistoricalUsageByApiKey,
 } from "../usage";
 
-// Fixed clock so the calendar-month windows the rollup derives are
-// deterministic. With HISTORICAL_MONTHS = 3 this makes the reported window
-// [2026-05-01, 2026-07-20) and the current-month boundary 2026-07-01.
+// Fixed clock so the windows the rollup derives are deterministic. 90 days
+// before 2026-07-20 is 2026-04-21, so the window snaps back to 2026-04-01 and
+// the current-month boundary is 2026-07-01.
 const NOW = new Date("2026-07-20T12:00:00.000Z");
 const CURRENT_MONTH_START = Date.parse("2026-07-01T00:00:00.000Z");
 const TODAY_START = Date.parse("2026-07-20T00:00:00.000Z");
-const WINDOW_START = Date.parse("2026-05-01T00:00:00.000Z");
+const WINDOW_START = Date.parse("2026-04-01T00:00:00.000Z");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -820,14 +820,18 @@ describe("historical usage rollup windows", () => {
 
     await getTeamHistoricalUsage("team-1");
 
-    // 2 closed months + month-to-date + today
-    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    // 3 closed months (Apr, May, Jun) + month-to-date + today
+    expect(mockAggregate).toHaveBeenCalledTimes(5);
     const ranges = mockAggregate.mock.calls.map(
       ([args]: any[]) => args.customRange,
     );
     expect(ranges).toEqual(
       expect.arrayContaining([
-        { start: WINDOW_START, end: Date.parse("2026-06-01T00:00:00.000Z") },
+        { start: WINDOW_START, end: Date.parse("2026-05-01T00:00:00.000Z") },
+        {
+          start: Date.parse("2026-05-01T00:00:00.000Z"),
+          end: Date.parse("2026-06-01T00:00:00.000Z"),
+        },
         {
           start: Date.parse("2026-06-01T00:00:00.000Z"),
           end: CURRENT_MONTH_START,
@@ -932,6 +936,30 @@ describe("historical usage rollup windows", () => {
     );
     await expect(getTeamHistoricalUsage("team-1")).rejects.toThrow("boom");
   });
+
+  // Snapping the window to a month boundary must never report LESS history than
+  // the rolling 90d window it replaced. The 1st of a month is the tight case: a
+  // fixed count of calendar months would fall short there.
+  it.each([
+    "2026-01-01T00:00:00.000Z",
+    "2026-03-01T00:00:00.000Z",
+    "2026-05-01T00:00:00.000Z",
+    "2026-07-01T00:00:00.000Z",
+    "2026-07-15T12:00:00.000Z",
+    "2027-03-01T00:00:00.000Z",
+  ])("covers at least 90 days when now is %s", async iso => {
+    vi.setSystemTime(new Date(iso));
+    serveBins([]);
+
+    await getTeamHistoricalUsage("team-1");
+
+    const starts = mockAggregate.mock.calls.map(
+      ([args]: any[]) => args.customRange.start,
+    );
+    const earliest = Math.min(...starts);
+    const daysCovered = (Date.parse(iso) - earliest) / (24 * 60 * 60 * 1000);
+    expect(daysCovered).toBeGreaterThanOrEqual(90);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -952,12 +980,12 @@ describe("historical usage rollup caching", () => {
     ]);
 
     const first = await getTeamHistoricalUsage("team-1");
-    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    expect(mockAggregate).toHaveBeenCalledTimes(5);
 
     const second = await getTeamHistoricalUsage("team-1");
     expect(second).toEqual(first);
     // No further Autumn work for the second request.
-    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    expect(mockAggregate).toHaveBeenCalledTimes(5);
   });
 
   // Closed months can never change, so they are cached until the month rolls
@@ -972,6 +1000,7 @@ describe("historical usage rollup caching", () => {
     const keys = redisSets.map(s => s.key);
     expect(keys).toEqual(
       expect.arrayContaining([
+        expect.stringContaining(":m:2026-04"),
         expect.stringContaining(":m:2026-05"),
         expect.stringContaining(":m:2026-06"),
         expect.stringContaining(":mtd:2026-07:2026-07-20"),
@@ -981,7 +1010,7 @@ describe("historical usage rollup caching", () => {
 
     // Only today is short-lived; the immutable windows are held much longer.
     const today = redisSets.find(s => s.key.includes(":d:2026-07-20"))!;
-    const closedMonth = redisSets.find(s => s.key.includes(":m:2026-05"))!;
+    const closedMonth = redisSets.find(s => s.key.includes(":m:2026-04"))!;
     expect(today.ttl).toBe(60);
     expect(closedMonth.ttl).toBeGreaterThan(today.ttl!);
   });
@@ -1049,8 +1078,8 @@ describe("historical usage rollup caching", () => {
 
     expect(b).toEqual(a);
     expect(c).toEqual(a);
-    // One call per window, not one per request (3 requests × 4 windows = 12).
-    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    // One call per window, not one per request (3 requests × 5 windows = 15).
+    expect(mockAggregate).toHaveBeenCalledTimes(5);
   });
 
   it("still answers when the cache is unavailable", async () => {
@@ -1128,7 +1157,7 @@ describe("getTeamHistoricalUsageByApiKey", () => {
 
     await getTeamHistoricalUsageByApiKey("team-1");
 
-    expect(mockAggregate).toHaveBeenCalledTimes(4);
+    expect(mockAggregate).toHaveBeenCalledTimes(5);
     for (const [args] of mockAggregate.mock.calls as any[][]) {
       expect(args.groupBy).toBe("properties.apiKeyId");
       expect(args.maxGroups).toBeGreaterThanOrEqual(100);
@@ -1143,6 +1172,48 @@ describe("getTeamHistoricalUsageByApiKey", () => {
     for (const [args] of mockAggregate.mock.calls as any[][]) {
       expect(args.groupBy).toBeUndefined();
       expect(args.maxGroups).toBeUndefined();
+    }
+  });
+
+  // Beyond maxGroups Autumn bundles the remainder into an "Other" group. Those
+  // credits are real but unattributable, which is a different fact from "this ID
+  // did not resolve to a key" — a caller reconciling per-key totals must be able
+  // to tell them apart, so "Other" is not folded into "Unknown".
+  it("surfaces Autumn's overflow group separately from unresolvable IDs", async () => {
+    apiKeysData = [{ id: 101, name: "Default" }];
+
+    serveBins([
+      {
+        period: Date.parse("2026-07-15T00:00:00.000Z"),
+        grouped_values: {
+          CREDITS: { "101": 5, Other: 40, "99999999": 2 },
+        },
+      },
+    ]);
+
+    await expect(getTeamHistoricalUsageByApiKey("team-1")).resolves.toEqual([
+      expect.objectContaining({ apiKey: "Default", creditsUsed: 5 }),
+      expect.objectContaining({ apiKey: "Other", creditsUsed: 40 }),
+      expect.objectContaining({ apiKey: "Unknown", creditsUsed: 2 }),
+    ]);
+  });
+
+  // Group values come from Autumn, so an inherited property name must not leak
+  // through as a "resolved" key name.
+  it("does not resolve prototype property names as API key names", async () => {
+    apiKeysData = [];
+
+    serveBins([
+      {
+        period: Date.parse("2026-07-15T00:00:00.000Z"),
+        grouped_values: { CREDITS: { constructor: 3, __proto__: 4 } },
+      },
+    ]);
+
+    const periods = await getTeamHistoricalUsageByApiKey("team-1");
+    for (const period of periods) {
+      expect(typeof period.apiKey).toBe("string");
+      expect(period.apiKey).toBe("Unknown");
     }
   });
 

--- a/apps/api/src/services/autumn/__tests__/usage.test.ts
+++ b/apps/api/src/services/autumn/__tests__/usage.test.ts
@@ -1,20 +1,27 @@
 import { vi, beforeEach } from "vitest";
 
-const mockAggregate = vi.fn<(args: any, options?: any) => Promise<any>>();
+// Historical aggregations run on the dedicated `autumnHistoricalClient` (which
+// carries a longer client-level timeout), NOT the hot-path `autumnClient`.
+// Keep the two aggregate mocks distinct so tests can assert the routing.
+const mockAggregate = vi.fn<(args: any) => Promise<any>>();
+const mockHotPathAggregate = vi.fn<(args: any) => Promise<any>>();
 const mockEntitiesGet = vi.fn<(args: any) => Promise<any>>();
 const mockCustomersGetOrCreate = vi.fn<(args: any) => Promise<any>>();
 
-// Historical aggregations override the Autumn client's global 2s timeout.
-const EXPECTED_HISTORICAL_TIMEOUT_MS = 15000;
-
 let autumnClientRef: {
-  events: { aggregate: typeof mockAggregate };
+  events: { aggregate: typeof mockHotPathAggregate };
   entities: { get: typeof mockEntitiesGet };
   customers: { getOrCreate: typeof mockCustomersGetOrCreate };
 } | null = {
-  events: { aggregate: mockAggregate },
+  events: { aggregate: mockHotPathAggregate },
   entities: { get: mockEntitiesGet },
   customers: { getOrCreate: mockCustomersGetOrCreate },
+};
+
+let autumnHistoricalClientRef: {
+  events: { aggregate: typeof mockAggregate };
+} | null = {
+  events: { aggregate: mockAggregate },
 };
 
 let teamLookup = {
@@ -27,6 +34,9 @@ let apiKeysData: Array<{ id: number; name: string }> = [];
 vi.mock("../client", () => ({
   get autumnClient() {
     return autumnClientRef;
+  },
+  get autumnHistoricalClient() {
+    return autumnHistoricalClientRef;
   },
 }));
 
@@ -58,9 +68,12 @@ import {
 beforeEach(() => {
   vi.clearAllMocks();
   autumnClientRef = {
-    events: { aggregate: mockAggregate },
+    events: { aggregate: mockHotPathAggregate },
     entities: { get: mockEntitiesGet },
     customers: { getOrCreate: mockCustomersGetOrCreate },
+  };
+  autumnHistoricalClientRef = {
+    events: { aggregate: mockAggregate },
   };
   teamLookup = { data: { org_id: "org-1" }, error: null };
   apiKeysData = [];
@@ -782,7 +795,6 @@ describe("getTeamHistoricalUsage", () => {
         range: "90d",
         binSize: "day",
       }),
-      expect.objectContaining({ timeoutMs: EXPECTED_HISTORICAL_TIMEOUT_MS }),
     );
   });
 
@@ -806,7 +818,6 @@ describe("getTeamHistoricalUsage", () => {
         range: "90d",
         binSize: "day",
       }),
-      expect.objectContaining({ timeoutMs: EXPECTED_HISTORICAL_TIMEOUT_MS }),
     );
   });
 
@@ -900,7 +911,6 @@ describe("getTeamHistoricalUsageByApiKey", () => {
         binSize: "day",
         groupBy: "properties.apiKeyId",
       }),
-      expect.objectContaining({ timeoutMs: EXPECTED_HISTORICAL_TIMEOUT_MS }),
     );
   });
 
@@ -978,50 +988,38 @@ describe("getTeamHistoricalUsageByApiKey", () => {
         entityId: "team-1",
         groupBy: "properties.apiKeyId",
       }),
-      expect.objectContaining({ timeoutMs: EXPECTED_HISTORICAL_TIMEOUT_MS }),
     );
   });
 });
 
 // ---------------------------------------------------------------------------
-// Per-call Autumn timeout for the historical aggregations
+// Historical aggregations run on the dedicated (longer-timeout) client
 // ---------------------------------------------------------------------------
 
 // These aggregations bin by day (and optionally group by API key), so Autumn
-// walks raw events and the call cost scales with the team's event volume. The
-// Autumn client's global 2s timeout is sized for the latency-sensitive balance
-// checks, so each historical call must override it or high-volume teams get a
-// timeout error surfaced as a 500.
-describe("historical usage Autumn timeout override", () => {
-  it("passes a 15s per-call timeout for the ungrouped aggregate", async () => {
+// walks raw events and the call cost scales with the team's event volume —
+// routinely several seconds. The Autumn SDK only honors a timeout set at the
+// client level (a per-call timeoutMs/signal does NOT override a lower client
+// default), so historical calls must go through `autumnHistoricalClient`, not
+// the hot-path `autumnClient` whose 2s budget is sized for balance checks. If
+// they regressed to the hot-path client, high-volume teams would time out and
+// surface a 500.
+describe("historical usage routes through the dedicated Autumn client", () => {
+  it("uses autumnHistoricalClient, not the hot-path client, for the ungrouped aggregate", async () => {
     mockAggregate.mockResolvedValue({ list: [] });
 
     await getTeamHistoricalUsage("team-1");
 
     expect(mockAggregate).toHaveBeenCalledTimes(1);
-    const [, options] = mockAggregate.mock.calls[0];
-    expect(options).toEqual({ timeoutMs: 15000 });
+    expect(mockHotPathAggregate).not.toHaveBeenCalled();
   });
 
-  it("passes a 15s per-call timeout for the grouped byApiKey aggregate", async () => {
+  it("uses autumnHistoricalClient, not the hot-path client, for the grouped byApiKey aggregate", async () => {
     mockAggregate.mockResolvedValue({ list: [] });
 
     await getTeamHistoricalUsageByApiKey("team-1");
 
     expect(mockAggregate).toHaveBeenCalledTimes(1);
-    const [, options] = mockAggregate.mock.calls[0];
-    expect(options).toEqual({ timeoutMs: 15000 });
-  });
-
-  it("overrides the Autumn client's global 2s timeout with a larger value", async () => {
-    mockAggregate.mockResolvedValue({ list: [] });
-
-    await getTeamHistoricalUsage("team-1");
-    await getTeamHistoricalUsageByApiKey("team-1");
-
-    expect(mockAggregate).toHaveBeenCalledTimes(2);
-    for (const [, options] of mockAggregate.mock.calls) {
-      expect(options?.timeoutMs).toBeGreaterThan(2000);
-    }
+    expect(mockHotPathAggregate).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/autumn/client.ts
+++ b/apps/api/src/services/autumn/client.ts
@@ -19,6 +19,24 @@ export const autumnClient = config.AUTUMN_SECRET_KEY
 // or `fetchOptions.signal` does NOT override a lower client default — so these
 // calls need their own client with a longer timeout. The hot-path client above
 // keeps its tight 2s budget for latency-sensitive balance checks.
+//
+// A cold rollup also fans out one aggregate per cached window, so a transient
+// 429/5xx from any one of them would fail the whole response. The SDK defaults
+// to no retries, so give this client a short backoff. Retries stay inside the
+// 15s client budget.
 export const autumnHistoricalClient = config.AUTUMN_SECRET_KEY
-  ? new Autumn({ secretKey: config.AUTUMN_SECRET_KEY, timeoutMs: 15000 })
+  ? new Autumn({
+      secretKey: config.AUTUMN_SECRET_KEY,
+      timeoutMs: 15000,
+      retryConfig: {
+        strategy: "backoff",
+        backoff: {
+          initialInterval: 200,
+          maxInterval: 1000,
+          exponent: 2,
+          maxElapsedTime: 5000,
+        },
+        retryConnectionErrors: true,
+      },
+    })
   : null;

--- a/apps/api/src/services/autumn/client.ts
+++ b/apps/api/src/services/autumn/client.ts
@@ -11,3 +11,14 @@ if (!config.AUTUMN_SECRET_KEY) {
 export const autumnClient = config.AUTUMN_SECRET_KEY
   ? new Autumn({ secretKey: config.AUTUMN_SECRET_KEY, timeoutMs: 2000 })
   : null;
+
+// The historical/analytics aggregations (`events.aggregate` bucketed by day,
+// optionally grouped by API key) make Autumn walk raw events, which routinely
+// takes several seconds and scales with the team's event volume. The Autumn
+// SDK only honors a timeout set at the client level — a per-call `timeoutMs`
+// or `fetchOptions.signal` does NOT override a lower client default — so these
+// calls need their own client with a longer timeout. The hot-path client above
+// keeps its tight 2s budget for latency-sensitive balance checks.
+export const autumnHistoricalClient = config.AUTUMN_SECRET_KEY
+  ? new Autumn({ secretKey: config.AUTUMN_SECRET_KEY, timeoutMs: 15000 })
+  : null;

--- a/apps/api/src/services/autumn/usage.ts
+++ b/apps/api/src/services/autumn/usage.ts
@@ -9,19 +9,29 @@ import { CREDITS_FEATURE_ID } from "./autumn.service";
 export const TOKENS_PER_CREDIT = 15;
 const HISTORICAL_BIN_SIZE = "day";
 
-// How many calendar months of history the endpoints report, including the
-// current (open) one. Replaces the previous rolling `range: "90d"` window,
-// which had two problems: the oldest month was silently truncated (a 90d
-// window opened mid-month, so e.g. May reported May 2 onward while still
-// being labelled as all of May), and a window that shifts every day makes
-// every month look mutable, which defeats caching.
-const HISTORICAL_MONTHS = 3;
+// The reported window starts at the beginning of the calendar month containing
+// (now - HISTORICAL_MIN_DAYS), so it always covers at least as much history as
+// the previous rolling `range: "90d"` did, and never less on the 1st of a
+// month. Snapping to a month boundary is what makes the rollup cacheable: a
+// window that shifts every day makes every month look mutable. It also fixes
+// under-reporting at the old window's edge, where a 90d span opened mid-month
+// (e.g. May counted from May 2) but was still labelled as the whole month.
+const HISTORICAL_MIN_DAYS = 90;
 
 // Autumn caps the number of distinct `groupBy` values per bin and buckets the
-// rest into "Other" (default 9). Teams routinely have more API keys than that,
-// and with per-day bins the top-9 differs day to day, so the default silently
-// scrambles per-key monthly totals. Ask for a ceiling no real team reaches.
+// rest into an overflow group (default 9). Teams routinely have more API keys
+// than that, and with per-day bins the top-9 differs day to day, so the default
+// silently scrambles per-key monthly totals. Ask for a ceiling no real team
+// reaches.
 const HISTORICAL_MAX_GROUPS = 250;
+
+// Autumn's label for the bucket holding every group beyond `maxGroups`. Its
+// credits are real but can no longer be attributed to individual keys, so it is
+// surfaced under its own name rather than folded into "Unknown" (which means
+// "this ID did not resolve to a key") — those are different facts and a caller
+// reconciling per-key totals needs to tell them apart. API key IDs are numeric,
+// so this can never collide with a real one.
+const AUTUMN_OVERFLOW_GROUP = "Other";
 
 // Bump when the cached payload shape changes, so old entries are ignored
 // rather than misread.
@@ -85,7 +95,9 @@ async function lookupApiKeyNames(
     .map(id => Number(id))
     .filter(n => Number.isInteger(n) && n > 0);
 
-  const nameMap: Record<string, string> = {};
+  // Prototype-free: group values come from Autumn, so an id like "constructor"
+  // must not resolve to an inherited property instead of a name.
+  const nameMap: Record<string, string> = Object.create(null);
 
   if (numericIds.length > 0) {
     const rows = await dbRr
@@ -99,7 +111,9 @@ async function lookupApiKeyNames(
   }
 
   for (const id of apiKeyIds) {
-    if (!nameMap[id]) nameMap[id] = "Unknown";
+    if (nameMap[id]) continue;
+    nameMap[id] =
+      id === AUTUMN_OVERFLOW_GROUP ? AUTUMN_OVERFLOW_GROUP : "Unknown";
   }
 
   return nameMap;
@@ -496,7 +510,7 @@ function sliceKey(teamId: string, grouped: boolean, suffix: string): string {
  *   - today so far — the only window re-queried during the day
  *
  * So the steady-state request scans a single day of events rather than ~90
- * days, and a fully cold cache costs HISTORICAL_MONTHS + 1 parallel queries.
+ * days, and a fully cold cache costs one parallel query per window.
  */
 function buildRollupSlices(
   teamId: string,
@@ -507,14 +521,23 @@ function buildRollupSlices(
   const todayStart = startOfDayUtc(now);
   const slices: RollupSlice[] = [];
 
-  for (let back = HISTORICAL_MONTHS - 1; back >= 1; back--) {
-    const start = addMonthsUtc(currentMonthStart, -back);
-    const end = addMonthsUtc(start, 1);
+  // Start at the month containing the oldest day the endpoint must still cover,
+  // so the reported span is never shorter than HISTORICAL_MIN_DAYS — including
+  // on the 1st of a month, when a fixed month count would fall short.
+  const oldestRequiredDay = new Date(
+    now.getTime() - HISTORICAL_MIN_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  for (
+    let start = startOfMonthUtc(oldestRequiredDay);
+    start.getTime() < currentMonthStart.getTime();
+    start = addMonthsUtc(start, 1)
+  ) {
     slices.push({
       key: sliceKey(teamId, grouped, `m:${isoMonth(start)}`),
       ttlSeconds: CLOSED_MONTHS_MAX_TTL_SECONDS,
       start,
-      end,
+      end: addMonthsUtc(start, 1),
     });
   }
 

--- a/apps/api/src/services/autumn/usage.ts
+++ b/apps/api/src/services/autumn/usage.ts
@@ -647,7 +647,22 @@ async function aggregateWindow(opts: {
     return response.list ?? [];
   } catch (err: any) {
     const status = err?.statusCode ?? err?.status ?? err?.response?.status;
-    if (status !== 404) throw err;
+    if (status !== 404) {
+      // Without this, an Autumn failure reaches the client as a bare exception
+      // ID with no way to tell which window, team or status was involved —
+      // which is why the original 500s on this endpoint went untriaged for two
+      // months. Adapted from #3592.
+      logger.error("Autumn events.aggregate failed for historical usage", {
+        teamId: opts.teamId,
+        orgId: opts.orgId,
+        grouped: opts.grouped,
+        windowStart: opts.start.toISOString(),
+        windowEnd: opts.end.toISOString(),
+        status,
+        error: err,
+      });
+      throw err;
+    }
     // Entity not found — the team has no usage of its own to report.
     return null;
   }

--- a/apps/api/src/services/autumn/usage.ts
+++ b/apps/api/src/services/autumn/usage.ts
@@ -1,12 +1,43 @@
 import { eq, inArray } from "drizzle-orm";
 import { dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
+import { logger } from "../../lib/logger";
+import { getValue, setValue } from "../redis";
 import { autumnClient, autumnHistoricalClient } from "./client";
 import { CREDITS_FEATURE_ID } from "./autumn.service";
 
 export const TOKENS_PER_CREDIT = 15;
-const HISTORICAL_RANGE = "90d";
 const HISTORICAL_BIN_SIZE = "day";
+
+// How many calendar months of history the endpoints report, including the
+// current (open) one. Replaces the previous rolling `range: "90d"` window,
+// which had two problems: the oldest month was silently truncated (a 90d
+// window opened mid-month, so e.g. May reported May 2 onward while still
+// being labelled as all of May), and a window that shifts every day makes
+// every month look mutable, which defeats caching.
+const HISTORICAL_MONTHS = 3;
+
+// Autumn caps the number of distinct `groupBy` values per bin and buckets the
+// rest into "Other" (default 9). Teams routinely have more API keys than that,
+// and with per-day bins the top-9 differs day to day, so the default silently
+// scrambles per-key monthly totals. Ask for a ceiling no real team reaches.
+const HISTORICAL_MAX_GROUPS = 250;
+
+// Bump when the cached payload shape changes, so old entries are ignored
+// rather than misread.
+const ROLLUP_CACHE_VERSION = "v1";
+
+// Today is still accruing usage, so its slice is only cached briefly — new
+// charges show up in the endpoint within this window.
+const TODAY_TTL_SECONDS = 60;
+
+// Elapsed days of the current month can no longer change, but the slice covers
+// a growing number of days, so it is re-keyed (not just re-read) each day.
+const MONTH_TO_DATE_TTL_SECONDS = 2 * 24 * 60 * 60;
+
+// Closed months can never change. The key names the month, so this TTL only
+// reclaims space once the month leaves the reported window.
+const CLOSED_MONTHS_MAX_TTL_SECONDS = 40 * 24 * 60 * 60;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -92,27 +123,31 @@ function nextMonthIso(monthStartIso: string): string {
   ).toISOString();
 }
 
-function aggregateHistoricalPeriodsByMonth(list: any[]): HistoricalPeriod[] {
-  const monthTotals = new Map<string, number>();
+/**
+ * Per-month credit totals, keyed by the month's UTC start as an ISO string.
+ * This is the cached rollup shape for the ungrouped endpoints.
+ */
+type MonthTotals = Record<string, number>;
+
+/**
+ * Per-month, per-API-key credit totals. Keyed by raw `apiKeyId` rather than
+ * display name so renaming a key is reflected immediately instead of being
+ * frozen into a cache entry for the rest of the month.
+ */
+type MonthApiKeyTotals = Record<string, Record<string, number>>;
+
+function sumByMonth(list: any[]): MonthTotals {
+  const totals: MonthTotals = Object.create(null);
 
   for (const entry of list) {
     const monthStart = toMonthStartIso(entry.period);
     if (!monthStart) continue;
 
-    monthTotals.set(
-      monthStart,
-      (monthTotals.get(monthStart) ?? 0) +
-        (entry.values?.[CREDITS_FEATURE_ID] ?? 0),
-    );
+    totals[monthStart] =
+      (totals[monthStart] ?? 0) + (entry.values?.[CREDITS_FEATURE_ID] ?? 0);
   }
 
-  const monthStarts = [...monthTotals.keys()].sort();
-
-  return monthStarts.map((startDate, i) => ({
-    startDate,
-    endDate: i < monthStarts.length - 1 ? nextMonthIso(startDate) : null,
-    creditsUsed: monthTotals.get(startDate) ?? 0,
-  }));
+  return totals;
 }
 
 function getGroupedCredits(entry: any): Record<string, number> | undefined {
@@ -122,11 +157,8 @@ function getGroupedCredits(entry: any): Record<string, number> | undefined {
   );
 }
 
-async function aggregateHistoricalPeriodsByApiKeyMonth(
-  list: any[],
-): Promise<HistoricalPeriodByApiKey[]> {
-  const monthApiKeyTotals = new Map<string, Map<string, number>>();
-  const allApiKeyIds = new Set<string>();
+function sumByMonthAndApiKey(list: any[]): MonthApiKeyTotals {
+  const totals: MonthApiKeyTotals = Object.create(null);
 
   for (const entry of list) {
     const monthStart = toMonthStartIso(entry.period);
@@ -135,25 +167,71 @@ async function aggregateHistoricalPeriodsByApiKeyMonth(
     const grouped = getGroupedCredits(entry);
     if (!grouped) continue;
 
-    const monthTotals =
-      monthApiKeyTotals.get(monthStart) ?? new Map<string, number>();
+    const monthTotals = totals[monthStart] ?? Object.create(null);
 
     for (const [apiKeyId, creditsUsed] of Object.entries(grouped)) {
-      allApiKeyIds.add(apiKeyId);
-      monthTotals.set(apiKeyId, (monthTotals.get(apiKeyId) ?? 0) + creditsUsed);
+      monthTotals[apiKeyId] = (monthTotals[apiKeyId] ?? 0) + creditsUsed;
     }
 
-    monthApiKeyTotals.set(monthStart, monthTotals);
+    totals[monthStart] = monthTotals;
+  }
+
+  return totals;
+}
+
+/** Merges rollup slices (closed months + current month) into one map. */
+function mergeMonthTotals(slices: MonthTotals[]): MonthTotals {
+  const merged: MonthTotals = Object.create(null);
+  for (const slice of slices) {
+    for (const [month, credits] of Object.entries(slice)) {
+      merged[month] = (merged[month] ?? 0) + credits;
+    }
+  }
+  return merged;
+}
+
+function mergeMonthApiKeyTotals(
+  slices: MonthApiKeyTotals[],
+): MonthApiKeyTotals {
+  const merged: MonthApiKeyTotals = Object.create(null);
+  for (const slice of slices) {
+    for (const [month, byKey] of Object.entries(slice)) {
+      const target = merged[month] ?? Object.create(null);
+      for (const [apiKeyId, credits] of Object.entries(byKey)) {
+        target[apiKeyId] = (target[apiKeyId] ?? 0) + credits;
+      }
+      merged[month] = target;
+    }
+  }
+  return merged;
+}
+
+function toHistoricalPeriods(totals: MonthTotals): HistoricalPeriod[] {
+  const monthStarts = Object.keys(totals).sort();
+
+  return monthStarts.map((startDate, i) => ({
+    startDate,
+    endDate: i < monthStarts.length - 1 ? nextMonthIso(startDate) : null,
+    creditsUsed: totals[startDate] ?? 0,
+  }));
+}
+
+async function toHistoricalPeriodsByApiKey(
+  totals: MonthApiKeyTotals,
+): Promise<HistoricalPeriodByApiKey[]> {
+  const allApiKeyIds = new Set<string>();
+  for (const byKey of Object.values(totals)) {
+    for (const apiKeyId of Object.keys(byKey)) allApiKeyIds.add(apiKeyId);
   }
 
   const nameMap = await lookupApiKeyNames([...allApiKeyIds]);
-  const monthStarts = [...monthApiKeyTotals.keys()].sort();
+  const monthStarts = Object.keys(totals).sort();
   const results: HistoricalPeriodByApiKey[] = [];
 
   for (let i = 0; i < monthStarts.length; i++) {
     const startDate = monthStarts[i];
     const endDate = i < monthStarts.length - 1 ? nextMonthIso(startDate) : null;
-    const monthTotals = monthApiKeyTotals.get(startDate);
+    const monthTotals = totals[startDate];
 
     if (!monthTotals) continue;
 
@@ -161,7 +239,7 @@ async function aggregateHistoricalPeriodsByApiKeyMonth(
     // unresolved IDs all show as "Unknown") so the response has one row per
     // name per month.
     const byName = new Map<string, number>();
-    for (const [apiKeyId, creditsUsed] of monthTotals) {
+    for (const [apiKeyId, creditsUsed] of Object.entries(monthTotals)) {
       const name = nameMap[apiKeyId];
       byName.set(name, (byName.get(name) ?? 0) + creditsUsed);
     }
@@ -361,80 +439,284 @@ interface HistoricalPeriodByApiKey {
   creditsUsed: number;
 }
 
+// ---------------------------------------------------------------------------
+// Rollup cache
+// ---------------------------------------------------------------------------
+
+function startOfMonthUtc(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function addMonthsUtc(date: Date, months: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+  );
+}
+
+function startOfDayUtc(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function isoMonth(date: Date): string {
+  return date.toISOString().slice(0, 7);
+}
+
 /**
- * Fetches a team's historical credit usage across billing periods from Autumn.
+ * One cacheable window of the reported history.
+ *
+ * The cache key encodes the window's own boundaries, so a stale entry can
+ * never be served for a different window — correctness comes from the key, and
+ * the TTL only reclaims space. When the day or month rolls over, the affected
+ * slices simply get new keys.
+ */
+interface RollupSlice {
+  key: string;
+  ttlSeconds: number;
+  start: Date;
+  end: Date;
+}
+
+function sliceKey(teamId: string, grouped: boolean, suffix: string): string {
+  return `usage-rollup:${ROLLUP_CACHE_VERSION}:${grouped ? "by-key" : "total"}:${teamId}:${suffix}`;
+}
+
+/**
+ * Splits the reported history into windows ordered by how often each can
+ * change, which is what keeps the recurring cost off the team's total event
+ * volume:
+ *
+ *   - one window per closed calendar month — immutable, computed once ever
+ *   - the current month up to midnight today — immutable, once per day
+ *   - today so far — the only window re-queried during the day
+ *
+ * So the steady-state request scans a single day of events rather than ~90
+ * days, and a fully cold cache costs HISTORICAL_MONTHS + 1 parallel queries.
+ */
+function buildRollupSlices(
+  teamId: string,
+  grouped: boolean,
+  now: Date,
+): RollupSlice[] {
+  const currentMonthStart = startOfMonthUtc(now);
+  const todayStart = startOfDayUtc(now);
+  const slices: RollupSlice[] = [];
+
+  for (let back = HISTORICAL_MONTHS - 1; back >= 1; back--) {
+    const start = addMonthsUtc(currentMonthStart, -back);
+    const end = addMonthsUtc(start, 1);
+    slices.push({
+      key: sliceKey(teamId, grouped, `m:${isoMonth(start)}`),
+      ttlSeconds: CLOSED_MONTHS_MAX_TTL_SECONDS,
+      start,
+      end,
+    });
+  }
+
+  // Empty on the 1st of the month, when there is no elapsed-but-closed part.
+  if (todayStart.getTime() > currentMonthStart.getTime()) {
+    slices.push({
+      key: sliceKey(
+        teamId,
+        grouped,
+        `mtd:${isoMonth(currentMonthStart)}:${isoDay(todayStart)}`,
+      ),
+      ttlSeconds: MONTH_TO_DATE_TTL_SECONDS,
+      start: currentMonthStart,
+      end: todayStart,
+    });
+  }
+
+  slices.push({
+    key: sliceKey(teamId, grouped, `d:${isoDay(todayStart)}`),
+    ttlSeconds: TODAY_TTL_SECONDS,
+    start: todayStart,
+    end: now,
+  });
+
+  return slices;
+}
+
+// Coalesces concurrent computations of the same key inside this process, so a
+// burst of dashboard requests on a cold cache produces one Autumn call rather
+// than one per request.
+const inFlightRollups = new Map<string, Promise<unknown>>();
+
+/**
+ * Reads a rollup slice from Redis, computing and caching it on a miss.
+ *
+ * Cache faults are never fatal: a Redis outage degrades to querying Autumn
+ * directly, which is the pre-cache behaviour.
+ */
+async function cachedRollup<T>(
+  key: string,
+  ttlSeconds: number,
+  compute: () => Promise<T>,
+): Promise<T> {
+  try {
+    const cached = await getValue(key);
+    if (cached !== null) {
+      const parsed = JSON.parse(cached);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as T;
+      }
+      logger.warn("Ignoring malformed usage rollup cache entry", { key });
+    }
+  } catch (error) {
+    logger.warn("Failed to read usage rollup cache", { key, error });
+  }
+
+  const existing = inFlightRollups.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const pending = (async () => {
+    const value = await compute();
+    try {
+      await setValue(key, JSON.stringify(value), ttlSeconds);
+    } catch (error) {
+      logger.warn("Failed to cache usage rollup", { key, error });
+    }
+    return value;
+  })();
+
+  inFlightRollups.set(key, pending);
+  try {
+    return await pending;
+  } finally {
+    inFlightRollups.delete(key);
+  }
+}
+
+/**
+ * Runs one `events.aggregate` over an explicit half-open [start, end) window.
+ *
+ * Returns the raw bin list, or `null` when the team has no Autumn entity (a
+ * team that was never provisioned has no usage of its own to report, and we
+ * must not fall back to the org total).
+ */
+async function aggregateWindow(opts: {
+  client: NonNullable<typeof autumnHistoricalClient>;
+  orgId: string;
+  teamId: string;
+  start: Date;
+  end: Date;
+  grouped: boolean;
+}): Promise<any[] | null> {
+  try {
+    const response = await opts.client.events.aggregate({
+      customerId: opts.orgId,
+      entityId: opts.teamId,
+      featureId: CREDITS_FEATURE_ID,
+      customRange: { start: opts.start.getTime(), end: opts.end.getTime() },
+      binSize: HISTORICAL_BIN_SIZE,
+      ...(opts.grouped
+        ? {
+            groupBy: "properties.apiKeyId",
+            maxGroups: HISTORICAL_MAX_GROUPS,
+          }
+        : {}),
+    });
+    return response.list ?? [];
+  } catch (err: any) {
+    const status = err?.statusCode ?? err?.status ?? err?.response?.status;
+    if (status !== 404) throw err;
+    // Entity not found — the team has no usage of its own to report.
+    return null;
+  }
+}
+
+/**
+ * Builds a team's per-month credit rollup over the reported window.
+ *
+ * Every slice from buildRollupSlices is fetched (or served from cache) in
+ * parallel and summed. That is what keeps this endpoint's cost off the team's
+ * total event volume: previously every request made Autumn walk ~90 days of raw
+ * events, and the `byApiKey=true` variant did so per group per daily bin, which
+ * is why high-volume teams timed out. Now only today's slice is re-queried
+ * during a day.
+ */
+async function getMonthlyRollup<T extends MonthTotals | MonthApiKeyTotals>(
+  teamId: string,
+  grouped: boolean,
+  summarize: (list: any[]) => T,
+  merge: (slices: T[]) => T,
+): Promise<T> {
+  const client = autumnHistoricalClient;
+  if (!client) {
+    throw new Error(
+      "Autumn client is not configured (AUTUMN_SECRET_KEY missing)",
+    );
+  }
+
+  const orgId = await lookupOrgId(teamId);
+  const empty = merge([]);
+
+  // A missing entity is cached as an empty slice on purpose: a team with no
+  // Autumn entity had no usage in those windows either, and once it is
+  // provisioned its usage lands in today's slice, which refreshes within a
+  // minute.
+  const fetchSlice = async (slice: RollupSlice): Promise<T> => {
+    if (slice.end.getTime() <= slice.start.getTime()) return empty;
+    const list = await aggregateWindow({
+      client,
+      orgId,
+      teamId,
+      start: slice.start,
+      end: slice.end,
+      grouped,
+    });
+    return list === null ? empty : summarize(list);
+  };
+
+  const results = await Promise.all(
+    buildRollupSlices(teamId, grouped, new Date()).map(slice =>
+      cachedRollup(slice.key, slice.ttlSeconds, () => fetchSlice(slice)),
+    ),
+  );
+
+  return merge(results);
+}
+
+/**
+ * Fetches a team's historical credit usage by calendar month.
  *
  * Scopes the aggregate to the team's Autumn entity so the response reflects
- * only that team's usage, not the whole org. Uses `events.aggregate` with the
- * last 90 days of daily usage and rolls those daily totals into calendar-month
- * buckets in API code. A team with no entity (never provisioned) has no
- * team-scoped usage, so we return an empty history rather than the org total.
+ * only that team's usage, not the whole org, and serves it from a cached
+ * per-month rollup (see getMonthlyRollup). A team with no entity (never
+ * provisioned) has no team-scoped usage, so we return an empty history rather
+ * than the org total.
  */
 export async function getTeamHistoricalUsage(
   teamId: string,
 ): Promise<HistoricalPeriod[]> {
-  if (!autumnHistoricalClient) {
-    throw new Error(
-      "Autumn client is not configured (AUTUMN_SECRET_KEY missing)",
-    );
-  }
-
-  const orgId = await lookupOrgId(teamId);
-
-  let response: any;
-  try {
-    response = await autumnHistoricalClient.events.aggregate({
-      customerId: orgId,
-      entityId: teamId,
-      featureId: CREDITS_FEATURE_ID,
-      range: HISTORICAL_RANGE,
-      binSize: HISTORICAL_BIN_SIZE,
-    });
-  } catch (err: any) {
-    const status = err?.statusCode ?? err?.status ?? err?.response?.status;
-    if (status !== 404) throw err;
-    // Entity not found — the team has no usage of its own to report.
-    return [];
-  }
-
-  return aggregateHistoricalPeriodsByMonth(response.list ?? []);
+  const totals = await getMonthlyRollup<MonthTotals>(
+    teamId,
+    false,
+    sumByMonth,
+    mergeMonthTotals,
+  );
+  return toHistoricalPeriods(totals);
 }
 
 /**
- * Fetches a team's historical credit usage grouped by API key from Autumn.
- *
- * Uses the last 90 days of daily usage plus `groupBy: "properties.apiKeyId"`
- * and rolls those daily totals into calendar-month buckets in API code.
+ * Fetches a team's historical credit usage by calendar month, broken down per
+ * API key. Served from the same cached rollup as the ungrouped variant.
  */
 export async function getTeamHistoricalUsageByApiKey(
   teamId: string,
 ): Promise<HistoricalPeriodByApiKey[]> {
-  if (!autumnHistoricalClient) {
-    throw new Error(
-      "Autumn client is not configured (AUTUMN_SECRET_KEY missing)",
-    );
-  }
-
-  const orgId = await lookupOrgId(teamId);
-
-  let response: any;
-  try {
-    response = await autumnHistoricalClient.events.aggregate({
-      customerId: orgId,
-      entityId: teamId,
-      featureId: CREDITS_FEATURE_ID,
-      range: HISTORICAL_RANGE,
-      binSize: HISTORICAL_BIN_SIZE,
-      groupBy: "properties.apiKeyId",
-    });
-  } catch (err: any) {
-    const status = err?.statusCode ?? err?.status ?? err?.response?.status;
-    if (status !== 404) throw err;
-    // Entity not found — the team has no usage of its own to report.
-    return [];
-  }
-
-  return aggregateHistoricalPeriodsByApiKeyMonth(response.list ?? []);
+  const totals = await getMonthlyRollup<MonthApiKeyTotals>(
+    teamId,
+    true,
+    sumByMonthAndApiKey,
+    mergeMonthApiKeyTotals,
+  );
+  return toHistoricalPeriodsByApiKey(totals);
 }
 
 /**

--- a/apps/api/src/services/autumn/usage.ts
+++ b/apps/api/src/services/autumn/usage.ts
@@ -113,7 +113,7 @@ async function lookupApiKeyNames(
   for (const id of apiKeyIds) {
     if (nameMap[id]) continue;
     nameMap[id] =
-      id === AUTUMN_OVERFLOW_GROUP ? AUTUMN_OVERFLOW_GROUP : "Unknown";
+      id === AUTUMN_OVERFLOW_GROUP ? "Other (unattributed)" : "Unknown";
   }
 
   return nameMap;

--- a/apps/api/src/services/autumn/usage.ts
+++ b/apps/api/src/services/autumn/usage.ts
@@ -25,12 +25,12 @@ const HISTORICAL_MIN_DAYS = 90;
 // reaches.
 const HISTORICAL_MAX_GROUPS = 250;
 
-// Autumn's label for the bucket holding every group beyond `maxGroups`. Its
-// credits are real but can no longer be attributed to individual keys, so it is
-// surfaced under its own name rather than folded into "Unknown" (which means
-// "this ID did not resolve to a key") — those are different facts and a caller
-// reconciling per-key totals needs to tell them apart. API key IDs are numeric,
-// so this can never collide with a real one.
+// Autumn's group name for the bucket holding everything beyond `maxGroups`.
+// Those credits are real but can no longer be attributed to individual keys, so
+// the row is labelled "Other (unattributed)" rather than folded into "Unknown"
+// (which means "this ID did not resolve to a key") — different facts, and a
+// caller reconciling per-key totals needs to tell them apart. API key IDs are
+// numeric, so this can never collide with a real one.
 const AUTUMN_OVERFLOW_GROUP = "Other";
 
 // Bump when the cached payload shape changes, so old entries are ignored

--- a/apps/api/src/services/autumn/usage.ts
+++ b/apps/api/src/services/autumn/usage.ts
@@ -1,21 +1,12 @@
-import { logger } from "../../lib/logger";
 import { eq, inArray } from "drizzle-orm";
 import { dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
-import { autumnClient } from "./client";
+import { autumnClient, autumnHistoricalClient } from "./client";
 import { CREDITS_FEATURE_ID } from "./autumn.service";
 
 export const TOKENS_PER_CREDIT = 15;
 const HISTORICAL_RANGE = "90d";
 const HISTORICAL_BIN_SIZE = "day";
-
-// The historical/analytics aggregations below are bucketed by day (and
-// optionally grouped by API key), so Autumn has to walk raw events and their
-// cost scales with the team's event volume. That routinely takes several
-// seconds. The Autumn client's global 2s timeout is sized for the
-// latency-sensitive balance checks on the request hot path, and it is far too
-// tight here, so these calls override it per call.
-const HISTORICAL_AGGREGATE_TIMEOUT_MS = 15000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -382,7 +373,7 @@ interface HistoricalPeriodByApiKey {
 export async function getTeamHistoricalUsage(
   teamId: string,
 ): Promise<HistoricalPeriod[]> {
-  if (!autumnClient) {
+  if (!autumnHistoricalClient) {
     throw new Error(
       "Autumn client is not configured (AUTUMN_SECRET_KEY missing)",
     );
@@ -392,16 +383,13 @@ export async function getTeamHistoricalUsage(
 
   let response: any;
   try {
-    response = await autumnClient.events.aggregate(
-      {
-        customerId: orgId,
-        entityId: teamId,
-        featureId: CREDITS_FEATURE_ID,
-        range: HISTORICAL_RANGE,
-        binSize: HISTORICAL_BIN_SIZE,
-      },
-      { timeoutMs: HISTORICAL_AGGREGATE_TIMEOUT_MS },
-    );
+    response = await autumnHistoricalClient.events.aggregate({
+      customerId: orgId,
+      entityId: teamId,
+      featureId: CREDITS_FEATURE_ID,
+      range: HISTORICAL_RANGE,
+      binSize: HISTORICAL_BIN_SIZE,
+    });
   } catch (err: any) {
     const status = err?.statusCode ?? err?.status ?? err?.response?.status;
     if (status !== 404) throw err;
@@ -421,7 +409,7 @@ export async function getTeamHistoricalUsage(
 export async function getTeamHistoricalUsageByApiKey(
   teamId: string,
 ): Promise<HistoricalPeriodByApiKey[]> {
-  if (!autumnClient) {
+  if (!autumnHistoricalClient) {
     throw new Error(
       "Autumn client is not configured (AUTUMN_SECRET_KEY missing)",
     );
@@ -431,17 +419,14 @@ export async function getTeamHistoricalUsageByApiKey(
 
   let response: any;
   try {
-    response = await autumnClient.events.aggregate(
-      {
-        customerId: orgId,
-        entityId: teamId,
-        featureId: CREDITS_FEATURE_ID,
-        range: HISTORICAL_RANGE,
-        binSize: HISTORICAL_BIN_SIZE,
-        groupBy: "properties.apiKeyId",
-      },
-      { timeoutMs: HISTORICAL_AGGREGATE_TIMEOUT_MS },
-    );
+    response = await autumnHistoricalClient.events.aggregate({
+      customerId: orgId,
+      entityId: teamId,
+      featureId: CREDITS_FEATURE_ID,
+      range: HISTORICAL_RANGE,
+      binSize: HISTORICAL_BIN_SIZE,
+      groupBy: "properties.apiKeyId",
+    });
   } catch (err: any) {
     const status = err?.statusCode ?? err?.status ?? err?.response?.status;
     if (status !== 404) throw err;


### PR DESCRIPTION
## Problem

`GET /team/{credit,token}-usage/historical?byApiKey=true` returns **500** in production, on v1 and v2:

```
$ curl -s -o /dev/null -w "%{http_code} %{time_total}s\n" -H "Authorization: Bearer fc-..." \
    https://api.firecrawl.dev/v2/team/credit-usage/historical
200 1.06s

$ curl ... "https://api.firecrawl.dev/v2/team/credit-usage/historical?byApiKey=true"
500 2.85s
```

| endpoint | `?byApiKey=true` |
| --- | --- |
| `/v1/team/credit-usage/historical` | 500 (2.90s) |
| `/v1/team/token-usage/historical` | 500 (2.92s) |
| `/v2/team/credit-usage/historical` | 500 (2.85s) |
| `/v2/team/token-usage/historical` | 500 (3.11s) |

## Root cause

Two layers.

**1. The query is expensive.** `byApiKey=true` adds `groupBy: "properties.apiKeyId"`, so Autumn walks ~90 days of raw events *per group per daily bin* — on every single request. Nothing was cached, so cost scaled directly with the team's event volume.

**2. The timeout that was supposed to absorb that is a no-op.** #4178 passed a per-call `timeoutMs: 15000`, but the Autumn SDK cannot lengthen a shorter client-level timeout. `TimeoutFixHook.beforeRequest` reads the *client's* `timeoutMs` and intersects it with the request signal:

```js
const signal = AbortSignal.any([request.signal, AbortSignal.timeout(timeoutMs)]);
```

`AbortSignal.any` fires on the first abort, so the effective budget is `min(perCall, client)`. With `autumnClient` pinned at `timeoutMs: 2000`, the per-call 15s was dead code.

Reproduced against the SDK with a local server that answers after 4s:

| client `timeoutMs` | per-call `timeoutMs` | result |
| --- | --- | --- |
| 2000 (main today) | 15000 | **aborted at 2017ms → `Status 555`** |
| 15000 | — | OK at 4011ms |

That `Status 555` is exactly what the endpoint turns into the 500 above.

## Fix

**Precomputed per-month rollup, cached in Redis.** The reported window is split into slices ordered by how often each can change:

| slice | mutability | recomputed |
| --- | --- | --- |
| one per closed calendar month | immutable | once ever |
| current month → midnight today | immutable | once per day |
| today so far | still accruing | ≤ once per minute |

Each slice is cached under a key that names its own window (`…:m:2026-06`, `…:mtd:2026-07:2026-07-31`, `…:d:2026-07-31`), so **correctness comes from the key, not from TTL expiry** — a stale entry can never be served for a different day or month. TTLs only reclaim space.

Result: a steady-state request scans **one day** of events instead of ~90, and a warm request makes no Autumn call at all. A fully cold cache costs `HISTORICAL_MONTHS + 1` parallel queries, which happens at most once per team per day.

Rollups are keyed by raw `apiKeyId` and names are resolved on read, so renaming a key shows up immediately rather than being frozen into a cache entry for a month.

**Supporting changes:**

- **Dedicated `autumnHistoricalClient`** with a *client-level* 15s budget, which the SDK does honour. The hot-path client keeps its 2s for latency-sensitive balance checks. This is the belt to the rollup's braces: caching stops the timeout being reachable in steady state, the client makes a cold miss survivable.
- **Whole calendar months instead of a rolling `range: "90d"`.** The old window opened mid-month, so the oldest month reported partial data while being labelled as the full month (e.g. May reported from May 2 but was returned as all of May). A window that shifts daily also makes every month look mutable, which defeats caching outright.
- **Explicit `maxGroups`.** Autumn defaults to 9 groups per bin and buckets the rest into `"Other"`. With per-day bins the top-9 differs day to day, so any team with more than 9 API keys had its per-key monthly totals silently scrambled.
- **Short backoff on the historical client.** A cold rollup now fans out one aggregate per window and the SDK does not retry by default; a transient 429/5xx on any one of them would fail the whole response (observed once during verification).

### Why Redis and not a table

The durable ideal is a `credit_usage_rollup(team_id, api_key_id, month, credits)` table written at billing time. That is not reachable from this repo: there is no migration tooling (no `drizzle-kit`, no `migrations/`), and `db/schema/public.ts` only *mirrors* migrations applied elsewhere. Neither Postgres nor ClickHouse currently holds a complete per-API-key credit ledger either — `requests` has `api_key_id` but no credits, `scrapes`/`scrape_results` cover scrapes only — so Autumn remains the only complete source. This derives the rollup from Autumn and stores it in the one place this repo can write to. A real table remains the follow-up, and would slot in behind the same two functions.

## Verification

Against **real Autumn**, running the actual `getTeamHistoricalUsageByApiKey` code path on high-volume teams:

| team (July credits) | `main`'s query shape | fix, cold | fix, warm | grouped vs ungrouped |
| --- | --- | --- | --- | --- |
| 9899 | 1964 ms | 1558 ms | **1 ms** | ✅ agree |
| 6248 | 1576 ms | 1640 ms | **1 ms** | ✅ agree |

Cache keys observed:

```
usage-rollup:v1:by-key:<team>:m:2026-05
usage-rollup:v1:by-key:<team>:m:2026-06
usage-rollup:v1:by-key:<team>:mtd:2026-07:2026-07-31
usage-rollup:v1:by-key:<team>:d:2026-07-31
```

Two findings from that run worth recording:

- **`customRange` behaves correctly** and its totals agree exactly with the old `range: "90d"` query.
- **`binSize: "month"` is unusable** — it returns `0` for every closed month, across all 1498 entities scanned. Month bins would have been the obvious optimisation (3 bins instead of 90) and would have silently zeroed all historical data. `binSize: "day"` is retained deliberately; please don't "optimise" this later without re-checking.

## Tests

- **`usage.test.ts`** — slice windowing (each closed month, month-to-date, today queried separately), key-per-window naming, steady state re-querying only today, concurrent cold requests coalescing to one call per window, cache-unavailable degradation, `maxGroups`, no `groupBy` leaking onto the ungrouped path, rename-visible-immediately, and the existing month-bucketing/404/rethrow behaviour.
- **`usage-timeout.test.ts`** (new) — drives the **real** Autumn clients against a transport that answers slower than the hot-path budget. The mock-based tests can only assert which client a call is routed to; they cannot catch a timeout. This one can: it fails on `main`'s implementation with `AutumnDefaultError: Status 555` at ~2.5s and passes with the fix.
- **`snips/v2/billing.test.ts`** — e2e `byApiKey=true` happy paths for credit and token historical, asserting 200 with a well-formed per-API-key payload.

Locally: 82 unit tests pass, `tsc --noEmit` clean on touched files, `knip` exit 0.

## Reviewer notes

- **Behaviour change:** the window is now 3 whole calendar months, so the oldest month reports from day 1 rather than mid-month. This corrects real under-reporting, but it does shift historical numbers slightly — worth a look if the dashboard reconciles against stored values.
- **Not verified:** the fixed code has not run against the team whose prod endpoint 500s (`lookupOrgId` needs Postgres, unavailable locally), and obviously not against a deployed build. The teams in the table were found by scanning Autumn directly.
- The `appendQuery` commit is unrelated housekeeping — `knip` already fails on `main` because that export is only used inside its own module, and the pre-commit gate must not be bypassed.

Supersedes #4179 and #4180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
