### PR TITLE
fix(api): mark sitemap job done even if getCrawl throws

### DIFF
--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1393,9 +1393,12 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
     zeroDataRetention: job.data.zeroDataRetention ?? false,
   });
 
-  const sc = await getCrawl(job.data.crawl_id);
-
+  // getCrawl must stay inside try/finally: if Redis throws here, the crawl's
+  // sitemap_jobs vs sitemap_jobs_done counters permanently disagree and the
+  // crawl hangs in scraping forever.
   try {
+    const sc = await getCrawl(job.data.crawl_id);
+
     if (!sc) {
       logger.error("Crawl not found");
       return { success: false, error: "Crawl not found" };


### PR DESCRIPTION
## Summary
- Move `getCrawl()` inside the `try`/`finally` in `processKickoffSitemapJob` so Redis/deserialization failures still record `sitemap_jobs_done`.
- Prevents crawls from hanging forever when `sitemap_jobs` and `sitemap_jobs_done` permanently disagree.

Fixes #4245

## Test plan
- [ ] Confirm `getCrawl` is inside the same `try` that owns the `sitemap_jobs_done` `finally`
- [ ] Simulate `getCrawl` throw and verify the job id is still sadd'd to `sitemap_jobs_done`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788723913&installation_model_id=11126&pr_number=4266&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4266&signature=ea01ecf7107738e8e0c10d5d1a05b40e1dc03eb12fbb0d6fcc1e35b88af2e323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `getCrawl()` inside the try/finally in `processKickoffSitemapJob` so sitemap kickoff jobs are still marked done if Redis/deserialization fails, preventing stuck crawls. Fixes #4245.

- **Bug Fixes**
  - Call `getCrawl(job.data.crawl_id)` inside the same try that has the `sitemap_jobs_done` finally.
  - On errors, the job is still added to `sitemap_jobs_done`, keeping counters in sync and avoiding hangs.

<sup>Written for commit c0cbeaf8d26ec375336ffa06b01967cc0c4ec7ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

