### PR TITLE
fix(api): don't starve sitemap index children of the sitemap fetch budget

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -19,6 +19,7 @@ import { filterLinks, filterUrl } from "@mendable/firecrawl-rs";
 import { extractBaseDomain } from "../../lib/url-utils";
 
 export const SITEMAP_LIMIT = 25;
+const SITEMAP_FETCH_CONCURRENCY = 3;
 const SITEMAP_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
 
 interface FilterResult {
@@ -612,19 +613,41 @@ export class WebCrawler {
         hasRobotsTxt: this.robotsTxt.length > 0,
       });
 
-      let count = (await Promise.race([
-        Promise.all([
-          this.tryFetchSitemapLinks(
-            this.initialUrl,
+      // Limited concurrency so children of early sitemap indexes claim
+      // SITEMAP_LIMIT slots before later top-level sitemaps do.
+      const sitemapSources = [this.initialUrl, ...robotsSitemaps];
+      let sourceIndex = 0;
+      let linkCount = 0;
+
+      const worker = async () => {
+        while (
+          sourceIndex < sitemapSources.length &&
+          this.sitemapsHit.size < SITEMAP_LIMIT &&
+          !abort?.aborted
+        ) {
+          const source = sitemapSources[sourceIndex++];
+          linkCount += await this.tryFetchSitemapLinks(
+            source,
             _urlsHandler,
             abort,
             mock,
             maxAge,
+          );
+        }
+      };
+
+      let count = (await Promise.race([
+        Promise.all(
+          Array.from(
+            {
+              length: Math.min(
+                SITEMAP_FETCH_CONCURRENCY,
+                sitemapSources.length,
+              ),
+            },
+            () => worker(),
           ),
-          ...robotsSitemaps.map(x =>
-            this.tryFetchSitemapLinks(x, _urlsHandler, abort, mock, maxAge),
-          ),
-        ]).then(results => results.reduce((a, x) => a + x, 0)),
+        ).then(() => linkCount),
         timeoutPromise,
       ]).finally(() => {
         clearTimeout(timeoutHandle);

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -599,13 +599,18 @@ export class WebCrawler {
     };
 
     let timeoutHandle: NodeJS.Timeout;
+    const timeoutController = new AbortController();
     const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error("Sitemap fetch timeout")),
-        timeout,
-      );
+      timeoutHandle = setTimeout(() => {
+        timeoutController.abort();
+        reject(new Error("Sitemap fetch timeout"));
+      }, timeout);
     });
+    const fetchAbort = abort
+      ? AbortSignal.any([abort, timeoutController.signal])
+      : timeoutController.signal;
 
+    let count = 0;
     try {
       const robotsSitemaps = this.robots.getSitemaps();
       this.logger.debug("Attempting to fetch sitemap links", {
@@ -626,7 +631,7 @@ export class WebCrawler {
           let i = 0;
           i < sitemapSources.length &&
           this.sitemapsHit.size < SITEMAP_LIMIT &&
-          !abort?.aborted;
+          !fetchAbort.aborted;
           i += SITEMAP_FETCH_CONCURRENCY
         ) {
           const results = await Promise.all(
@@ -636,7 +641,7 @@ export class WebCrawler {
                 this.tryFetchSitemapLinks(
                   source,
                   _urlsHandler,
-                  abort,
+                  fetchAbort,
                   mock,
                   maxAge,
                 ),
@@ -647,12 +652,28 @@ export class WebCrawler {
         return linkCount;
       };
 
-      let count = (await Promise.race([fetchSources(), timeoutPromise]).finally(
+      count = (await Promise.race([fetchSources(), timeoutPromise]).finally(
         () => {
           clearTimeout(timeoutHandle);
         },
       )) as number;
+    } catch (error) {
+      if (error.message === "Sitemap fetch timeout") {
+        this.logger.warn("Sitemap fetch timed out", {
+          method: "tryGetSitemap",
+          timeout,
+          deliveredCount,
+        });
+      } else {
+        this.logger.error("Error fetching sitemap", {
+          method: "tryGetSitemap",
+          error,
+        });
+      }
+      count = deliveredCount;
+    }
 
+    try {
       if (count > 0) {
         if (
           await redisEvictConnection.sadd(
@@ -670,23 +691,14 @@ export class WebCrawler {
         3600,
         "NX",
       );
-
-      return count;
     } catch (error) {
-      if (error.message === "Sitemap fetch timeout") {
-        this.logger.warn("Sitemap fetch timed out", {
-          method: "tryGetSitemap",
-          timeout,
-          deliveredCount,
-        });
-      } else {
-        this.logger.error("Error fetching sitemap", {
-          method: "tryGetSitemap",
-          error,
-        });
-      }
-      return deliveredCount;
+      this.logger.error("Error dispatching initial URL after sitemap fetch", {
+        method: "tryGetSitemap",
+        error,
+      });
     }
+
+    return count;
   }
 
   public async filterURL(href: string, url: string): Promise<FilterResult> {

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -543,6 +543,7 @@ export class WebCrawler {
       method: "tryGetSitemap",
     });
     let leftOfLimit = this.limit;
+    let deliveredCount = 0;
 
     const normalizeUrl = (url: string) => {
       url = url.replace(/^https?:\/\//, "").replace(/^www\./, "");
@@ -555,6 +556,7 @@ export class WebCrawler {
     const _urlsHandler = async (urls: string[]) => {
       this.logger.debug("urlsHandler invoked");
       if (fromMap && onlySitemap) {
+        deliveredCount += urls.length;
         return await urlsHandler(urls);
       } else {
         let filteredLinksResult = await this.filterLinks(
@@ -590,6 +592,7 @@ export class WebCrawler {
         );
 
         if (uniqueURLs.length > 0) {
+          deliveredCount += uniqueURLs.length;
           return await urlsHandler(uniqueURLs);
         }
       }
@@ -613,45 +616,42 @@ export class WebCrawler {
         hasRobotsTxt: this.robotsTxt.length > 0,
       });
 
-      // Limited concurrency so children of early sitemap indexes claim
+      // Fetched in batches so children of early sitemap indexes claim
       // SITEMAP_LIMIT slots before later top-level sitemaps do.
       const sitemapSources = [this.initialUrl, ...robotsSitemaps];
-      let sourceIndex = 0;
-      let linkCount = 0;
 
-      const worker = async () => {
-        while (
-          sourceIndex < sitemapSources.length &&
+      const fetchSources = async () => {
+        let linkCount = 0;
+        for (
+          let i = 0;
+          i < sitemapSources.length &&
           this.sitemapsHit.size < SITEMAP_LIMIT &&
-          !abort?.aborted
+          !abort?.aborted;
+          i += SITEMAP_FETCH_CONCURRENCY
         ) {
-          const source = sitemapSources[sourceIndex++];
-          linkCount += await this.tryFetchSitemapLinks(
-            source,
-            _urlsHandler,
-            abort,
-            mock,
-            maxAge,
+          const results = await Promise.all(
+            sitemapSources
+              .slice(i, i + SITEMAP_FETCH_CONCURRENCY)
+              .map(source =>
+                this.tryFetchSitemapLinks(
+                  source,
+                  _urlsHandler,
+                  abort,
+                  mock,
+                  maxAge,
+                ),
+              ),
           );
+          linkCount += results.reduce((a, x) => a + x, 0);
         }
+        return linkCount;
       };
 
-      let count = (await Promise.race([
-        Promise.all(
-          Array.from(
-            {
-              length: Math.min(
-                SITEMAP_FETCH_CONCURRENCY,
-                sitemapSources.length,
-              ),
-            },
-            () => worker(),
-          ),
-        ).then(() => linkCount),
-        timeoutPromise,
-      ]).finally(() => {
-        clearTimeout(timeoutHandle);
-      })) as number;
+      let count = (await Promise.race([fetchSources(), timeoutPromise]).finally(
+        () => {
+          clearTimeout(timeoutHandle);
+        },
+      )) as number;
 
       if (count > 0) {
         if (
@@ -677,14 +677,15 @@ export class WebCrawler {
         this.logger.warn("Sitemap fetch timed out", {
           method: "tryGetSitemap",
           timeout,
+          deliveredCount,
         });
-        return 0;
+      } else {
+        this.logger.error("Error fetching sitemap", {
+          method: "tryGetSitemap",
+          error,
+        });
       }
-      this.logger.error("Error fetching sitemap", {
-        method: "tryGetSitemap",
-        error,
-      });
-      return 0;
+      return deliveredCount;
     }
   }
 

--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -658,7 +658,7 @@ export class WebCrawler {
         },
       )) as number;
     } catch (error) {
-      if (error.message === "Sitemap fetch timeout") {
+      if (error instanceof Error && error.message === "Sitemap fetch timeout") {
         this.logger.warn("Sitemap fetch timed out", {
           method: "tryGetSitemap",
           timeout,

--- a/apps/api/src/scraper/WebScraper/sitemap.ts
+++ b/apps/api/src/scraper/WebScraper/sitemap.ts
@@ -68,6 +68,7 @@ export async function getLinksFromSitemap(
       try {
         const { buffer } = await fetchFileToBuffer(sitemapUrl, false, {
           headers,
+          signal: abort,
         });
         const decompressed = await gunzipAsync(buffer);
         content = decompressed.toString("utf-8");


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788555281&installation_model_id=11126&pr_number=4237&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4237&signature=09754a9263c99fa659edd1f3d99d2d9dd1b48b0b8b260ad6ecf186cd6555a684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sitemap index children from being starved by the fetch budget by batching top-level sitemap fetches with limited concurrency and processing sources in order. Early indexes can claim `SITEMAP_LIMIT` slots, fetches (including gzip downloads) abort on timeout, and partial results are kept.

- **Bug Fixes**
  - Added `SITEMAP_FETCH_CONCURRENCY = 3`, batched `[initialUrl, ...robotsSitemaps]` fetches, used `AbortSignal.any` with a timeout controller, and passed `signal` to gzip sitemap downloads.
  - Tracked delivered links, returned partial counts on timeout with improved logging, guarded non-error rejections, and always attempt to dispatch the initial URL after sitemap fetch.

<sup>Written for commit 869e6391721a86bd6bcf51e27cb37f1780b07bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

