### PR TITLE
Say which 403 a covered URL got: switched off, or unsupported site

### DIFF
--- a/apps/api/src/lib/exchange.test.ts
+++ b/apps/api/src/lib/exchange.test.ts
@@ -10,6 +10,7 @@ import {
   getExchangeRequestLogContext,
   getExchangeResponseLogContext,
   getExchangeSuccessCredits,
+  getThirdPartyDataSourceNotEnabledResponse,
   getThirdPartyDataTermsRequiredResponse,
   isSuccessfulExchangeStatusCode,
   isSupportedExchangeFormatRequest,
@@ -455,7 +456,88 @@ describe("Exchange routing", () => {
           },
         },
       }),
+    ).resolves.toEqual({
+      allowed: false,
+      termsRequired: false,
+      notEnabled: { dataSourceId: "acme" },
+    });
+  });
+
+  /**
+   * A refusal that is a fact about the organization has to be told apart from
+   * one that is a fact about us. Both leave the URL to the ordinary path, both
+   * end in the same 403 for a blocked domain, and a caller that reads the
+   * second as the first tells a customer their admin switched something off
+   * when nothing of theirs is switched off at all.
+   */
+  it("marks a switched-off source as such, and marks nothing else", async () => {
+    await expect(
+      getExchangeAccessForRequest({
+        url: "https://profiles.example/person/example-person",
+        formats: [{ type: "markdown" }],
+        flags: {
+          professionalProfileCompanyDataBeta: true,
+          organizationDataSourceAccess: {
+            acme: {
+              status: "suspended",
+              termsKey: "acme",
+              termsVersion: "2026-01-01",
+            },
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      termsRequired: false,
+      notEnabled: { dataSourceId: "acme" },
+    });
+
+    // No provider claims this URL, so nothing about the org was consulted.
+    await expect(
+      getExchangeAccessForRequest({
+        url: "https://unclaimed.example/person/example-person",
+        formats: [{ type: "markdown" }],
+        flags: ENABLED_EXCHANGE_FLAGS,
+      }),
     ).resolves.toEqual({ allowed: false, termsRequired: false });
+
+    // A request shape the Exchange cannot serve, by an org that is fully enabled.
+    await expect(
+      getExchangeAccessForRequest({
+        url: "https://profiles.example/person/example-person",
+        formats: [{ type: "html" }],
+        flags: ENABLED_EXCHANGE_FLAGS,
+      }),
+    ).resolves.toEqual({ allowed: false, termsRequired: false });
+
+    // The catalog is unreachable. This is the one that reached a customer: an
+    // org that had just switched FullEnrich on was told it was switched off,
+    // because a refusal we could not explain was reported as one we could.
+    clearExchangeProvidersForTest();
+    vi.mocked(fetch).mockRejectedValue(new Error("connect timeout"));
+    await expect(
+      getExchangeAccessForRequest({
+        url: "https://profiles.example/person/example-person",
+        formats: [{ type: "markdown" }],
+        flags: ENABLED_EXCHANGE_FLAGS,
+      }),
+    ).resolves.toEqual({ allowed: false, termsRequired: false });
+  });
+
+  it("names the data source in the switched-off refusal", () => {
+    expect(getThirdPartyDataSourceNotEnabledResponse("acme")).toMatchObject({
+      success: false,
+      code: "THIRD_PARTY_DATA_SOURCE_NOT_ENABLED",
+      requiresAction: {
+        type: "enable_data_source",
+        dataSource: "acme",
+      },
+    });
+
+    // The two 403s a covered URL can end in must never share a code.
+    expect(getThirdPartyDataSourceNotEnabledResponse("acme").code).not.toBe(
+      getThirdPartyDataTermsRequiredResponse(ACME_TERMS).code,
+    );
   });
 
   it("allows providers with no declared terms without acceptance", async () => {
@@ -478,7 +560,11 @@ describe("Exchange routing", () => {
           },
         },
       }),
-    ).resolves.toEqual({ allowed: false, termsRequired: false });
+    ).resolves.toEqual({
+      allowed: false,
+      termsRequired: false,
+      notEnabled: { dataSourceId: "openfacts" },
+    });
   });
 
   it("does not route unless the beta flag is enabled", async () => {

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -72,6 +72,10 @@ const EXCHANGE_BETA_FLAG = "professionalProfileCompanyDataBeta";
 const THIRD_PARTY_DATA_TERMS_REQUIRED_CODE = "THIRD_PARTY_DATA_TERMS_REQUIRED";
 const THIRD_PARTY_DATA_TERMS_REQUIRED_MESSAGE =
   "An organization admin must accept this data source's terms before this URL can be processed.";
+const THIRD_PARTY_DATA_SOURCE_NOT_ENABLED_CODE =
+  "THIRD_PARTY_DATA_SOURCE_NOT_ENABLED";
+const THIRD_PARTY_DATA_SOURCE_NOT_ENABLED_MESSAGE =
+  "This organization's access to the data source covering this URL is switched off.";
 
 const EXCHANGE_PROVIDERS_PATH = "/v1/providers";
 const EXCHANGE_PROVIDERS_TIMEOUT_MS = 2_000;
@@ -474,6 +478,16 @@ export type ExchangeAccess =
   | {
       allowed: false;
       termsRequired: false;
+      /**
+       * Set only when a provider covers this URL and the organization's access
+       * to it is switched off. Every other refusal collapses into this same
+       * variant - an unconfigured Exchange, an unreachable catalog, a URL no
+       * provider claims, a request shape the Exchange cannot serve - and none
+       * of those is a fact about the organization. A caller that cannot tell
+       * the two apart has to guess, and the only guess it can make from a bare
+       * refusal is the accusatory one.
+       */
+      notEnabled?: { dataSourceId: string };
     };
 
 export async function getExchangeAccessForRequest(
@@ -495,6 +509,13 @@ export async function getExchangeAccessForRequest(
     const decision = getProviderAccessDecision(provider, input.flags);
     if (decision === "terms_required" && provider.terms !== undefined) {
       return { allowed: false, termsRequired: true, terms: provider.terms };
+    }
+    if (decision === "not_enabled") {
+      return {
+        allowed: false,
+        termsRequired: false,
+        notEnabled: { dataSourceId: provider.id },
+      };
     }
     if (decision !== "allowed") {
       return { allowed: false, termsRequired: false };
@@ -528,6 +549,25 @@ export function getThirdPartyDataTermsRequiredResponse(terms: ExchangeTerms) {
       type: "accept_terms",
       terms: terms.key,
       version: terms.version,
+      url: getThirdPartyDataTermsSettingsUrl(),
+    },
+  };
+}
+
+/**
+ * The refusal for a URL a provider covers whose data source the organization
+ * has switched off. Carries a code for the same reason the terms refusal does:
+ * it shares a status with the blocklist refusal beside it, and only the code
+ * says which of the two happened.
+ */
+export function getThirdPartyDataSourceNotEnabledResponse(dataSourceId: string) {
+  return {
+    success: false as const,
+    code: THIRD_PARTY_DATA_SOURCE_NOT_ENABLED_CODE as "THIRD_PARTY_DATA_SOURCE_NOT_ENABLED",
+    error: THIRD_PARTY_DATA_SOURCE_NOT_ENABLED_MESSAGE,
+    requiresAction: {
+      type: "enable_data_source",
+      dataSource: dataSourceId,
       url: getThirdPartyDataTermsSettingsUrl(),
     },
   };

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -29,7 +29,10 @@ import {
   CREDITS_FEATURE_ID,
 } from "../services/autumn/autumn.service";
 import { getTeamBalance } from "../services/autumn/usage";
-import { getThirdPartyDataTermsRequiredResponse } from "../lib/exchange";
+import {
+  getThirdPartyDataSourceNotEnabledResponse,
+  getThirdPartyDataTermsRequiredResponse,
+} from "../lib/exchange";
 import { getExchangeAccessForRequestBody } from "../lib/exchange-request";
 import { getScrapeZDR } from "../lib/zdr-helpers";
 
@@ -346,10 +349,27 @@ function blocklistGate(
       })
     ) {
       if (!res.headersSent) {
-        return res.status(403).json({
-          success: false,
-          error: UNSUPPORTED_SITE_MESSAGE,
-        });
+        // Which requests get refused here does not change with what follows:
+        // only what the refusal says. A blocked URL that a provider covers is
+        // refused for two quite different reasons - the site is unsupported,
+        // or the org switched that provider off - and answering both with the
+        // same bare 403 leaves every caller to guess between them.
+        const notEnabled =
+          typeof exchangeAccess === "object" &&
+          !exchangeAccess.allowed &&
+          !exchangeAccess.termsRequired
+            ? exchangeAccess.notEnabled
+            : undefined;
+
+        return res
+          .status(403)
+          .json(
+            notEnabled === undefined
+              ? { success: false, error: UNSUPPORTED_SITE_MESSAGE }
+              : getThirdPartyDataSourceNotEnabledResponse(
+                  notEnabled.dataSourceId,
+                ),
+          );
       }
     }
     next();


### PR DESCRIPTION
## The problem

A URL a licensed provider covers can be refused with 403 for two quite different reasons, and nothing in the response says which.

`getExchangeAccessForRequest` returns the same bare `{ allowed: false, termsRequired: false }` for all of:

- the organization switched that data source off
- the Exchange is not configured in this environment
- the provider catalog was unreachable or timed out (2s timeout, 60s TTL, 30s failure TTL)
- no provider claims the URL
- the request shape is one the Exchange cannot serve
- the access check itself threw

`blocklistGate` then refuses every one of them with the same `UNSUPPORTED_SITE_MESSAGE` 403, because a URL a provider covers is generally one the blocklist holds — the Exchange bypass is what normally lifts it.

The terms refusal already carries a code (`THIRD_PARTY_DATA_TERMS_REQUIRED`) for exactly this reason. Its sibling did not, so a caller receiving the bare 403 has to guess, and the only guess available is the accusatory one. That is how a dashboard user who had just enabled FullEnrich in settings was told "FullEnrich is switched off for your organization. An organization admin can turn it back on."

## The change

- `ExchangeAccess`'s refusal variant gains an optional `notEnabled: { dataSourceId }`, set only when a provider covers the URL *and* the organization's access to it is switched off.
- `blocklistGate` answers that case with `THIRD_PARTY_DATA_SOURCE_NOT_ENABLED`, naming the data source, instead of the generic message.

**Which requests get refused does not change** — only what the refusal says. The `notEnabled` case is still gated behind the same `isUrlBlocked` check, so a switched-off data source on a domain that is not blocklisted still falls through to the ordinary scrape path exactly as before.

## Test plan

- [x] `npx vitest run src/lib/exchange.test.ts` — 22 passed
- [x] New cases confirmed failing before the fix (`notEnabled` absent from the disabled-access results)
- [x] Covered: a suspended status marks `notEnabled`; an unclaimed URL, an unservable request shape, and an unreachable catalog all do **not**
- [x] The two codes a covered URL can end in are asserted distinct
- [x] `npx tsc --noEmit` clean for the touched files (two pre-existing errors elsewhere: `deterministicJson/pipeline/validate.ts`, `autumn.service.ts`)
- [x] `npx vitest run src/lib src/routes src/controllers` — 877 passed; 5 pre-existing failures, none referencing the touched files (Redis-dependent `crawl-redis`/`job-priority`, embeddings-dependent `ranker`, an arithmetic drift in `browser-billing`, an import error in `crawl.test.ts`)
- [ ] `pnpm harness pnpm test:snips` — the CI gate; needs the full harness environment, not run locally

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788139805&installation_model_id=11126&pr_number=4200&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4200&signature=e0a6b754d44ad1869758ba0a9bcf8e481a6d693676eef1f881b44b4da07614ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Differentiate 403s for covered URLs: we now tell when a data source is switched off vs an unsupported site. This avoids misleading users with the generic blocklist message.

- **Bug Fixes**
  - `ExchangeAccess` adds `notEnabled: { dataSourceId }` when a provider covers the URL and org access is off.
  - `blocklistGate` returns `THIRD_PARTY_DATA_SOURCE_NOT_ENABLED` with an `enable_data_source` action instead of the generic 403 in that case.
  - No routing changes; only the 403 message/code changes. Tests added to assert distinct codes and behavior.

<sup>Written for commit 6b9ae84436c928ae4687f5eb43a15abccc8fe5d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

