### PR TITLE
[WIP] fix(api): crawl pages linked only through section anchors

### DIFF
--- a/apps/api/native/src/crawler.rs
+++ b/apps/api/native/src/crawler.rs
@@ -122,7 +122,6 @@ const ROBOTS_TXT: &str = "ROBOTS_TXT";
 const FILE_TYPE: &str = "FILE_TYPE";
 const SOCIAL_MEDIA: &str = "SOCIAL_MEDIA";
 const EXTERNAL_LINK: &str = "EXTERNAL_LINK";
-const SECTION_LINK: &str = "SECTION_LINK";
 const NON_WEB_PROTOCOL: &str = "NON_WEB_PROTOCOL";
 
 #[inline]
@@ -277,6 +276,7 @@ fn _filter_links(data: FilterLinksCall) -> std::result::Result<FilterLinksResult
   );
 
   let mut result_links = Vec::new();
+  let mut seen_result_links = HashSet::new();
   let mut denial_reasons = HashMap::new();
 
   for link in data.links {
@@ -284,12 +284,20 @@ fn _filter_links(data: FilterLinksCall) -> std::result::Result<FilterLinksResult
       break;
     }
 
-    let url = match base_url.join(&link) {
+    let mut url = match base_url.join(&link) {
       Ok(url) => url,
       Err(_) => {
         denial_reasons.insert(link, URL_PARSE_ERROR.to_string());
         continue;
       }
+    };
+
+    let is_internal = is_internal_link(&url, &base_url);
+    let result_link = if is_internal && !no_sections(url.as_str()) {
+      url.set_fragment(None);
+      url.to_string()
+    } else {
+      link.clone()
     };
 
     let path = url.path();
@@ -310,13 +318,8 @@ fn _filter_links(data: FilterLinksCall) -> std::result::Result<FilterLinksResult
       continue;
     }
 
-    if is_internal_link(&url, &base_url) {
+    if is_internal {
       // INTERNAL LINKS
-      if !no_sections(url_str) {
-        denial_reasons.insert(link, SECTION_LINK.to_string());
-        continue;
-      }
-
       if !data.allow_backward_crawling && !path.starts_with(initial_path) {
         denial_reasons.insert(link, BACKWARD_CRAWLING.to_string());
         continue;
@@ -345,7 +348,9 @@ fn _filter_links(data: FilterLinksCall) -> std::result::Result<FilterLinksResult
         }
       }
 
-      result_links.push(link);
+      if seen_result_links.insert(url_str.to_string()) {
+        result_links.push(result_link);
+      }
     } else {
       // EXTERNAL LINKS
       if is_social_media_or_email(url_str) {
@@ -435,7 +440,7 @@ fn _filter_url(data: FilterUrlCall) -> std::result::Result<FilterUrlResult, Stri
     }
   }
 
-  let url = match Url::parse(&full_url) {
+  let mut url = match Url::parse(&full_url) {
     Ok(url) => url,
     Err(_) => {
       return Ok(FilterUrlResult {
@@ -456,6 +461,12 @@ fn _filter_url(data: FilterUrlCall) -> std::result::Result<FilterUrlResult, Stri
       });
     }
   };
+
+  let is_internal = is_internal_link(&url, &base_url);
+  if is_internal && !no_sections(url.as_str()) {
+    url.set_fragment(None);
+    full_url = url.to_string();
+  }
 
   let path = url.path();
   let url_str = url.as_str();
@@ -480,16 +491,8 @@ fn _filter_url(data: FilterUrlCall) -> std::result::Result<FilterUrlResult, Stri
     data.robots_user_agent.as_deref(),
   );
 
-  if is_internal_link(&url, &base_url) {
+  if is_internal {
     // INTERNAL LINKS
-    if !no_sections(url_str) {
-      return Ok(FilterUrlResult {
-        allowed: false,
-        url: None,
-        denial_reason: Some(SECTION_LINK.to_string()),
-      });
-    }
-
     if !excludes_regex.is_empty() && excludes_regex.iter().any(|r| r.is_match(path)) {
       return Ok(FilterUrlResult {
         allowed: false,
@@ -752,6 +755,122 @@ pub async fn process_sitemap(xml_content: String) -> Result<SitemapProcessingRes
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  fn filter_links_call(links: Vec<String>) -> FilterLinksCall {
+    FilterLinksCall {
+      links,
+      limit: Some(10),
+      max_depth: 10,
+      base_url: "https://example.com".to_string(),
+      initial_url: "https://example.com".to_string(),
+      regex_on_full_url: false,
+      excludes: vec![],
+      includes: vec![],
+      allow_backward_crawling: true,
+      ignore_robots_txt: true,
+      robots_txt: String::new(),
+      robots_user_agent: None,
+      allow_external_content_links: false,
+      allow_subdomains: false,
+    }
+  }
+
+  fn filter_url_call(href: &str, current_url: &str) -> FilterUrlCall {
+    FilterUrlCall {
+      href: href.to_string(),
+      url: current_url.to_string(),
+      base_url: "https://example.com".to_string(),
+      excludes: vec![],
+      ignore_robots_txt: true,
+      robots_txt: String::new(),
+      robots_user_agent: None,
+      allow_external_content_links: false,
+      allow_subdomains: false,
+    }
+  }
+
+  fn discover_links(hrefs: &[&str], current_url: &str) -> Vec<String> {
+    let links = hrefs
+      .iter()
+      .filter_map(|href| {
+        let result = _filter_url(filter_url_call(href, current_url)).unwrap();
+        assert!(result.allowed);
+        result.url
+      })
+      .collect();
+
+    _filter_links(filter_links_call(links)).unwrap().links
+  }
+
+  #[test]
+  fn test_section_only_link_discovers_base_page() {
+    assert_eq!(
+      discover_links(&["/page#section"], "https://example.com/index"),
+      vec!["https://example.com/page"]
+    );
+  }
+
+  #[test]
+  fn test_multiple_section_links_collapse_to_one_base_page() {
+    assert_eq!(
+      discover_links(
+        &["/page#overview", "/page#details", "/page#faq"],
+        "https://example.com/index"
+      ),
+      vec!["https://example.com/page"]
+    );
+  }
+
+  #[test]
+  fn test_plain_and_section_links_collapse_to_one_page() {
+    assert_eq!(
+      discover_links(
+        &["/page", "/page#overview", "/page#details"],
+        "https://example.com/index"
+      ),
+      vec!["https://example.com/page"]
+    );
+  }
+
+  #[test]
+  fn test_hash_routes_remain_distinct_crawlable_urls() {
+    assert_eq!(
+      discover_links(
+        &["/app#/route/1", "/app#/route/2", "/app#nested/route"],
+        "https://example.com/index"
+      ),
+      vec![
+        "https://example.com/app#/route/1",
+        "https://example.com/app#/route/2",
+        "https://example.com/app#nested/route"
+      ]
+    );
+  }
+
+  #[test]
+  fn test_fragment_only_link_normalizes_to_already_visited_page() {
+    let page = "https://example.com/page";
+    let result = _filter_url(filter_url_call("#details", page)).unwrap();
+    assert!(result.allowed);
+    assert_eq!(result.url.as_deref(), Some(page));
+
+    let mut visited = HashSet::from([page.to_string()]);
+    assert!(!visited.insert(result.url.unwrap()));
+  }
+
+  #[test]
+  fn test_section_link_base_still_passes_through_filters() {
+    let original_link = "https://example.com/page#details";
+    let mut data = filter_links_call(vec![original_link.to_string()]);
+    data.excludes = vec!["^/page$".to_string()];
+
+    let result = _filter_links(data).unwrap();
+    assert!(result.links.is_empty());
+    assert_eq!(
+      result.denial_reasons.get(original_link).map(String::as_str),
+      Some(EXCLUDE_PATTERN)
+    );
+  }
 
   #[test]
   fn test_parse_sitemap_xml_urlset() {

--- a/apps/api/src/__tests__/snips/v2/crawl-section-anchors.test.ts
+++ b/apps/api/src/__tests__/snips/v2/crawl-section-anchors.test.ts
@@ -1,0 +1,75 @@
+import {
+  ALLOW_TEST_SUITE_WEBSITE,
+  describeIf,
+  TEST_SUITE_WEBSITE,
+} from "../lib";
+import { crawl, Identity, idmux, scrapeTimeout } from "./lib";
+
+const resultUrl = (page: { metadata: { url?: string; sourceURL?: string } }) =>
+  page.metadata.url ?? page.metadata.sourceURL!;
+
+describeIf(ALLOW_TEST_SUITE_WEBSITE)("Section-anchor crawl discovery", () => {
+  let identity: Identity;
+
+  beforeAll(async () => {
+    identity = await idmux({
+      name: "crawl-section-anchors",
+      concurrency: 10,
+      credits: 100,
+    });
+  }, 10000);
+
+  it(
+    "crawls a page linked only through multiple section anchors once",
+    async () => {
+      const rootPath = "/crawl/section-anchor-only";
+      const detailPath = `${rootPath}/detail`;
+      const result = await crawl(
+        {
+          url: `${TEST_SUITE_WEBSITE}${rootPath}`,
+          sitemap: "skip",
+          limit: 10,
+        },
+        identity,
+      );
+
+      const urls = result.data.map(resultUrl).map(value => new URL(value));
+      const paths = urls.map(url => url.pathname.replace(/\/$/, ""));
+
+      expect(result.completed).toBe(2);
+      expect(paths).toEqual(expect.arrayContaining([rootPath, detailPath]));
+      expect(paths.filter(path => path === detailPath)).toHaveLength(1);
+      expect(urls.every(url => url.hash === "")).toBe(true);
+    },
+    2 * scrapeTimeout,
+  );
+
+  it(
+    "does not re-enqueue an already-crawled page from a later section link",
+    async () => {
+      const rootPath = "/crawl/section-anchor-dedupe";
+      const detailPath = `${rootPath}/detail`;
+      const laterPath = `${rootPath}/later`;
+      const result = await crawl(
+        {
+          url: `${TEST_SUITE_WEBSITE}${rootPath}`,
+          sitemap: "skip",
+          ignoreQueryParameters: true,
+          limit: 10,
+        },
+        identity,
+      );
+
+      const urls = result.data.map(resultUrl).map(value => new URL(value));
+      const paths = urls.map(url => url.pathname.replace(/\/$/, ""));
+
+      expect(result.completed).toBe(3);
+      expect(paths).toEqual(
+        expect.arrayContaining([rootPath, detailPath, laterPath]),
+      );
+      expect(paths.filter(path => path === detailPath)).toHaveLength(1);
+      expect(urls.every(url => url.hash === "")).toBe(true);
+    },
+    3 * scrapeTimeout,
+  );
+});

--- a/apps/api/src/lib/crawl-redis.test.ts
+++ b/apps/api/src/lib/crawl-redis.test.ts
@@ -1,4 +1,61 @@
-import { generateURLPermutations } from "./crawl-redis";
+import {
+  generateURLPermutations,
+  normalizeURL,
+  type StoredCrawl,
+} from "./crawl-redis";
+
+describe("normalizeURL crawl dedupe keys", () => {
+  const storedCrawl = (ignoreQueryParameters: boolean) =>
+    ({ crawlerOptions: { ignoreQueryParameters } }) as StoredCrawl;
+
+  it("deduplicates plain and section-anchor URLs while preserving the query", () => {
+    const sc = storedCrawl(false);
+
+    expect(normalizeURL("https://example.com/page#overview", sc)).toBe(
+      normalizeURL("https://example.com/page#details", sc),
+    );
+    expect(normalizeURL("https://example.com/page#overview", sc)).toBe(
+      normalizeURL("https://example.com/page", sc),
+    );
+    expect(normalizeURL("https://example.com/page?lang=en#details", sc)).toBe(
+      "https://example.com/page?lang=en",
+    );
+  });
+
+  it("also deduplicates query variants when ignoreQueryParameters is enabled", () => {
+    const sc = storedCrawl(true);
+    const plainPage = normalizeURL("https://example.com/page", sc);
+
+    expect(normalizeURL("https://example.com/page?lang=en#overview", sc)).toBe(
+      plainPage,
+    );
+    expect(normalizeURL("https://example.com/page?lang=ja#details", sc)).toBe(
+      plainPage,
+    );
+  });
+
+  it("keeps hash routes distinct after query normalization", () => {
+    const sc = storedCrawl(true);
+
+    expect(normalizeURL("https://example.com/app?lang=en#/route/1", sc)).toBe(
+      "https://example.com/app#/route/1",
+    );
+    expect(normalizeURL("https://example.com/app#nested/route", sc)).toBe(
+      "https://example.com/app#nested/route",
+    );
+    expect(normalizeURL("https://example.com/app#/route/1", sc)).not.toBe(
+      normalizeURL("https://example.com/app#/route/2", sc),
+    );
+  });
+
+  it("uses the already-visited page key for a fragment-only link", () => {
+    const sc = storedCrawl(false);
+    const page = "https://example.com/page";
+    const visited = new Set([normalizeURL(page, sc)]);
+
+    expect(visited.has(normalizeURL(`${page}#details`, sc))).toBe(true);
+  });
+});
 
 describe("generateURLPermutations", () => {
   it("generates permutations correctly", () => {

--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -385,12 +385,10 @@ export function normalizeURL(url: string, sc: StoredCrawl): string {
   if (sc && sc.crawlerOptions && sc.crawlerOptions.ignoreQueryParameters) {
     urlO.search = "";
   }
-  // allow hash-based routes
-  if (
-    !urlO.hash ||
-    urlO.hash.length <= 2 ||
-    (!urlO.hash.startsWith("#/") && !urlO.hash.startsWith("#!/"))
-  ) {
+  // Keep this in sync with the crawler's SPA hash-route exception: fragments
+  // with substantial content and a slash represent routes, not page sections.
+  const hashPart = urlO.hash.slice(1);
+  if (!(hashPart.length > 1 && hashPart.includes("/"))) {
     urlO.hash = "";
   }
   return urlO.href;

--- a/apps/api/src/scraper/WebScraper/__tests__/crawler.test.ts
+++ b/apps/api/src/scraper/WebScraper/__tests__/crawler.test.ts
@@ -3,16 +3,23 @@ import type { Mocked, MockedFunction } from "vitest";
 import { WebCrawler } from "../crawler";
 import axios from "axios";
 import robotsParser from "robots-parser";
+import * as firecrawlRs from "@mendable/firecrawl-rs";
 
 vi.mock("axios");
 vi.mock("robots-parser");
+vi.mock("@mendable/firecrawl-rs", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("@mendable/firecrawl-rs")>();
+  return {
+    ...actual,
+    filterLinks: vi.fn(actual.filterLinks),
+  };
+});
 
 describe("WebCrawler", () => {
   let crawler: WebCrawler;
   const mockAxios = axios as Mocked<typeof axios>;
-  const mockRobotsParser = robotsParser as MockedFunction<
-    typeof robotsParser
-  >;
+  const mockRobotsParser = robotsParser as MockedFunction<typeof robotsParser>;
 
   let maxCrawledDepth: number;
 
@@ -180,5 +187,92 @@ describe("WebCrawler", () => {
       true,
     );
     expect(sourceValidationResult.links).toEqual([initialUrl]);
+  });
+
+  describe("section anchors in the TypeScript fallback", () => {
+    beforeEach(() => {
+      crawler = new WebCrawler({
+        jobId: "TEST",
+        initialUrl: "https://example.com",
+        includes: [],
+        excludes: [],
+        maxCrawledDepth: 10,
+      });
+    });
+
+    const filterWithFallback = async (links: string[]) => {
+      vi.mocked(firecrawlRs.filterLinks).mockRejectedValueOnce(
+        new Error("force TypeScript fallback"),
+      );
+      return crawler["filterLinks"](links, 10, 10);
+    };
+
+    it("discovers a page linked only through a section anchor", async () => {
+      const result = await filterWithFallback([
+        "https://example.com/page#section",
+      ]);
+
+      expect(result.links).toEqual(["https://example.com/page"]);
+      expect(result.denialReasons).toEqual(new Map());
+    });
+
+    it("collapses multiple section anchors to one base page", async () => {
+      const result = await filterWithFallback([
+        "https://example.com/page#overview",
+        "https://example.com/page#details",
+        "https://example.com/page#faq",
+      ]);
+
+      expect(result.links).toEqual(["https://example.com/page"]);
+    });
+
+    it("collapses plain and section links to one page", async () => {
+      const result = await filterWithFallback([
+        "https://example.com/page",
+        "https://example.com/page#overview",
+        "https://example.com/page#details",
+      ]);
+
+      expect(result.links).toEqual(["https://example.com/page"]);
+    });
+
+    it("keeps hash routes as distinct crawlable URLs", async () => {
+      const result = await filterWithFallback([
+        "https://example.com/app#/route/1",
+        "https://example.com/app#/route/2",
+        "https://example.com/app#nested/route",
+      ]);
+
+      expect(result.links).toEqual([
+        "https://example.com/app#/route/1",
+        "https://example.com/app#/route/2",
+        "https://example.com/app#nested/route",
+      ]);
+    });
+
+    it("does not re-enqueue an already-crawled page through a fragment-only link", async () => {
+      const page = "https://example.com/page";
+      crawler.setBaseUrl(page);
+
+      const result = await filterWithFallback([page, "#details"]);
+
+      expect(result.links).toEqual([page]);
+    });
+
+    it("applies the normal filter pipeline to the stripped base URL", async () => {
+      crawler = new WebCrawler({
+        jobId: "TEST",
+        initialUrl: "https://example.com",
+        includes: [],
+        excludes: ["^/page$"],
+        maxCrawledDepth: 10,
+      });
+      const originalLink = "https://example.com/page#details";
+
+      const result = await filterWithFallback([originalLink]);
+
+      expect(result.links).toEqual([]);
+      expect(result.denialReasons.has(originalLink)).toBe(true);
+    });
   });
 });

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -37,7 +37,6 @@ enum DenialReason {
   BACKWARD_CRAWLING = "This URL is outside the initial URL's path hierarchy, and backward crawling is disabled. By default, Firecrawl only crawls URLs that are 'below' or 'within' the starting URL path. To crawl this URL, either set allowBackwardCrawling: true or set crawlEntireDomain: true to crawl the entire domain.",
   SOCIAL_MEDIA = "This URL points to a social media platform or is an email link. Firecrawl automatically skips social media links and mailto: links during crawling.",
   EXTERNAL_LINK = "This URL points to a different domain than the one being crawled, and external links are disabled. By default, Firecrawl only crawls URLs on the same domain as the starting URL. To crawl external links, set allowExternalLinks: true in your crawl request.",
-  SECTION_LINK = "This URL contains a section anchor (#) and points to a specific section of a page rather than a separate page. Firecrawl treats these as duplicates of the base URL and skips them to avoid crawling the same content multiple times.",
   NON_WEB_PROTOCOL = "This URL uses a non-web protocol (such as mailto:, tel:, ftp:, ssh:, file:, or telnet:) that Firecrawl cannot scrape. Firecrawl only supports HTTP and HTTPS protocols.",
 }
 
@@ -287,8 +286,13 @@ export class WebCrawler {
       });
     }
 
+    const seenLinks = new Set<string>();
     const filteredLinks = sitemapLinks
-      .filter(link => {
+      .map(originalLink => ({
+        originalLink,
+        link: this.normalizeSectionLink(originalLink),
+      }))
+      .filter(({ originalLink, link }) => {
         let url: URL;
         try {
           url = new URL(link.trim(), this.baseUrl);
@@ -301,6 +305,9 @@ export class WebCrawler {
           return false;
         }
         const path = url.pathname;
+        const isInternal =
+          url.hostname.replace(/^www\./, "") ===
+          new URL(this.baseUrl).hostname.replace(/^www\./, "");
 
         const urlStr = url.toString();
         const nonWebProtocols = [
@@ -316,7 +323,7 @@ export class WebCrawler {
           if (config.FIRECRAWL_DEBUG_FILTER_LINKS) {
             this.logger.debug(`${link} NON-WEB PROTOCOL FAIL`);
           }
-          denialReasons.set(link, DenialReason.NON_WEB_PROTOCOL);
+          denialReasons.set(originalLink, DenialReason.NON_WEB_PROTOCOL);
           return false;
         }
 
@@ -328,7 +335,7 @@ export class WebCrawler {
             this.logger.debug(`${link} DEPTH FAIL`);
           }
           denialReasons.set(
-            link,
+            originalLink,
             `This URL exceeds the maximum crawl depth you configured. The URL's depth is ${depth}, but maxDepth is set to ${maxDepth}. To crawl this URL, increase the maxDepth value in your crawl request.`,
           );
           return false;
@@ -346,7 +353,7 @@ export class WebCrawler {
               this.logger.debug(`${link} EXCLUDE FAIL`);
             }
             denialReasons.set(
-              link,
+              originalLink,
               `This URL's path ("${excincPath}") matches the exclude pattern "${matchingPattern}" you provided in the excludePaths parameter. URLs matching excludePaths are intentionally skipped during crawling. If this URL should be crawled, adjust your excludePaths patterns.`,
             );
             return false;
@@ -364,7 +371,7 @@ export class WebCrawler {
               this.logger.debug(`${link} INCLUDE FAIL`);
             }
             denialReasons.set(
-              link,
+              originalLink,
               `This URL's path ("${excincPath}") does not match any of the regex patterns you provided in the includePaths parameter: [${this.includes.map(p => `"${p}"`).join(", ")}]. When includePaths is specified, only URLs matching at least one pattern are crawled. If this URL should be crawled, add a matching pattern to includePaths or remove the includePaths restriction.`,
             );
             return false;
@@ -375,7 +382,7 @@ export class WebCrawler {
         const normalizedInitialUrl = new URL(this.initialUrl);
         let normalizedLink;
         try {
-          normalizedLink = new URL(link);
+          normalizedLink = new URL(link, this.baseUrl);
         } catch (_) {
           if (config.FIRECRAWL_DEBUG_FILTER_LINKS) {
             this.logger.debug(`${link} URL PARSE FAIL`);
@@ -404,7 +411,7 @@ export class WebCrawler {
               );
             }
             denialReasons.set(
-              link,
+              originalLink,
               `This URL's path ("${normalizedLink.pathname}") is outside the initial URL's path hierarchy ("${normalizedInitialUrl.pathname}"), and backward crawling is disabled. By default, Firecrawl only crawls URLs that are 'below' or 'within' the starting URL path. To crawl this URL, either set allowBackwardCrawling: true or set crawlEntireDomain: true to crawl the entire domain.`,
             );
             return false;
@@ -425,7 +432,7 @@ export class WebCrawler {
             this.logger.debug(`${link} ROBOTS FAIL`);
           }
           denialReasons.set(
-            link,
+            originalLink,
             `This URL is blocked by the website's robots.txt file, which instructs crawlers not to access this page. Firecrawl respects robots.txt by default. To crawl this URL anyway, set ignoreRobotsTxt: true in your crawl request (note: this may violate the website's crawling policies).`,
           );
           return false;
@@ -437,7 +444,7 @@ export class WebCrawler {
           }
           const extension = link.split("?")[0].split(".").pop()?.toLowerCase();
           denialReasons.set(
-            link,
+            originalLink,
             `This URL points to a file with extension ".${extension}" that Firecrawl does not crawl. Firecrawl automatically skips non-document file extensions like .png, .jpg, .mp4, .zip, .css, .js, etc. to focus on web pages with textual content.`,
           );
           return false;
@@ -446,8 +453,16 @@ export class WebCrawler {
         if (config.FIRECRAWL_DEBUG_FILTER_LINKS) {
           this.logger.debug(`${link} OK`);
         }
+
+        if (isInternal) {
+          if (seenLinks.has(urlStr)) {
+            return false;
+          }
+          seenLinks.add(urlStr);
+        }
         return true;
       })
+      .map(({ link }) => link)
       .slice(0, limit);
 
     return { links: filteredLinks, denialReasons };
@@ -753,6 +768,32 @@ export class WebCrawler {
     }
 
     return await this.extractLinksFromHTMLCheerio(html, url);
+  }
+
+  private normalizeSectionLink(link: string): string {
+    try {
+      const url = new URL(link.trim(), this.baseUrl);
+      const baseUrl = new URL(this.baseUrl);
+      const hostname = url.hostname.replace(/^www\./, "");
+      const baseHostname = baseUrl.hostname.replace(/^www\./, "");
+
+      if (hostname === baseHostname && !this.noSections(url.toString())) {
+        url.hash = "";
+        return url.toString();
+      }
+    } catch (_) {}
+
+    return link;
+  }
+
+  private noSections(link: string): boolean {
+    if (!link.includes("#")) {
+      return true;
+    }
+
+    // Preserve hash fragments that represent SPA routes rather than sections.
+    const hashPart = link.split("#")[1];
+    return Boolean(hashPart && hashPart.length > 1 && hashPart.includes("/"));
   }
 
   private isRobotsAllowed(

--- a/apps/test-site/src/pages/crawl/section-anchor-dedupe/detail.astro
+++ b/apps/test-site/src/pages/crawl/section-anchor-dedupe/detail.astro
@@ -1,0 +1,16 @@
+---
+
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Already-crawled detail</title>
+  </head>
+  <body>
+    <main>
+      <h1>Already-crawled detail</h1>
+      <a href="/crawl/section-anchor-dedupe/later">Continue</a>
+    </main>
+  </body>
+</html>

--- a/apps/test-site/src/pages/crawl/section-anchor-dedupe/index.astro
+++ b/apps/test-site/src/pages/crawl/section-anchor-dedupe/index.astro
@@ -1,0 +1,16 @@
+---
+
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Section-anchor Redis dedupe fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Section-anchor Redis dedupe fixture</h1>
+      <a href="/crawl/section-anchor-dedupe/detail?view=plain">Detail</a>
+    </main>
+  </body>
+</html>

--- a/apps/test-site/src/pages/crawl/section-anchor-dedupe/later.astro
+++ b/apps/test-site/src/pages/crawl/section-anchor-dedupe/later.astro
@@ -1,0 +1,18 @@
+---
+
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Late section-anchor discovery</title>
+  </head>
+  <body>
+    <main>
+      <h1>Late section-anchor discovery</h1>
+      <a href="/crawl/section-anchor-dedupe/detail?view=anchor#details"
+        >Detail section</a
+      >
+    </main>
+  </body>
+</html>

--- a/apps/test-site/src/pages/crawl/section-anchor-only/detail.astro
+++ b/apps/test-site/src/pages/crawl/section-anchor-only/detail.astro
@@ -1,0 +1,17 @@
+---
+
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Section-anchor-only detail</title>
+  </head>
+  <body>
+    <main>
+      <h1>Section-anchor-only detail</h1>
+      <section id="overview">Overview content</section>
+      <section id="specifications">Specifications content</section>
+    </main>
+  </body>
+</html>

--- a/apps/test-site/src/pages/crawl/section-anchor-only/index.astro
+++ b/apps/test-site/src/pages/crawl/section-anchor-only/index.astro
@@ -1,0 +1,19 @@
+---
+
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Section-anchor-only crawl fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Section-anchor-only crawl fixture</h1>
+      <a href="/crawl/section-anchor-only/detail#overview">Overview</a>
+      <a href="/crawl/section-anchor-only/detail#specifications"
+        >Specifications</a
+      >
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Fix crawler discovery for pages linked only through section-anchor URLs.

Internal URLs such as `/detail#overview` are now normalized to `/detail` before being processed by the existing crawl filters. Multiple section links, and combinations of plain and section links, collapse to one base URL.

## Problem

The crawler previously rejected internal URLs containing a `#` fragment with `SECTION_LINK`. Although the denial reason described these URLs as duplicates of their base URL, the base URL was never actually enqueued.

That made pages permanently undiscoverable when they were:

- linked only as `/page#section`
- absent from the sitemap
- never linked elsewhere without a fragment

## Implementation

For ordinary section anchors, both the Rust implementation and TypeScript fallback now:

1. Resolve the discovered URL.
2. Strip its fragment.
3. Run the resulting base URL through the normal depth, include/exclude, backward-crawling, robots, and file-type filters.
4. Deduplicate the normalized result before returning it for enqueueing.

The existing enqueue normalization remains the final dedupe layer. This ensures:

- `page#a` and `page#b` crawl `page` once
- `page` plus `page#a` crawl `page` once
- fragment-only links to the current page do not re-enqueue it
- query variants also collapse when `ignoreQueryParameters` is enabled

Successful fragment stripping is treated as normalization rather than denial, so it does not emit `SECTION_LINK`. If the stripped base URL fails another filter, the real denial reason is reported against the original fragment URL.

## Hash-route compatibility

The hash-route exception introduced in #1814 is preserved: fragments with substantial content containing `/`, including `#/route/1` and `#nested/ route`, remain distinct crawlable URLs.

The downstream crawl dedupe normalization now uses the same predicate, preventing valid hash routes from being collapsed later in the enqueue path.

## Tests

Added Rust and TypeScript coverage for:

- pages linked only through section anchors
- multiple anchors to one page
- mixed plain and anchor links
- slash-containing hash routes
- fragment-only links to already-visited pages
- normal filter rejection after fragment stripping
- dedupe behavior with `ignoreQueryParameters`

## Related work

- #1814
- #1676

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788444405&installation_model_id=11126&pr_number=4224&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4224&signature=c9c38556f0d9d0f085e677fb7271e2d24b83950833c6b90e530b63c343cf459c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crawler discovery for pages linked only via section anchors by stripping fragments from internal URLs before filtering, so base pages get enqueued. Hash-route fragments remain crawlable and are not collapsed.

- **Bug Fixes**
  - Normalize internal links by removing `#fragment` before depth/include/robots/file checks in Rust and the TypeScript fallback (no more `SECTION_LINK` denials).
  - Deduplicate normalized results: multiple anchors and plain+anchor links collapse to one page; fragment-only links don’t re-enqueue a visited page.
  - Preserve SPA hash routes with a slash in the fragment (e.g., `#/route/1`, `#nested/route`) across filtering and enqueue dedupe.
  - Align enqueue dedupe in `normalizeURL` with the same rule and honor `ignoreQueryParameters` when collapsing query variants.
  - Add tests: Rust unit coverage; TypeScript fallback tests; `crawl-redis` normalization tests; and test-site + v2 snips ensuring section-anchor-only pages are crawled once and late anchor links don’t re-enqueue.

<sup>Written for commit 7b1ddaba9a80cb9bfaed534b44516460c575e2b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

