### PR TITLE
fix(python): reject unknown keyword arguments in the async v2 client

### DIFF
--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -64,7 +64,45 @@ from .methods.aio import browser as async_browser  # type: ignore[attr-defined]
 from .methods.aio import monitor as async_monitor  # type: ignore[attr-defined]
 from .methods.aio import research as async_research  # type: ignore[attr-defined]
 
-from .client import _SCRAPE_OPTION_KEYS
+from inspect import signature as _signature
+
+from .client import _SCRAPE_OPTION_KEYS, FirecrawlClient as _SyncClient
+
+
+def _sync_kwargs(method) -> frozenset:
+    """The keyword names the sync client accepts for the same call.
+
+    This module's docstring says it mirrors the regular client surface, so the set of
+    accepted options is defined as the sync signature rather than restated here. It
+    cannot drift when a new option is added to one side only.
+    """
+    return frozenset(
+        name for name in _signature(method).parameters if name != "self"
+    )
+
+
+def _reject_unknown(method_name: str, kwargs: dict, allowed: frozenset) -> None:
+    """Raise on an unknown keyword, the way the sync client already does.
+
+    The sync methods list every option explicitly, so a misspelled one is a TypeError at
+    the call site. The async methods take **kwargs and hand them to a pydantic model,
+    and pydantic ignores unknown fields by default, so the same typo silently produced a
+    request with default settings instead.
+    """
+    unknown = sorted(set(kwargs) - allowed)
+    if unknown:
+        raise TypeError(
+            f"AsyncFirecrawlClient.{method_name}() got an unexpected keyword argument "
+            f"{unknown[0]!r}"
+        )
+
+
+_SCRAPE_KWARGS = _sync_kwargs(_SyncClient.scrape)
+_SEARCH_KWARGS = _sync_kwargs(_SyncClient.search)
+_START_CRAWL_KWARGS = _sync_kwargs(_SyncClient.start_crawl) | frozenset(_SCRAPE_OPTION_KEYS) | {"ignore_sitemap"}
+_CRAWL_KWARGS = _START_CRAWL_KWARGS | {"poll_interval", "timeout", "request_timeout"}
+_START_BATCH_KWARGS = _sync_kwargs(_SyncClient.start_batch_scrape)
+_BATCH_KWARGS = _START_BATCH_KWARGS | {"poll_interval", "timeout"}
 from .watcher_async import AsyncWatcher
 
 class AsyncFirecrawlClient:
@@ -105,6 +143,7 @@ class AsyncFirecrawlClient:
         url: str,
         **kwargs,
     ):
+        _reject_unknown("scrape", kwargs, _SCRAPE_KWARGS)
         options = ScrapeOptions(**{k: v for k, v in kwargs.items() if v is not None}) if kwargs else None
         return await async_scrape.scrape(self.async_http_client, url, options)
 
@@ -240,10 +279,12 @@ class AsyncFirecrawlClient:
         query: str,
         **kwargs,
     ) -> SearchData:
+        _reject_unknown("search", kwargs, _SEARCH_KWARGS)
         request = SearchRequest(query=query, **{k: v for k, v in kwargs.items() if v is not None})
         return await async_search.search(self.async_http_client, request)
 
     async def start_crawl(self, url: str, **kwargs) -> CrawlResponse:
+        _reject_unknown("start_crawl", kwargs, _START_CRAWL_KWARGS)
         if kwargs.get("scrape_options") is None:
             scrape_kwargs = {k: kwargs.pop(k) for k in list(kwargs) if k in _SCRAPE_OPTION_KEYS and kwargs[k] is not None}
             if scrape_kwargs:
@@ -305,6 +346,7 @@ class AsyncFirecrawlClient:
             await asyncio.sleep(poll_interval)
 
     async def crawl(self, **kwargs) -> CrawlJob:
+        _reject_unknown("crawl", kwargs, _CRAWL_KWARGS)
         # wrapper combining start and wait
         resp = await self.start_crawl(
             **{k: v for k, v in kwargs.items() if k not in ("poll_interval", "timeout", "request_timeout")}
@@ -529,6 +571,7 @@ class AsyncFirecrawlClient:
         )
 
     async def start_batch_scrape(self, urls: List[str], **kwargs) -> Any:
+        _reject_unknown("start_batch_scrape", kwargs, _START_BATCH_KWARGS)
         return await async_batch.start_batch_scrape(self.async_http_client, urls, **kwargs)
 
     async def wait_batch_scrape(self, job_id: str, poll_interval: int = 2, timeout: Optional[int] = None) -> Any:
@@ -542,6 +585,7 @@ class AsyncFirecrawlClient:
             await asyncio.sleep(poll_interval)
 
     async def batch_scrape(self, urls: List[str], **kwargs) -> Any:
+        _reject_unknown("batch_scrape", kwargs, _BATCH_KWARGS)
         # waiter wrapper
         start = await self.start_batch_scrape(urls, **{k: v for k, v in kwargs.items() if k not in ("poll_interval", "timeout")})
         job_id = start.id

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -101,7 +101,7 @@ _SCRAPE_KWARGS = _sync_kwargs(_SyncClient.scrape)
 _SEARCH_KWARGS = _sync_kwargs(_SyncClient.search)
 _START_CRAWL_KWARGS = _sync_kwargs(_SyncClient.start_crawl) | frozenset(_SCRAPE_OPTION_KEYS) | {"ignore_sitemap"}
 _CRAWL_KWARGS = _START_CRAWL_KWARGS | {"poll_interval", "timeout", "request_timeout"}
-_START_BATCH_KWARGS = _sync_kwargs(_SyncClient.start_batch_scrape)
+_START_BATCH_KWARGS = _sync_kwargs(_SyncClient.start_batch_scrape) | {"options"}
 _BATCH_KWARGS = _START_BATCH_KWARGS | {"poll_interval", "timeout"}
 from .watcher_async import AsyncWatcher
 
@@ -572,6 +572,22 @@ class AsyncFirecrawlClient:
 
     async def start_batch_scrape(self, urls: List[str], **kwargs) -> Any:
         _reject_unknown("start_batch_scrape", kwargs, _START_BATCH_KWARGS)
+        # Fold flat scrape options into ScrapeOptions, as the sync client and
+        # start_crawl above both do. Without this they stay loose keywords and the
+        # batch payload builder, which only reads `options` plus a fixed key list,
+        # drops them: formats=["markdown"] silently returned the default format.
+        if kwargs.get("options") is None:
+            scrape_kwargs = {
+                k: kwargs.pop(k)
+                for k in list(kwargs)
+                if k in _SCRAPE_OPTION_KEYS and kwargs[k] is not None
+            }
+            if scrape_kwargs:
+                kwargs["options"] = ScrapeOptions(**scrape_kwargs)
+        else:
+            for k in list(kwargs):
+                if k in _SCRAPE_OPTION_KEYS:
+                    kwargs.pop(k)
         return await async_batch.start_batch_scrape(self.async_http_client, urls, **kwargs)
 
     async def wait_batch_scrape(self, job_id: str, poll_interval: int = 2, timeout: Optional[int] = None) -> Any:

--- a/apps/python-sdk/tests/test_async_unknown_kwargs.py
+++ b/apps/python-sdk/tests/test_async_unknown_kwargs.py
@@ -98,3 +98,61 @@ def test_crawl_still_accepts_its_polling_arguments(clients):
     finally:
         aio_crawl.start_crawl, aio_crawl.get_crawl_status = starts, statuses
     assert job.status == "completed"
+
+
+def test_batch_scrape_folds_flat_options_like_the_sync_client(clients):
+    """Flat scrape options must reach the request, not sit in loose kwargs.
+
+    The batch payload builder reads `options` plus a fixed key list, so a loose
+    `formats=["markdown"]` was dropped and the caller got the default format.
+    """
+    sync, async_ = clients
+    import firecrawl.v2.client as sync_mod
+    import firecrawl.v2.client_async as async_mod
+
+    captured = {}
+    real_sync = sync_mod.batch_module.start_batch_scrape
+    real_async = async_mod.async_batch.start_batch_scrape
+
+    async def fake_async(client, urls, **kwargs):
+        captured["async"] = kwargs
+
+    sync_mod.batch_module.start_batch_scrape = lambda client, urls, **kw: captured.__setitem__("sync", kw)
+    async_mod.async_batch.start_batch_scrape = fake_async
+    try:
+        kwargs = {"formats": ["markdown"], "only_main_content": True}
+        sync.start_batch_scrape(["https://example.com"], **kwargs)
+        asyncio.run(async_.start_batch_scrape(["https://example.com"], **kwargs))
+    finally:
+        sync_mod.batch_module.start_batch_scrape = real_sync
+        async_mod.async_batch.start_batch_scrape = real_async
+
+    assert captured["async"]["options"].formats == captured["sync"]["options"].formats
+    assert captured["async"]["options"].only_main_content is True
+
+
+def test_explicit_batch_options_win_over_flat_ones(clients):
+    _, async_ = clients
+    import firecrawl.v2.client_async as async_mod
+    from firecrawl.v2.types import ScrapeOptions
+
+    captured = {}
+
+    async def fake_async(client, urls, **kwargs):
+        captured.update(kwargs)
+
+    real = async_mod.async_batch.start_batch_scrape
+    async_mod.async_batch.start_batch_scrape = fake_async
+    try:
+        asyncio.run(
+            async_.start_batch_scrape(
+                ["https://example.com"],
+                options=ScrapeOptions(formats=["html"]),
+                only_main_content=True,
+            )
+        )
+    finally:
+        async_mod.async_batch.start_batch_scrape = real
+
+    assert captured["options"].formats == ["html"]
+    assert "only_main_content" not in captured

--- a/apps/python-sdk/tests/test_async_unknown_kwargs.py
+++ b/apps/python-sdk/tests/test_async_unknown_kwargs.py
@@ -1,0 +1,100 @@
+"""The async client should reject an unknown option, the way the sync client does.
+
+The sync methods list every option explicitly, so a misspelled one is a TypeError at the
+call site. The async methods take **kwargs and pass them to a pydantic model, and pydantic
+ignores unknown fields by default, so the same typo used to produce a request with default
+settings and no warning.
+"""
+
+import asyncio
+
+import pytest
+
+from firecrawl.v2.client import FirecrawlClient
+from firecrawl.v2.client_async import AsyncFirecrawlClient
+
+
+@pytest.fixture
+def clients():
+    return FirecrawlClient(api_key="fc-test"), AsyncFirecrawlClient(api_key="fc-test")
+
+
+def test_sync_and_async_agree_on_an_unknown_scrape_option(clients):
+    sync, async_ = clients
+    with pytest.raises(TypeError):
+        sync.scrape("https://example.com", tiemout=5000)
+    with pytest.raises(TypeError):
+        asyncio.run(async_.scrape("https://example.com", tiemout=5000))
+
+
+def test_unknown_search_option_raises(clients):
+    _, async_ = clients
+    with pytest.raises(TypeError):
+        asyncio.run(async_.search("query", limitt=3))
+
+
+def test_unknown_crawl_option_raises(clients):
+    _, async_ = clients
+    with pytest.raises(TypeError):
+        asyncio.run(async_.start_crawl("https://example.com", limitt=3))
+
+
+def test_unknown_batch_scrape_option_raises(clients):
+    _, async_ = clients
+    with pytest.raises(TypeError):
+        asyncio.run(async_.start_batch_scrape(["https://example.com"], max_concurrncy=2))
+
+
+def test_the_error_names_the_offending_keyword(clients):
+    _, async_ = clients
+    with pytest.raises(TypeError, match="tiemout"):
+        asyncio.run(async_.scrape("https://example.com", tiemout=5000))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout": 5000},
+        {"only_main_content": True},
+        {"formats": ["markdown"]},
+        {"skip_tls_verification": True},
+    ],
+)
+def test_real_scrape_options_are_still_accepted(clients, kwargs):
+    """Guard against the check being too strict, which would be worse than the bug."""
+    _, async_ = clients
+    import firecrawl.v2.methods.aio.scrape as aio_scrape
+
+    captured = {}
+
+    async def fake_scrape(client, url, options=None, **_):
+        captured["options"] = options
+
+    original, aio_scrape.scrape = aio_scrape.scrape, fake_scrape
+    try:
+        asyncio.run(async_.scrape("https://example.com", **kwargs))
+    finally:
+        aio_scrape.scrape = original
+
+    key, value = next(iter(kwargs.items()))
+    assert getattr(captured["options"], key) == value
+
+
+def test_crawl_still_accepts_its_polling_arguments(clients):
+    """`crawl` takes poll_interval and timeout on top of the start_crawl options."""
+    _, async_ = clients
+    import firecrawl.v2.methods.aio.crawl as aio_crawl
+
+    async def fake_start(client, request):
+        return type("Response", (), {"id": "job-1"})()
+
+    async def fake_status(client, job_id, **_):
+        return type("Job", (), {"status": "completed"})()
+
+    starts, statuses = aio_crawl.start_crawl, aio_crawl.get_crawl_status
+    aio_crawl.start_crawl, aio_crawl.get_crawl_status = fake_start, fake_status
+    try:
+        job = asyncio.run(async_.crawl(url="https://example.com", limit=1, poll_interval=0))
+    finally:
+        aio_crawl.start_crawl, aio_crawl.get_crawl_status = starts, statuses
+    assert job.status == "completed"


### PR DESCRIPTION
The sync v2 client lists every option explicitly, so a misspelled one raises `TypeError` at the call site. The async client takes `**kwargs` and passes them straight to a pydantic model, and pydantic ignores unknown fields by default, so the same typo silently produced a request with default settings.

```python
client.scrape("https://example.com", tiemout=5000)               # TypeError
await async_client.scrape("https://example.com", tiemout=5000)   # runs with no timeout
```

Same on `search`, `start_crawl`, `crawl`, `start_batch_scrape` and `batch_scrape`. The one that worried me is `skip_tls_verification`, where a typo quietly falls back to the default.

The fix derives each method's accepted keywords from the sync signature instead of restating them, so the two cannot drift when an option is added to one side only. `client_async.py` already says it mirrors the regular client surface, and this makes that true for unknown keys too.

I checked that typos now raise on all six methods, and that real options still reach the request, including `ignore_sitemap` and the scrape options `start_crawl` folds in. Added `tests/test_async_unknown_kwargs.py` with 10 tests. Five of them fail without the change, which is why they are worth having.

The suite was 13 failed, 38 passed before this change and 13 failed, 48 passed after. Those 13 pre-date it and I have not touched them.

Not a security hole. It only bites when the caller has already made a mistake, and what breaks is one request's settings.

I have not looked at the v1 client, or at whether any caller passes extra keys on purpose. If firecrawl wants those tolerated, an allow-list is the smaller change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788251880&installation_model_id=11126&pr_number=4205&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4205&signature=d1771ef3c457c3c13d67e725579f9ce4384ab58532efea9d32276518dd85e854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unknown keyword arguments in the `firecrawl.v2` async client to match the sync client. Typos now raise `TypeError` instead of being silently ignored.

- **Bug Fixes**
  - Validate keywords for `scrape`, `search`, `start_crawl`, `crawl`, `start_batch_scrape`, `batch_scrape` in `AsyncFirecrawlClient`.
  - Derive allowed keywords from `FirecrawlClient` method signatures (plus `_SCRAPE_OPTION_KEYS`, `ignore_sitemap`, and polling args) to prevent drift.
  - Fold flat scrape keywords into `ScrapeOptions` in `start_batch_scrape`/`batch_scrape`; explicit `options` wins over flat keys.
  - Add tests in `apps/python-sdk/tests/test_async_unknown_kwargs.py` covering error cases, valid options, and batch option folding.

<sup>Written for commit 4cb42e49e1542fefad53e4f1bace9ddf0c3fd3d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

