### PR TITLE
chore(api): update anydoc

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-anydoc = "0.1.2"
+anydoc = "0.1.6"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"

--- a/apps/api/native/src/document.rs
+++ b/apps/api/native/src/document.rs
@@ -6,10 +6,7 @@ use napi_derive::napi;
 /// from the file content; `extension_hint` (with or without a leading dot) is
 /// only consulted for signature-less formats like CSV.
 #[napi]
-pub fn convert_document_to_markdown(
-  data: &[u8],
-  extension_hint: Option<String>,
-) -> Result<String> {
+pub fn convert_document_to_markdown(data: &[u8], extension_hint: Option<String>) -> Result<String> {
   let format = anydoc::Format::from_bytes(data).or_else(|| {
     extension_hint
       .as_deref()


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788546335&installation_model_id=11126&pr_number=4236&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4236&signature=afd20e8c4b546182c48a38c47d8e38dd8b7ce2d1c1b50eea920b48bdb2b99635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the document parser in the native API crate to pick up fixes and improvements. No behavior changes expected for markdown conversion.

- **Dependencies**
  - Bumped `anydoc` from 0.1.2 to 0.1.6.

<sup>Written for commit ac3dcffb7c0cdb18dde484e3787659e037243043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

