### PR TITLE
feat(api): add Atlas Cloud model provider

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -99,6 +99,7 @@ const configSchema = z.object({
   BULL_AUTH_KEY: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
+  ATLASCLOUD_API_KEY: z.string().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),

--- a/apps/api/src/lib/generic-ai.test.ts
+++ b/apps/api/src/lib/generic-ai.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getModel, selectDefaultProvider } from "./generic-ai";
+
+describe("Atlas Cloud provider", () => {
+  it("selects Atlas Cloud when no local Ollama endpoint is configured", () => {
+    expect(selectDefaultProvider(undefined, "atlas-key")).toBe("atlascloud");
+    expect(selectDefaultProvider("http://localhost:11434", "atlas-key")).toBe(
+      "ollama",
+    );
+  });
+
+  it("uses the Atlas Cloud default nested model ID", () => {
+    const model = getModel("ignored", "atlascloud");
+
+    expect(model.provider).toBe("openai.chat");
+    expect(model.modelId).toBe("deepseek-ai/deepseek-v4-pro");
+  });
+});

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -9,8 +9,9 @@ import { fireworks } from "@ai-sdk/fireworks";
 import { deepinfra } from "@ai-sdk/deepinfra";
 import { createVertex } from "@ai-sdk/google-vertex";
 
-type Provider =
+export type Provider =
   | "openai"
+  | "atlascloud"
   | "ollama"
   | "anthropic"
   | "groq"
@@ -19,13 +20,30 @@ type Provider =
   | "fireworks"
   | "deepinfra"
   | "vertex";
-const defaultProvider: Provider = config.OLLAMA_BASE_URL ? "ollama" : "openai";
+
+export function selectDefaultProvider(
+  ollamaBaseUrl?: string,
+  atlasCloudApiKey?: string,
+): Provider {
+  if (ollamaBaseUrl) return "ollama";
+  if (atlasCloudApiKey) return "atlascloud";
+  return "openai";
+}
+
+const defaultProvider = selectDefaultProvider(
+  config.OLLAMA_BASE_URL,
+  config.ATLASCLOUD_API_KEY,
+);
 
 const providerList: Record<Provider, any> = {
   openai: createOpenAI({
     apiKey: config.OPENAI_API_KEY,
     baseURL: config.OPENAI_BASE_URL,
   }), //OPENAI_API_KEY
+  atlascloud: createOpenAI({
+    apiKey: config.ATLASCLOUD_API_KEY,
+    baseURL: "https://api.atlascloud.ai/v1",
+  }),
   ollama: createOllama({
     baseURL: config.OLLAMA_BASE_URL,
   }),
@@ -57,10 +75,15 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   if (name === "gemini-2.5-pro") {
     name = "gemini-2.5-pro";
   }
-  const modelName = config.MODEL_NAME || name;
+  const modelName =
+    config.MODEL_NAME ||
+    (provider === "atlascloud" ? "deepseek-ai/deepseek-v4-pro" : name);
   // o3-mini returns empty text via the Responses API — force Chat Completions
   if (provider === "openai" && modelName.startsWith("o3-mini")) {
     return providerList.openai.chat(modelName);
+  }
+  if (provider === "atlascloud") {
+    return providerList.atlascloud.chat(modelName);
   }
   return providerList[provider](modelName);
 }


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class OpenAI-compatible model provider
- select Atlas Cloud by default when `ATLASCLOUD_API_KEY` is configured and no local Ollama endpoint takes precedence
- use the Atlas Cloud endpoint and a nested default model ID through the Chat Completions API
- cover provider selection and model construction with focused tests

## Testing

- `pnpm exec vitest run src/lib/generic-ai.test.ts` (2 passed)
- `pnpm exec prettier --check src/config.ts src/lib/generic-ai.ts src/lib/generic-ai.test.ts`
- live Atlas Cloud Chat Completions request through `getModel()` (non-empty response, `finishReason=stop`)
- `git diff --check`

## Build note

`pnpm run build` could not complete in this environment because the FoundationDB install script requires local `foundationdb/fdb_c.h`. Installing with scripts disabled then leaves the internal native `@mendable/firecrawl-rs` workspace package unavailable; the resulting errors are confined to existing document converter and scraper modules outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788089728&installation_model_id=11126&pr_number=4193&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4193&signature=edf9e45535a934bbbe40373ab446519592e1a953a5bb9cb1e9ae637425228ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Atlas Cloud as an OpenAI-compatible provider. It becomes the default when `ATLASCLOUD_API_KEY` is set and no local Ollama endpoint is configured.

- **New Features**
  - Added `atlascloud` provider using the OpenAI Chat Completions API (`https://api.atlascloud.ai/v1`).
  - Defaults to model `deepseek-ai/deepseek-v4-pro` for Atlas Cloud.
  - Introduced `selectDefaultProvider()` to choose between Ollama → Atlas Cloud → OpenAI.
  - Added `ATLASCLOUD_API_KEY` to config and tests for provider selection/model wiring.

- **Migration**
  - Set `ATLASCLOUD_API_KEY` to enable Atlas Cloud; it will become default unless `OLLAMA_BASE_URL` is set.

<sup>Written for commit e1a7208eae16b1909b410cab20d7a4727651e9df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

