### PR TITLE
fix(api): disable executeJavascript during scrape replay

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-browser.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-browser.test.ts
@@ -64,9 +64,8 @@ describe("Scrape browser interact replay", () => {
     (TEST_PRODUCTION || HAS_FIRE_ENGINE);
 
   itIf(canRunReplayHappyPath)(
-    "replays scrape URL/waitFor/actions before interactive code runs",
+    "replays scrape URL, waitFor, and supported actions before interactive code runs",
     async () => {
-      const marker = crypto.randomUUID();
       const url = `${TEST_SUITE_WEBSITE}?testId=${crypto.randomUUID()}`;
       let scrapeId: string | null = null;
 
@@ -78,8 +77,8 @@ describe("Scrape browser interact replay", () => {
             waitFor: 500,
             actions: [
               {
-                type: "executeJavascript",
-                script: `window.__firecrawlReplayMarker = "${marker}";`,
+                type: "click",
+                selector: `a[href="/about"]`,
               },
             ],
           },
@@ -97,8 +96,7 @@ describe("Scrape browser interact replay", () => {
             language: "node",
             timeout: 60,
             code: `
-              const replayMarker = await page.evaluate(() => window.__firecrawlReplayMarker ?? null);
-              console.log(replayMarker ?? "missing-marker");
+              console.log(page.url());
             `,
           },
           identity,
@@ -106,7 +104,7 @@ describe("Scrape browser interact replay", () => {
 
         expect(executeResponse.statusCode).toBe(200);
         expect(executeResponse.body.success).toBe(true);
-        expect(executeResponse.body.stdout).toContain(marker);
+        expect(executeResponse.body.stdout).toContain("/about");
         expect(typeof executeResponse.body.cdpUrl).toBe("string");
         expect(executeResponse.body.cdpUrl.length).toBeGreaterThan(0);
       } finally {
@@ -131,8 +129,8 @@ describe("Scrape browser interact replay", () => {
             origin: "website-replay-test",
             actions: [
               {
-                type: "executeJavascript",
-                script: "window.open('about:blank', '_blank');",
+                type: "click",
+                selector: `a[href="https://github.com/firecrawl/firecrawl"]`,
               },
             ],
           },
@@ -182,6 +180,58 @@ describe("Scrape browser interact replay", () => {
 
         expect(visibleUrl).not.toBe("about:blank");
         expect(visibleUrl).toContain(TEST_SUITE_WEBSITE);
+      } finally {
+        if (scrapeId) {
+          await scrapeStopInteractiveBrowserRaw(scrapeId, identity);
+        }
+      }
+    },
+    scrapeTimeout,
+  );
+
+  itIf(canRunReplayHappyPath)(
+    "does not replay executeJavascript actions into the interactive browser session",
+    async () => {
+      const marker = crypto.randomUUID();
+      const url = `${TEST_SUITE_WEBSITE}?testId=${crypto.randomUUID()}`;
+      let scrapeId: string | null = null;
+
+      try {
+        const scrapeResponse = await scrapeRaw(
+          {
+            url,
+            origin: "website-replay-test",
+            actions: [
+              {
+                type: "executeJavascript",
+                script: `window.__firecrawlReplayMarker = "${marker}";`,
+              },
+            ],
+          },
+          identity,
+        );
+
+        expect(scrapeResponse.statusCode).toBe(200);
+        expect(scrapeResponse.body.success).toBe(true);
+        expect(typeof scrapeResponse.body.scrape_id).toBe("string");
+        scrapeId = scrapeResponse.body.scrape_id as string;
+
+        const executeResponse = await interactWithReplicaRetry(
+          scrapeId,
+          {
+            language: "node",
+            timeout: 60,
+            code: `
+              const replayMarker = await page.evaluate(() => window.__firecrawlReplayMarker ?? null);
+              console.log(replayMarker ?? "missing-marker");
+            `,
+          },
+          identity,
+        );
+
+        expect(executeResponse.statusCode).toBe(200);
+        expect(executeResponse.body.success).toBe(true);
+        expect(executeResponse.body.stdout).toContain("missing-marker");
       } finally {
         if (scrapeId) {
           await scrapeStopInteractiveBrowserRaw(scrapeId, identity);

--- a/apps/api/src/lib/scrape-interact/scrape-replay.test.ts
+++ b/apps/api/src/lib/scrape-interact/scrape-replay.test.ts
@@ -37,7 +37,7 @@ describe("scrape replay", () => {
       actions: [{ type: "click", selector: "a[href='/about']", all: false }],
     });
 
-    expect(script).not.toContain("eval");
+    expect(script).not.toMatch(/\beval\s*\(/);
     expect(script).not.toContain("executeJavascript");
   });
 });

--- a/apps/api/src/lib/scrape-interact/scrape-replay.test.ts
+++ b/apps/api/src/lib/scrape-interact/scrape-replay.test.ts
@@ -1,0 +1,43 @@
+import {
+  buildReplayContextFromScrape,
+  buildReplayScript,
+} from "./scrape-replay";
+
+describe("scrape replay", () => {
+  it("drops executeJavascript actions from replay context", () => {
+    const replay = buildReplayContextFromScrape({
+      id: "scrape-id",
+      team_id: "team-id",
+      url: "https://example.com",
+      options: {
+        waitFor: 250,
+        actions: [
+          { type: "wait", milliseconds: 100 },
+          {
+            type: "executeJavascript",
+            script: "window.__firecrawlReplayMarker = 'pwned';",
+          },
+          { type: "click", selector: "a[href='/about']" },
+        ],
+      },
+    });
+
+    expect(replay.error).toBeUndefined();
+    expect(replay.context).toBeDefined();
+    expect(replay.context?.actions).toEqual([
+      { type: "wait", milliseconds: 100 },
+      { type: "click", selector: "a[href='/about']", all: false },
+    ]);
+  });
+
+  it("never emits eval-based javascript replay code", () => {
+    const script = buildReplayScript({
+      targetUrl: "https://example.com",
+      waitForMs: 0,
+      actions: [{ type: "click", selector: "a[href='/about']", all: false }],
+    });
+
+    expect(script).not.toContain("eval");
+    expect(script).not.toContain("executeJavascript");
+  });
+});

--- a/apps/api/src/lib/scrape-interact/scrape-replay.ts
+++ b/apps/api/src/lib/scrape-interact/scrape-replay.ts
@@ -17,7 +17,6 @@ type ReplayAction =
   | { type: "write"; text: string }
   | { type: "press"; key: string }
   | { type: "scroll"; direction?: "up" | "down"; selector?: string }
-  | { type: "executeJavascript"; script: string }
   | { type: "screenshot" | "pdf" | "scrape" };
 
 interface ScrapeReplayContext {
@@ -113,12 +112,6 @@ function sanitizeReplayActions(rawActions: unknown): ReplayAction[] {
         direction,
         ...(selector ? { selector } : {}),
       });
-      continue;
-    }
-
-    if (type === "executeJavascript") {
-      if (typeof rawAction.script !== "string") continue;
-      actions.push({ type, script: rawAction.script });
       continue;
     }
 
@@ -344,11 +337,6 @@ for (let i = 0; i < replay.actions.length; i += 1) {
           await page.mouse.wheel(0, action.direction === "up" ? -800 : 800);
         }
         break;
-      case "executeJavascript": {
-        const wrapped = \`(async () => { \${action.script} })()\`;
-        await page.evaluate(script => (0, eval)(script), wrapped);
-        break;
-      }
       case "screenshot":
       case "pdf":
       case "scrape":


### PR DESCRIPTION
Closes #4190

## Summary

This PR fixes a critical RCE path in scrape replay by removing support for replaying `executeJavascript` actions from saved scrape context.

## What changed

- removed `executeJavascript` from the replay action model in `apps/api/src/lib/scrape-interact/scrape-replay.ts`
- stopped replay sanitization from carrying user-supplied JavaScript into replay context
- removed the `page.evaluate(... eval ...)` execution path from the generated replay script
- added a unit test to verify replay context drops `executeJavascript` and that replay script generation no longer emits `eval`
- updated scrape-browser snips to:
  - use supported replayable actions in the happy path
  - add a regression test proving `executeJavascript` is not re-executed in the interactive replay session

## Security rationale

Replaying arbitrary user JavaScript is not safe in this executor. Instead of trying to sanitize or sandbox arbitrary scripts, replay now only supports non-code interaction actions such as:

- `wait`
- `click`
- `write`
- `press`
- `scroll`

This removes the vulnerable behavior entirely.

## Testing

Added:
- `apps/api/src/lib/scrape-interact/scrape-replay.test.ts`
- replay regression coverage in `apps/api/src/__tests__/snips/v2/scrape-browser.test.ts`

Local harness verification was blocked in this environment because `pnpm` attempted to build `foundationdb` and failed due to missing native headers (`foundationdb/fdb_c.h`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788350885&installation_model_id=11126&pr_number=4214&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4214&signature=064a338a692b63d74712ec359d7408fc9fc6869e22e5c08fbe97831a085da53a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables replay of user JavaScript during scrape replay to remove an RCE vector; only non-code actions are now replayed.

- **Bug Fixes**
  - Sanitization strips user-supplied JavaScript from replay context.
  - Removed the eval-based execution path from the generated replay script.
  - Tests enforce filtering and assert no eval usage; matcher updated to avoid false positives.

- **Migration**
  - Use supported actions only: `wait`, `click`, `write`, `press`, `scroll`.

<sup>Written for commit 0aa2a44b30c7fc881b21fec72b262bf22adb2dd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

