### PR TITLE
fix(api): surface JSON-format extraction failures instead of silently dropping the key

### DIFF
--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -381,10 +381,11 @@ export async function extractData({
     // Surface the failure to the caller: swallowing it here made a failed
     // extraction indistinguishable from a successful-but-empty one — the
     // scrape returned 200 with the json field silently absent (and billed).
+    // `warning` is provably undefined here (only assigned on the success
+    // path of the try above), so assign directly — the caller merges any
+    // pre-existing document warnings.
     const reason = error instanceof Error ? error.message : String(error);
-    warning =
-      `JSON extraction failed: ${reason.slice(0, 300)}` +
-      (warning ? " " + warning : "");
+    warning = `JSON extraction failed: ${reason.slice(0, 300)}`;
   }
 
   let extractedData = extract?.extractedData;

--- a/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/extractSmartScrape.ts
@@ -378,7 +378,13 @@ export async function extractData({
     logger.error("failed during extractSmartScrape.ts:generateCompletions", {
       error,
     });
-    // console.log("failed during extractSmartScrape.ts:generateCompletions", error);
+    // Surface the failure to the caller: swallowing it here made a failed
+    // extraction indistinguishable from a successful-but-empty one — the
+    // scrape returned 200 with the json field silently absent (and billed).
+    const reason = error instanceof Error ? error.message : String(error);
+    warning =
+      `JSON extraction failed: ${reason.slice(0, 300)}` +
+      (warning ? " " + warning : "");
   }
 
   let extractedData = extract?.extractedData;

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.test.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.test.ts
@@ -1,4 +1,18 @@
-import { removeDefaultProperty } from "./llmExtract";
+import { vi } from "vitest";
+
+vi.mock("../lib/extractSmartScrape", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("../lib/extractSmartScrape")>();
+  return {
+    ...actual,
+    extractData: vi.fn(async () => ({
+      extractedDataArray: [],
+      warning: undefined,
+      costLimitExceededTokenUsage: null,
+    })),
+  };
+});
+import { performLLMExtract, removeDefaultProperty } from "./llmExtract";
 import { trimToTokenLimit } from "./llmExtract";
 import { performSummary } from "./llmExtract";
 import { performCleanContent } from "./llmExtract";
@@ -336,5 +350,47 @@ describe("performCleanContent", () => {
 
     expect(result.markdown).toBe("Some content");
     expect(result.warning).toBeUndefined();
+  });
+});
+
+describe("performLLMExtract empty-result handling", () => {
+  it("keeps the json key (null) and adds a warning when extraction produces nothing", async () => {
+    const mockMeta = {
+      options: {
+        formats: [
+          {
+            type: "json",
+            schema: {
+              type: "object",
+              properties: { rows: { type: "array" } },
+            },
+          },
+        ],
+      },
+      internalOptions: { zeroDataRetention: false, teamId: "test-team" },
+      logger: {
+        child: vi.fn(() => ({
+          info: vi.fn(),
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        })),
+        debug: vi.fn(),
+        info: vi.fn(),
+      },
+      costTracking: {},
+      id: "test-id",
+      url: "https://example.com/doc.pdf",
+    } as any;
+
+    const document = { markdown: "# some content", metadata: {} } as any;
+
+    const result = await performLLMExtract(mockMeta, document);
+
+    // the requested format must never vanish silently
+    expect(result.json).toBeNull();
+    expect(result.warning).toContain(
+      "JSON extraction did not produce a result",
+    );
   });
 });

--- a/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts
@@ -1029,6 +1029,16 @@ export async function performLLMExtract(
     const extractedData =
       extractedDataArray[extractedDataArray.length - 1] ?? undefined;
 
+    // A requested format must never vanish silently: when extraction
+    // produced nothing, keep the key (null) and say why in `warning` —
+    // otherwise the response is a 200 with the json field absent and no
+    // signal to the caller that anything failed.
+    if (extractedData === undefined && !warning) {
+      document.warning =
+        "JSON extraction did not produce a result." +
+        (document.warning ? " " + document.warning : "");
+    }
+
     // // Prepare the schema, potentially wrapping it
     // const { schemaToUse, schemaWasWrapped } = prepareSmartScrapeSchema(
     //   originalOptions.schema,
@@ -1114,12 +1124,12 @@ export async function performLLMExtract(
     });
 
     if (meta.internalOptions.v1OriginalFormat === "extract") {
-      document.extract = extractedData;
+      document.extract = extractedData ?? null;
     } else if (meta.internalOptions.v1OriginalFormat === "json") {
-      document.json = extractedData;
+      document.json = extractedData ?? null;
     } else {
       // v2 API or no v1OriginalFormat - use json field
-      document.json = extractedData;
+      document.json = extractedData ?? null;
     }
     // document.warning = warning;
   }


### PR DESCRIPTION
## Problem

A scrape with `formats: ["json"]` can return **200 with the `json` field silently absent** — no warning, no error — while the format is still billed.

Chain: when `generateCompletions` throws inside `extractData` (`extractSmartScrape.ts`), the catch logs and continues → `extract` stays `undefined` → `extractedDataArray` comes back as `[undefined]` → `performLLMExtract` assigns `document.json = undefined` → JSON serialization drops the key from the response. The only trace is an internal log line.

**Repro** (deterministic, twice, including once on a parse-cache hit): `POST /v2/scrape` with `parsers: ["pdf"]`, `formats: [{type: "json", schema: <array-of-rows schema>}]` on a large public PDF — `https://www.federalreserve.gov/releases/z1/current/z1.pdf` (195 pages). Result: 200, `creditsUsed: 199`, no `json` key, no `warning`. The same request on a 3-page PDF (`g19/current/g19.pdf`) works fine, so the extraction call fails deterministically on large inputs and the failure is then swallowed.

## Fix

- **`extractData`**: a swallowed extraction failure now surfaces as `warning: "JSON extraction failed: <reason>"` in the returned envelope (cost-limit errors still rethrow, unchanged).
- **`performLLMExtract`**: a requested format never vanishes — empty results keep the key (`json: null`) and attach `"JSON extraction did not produce a result."` when no more specific warning explains the emptiness.
- Regression test: mocked empty `extractedDataArray` → `json: null` + warning (19/19 in the file pass; `tsc` clean on touched files).

## Follow-ups (deliberately out of scope, flagging for owners)

1. **Billing on delivery** — the json premium is charged on request, not on result; with this PR the failure is at least visible, but charging for an undelivered format is worth fixing at the billing calc.
2. **The large-input root cause** — likely trim-budget arithmetic (input trimmed to the model window without subtracting the completion budget). The repro above should make it a quick check against provider logs.
3. `performLLMExtract` keeps only the last element of `extractedDataArray` (the in-code comment already flags it: "here it only get's the last page!!!").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788482449&installation_model_id=11126&pr_number=4231&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4231&signature=40eef4521d114396e8b34cb1cbacd701a018c38e1ad21a23c0158605497a8205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents silent loss of the `json` format by surfacing extraction failures and keeping the `json` key (as null) when no result is produced. Clients now see a clear warning instead of a 200 with the `json` field missing.

- **Bug Fixes**
  - `extractData`: on extraction errors, return a warning with the failure reason; assign it directly (no suffix concat). Cost-limit errors still rethrow.
  - `performLLMExtract`: never drop the requested format; set `json`/`extract` to `null` when empty and add a default warning if none exists.
  - Added a regression test for empty extraction results → `json: null` + warning.

<sup>Written for commit d7448d89b93e10838163950ff5ce4e36fe0781e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

