### PR TITLE
fix(api): strip NUL bytes before persisting scrape results to Postgres

### DIFF
--- a/apps/api/src/__tests__/nuq-sanitize.test.ts
+++ b/apps/api/src/__tests__/nuq-sanitize.test.ts
@@ -1,0 +1,81 @@
+import { stripNulBytes } from "../services/worker/nuq";
+
+// Regression coverage for firecrawl #4113: Postgres JSON rejects embedded NUL
+// (\u0000) with error 22P05, which previously threw out of jobFinish and
+// crash-looped the nuq-worker. stripNulBytes is applied to returnvalue
+// (jobFinish) and failedReason (jobFail) before the UPDATE.
+describe("stripNulBytes", () => {
+  it("removes NUL bytes from nested objects and arrays (returnvalue shape)", () => {
+    const input = {
+      a: "x\u0000y",
+      nested: { b: ["1\u00002", { c: "\u0000z" }] },
+      "k\u0000ey": 1,
+    };
+    const expected = {
+      a: "xy",
+      nested: { b: ["12", { c: "z" }] },
+      key: 1,
+    };
+    expect(stripNulBytes(input)).toEqual(expected);
+  });
+
+  it("is loss-free for NUL-free input (no whitespace collapse, control chars preserved)", () => {
+    const input = {
+      a: "normal",
+      b: 1,
+      c: null,
+      d: ["keep", { e: "tabs\tand\nnewlines" }],
+    };
+    expect(stripNulBytes(input)).toEqual(input);
+  });
+
+  it("is idempotent (apply twice === apply once)", () => {
+    const x = { a: "x\u0000y", nested: { b: ["1\u00002", { c: "\u0000z" }] } };
+    expect(stripNulBytes(stripNulBytes(x))).toEqual(stripNulBytes(x));
+  });
+
+  it("strips NUL from a plain string (failedReason shape)", () => {
+    expect(stripNulBytes("a\u0000b")).toBe("ab");
+  });
+
+  it("passes primitives and null through untouched", () => {
+    expect(stripNulBytes(null as null)).toBeNull();
+    expect(stripNulBytes(42)).toBe(42);
+    expect(stripNulBytes(true)).toBe(true);
+    expect(stripNulBytes(undefined as undefined)).toBeUndefined();
+  });
+
+  it("strips NUL at any depth and does not overflow the stack on pathologically deep nesting (iterative walk — a naive recursion would either cap out and leave NUL unsanitized, or throw RangeError, both reintroducing the #4113 crash)", () => {
+    // 50,000 levels deep — far beyond a recursive call-stack budget (~3.4k) and
+    // beyond any prior depth cap. The leaf carries a NUL that must still be
+    // stripped, because the value serializes fine for pg and would otherwise
+    // trigger 22P05 at the UPDATE.
+    let deep: Record<string, unknown> = { leaf: "has\u0000nul" };
+    for (let i = 0; i < 50_000; i++) {
+      deep = { a: deep };
+    }
+    // Must not throw...
+    let result: Record<string, unknown> = {} as Record<string, unknown>;
+    expect(() => {
+      result = stripNulBytes(deep) as Record<string, unknown>;
+    }).not.toThrow();
+    // ...and the deep NUL must actually be removed.
+    let leaf: unknown = result;
+    for (let i = 0; i < 50_000; i++) {
+      leaf = (leaf as Record<string, unknown>).a;
+    }
+    expect((leaf as Record<string, unknown>).leaf).toBe("hasnul");
+  });
+
+  it("preserves an input __proto__ key as a normal own property (no NUL involved; a plain output object would silently drop it)", () => {
+    // JSON.parse yields __proto__ as an own enumerable property; the sanitizer
+    // must not lose it (it has no NUL and would otherwise round-trip fine).
+    const input = JSON.parse('{"__proto__":"kept","normal":"yes"}');
+    const result = stripNulBytes(input) as Record<string, unknown>;
+    expect(Object.keys(result).sort()).toEqual(["__proto__", "normal"]);
+    expect(result.__proto__).toBe("kept");
+    expect(result.normal).toBe("yes");
+    // And it must not pollute Object.prototype globally.
+    expect(({} as Record<string, unknown>).kept).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -10,6 +10,86 @@ import { nuqRedis } from "./redis";
 
 // === Basics
 
+/**
+ * Strips NUL bytes (\u0000) from any value before it is persisted to Postgres.
+ *
+ * Postgres JSON/JSONB columns reject embedded NUL with error code 22P05
+ * ("... cannot be converted to text"), which previously threw out of jobFinish
+ * and crash-looped the worker when scraped content contained a NUL byte (#4113).
+ *
+ * The transform is loss-free: only \u0000 is removed. NUL-free input is returned
+ * byte-identical (no whitespace collapse, no trimming, other control chars pass
+ * through). Every string is sanitized — including object keys, since Postgres
+ * rejects NUL in keys as well as values — so the protection is not bypassed at
+ * any depth. It walks the structure iteratively with an explicit stack rather
+ * than recursing, so a pathologically deep object cannot overflow the call
+ * stack (which would itself crash the worker, the same blast radius as #4113).
+ * Output objects use a null prototype so an input key like "__proto__" survives
+ * as a normal own property instead of being silently dropped, and the value is
+ * cloned rather than mutated.
+ */
+export function stripNulBytes<T>(value: T): T {
+  if (typeof value === "string") {
+    return value.replace(/\u0000/g, "") as T;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  // Root container (array or object). Walk it with an explicit stack so depth
+  // is bounded by heap, not the call stack, and every nested string/key is
+  // sanitized regardless of depth (no recursion ceiling to bypass).
+  const root: unknown = Array.isArray(value)
+    ? new Array(value.length)
+    : Object.create(null);
+
+  // Each frame holds a destination container and the (slot, source-value) pairs
+  // still to write into it. `slot` is an array index or a sanitized object key.
+  type Slot = number | string;
+  type Frame = {
+    dst: unknown[] | Record<string, unknown>;
+    pending: Array<{ slot: Slot; src: unknown }>;
+  };
+  const pendingFor = (src: unknown): Array<{ slot: Slot; src: unknown }> =>
+    Array.isArray(src)
+      ? src.map((v, i) => ({ slot: i, src: v }))
+      : Object.entries(src as Record<string, unknown>).map(([k, v]) => ({
+          slot: k.replace(/\u0000/g, ""),
+          src: v,
+        }));
+  const stack: Frame[] = [
+    { dst: root as Frame["dst"], pending: pendingFor(value) },
+  ];
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    for (const { slot, src } of frame.pending) {
+      let sanitized: unknown;
+      if (typeof src === "string") {
+        sanitized = src.replace(/\u0000/g, "");
+      } else if (src !== null && typeof src === "object") {
+        // New container: a fresh array or a null-prototype object (so an input
+        // "__proto__" key is preserved as a normal own property, not dropped).
+        sanitized = Array.isArray(src)
+          ? new Array(src.length)
+          : Object.create(null);
+        stack.push({
+          dst: sanitized as Frame["dst"],
+          pending: pendingFor(src),
+        });
+      } else {
+        sanitized = src;
+      }
+      if (typeof slot === "number") {
+        (frame.dst as unknown[])[slot] = sanitized;
+      } else {
+        (frame.dst as Record<string, unknown>)[slot] = sanitized;
+      }
+    }
+  }
+  return root as T;
+}
+
 const nuqPool = new Pool({
   connectionString: config.NUQ_DATABASE_URL, // may be a pgbouncer transaction pooler URL
   application_name: "nuq",
@@ -1377,9 +1457,10 @@ class NuQ<JobData = any, JobReturnValue = any> {
 
       const start = Date.now();
       try {
+        const sanitizedReturnvalue = stripNulBytes(returnvalue);
         const result = await nuqPool.query(
           `UPDATE ${this.queueName} SET status = 'completed'::nuq.job_status, lock = null, locked_at = null, finished_at = now(), returnvalue = $3 WHERE id = $1 AND lock = $2 RETURNING id, listen_channel_id;`,
-          [id, lock, returnvalue],
+          [id, lock, sanitizedReturnvalue],
         );
 
         const success = result.rowCount !== 0;
@@ -1435,9 +1516,10 @@ class NuQ<JobData = any, JobReturnValue = any> {
 
       const start = Date.now();
       try {
+        const sanitizedFailedReason = stripNulBytes(failedReason);
         const result = await nuqPool.query(
           `UPDATE ${this.queueName} SET status = 'failed'::nuq.job_status, lock = null, locked_at = null, finished_at = now(), failedreason = $3 WHERE id = $1 AND lock = $2 RETURNING id, listen_channel_id;`,
-          [id, lock, failedReason],
+          [id, lock, sanitizedFailedReason],
         );
 
         const success = result.rowCount !== 0;


### PR DESCRIPTION
## What

Fixes a worker crash-loop on self-hosted deployments where scraped content contained a NUL byte (`\u0000`). Postgres rejects embedded NUL in JSON/JSONB with error `22P05` ("… cannot be converted to text"), the throw happened inside `jobFinish`, so the job never reached a terminal state and the worker kept re-running the same poison job after every restart — taking the whole `api` container down each time.

Fixes #4113.

## Root cause

`jobFinish` (`apps/api/src/services/worker/nuq.ts`) binds the scraped `returnvalue` straight to the `returnvalue` JSONB column via an `UPDATE … returnvalue = $3` query. `jobFail` does the same for `failedreason`. When the scraped content (or a stringified error) contained `\u0000`, Postgres threw `22P05`, the error propagated out of `jobFinish`/`jobFail`, and the worker process crashed — only to pick up the same job again on restart.

## Fix

Added a small `stripNulBytes` helper that recursively removes `\u0000` from strings — including object keys and values inside nested arrays/objects, since `returnvalue` is an arbitrarily-deep `Document` (markdown, html, extract, json, …). It is called right before the `UPDATE` in both `jobFinish` and `jobFail`.

A few properties worth calling out:

- **Loss-free for normal content.** Only `\u0000` is touched — no whitespace collapsing, no trimming, other control chars pass through. A NUL-free result is byte-identical to before, so existing jobs are unaffected. (I did look at the existing `sanitizeStrings` in the extract pipeline, but it also collapses whitespace and trims, which is too aggressive here.)
- **Recursion is depth-capped.** A naive recursion would itself overflow the stack on a pathologically deep object — which would reintroduce the same worker-crash class this PR is fixing. The cap sits far above any real `Document` depth and well below the stack limit, so only exotic, non-real inputs are affected.
- **Scope.** Only the two terminal-state writes that carry untrusted scraped/error content are sanitized (`returnvalue`, `failedreason`). The job-input `data` column is API-request-sourced and is not the crash path reported here.

The crawl-finished queue, which routes through the same `jobFinish`/`jobFail`, gets the same protection automatically.

## Tests

New unit test `apps/api/src/__tests__/nuq-sanitize.test.ts` (pure, no DB needed) covering:

- NUL stripped from nested objects/arrays, including object keys
- loss-free no-op for NUL-free input (tabs/newlines/control chars preserved)
- idempotent (apply twice === apply once)
- plain string branch (the `failedreason` shape)
- primitives and `null` passed through untouched
- pathologically deep nesting does not throw (regression guard for the depth cap)

```
✓ src/__tests__/nuq-sanitize.test.ts (6 tests)
```

## Out of scope

- The FoundationDB queue backend (`nuq-fdb`) is unaffected by the Postgres `22P05` error and is intentionally untouched.
- The job-input `data`-column writes (API-sourced payload) are out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788189400&installation_model_id=11126&pr_number=4203&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4203&signature=5db14f5176e3bd63d40b51e18b0b82cef92b9f62c9b513ff60cac86de32fe983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented nuq-worker crash loops by stripping NUL bytes from scraped results and failure reasons before writing to Postgres JSONB. Jobs now reach terminal states and self-hosted deployments won’t crash on NUL-containing content.

- **Bug Fixes**
  - Added a `stripNulBytes` helper that removes `\u0000` from strings and object keys/values (arrays/objects) at any depth without altering other characters.
  - Applied in `jobFinish` (returnvalue) and `jobFail` (failedreason) to avoid Postgres `22P05` errors.
  - Switched to an iterative walk (no recursion) to prevent stack overflows on deep objects; output uses null-prototype objects so `"__proto__"` keys are preserved as own properties.
  - Added unit tests for nested structures, idempotency, primitives/null, plain strings, 50k-deep nesting, and `"__proto__"` preservation.

<sup>Written for commit c4c93a5d9834edf102373cb8293515fd10068f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

