### PR TITLE
fix(api): force Chat Completions when OPENAI_BASE_URL is set

### DIFF
--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -58,8 +58,13 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
     name = "gemini-2.5-pro";
   }
   const modelName = config.MODEL_NAME || name;
-  // o3-mini returns empty text via the Responses API — force Chat Completions
-  if (provider === "openai" && modelName.startsWith("o3-mini")) {
+  // o3-mini returns empty text via the Responses API — force Chat Completions.
+  // Custom OpenAI-compatible backends (OPENAI_BASE_URL) often lack Responses API
+  // support and silently return empty `json` extractions — prefer Chat Completions.
+  if (
+    provider === "openai" &&
+    (modelName.startsWith("o3-mini") || Boolean(config.OPENAI_BASE_URL))
+  ) {
     return providerList.openai.chat(modelName);
   }
   return providerList[provider](modelName);

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -20,7 +20,7 @@ type Provider =
   | "deepinfra"
   | "vertex";
 const defaultProvider: Provider = config.OLLAMA_BASE_URL ? "ollama" : "openai";
-const responsesOnlyOpenAIModelPrefixes = ["o3-pro", "gpt-5-pro"];
+const responsesOnlyOpenAIModelPrefixes = ["o1-pro", "o3-pro", "gpt-5-pro"];
 
 const providerList: Record<Provider, any> = {
   openai: createOpenAI({

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -20,6 +20,7 @@ type Provider =
   | "deepinfra"
   | "vertex";
 const defaultProvider: Provider = config.OLLAMA_BASE_URL ? "ollama" : "openai";
+const responsesOnlyOpenAIModelPrefixes = ["o3-pro", "gpt-5-pro"];
 
 const providerList: Record<Provider, any> = {
   openai: createOpenAI({
@@ -58,12 +59,16 @@ export function getModel(name: string, provider: Provider = defaultProvider) {
     name = "gemini-2.5-pro";
   }
   const modelName = config.MODEL_NAME || name;
+  const isResponsesOnlyOpenAIModel = responsesOnlyOpenAIModelPrefixes.some(
+    prefix => modelName === prefix || modelName.startsWith(`${prefix}-`),
+  );
   // o3-mini returns empty text via the Responses API — force Chat Completions.
   // Custom OpenAI-compatible backends (OPENAI_BASE_URL) often lack Responses API
   // support and silently return empty `json` extractions — prefer Chat Completions.
   if (
     provider === "openai" &&
-    (modelName.startsWith("o3-mini") || Boolean(config.OPENAI_BASE_URL))
+    (modelName.startsWith("o3-mini") ||
+      (Boolean(config.OPENAI_BASE_URL) && !isResponsesOnlyOpenAIModel))
   ) {
     return providerList.openai.chat(modelName);
   }


### PR DESCRIPTION
## Summary
- Broaden the `o3-mini` Responses-API escape hatch: when `OPENAI_BASE_URL` is set, route OpenAI models through Chat Completions.
- Avoids silent empty `json` extractions on OpenAI-compatible backends that do not implement the Responses API.

Fixes #4252

## Test plan
- [ ] With default OpenAI (no `OPENAI_BASE_URL`), behavior unchanged for non-`o3-mini` models
- [ ] With `OPENAI_BASE_URL` pointing at a Chat Completions-only backend, `formats: ["json"]` returns a `json` field
