### PR TITLE
fix(python-sdk): raise FirecrawlError on failed/cancelled batch/crawl waits

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_wait_terminal_failure.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_wait_terminal_failure.py
@@ -1,0 +1,53 @@
+import pytest
+
+from firecrawl.v2.methods import batch, crawl
+from firecrawl.v2.types import BatchScrapeJob, CrawlJob
+from firecrawl.v2.utils.error_handler import FirecrawlError
+
+
+class TestWaitTerminalFailure:
+    def test_wait_for_batch_completion_raises_on_failed(self):
+        batch.get_batch_scrape_status = lambda *args, **kwargs: BatchScrapeJob(
+            status="failed", completed=0, total=3, data=[]
+        )
+
+        with pytest.raises(FirecrawlError, match="Batch scrape job stub ended with status 'failed'"):
+            batch.wait_for_batch_completion(client=None, job_id="stub")
+
+    def test_wait_for_batch_completion_raises_on_cancelled(self):
+        batch.get_batch_scrape_status = lambda *args, **kwargs: BatchScrapeJob(
+            status="cancelled", completed=0, total=3, data=[]
+        )
+
+        with pytest.raises(FirecrawlError, match="Batch scrape job stub ended with status 'cancelled'"):
+            batch.wait_for_batch_completion(client=None, job_id="stub")
+
+    def test_wait_for_batch_completion_returns_completed(self):
+        expected = BatchScrapeJob(status="completed", completed=3, total=3, data=[])
+        batch.get_batch_scrape_status = lambda *args, **kwargs: expected
+
+        result = batch.wait_for_batch_completion(client=None, job_id="stub")
+        assert result == expected
+
+    def test_wait_for_crawl_completion_raises_on_failed(self):
+        crawl.get_crawl_status = lambda *args, **kwargs: CrawlJob(
+            status="failed", completed=0, total=3, data=[]
+        )
+
+        with pytest.raises(FirecrawlError, match="Crawl job stub ended with status 'failed'"):
+            crawl.wait_for_crawl_completion(client=None, job_id="stub")
+
+    def test_wait_for_crawl_completion_raises_on_cancelled(self):
+        crawl.get_crawl_status = lambda *args, **kwargs: CrawlJob(
+            status="cancelled", completed=0, total=3, data=[]
+        )
+
+        with pytest.raises(FirecrawlError, match="Crawl job stub ended with status 'cancelled'"):
+            crawl.wait_for_crawl_completion(client=None, job_id="stub")
+
+    def test_wait_for_crawl_completion_returns_completed(self):
+        expected = CrawlJob(status="completed", completed=3, total=3, data=[])
+        crawl.get_crawl_status = lambda *args, **kwargs: expected
+
+        result = crawl.wait_for_crawl_completion(client=None, job_id="stub")
+        assert result == expected

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -551,7 +551,7 @@ class FirecrawlClient:
 
         Raises:
             ValueError: If request is invalid
-            Exception: If the crawl fails to start or complete
+            FirecrawlError: If the crawl fails to start or complete
             TimeoutError: If timeout is reached
         """
         if scrape_options is None:
@@ -1618,6 +1618,10 @@ class FirecrawlClient:
     ):
         """
         Start a batch scrape job and wait until completion.
+
+        Raises:
+            FirecrawlError: If the batch scrape fails to start or complete
+            TimeoutError: If the wait timeout is reached
         """
         options = ScrapeOptions(
             **{k: v for k, v in dict(

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -50,6 +50,7 @@ from .types import (
 )
 from .utils.http_client import HttpClient
 from .utils.http_client_async import AsyncHttpClient
+from .utils.error_handler import FirecrawlError
 
 from .methods.aio import scrape as async_scrape  # type: ignore[attr-defined]
 from .methods.aio import parse as async_parse  # type: ignore[attr-defined]
@@ -284,6 +285,7 @@ class AsyncFirecrawlClient:
             CrawlJob: The final status of the crawl job when it reaches a terminal state.
 
         Raises:
+            FirecrawlError: If the crawl fails or is cancelled
             TimeoutError: If the crawl does not reach a terminal state within the specified timeout.
 
         Terminal states:
@@ -298,8 +300,12 @@ class AsyncFirecrawlClient:
                 job_id,
                 request_timeout=request_timeout,
             )
-            if status.status in ["completed", "failed", "cancelled"]:
+            if status.status == "completed":
                 return status
+            if status.status in ("failed", "cancelled"):
+                raise FirecrawlError(
+                    f"Crawl job {job_id} ended with status '{status.status}'"
+                )
             if timeout and (time.monotonic() - start) > timeout:
                 raise TimeoutError("Crawl wait timed out")
             await asyncio.sleep(poll_interval)
@@ -532,11 +538,22 @@ class AsyncFirecrawlClient:
         return await async_batch.start_batch_scrape(self.async_http_client, urls, **kwargs)
 
     async def wait_batch_scrape(self, job_id: str, poll_interval: int = 2, timeout: Optional[int] = None) -> Any:
+        """
+        Poll batch scrape status until the job reaches a terminal state.
+
+        Raises:
+            FirecrawlError: If the batch scrape fails or is cancelled
+            TimeoutError: If the batch wait times out
+        """
         start = asyncio.get_event_loop().time()
         while True:
             status = await async_batch.get_batch_scrape_status(self.async_http_client, job_id)
-            if status.status in ["completed", "failed", "cancelled"]:
+            if status.status == "completed":
                 return status
+            if status.status in ("failed", "cancelled"):
+                raise FirecrawlError(
+                    f"Batch scrape job {job_id} ended with status '{status.status}'"
+                )
             if timeout and (asyncio.get_event_loop().time() - start) > timeout:
                 raise TimeoutError("Batch wait timed out")
             await asyncio.sleep(poll_interval)

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -14,7 +14,7 @@ from ..types import (
     PaginationConfig,
     AuditMetadata,
 )
-from ..utils import HttpClient, handle_response_error, validate_scrape_options, prepare_scrape_options
+from ..utils import HttpClient, FirecrawlError, handle_response_error, validate_scrape_options, prepare_scrape_options
 from ..utils.normalize import normalize_document_input
 from ..types import CrawlErrorsResponse
 
@@ -321,9 +321,13 @@ def wait_for_batch_completion(
     while True:
         status_job = get_batch_scrape_status(client, job_id)
         
-        # Check if job is complete
-        if status_job.status in ["completed", "failed", "cancelled"]:
+        if status_job.status == "completed":
             return status_job
+
+        if status_job.status in ("failed", "cancelled"):
+            raise FirecrawlError(
+                f"Batch scrape job {job_id} ended with status '{status_job.status}'"
+            )
         
         # Check timeout
         if timeout and (time.monotonic() - start_time) > timeout:

--- a/apps/python-sdk/firecrawl/v2/methods/crawl.py
+++ b/apps/python-sdk/firecrawl/v2/methods/crawl.py
@@ -10,7 +10,7 @@ from ..types import (
     CrawlResponse, Document, CrawlParamsRequest, CrawlParamsResponse, CrawlParamsData,
     WebhookConfig, CrawlErrorsResponse, ActiveCrawlsResponse, ActiveCrawl, PaginationConfig
 )
-from ..utils import HttpClient, handle_response_error, validate_scrape_options, prepare_scrape_options
+from ..utils import HttpClient, FirecrawlError, handle_response_error, validate_scrape_options, prepare_scrape_options
 from ..utils.normalize import normalize_document_input
 
 
@@ -392,7 +392,7 @@ def wait_for_crawl_completion(
         CrawlJob when job completes
         
     Raises:
-        Exception: If the job fails
+        FirecrawlError: If the job fails or is cancelled
         TimeoutError: If timeout is reached
     """
     start_time = time.monotonic()
@@ -404,9 +404,13 @@ def wait_for_crawl_completion(
             request_timeout=request_timeout,
         )
         
-        # Check if job is complete
-        if crawl_job.status in ["completed", "failed", "cancelled"]:
+        if crawl_job.status == "completed":
             return crawl_job
+
+        if crawl_job.status in ("failed", "cancelled"):
+            raise FirecrawlError(
+                f"Crawl job {job_id} ended with status '{crawl_job.status}'"
+            )
         
         # Check timeout
         if timeout is not None and (time.monotonic() - start_time) > timeout:
@@ -440,7 +444,7 @@ def crawl(
         
     Raises:
         ValueError: If request is invalid
-        Exception: If the crawl fails to start or complete
+        FirecrawlError: If the crawl fails to start or complete
         TimeoutError: If timeout is reached
     """
     # Start the crawl


### PR DESCRIPTION
## Problem

`wait_for_batch_completion()` and `wait_for_crawl_completion()` treated `failed` and `cancelled` terminal states the same as `completed`, returning the job with empty `data` and no error. Sync docstrings promised `FirecrawlError` on failure, but nothing was raised — so callers could not distinguish a failed job from an empty success (fixes #4212).

## Triage / Root cause

In `batch.py` and `crawl.py`, the wait loops returned on any of `completed`, `failed`, or `cancelled`. The async client had the same behavior but documented only `TimeoutError`, so sync and async docs were inconsistent.

## Fix

- Raise `FirecrawlError` when a wait loop sees `failed` or `cancelled`; return normally only for `completed`.
- Apply the same behavior in `AsyncFirecrawl.wait_crawl` and `wait_batch_scrape`.
- Align docstrings on sync `client.py`, `batch.py`, `crawl.py`, and async `client_async.py`.

## Verification

```bash
cd apps/python-sdk
pytest firecrawl/__tests__/unit/v2/methods/test_wait_terminal_failure.py -q
pytest firecrawl/__tests__/unit -q --ignore=firecrawl/__tests__/unit/v2/watcher
```

Results: 6 new regression tests pass; full unit suite 399 passed.

## Notes / Risks

- This matches v1 SDK behavior (v1 raised on failed/stopped crawl status) and restores the documented sync contract. Callers that previously checked `.status` after `batch_scrape()` / `crawl()` without handling exceptions will need to catch `FirecrawlError` instead.
- Error detail still requires `get_batch_scrape_errors()` / `get_crawl_errors()` — no model field added in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788407202&installation_model_id=11126&pr_number=4222&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4222&signature=20184d86d5ccdbfa5dff09ab461f4ff61a411f9a295f03322d9a09cb231fcdec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `FirecrawlError` when `wait_for_batch_completion()` and `wait_for_crawl_completion()` (and async equivalents) see `failed` or `cancelled`, so callers can properly handle failures. Aligns sync/async behavior and docstrings; adds targeted tests.

- **Bug Fixes**
  - Raise `FirecrawlError` on `failed`/`cancelled` in `wait_for_crawl_completion`, `wait_for_batch_completion`, `AsyncFirecrawl.wait_crawl`, and `AsyncFirecrawl.wait_batch_scrape`.
  - Update docstrings in `v2/client.py` and `v2/client_async.py` to reflect the behavior.
  - Add unit tests for failure and success paths in `test_wait_terminal_failure.py`.

- **Migration**
  - Wrap calls to `crawl()`/`batch_scrape()` and `wait_*` helpers in a `try/except` for `FirecrawlError`.
  - Use `get_crawl_errors()` or `get_batch_scrape_errors()` to fetch error details after catching.

<sup>Written for commit 16762854c603dbd65dd935d72217b333d94bf4f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

