### PR TITLE
fix(api): await crawl-status-ws send to avoid unhandledRejection

### DIFF
--- a/apps/api/src/controllers/v1/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v1/crawl-status-ws.ts
@@ -96,10 +96,12 @@ async function crawlStatusWS(
 
     for (const job of newlyDoneJobs) {
       if (job.returnvalue) {
-        send(ws, {
+        // Await/catch so a late close between readyState check and ws.send
+        // callback cannot escape as an unhandledRejection (Node 15+ exit).
+        await send(ws, {
           type: "document",
           data: job.returnvalue,
-        });
+        }).catch(() => {});
       } else {
         // Crawl errors are ignored.
       }

--- a/apps/api/src/controllers/v1/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v1/crawl-status-ws.ts
@@ -41,7 +41,7 @@ type DoneMessage = { type: "done" };
 
 type Message = ErrorMessage | CatchupMessage | DoneMessage | DocumentMessage;
 
-function send(ws: WebSocket, msg: Message) {
+function send(ws: WebSocket, msg: Message): Promise<null> {
   if (ws.readyState === 1) {
     return new Promise((resolve, reject) => {
       ws.send(JSON.stringify(msg), err => {
@@ -50,6 +50,9 @@ function send(ws: WebSocket, msg: Message) {
       });
     });
   }
+  // Always return a Promise so callers can safely await / .catch() when
+  // the socket is already closed (readyState !== OPEN).
+  return Promise.resolve(null);
 }
 
 function close(ws: WebSocket, code: number, msg: Message) {

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -100,10 +100,12 @@ async function crawlStatusWS(
 
     for (const job of newlyDoneJobs) {
       if (job.returnvalue) {
-        send(ws, {
+        // Await/catch so a late close between readyState check and ws.send
+        // callback cannot escape as an unhandledRejection (Node 15+ exit).
+        await send(ws, {
           type: "document",
           data: job.returnvalue,
-        });
+        }).catch(() => {});
       } else {
         // Crawl errors are ignored.
       }

--- a/apps/api/src/controllers/v2/crawl-status-ws.ts
+++ b/apps/api/src/controllers/v2/crawl-status-ws.ts
@@ -42,7 +42,7 @@ type DoneMessage = { type: "done" };
 
 type Message = ErrorMessage | CatchupMessage | DoneMessage | DocumentMessage;
 
-function send(ws: WebSocket, msg: Message) {
+function send(ws: WebSocket, msg: Message): Promise<null> {
   if (ws.readyState === 1) {
     return new Promise((resolve, reject) => {
       ws.send(JSON.stringify(msg), err => {
@@ -51,6 +51,9 @@ function send(ws: WebSocket, msg: Message) {
       });
     });
   }
+  // Always return a Promise so callers can safely await / .catch() when
+  // the socket is already closed (readyState !== OPEN).
+  return Promise.resolve(null);
 }
 
 function close(ws: WebSocket, code: number, msg: Message) {


### PR DESCRIPTION
## Summary
- Await and `.catch()` document `send()` calls in the crawl-status-ws polling loops (v1 + v2) so a WebSocket close racing the `ws.send` callback cannot escape as `unhandledRejection` (Node 15+ process exit).
- Make `send()` always return a `Promise` (resolve when `readyState !== OPEN`) so `await send(...).catch(...)` is safe when the socket is already closed — the late-close case this PR targets.

## Test plan
- [x] Minimal harness: fire-and-forget `send` → `unhandled >= 1`; `await send(...).catch(() => {})` → `unhandled === 0`.
- [x] Closed-socket path: `send()` with `readyState !== 1` returns a thenable; `await send(...).catch(() => {})` does not throw `TypeError`.

Fixes #4243