### PR TITLE
fix(api): prevent premature crawl watcher completion

### DIFF
--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -83,8 +83,8 @@ async function crawlStatusWS(
   const loop = async () => {
     if (finished) return;
 
-    const jobIDs = await getCrawlJobs(req.params.jobId);
     const kickoffFinished = await isCrawlKickoffFinished(req.params.jobId);
+    const jobIDs = await getCrawlJobs(req.params.jobId);
 
     if (
       shouldCloseCrawlStatusWS(

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -4,7 +4,6 @@ import {
   CrawlStatusParams,
   CrawlStatusResponse,
   Document,
-  ErrorResponse,
   RequestWithAuth,
 } from "./types";
 import { WebSocket } from "ws";
@@ -16,12 +15,18 @@ import {
   getCrawlExpiry,
   getCrawlJobs,
   getDoneJobsOrdered,
+  isCrawlKickoffFinished,
 } from "../../lib/crawl-redis";
 import { getJobs, PseudoJob } from "./crawl-status";
 import * as Sentry from "@sentry/node";
 import { getConcurrencyLimitedJobs } from "../../lib/concurrency-limit";
 import { scrapeQueue, NuQJobStatus } from "../../services/worker/nuq-router";
 import { getErrorContactMessage } from "../../lib/deployment";
+import {
+  CrawlWebSocketStatus,
+  deriveCrawlStatus,
+  shouldCloseCrawlStatusWS,
+} from "../../lib/crawl-status-ws";
 
 type ErrorMessage = {
   type: "error";
@@ -79,8 +84,15 @@ async function crawlStatusWS(
     if (finished) return;
 
     const jobIDs = await getCrawlJobs(req.params.jobId);
+    const kickoffFinished = await isCrawlKickoffFinished(req.params.jobId);
 
-    if (jobIDs.length === doneJobIDs.length) {
+    if (
+      shouldCloseCrawlStatusWS(
+        jobIDs.length,
+        doneJobIDs.length,
+        kickoffFinished,
+      )
+    ) {
       return close(ws, 1000, { type: "done" });
     }
 
@@ -143,14 +155,12 @@ async function crawlStatusWS(
   // Check if the crawl failed during kickoff (e.g. queue full)
   const crawlError = await getCrawlError(req.params.jobId);
 
-  let status: Exclude<CrawlStatusResponse, ErrorResponse>["status"] =
-    sc.cancelled
-      ? "cancelled"
-      : validJobStatuses.every(x => x[1] === "completed")
-        ? "completed"
-        : "scraping";
+  let status: CrawlWebSocketStatus = deriveCrawlStatus(
+    sc.cancelled === true,
+    validJobStatuses,
+  );
 
-  if (crawlError && jobIDs.length === 0 && status === "completed") {
+  if (crawlError && jobIDs.length === 0 && status !== "cancelled") {
     status = "failed";
   }
 

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -80,19 +80,66 @@ async function crawlStatusWS(
   let doneJobIDs: string[] = [];
   let finished = false;
 
+  const closeWithTerminalStatus = async (
+    status: "cancelled" | "failed",
+    jobCount: number,
+    error?: string,
+  ) => {
+    const expiresAt = (await getCrawlExpiry(req.params.jobId)).toISOString();
+    await send(ws, {
+      type: "catchup",
+      data:
+        status === "failed"
+          ? {
+              success: false,
+              error: error ?? "Crawl failed during kickoff",
+              status: "failed",
+              total: 0,
+              completed: 0,
+              creditsUsed: 0,
+              expiresAt,
+              data: [],
+            }
+          : {
+              success: true,
+              status: "cancelled",
+              total: jobCount,
+              completed: doneJobIDs.length,
+              creditsUsed: jobCount,
+              expiresAt,
+              data: [],
+            },
+    });
+
+    finished = true;
+    return close(ws, 1000, { type: "done" });
+  };
+
   const loop = async () => {
     if (finished) return;
 
     const kickoffFinished = await isCrawlKickoffFinished(req.params.jobId);
     const jobIDs = await getCrawlJobs(req.params.jobId);
+    const currentCrawl = await getCrawl(req.params.jobId);
+    const crawlError = await getCrawlError(req.params.jobId);
 
     if (
-      shouldCloseCrawlStatusWS(
-        jobIDs.length,
-        doneJobIDs.length,
+      shouldCloseCrawlStatusWS({
+        jobCount: jobIDs.length,
+        completedJobCount: doneJobIDs.length,
         kickoffFinished,
-      )
+        cancelled: currentCrawl?.cancelled === true,
+        hasCrawlError: crawlError !== null,
+      })
     ) {
+      if (currentCrawl?.cancelled === true) {
+        return closeWithTerminalStatus("cancelled", jobIDs.length);
+      }
+
+      if (crawlError !== null) {
+        return closeWithTerminalStatus("failed", jobIDs.length, crawlError);
+      }
+
       finished = true;
       return close(ws, 1000, { type: "done" });
     }

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -93,6 +93,7 @@ async function crawlStatusWS(
         kickoffFinished,
       )
     ) {
+      finished = true;
       return close(ws, 1000, { type: "done" });
     }
 
@@ -127,11 +128,13 @@ async function crawlStatusWS(
 
   setTimeout(loop, 1000);
 
-  let [_doneJobIDs, jobIDs, throttledJobsSet] = await Promise.all([
-    getDoneJobsOrdered(req.params.jobId),
-    getCrawlJobs(req.params.jobId),
-    getConcurrencyLimitedJobs(req.auth.team_id),
-  ]);
+  let [_doneJobIDs, jobIDs, throttledJobsSet, kickoffFinished] =
+    await Promise.all([
+      getDoneJobsOrdered(req.params.jobId),
+      getCrawlJobs(req.params.jobId),
+      getConcurrencyLimitedJobs(req.auth.team_id),
+      isCrawlKickoffFinished(req.params.jobId),
+    ]);
 
   doneJobIDs = _doneJobIDs;
   const jobs = new Map((await scrapeQueue.getJobs(jobIDs)).map(x => [x.id, x]));
@@ -160,6 +163,7 @@ async function crawlStatusWS(
 
   let status: CrawlWebSocketStatus = deriveCrawlStatus(
     sc.cancelled === true,
+    kickoffFinished,
     jobIDs.length,
     failedJobCount,
     validJobStatuses,

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -138,6 +138,7 @@ async function crawlStatusWS(
 
   const validJobStatuses: [string, NuQJobStatus][] = [];
   const validJobIDs: string[] = [];
+  let failedJobCount = 0;
 
   for (const id of jobIDs) {
     if (throttledJobsSet.has(id)) {
@@ -148,6 +149,8 @@ async function crawlStatusWS(
       if (job && job.status !== "failed") {
         validJobStatuses.push([id, job.status]);
         validJobIDs.push(id);
+      } else if (job?.status === "failed") {
+        failedJobCount++;
       }
     }
   }
@@ -157,6 +160,8 @@ async function crawlStatusWS(
 
   let status: CrawlWebSocketStatus = deriveCrawlStatus(
     sc.cancelled === true,
+    jobIDs.length,
+    failedJobCount,
     validJobStatuses,
   );
 

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -161,13 +161,13 @@ async function crawlStatusWS(
   // Check if the crawl failed during kickoff (e.g. queue full)
   const crawlError = await getCrawlError(req.params.jobId);
 
-  let status: CrawlWebSocketStatus = deriveCrawlStatus(
-    sc.cancelled === true,
+  let status: CrawlWebSocketStatus = deriveCrawlStatus({
+    cancelled: sc.cancelled === true,
     kickoffFinished,
-    jobIDs.length,
+    jobCount: jobIDs.length,
     failedJobCount,
     validJobStatuses,
-  );
+  });
 
   if (crawlError && jobIDs.length === 0 && status !== "cancelled") {
     status = "failed";

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -3,11 +3,51 @@ import { deriveCrawlStatus, shouldCloseCrawlStatusWS } from "./crawl-status-ws";
 
 describe("shouldCloseCrawlStatusWS", () => {
   it("does not close while kickoff is still initializing an empty crawl", () => {
-    expect(shouldCloseCrawlStatusWS(0, 0, false)).toBe(false);
+    expect(
+      shouldCloseCrawlStatusWS({
+        jobCount: 0,
+        completedJobCount: 0,
+        kickoffFinished: false,
+        cancelled: false,
+        hasCrawlError: false,
+      }),
+    ).toBe(false);
   });
 
   it("closes an empty crawl after kickoff has finished", () => {
-    expect(shouldCloseCrawlStatusWS(0, 0, true)).toBe(true);
+    expect(
+      shouldCloseCrawlStatusWS({
+        jobCount: 0,
+        completedJobCount: 0,
+        kickoffFinished: true,
+        cancelled: false,
+        hasCrawlError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("closes a cancelled crawl even if kickoff never finishes", () => {
+    expect(
+      shouldCloseCrawlStatusWS({
+        jobCount: 2,
+        completedJobCount: 0,
+        kickoffFinished: false,
+        cancelled: true,
+        hasCrawlError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("closes a crawl with a kickoff error", () => {
+    expect(
+      shouldCloseCrawlStatusWS({
+        jobCount: 0,
+        completedJobCount: 0,
+        kickoffFinished: false,
+        cancelled: false,
+        hasCrawlError: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -13,12 +13,16 @@ describe("shouldCloseCrawlStatusWS", () => {
 
 describe("deriveCrawlStatus", () => {
   it("does not mark an empty job list as completed", () => {
-    expect(deriveCrawlStatus(false, [])).toBe("scraping");
+    expect(deriveCrawlStatus(false, 0, 0, [])).toBe("scraping");
+  });
+
+  it("marks an all-failed crawl as completed", () => {
+    expect(deriveCrawlStatus(false, 2, 2, [])).toBe("completed");
   });
 
   it("marks a non-empty all-completed job list as completed", () => {
     expect(
-      deriveCrawlStatus(false, [
+      deriveCrawlStatus(false, 2, 2, [
         ["job-1", "completed"],
         ["job-2", "completed"],
       ]),
@@ -26,12 +30,12 @@ describe("deriveCrawlStatus", () => {
   });
 
   it("keeps cancelled crawls cancelled", () => {
-    expect(deriveCrawlStatus(true, [])).toBe("cancelled");
+    expect(deriveCrawlStatus(true, 0, 0, [])).toBe("cancelled");
   });
 
   it("keeps active jobs scraping", () => {
     expect(
-      deriveCrawlStatus(false, [
+      deriveCrawlStatus(false, 2, 1, [
         ["job-1", "completed"],
         ["job-2", "active"],
       ]),

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -31,7 +31,7 @@ describe("deriveCrawlStatus", () => {
 
   it("marks a non-empty all-completed job list as completed", () => {
     expect(
-      deriveCrawlStatus(false, true, 2, 2, [
+      deriveCrawlStatus(false, true, 2, 0, [
         ["job-1", "completed"],
         ["job-2", "completed"],
       ]),

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -49,6 +49,18 @@ describe("shouldCloseCrawlStatusWS", () => {
       }),
     ).toBe(true);
   });
+
+  it("keeps visible jobs open when a kickoff error is present", () => {
+    expect(
+      shouldCloseCrawlStatusWS({
+        jobCount: 2,
+        completedJobCount: 0,
+        kickoffFinished: false,
+        cancelled: false,
+        hasCrawlError: true,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("deriveCrawlStatus", () => {

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -13,16 +13,25 @@ describe("shouldCloseCrawlStatusWS", () => {
 
 describe("deriveCrawlStatus", () => {
   it("does not mark an empty job list as completed", () => {
-    expect(deriveCrawlStatus(false, 0, 0, [])).toBe("scraping");
+    expect(deriveCrawlStatus(false, false, 0, 0, [])).toBe("scraping");
+  });
+
+  it("keeps completed visible jobs scraping while kickoff is unfinished", () => {
+    expect(
+      deriveCrawlStatus(false, false, 2, 0, [
+        ["job-1", "completed"],
+        ["job-2", "completed"],
+      ]),
+    ).toBe("scraping");
   });
 
   it("marks an all-failed crawl as completed", () => {
-    expect(deriveCrawlStatus(false, 2, 2, [])).toBe("completed");
+    expect(deriveCrawlStatus(false, true, 2, 2, [])).toBe("completed");
   });
 
   it("marks a non-empty all-completed job list as completed", () => {
     expect(
-      deriveCrawlStatus(false, 2, 2, [
+      deriveCrawlStatus(false, true, 2, 2, [
         ["job-1", "completed"],
         ["job-2", "completed"],
       ]),
@@ -30,12 +39,12 @@ describe("deriveCrawlStatus", () => {
   });
 
   it("keeps cancelled crawls cancelled", () => {
-    expect(deriveCrawlStatus(true, 0, 0, [])).toBe("cancelled");
+    expect(deriveCrawlStatus(true, false, 0, 0, [])).toBe("cancelled");
   });
 
   it("keeps active jobs scraping", () => {
     expect(
-      deriveCrawlStatus(false, 2, 1, [
+      deriveCrawlStatus(false, true, 2, 1, [
         ["job-1", "completed"],
         ["job-2", "active"],
       ]),

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -13,41 +13,83 @@ describe("shouldCloseCrawlStatusWS", () => {
 
 describe("deriveCrawlStatus", () => {
   it("does not mark an empty job list as completed", () => {
-    expect(deriveCrawlStatus(false, false, 0, 0, [])).toBe("scraping");
+    expect(
+      deriveCrawlStatus({
+        cancelled: false,
+        kickoffFinished: false,
+        jobCount: 0,
+        failedJobCount: 0,
+        validJobStatuses: [],
+      }),
+    ).toBe("scraping");
   });
 
   it("keeps completed visible jobs scraping while kickoff is unfinished", () => {
     expect(
-      deriveCrawlStatus(false, false, 2, 0, [
-        ["job-1", "completed"],
-        ["job-2", "completed"],
-      ]),
+      deriveCrawlStatus({
+        cancelled: false,
+        kickoffFinished: false,
+        jobCount: 2,
+        failedJobCount: 0,
+        validJobStatuses: [
+          ["job-1", "completed"],
+          ["job-2", "completed"],
+        ],
+      }),
     ).toBe("scraping");
   });
 
   it("marks an all-failed crawl as completed", () => {
-    expect(deriveCrawlStatus(false, true, 2, 2, [])).toBe("completed");
+    expect(
+      deriveCrawlStatus({
+        cancelled: false,
+        kickoffFinished: true,
+        jobCount: 2,
+        failedJobCount: 2,
+        validJobStatuses: [],
+      }),
+    ).toBe("completed");
   });
 
   it("marks a non-empty all-completed job list as completed", () => {
     expect(
-      deriveCrawlStatus(false, true, 2, 0, [
-        ["job-1", "completed"],
-        ["job-2", "completed"],
-      ]),
+      deriveCrawlStatus({
+        cancelled: false,
+        kickoffFinished: true,
+        jobCount: 2,
+        failedJobCount: 0,
+        validJobStatuses: [
+          ["job-1", "completed"],
+          ["job-2", "completed"],
+        ],
+      }),
     ).toBe("completed");
   });
 
   it("keeps cancelled crawls cancelled", () => {
-    expect(deriveCrawlStatus(true, false, 0, 0, [])).toBe("cancelled");
+    expect(
+      deriveCrawlStatus({
+        cancelled: true,
+        kickoffFinished: false,
+        jobCount: 0,
+        failedJobCount: 0,
+        validJobStatuses: [],
+      }),
+    ).toBe("cancelled");
   });
 
   it("keeps active jobs scraping", () => {
     expect(
-      deriveCrawlStatus(false, true, 2, 1, [
-        ["job-1", "completed"],
-        ["job-2", "active"],
-      ]),
+      deriveCrawlStatus({
+        cancelled: false,
+        kickoffFinished: true,
+        jobCount: 2,
+        failedJobCount: 1,
+        validJobStatuses: [
+          ["job-1", "completed"],
+          ["job-2", "active"],
+        ],
+      }),
     ).toBe("scraping");
   });
 });

--- a/apps/api/src/lib/crawl-status-ws.test.ts
+++ b/apps/api/src/lib/crawl-status-ws.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { deriveCrawlStatus, shouldCloseCrawlStatusWS } from "./crawl-status-ws";
+
+describe("shouldCloseCrawlStatusWS", () => {
+  it("does not close while kickoff is still initializing an empty crawl", () => {
+    expect(shouldCloseCrawlStatusWS(0, 0, false)).toBe(false);
+  });
+
+  it("closes an empty crawl after kickoff has finished", () => {
+    expect(shouldCloseCrawlStatusWS(0, 0, true)).toBe(true);
+  });
+});
+
+describe("deriveCrawlStatus", () => {
+  it("does not mark an empty job list as completed", () => {
+    expect(deriveCrawlStatus(false, [])).toBe("scraping");
+  });
+
+  it("marks a non-empty all-completed job list as completed", () => {
+    expect(
+      deriveCrawlStatus(false, [
+        ["job-1", "completed"],
+        ["job-2", "completed"],
+      ]),
+    ).toBe("completed");
+  });
+
+  it("keeps cancelled crawls cancelled", () => {
+    expect(deriveCrawlStatus(true, [])).toBe("cancelled");
+  });
+
+  it("keeps active jobs scraping", () => {
+    expect(
+      deriveCrawlStatus(false, [
+        ["job-1", "completed"],
+        ["job-2", "active"],
+      ]),
+    ).toBe("scraping");
+  });
+});

--- a/apps/api/src/lib/crawl-status-ws.ts
+++ b/apps/api/src/lib/crawl-status-ws.ts
@@ -1,0 +1,33 @@
+import type { NuQJobStatus } from "../services/worker/nuq-router";
+
+export type CrawlWebSocketStatus =
+  | "cancelled"
+  | "completed"
+  | "failed"
+  | "scraping";
+
+export function shouldCloseCrawlStatusWS(
+  jobCount: number,
+  completedJobCount: number,
+  kickoffFinished: boolean,
+): boolean {
+  return kickoffFinished && jobCount === completedJobCount;
+}
+
+export function deriveCrawlStatus(
+  cancelled: boolean,
+  validJobStatuses: ReadonlyArray<readonly [string, NuQJobStatus]>,
+): CrawlWebSocketStatus {
+  if (cancelled) return "cancelled";
+
+  // An empty list means the crawl is still being initialized. Require at least
+  // one visible job before reporting a crawl as completed.
+  if (
+    validJobStatuses.length > 0 &&
+    validJobStatuses.every(([, status]) => status === "completed")
+  ) {
+    return "completed";
+  }
+
+  return "scraping";
+}

--- a/apps/api/src/lib/crawl-status-ws.ts
+++ b/apps/api/src/lib/crawl-status-ws.ts
@@ -16,12 +16,16 @@ export function shouldCloseCrawlStatusWS(
 
 export function deriveCrawlStatus(
   cancelled: boolean,
+  jobCount: number,
+  failedJobCount: number,
   validJobStatuses: ReadonlyArray<readonly [string, NuQJobStatus]>,
 ): CrawlWebSocketStatus {
   if (cancelled) return "cancelled";
 
-  // An empty list means the crawl is still being initialized. Require at least
-  // one visible job before reporting a crawl as completed.
+  if (jobCount > 0 && jobCount === failedJobCount) {
+    return "completed";
+  }
+
   if (
     validJobStatuses.length > 0 &&
     validJobStatuses.every(([, status]) => status === "completed")

--- a/apps/api/src/lib/crawl-status-ws.ts
+++ b/apps/api/src/lib/crawl-status-ws.ts
@@ -14,13 +14,21 @@ export function shouldCloseCrawlStatusWS(
   return kickoffFinished && jobCount === completedJobCount;
 }
 
-export function deriveCrawlStatus(
-  cancelled: boolean,
-  kickoffFinished: boolean,
-  jobCount: number,
-  failedJobCount: number,
-  validJobStatuses: ReadonlyArray<readonly [string, NuQJobStatus]>,
-): CrawlWebSocketStatus {
+type DeriveCrawlStatusOptions = {
+  cancelled: boolean;
+  kickoffFinished: boolean;
+  jobCount: number;
+  failedJobCount: number;
+  validJobStatuses: ReadonlyArray<readonly [string, NuQJobStatus]>;
+};
+
+export function deriveCrawlStatus({
+  cancelled,
+  kickoffFinished,
+  jobCount,
+  failedJobCount,
+  validJobStatuses,
+}: DeriveCrawlStatusOptions): CrawlWebSocketStatus {
   if (cancelled) return "cancelled";
 
   if (!kickoffFinished) return "scraping";

--- a/apps/api/src/lib/crawl-status-ws.ts
+++ b/apps/api/src/lib/crawl-status-ws.ts
@@ -23,7 +23,7 @@ export function shouldCloseCrawlStatusWS({
 }: ShouldCloseCrawlStatusWSOptions): boolean {
   return (
     cancelled ||
-    hasCrawlError ||
+    (hasCrawlError && jobCount === 0) ||
     (kickoffFinished && jobCount === completedJobCount)
   );
 }

--- a/apps/api/src/lib/crawl-status-ws.ts
+++ b/apps/api/src/lib/crawl-status-ws.ts
@@ -16,11 +16,14 @@ export function shouldCloseCrawlStatusWS(
 
 export function deriveCrawlStatus(
   cancelled: boolean,
+  kickoffFinished: boolean,
   jobCount: number,
   failedJobCount: number,
   validJobStatuses: ReadonlyArray<readonly [string, NuQJobStatus]>,
 ): CrawlWebSocketStatus {
   if (cancelled) return "cancelled";
+
+  if (!kickoffFinished) return "scraping";
 
   if (jobCount > 0 && jobCount === failedJobCount) {
     return "completed";

--- a/apps/api/src/lib/crawl-status-ws.ts
+++ b/apps/api/src/lib/crawl-status-ws.ts
@@ -6,12 +6,26 @@ export type CrawlWebSocketStatus =
   | "failed"
   | "scraping";
 
-export function shouldCloseCrawlStatusWS(
-  jobCount: number,
-  completedJobCount: number,
-  kickoffFinished: boolean,
-): boolean {
-  return kickoffFinished && jobCount === completedJobCount;
+type ShouldCloseCrawlStatusWSOptions = {
+  jobCount: number;
+  completedJobCount: number;
+  kickoffFinished: boolean;
+  cancelled: boolean;
+  hasCrawlError: boolean;
+};
+
+export function shouldCloseCrawlStatusWS({
+  jobCount,
+  completedJobCount,
+  kickoffFinished,
+  cancelled,
+  hasCrawlError,
+}: ShouldCloseCrawlStatusWSOptions): boolean {
+  return (
+    cancelled ||
+    hasCrawlError ||
+    (kickoffFinished && jobCount === completedJobCount)
+  );
 }
 
 type DeriveCrawlStatusOptions = {

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1372,13 +1372,16 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
     return { success: true };
   } catch (error) {
     logger.error("An error occurred!", { error });
-    await setCrawlError(
-      job.data.crawl_id,
-      error instanceof Error
-        ? error.message
-        : "An unexpected error occurred during crawl setup",
-    );
-    await finishCrawlKickoff(job.data.crawl_id);
+    try {
+      await setCrawlError(
+        job.data.crawl_id,
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred during crawl setup",
+      );
+    } finally {
+      await finishCrawlKickoff(job.data.crawl_id);
+    }
     return { success: false, error };
   }
 }

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1372,13 +1372,13 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
     return { success: true };
   } catch (error) {
     logger.error("An error occurred!", { error });
-    await finishCrawlKickoff(job.data.crawl_id);
     await setCrawlError(
       job.data.crawl_id,
       error instanceof Error
         ? error.message
         : "An unexpected error occurred during crawl setup",
     );
+    await finishCrawlKickoff(job.data.crawl_id);
     return { success: false, error };
   }
 }


### PR DESCRIPTION
## Summary

- Prevent the v2 crawl status WebSocket from reporting a crawl as completed while kickoff is still initializing and no jobs are visible yet.
- Prevent the polling loop from closing the WebSocket when both job counts are zero before kickoff has finished.
- Preserve kickoff error handling and cancellation precedence.
- Add focused tests for status derivation and WebSocket close decisions.

## Reproduction

I reproduced the issue locally on the self-hosted stack by creating a crawl and connecting the watcher immediately. Before this fix, the initial WebSocket response could report `completed` with no documents and close before the crawl finished. REST status later showed the crawl completed with all documents available.

## Verification

- Focused Vitest test: 6 tests passed.
- Knip: exits successfully; it reports only the existing `knip.config.ts` configuration hint for `src/lib/threat-protection/types.ts`.
- Docker API image rebuilt successfully from the final rebased branch.
- API liveness returned `{"status":"ok"}`.
- Manual local verification: On the self hosted stack, I created a v2 crawl and connected the WebSocket immediately after receiving the crawl ID. I inspected the initial WebSocket status, tracked the document messages, and compared the result with the final REST crawl status. Before the fix, the initial WebSocket response could report completion with no documents while REST later showed completed data. After the fix, the initial state remained in progress and the documents arrived before the crawl reached its final state.

## Scope and limitations

- This change is intentionally limited to the v2 crawl status WebSocket.
- There is no existing WebSocket snip harness in the repository, so the permanent regression coverage is focused helper coverage plus live local verification.
- The regular full API TypeScript build remains limited by the pre-existing missing `@mendable/firecrawl-rs` workspace dependency; the Docker API build succeeds.

Fixes #4223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472581&installation_model_id=11126&pr_number=4229&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4229&signature=76c6370234d89f747b38a17474d65b5ffe8b35b3f14334227449eab053ab0f2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the v2 crawl status WebSocket from closing during kickoff and adds terminal handling that sends a final payload on cancel or kickoff error. Keeps the socket open if a kickoff error occurs but jobs are visible, and ensures kickoff always finishes even if setting the error fails.

- **Bug Fixes**
  - Updated close logic via `isCrawlKickoffFinished` and `shouldCloseCrawlStatusWS`: don’t close during kickoff; close when kickoff is finished and counts match; close on cancel; close on kickoff error only when there are no jobs; otherwise stay open.
  - Centralized status rules in `deriveCrawlStatus`: never complete empty lists; keep cancelled crawls; mark all‑failed as completed; keep scraping until kickoff ends.
  - On cancel/error, send a final `catchup` payload then close; in the worker, ensure `finishCrawlKickoff` runs even if `setCrawlError` fails; added unit tests for status and close conditions.

<sup>Written for commit b4c5426febd449567e764de0b383998d1be55d70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



