### PR TITLE
feat(api): accept input aliases for the developer search category

### DIFF
--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1046,6 +1046,75 @@ describe("V2 Types Validation", () => {
       ).toThrow();
     });
 
+    it("should normalize every developer category alias to developer", () => {
+      const aliases = [
+        "repo",
+        "code",
+        "developer",
+        "docs",
+        "devdex",
+        "repo_search",
+        "developer_index",
+      ];
+
+      for (const alias of aliases) {
+        expect(
+          searchRequestSchema.parse({ query: "test", categories: [alias] })
+            .categories,
+        ).toEqual([{ type: "developer" }]);
+
+        expect(
+          searchRequestSchema.parse({
+            query: "test",
+            categories: [{ type: alias }],
+          }).categories,
+        ).toEqual([{ type: "developer" }]);
+      }
+    });
+
+    it("should deduplicate developer aliases into one developer category", () => {
+      expect(
+        searchRequestSchema.parse({
+          query: "test",
+          categories: ["code", "developer"],
+        }).categories,
+      ).toEqual([{ type: "developer" }]);
+
+      expect(
+        searchRequestSchema.parse({
+          query: "test",
+          categories: [{ type: "repo_search" }, { type: "developer" }],
+        }).categories,
+      ).toEqual([{ type: "developer" }]);
+
+      expect(
+        searchRequestSchema.parse({
+          query: "test",
+          categories: ["docs", "github", "developer_index"],
+        }).categories,
+      ).toEqual([{ type: "developer" }, { type: "github" }]);
+    });
+
+    it("should reject developer alias params and unknown categories", () => {
+      expect(() =>
+        searchRequestSchema.parse({
+          query: "test",
+          categories: [{ type: "code", repos: ["firecrawl/firecrawl"] }],
+        }),
+      ).toThrow();
+
+      expect(() =>
+        searchRequestSchema.parse({ query: "test", categories: ["bogus"] }),
+      ).toThrow();
+
+      expect(() =>
+        searchRequestSchema.parse({
+          query: "test",
+          categories: [{ type: "bogus" }],
+        }),
+      ).toThrow();
+    });
+
     it("should accept search request with advanced categories format", () => {
       const input: SearchRequestInput = {
         query: "test",

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1913,6 +1913,49 @@ const developerCategoryOptions = z.strictObject({
   type: z.literal("developer"),
 });
 
+const developerCategoryAliases = new Set([
+  "repo",
+  "code",
+  "developer",
+  "docs",
+  "devdex",
+  "repo_search",
+  "developer_index",
+]);
+
+function isDeveloperCategoryAlias(value: unknown): value is string {
+  return typeof value === "string" && developerCategoryAliases.has(value);
+}
+
+function normalizeDeveloperCategoryAliases(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+  let seenString = false;
+  let seenObject = false;
+  const normalized: unknown[] = [];
+  for (const category of value) {
+    if (isDeveloperCategoryAlias(category)) {
+      if (seenString) continue;
+      seenString = true;
+      normalized.push("developer");
+    } else if (
+      typeof category === "object" &&
+      category !== null &&
+      isDeveloperCategoryAlias((category as { type?: unknown }).type)
+    ) {
+      if (Object.keys(category).length === 1) {
+        if (seenObject) continue;
+        seenObject = true;
+        normalized.push({ type: "developer" });
+      } else {
+        normalized.push({ ...category, type: "developer" });
+      }
+    } else {
+      normalized.push(category);
+    }
+  }
+  return normalized;
+}
+
 const searchDomainSchema = z
   .string()
   .trim()
@@ -1947,19 +1990,20 @@ export const searchRequestSchema = z
       .optional()
       .prefault(["web"]),
     categories: z
-      .union([
-        // Array of strings (simple format)
-        z.array(z.enum(["github", "research", "pdf", "developer"])),
-        // Array of objects (advanced format)
-        z.array(
-          z.union([
-            githubCategoryOptions,
-            researchCategoryOptions,
-            pdfCategoryOptions,
-            developerCategoryOptions,
-          ]),
-        ),
-      ])
+      .preprocess(
+        normalizeDeveloperCategoryAliases,
+        z.union([
+          z.array(z.enum(["github", "research", "pdf", "developer"])),
+          z.array(
+            z.union([
+              githubCategoryOptions,
+              researchCategoryOptions,
+              pdfCategoryOptions,
+              developerCategoryOptions,
+            ]),
+          ),
+        ]),
+      )
       .optional(),
     includeDomains: z.array(searchDomainSchema).optional(),
     excludeDomains: z.array(searchDomainSchema).optional(),


### PR DESCRIPTION
Callers still send `code` after the #4185 rename, and downstream integrations want stable synonyms. This adds input aliases for the `developer` category on v2 search.

A `z.preprocess` seam on `categories` in `searchRequestSchema` rewrites alias names to `developer` before validation, in both the string form and the object form. Duplicates that collapse to `developer` deduplicate to one entry, so `["code", "developer"]` runs one developer arm. Everything downstream — the key-restriction gate, `wantsDeveloperCategory`, the upstream call, the `data.developer` response group — sees only the canonical name. Output is unchanged.

| input | canonical |
|---|---|
| `developer` | `developer` |
| `code` | `developer` |
| `repo` | `developer` |
| `docs` | `developer` |
| `devdex` | `developer` |
| `repo_search` | `developer` |
| `developer_index` | `developer` |

Because normalization runs before validation:
- an unknown category returns the same zod error envelope as before (verified byte-identical against main);
- an alias object with extra params (`{ type: "code", repos: [...] }`) is still rejected by the strict developer schema — query + limit stay the only knobs.

Tests (`types-validation.test.ts`): all seven names normalize in both forms; alias+canonical dedupes to one entry; a deduped alias keeps its position next to other categories; alias params and unknown categories still reject. `vitest` on the touched suites: 124 passed. `prettier --check`: clean. `tsc --noEmit`: only the pre-existing `document/index.ts` TS2366, verified present on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4vZ6XH65bUJDkLthyfmvC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788110615&installation_model_id=11126&pr_number=4195&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4195&signature=ab0a0c5551c4ff549b5014fa1a5943b40bcc5980ec992a525bba52483851973f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds input aliases for the v2 `developer` search category so callers can use `code`, `repo`, `docs`, `devdex`, `repo_search`, or `developer_index`. Aliases normalize to `developer` before validation and dedupe to a single entry; output remains the same.

- **New Features**
  - Preprocesses `categories` in `searchRequestSchema` to rewrite alias strings or objects to `developer`.
  - Deduplicates alias + canonical to one `developer` item; keeps order relative to other categories.
  - Validation behavior unchanged: unknown categories still error; alias objects with extra params are rejected by the strict `developer` schema.
  - Tests cover normalization, dedupe, ordering, and errors.

<sup>Written for commit ca441db2513030ce8ca4682f8a7b46b143a98671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

