### PR TITLE
Add Novita AI as a provider option

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -100,7 +100,7 @@ const configSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
-  NOVITA_API_KEY: z.string().optional(),
+  NOVITA_API_KEY: emptyStringAsUndefined(z.string().trim().min(1)),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -100,6 +100,7 @@ const configSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
+  NOVITA_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/apps/api/src/lib/__tests__/generic-ai.test.ts
+++ b/apps/api/src/lib/__tests__/generic-ai.test.ts
@@ -1,0 +1,19 @@
+vi.mock("../../config", () => ({
+  config: {
+    OPENAI_API_KEY: "openai-key",
+    NOVITA_API_KEY: "novita-key",
+  },
+}));
+
+import { getModel } from "../generic-ai";
+
+describe("getModel novita provider", () => {
+  it("uses the Chat Completions path, not the Responses API", () => {
+    // Novita's OpenAI-compatible endpoint only implements
+    // /v1/chat/completions; the AI SDK's bare createOpenAI() call defaults
+    // to the Responses API, which 404s against Novita.
+    const model = getModel("deepseek/deepseek-v4-pro", "novita");
+    expect(model.provider).toBe("openai.chat");
+    expect(model.modelId).toBe("deepseek/deepseek-v4-pro");
+  });
+});

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -67,6 +67,10 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
   if (provider === "openai" && modelName.startsWith("o3-mini")) {
     return providerList.openai.chat(modelName);
   }
+  // Novita only supports the Chat Completions path, not Responses
+  if (provider === "novita") {
+    return providerList.novita.chat(modelName);
+  }
   return providerList[provider](modelName);
 }
 

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -18,7 +18,8 @@ type Provider =
   | "openrouter"
   | "fireworks"
   | "deepinfra"
-  | "vertex";
+  | "vertex"
+  | "novita";
 const defaultProvider: Provider = config.OLLAMA_BASE_URL ? "ollama" : "openai";
 
 const providerList: Record<Provider, any> = {
@@ -37,6 +38,10 @@ const providerList: Record<Provider, any> = {
   }),
   fireworks, //FIREWORKS_API_KEY
   deepinfra, //DEEPINFRA_API_KEY
+  novita: createOpenAI({
+    apiKey: config.NOVITA_API_KEY,
+    baseURL: "https://api.novita.ai/v3/openai",
+  }), //NOVITA_API_KEY
   vertex: createVertex({
     project: "firecrawl",
     //https://github.com/vercel/ai/issues/6644 bug

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -40,7 +40,7 @@ const providerList: Record<Provider, any> = {
   deepinfra, //DEEPINFRA_API_KEY
   novita: createOpenAI({
     apiKey: config.NOVITA_API_KEY,
-    baseURL: "https://api.novita.ai/v3/openai",
+    baseURL: "https://api.novita.ai/openai",
   }), //NOVITA_API_KEY
   vertex: createVertex({
     project: "firecrawl",


### PR DESCRIPTION
## Summary

- Adds Novita AI as a provider option.
- Follows the existing provider pattern rather than introducing a new abstraction.

## Validation

Compared against the baseline on `7666c1f9ae87`: unverified_locally. Pre-existing failures are left as-is.

## Reviewer Notes

- **No tests were run against this change, in either the original submission or this revision.** Our sandbox ran out of disk space while installing the `apps/api` workspace's dependencies (886 packages; it failed partway through with `ENOSPC` on a 9.6G root partition), so neither `pnpm run build` (tsc) nor `pnpm test` (vitest) were executed. This diff has not been locally verified to even type-check.
- **No end-to-end request was made against the live Novita API through this codebase's `@ai-sdk/openai` `createOpenAI`.** The base URL `https://api.novita.ai/openai` was independently verified live (with a real API key) to work for both `/models` and `/chat/completions`, but the exact request URL `createOpenAI` produces after path concatenation was not exercised through this integration.
- **`providerList` is typed as `Record<Provider, any>`**, so this addition would not be caught by TypeScript if there were a structural mismatch — and since `tsc` wasn't run, that safety net was not actually exercised this time either.
- **No documentation was updated.** If this repo has a user-facing list of supported providers outside `apps/api/src`, it was not searched for or updated.
- **The base URL literal was corrected in this revision.** The original commit used `https://api.novita.ai/v3/openai`, an older path that Novita's current documentation (novita.ai/docs/guides/llm-api) no longer shows; the currently documented endpoint is `https://api.novita.ai/openai`. Both paths return identical, working results today (verified against `/models` and `/chat/completions`), so this was a stale citation rather than a functional break — but if your own testing shows Novita's API surface has moved again since 2026-08-01, please treat your own verification as authoritative over this PR's claim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788189917&installation_model_id=11126&pr_number=4204&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4204&signature=c741f054116e9893e4625948c928d3946c732a4d52c93fdf5c596921eed650b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Novita AI as a provider option using `createOpenAI` with base URL https://api.novita.ai/openai. Adds `NOVITA_API_KEY` (blank values treated as unset) and forces the Chat Completions path for Novita to avoid 404s on the Responses API.

- **Migration**
  - To use Novita, set a non-empty `NOVITA_API_KEY` and select the `novita` provider where you configure AI providers.

<sup>Written for commit 2c6355001c3328ef970056ef60f6c3e669abf567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

