### PR TITLE
fix(search): recover path-scoped site: queries that return no results

### DIFF
--- a/apps/api/knip.config.ts
+++ b/apps/api/knip.config.ts
@@ -15,9 +15,6 @@ const config: KnipConfig = {
   ignore: [
     "native/**",
     "src/scraper/scrapeURL/engines/fire-engine/branding-script/**",
-    // Shared type contract co-owned by concurrent threat-protection branches;
-    // the provider/verdict types are consumed by the core-lib branch.
-    "src/lib/threat-protection/types.ts",
   ],
   ignoreDependencies: ["undici-types", "stripe"],
 };

--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -61,16 +61,14 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
   );
 
   it.concurrent(
-    "works with a path-scoped site: operator",
+    "falls back to the hostname when a path-scoped site: filter matches nothing",
     async () => {
-      // Google-style `site:host/path` filters used to be passed through to
-      // backends that only understand hostnames, matching nothing and
-      // returning zero results. The path is now stripped for the backend
-      // (and used to rank on-path results first), so the domain restriction
-      // must still hold and results must be non-empty.
+      // `site:host/path` acts as a strict URL-prefix filter, so a path with
+      // no indexed pages under it returns zero results. The fallback retries with `site:host`, so this query must
+      // return non-empty, domain-constrained results instead of nothing.
       const res = await search(
         {
-          query: "site:github.com/firecrawl/firecrawl scraping",
+          query: "site:firecrawl.dev/this-path-does-not-exist firecrawl",
           limit: 5,
         },
         identity,
@@ -82,7 +80,7 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
         expect(result.url).toBeDefined();
         const hostname = new URL(result.url!).hostname;
         expect(
-          hostname === "github.com" || hostname.endsWith(".github.com"),
+          hostname === "firecrawl.dev" || hostname.endsWith(".firecrawl.dev"),
         ).toBe(true);
       }
     },

--- a/apps/api/src/__tests__/snips/v2/search.test.ts
+++ b/apps/api/src/__tests__/snips/v2/search.test.ts
@@ -61,6 +61,35 @@ describeIf(TEST_PRODUCTION || HAS_SEARCH || HAS_PROXY)("Search tests", () => {
   );
 
   it.concurrent(
+    "works with a path-scoped site: operator",
+    async () => {
+      // Google-style `site:host/path` filters used to be passed through to
+      // backends that only understand hostnames, matching nothing and
+      // returning zero results. The path is now stripped for the backend
+      // (and used to rank on-path results first), so the domain restriction
+      // must still hold and results must be non-empty.
+      const res = await search(
+        {
+          query: "site:github.com/firecrawl/firecrawl scraping",
+          limit: 5,
+        },
+        identity,
+      );
+
+      expect(res.web).toBeDefined();
+      expect(res.web?.length).toBeGreaterThan(0);
+      for (const result of res.web ?? []) {
+        expect(result.url).toBeDefined();
+        const hostname = new URL(result.url!).hostname;
+        expect(
+          hostname === "github.com" || hostname.endsWith(".github.com"),
+        ).toBe(true);
+      }
+    },
+    60000,
+  );
+
+  it.concurrent(
     "rejects includeDomains with excludeDomains",
     async () => {
       const res = await searchWithFailure(

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -95,7 +95,7 @@ const booleanFlag = z
     value === undefined ? undefined : value === true || value === "true",
   );
 
-export const developerSearchSchema = z.strictObject({
+const developerSearchSchema = z.strictObject({
   query: z.string().min(1),
   k: kSchema(100),
   types: multiString,
@@ -113,7 +113,7 @@ export const developerSearchSchema = z.strictObject({
   ...commonQuery,
 });
 
-export const DEVELOPER_SEARCH_QUERY_KEYS = [
+const DEVELOPER_SEARCH_QUERY_KEYS = [
   "query",
   "k",
   "types",

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -87,7 +87,7 @@ export function isKeylessIpEligible(ip: string): boolean {
 const requestsKey = (ip: string) => `keyless_requests:${ip}`;
 const creditsKey = (ip: string) => `keyless_credits:${ip}`;
 
-export type KeylessQuotaReason = "requests" | "credits";
+type KeylessQuotaReason = "requests" | "credits";
 
 type KeylessConsumeResult = {
   ok: boolean;
@@ -286,11 +286,14 @@ return next
  * consumption). Used by the hosted MCP before a keyless tool call so an
  * ineligible caller receives structured recovery without an OAuth challenge.
  */
-export async function checkKeylessEligibility(
-  ip: string,
-): Promise<{
+export async function checkKeylessEligibility(ip: string): Promise<{
   eligible: boolean;
-  reason?: KeylessQuotaReason | "disabled" | "ineligible_ip" | "suspicious" | "error";
+  reason?:
+    | KeylessQuotaReason
+    | "disabled"
+    | "ineligible_ip"
+    | "suspicious"
+    | "error";
   retryAfterSeconds?: number;
 }> {
   if (!isKeylessConfigured()) return { eligible: false, reason: "disabled" };

--- a/apps/api/src/lib/research-upstream.ts
+++ b/apps/api/src/lib/research-upstream.ts
@@ -9,7 +9,7 @@ const dispatcher = new Agent({
   bodyTimeout: TIMEOUT_MS,
 });
 
-export function appendQuery(
+function appendQuery(
   url: URL,
   params: Record<string, unknown>,
   allowed: string[],

--- a/apps/api/src/lib/search-query-builder.test.ts
+++ b/apps/api/src/lib/search-query-builder.test.ts
@@ -1,0 +1,134 @@
+import {
+  extractSitePathFilters,
+  rankSitePathMatchesFirst,
+} from "./search-query-builder";
+
+describe("extractSitePathFilters", () => {
+  it("rewrites a path-scoped site: operator to its hostname", () => {
+    const { query, pathPrefixes } = extractSitePathFilters(
+      "site:example.com/docs installation guide",
+    );
+    expect(query).toBe("site:example.com installation guide");
+    expect(pathPrefixes).toEqual(["example.com/docs"]);
+  });
+
+  it("keeps deeper paths as a single prefix", () => {
+    const { query, pathPrefixes } = extractSitePathFilters(
+      "site:github.com/example/repo SECURITY.md",
+    );
+    expect(query).toBe("site:github.com SECURITY.md");
+    expect(pathPrefixes).toEqual(["github.com/example/repo"]);
+  });
+
+  it("leaves hostname-only site: operators untouched", () => {
+    const { query, pathPrefixes } = extractSitePathFilters(
+      "site:example.com installation guide",
+    );
+    expect(query).toBe("site:example.com installation guide");
+    expect(pathPrefixes).toEqual([]);
+  });
+
+  it("strips a bare trailing slash without recording a prefix", () => {
+    const { query, pathPrefixes } = extractSitePathFilters(
+      "site:example.com/ installation guide",
+    );
+    expect(query).toBe("site:example.com installation guide");
+    expect(pathPrefixes).toEqual([]);
+  });
+
+  it("leaves negated site: operators untouched", () => {
+    const input = "widgets -site:example.com/forum";
+    const { query, pathPrefixes } = extractSitePathFilters(input);
+    expect(query).toBe(input);
+    expect(pathPrefixes).toEqual([]);
+  });
+
+  it("handles multiple and parenthesized operators", () => {
+    const { query, pathPrefixes } = extractSitePathFilters(
+      "(site:example.com/docs OR site:example.org/kb) setup",
+    );
+    expect(query).toBe("(site:example.com OR site:example.org) setup");
+    expect(pathPrefixes).toEqual(["example.com/docs", "example.org/kb"]);
+  });
+
+  it("strips protocols and www from recorded prefixes", () => {
+    const { query, pathPrefixes } = extractSitePathFilters(
+      "site:https://www.example.com/docs/api reference",
+    );
+    expect(query).toBe("site:www.example.com reference");
+    expect(pathPrefixes).toEqual(["example.com/docs/api"]);
+  });
+
+  it("ignores site: values that are not hostnames", () => {
+    const input = "site:localhost/admin dashboard";
+    const { query, pathPrefixes } = extractSitePathFilters(input);
+    expect(query).toBe(input);
+    expect(pathPrefixes).toEqual([]);
+  });
+});
+
+describe("rankSitePathMatchesFirst", () => {
+  const results = [
+    { url: "https://example.com/blog/post" },
+    { url: "https://example.com/docs/setup" },
+    { url: "https://www.example.com/docs" },
+    { url: "https://example.com/pricing" },
+  ];
+
+  it("moves results under the path prefix to the front, preserving order", () => {
+    const ranked = rankSitePathMatchesFirst(results, ["example.com/docs"]);
+    expect(ranked.map(r => r.url)).toEqual([
+      "https://example.com/docs/setup",
+      "https://www.example.com/docs",
+      "https://example.com/blog/post",
+      "https://example.com/pricing",
+    ]);
+  });
+
+  it("does not treat sibling paths sharing a prefix string as matches", () => {
+    const ranked = rankSitePathMatchesFirst(
+      [
+        { url: "https://example.com/docs-old/setup" },
+        { url: "https://example.com/docs/setup" },
+      ],
+      ["example.com/docs"],
+    );
+    expect(ranked[0].url).toBe("https://example.com/docs/setup");
+    expect(
+      rankSitePathMatchesFirst(
+        [{ url: "https://example.com/docs-old/setup" }],
+        ["example.com/docs"],
+      ),
+    ).toEqual([{ url: "https://example.com/docs-old/setup" }]);
+  });
+
+  it("matches subdomains of the prefix host", () => {
+    const ranked = rankSitePathMatchesFirst(
+      [
+        { url: "https://example.com/other" },
+        { url: "https://docs.example.com/kb/article" },
+      ],
+      ["example.com/kb"],
+    );
+    expect(ranked[0].url).toBe("https://docs.example.com/kb/article");
+  });
+
+  it("returns results unchanged when no prefixes are given", () => {
+    expect(rankSitePathMatchesFirst(results, [])).toBe(results);
+  });
+
+  it("returns results unchanged when nothing matches", () => {
+    const ranked = rankSitePathMatchesFirst(results, ["example.net/docs"]);
+    expect(ranked).toEqual(results);
+  });
+
+  it("skips results with missing or unparseable URLs", () => {
+    const mixed = [
+      { url: undefined },
+      { url: "not a url" },
+      { url: "https://example.com/docs/setup" },
+    ];
+    const ranked = rankSitePathMatchesFirst(mixed, ["example.com/docs"]);
+    expect(ranked[0].url).toBe("https://example.com/docs/setup");
+  });
+});

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -20,6 +20,104 @@ interface QueryBuilderResult {
   categoryMap: Map<string, string>;
 }
 
+interface SitePathFilterResult {
+  query: string;
+  pathPrefixes: string[];
+}
+
+/**
+ * Rewrites path-scoped `site:` operators to their hostname.
+ *
+ * Google treats `site:host/path` as a URL-prefix restriction, but the search
+ * backends here only understand hostnames — a path makes the filter match
+ * nothing, so the whole search returns zero results. Rewriting to `site:host`
+ * keeps the domain restriction; the extracted prefixes let the caller rank
+ * results under the requested path first (see rankSitePathMatchesFirst).
+ *
+ * Negated operators (`-site:`) are left untouched: widening an exclusion to
+ * the whole domain would drop results the user wanted.
+ */
+export function extractSitePathFilters(query: string): SitePathFilterResult {
+  const pathPrefixes: string[] = [];
+  const rewritten = query.replace(
+    /(^|[^-\w])site:([^\s()"']+)/gi,
+    (match, boundary: string, rawValue: string) => {
+      const value = rawValue.replace(/^https?:\/\//i, "");
+      const slash = value.indexOf("/");
+      const host = slash === -1 ? value : value.slice(0, slash);
+      const path = slash === -1 ? "" : value.slice(slash).replace(/\/+$/, "");
+      if (!host.includes(".")) {
+        return match;
+      }
+      if (path.length > 0) {
+        pathPrefixes.push(
+          host.toLowerCase().replace(/^www\./, "") + path.toLowerCase(),
+        );
+      }
+      return `${boundary}site:${host}`;
+    },
+  );
+  return { query: rewritten, pathPrefixes };
+}
+
+function urlMatchesSitePathPrefix(
+  url: string | undefined,
+  pathPrefixes: string[],
+): boolean {
+  if (!url) return false;
+  let hostname: string;
+  let pathname: string;
+  try {
+    const parsed = new URL(url);
+    hostname = parsed.hostname.toLowerCase().replace(/^www\./, "");
+    pathname = parsed.pathname.toLowerCase().replace(/\/+$/, "");
+  } catch {
+    return false;
+  }
+  for (const prefix of pathPrefixes) {
+    const slash = prefix.indexOf("/");
+    const prefixHost = slash === -1 ? prefix : prefix.slice(0, slash);
+    const prefixPath = slash === -1 ? "" : prefix.slice(slash);
+    if (hostname !== prefixHost && !hostname.endsWith("." + prefixHost)) {
+      continue;
+    }
+    if (
+      prefixPath === "" ||
+      pathname === prefixPath ||
+      pathname.startsWith(prefixPath + "/")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Reorders results so that URLs under a requested `site:host/path` prefix come
+ * first, preserving relative order within each group. Results are never
+ * dropped: the hostname rewrite in extractSitePathFilters already constrains
+ * them to the right domain, and off-path pages are still better than the
+ * zero results the unrewritten query produced.
+ */
+export function rankSitePathMatchesFirst<T extends { url?: string }>(
+  results: T[],
+  pathPrefixes: string[],
+): T[] {
+  if (pathPrefixes.length === 0 || results.length === 0) {
+    return results;
+  }
+  const onPath: T[] = [];
+  const offPath: T[] = [];
+  for (const result of results) {
+    if (urlMatchesSitePathPrefix(result.url, pathPrefixes)) {
+      onPath.push(result);
+    } else {
+      offPath.push(result);
+    }
+  }
+  return onPath.length > 0 ? [...onPath, ...offPath] : results;
+}
+
 // Default research sites
 const DEFAULT_RESEARCH_SITES = [
   "arxiv.org",

--- a/apps/api/src/lib/search-query-builder.ts
+++ b/apps/api/src/lib/search-query-builder.ts
@@ -28,11 +28,15 @@ interface SitePathFilterResult {
 /**
  * Rewrites path-scoped `site:` operators to their hostname.
  *
- * Google treats `site:host/path` as a URL-prefix restriction, but the search
- * backends here only understand hostnames — a path makes the filter match
- * nothing, so the whole search returns zero results. Rewriting to `site:host`
- * keeps the domain restriction; the extracted prefixes let the caller rank
- * results under the requested path first (see rankSitePathMatchesFirst).
+ * `site:host/path` acts as a strict URL-prefix restriction, so a stale or
+ * guessed path (or one with query parameters) returns zero results even when
+ * the site has relevant pages. This rewrite is
+ * the fallback for that case: `site:host` keeps the domain restriction, and
+ * the extracted prefixes let the caller rank results under the requested path
+ * first (see rankSitePathMatchesFirst). Callers should only fall back to the
+ * rewritten query when the original one returned nothing — when the prefix
+ * does match indexed pages, the provider's strict filtering is the better
+ * result set.
  *
  * Negated operators (`-site:`) are left untouched: widening an exclusion to
  * the whole domain would drop results the user wanted.
@@ -96,8 +100,8 @@ function urlMatchesSitePathPrefix(
  * Reorders results so that URLs under a requested `site:host/path` prefix come
  * first, preserving relative order within each group. Results are never
  * dropped: the hostname rewrite in extractSitePathFilters already constrains
- * them to the right domain, and off-path pages are still better than the
- * zero results the unrewritten query produced.
+ * them to the right domain, and off-path pages are still better than the zero
+ * results the original path-scoped query produced.
  */
 export function rankSitePathMatchesFirst<T extends { url?: string }>(
   results: T[],

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -3,7 +3,9 @@ import { search } from "./v2";
 import { SearchV2Response } from "../lib/entities";
 import {
   buildSearchQuery,
+  extractSitePathFilters,
   getCategoryFromUrl,
+  rankSitePathMatchesFirst,
   CategoryOption,
 } from "../lib/search-query-builder";
 import { ScrapeOptions, TeamFlags } from "../controllers/v2/types";
@@ -96,8 +98,10 @@ export async function executeSearch(
   logger.info("Searching for results");
 
   const searchTypes = [...new Set(sources.map((s: any) => s.type))];
+  const { query: siteScopedQuery, pathPrefixes } =
+    extractSitePathFilters(query);
   const { query: searchQuery, categoryMap } = buildSearchQuery(
-    query,
+    siteScopedQuery,
     categories,
     {
       includeDomains: options.includeDomains,
@@ -176,6 +180,30 @@ export async function executeSearch(
           isAllowed(x.url),
         );
       }
+    }
+  }
+
+  // Path-scoped site: filters were rewritten to their hostname for the
+  // backend; surface results under the requested path first, before the
+  // result sets are sliced down to the requested limit.
+  if (pathPrefixes.length > 0) {
+    if (searchResponse.web) {
+      searchResponse.web = rankSitePathMatchesFirst(
+        searchResponse.web,
+        pathPrefixes,
+      );
+    }
+    if (searchResponse.news) {
+      searchResponse.news = rankSitePathMatchesFirst(
+        searchResponse.news,
+        pathPrefixes,
+      );
+    }
+    if (searchResponse.images) {
+      searchResponse.images = rankSitePathMatchesFirst(
+        searchResponse.images,
+        pathPrefixes,
+      );
     }
   }
 

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -98,10 +98,8 @@ export async function executeSearch(
   logger.info("Searching for results");
 
   const searchTypes = [...new Set(sources.map((s: any) => s.type))];
-  const { query: siteScopedQuery, pathPrefixes } =
-    extractSitePathFilters(query);
   const { query: searchQuery, categoryMap } = buildSearchQuery(
-    siteScopedQuery,
+    query,
     categories,
     {
       includeDomains: options.includeDomains,
@@ -116,7 +114,7 @@ export async function executeSearch(
       )
     : null;
 
-  const searchResponse = (await search({
+  let searchResponse = (await search({
     query: searchQuery,
     logger,
     advanced: false,
@@ -129,6 +127,67 @@ export async function executeSearch(
     type: searchTypes,
     enterprise: options.enterprise,
   })) as SearchV2Response;
+
+  // `site:host/path` acts as a strict URL-prefix filter, so a stale or
+  // guessed path returns zero results even when the site has relevant
+  // pages. When that happens, retry once with the filters
+  // widened to their hostname and rank on-path results first. Queries whose
+  // prefix does match indexed pages keep the provider's strict filtering and
+  // never pay for the retry.
+  const hasNoResults =
+    !searchResponse.web?.length &&
+    !searchResponse.news?.length &&
+    !searchResponse.images?.length;
+  if (hasNoResults) {
+    const { query: siteScopedQuery, pathPrefixes } =
+      extractSitePathFilters(query);
+    if (pathPrefixes.length > 0) {
+      logger.info(
+        "Path-scoped site: query returned no results; retrying with hostname-only filters",
+        { pathPrefixCount: pathPrefixes.length },
+      );
+      const { query: fallbackQuery } = buildSearchQuery(
+        siteScopedQuery,
+        categories,
+        {
+          includeDomains: options.includeDomains,
+          excludeDomains: options.excludeDomains,
+        },
+      );
+      searchResponse = (await search({
+        query: fallbackQuery,
+        logger,
+        advanced: false,
+        num_results: num_results_buffer,
+        tbs: options.tbs,
+        filter: options.filter,
+        lang: options.lang,
+        country: options.country,
+        location: options.location,
+        type: searchTypes,
+        enterprise: options.enterprise,
+      })) as SearchV2Response;
+
+      if (searchResponse.web) {
+        searchResponse.web = rankSitePathMatchesFirst(
+          searchResponse.web,
+          pathPrefixes,
+        );
+      }
+      if (searchResponse.news) {
+        searchResponse.news = rankSitePathMatchesFirst(
+          searchResponse.news,
+          pathPrefixes,
+        );
+      }
+      if (searchResponse.images) {
+        searchResponse.images = rankSitePathMatchesFirst(
+          searchResponse.images,
+          pathPrefixes,
+        );
+      }
+    }
+  }
 
   if (developerResults) {
     const developer = await developerResults;
@@ -180,30 +239,6 @@ export async function executeSearch(
           isAllowed(x.url),
         );
       }
-    }
-  }
-
-  // Path-scoped site: filters were rewritten to their hostname for the
-  // backend; surface results under the requested path first, before the
-  // result sets are sliced down to the requested limit.
-  if (pathPrefixes.length > 0) {
-    if (searchResponse.web) {
-      searchResponse.web = rankSitePathMatchesFirst(
-        searchResponse.web,
-        pathPrefixes,
-      );
-    }
-    if (searchResponse.news) {
-      searchResponse.news = rankSitePathMatchesFirst(
-        searchResponse.news,
-        pathPrefixes,
-      );
-    }
-    if (searchResponse.images) {
-      searchResponse.images = rankSitePathMatchesFirst(
-        searchResponse.images,
-        pathPrefixes,
-      );
     }
   }
 


### PR DESCRIPTION
Closing — superseding with a different approach.