### PR TITLE
fix(api): clear extendLockInterval if addJobPriority throws

### DIFF
--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1656,11 +1656,13 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
         }
       } finally {
         await deleteJobPriority(job.data.team_id, job.id);
-        if (extendLockInterval) {
-          clearInterval(extendLockInterval);
-        }
       }
     } finally {
+      // Clear outside the addJobPriority try so a Redis throw after setInterval
+      // cannot leave the lock-renewal timer firing forever (#4246).
+      if (extendLockInterval) {
+        clearInterval(extendLockInterval);
+      }
       if (!job.data.skipNuq && !isFdbJob) {
         await concurrentJobDone(job);
       }

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1587,9 +1587,10 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
   // FDB-backed jobs hold their concurrency slot through the queue lease; the
   // Redis slot mirror and promotion-on-done below are PG-backend machinery
   const isFdbJob = (job as any).backend === "fdb";
+  // Hoisted so the finally that clears it can see the binding (cubic P0 / #4246).
+  let extendLockInterval: NodeJS.Timeout | null = null;
   try {
     try {
-      let extendLockInterval: NodeJS.Timeout | null = null;
       if (
         !isFdbJob &&
         job.data?.mode !== "kickoff" &&


### PR DESCRIPTION
## Summary
- Move `clearInterval(extendLockInterval)` into the outer `finally` that always runs after the lock timer is created.
- Prevents a Redis throw from `addJobPriority` from leaking a forever-firing concurrency lock renewal.

Fixes #4246

## Test plan
- [ ] Confirm `clearInterval` runs even when `addJobPriority` throws
- [ ] Confirm the happy path still clears the interval once


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788748792&installation_model_id=11126&pr_number=4269&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4269&signature=b4c163484c866e7a619a65a4930eebbdba71cff4bec1aab8117b2b7c34c22e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always clear the concurrency lock-renewal timer, even when `addJobPriority` throws, by moving `clearInterval(extendLockInterval)` to the outer `finally` in `scrape-worker` and hoisting `extendLockInterval` to outer scope. Prevents a forever-firing interval, ReferenceErrors, and worker leaks; fixes #4246.

<sup>Written for commit ea6074765eac35838e5e00d9415d9d070b01d064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

