### PR TITLE
fix(api): register NuQ RabbitMQ consumer before setting listener

### DIFF
--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -220,11 +220,40 @@ class NuQ<JobData = any, JobReturnValue = any> {
           // resources acquired before the failure so retries do not leak
           // connections/channels.
           this.listener = null;
+          // Prefer the shared close helper (expected AMQP close errors are soft).
+          // Keep the original consume failure as the thrown error so retries stay
+          // tied to the real cause; log unexpected close failures instead.
           if (channel) {
-            await channel.close().catch(() => {});
+            try {
+              await closeAmqpResource(
+                () => channel.close(),
+                "listener channel",
+              );
+            } catch (closeErr) {
+              logger.warn(
+                "NuQ failed to close channel after consume failure",
+                {
+                  module: "nuq/rabbitmq",
+                  error: closeErr,
+                },
+              );
+            }
           }
           if (connection) {
-            await connection.close().catch(() => {});
+            try {
+              await closeAmqpResource(
+                () => connection.close(),
+                "listener connection",
+              );
+            } catch (closeErr) {
+              logger.warn(
+                "NuQ failed to close connection after consume failure",
+                {
+                  module: "nuq/rabbitmq",
+                  error: closeErr,
+                },
+              );
+            }
           }
           throw err;
         }

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -79,7 +79,7 @@ async function closeAmqpResource(
     await close();
   } catch (error) {
     if (isExpectedAmqpCloseError(error)) {
-      logger.info(`NuQ ${resource} already closing during shutdown`, {
+      logger.info(`NuQ ${resource} already closing`, {
         module: "nuq/rabbitmq",
       });
       return;

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -143,72 +143,80 @@ class NuQ<JobData = any, JobReturnValue = any> {
           },
         );
 
+        // Register the consumer BEFORE publishing this.listener so a
+        // consume() failure cannot leave a consumer-less channel that
+        // permanently trips the early-return guard (#4244).
+        let reconnectTimeout: NodeJS.Timeout | null = null;
+
+        const onClose = function onClose() {
+          logger.info("NuQ listener channel closed", {
+            module: "nuq/rabbitmq",
+          });
+          this.listener = null;
+
+          if (reconnectTimeout) clearTimeout(reconnectTimeout);
+          reconnectTimeout = setTimeout(
+            (() => {
+              this.startListener().catch(err =>
+                logger.error("Error in NuQ listener reconnect", {
+                  err,
+                  module: "nuq/rabbitmq",
+                }),
+              );
+            }).bind(this),
+            250,
+          );
+          return;
+        }.bind(this);
+
+        await channel.consume(
+          queue.queue,
+          (msg => {
+            if (msg === null) {
+              onClose();
+              return;
+            }
+
+            logger.info("NuQ job received", {
+              module: "nuq/rabbitmq",
+              jobId: msg.properties.correlationId,
+              status: msg.content.toString(),
+            });
+
+            const jobId = msg.properties.correlationId as string;
+            const status = msg.content.toString() as "completed" | "failed";
+
+            if (jobId in this.listens) {
+              this.listens[jobId].forEach(listener => listener(status));
+            }
+            delete this.listens[jobId];
+
+            if (this.listener && this.listener.type === "rabbitmq") {
+              this.listener.channel.ack(msg);
+            }
+          }).bind(this),
+          {
+            noAck: false,
+          },
+        );
+
         this.listener = {
           type: "rabbitmq",
           connection,
           channel,
           queue: queue.queue,
         };
+
+        this.listener.connection.on("close", onClose);
+        this.listener.channel.on("close", onClose);
+      } catch (err) {
+        // Ensure the early-exit guard cannot lock out retries after a
+        // half-initialized (no consumer) channel (#4244).
+        this.listener = null;
+        throw err;
       } finally {
         this.listenerStarting = false;
       }
-
-      let reconnectTimeout: NodeJS.Timeout | null = null;
-
-      const onClose = function onClose() {
-        logger.info("NuQ listener channel closed", {
-          module: "nuq/rabbitmq",
-        });
-        this.listener = null;
-
-        if (reconnectTimeout) clearTimeout(reconnectTimeout);
-        reconnectTimeout = setTimeout(
-          (() => {
-            this.startListener().catch(err =>
-              logger.error("Error in NuQ listener reconnect", {
-                err,
-                module: "nuq/rabbitmq",
-              }),
-            );
-          }).bind(this),
-          250,
-        );
-        return;
-      }.bind(this);
-
-      this.listener.connection.on("close", onClose);
-      this.listener.channel.on("close", onClose);
-
-      await this.listener.channel.consume(
-        this.listener.queue,
-        (msg => {
-          if (msg === null) {
-            onClose();
-            return;
-          }
-
-          logger.info("NuQ job received", {
-            module: "nuq/rabbitmq",
-            jobId: msg.properties.correlationId,
-            status: msg.content.toString(),
-          });
-
-          const jobId = msg.properties.correlationId as string;
-          const status = msg.content.toString() as "completed" | "failed";
-
-          if (jobId in this.listens) {
-            this.listens[jobId].forEach(listener => listener(status));
-          }
-          delete this.listens[jobId];
-
-          if (this.listener && this.listener.type === "rabbitmq") {
-            this.listener.channel.ack(msg);
-          }
-        }).bind(this),
-        {
-          noAck: false,
-        },
-      );
     } else {
       this.listenerStarting = true;
 

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -127,93 +127,107 @@ class NuQ<JobData = any, JobReturnValue = any> {
       this.listenerStarting = true;
 
       try {
-        const connection = await amqp.connect(config.NUQ_RABBITMQ_URL);
-        const channel = await connection.createChannel();
-        await channel.prefetch(5);
-        const queue = await channel.assertQueue(
-          this.queueName + ".listen." + this.listenChannelId,
-          {
-            exclusive: true,
-            autoDelete: true,
-            durable: false,
-            arguments: {
-              "x-queue-type": "classic",
-              "x-message-ttl": 60000,
+        let connection: Awaited<ReturnType<typeof amqp.connect>> | undefined;
+        let channel: Awaited<
+          ReturnType<Awaited<ReturnType<typeof amqp.connect>>["createChannel"]>
+        > | undefined;
+        try {
+          connection = await amqp.connect(config.NUQ_RABBITMQ_URL);
+          channel = await connection.createChannel();
+          await channel.prefetch(5);
+          const queue = await channel.assertQueue(
+            this.queueName + ".listen." + this.listenChannelId,
+            {
+              exclusive: true,
+              autoDelete: true,
+              durable: false,
+              arguments: {
+                "x-queue-type": "classic",
+                "x-message-ttl": 60000,
+              },
             },
-          },
-        );
-
-        // Register the consumer BEFORE publishing this.listener so a
-        // consume() failure cannot leave a consumer-less channel that
-        // permanently trips the early-return guard (#4244).
-        let reconnectTimeout: NodeJS.Timeout | null = null;
-
-        const onClose = function onClose() {
-          logger.info("NuQ listener channel closed", {
-            module: "nuq/rabbitmq",
-          });
-          this.listener = null;
-
-          if (reconnectTimeout) clearTimeout(reconnectTimeout);
-          reconnectTimeout = setTimeout(
-            (() => {
-              this.startListener().catch(err =>
-                logger.error("Error in NuQ listener reconnect", {
-                  err,
-                  module: "nuq/rabbitmq",
-                }),
-              );
-            }).bind(this),
-            250,
           );
-          return;
-        }.bind(this);
 
-        await channel.consume(
-          queue.queue,
-          (msg => {
-            if (msg === null) {
-              onClose();
-              return;
-            }
+          // Register the consumer BEFORE publishing this.listener so a
+          // consume() failure cannot leave a consumer-less channel that
+          // permanently trips the early-return guard (#4244).
+          let reconnectTimeout: NodeJS.Timeout | null = null;
 
-            logger.info("NuQ job received", {
+          const onClose = function onClose() {
+            logger.info("NuQ listener channel closed", {
               module: "nuq/rabbitmq",
-              jobId: msg.properties.correlationId,
-              status: msg.content.toString(),
             });
+            this.listener = null;
 
-            const jobId = msg.properties.correlationId as string;
-            const status = msg.content.toString() as "completed" | "failed";
+            if (reconnectTimeout) clearTimeout(reconnectTimeout);
+            reconnectTimeout = setTimeout(
+              (() => {
+                this.startListener().catch(err =>
+                  logger.error("Error in NuQ listener reconnect", {
+                    err,
+                    module: "nuq/rabbitmq",
+                  }),
+                );
+              }).bind(this),
+              250,
+            );
+            return;
+          }.bind(this);
 
-            if (jobId in this.listens) {
-              this.listens[jobId].forEach(listener => listener(status));
-            }
-            delete this.listens[jobId];
+          await channel.consume(
+            queue.queue,
+            (msg => {
+              if (msg === null) {
+                onClose();
+                return;
+              }
 
-            if (this.listener && this.listener.type === "rabbitmq") {
-              this.listener.channel.ack(msg);
-            }
-          }).bind(this),
-          {
-            noAck: false,
-          },
-        );
+              logger.info("NuQ job received", {
+                module: "nuq/rabbitmq",
+                jobId: msg.properties.correlationId,
+                status: msg.content.toString(),
+              });
 
-        this.listener = {
-          type: "rabbitmq",
-          connection,
-          channel,
-          queue: queue.queue,
-        };
+              const jobId = msg.properties.correlationId as string;
+              const status = msg.content.toString() as "completed" | "failed";
 
-        this.listener.connection.on("close", onClose);
-        this.listener.channel.on("close", onClose);
-      } catch (err) {
-        // Ensure the early-exit guard cannot lock out retries after a
-        // half-initialized (no consumer) channel (#4244).
-        this.listener = null;
-        throw err;
+              if (jobId in this.listens) {
+                this.listens[jobId].forEach(listener => listener(status));
+              }
+              delete this.listens[jobId];
+
+              if (this.listener && this.listener.type === "rabbitmq") {
+                this.listener.channel.ack(msg);
+              }
+            }).bind(this),
+            {
+              noAck: false,
+            },
+          );
+
+          this.listener = {
+            type: "rabbitmq",
+            connection,
+            channel,
+            queue: queue.queue,
+          };
+
+          this.listener.connection.on("close", onClose);
+          this.listener.channel.on("close", onClose);
+        } catch (err) {
+          // Ensure the early-exit guard cannot lock out retries after a
+          // half-initialized (no consumer) channel (#4244). Close any broker
+          // resources acquired before the failure so retries do not leak
+          // connections/channels.
+          this.listener = null;
+          if (channel) {
+            await channel.close().catch(() => {});
+          }
+          if (connection) {
+            await connection.close().catch(() => {});
+          }
+          throw err;
+        }
       } finally {
         this.listenerStarting = false;
       }


### PR DESCRIPTION
## Summary
- `NuQ.startListener()` set `this.listener` inside `try/finally`, then called `channel.consume()` **outside** that block.
- If `consume()` threw, the early-return guard saw a truthy listener forever and never re-registered a consumer — every `waitForJob()` hung until timeout.
- Move `consume()` into the try, only publish `this.listener` after a successful consume, and clear it on failure.

Fixes #4244

## Test plan
- [ ] Simulate `channel.consume()` throwing after connect/assertQueue; confirm a later `startListener()` retries instead of no-op'ing.
- [ ] Confirm normal RabbitMQ listen path still delivers completion messages to `waitForJob()`.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788722703&installation_model_id=11126&pr_number=4263&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4263&signature=75978a7f3a2a88cde44e2b89a9700da2351ef74630e49263ea01b8d5d8825d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `NuQ` could set a listener without a consumer, causing `waitForJob()` to hang. We now register the `RabbitMQ` consumer first, only set `this.listener` on success, and clean up with `closeAmqpResource` on failure; fixes #4244.

- **Bug Fixes**
  - Move `channel.consume()` into `startListener()` and set `this.listener` only after a successful consume; `noAck: false` unchanged.
  - On failure, clear the listener and close the channel/connection via `closeAmqpResource` to prevent leaks and allow retries; centralize `onClose` for fast auto-retry; update its expected-close log to "already closing" for restart safety.

<sup>Written for commit e2aef21298727b177f017c9255ae19cbd725d39f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

