### PR TITLE
fix wrapped file size limit errors

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
@@ -237,7 +237,9 @@ export async function fireEngineCheckStatus(
       typeof status.error === "string" &&
       status.error.includes("File exceeds size limit")
     ) {
-      throw new UnsupportedFileError(status.error);
+      throw new UnsupportedFileError(
+        status.error.slice(status.error.indexOf("File exceeds size limit")),
+      );
     } else if (
       typeof status.error === "string" &&
       status.error.includes("failed to finish without timing out")

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -273,7 +273,9 @@ export async function fireEngineScrape<
       typeof status.error === "string" &&
       status.error.includes("File exceeds size limit")
     ) {
-      throw new UnsupportedFileError(status.error);
+      throw new UnsupportedFileError(
+        status.error.slice(status.error.indexOf("File exceeds size limit")),
+      );
     } else if (
       typeof status.error === "string" &&
       status.error.includes("failed to finish without timing out")


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788614467&installation_model_id=11126&pr_number=4248&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4248&signature=f6aacd0085eb3ed87e950a3a7c93b6bb3f2b078f2f2567c3d38eb03060decd73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handling of wrapped "File exceeds size limit" errors by trimming the message and throwing `UnsupportedFileError` with the clean substring. Ensures consistent error reporting in fire engine status checks and scrape flows so clients can reliably detect size limit failures.

<sup>Written for commit 70abe66f325a6f4d484e1ddf72bedfd393f15164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

