### PR TITLE
fix(api): stop billing scrapes that fail DNS resolution

### DIFF
--- a/apps/api/src/lib/scrape-billing.test.ts
+++ b/apps/api/src/lib/scrape-billing.test.ts
@@ -4,6 +4,10 @@ import {
 } from "./scrape-billing";
 import { UnsafeDomainBlockedError } from "./threat-protection/error";
 import type { ThreatDecision } from "./threat-protection/types";
+import {
+  DNSResolutionError,
+  LockdownMissError,
+} from "../scraper/scrapeURL/error";
 
 describe("calculateCreditsToBeBilled", () => {
   it("bills handled Exchange successes at the reported credit cost", async () => {
@@ -89,6 +93,46 @@ describe("calculateCreditsToBeBilled", () => {
     );
 
     expect(credits).toBe(10);
+  });
+
+  it("bills nothing for DNS resolution failures", async () => {
+    const credits = await calculateCreditsToBeBilled(
+      {
+        formats: [{ type: "markdown" }],
+      } as any,
+      {
+        teamId: "team-id",
+        orgId: null,
+      },
+      null,
+      {
+        totalCost: 0,
+      } as any,
+      {} as any,
+      new DNSResolutionError("nonexistent.example.com"),
+    );
+
+    expect(credits).toBe(0);
+  });
+
+  it("bills 1 credit for lockdown cache misses", async () => {
+    const credits = await calculateCreditsToBeBilled(
+      {
+        formats: [{ type: "markdown" }],
+      } as any,
+      {
+        teamId: "team-id",
+        orgId: null,
+      },
+      null,
+      {
+        totalCost: 0,
+      } as any,
+      {} as any,
+      new LockdownMissError(),
+    );
+
+    expect(credits).toBe(1);
   });
 
   it("bills deterministic JSON at 3 credits when a cached script was reused", async () => {

--- a/apps/api/src/lib/scrape-billing.ts
+++ b/apps/api/src/lib/scrape-billing.ts
@@ -103,11 +103,9 @@ export async function calculateCreditsToBeBilled(
       creditsToBeBilled = Math.ceil((costTrackingJSON.totalCost ?? 1) * 1800);
     }
 
-    // Bill for DNS resolution errors
     if (
       error instanceof TransportableError &&
-      (error.code === "SCRAPE_DNS_RESOLUTION_ERROR" ||
-        error.code === "SCRAPE_LOCKDOWN_CACHE_MISS")
+      error.code === "SCRAPE_LOCKDOWN_CACHE_MISS"
     ) {
       creditsToBeBilled = 1;
     }


### PR DESCRIPTION
## What

Removes the base 1-credit charge for scrapes that fail DNS resolution. DNS failures now bill 0 credits, like every other failure class. Lockdown cache misses keep their existing 1-credit charge.

## Why

DNS resolution failures were the only failure class that billed a base credit: timeouts, engine failures, TLS errors, and blocked pages all bill 0. The customer receives no content in either case, so DNS shouldn't be the exception.

## Changes

- `calculateCreditsToBeBilled` (`src/lib/scrape-billing.ts`): removed `SCRAPE_DNS_RESOLUTION_ERROR` from the failure-path billing exception; `SCRAPE_LOCKDOWN_CACHE_MISS` still bills 1 credit.
- Unit tests: DNS failures bill 0, lockdown cache misses bill 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)