### PR TITLE
feat(api): negative DNS cache for scrape hostnames

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { it, expect, beforeAll, afterAll } from "vitest";
 import crypto from "crypto";
+import { config } from "../../../config";
 import { describeIf, TEST_PRODUCTION } from "../lib";
 import { scrapeRaw, scrapeTimeout, idmux, Identity } from "./lib";
 import { redisEvictConnection } from "../../../services/redis";
+import {
+  cacheDnsFailure,
+  isDnsFailureCached,
+} from "../../../lib/dns-negative-cache";
 
 let identity: Identity;
 
@@ -18,76 +23,81 @@ afterAll(async () => {
   redisEvictConnection.disconnect();
 });
 
-describe("negative DNS cache", () => {
-  // Population needs a real DNS failure classified as
-  // SCRAPE_DNS_RESOLUTION_ERROR, which self-hosted engines don't produce.
+describeIf(config.DNS_NEGATIVE_CACHE_TTL_MS > 0)("negative DNS cache", () => {
+  // Needs a real DNS failure classified as SCRAPE_DNS_RESOLUTION_ERROR,
+  // which self-hosted engines don't produce. Asserts behavior only — the
+  // test process must never touch the production evict Redis.
   describeIf(TEST_PRODUCTION)("population", () => {
     it(
-      "counts failures per hostname and keeps failing with the same error",
+      "keeps failing a dead hostname with the same error",
       async () => {
         const hostname = `${crypto.randomUUID()}-dead.invalid`;
 
-        const first = await scrapeRaw(
-          { url: `https://${hostname}/` },
-          identity,
-        );
-        expect(first.statusCode).toBe(200);
-        expect(first.body.success).toBe(false);
-        expect(first.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
-
-        expect(await redisEvictConnection.get(`dnsneg:${hostname}`)).toBe("1");
-
-        const second = await scrapeRaw(
-          { url: `https://${hostname}/` },
-          identity,
-        );
-        expect(second.statusCode).toBe(200);
-        expect(second.body.success).toBe(false);
-        expect(second.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
-
-        expect(await redisEvictConnection.get(`dnsneg:${hostname}`)).toBe("2");
+        for (let i = 0; i < 2; i++) {
+          const response = await scrapeRaw(
+            { url: `https://${hostname}/` },
+            identity,
+          );
+          expect(response.statusCode).toBe(200);
+          expect(response.body.success).toBe(false);
+          expect(response.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+        }
       },
       scrapeTimeout * 2,
     );
   });
 
-  it(
-    "fails fast without engines when the hostname is at the block threshold",
-    async () => {
-      // iana.org resolves fine — a DNS error can only come from the cache.
-      const hostname = "iana.org";
-      await redisEvictConnection.set(`dnsneg:${hostname}`, "2", "PX", 60000);
-      try {
-        const response = await scrapeRaw(
-          { url: `https://${hostname}/` },
-          identity,
-        );
-        expect(response.statusCode).toBe(200);
-        expect(response.body.success).toBe(false);
-        expect(response.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
-      } finally {
-        await redisEvictConnection.del(`dnsneg:${hostname}`);
-      }
-    },
-    scrapeTimeout,
-  );
+  // These write markers directly, so they only run against the local
+  // harness Redis — never against production.
+  describeIf(!TEST_PRODUCTION)("fail-fast", () => {
+    it("blocks only after two recorded failures", async () => {
+      const hostname = `${crypto.randomUUID()}-dead.invalid`;
 
-  it(
-    "does not block a hostname after a single failure",
-    async () => {
-      const hostname = "example.com";
-      await redisEvictConnection.set(`dnsneg:${hostname}`, "1", "PX", 60000);
-      try {
-        const response = await scrapeRaw(
-          { url: `https://${hostname}/` },
-          identity,
-        );
-        expect(response.statusCode).toBe(200);
-        expect(response.body.success).toBe(true);
-      } finally {
-        await redisEvictConnection.del(`dnsneg:${hostname}`);
-      }
-    },
-    scrapeTimeout,
-  );
+      expect(await isDnsFailureCached(hostname)).toBe(false);
+      await cacheDnsFailure(hostname);
+      expect(await isDnsFailureCached(hostname)).toBe(false);
+      await cacheDnsFailure(hostname);
+      expect(await isDnsFailureCached(hostname)).toBe(true);
+    });
+
+    it(
+      "fails fast without engines when the hostname is at the block threshold",
+      async () => {
+        // iana.org resolves fine — a DNS error can only come from the cache.
+        const hostname = "iana.org";
+        await redisEvictConnection.set(`dnsneg:${hostname}`, "2", "PX", 60000);
+        try {
+          const response = await scrapeRaw(
+            { url: `https://${hostname}/` },
+            identity,
+          );
+          expect(response.statusCode).toBe(200);
+          expect(response.body.success).toBe(false);
+          expect(response.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+        } finally {
+          await redisEvictConnection.del(`dnsneg:${hostname}`);
+        }
+      },
+      scrapeTimeout,
+    );
+
+    it(
+      "does not block a hostname after a single failure",
+      async () => {
+        const hostname = "example.com";
+        await redisEvictConnection.set(`dnsneg:${hostname}`, "1", "PX", 60000);
+        try {
+          const response = await scrapeRaw(
+            { url: `https://${hostname}/` },
+            identity,
+          );
+          expect(response.statusCode).toBe(200);
+          expect(response.body.success).toBe(true);
+        } finally {
+          await redisEvictConnection.del(`dnsneg:${hostname}`);
+        }
+      },
+      scrapeTimeout,
+    );
+  });
 });

--- a/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
@@ -19,9 +19,11 @@ afterAll(async () => {
 });
 
 describe("negative DNS cache", () => {
+  // Population needs a real DNS failure classified as
+  // SCRAPE_DNS_RESOLUTION_ERROR, which self-hosted engines don't produce.
   describeIf(TEST_PRODUCTION)("population", () => {
     it(
-      "records a failed hostname and keeps failing it with the same error",
+      "counts failures per hostname and keeps failing with the same error",
       async () => {
         const hostname = `${crypto.randomUUID()}-dead.invalid`;
 
@@ -33,7 +35,7 @@ describe("negative DNS cache", () => {
         expect(first.body.success).toBe(false);
         expect(first.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
 
-        expect(await redisEvictConnection.exists(`dnsneg:${hostname}`)).toBe(1);
+        expect(await redisEvictConnection.get(`dnsneg:${hostname}`)).toBe("1");
 
         const second = await scrapeRaw(
           { url: `https://${hostname}/` },
@@ -42,17 +44,19 @@ describe("negative DNS cache", () => {
         expect(second.statusCode).toBe(200);
         expect(second.body.success).toBe(false);
         expect(second.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+
+        expect(await redisEvictConnection.get(`dnsneg:${hostname}`)).toBe("2");
       },
       scrapeTimeout * 2,
     );
   });
 
   it(
-    "fails fast without engines when the hostname has a marker",
+    "fails fast without engines when the hostname is at the block threshold",
     async () => {
       // iana.org resolves fine — a DNS error can only come from the cache.
       const hostname = "iana.org";
-      await redisEvictConnection.set(`dnsneg:${hostname}`, "1", "PX", 60000);
+      await redisEvictConnection.set(`dnsneg:${hostname}`, "2", "PX", 60000);
       try {
         const response = await scrapeRaw(
           { url: `https://${hostname}/` },
@@ -61,6 +65,25 @@ describe("negative DNS cache", () => {
         expect(response.statusCode).toBe(200);
         expect(response.body.success).toBe(false);
         expect(response.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+      } finally {
+        await redisEvictConnection.del(`dnsneg:${hostname}`);
+      }
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "does not block a hostname after a single failure",
+    async () => {
+      const hostname = "example.com";
+      await redisEvictConnection.set(`dnsneg:${hostname}`, "1", "PX", 60000);
+      try {
+        const response = await scrapeRaw(
+          { url: `https://${hostname}/` },
+          identity,
+        );
+        expect(response.statusCode).toBe(200);
+        expect(response.body.success).toBe(true);
       } finally {
         await redisEvictConnection.del(`dnsneg:${hostname}`);
       }

--- a/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import crypto from "crypto";
+import { describeIf, TEST_PRODUCTION } from "../lib";
+import { scrapeRaw, scrapeTimeout, idmux, Identity } from "./lib";
+import { redisEvictConnection } from "../../../services/redis";
+
+let identity: Identity;
+
+beforeAll(async () => {
+  identity = await idmux({
+    name: "scrape-dns-negative-cache",
+    concurrency: 10,
+    credits: 100,
+  });
+}, 10000);
+
+afterAll(async () => {
+  redisEvictConnection.disconnect();
+});
+
+describe("negative DNS cache", () => {
+  describeIf(TEST_PRODUCTION)("population", () => {
+    it(
+      "records a failed hostname and keeps failing it with the same error",
+      async () => {
+        const hostname = `${crypto.randomUUID()}-dead.invalid`;
+
+        const first = await scrapeRaw(
+          { url: `https://${hostname}/` },
+          identity,
+        );
+        expect(first.statusCode).toBe(200);
+        expect(first.body.success).toBe(false);
+        expect(first.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+
+        expect(await redisEvictConnection.exists(`dnsneg:${hostname}`)).toBe(1);
+
+        const second = await scrapeRaw(
+          { url: `https://${hostname}/` },
+          identity,
+        );
+        expect(second.statusCode).toBe(200);
+        expect(second.body.success).toBe(false);
+        expect(second.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+      },
+      scrapeTimeout * 2,
+    );
+  });
+
+  it(
+    "fails fast without engines when the hostname has a marker",
+    async () => {
+      // iana.org resolves fine — a DNS error can only come from the cache.
+      const hostname = "iana.org";
+      await redisEvictConnection.set(`dnsneg:${hostname}`, "1", "PX", 60000);
+      try {
+        const response = await scrapeRaw(
+          { url: `https://${hostname}/` },
+          identity,
+        );
+        expect(response.statusCode).toBe(200);
+        expect(response.body.success).toBe(false);
+        expect(response.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
+      } finally {
+        await redisEvictConnection.del(`dnsneg:${hostname}`);
+      }
+    },
+    scrapeTimeout,
+  );
+});

--- a/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-dns-negative-cache.test.ts
@@ -7,6 +7,7 @@ import { redisEvictConnection } from "../../../services/redis";
 import {
   cacheDnsFailure,
   isDnsFailureCached,
+  dnsNegativeCacheRedis,
 } from "../../../lib/dns-negative-cache";
 
 let identity: Identity;
@@ -21,6 +22,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   redisEvictConnection.disconnect();
+  dnsNegativeCacheRedis?.disconnect();
 });
 
 describeIf(config.DNS_NEGATIVE_CACHE_TTL_MS > 0)("negative DNS cache", () => {
@@ -33,7 +35,9 @@ describeIf(config.DNS_NEGATIVE_CACHE_TTL_MS > 0)("negative DNS cache", () => {
       async () => {
         const hostname = `${crypto.randomUUID()}-dead.invalid`;
 
-        for (let i = 0; i < 2; i++) {
+        // Two real DNS failures reach the block threshold; the third scrape
+        // is served by the fail-fast path and must be indistinguishable.
+        for (let i = 0; i < 3; i++) {
           const response = await scrapeRaw(
             { url: `https://${hostname}/` },
             identity,
@@ -43,7 +47,7 @@ describeIf(config.DNS_NEGATIVE_CACHE_TTL_MS > 0)("negative DNS cache", () => {
           expect(response.body.code).toBe("SCRAPE_DNS_RESOLUTION_ERROR");
         }
       },
-      scrapeTimeout * 2,
+      scrapeTimeout * 3,
     );
   });
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -157,6 +157,9 @@ const configSchema = z.object({
   // (e.g. 600000 = 10min) also short-circuits repeat lookups for URLs with no
   // index entry. Kept short so any missed cache-clear self-heals quickly.
   INDEX_CACHE_NEGATIVE_TTL_MS: z.coerce.number().default(0),
+  // Fail-fast window for hostnames that failed DNS resolution, in ms.
+  // 0 disables the negative DNS cache.
+  DNS_NEGATIVE_CACHE_TTL_MS: z.coerce.number().default(900000),
   REDIS_URL: z.string().optional(),
   REDIS_EVICT_URL: z.string().optional(),
   REDIS_RATE_LIMIT_URL: z.string().optional(),

--- a/apps/api/src/lib/dns-negative-cache.ts
+++ b/apps/api/src/lib/dns-negative-cache.ts
@@ -3,13 +3,30 @@ import { redisEvictConnection } from "../services/redis";
 import { logger as _logger } from "./logger";
 import type { Logger } from "winston";
 
-// Markers are never refreshed on read, so a dead hostname re-probes once
-// per TTL window.
+// A hostname fails fast only after BLOCK_THRESHOLD DNS failures within the
+// TTL window, so a single transient resolver failure never blocks a host.
+// Reads never extend the TTL, so a blocked hostname re-probes once per
+// window. Reads and writes are bounded by a timeout and fail open — the
+// shared evict Redis client queues commands while disconnected, and the
+// scrape path must not hang on it.
 
 const KEY_PREFIX = "dnsneg:";
 const TTL_MS = config.DNS_NEGATIVE_CACHE_TTL_MS;
+const BLOCK_THRESHOLD = 2;
+const TIMEOUT_MS = 150;
 
 const useDnsNegativeCache = TTL_MS > 0;
+
+const TIMED_OUT = Symbol("dns-negative-cache-timeout");
+
+function withTimeout<T>(promise: Promise<T>): Promise<T | typeof TIMED_OUT> {
+  return Promise.race([
+    promise,
+    new Promise<typeof TIMED_OUT>(resolve =>
+      setTimeout(() => resolve(TIMED_OUT), TIMEOUT_MS).unref?.(),
+    ),
+  ]);
+}
 
 function keyFor(hostname: string): string {
   return KEY_PREFIX + hostname.toLowerCase();
@@ -23,7 +40,15 @@ export async function isDnsFailureCached(
     return false;
   }
   try {
-    return (await redisEvictConnection.exists(keyFor(hostname))) === 1;
+    const raw = await withTimeout(redisEvictConnection.get(keyFor(hostname)));
+    if (raw === TIMED_OUT) {
+      logger.warn("Negative DNS cache read timed out", {
+        module: "dns-negative-cache",
+        hostname,
+      });
+      return false;
+    }
+    return raw !== null && parseInt(raw, 10) >= BLOCK_THRESHOLD;
   } catch (error) {
     logger.warn("Negative DNS cache read failed", {
       module: "dns-negative-cache",
@@ -42,7 +67,19 @@ export async function cacheDnsFailure(
     return;
   }
   try {
-    await redisEvictConnection.set(keyFor(hostname), "1", "PX", TTL_MS);
+    const result = await withTimeout(
+      redisEvictConnection
+        .pipeline()
+        .incr(keyFor(hostname))
+        .pexpire(keyFor(hostname), TTL_MS)
+        .exec(),
+    );
+    if (result === TIMED_OUT) {
+      logger.warn("Negative DNS cache write timed out", {
+        module: "dns-negative-cache",
+        hostname,
+      });
+    }
   } catch (error) {
     logger.warn("Negative DNS cache write failed", {
       module: "dns-negative-cache",

--- a/apps/api/src/lib/dns-negative-cache.ts
+++ b/apps/api/src/lib/dns-negative-cache.ts
@@ -1,21 +1,36 @@
+import IORedis from "ioredis";
 import { config } from "../config";
-import { redisEvictConnection } from "../services/redis";
 import { logger as _logger } from "./logger";
 import type { Logger } from "winston";
 
 // A hostname fails fast only after BLOCK_THRESHOLD DNS failures within the
 // TTL window, so a single transient resolver failure never blocks a host.
 // Reads never extend the TTL, so a blocked hostname re-probes once per
-// window. Reads and writes fail open: skipped while the client is
-// disconnected (never queued for later delivery) and bounded by a timeout,
-// so the scrape path can neither hang nor backlog on cache trouble.
+// window. Everything fails open: the dedicated client rejects commands
+// immediately while disconnected (never queues or retries them), and calls
+// are bounded by a timeout so the scrape path can never hang on the cache.
 
 const KEY_PREFIX = "dnsneg:";
-const TTL_MS = config.DNS_NEGATIVE_CACHE_TTL_MS;
+const TTL_MS = Math.floor(config.DNS_NEGATIVE_CACHE_TTL_MS);
 const BLOCK_THRESHOLD = 2;
 const TIMEOUT_MS = 150;
 
 const useDnsNegativeCache = TTL_MS > 0;
+
+export const dnsNegativeCacheRedis: IORedis | null = useDnsNegativeCache
+  ? new IORedis((config.REDIS_EVICT_URL ?? config.REDIS_RATE_LIMIT_URL)!, {
+      enableAutoPipelining: true,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+    })
+  : null;
+
+dnsNegativeCacheRedis?.on("error", error => {
+  _logger.warn("Negative DNS cache Redis connection error", {
+    module: "dns-negative-cache",
+    error,
+  });
+});
 
 const TIMED_OUT = Symbol("dns-negative-cache-timeout");
 
@@ -36,11 +51,14 @@ export async function isDnsFailureCached(
   hostname: string,
   logger: Logger = _logger,
 ): Promise<boolean> {
-  if (!useDnsNegativeCache || redisEvictConnection.status !== "ready") {
+  if (
+    dnsNegativeCacheRedis === null ||
+    dnsNegativeCacheRedis.status !== "ready"
+  ) {
     return false;
   }
   try {
-    const raw = await withTimeout(redisEvictConnection.get(keyFor(hostname)));
+    const raw = await withTimeout(dnsNegativeCacheRedis.get(keyFor(hostname)));
     if (raw === TIMED_OUT) {
       logger.warn("Negative DNS cache read timed out", {
         module: "dns-negative-cache",
@@ -48,7 +66,11 @@ export async function isDnsFailureCached(
       });
       return false;
     }
-    return raw !== null && Number(raw) >= BLOCK_THRESHOLD;
+    if (raw === null) {
+      return false;
+    }
+    const count = Number(raw);
+    return Number.isSafeInteger(count) && count >= BLOCK_THRESHOLD;
   } catch (error) {
     logger.warn("Negative DNS cache read failed", {
       module: "dns-negative-cache",
@@ -63,12 +85,15 @@ export async function cacheDnsFailure(
   hostname: string,
   logger: Logger = _logger,
 ): Promise<void> {
-  if (!useDnsNegativeCache || redisEvictConnection.status !== "ready") {
+  if (
+    dnsNegativeCacheRedis === null ||
+    dnsNegativeCacheRedis.status !== "ready"
+  ) {
     return;
   }
   try {
     const result = await withTimeout(
-      redisEvictConnection
+      dnsNegativeCacheRedis
         .pipeline()
         .incr(keyFor(hostname))
         .pexpire(keyFor(hostname), TTL_MS)

--- a/apps/api/src/lib/dns-negative-cache.ts
+++ b/apps/api/src/lib/dns-negative-cache.ts
@@ -21,7 +21,10 @@ export const dnsNegativeCacheRedis: IORedis | null = useDnsNegativeCache
   ? new IORedis((config.REDIS_EVICT_URL ?? config.REDIS_RATE_LIMIT_URL)!, {
       enableAutoPipelining: true,
       enableOfflineQueue: false,
-      maxRetriesPerRequest: 1,
+      // Callers time out in 150ms, so a retried or resent command can only
+      // ever deliver a stale write after the scrape has moved on.
+      maxRetriesPerRequest: 0,
+      autoResendUnfulfilledCommands: false,
     })
   : null;
 

--- a/apps/api/src/lib/dns-negative-cache.ts
+++ b/apps/api/src/lib/dns-negative-cache.ts
@@ -6,9 +6,9 @@ import type { Logger } from "winston";
 // A hostname fails fast only after BLOCK_THRESHOLD DNS failures within the
 // TTL window, so a single transient resolver failure never blocks a host.
 // Reads never extend the TTL, so a blocked hostname re-probes once per
-// window. Reads and writes are bounded by a timeout and fail open — the
-// shared evict Redis client queues commands while disconnected, and the
-// scrape path must not hang on it.
+// window. Reads and writes fail open: skipped while the client is
+// disconnected (never queued for later delivery) and bounded by a timeout,
+// so the scrape path can neither hang nor backlog on cache trouble.
 
 const KEY_PREFIX = "dnsneg:";
 const TTL_MS = config.DNS_NEGATIVE_CACHE_TTL_MS;
@@ -36,7 +36,7 @@ export async function isDnsFailureCached(
   hostname: string,
   logger: Logger = _logger,
 ): Promise<boolean> {
-  if (!useDnsNegativeCache) {
+  if (!useDnsNegativeCache || redisEvictConnection.status !== "ready") {
     return false;
   }
   try {
@@ -48,7 +48,7 @@ export async function isDnsFailureCached(
       });
       return false;
     }
-    return raw !== null && parseInt(raw, 10) >= BLOCK_THRESHOLD;
+    return raw !== null && Number(raw) >= BLOCK_THRESHOLD;
   } catch (error) {
     logger.warn("Negative DNS cache read failed", {
       module: "dns-negative-cache",
@@ -63,7 +63,7 @@ export async function cacheDnsFailure(
   hostname: string,
   logger: Logger = _logger,
 ): Promise<void> {
-  if (!useDnsNegativeCache) {
+  if (!useDnsNegativeCache || redisEvictConnection.status !== "ready") {
     return;
   }
   try {

--- a/apps/api/src/lib/dns-negative-cache.ts
+++ b/apps/api/src/lib/dns-negative-cache.ts
@@ -1,0 +1,53 @@
+import { config } from "../config";
+import { redisEvictConnection } from "../services/redis";
+import { logger as _logger } from "./logger";
+import type { Logger } from "winston";
+
+// Markers are never refreshed on read, so a dead hostname re-probes once
+// per TTL window.
+
+const KEY_PREFIX = "dnsneg:";
+const TTL_MS = config.DNS_NEGATIVE_CACHE_TTL_MS;
+
+const useDnsNegativeCache = TTL_MS > 0;
+
+function keyFor(hostname: string): string {
+  return KEY_PREFIX + hostname.toLowerCase();
+}
+
+export async function isDnsFailureCached(
+  hostname: string,
+  logger: Logger = _logger,
+): Promise<boolean> {
+  if (!useDnsNegativeCache) {
+    return false;
+  }
+  try {
+    return (await redisEvictConnection.exists(keyFor(hostname))) === 1;
+  } catch (error) {
+    logger.warn("Negative DNS cache read failed", {
+      module: "dns-negative-cache",
+      error,
+      hostname,
+    });
+    return false;
+  }
+}
+
+export async function cacheDnsFailure(
+  hostname: string,
+  logger: Logger = _logger,
+): Promise<void> {
+  if (!useDnsNegativeCache) {
+    return;
+  }
+  try {
+    await redisEvictConnection.set(keyFor(hostname), "1", "PX", TTL_MS);
+  } catch (error) {
+    logger.warn("Negative DNS cache write failed", {
+      module: "dns-negative-cache",
+      error,
+      hostname,
+    });
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -64,6 +64,10 @@ import { CostTracking } from "../../lib/cost-tracking";
 import { getEngineForUrl } from "../WebScraper/utils/engine-forcing";
 import { useIndex } from "../../services/index";
 import {
+  cacheDnsFailure,
+  isDnsFailureCached,
+} from "../../lib/dns-negative-cache";
+import {
   fetchRobotsTxt,
   createRobotsChecker,
   isUrlAllowedByRobots,
@@ -1121,6 +1125,28 @@ export async function scrapeURL(
       });
     }
 
+    {
+      let hostname: string | null = null;
+      try {
+        hostname = new URL(meta.rewrittenUrl ?? meta.url).hostname;
+      } catch {}
+      if (hostname && (await isDnsFailureCached(hostname, meta.logger))) {
+        meta.logger.info("Hostname is in the negative DNS cache", {
+          hostname,
+        });
+        setSpanAttributes(span, {
+          "scrape.dns_negative_cache_hit": true,
+        });
+        return {
+          success: false,
+          error: new DNSResolutionError(hostname),
+          ...(meta.threatDecisions.length > 0
+            ? { threatDecisions: meta.threatDecisions }
+            : {}),
+        };
+      }
+    }
+
     if (internalOptions.isPreCrawl === true) {
       setSpanAttributes(span, {
         "scrape.is_precrawl": true,
@@ -1493,6 +1519,9 @@ export async function scrapeURL(
       } else if (error instanceof DNSResolutionError) {
         errorType = "DNSResolutionError";
         meta.logger.warn("scrapeURL: DNS resolution error", { error });
+        if (!internalOptions.zeroDataRetention) {
+          await cacheDnsFailure(error.hostname, meta.logger);
+        }
       } else if (error instanceof ScrapeRetryLimitError) {
         errorType = "ScrapeRetryLimitError";
         meta.logger.warn("scrapeURL: Retry limit reached", {

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1134,12 +1134,17 @@ export async function scrapeURL(
         meta.logger.info("Hostname is in the negative DNS cache", {
           hostname,
         });
+        const error = new DNSResolutionError(hostname);
         setSpanAttributes(span, {
           "scrape.dns_negative_cache_hit": true,
+          "scrape.success": false,
+          "scrape.error": error.message,
+          "scrape.error_type": "DNSResolutionError",
+          "scrape.duration_ms": Date.now() - startTime,
         });
         return {
           success: false,
-          error: new DNSResolutionError(hostname),
+          error,
           ...(meta.threatDecisions.length > 0
             ? { threatDecisions: meta.threatDecisions }
             : {}),


### PR DESCRIPTION
## What

Adds a short-lived per-hostname circuit breaker for DNS resolution failures. When a scrape fails with a DNS error, the hostname gets a Redis marker (`DNS_NEGATIVE_CACHE_TTL_MS`, default 15 minutes, `0` disables). While the marker is fresh, repeat scrapes of that hostname return the same DNS error immediately — before any engine work — instead of re-running the whole engine waterfall against a hostname that cannot resolve.

## Design notes

- Markers live on the existing evict Redis connection and are never refreshed on read, so a dead hostname re-probes once per TTL window and domains that come back self-heal.
- Cache reads/writes fail open — Redis trouble never blocks a scrape.
- Zero-data-retention requests never write markers.
- The client-facing error contract is unchanged (same `SCRAPE_DNS_RESOLUTION_ERROR` code and message).

## Tests

- E2E: a scrape of a guaranteed-nonexistent `.invalid` hostname fails with the DNS error code and leaves a marker; a repeat scrape fails the same way.
- E2E: a manually planted marker on a hostname that resolves fine still returns the DNS error, proving the fail-fast path fires before any lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788722668&installation_model_id=11126&pr_number=4262&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4262&signature=ac5c7a3714b8ed2bf9b643bce2d6b14475e3500110dd358ce8d3ee5c1a4de4e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a short-lived negative DNS cache for scrape hostnames to fail fast on repeated DNS resolution errors. Uses a dedicated Redis client with no offline queue, no retries/resends, and 150ms bounds to avoid stalls or late writes.

- **New Features**
  - Fail fast only after two DNS failures within the TTL window; early-return `SCRAPE_DNS_RESOLUTION_ERROR` before any engine work.
  - Per-hostname Redis marker with TTL from `DNS_NEGATIVE_CACHE_TTL_MS` (default 15m, `0` disables); reads don’t refresh TTL so recovered domains self-heal.
  - Dedicated cache connection: skips ops when not ready, fails open, never enqueues while disconnected, and never retries or resends; cache calls are bounded to 150ms.
  - Only safe-integer counters are honored; TTL is floored to whole ms; cache-hit spans record failure attributes; zero-data-retention requests never write markers. Tests avoid production Redis and include an end-to-end fail-fast check.

<sup>Written for commit 34af6bc4125b28c2f1b6ccddd83f1bf1236005eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

