### PR TITLE
docs: align self-hosting guidance with the public quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,140 +1,71 @@
-# Contributors guide:
+# Contributing to Firecrawl
 
-Welcome to [Firecrawl](https://firecrawl.dev) 🔥! Here are some instructions on how to get the project locally, so you can run it on your own (and contribute)
+Thanks for helping make Firecrawl better. Keep each change focused, prove the behavior you changed, and make the pull request easy to review.
 
-If you're contributing, note that the process is similar to other open source repos i.e. (fork firecrawl, make changes, run tests, PR). If you have any questions, and would like help getting on board, reach out to help@firecrawl.com for more or submit an issue!
+## Choose the right workflow
 
-## Running the project locally
+| If you want to | Start here |
+| --- | --- |
+| Change the API, workers, or tests | [Run Firecrawl locally for development](https://docs.firecrawl.dev/contributing/guide) |
+| Run Firecrawl on your own infrastructure without changing product code | [Self-hosting Firecrawl](https://docs.firecrawl.dev/contributing/self-host) |
+| Change an SDK | The matching directory under [`apps/`](./apps/) and its package scripts |
+| Improve the public documentation | The [`firecrawl-docs`](https://github.com/firecrawl/firecrawl-docs) repository |
 
-First, start by installing dependencies:
+Local development and self-hosting are different paths. Development uses the API harness and `apps/api/.env`; the Docker Compose deployment uses the root configuration. Do not copy one environment file into the other.
 
-1. node.js [instructions](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs)
-2. rust [instructions](https://www.rust-lang.org/tools/install)
-3. pnpm [instructions](https://pnpm.io/installation)
-4. redis [instructions](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
-5. postgresql
-6. Docker (optional) (for running postgres)
+## Set up API development
 
-You need to set up the PostgreSQL database by running the SQL file at `apps/nuq-postgres/nuq.sql`. Easiest way is to use the docker image inside `apps/nuq-postgres`. With Docker running, build the image:
+The public [Running Locally](https://docs.firecrawl.dev/contributing/guide) guide is the canonical first-success path. It covers Node.js 22, pnpm `11.4.0`, Redis, the harness-managed PostgreSQL and RabbitMQ containers, and a verified local scrape.
 
-```bash
-docker build -t nuq-postgres .
-```
-
-and then run:
+The source-owned commands live in [`apps/api/package.json`](./apps/api/package.json). From `apps/api`:
 
 ```bash
-docker run --name nuqdb \          
-  -e POSTGRES_PASSWORD=postgres \
-  -p 5433:5432 \
-  -v nuq-data:/var/lib/postgresql/data \
-  -d nuq-postgres
-```
-
-Set environment variables in a .env in the /apps/api/ directory you can copy over the template in .env.example.
-
-To start, we won't set up authentication, or any optional sub services (pdf parsing, JS blocking support, AI features)
-
-.env:
-
-```
-# ===== Required ENVS ======
-NUM_WORKERS_PER_QUEUE=8
-PORT=3002
-HOST=0.0.0.0
-REDIS_URL=redis://localhost:6379
-REDIS_RATE_LIMIT_URL=redis://localhost:6379
-
-## To turn on DB authentication, you need to set up supabase.
-USE_DB_AUTHENTICATION=false
-
-## Using the PostgreSQL for queuing -- change if credentials, host, or DB is different
-NUQ_DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres
-
-# ===== Optional ENVS ======
-
-# Supabase Setup (used to support DB authentication, advanced logging, etc.)
-SUPABASE_ANON_TOKEN=
-SUPABASE_URL=
-SUPABASE_SERVICE_TOKEN=
-
-# Other Optionals
-TEST_API_KEY= # use if you've set up authentication and want to test with a real API key
-OPENAI_API_KEY= # add for LLM dependent features (image alt generation, etc.)
-BULL_AUTH_KEY= @
-PLAYWRIGHT_MICROSERVICE_URL=  # set if you'd like to run a playwright fallback
-LLAMAPARSE_API_KEY= #Set if you have a llamaparse key you'd like to use to parse pdfs
-SLACK_WEBHOOK_URL= # set if you'd like to send slack server health status messages
-
-
-```
-
-### Installing dependencies
-
-First, install the dependencies using pnpm.
-
-```bash
-# cd apps/api # to make sure you're in the right folder
-pnpm install # make sure you have pnpm version 9+!
-```
-
-### Running the project
-
-You're going to need to open 3 terminals.
-
-### Terminal 1 - setting up redis
-
-Run the command anywhere within your project
-
-```bash
-redis-server
-```
-
-### Terminal 2 - setting up the service
-
-Now, navigate to the apps/api/ directory and run:
-
-```bash
+pnpm install
 pnpm start
-# if you are going to use the [llm-extract feature](https://github.com/firecrawl/firecrawl/pull/586/), you should also export OPENAI_API_KEY=sk-______
 ```
 
-This will start the workers who are responsible for processing crawl jobs.
+`pnpm start` builds Firecrawl and launches the API, workers, and local dependency containers. Keep Redis running separately as described in the public guide.
 
-### Terminal 3 - sending our first request.
+## Make a focused change
 
-Alright: now let’s send our first request.
+1. Fork the repository and create a branch whose name describes the change.
+2. Reproduce the current behavior before editing.
+3. Add or update coverage for the successful path and relevant failures.
+4. Make the smallest change that satisfies those tests.
+5. Run the narrowest useful checks before opening a pull request.
 
-```curl
-curl -X GET http://localhost:3002/test
-```
+For API changes, prefer end-to-end snippet coverage when the behavior crosses routes, workers, queues, or scraping engines.
 
-This should return the response Hello, world!
+## Run API tests with the harness
 
-If you’d like to test the crawl endpoint, you can run this
-
-```curl
-curl -X POST http://localhost:3002/v1/crawl \
-    -H 'Content-Type: application/json' \
-    -d '{
-      "url": "https://mendable.ai"
-    }'
-```
-
-### Alternative: Using Docker Compose
-
-For a simpler setup, you can use Docker Compose to run all services:
-
-1. Prerequisites: Make sure you have Docker and Docker Compose installed
-2. Copy the `.env.example` file to `.env` in the `/apps/api/` directory and configure as needed
-3. From the root directory, run:
+From `apps/api`, run the snippet suites with their dependencies:
 
 ```bash
-docker compose up
+pnpm harness pnpm test:snips
 ```
 
-This will start Redis, the API server, and workers automatically in the correct configuration.
+For a narrower test, pass the relevant Vitest path through the same harness:
 
-## Tests:
+```bash
+pnpm harness pnpm exec vitest run path/to/test.ts
+```
 
-The best way to do this is run the test with `npm run test:snips`.
+The harness starts the API, workers, PostgreSQL, and RabbitMQ for the command, then cleans up the processes and containers it started.
+
+Do not bypass failing checks. Fix failures caused by your change and call out unrelated repository failures with enough detail for a reviewer to reproduce them.
+
+## Open the pull request
+
+Include:
+
+- why the change is needed;
+- what behavior changed;
+- the exact tests or checks you ran;
+- any configuration, migration, security, or deployment impact; and
+- screenshots or request/response evidence when they make the result easier to verify.
+
+Keep credentials, local environment files, raw user data, and generated secrets out of commits and pull requests.
+
+## Get help
+
+Use [GitHub issues](https://github.com/firecrawl/firecrawl/issues) for reproducible bugs and feature discussions. For community help, join the [Firecrawl Discord](https://discord.gg/firecrawl).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -1,227 +1,72 @@
 # Self-hosting Firecrawl
 
-#### Contributor?
-
-Welcome to [Firecrawl](https://firecrawl.dev) 🔥! Here are some instructions on how to get the project locally so you can run it on your own and contribute.
-
-If you're contributing, note that the process is similar to other open-source repos, i.e., fork Firecrawl, make changes, run tests, PR.
-
-If you have any questions or would like help getting on board, join our Discord community [here](https://discord.gg/firecrawl) for more information or submit an issue on Github [here](https://github.com/firecrawl/firecrawl/issues/new/choose)!
-
-## Why?
-
-Self-hosting Firecrawl is particularly beneficial for organizations with stringent security policies that require data to remain within controlled environments. Here are some key reasons to consider self-hosting:
-
-- **Enhanced Security and Compliance:** By self-hosting, you ensure that all data handling and processing complies with internal and external regulations, keeping sensitive information within your secure infrastructure. Note that Firecrawl is a Mendable product and relies on SOC2 Type2 certification, which means that the platform adheres to high industry standards for managing data security.
-- **Customizable Services:** Self-hosting allows you to tailor the services, such as the Playwright service, to meet specific needs or handle particular use cases that may not be supported by the standard cloud offering.
-- **Learning and Community Contribution:** By setting up and maintaining your own instance, you gain a deeper understanding of how Firecrawl works, which can also lead to more meaningful contributions to the project.
-
-### Considerations
-
-However, there are some limitations and additional responsibilities to be aware of:
-
-1. **Limited Access to Fire-engine:** Currently, self-hosted instances of Firecrawl do not have access to Fire-engine, which includes advanced features for handling IP blocks, robot detection mechanisms, and more. This means that while you can manage basic scraping tasks, more complex scenarios might require additional configuration or might not be supported.
-2. **Manual Configuration Required:** If you need to use scraping methods beyond the basic fetch and Playwright options, you will need to manually configure these in the `.env` file. This requires a deeper understanding of the technologies and might involve more setup time.
-
-Self-hosting Firecrawl is ideal for those who need full control over their scraping and data processing environments but comes with the trade-off of additional maintenance and configuration efforts.
-
-## Steps
-
-1. First, start by installing the dependencies
-
-- Docker [instructions](https://docs.docker.com/get-docker/)
-
-
-2. Set environment variables
-
-Create an `.env` in the root directory using the template below.
-
-`.env:`
-```
-# ===== Required ENVS ======
-PORT=3002
-HOST=0.0.0.0
-
-# Note: PORT is used by both the main API server and worker liveness check endpoint
-
-# To turn on DB authentication, you need to set up Supabase.
-USE_DB_AUTHENTICATION=false
-
-# ===== Optional ENVS ======
-
-## === AI features (JSON format on scrape, /extract API) ===
-# Provide your OpenAI API key here to enable AI features
-# OPENAI_API_KEY=
-
-# Experimental: Use Ollama
-# OLLAMA_BASE_URL=http://localhost:11434/api
-# MODEL_NAME=deepseek-r1:7b
-# MODEL_EMBEDDING_NAME=nomic-embed-text
-
-# Experimental: Use any OpenAI-compatible API
-# OPENAI_BASE_URL=https://example.com/v1
-# OPENAI_API_KEY=
-
-## === Proxy ===
-# PROXY_SERVER can be a full URL (e.g. http://0.1.2.3:1234) or just an IP and port combo (e.g. 0.1.2.3:1234)
-# Do not uncomment PROXY_USERNAME and PROXY_PASSWORD if your proxy is unauthenticated
-# PROXY_SERVER=
-# PROXY_USERNAME=
-# PROXY_PASSWORD=
-
-## === /search API ===
-# By default, the /search API will use Google search.
-
-# You can specify a SearXNG server with the JSON format enabled, if you'd like to use that instead of direct Google.
-# You can also customize the engines and categories parameters, but the defaults should also work just fine.
-# SEARXNG_ENDPOINT=http://your.searxng.server
-# SEARXNG_ENGINES=
-# SEARXNG_CATEGORIES=
-
-## === Other ===
-
-# Supabase Setup (used to support DB authentication, advanced logging, etc.)
-# SUPABASE_ANON_TOKEN=
-# SUPABASE_URL=
-# SUPABASE_SERVICE_TOKEN=
-
-# Use if you've set up authentication and want to test with a real API key
-# TEST_API_KEY=
-
-# This key lets you access the queue admin panel. Change this if your deployment is publicly accessible.
-BULL_AUTH_KEY=CHANGEME
-
-# This is now autoconfigured by the docker-compose.yaml. You shouldn't need to set it.
-# PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape
-# REDIS_URL=redis://redis:6379
-# REDIS_RATE_LIMIT_URL=redis://redis:6379
-
-## === PostgreSQL Database Configuration ===
-# Configure PostgreSQL credentials. These should match the credentials used by the nuq-postgres container.
-# If you change these, ensure all three are set consistently.
-# POSTGRES_USER=firecrawl
-# POSTGRES_PASSWORD=firecrawl_password
-# POSTGRES_DB=firecrawl
-
-# Set if you have a llamaparse key you'd like to use to parse pdfs
-# LLAMAPARSE_API_KEY=
-
-# Set if you'd like to send server health status messages to Slack
-# SLACK_WEBHOOK_URL=
-
-## === System Resource Configuration ===
-# Maximum CPU usage threshold (0.0-1.0). Worker will reject new jobs when CPU usage exceeds this value.
-# Default: 0.8 (80%)
-# MAX_CPU=0.8
-
-# Maximum RAM usage threshold (0.0-1.0). Worker will reject new jobs when memory usage exceeds this value.
-# Default: 0.8 (80%)
-# MAX_RAM=0.8
-
-# Set if you'd like to allow local webhooks to be sent to your self-hosted instance
-# ALLOW_LOCAL_WEBHOOKS=true
-```
-
-### Security considerations
-
-- **Use strong PostgreSQL credentials.** The defaults in the `.env` template are for local development only. When deploying to a server, set `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` to secure values and ensure they match the database service configuration.
-- **Keep the database port internal.** The provided `docker-compose.yaml` does not expose PostgreSQL to the host or the internet. Avoid adding a `ports` mapping for `nuq-postgres` unless you are restricting access with a firewall. To access the database for maintenance, prefer using `docker compose exec nuq-postgres psql` or a temporary, firewalled tunnel.
-- **Protect the admin UI.** Set `BULL_AUTH_KEY` to a strong secret, especially on any deployment reachable from untrusted networks.
-
-3.  Build and run the Docker containers:
-
-    ```bash
-    docker compose build
-    docker compose up
-    ```
-
-    If you encounter an error, make sure you're using `docker compose` and not `docker-compose`.
-    
-    This will run a local instance of Firecrawl which can be accessed at `http://localhost:3002`.
-    
-    You should be able to see the Bull Queue Manager UI on `http://localhost:3002/admin/CHANGEME/queues`.
-
-5. *(Optional)* Test the API
-
-If you’d like to test the crawl endpoint, you can run this:
-
-  ```bash
-  curl -X POST http://localhost:3002/v1/crawl \
-      -H 'Content-Type: application/json' \
-      -d '{
-        "url": "https://firecrawl.dev"
-      }'
-  ```   
-
-## Troubleshooting
-
-This section provides solutions to common issues you might encounter while setting up or running your self-hosted instance of Firecrawl.
-
-### API Keys for SDK Usage
-
-**Note:** When using Firecrawl SDKs with a self-hosted instance, API keys are optional. API keys are only required when connecting to the cloud service (api.firecrawl.dev).
-
-### Supabase client is not configured
-
-**Symptom:**
-```bash
-[YYYY-MM-DDTHH:MM:SS.SSSz]ERROR - Attempted to access Supabase client when it's not configured.
-[YYYY-MM-DDTHH:MM:SS.SSSz]ERROR - Error inserting scrape event: Error: Supabase client is not configured.
-```
-
-**Explanation:**
-This error occurs because the Supabase client setup is not completed. You should be able to scrape and crawl with no problems. Right now it's not possible to configure Supabase in self-hosted instances.
-
-### You're bypassing authentication
-
-**Symptom:**
-```bash
-[YYYY-MM-DDTHH:MM:SS.SSSz]WARN - You're bypassing authentication
-```
-
-**Explanation:**
-This error occurs because the Supabase client setup is not completed. You should be able to scrape and crawl with no problems. Right now it's not possible to configure Supabase in self-hosted instances.
-
-### Docker containers fail to start
-
-**Symptom:**
-Docker containers exit unexpectedly or fail to start.
-
-**Solution:**
-Check the Docker logs for any error messages using the command:
-```bash
-docker logs [container_name]
-```
-
-- Ensure all required environment variables are set correctly in the .env file.
-- Verify that all Docker services defined in docker-compose.yml are correctly configured and the necessary images are available.
-
-### Connection issues with Redis
-
-**Symptom:**
-Errors related to connecting to Redis, such as timeouts or "Connection refused".
-
-**Solution:**
-- Ensure that the Redis service is up and running in your Docker environment.
-- Verify that the REDIS_URL and REDIS_RATE_LIMIT_URL in your .env file point to the correct Redis instance, ensure that it points to the same URL in the `docker-compose.yaml` file (`redis://redis:6379`)
-- Check network settings and firewall rules that may block the connection to the Redis port.
-
-### API endpoint does not respond
-
-**Symptom:**
-API requests to the Firecrawl instance timeout or return no response.
-
-**Solution:**
-- Ensure that the Firecrawl service is running by checking the Docker container status.
-- Verify that the PORT and HOST settings in your .env file are correct and that no other service is using the same port.
-- Check the network configuration to ensure that the host is accessible from the client making the API request.
-
-By addressing these common issues, you can ensure a smoother setup and operation of your self-hosted Firecrawl instance.
-
-## Install Firecrawl on a Kubernetes Cluster (Simple Version)
-
-Read the [examples/kubernetes/cluster-install/README.md](https://github.com/firecrawl/firecrawl/blob/main/examples/kubernetes/cluster-install/README.md) for instructions on how to install Firecrawl on a Kubernetes Cluster.
-
-## Install Firecrawl on a Kubernetes Cluster with Helm
-
-Read the [examples/kubernetes/firecrawl-helm/README.md](https://github.com/firecrawl/firecrawl/blob/main/examples/kubernetes/firecrawl-helm/README.md) for instructions on how to install Firecrawl on a Kubernetes Cluster with Helm.
+Use the [Firecrawl self-hosting guide](https://docs.firecrawl.dev/contributing/self-host)
+when your goal is a first successful Docker Compose deployment. It recommends
+an evaluation path, explains the tradeoffs, and ends with a functional scrape.
+
+Use this file when you need revision-specific context before changing that
+baseline. It travels with the source and intentionally does not duplicate the
+quickstart.
+
+## Choose the right source
+
+| If you need to decide or do this | Start here |
+| --- | --- |
+| Decide whether self-hosting fits and run the first scrape | [Public self-hosting guide](https://docs.firecrawl.dev/contributing/self-host) |
+| Check which variables and services exist at this revision | [Root Compose configuration](./docker-compose.yaml) |
+| Adapt a Kubernetes deployment | [Kubernetes manifests](./examples/kubernetes/cluster-install/) or [Helm chart](./examples/kubernetes/firecrawl-helm/) |
+| Change Firecrawl product code | [Contributing guide](./CONTRIBUTING.md) |
+
+## Keep these defaults for the first run
+
+- **Source revision → exact release tag.** Change it after reviewing the Compose
+  file from the target release. A checkout of `main` and floating image tags can
+  change independently.
+- **API authentication → `USE_DB_AUTHENTICATION=false`.** Change it after
+  provisioning the additional database schema and application configuration.
+  Changing this variable alone is not a complete authenticated deployment.
+- **Queue backend → NuQ PostgreSQL.** Change it when you intentionally set
+  `NUQ_BACKEND=fdb` and are prepared to operate the FoundationDB backend.
+- **Scraping engines → bundled Playwright with basic fetch fallback.** Change
+  them after supplying and configuring a separate engine such as Fire-engine.
+- **AI-backed features → no model provider.** Change this after configuring
+  OpenAI, an OpenAI-compatible endpoint, or Ollama.
+- **Queue administration UI → disabled.** Enable it only with a strong
+  `BULL_AUTH_KEY` and restricted network access.
+
+The root `.env` overrides only variables referenced by `docker-compose.yaml`.
+Do not use `apps/api/.env.example` as a drop-in Compose contract.
+
+## What the default stack commits you to
+
+At this revision, Compose runs the Firecrawl API and workers, Playwright, Redis,
+RabbitMQ, NuQ PostgreSQL, and FoundationDB services for the optional queue
+backend. Only the API is published to the host by default, on port `3002`.
+
+Self-hosting gives you source and infrastructure control. In return, you own
+security, availability, capacity, upgrades, data retention, and compliance.
+
+## Decide before production
+
+- **If the API will leave a trusted network,** add a complete authentication
+  design, TLS termination, and network policy first. The default API is
+  unauthenticated.
+- **If data must survive service replacement,** add and test persistence,
+  backups, and recovery for NuQ PostgreSQL, Redis, and RabbitMQ. The root
+  Compose file defines no persistent volumes for them.
+- **If you change the PostgreSQL settings,** keep the API and database values
+  consistent. At this revision, the bundled `pg_cron` configuration targets
+  the default `postgres` database.
+- **If you publish dependency ports,** secure them explicitly. PostgreSQL,
+  Redis, RabbitMQ, and worker ports should remain private by default.
+- **If you have availability or scale targets,** define monitoring, resource
+  limits, scaling triggers, and upgrade and rollback procedures. The checked-in
+  Compose file is a source-aligned starting point, not a production
+  architecture.
+
+Treat the Kubernetes and Helm examples as versioned starting points, not as
+evidence that these production decisions have been made for you.
+
+For help, use the
+[self-host issue template](https://github.com/firecrawl/firecrawl/issues/new?template=self_host_issue.md)
+or join the [Firecrawl Discord community](https://discord.gg/firecrawl).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -1,14 +1,13 @@
 # Self-hosting Firecrawl
 
-Use the [Firecrawl self-hosting guide](https://docs.firecrawl.dev/contributing/self-host)
-when your goal is a first successful Docker Compose deployment. It recommends
-an evaluation path, explains the tradeoffs, and ends with a functional scrape.
+Want to get Firecrawl running? Start with the
+[Firecrawl self-hosting guide](https://docs.firecrawl.dev/contributing/self-host).
+It takes you from checkout to a successful scrape with Docker Compose.
 
-Use this file when you need revision-specific context before changing that
-baseline. It travels with the source and intentionally does not duplicate the
-quickstart.
+Use this file when you are changing the baseline. It stays with the source, so
+the services and configuration match the revision you checked out.
 
-## Choose the right source
+## Pick the guide for the job
 
 | If you need to decide or do this | Start here |
 | --- | --- |
@@ -17,36 +16,39 @@ quickstart.
 | Adapt a Kubernetes deployment | [Kubernetes manifests](./examples/kubernetes/cluster-install/) or [Helm chart](./examples/kubernetes/firecrawl-helm/) |
 | Change Firecrawl product code | [Contributing guide](./CONTRIBUTING.md) |
 
-## Keep these defaults for the first run
+## Keep the first run simple
 
-- **Source revision → exact release tag.** Change it after reviewing the Compose
-  file from the target release. A checkout of `main` and floating image tags can
-  change independently.
-- **API authentication → `USE_DB_AUTHENTICATION=false`.** Change it after
-  provisioning the additional database schema and application configuration.
-  Changing this variable alone is not a complete authenticated deployment.
-- **Queue backend → NuQ PostgreSQL.** Change it when you intentionally set
-  `NUQ_BACKEND=fdb` and are prepared to operate the FoundationDB backend.
-- **Scraping engines → bundled Playwright with basic fetch fallback.** Change
-  them after supplying and configuring a separate engine such as Fire-engine.
-- **AI-backed features → no model provider.** Change this after configuring
-  OpenAI, an OpenAI-compatible endpoint, or Ollama.
-- **Queue administration UI → disabled.** Enable it only with a strong
+- **Release: an exact tag.** Review the target release's Compose file before
+  changing it. A checkout of `main` and floating image tags can change
+  independently.
+- **API authentication: `USE_DB_AUTHENTICATION=false`.** Add authentication
+  after provisioning the required database schema and application
+  configuration. Changing this variable alone is not a complete authenticated
+  deployment.
+- **Queue: NuQ PostgreSQL.** Keep it unless you intentionally set
+  `NUQ_BACKEND=fdb` and are prepared to operate FoundationDB.
+- **Scraping: bundled Playwright with basic fetch fallback.** Connect and
+  configure a separate engine such as Fire-engine only when you need it.
+- **AI-backed features: no model provider.** Connect OpenAI, an OpenAI-compatible
+  endpoint, or Ollama when a feature needs it.
+- **Queue administration UI: off.** Enable it only with a strong
   `BULL_AUTH_KEY` and restricted network access.
+
+Get this baseline working before swapping backends or adding providers.
 
 The root `.env` overrides only variables referenced by `docker-compose.yaml`.
 Do not use `apps/api/.env.example` as a drop-in Compose contract.
 
-## What the default stack commits you to
+## What the stack runs
 
 At this revision, Compose runs the Firecrawl API and workers, Playwright, Redis,
 RabbitMQ, NuQ PostgreSQL, and FoundationDB services for the optional queue
 backend. Only the API is published to the host by default, on port `3002`.
 
-Self-hosting gives you source and infrastructure control. In return, you own
+Self-hosting gives you source and infrastructure control. You also own
 security, availability, capacity, upgrades, data retention, and compliance.
 
-## Decide before production
+## Before production
 
 - **If the API will leave a trusted network,** add a complete authentication
   design, TLS termination, and network policy first. The default API is
@@ -67,6 +69,6 @@ security, availability, capacity, upgrades, data retention, and compliance.
 Treat the Kubernetes and Helm examples as versioned starting points, not as
 evidence that these production decisions have been made for you.
 
-For help, use the
+Stuck? Open a
 [self-host issue template](https://github.com/firecrawl/firecrawl/issues/new?template=self_host_issue.md)
 or join the [Firecrawl Discord community](https://discord.gg/firecrawl).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -14,7 +14,8 @@ the services and configuration match the revision you checked out.
 | Decide whether self-hosting fits and run the first scrape | [Public self-hosting guide](https://docs.firecrawl.dev/contributing/self-host) |
 | Check which variables and services exist at this revision | [Root Compose configuration](./docker-compose.yaml) |
 | Adapt a Kubernetes deployment | [Kubernetes manifests](./examples/kubernetes/cluster-install/) or [Helm chart](./examples/kubernetes/firecrawl-helm/) |
-| Change Firecrawl product code | [Contributing guide](./CONTRIBUTING.md) |
+| Change Firecrawl product code | [Running Locally](https://docs.firecrawl.dev/contributing/guide), then the [contribution guide](./CONTRIBUTING.md) |
+| Connect an agent or terminal client | [Local MCP](https://docs.firecrawl.dev/mcp-server/local) or [Firecrawl CLI](https://docs.firecrawl.dev/sdks/cli#connect-the-cli-to-self-hosted-firecrawl) |
 
 ## Keep the first run simple
 

--- a/examples/kubernetes/cluster-install/README.md
+++ b/examples/kubernetes/cluster-install/README.md
@@ -1,39 +1,132 @@
-# Install Firecrawl on a Kubernetes Cluster (Simple Version)
-# Before installing
-1. Set [secret.yaml](secret.yaml) and [configmap.yaml](configmap.yaml) and do not check in secrets
-   - **Note**: If `REDIS_PASSWORD` is configured in the secret, please modify the ConfigMap to reflect the following format for `REDIS_URL` and `REDIS_RATE_LIMIT_URL`:
-     ```yaml
-     REDIS_URL: "redis://:password@host:port"
-     REDIS_RATE_LIMIT_URL: "redis://:password@host:port"
-     ```
-     Replace `password`, `host`, and `port` with the appropriate values.
+# Deploy Firecrawl with Kubernetes manifests
 
-## Install
-```bash
-kubectl apply -f configmap.yaml
-kubectl apply -f secret.yaml
-kubectl apply -f playwright-service.yaml
-kubectl apply -f api.yaml
-kubectl apply -f worker.yaml
-kubectl apply -f nuq-worker.yaml
-kubectl apply -f nuq-postgres.yaml
-kubectl apply -f redis.yaml
+Use these manifests when you want to inspect and adapt each Kubernetes resource directly. They are a source-aligned starting point, not a production architecture or a supported replacement for making your own security, persistence, availability, and upgrade decisions.
+
+> [!WARNING]
+> The example disables database authentication and references a `docker-registry-secret` for image pulls. Keep the API private while evaluating, review every image, and create or replace the pull secret before applying the workloads.
+
+## Choose this path when
+
+- **Use these manifests** when you want direct control over each Deployment, Service, ConfigMap, and Secret.
+- **Use the [Helm chart](../firecrawl-helm/)** when you want a values-driven render and upgrade workflow.
+- **Use the [Docker Compose self-hosting guide](https://docs.firecrawl.dev/contributing/self-host)** when you are still proving the first scrape and do not need Kubernetes yet.
+
+## Review the deployment decisions
+
+Before applying anything:
+
+1. Review [`configmap.yaml`](./configmap.yaml) and [`secret.yaml`](./secret.yaml).
+2. Replace every placeholder secret and keep the populated file out of Git.
+3. Point image references at registries and immutable tags you trust.
+4. Create `docker-registry-secret`, or remove the `imagePullSecrets` entries after confirming the images are public.
+5. Decide how PostgreSQL data, Redis state, and other required data survive pod replacement.
+6. Keep `USE_DB_AUTHENTICATION=false` reachable only from a trusted network.
+
+If `REDIS_PASSWORD` is set in the Secret, update `REDIS_URL` and `REDIS_RATE_LIMIT_URL` in the ConfigMap:
+
+```yaml
+REDIS_URL: "redis://:password@host:port"
+REDIS_RATE_LIMIT_URL: "redis://:password@host:port"
 ```
 
+Replace `password`, `host`, and `port` with values that resolve from inside the cluster.
 
-# Port Forwarding for Testing
+## Apply the manifests
+
+Create one namespace for the evaluation deployment:
+
 ```bash
-kubectl port-forward svc/api 3002:3002 -n dev
+kubectl create namespace firecrawl
 ```
 
-# Delete Firecrawl
+From this directory, apply the configuration and workloads:
+
 ```bash
-kubectl delete -f configmap.yaml
-kubectl delete -f secret.yaml
-kubectl delete -f playwright-service.yaml
-kubectl delete -f api.yaml
-kubectl delete -f worker.yaml
-kubectl delete -f nuq-worker.yaml
-kubectl delete -f nuq-postgres.yaml
-kubectl delete -f redis.yaml
+kubectl apply -n firecrawl \
+  -f configmap.yaml \
+  -f secret.yaml \
+  -f playwright-service.yaml \
+  -f api.yaml \
+  -f worker.yaml \
+  -f nuq-worker.yaml \
+  -f nuq-postgres.yaml \
+  -f redis.yaml
+```
+
+Inspect the rollout before testing:
+
+```bash
+kubectl get pods -n firecrawl
+kubectl rollout status deployment/api -n firecrawl
+```
+
+If a pod does not become ready, inspect its events and logs before changing configuration:
+
+```bash
+kubectl describe pod -n firecrawl POD_NAME
+kubectl logs -n firecrawl POD_NAME --all-containers --tail=200
+```
+
+## Verify one scrape
+
+Forward the API service to your machine:
+
+```bash
+kubectl port-forward svc/api 3002:3002 -n firecrawl
+```
+
+In another terminal, check API reachability:
+
+```bash
+curl --fail --silent --show-error \
+  http://localhost:3002/v0/health/readiness
+```
+
+Then test the end-to-end scraping path:
+
+```bash
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --max-time 75 \
+  -X POST \
+  http://localhost:3002/v2/scrape \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com",
+    "formats": ["markdown"],
+    "timeout": 60000
+  }'
+```
+
+A successful response includes `success: true`, Markdown, and an HTTP status in the response metadata.
+
+## Prepare your own production design
+
+Before exposing the API, define:
+
+- authentication, TLS, ingress, and network policy;
+- persistent storage, backups, and tested recovery;
+- resource requests, limits, autoscaling, and disruption budgets;
+- monitoring, alerts, capacity targets, and incident ownership;
+- image provenance, immutable versioning, and rollback; and
+- secret management and provider data flows.
+
+The example manifests do not make those decisions for you.
+
+## Remove the evaluation deployment
+
+Delete only the resources applied from this directory:
+
+```bash
+kubectl delete -n firecrawl \
+  -f configmap.yaml \
+  -f secret.yaml \
+  -f playwright-service.yaml \
+  -f api.yaml \
+  -f worker.yaml \
+  -f nuq-worker.yaml \
+  -f nuq-postgres.yaml \
+  -f redis.yaml
 ```

--- a/examples/kubernetes/firecrawl-helm/README.md
+++ b/examples/kubernetes/firecrawl-helm/README.md
@@ -1,41 +1,41 @@
-# Firecrawl Helm Chart
+# Deploy Firecrawl with Helm
 
-This chart deploys Firecrawl on Kubernetes with:
+Use this chart when you want a repeatable, values-driven Kubernetes render and upgrade workflow. The chart deploys the Firecrawl API, workers, Playwright, Redis, NuQ PostgreSQL, and RabbitMQ, with optional worker types controlled by values.
 
-- `api`
-- `worker` (queue-worker)
-- `extract-worker`
-- `nuq-worker`
-- `nuq-prefetch-worker`
-- `cclog-worker`
-- `playwright-service`
-- `redis`
-- `nuq-postgres`
-- `rabbitmq`
+> [!WARNING]
+> This chart is a source-aligned starting point, not a production guarantee. Its default values use third-party `winkkgmbh` images tagged `latest`, disable resource requests and limits, and do not complete your authentication, persistence, availability, or secret-management design.
 
-## Image Strategy
+## Choose Helm or another path
 
-- **x86-only cluster**: use official Firecrawl images from GHCR (`ghcr.io/firecrawl/...`).
-- **ARM or mixed ARM+x86 cluster**: use your multi-arch `winkkgmbh` images.
+- **Use this chart** when you want values, overlays, rendered diffs, and Helm-managed upgrades.
+- **Use the [raw manifests](../cluster-install/)** when you want to inspect and own every Kubernetes resource directly.
+- **Use the [Docker Compose self-hosting guide](https://docs.firecrawl.dev/contributing/self-host)** when you are still proving the first scrape.
 
-Official Firecrawl images are fine for x86. Use winkk images only when ARM support is needed.
+## Choose and trust the container images
 
-## Configure Values
+- **x86-only cluster:** use official Firecrawl images from `ghcr.io/firecrawl/...`.
+- **ARM or mixed ARM+x86 cluster:** build and publish your own multi-architecture images, or explicitly review and accept another publisher's images.
 
-Use `values.yaml` plus one overlay.
+Pin immutable image tags or digests before production. Do not rely on `latest` for a controlled upgrade or rollback.
 
-Important fields:
+## Configure the release
 
-- `secret.*` for API keys and sensitive values.
-- `config.extra` / `secret.extra` for custom env vars.
-- `image.dockerSecretEnabled` and `imagePullSecrets` for private registries.
-- `resources.enabled` enables/disables all container resource requests/limits.
-  Default: `false`.
-- `rabbitmq.enabled`, `extractWorker.enabled`, `nuqPrefetchWorker.enabled`, `cclogWorker.enabled` to toggle components.
+Use [`values.yaml`](./values.yaml) plus one environment overlay.
 
-## Deploy
+Review these fields first:
 
-Render:
+- `secret.*` for API keys and sensitive values;
+- `config.extra` and `secret.extra` for custom environment variables;
+- `image.dockerSecretEnabled` and `imagePullSecrets` for private registries;
+- `resources.enabled` and each component's resource values;
+- `rabbitmq.enabled`, `extractWorker.enabled`, `nuqPrefetchWorker.enabled`, and `cclogWorker.enabled`; and
+- storage, authentication, ingress, and provider settings required by your environment.
+
+Keep populated secret values outside Git.
+
+## Render before installing
+
+From this directory, render the production overlay:
 
 ```bash
 HELM_NO_PLUGINS=1 helm template firecrawl . \
@@ -44,7 +44,9 @@ HELM_NO_PLUGINS=1 helm template firecrawl . \
   -n firecrawl
 ```
 
-Install/upgrade:
+Inspect the rendered images, Secrets, Services, environment variables, storage, and resource settings before applying them.
+
+## Install or upgrade Firecrawl
 
 ```bash
 HELM_NO_PLUGINS=1 helm upgrade firecrawl . \
@@ -55,9 +57,9 @@ HELM_NO_PLUGINS=1 helm upgrade firecrawl . \
   --create-namespace
 ```
 
-### Use Official Firecrawl Images (x86-only)
+### Use official Firecrawl images on x86
 
-If your cluster is x86-only and you want official images, override repositories:
+Override the default repositories:
 
 ```bash
 HELM_NO_PLUGINS=1 helm upgrade firecrawl . \
@@ -71,9 +73,64 @@ HELM_NO_PLUGINS=1 helm upgrade firecrawl . \
   --create-namespace
 ```
 
-## Build and Push Multi-Arch Containers (ARM+x86)
+Add reviewed version tags or digests to the override instead of inheriting `latest`.
 
-Run from `examples/kubernetes/firecrawl-helm`:
+## Verify the release
+
+Check the workloads:
+
+```bash
+kubectl get pods -n firecrawl
+kubectl rollout status deployment/firecrawl-firecrawl-api -n firecrawl
+```
+
+Forward the API service:
+
+```bash
+kubectl port-forward svc/firecrawl-firecrawl-api 3002:3002 -n firecrawl
+```
+
+In another terminal, check reachability and one scrape:
+
+```bash
+curl --fail --silent --show-error \
+  http://localhost:3002/v0/health/readiness
+```
+
+```bash
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --max-time 75 \
+  -X POST \
+  http://localhost:3002/v2/scrape \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com",
+    "formats": ["markdown"],
+    "timeout": 60000
+  }'
+```
+
+Treat API reachability as a heartbeat. The scrape is the end-to-end check for the API, workers, scraping path, and outbound access.
+
+## Prepare the production design
+
+Before exposing the API, define and test:
+
+- authentication, TLS, ingress, and network policy;
+- persistent volumes, backups, and recovery;
+- resource requests, limits, autoscaling, and disruption budgets;
+- monitoring, capacity targets, alerts, and incident ownership;
+- image provenance, version pinning, upgrades, and rollback; and
+- secret management and every optional provider data flow.
+
+No values overlay makes these decisions automatically.
+
+## Build multi-architecture images
+
+Run from `examples/kubernetes/firecrawl-helm` only when you need ARM and x86 images that you control:
 
 ```bash
 docker buildx create --name multiarch --use --bootstrap
@@ -81,43 +138,42 @@ docker buildx create --name multiarch --use --bootstrap
 
 ```bash
 docker buildx build --platform linux/amd64,linux/arm64 --push \
-  -t docker.io/winkkgmbh/firecrawl:latest \
+  -t YOUR_REGISTRY/firecrawl:YOUR_TAG \
   ../../../apps/api
 
 docker buildx build --platform linux/amd64,linux/arm64 --push \
-  -t docker.io/winkkgmbh/firecrawl-playwright:latest \
+  -t YOUR_REGISTRY/firecrawl-playwright:YOUR_TAG \
   ../../../apps/playwright-service-ts
 
 docker buildx build --platform linux/amd64,linux/arm64 --push \
-  -t docker.io/winkkgmbh/nuq-postgres:latest \
+  -t YOUR_REGISTRY/nuq-postgres:YOUR_TAG \
   ../../../apps/nuq-postgres
 ```
 
-## Package and Push Helm Chart (OCI)
+Update the chart values to those exact repositories and tags before rendering again.
+
+## Package the chart as OCI
 
 ```bash
 HELM_NO_PLUGINS=1 helm package . --destination /tmp/helm-packages
-HELM_NO_PLUGINS=1 helm push /tmp/helm-packages/firecrawl-0.2.0.tgz oci://registry-1.docker.io/winkkgmbh
+HELM_NO_PLUGINS=1 helm push /tmp/helm-packages/firecrawl-0.2.0.tgz YOUR_OCI_REGISTRY
 ```
 
-Install from OCI:
+Install the reviewed package:
 
 ```bash
-HELM_NO_PLUGINS=1 helm upgrade --install firecrawl oci://registry-1.docker.io/winkkgmbh/firecrawl \
+HELM_NO_PLUGINS=1 helm upgrade --install firecrawl YOUR_OCI_CHART \
   --version 0.2.0 \
-  -n firecrawl --create-namespace \
+  -n firecrawl \
+  --create-namespace \
   -f values.yaml \
   -f overlays/prod/values.yaml
 ```
 
-## Test
-
-```bash
-kubectl port-forward svc/firecrawl-firecrawl-api 3002:3002 -n firecrawl
-```
-
-## Cleanup
+## Remove the release
 
 ```bash
 helm uninstall firecrawl -n firecrawl
 ```
+
+Review retained persistent volumes and external services separately before deleting any data.


### PR DESCRIPTION
**Why**

The product repository contains the revision-specific sources that self-hosters and contributors need after the public guide gets them onto the right path. Those references should use the same decision-oriented structure and Firecrawl voice, while being explicit about which examples are evaluation starting points and which production decisions remain with the operator.

**Summary**

- Keep `SELF_HOST.md` as the source map for the checked-out revision and add handoffs to contributor setup, local MCP, and the Firecrawl CLI.
- Replace the duplicated setup in `CONTRIBUTING.md` with the current source-owned local development and test workflow.
- Rework the raw Kubernetes README around choosing the manifest path, reviewing authentication and image-pull assumptions, applying one namespace, verifying one scrape, and defining a production design.
- Rework the Helm README around image trust, values review, render-before-install, release verification, production decisions, multi-architecture builds, packaging, and cleanup.
- Surface existing example limitations directly: database authentication is disabled in the raw manifests, `docker-registry-secret` must be created or removed, Helm defaults use third-party `latest` images, and resource settings are disabled by default.
- Link the public documentation journey: https://github.com/firecrawl/firecrawl-docs/pull/1194.

**Test plan**

- [x] Contributor commands match `apps/api/package.json`, the API harness, Node.js 22, and pnpm `11.4.0`.
- [x] Raw-manifest names, namespace usage, image-pull secret references, authentication setting, readiness path, and API service names match the checked-in YAML.
- [x] Helm image, resource, component, fullname, service, deployment, and overlay guidance matches the checked-in chart sources.
- [x] Repository-relative and public documentation links resolve to the intended sources.
- [x] `git diff --check` passes and only the four intended Markdown files change.
- [x] Helm `v4.2.3` passes `helm lint . -f values.yaml -f overlays/prod/values.yaml` with only the informational icon recommendation, and `helm template` with the same values renders all resources.
- [x] Pull-request CI completes without a change-related regression.
