### PR TITLE
fix(api): reject malformed hostnames at request validation

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -171,6 +171,24 @@ describe("Scrape tests", () => {
     scrapeTimeout,
   );
 
+  it.concurrent(
+    "returns 400 for hostnames that are URL-construction bugs",
+    async () => {
+      for (const url of [
+        "http://.bloomingdales.com",
+        "http://image_000000279753.jpg",
+        "sitemap.xml",
+      ]) {
+        const raw = await scrapeRaw({ url }, identity);
+
+        expect(raw.statusCode).toBe(400);
+        expect(raw.body.success).toBe(false);
+        expect(JSON.stringify(raw.body)).toContain("top-level domain");
+      }
+    },
+    scrapeTimeout,
+  );
+
   // TEMP: domain broken
   // it.concurrent("works with Punycode domains", async () => {
   //   await scrape({

--- a/apps/api/src/controllers/__tests__/url-schema.test.ts
+++ b/apps/api/src/controllers/__tests__/url-schema.test.ts
@@ -60,4 +60,28 @@ describe.each([
     expect(result.success).toBe(false);
     expect(result.error!.issues[0].message).toContain("top-level domain");
   });
+
+  it.each([
+    ["a leading dot", "http://.bloomingdales.com"],
+    ["an empty label", "http://www..example.com"],
+    ["a file name as host", "http://image_000000279753.jpg"],
+    ["a bare file path fragment", "sitemap.xml"],
+  ])("rejects a hostname with %s", (_case, url) => {
+    const result = parse({ url });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.issues[0].message).toContain("top-level domain");
+  });
+
+  it.each([
+    ["a file-extension TLD that is delegated", "https://weather.mov"],
+    ["a registrable .zip domain", "https://update.zip"],
+    ["a ccTLD abbreviating a file extension", "https://docs.md"],
+    ["an IP literal", "http://8.8.8.8/"],
+    ["a file extension in the path", "https://example.com/report.pdf"],
+  ])("still accepts %s", (_case, url) => {
+    const result = parse({ url });
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/apps/api/src/lib/url-utils.ts
+++ b/apps/api/src/lib/url-utils.ts
@@ -28,9 +28,7 @@ const REGISTRABLE_DOMAIN_OPTIONS = {
  * Parses a hostname against the public suffix list to find its registrable domain.
  * @param hostname - The hostname to parse (not a full URL)
  */
-export function parseHostname(
-  hostname: string,
-): ReturnType<typeof parseTld> {
+export function parseHostname(hostname: string): ReturnType<typeof parseTld> {
   return parseTld(hostname, REGISTRABLE_DOMAIN_OPTIONS);
 }
 
@@ -40,6 +38,69 @@ export function parseHostname(
  */
 const LOOKS_LIKE_TLD =
   /(\.[a-zA-Z0-9-Ѐ-ӿԀ-ԯⷠ-ⷿꙀ-ꚟ]{2,}|\.xn--[a-zA-Z0-9-]{1,})(:\d+)?([\/?#]|$)/i;
+
+// File extensions that are NOT delegated TLDs. zip, mov, md, sh, rs, py,
+// pl, app, dev, page, new, docs, map, foo, ing are real TLDs and must stay
+// out of this list.
+const FILE_EXTENSION_FINAL_LABELS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "svg",
+  "ico",
+  "bmp",
+  "tif",
+  "tiff",
+  "avif",
+  "heic",
+  "pdf",
+  "doc",
+  "docx",
+  "xls",
+  "xlsx",
+  "ppt",
+  "pptx",
+  "csv",
+  "txt",
+  "rtf",
+  "odt",
+  "html",
+  "htm",
+  "xml",
+  "json",
+  "css",
+  "js",
+  "php",
+  "asp",
+  "aspx",
+  "jsp",
+  "mp3",
+  "mp4",
+  "m4a",
+  "avi",
+  "mkv",
+  "wav",
+  "ogg",
+  "webm",
+  "flac",
+  "rar",
+  "gz",
+  "tgz",
+  "bz2",
+  "7z",
+  "tar",
+  "woff",
+  "woff2",
+  "ttf",
+  "otf",
+  "eot",
+  "exe",
+  "msi",
+  "dmg",
+  "apk",
+]);
 
 /**
  * Whether a URL's host is plausibly reachable. Used only for request validation.
@@ -58,10 +119,23 @@ const LOOKS_LIKE_TLD =
  * pattern is that a typo'd TLD such as example.invalidtld still passes, exactly as
  * it did before.
  *
+ * Hostnames that can only come from client-side URL-construction bugs are
+ * rejected: leading-dot/empty labels and a bare file name as the host
+ * (image_0001.jpg).
+ *
  * @param url - A full URL string; tldts extracts the host itself.
  */
 export function hasReachableHost(url: string): boolean {
-  if (parseTld(url).isIp === true) return true;
+  const parsed = parseTld(url);
+  if (parsed.isIp === true) return true;
+  if (
+    parsed.hostname === null ||
+    parsed.hostname.startsWith(".") ||
+    parsed.publicSuffix === null ||
+    FILE_EXTENSION_FINAL_LABELS.has(parsed.publicSuffix)
+  ) {
+    return false;
+  }
   return LOOKS_LIKE_TLD.test(url);
 }
 


### PR DESCRIPTION
## What

URLs whose hostname can only come from a client-side URL-construction bug now fail request validation with a 400 instead of getting accepted and failing DNS resolution later:

- leading-dot or empty labels (`.bloomingdales.com`, `a..b.com`)
- a bare file name as the host (`image_000000279753.jpg`, `sitemap.xml`)

## How

The checks live inside `hasReachableHost`, running on the tldts parse it already performs — the validation chain gains no extra URL parse and no extra zod refine. The rejected cases reuse the existing "URL must have a valid top-level domain or be an IP address" error.

The file-extension list deliberately excludes extensions that are delegated TLDs (`.zip`, `.mov`, `.md`, `.sh`, …), so real domains under those keep working. Extensions in the path (`example.com/report.pdf`) are unaffected, and `/parse` is untouched since it takes file uploads, not URLs.

## Tests

- Schema-level cases for all rejected shapes and for the near-misses that must keep working (`update.zip`, `weather.mov`, `docs.md`, IP literals, path extensions), for both v1 and v2.
- E2E snip asserting the 400 contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)