### PR TITLE
feat(api): log developer category searches to the code_searches ledger

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
@@ -1,0 +1,268 @@
+import { vi } from "vitest";
+
+const mockLogRequest = vi.fn();
+const mockLogSearch = vi.fn();
+const mockLogResearchEndpoint = vi.fn();
+
+vi.mock("../../../services/logging/log_job", () => ({
+  logRequest: (...args: any[]) => mockLogRequest(...args),
+  logSearch: (...args: any[]) => mockLogSearch(...args),
+  logResearchEndpoint: (...args: any[]) => mockLogResearchEndpoint(...args),
+}));
+
+const mockExecuteSearch = vi.fn();
+
+vi.mock("../../../search/execute", () => ({
+  executeSearch: (...args: any[]) => mockExecuteSearch(...args),
+}));
+
+vi.mock("../../../services/billing/credit_billing", () => ({
+  billTeam: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../lib/keyless", () => ({
+  KEYLESS_FREE_TIER_LIMIT_MESSAGE: "keyless limit reached",
+  adjustKeylessCredits: vi.fn().mockResolvedValue(undefined),
+  logKeylessCreditUsage: vi.fn().mockResolvedValue(undefined),
+  reserveKeylessCredits: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock("../../../lib/keyless-credit-projection", () => ({
+  projectSearchTotalCredits: () => 0,
+}));
+
+vi.mock("../../../lib/threat-protection/request", () => ({
+  resolveThreatProtection: vi.fn().mockResolvedValue({ policy: null }),
+  checkUrlsAgainstThreatPolicy: vi.fn(),
+}));
+
+vi.mock("../../../lib/key-restriction", () => ({
+  actionTypesOf: () => [],
+  formatTypesOf: () => [],
+  checkKeyFormatRestriction: vi.fn().mockResolvedValue({ allowed: true }),
+  checkKeyEndpointRestriction: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock("../../../services/sentry", () => ({
+  applyZdrScope: vi.fn(),
+  captureExceptionWithZdrCheck: vi.fn(),
+}));
+
+vi.mock("../../../lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+import { searchController } from "../search";
+
+const TEAM_ID = "11111111-1111-1111-1111-111111111111";
+
+const developerResults = [
+  {
+    url: "https://github.com/example/repo",
+    title: "example/repo",
+    description: "a repo",
+    position: 1,
+    category: "developer",
+  },
+  {
+    url: "https://github.com/example/other",
+    title: "example/other",
+    description: "another repo",
+    position: 2,
+    category: "developer",
+  },
+];
+
+function executeResult(overrides: Record<string, any> = {}) {
+  return {
+    response: { web: [], developer: developerResults },
+    totalResultsCount: 2,
+    searchCredits: 2,
+    scrapeCredits: 0,
+    totalCredits: 2,
+    shouldScrape: false,
+    ...overrides,
+  };
+}
+
+function makeReq(body: Record<string, any>, headers: Record<string, any> = {}) {
+  return {
+    body,
+    headers,
+    auth: { team_id: TEAM_ID },
+    acuc: { api_key_id: 7, flags: null },
+  } as any;
+}
+
+function makeRes() {
+  const res: any = {
+    status: vi.fn(),
+    json: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  return res;
+}
+
+async function flushAsync() {
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLogRequest.mockResolvedValue(undefined);
+  mockLogSearch.mockResolvedValue(undefined);
+  mockLogResearchEndpoint.mockResolvedValue(undefined);
+  mockExecuteSearch.mockResolvedValue(executeResult());
+});
+
+describe("developer category code_searches ledger", () => {
+  it("writes exactly one code_searches row for a developer category search", async () => {
+    const req = makeReq({
+      query: "vector database client",
+      categories: ["developer"],
+      origin: "sdk",
+      integration: "cli",
+    });
+    const res = makeRes();
+
+    await searchController(req, res);
+    await flushAsync();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockLogResearchEndpoint).toHaveBeenCalledTimes(1);
+    const row = mockLogResearchEndpoint.mock.calls[0][0];
+    expect(row.table).toBe("code_searches");
+    expect(row.team_id).toBe(TEAM_ID);
+    expect(row.target).toBe("vector database client");
+    expect(row.num_results).toBe(2);
+    expect(row.credits_cost).toBe(0);
+    expect(row.is_successful).toBe(true);
+    expect(row.options.origin).toBe("sdk");
+    expect(row.options.integration).toBe("cli");
+    expect(row.options.api_version).toBe("v2");
+    expect(row.options.categories).toEqual([{ type: "developer" }]);
+    expect(row.options.via).toBe("search_category");
+    expect(row.request_id).toBe(res.json.mock.calls[0][0].id);
+  });
+
+  it("counts alias category inputs the same as developer", async () => {
+    for (const alias of ["repo", "code", "docs", "developer_index"]) {
+      mockLogResearchEndpoint.mockClear();
+      const req = makeReq({
+        query: "http client",
+        categories: [alias],
+        origin: "sdk",
+      });
+      const res = makeRes();
+
+      await searchController(req, res);
+      await flushAsync();
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockLogResearchEndpoint).toHaveBeenCalledTimes(1);
+      const row = mockLogResearchEndpoint.mock.calls[0][0];
+      expect(row.table).toBe("code_searches");
+      expect(row.options.categories).toEqual([{ type: "developer" }]);
+    }
+  });
+
+  it("writes no row for a search without the developer category", async () => {
+    mockExecuteSearch.mockResolvedValue(
+      executeResult({ response: { web: [] } }),
+    );
+
+    for (const categories of [undefined, ["github"]]) {
+      mockLogResearchEndpoint.mockClear();
+      const req = makeReq({
+        query: "http client",
+        ...(categories ? { categories } : {}),
+      });
+      const res = makeRes();
+
+      await searchController(req, res);
+      await flushAsync();
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(mockLogResearchEndpoint).not.toHaveBeenCalled();
+    }
+  });
+
+  it("uses the x-origin header when the body has no origin", async () => {
+    const req = makeReq(
+      { query: "http client", categories: ["developer"] },
+      { "x-origin": "mcp-server" },
+    );
+    const res = makeRes();
+
+    await searchController(req, res);
+    await flushAsync();
+
+    expect(mockLogResearchEndpoint).toHaveBeenCalledTimes(1);
+    const row = mockLogResearchEndpoint.mock.calls[0][0];
+    expect(row.options.origin).toBe("mcp-server");
+  });
+
+  it("prefers the body origin over the x-origin header", async () => {
+    const req = makeReq(
+      { query: "http client", categories: ["developer"], origin: "website" },
+      { "x-origin": "mcp-server" },
+    );
+    const res = makeRes();
+
+    await searchController(req, res);
+    await flushAsync();
+
+    const row = mockLogResearchEndpoint.mock.calls[0][0];
+    expect(row.options.origin).toBe("website");
+  });
+
+  it("falls back to api when neither body origin nor header is present", async () => {
+    const req = makeReq({ query: "http client", categories: ["developer"] });
+    const res = makeRes();
+
+    await searchController(req, res);
+    await flushAsync();
+
+    const row = mockLogResearchEndpoint.mock.calls[0][0];
+    expect(row.options.origin).toBe("api");
+  });
+
+  it("records zero results when the developer arm returns nothing", async () => {
+    mockExecuteSearch.mockResolvedValue(
+      executeResult({ response: { web: [] }, totalResultsCount: 0 }),
+    );
+    const req = makeReq({ query: "http client", categories: ["developer"] });
+    const res = makeRes();
+
+    await searchController(req, res);
+    await flushAsync();
+
+    expect(mockLogResearchEndpoint).toHaveBeenCalledTimes(1);
+    expect(mockLogResearchEndpoint.mock.calls[0][0].num_results).toBe(0);
+  });
+
+  it("keeps the response unchanged when the ledger write fails", async () => {
+    mockLogResearchEndpoint.mockRejectedValue(new Error("ledger down"));
+    const req = makeReq({
+      query: "vector database client",
+      categories: ["developer"],
+    });
+    const res = makeRes();
+
+    await searchController(req, res);
+    await flushAsync();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data.developer).toEqual(developerResults);
+    expect(body.creditsUsed).toBe(2);
+  });
+});

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -17,6 +17,7 @@ import type {
 import type { RequestWithAuth } from "../v1/types";
 import { wrap } from "../../routes/shared";
 import { integrationSchema } from "../../utils/integration";
+import { requestOrigin } from "../../lib/request-origin";
 
 const SEARCH_CREDITS_PER_TEN_RESULTS = 2;
 const ZDR_SEARCH_CREDITS_PER_TEN_RESULTS = 10;
@@ -191,16 +192,6 @@ function addLegacySnakeCaseAliases<T>(value: T): T {
 
 function resultCount(body: any): number {
   return Array.isArray(body?.results) ? body.results.length : 0;
-}
-
-function firstHeaderValue(req: Request, key: string): string | undefined {
-  const value = req.headers[key];
-  if (Array.isArray(value)) return value[0];
-  return typeof value === "string" ? value : undefined;
-}
-
-function requestOrigin(params: ResearchQueryParams, req: Request) {
-  return params.origin ?? firstHeaderValue(req, "x-origin") ?? "api";
 }
 
 function creditsFor(

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -14,7 +14,11 @@ import {
   reserveKeylessCredits,
 } from "../../lib/keyless";
 import { v7 as uuidv7 } from "uuid";
-import { logSearch, logRequest } from "../../services/logging/log_job";
+import {
+  logSearch,
+  logRequest,
+  logResearchEndpoint,
+} from "../../services/logging/log_job";
 import { logger as _logger } from "../../lib/logger";
 import { ScrapeJobTimeoutError } from "../../lib/error";
 import { z } from "zod";
@@ -36,6 +40,7 @@ import {
   formatTypesOf,
 } from "../../lib/key-restriction";
 import { wantsDeveloperCategory } from "../../search/developer";
+import { requestOrigin } from "../../lib/request-origin";
 
 export async function searchController(
   req: RequestWithAuth<{}, SearchResponse, SearchRequest>,
@@ -67,6 +72,8 @@ export async function searchController(
   let reconciledKeylessCredits = false;
 
   try {
+    const rawOrigin =
+      typeof req.body?.origin === "string" ? req.body.origin : undefined;
     req.body = searchRequestSchema.parse(req.body);
 
     const requestedFormats = formatTypesOf(req.body.scrapeOptions?.formats);
@@ -299,6 +306,33 @@ export async function searchController(
       },
       false,
     );
+
+    if (wantsDeveloperCategory(req.body.categories as CategoryOption[])) {
+      logResearchEndpoint({
+        table: "code_searches",
+        id: uuidv7(),
+        request_id: agentRequestId ?? jobId,
+        team_id: req.auth.team_id,
+        target: req.body.query,
+        options: {
+          origin: requestOrigin({ origin: rawOrigin }, req),
+          integration: req.body.integration ?? null,
+          api_version: "v2",
+          categories: req.body.categories,
+          via: "search_category",
+        },
+        response: null,
+        num_results: result.response.developer?.length ?? 0,
+        time_taken: timeTakenInSeconds,
+        credits_cost: 0,
+        is_successful: true,
+        zeroDataRetention,
+      }).catch(ledgerError => {
+        logger.warn("Failed to log developer category usage", {
+          error: ledgerError,
+        });
+      });
+    }
 
     const totalRequestTime = new Date().getTime() - middlewareStartTime;
     const controllerTime = new Date().getTime() - controllerStartTime;

--- a/apps/api/src/lib/request-origin.ts
+++ b/apps/api/src/lib/request-origin.ts
@@ -1,0 +1,17 @@
+import type { Request } from "express";
+
+function firstHeaderValue(
+  req: Pick<Request, "headers">,
+  key: string,
+): string | undefined {
+  const value = req.headers[key];
+  if (Array.isArray(value)) return value[0];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function requestOrigin(
+  params: { origin?: string },
+  req: Pick<Request, "headers">,
+): string {
+  return params.origin ?? firstHeaderValue(req, "x-origin") ?? "api";
+}


### PR DESCRIPTION
Dev-index usage from the `/v2/search` category path was invisible: only `/v2/developer/search` wrote `code_searches` rows, and the category path read `origin` from the body alone, so MCP traffic (X-Origin header) logged as `api`.

Now both paths land in `code_searches`:

| Path | Origin / integration source | Ledger rows | Credits on the row |
|---|---|---|---|
| `/v2/developer/search` (proxy) | body/query `origin` → `X-Origin` header → `api` | `requests` (kind `code_search`) + `code_searches` | full search credits (unchanged) |
| `/v2/search` with `developer` category | body `origin` → `X-Origin` header → `api` | `requests` (kind `search`) + `searches` + `code_searches` | `0`, marked `via: "search_category"` |

Decisions:

- **`credits_cost` is 0 on the category-path row.** The search request already bills `ceil(total/10) * perTen` over a total that includes the developer group; the `searches` row carries those credits. A nonzero value here would double-count in the ledger. `options.via = "search_category"` plus `request_id` = the search job id tie the row to the billing row.
- **Origin derivation is scoped to the ledger row.** `searchRequestSchema` prefaults `origin` to `"api"`, so the raw body value is captured before parse and resolved through `requestOrigin` (factored out of the proxy into `lib/request-origin.ts`, proxy behavior unchanged). The search request's own `origin` field is untouched — it feeds highlight-mode cohort selection, and rewriting it would change responses for MCP callers.
- **Fire-and-forget.** The write is not awaited and failures only log a warning; the search response cannot fail or slow on it.
- `num_results` is the served developer group count (post threat-filter); `options` carries the normalized categories, so alias inputs (`repo`, `code`, `docs`, …) from #4195 count identically.

Tests (`search-developer-ledger.test.ts`): one row per developer-category search with origin/integration/categories asserted, alias inputs write the same row, non-developer searches write nothing, X-Origin honored when the body has no origin, body origin wins over the header, zero-result arm still writes `num_results: 0`, ledger failure leaves the response intact.

Gates: vitest (new suite + `developer.test.ts`, `search-schema.test.ts`, `log_job.test.ts` — 19 passed), prettier clean on touched files, `tsc --noEmit` byte-identical to clean-main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4vZ6XH65bUJDkLthyfmvC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788112689&installation_model_id=11126&pr_number=4196&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4196&signature=27ed421dda4a3fedb804f31c0ebe52b9efddeda89de8c638408bb6a7e475bed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs developer-category searches from `/v2/search` to the `code_searches` ledger so dev-index usage is tracked without changing billing.

- New Features
  - Write a `code_searches` row for `/v2/search` when the `developer` category (or aliases) is requested; include origin, integration, `api_version: "v2"`, normalized categories, and `via: "search_category"`.
  - Set `credits_cost: 0` and link to the search via `request_id` to avoid double billing.
  - Record `num_results` from the served developer results; still writes when zero.
  - Resolve origin using body > `X-Origin` header > `"api"`; does not mutate the request’s own `origin`.
  - Treat `repo`, `code`, `docs`, and `developer_index` as `developer`; non-developer searches do not log.

- Refactors
  - Extracted origin resolution to `apps/api/src/lib/request-origin.ts` and reused in the research proxy.

<sup>Written for commit 8119ba725cb20dbb984631d46b102a3413a20799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

