### PR TITLE
fix(api): restore the five labs routes dropped by the rate limit change

### DIFF
--- a/apps/api/src/__tests__/routes/labs.routes.test.ts
+++ b/apps/api/src/__tests__/routes/labs.routes.test.ts
@@ -1,0 +1,114 @@
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../config", () => ({
+  config: {
+    LABS_SEARCH_URL: "https://labs.test",
+    LABS_SEARCH_SECRET: "test-secret",
+  },
+}));
+
+vi.mock("../../lib/logger", () => {
+  const logger = {
+    child: () => logger,
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  };
+  return { logger };
+});
+
+vi.mock("../../routes/shared", () => ({
+  authMiddleware: () => (_req: any, _res: any, next: any) => next(),
+  wrap: (fn: any) => fn,
+}));
+
+import { labsRouter } from "../../routes/labs";
+
+/**
+ * Every path the Labs Search service serves, because this proxy forwards one route at a
+ * time and a path missing here is a 404 no matter what the service does. The list was
+ * pruned by accident once — a rate-limit change rewrote every route in the file and lost
+ * five of them, taking provider packs off the dashboard until it was noticed by hand.
+ * Adding a route upstream means adding it here too, and this list is the reminder.
+ */
+const LABS_ROUTES = [
+  "POST /search",
+  "POST /search/data/sites",
+  "POST /search/data/documents",
+  "POST /search/data/pages",
+  "GET /search/data",
+  "PATCH /search/data/:sourceId",
+  "DELETE /search/data/:sourceId",
+  "POST /search/data/:sourceId/refresh",
+  "GET /search/providers",
+  "GET /search/packs",
+  "PATCH /search/packs/:packId",
+  "POST /search/configs",
+  "GET /search/configs",
+  "PATCH /search/configs/:id",
+  "DELETE /search/configs/:id",
+];
+
+// Express populates `methods` on every route but does not declare it on IRoute.
+type RouteWithMethods = { path: unknown; methods: Record<string, boolean> };
+
+function registeredRoutes(): string[] {
+  return labsRouter.stack.flatMap(layer => {
+    const route = layer.route as RouteWithMethods | undefined;
+    // The catch-all matches by regex and has no literal path; only named routes count.
+    if (route === undefined || typeof route.path !== "string") return [];
+    const path = route.path;
+    return Object.keys(route.methods)
+      .filter(method => method !== "_all")
+      .map(method => `${method.toUpperCase()} ${path}`);
+  });
+}
+
+function appWithLabs() {
+  const app = express();
+  app.use("/labs", labsRouter);
+  return app;
+}
+
+describe("labs router", () => {
+  it("proxies every route the Labs Search service serves", () => {
+    expect(registeredRoutes().sort()).toEqual([...LABS_ROUTES].sort());
+  });
+
+  it("keeps the provider pack routes the dashboard reads", () => {
+    // Called out separately from the list above so a deletion names what it broke.
+    expect(registeredRoutes()).toContain("GET /search/packs");
+    expect(registeredRoutes()).toContain("PATCH /search/packs/:packId");
+  });
+
+  it("answers an unproxied labs path with JSON naming the gap", async () => {
+    const response = await request(appWithLabs()).get(
+      "/labs/search/not-a-route",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.type).toBe("application/json");
+    expect(response.body.code).toBe("LABS_ROUTE_NOT_PROXIED");
+    expect(response.body.error).toContain("/labs/search/not-a-route");
+    expect(response.body.error).toContain("does not forward it yet");
+  });
+
+  it("names the method so a wrong-verb route is not read as a missing record", async () => {
+    // GET /search/configs is proxied; PUT is not. The reply has to say which.
+    const response = await request(appWithLabs()).put("/labs/search/configs");
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe("LABS_ROUTE_NOT_PROXIED");
+    expect(response.body.error).toContain("PUT /labs/search/configs");
+  });
+
+  it("lets proxied routes through rather than swallowing them in the catch-all", async () => {
+    const response = await request(appWithLabs()).get("/labs/search/packs");
+
+    // The upstream fetch is unmocked and fails, but reaching the proxy at all proves the
+    // catch-all sits behind the real routes instead of shadowing them.
+    expect(response.body.code).not.toBe("LABS_ROUTE_NOT_PROXIED");
+  });
+});

--- a/apps/api/src/__tests__/routes/labs.routes.test.ts
+++ b/apps/api/src/__tests__/routes/labs.routes.test.ts
@@ -26,13 +26,6 @@ vi.mock("../../routes/shared", () => ({
 
 import { labsRouter } from "../../routes/labs";
 
-/**
- * Every path the Labs Search service serves, because this proxy forwards one route at a
- * time and a path missing here is a 404 no matter what the service does. The list was
- * pruned by accident once — a rate-limit change rewrote every route in the file and lost
- * five of them, taking provider packs off the dashboard until it was noticed by hand.
- * Adding a route upstream means adding it here too, and this list is the reminder.
- */
 const LABS_ROUTES = [
   "POST /search",
   "POST /search/data/sites",
@@ -51,18 +44,13 @@ const LABS_ROUTES = [
   "DELETE /search/configs/:id",
 ];
 
-// Express populates `methods` on every route but does not declare it on IRoute.
-type RouteWithMethods = { path: unknown; methods: Record<string, boolean> };
-
 function registeredRoutes(): string[] {
   return labsRouter.stack.flatMap(layer => {
-    const route = layer.route as RouteWithMethods | undefined;
-    // The catch-all matches by regex and has no literal path; only named routes count.
+    const route = layer.route;
     if (route === undefined || typeof route.path !== "string") return [];
     const path = route.path;
-    return Object.keys(route.methods)
-      .filter(method => method !== "_all")
-      .map(method => `${method.toUpperCase()} ${path}`);
+    const methods = new Set(route.stack.map(entry => entry.method));
+    return [...methods].map(method => `${method.toUpperCase()} ${path}`);
   });
 }
 
@@ -78,7 +66,6 @@ describe("labs router", () => {
   });
 
   it("keeps the provider pack routes the dashboard reads", () => {
-    // Called out separately from the list above so a deletion names what it broke.
     expect(registeredRoutes()).toContain("GET /search/packs");
     expect(registeredRoutes()).toContain("PATCH /search/packs/:packId");
   });
@@ -96,7 +83,6 @@ describe("labs router", () => {
   });
 
   it("names the method so a wrong-verb route is not read as a missing record", async () => {
-    // GET /search/configs is proxied; PUT is not. The reply has to say which.
     const response = await request(appWithLabs()).put("/labs/search/configs");
 
     expect(response.status).toBe(404);
@@ -107,8 +93,6 @@ describe("labs router", () => {
   it("lets proxied routes through rather than swallowing them in the catch-all", async () => {
     const response = await request(appWithLabs()).get("/labs/search/packs");
 
-    // The upstream fetch is unmocked and fails, but reaching the proxy at all proves the
-    // catch-all sits behind the real routes instead of shadowing them.
     expect(response.body.code).not.toBe("LABS_ROUTE_NOT_PROXIED");
   });
 });

--- a/apps/api/src/routes/labs.ts
+++ b/apps/api/src/routes/labs.ts
@@ -139,6 +139,11 @@ export const labsRouter = express.Router();
 // No credit check or billing here on purpose: the service behind this proxy
 // makes its own calls to the public API with the caller's own key, so usage is
 // billed on those existing paths instead.
+//
+// This list mirrors the upstream service one route at a time; there is no
+// catch-all proxy. An endpoint added upstream stays a 404 here until it is also
+// listed below, so keep the two in sync when the service grows. LABS_ROUTES in
+// labs.routes.test.ts locks the list so a route cannot be dropped unnoticed.
 labsRouter.post(
   "/search",
   authMiddleware(RateLimiterMode.Labs),
@@ -157,8 +162,20 @@ labsRouter.post(
   wrap(labsProxyController),
 );
 
+labsRouter.post(
+  "/search/data/pages",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(labsProxyController),
+);
+
 labsRouter.get(
   "/search/data",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(labsProxyController),
+);
+
+labsRouter.patch(
+  "/search/data/:sourceId",
   authMiddleware(RateLimiterMode.Labs),
   wrap(labsProxyController),
 );
@@ -169,8 +186,26 @@ labsRouter.delete(
   wrap(labsProxyController),
 );
 
+labsRouter.post(
+  "/search/data/:sourceId/refresh",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(labsProxyController),
+);
+
 labsRouter.get(
   "/search/providers",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(labsProxyController),
+);
+
+labsRouter.get(
+  "/search/packs",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(labsProxyController),
+);
+
+labsRouter.patch(
+  "/search/packs/:packId",
   authMiddleware(RateLimiterMode.Labs),
   wrap(labsProxyController),
 );
@@ -198,3 +233,24 @@ labsRouter.delete(
   authMiddleware(RateLimiterMode.Labs),
   wrap(labsProxyController),
 );
+
+// A path missing from the list above falls to Express, which answers with an HTML
+// "Cannot GET" page. Callers parse these responses as JSON, so that page decays into an
+// empty body and a bare 404 — indistinguishable from the upstream service reporting that
+// a pack or a config does not exist. The two want opposite responses: one is a deploy gap
+// to report, the other is a record to stop asking for. Name the gap so the difference
+// survives the trip back to the browser.
+labsRouter.all(/(.*)/, (req: Request, res: Response) => {
+  rootLogger.warn("Labs path is not proxied by this API", {
+    module: "api/labs",
+    method: req.method,
+    path: req.originalUrl,
+  });
+  return res.status(404).json({
+    success: false,
+    code: "LABS_ROUTE_NOT_PROXIED",
+    error:
+      `${req.method} ${req.baseUrl}${req.path} is not routed by this API. The Labs Search ` +
+      `service may serve it, but this proxy does not forward it yet.`,
+  });
+});

--- a/apps/api/src/routes/labs.ts
+++ b/apps/api/src/routes/labs.ts
@@ -58,8 +58,6 @@ function upstreamHeaders(req: RequestWithAuth<any, any, any>) {
   if (apiKey) headers["x-labs-search-key"] = apiKey;
 
   if (isMultipart(req)) {
-    // The body is piped through unparsed, so the multipart boundary and length
-    // have to travel with it.
     for (const h of ["content-type", "content-length"]) {
       const value = req.headers[h];
       if (typeof value === "string") headers[h] = value;
@@ -136,14 +134,6 @@ async function labsProxyController(req: Request, res: Response) {
 
 export const labsRouter = express.Router();
 
-// No credit check or billing here on purpose: the service behind this proxy
-// makes its own calls to the public API with the caller's own key, so usage is
-// billed on those existing paths instead.
-//
-// This list mirrors the upstream service one route at a time; there is no
-// catch-all proxy. An endpoint added upstream stays a 404 here until it is also
-// listed below, so keep the two in sync when the service grows. LABS_ROUTES in
-// labs.routes.test.ts locks the list so a route cannot be dropped unnoticed.
 labsRouter.post(
   "/search",
   authMiddleware(RateLimiterMode.Labs),
@@ -234,12 +224,6 @@ labsRouter.delete(
   wrap(labsProxyController),
 );
 
-// A path missing from the list above falls to Express, which answers with an HTML
-// "Cannot GET" page. Callers parse these responses as JSON, so that page decays into an
-// empty body and a bare 404 — indistinguishable from the upstream service reporting that
-// a pack or a config does not exist. The two want opposite responses: one is a deploy gap
-// to report, the other is a record to stop asking for. Name the gap so the difference
-// survives the trip back to the browser.
 labsRouter.all(/(.*)/, (req: Request, res: Response) => {
   rootLogger.warn("Labs path is not proxied by this API", {
     module: "api/labs",


### PR DESCRIPTION
b3d789136 rewrote every route in labs.ts to swap RateLimiterMode.Search for RateLimiterMode.Labs and lost five of them on the way: GET /search/packs, PATCH /search/packs/:packId, POST /search/data/pages, PATCH /search/data/:sourceId and POST /search/data/:sourceId/refresh. It also deleted the comment warning that this list has no catch-all and must be kept in sync with the service by hand. Production has answered those five paths with a 404 since the deploy, which is why provider packs stopped loading in the dashboard while engines and data kept working.

Express replies to an unclaimed path with an HTML "Cannot GET" page, which a dashboard fetch parses into nothing and reports as a bare 404 — the same thing it shows when the service says a pack does not exist. One is a deploy gap and the other is a missing record, so answer the gap with JSON that names it.

LABS_ROUTES in the new test locks the list so the next rewrite of this file cannot quietly shorten it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788623909&installation_model_id=11126&pr_number=4249&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4249&signature=52fad093f60c881396021b75dda2f29b575cf2915f1447db60fa9fa0e452266b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores five missing Labs proxy routes and adds a JSON 404 catch-all for unproxied paths. Fixes provider packs loading in the dashboard and surfaces route gaps clearly.

- Bug Fixes
  - Restored routes: GET /search/packs, PATCH /search/packs/:packId, POST /search/data/pages, PATCH /search/data/:sourceId, POST /search/data/:sourceId/refresh (all behind the Labs rate limiter).
  - Added catch-all that returns JSON 404 with code "LABS_ROUTE_NOT_PROXIED" and includes method + path to distinguish deploy gaps from missing records.
  - Added tests that lock the full Labs route list and validate the JSON 404 behavior to prevent silent regressions.

<sup>Written for commit 1a9bdf47febcf46494cea508a6c81dc5f98103da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

