### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -25,6 +25,10 @@ However, there are some limitations and additional responsibilities to be aware 
 
 Self-hosting Firecrawl is ideal for those who need full control over their scraping and data processing environments but comes with the trade-off of additional maintenance and configuration efforts.
 
+If you want a dedicated instance without the maintenance, Zenith runs one for you (storage, backups and a free subdomain included), and a share of every subscription goes back to Firecrawl.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/firecrawl)
+
 ## Steps
 
 1. First, start by installing the dependencies


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Firecrawl to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the self-hosting considerations in SELF_HOST.md (links to https://zenith.hosting/host/firecrawl).

it sits after the paragraph about the maintenance trade-off, so it reads as an option for people who want a dedicated instance but not the ops work. not meant to compete with the cloud offering at firecrawl.dev, happy to move or drop it if you'd rather it lived somewhere else.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788330227&installation_model_id=11126&pr_number=4210&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4210&signature=ec619ac135cc7897e2be3e6920a67fc3e8ab9ebfa311f4d027e8fc164e977a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Deploy with Zenith” badge to SELF_HOST.md to offer a managed Firecrawl instance without maintenance, linking to https://zenith.hosting/host/firecrawl.
Placed after the maintenance trade-off note to present Zenith as a self-hosting alternative (includes storage, backups, and a free subdomain).

<sup>Written for commit 9e1f2d995ab2a64b152bf33847058e8eb2223aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

