### PR TITLE
Bound redirect following in safeFetch to a browser-like limit

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -39,7 +39,7 @@ function createBaseAgent(skipTlsVerification: boolean) {
       });
 
   // Add redirect interceptor for handling redirects
-  return baseAgent.compose(interceptors.redirect({ maxRedirections: 5000 }));
+  return baseAgent.compose(interceptors.redirect({ maxRedirections: 20 }));
 }
 
 function attachSecurityCheck(agent: undici.Dispatcher) {


### PR DESCRIPTION
The secure dispatcher used for scraping and webhook delivery in `safeFetch.ts` follows up to 5000 redirects per request:

```ts
return baseAgent.compose(interceptors.redirect({ maxRedirections: 5000 }));
```

That is far beyond any legitimate redirect depth. Browsers cap redirect chains at around 20, and undici does not auto-follow redirects at all by default. Two practical concerns with 5000:

- Each redirect hop opens a new connection that re-runs the private-IP connect check in `attachSecurityCheck`, so a single request against an attacker-controlled site can be driven through thousands of round-trips and hold a worker for a long time. That is a cheap resource-exhaustion lever.
- It hides genuinely broken redirect loops behind a very large budget instead of failing fast.

This caps the chain at 20, which is well above what real targets need (stacked URL shorteners, consent and geo redirects rarely exceed a handful of hops) while removing the effectively-unbounded following behavior. No functional change for normal scrapes.

Happy to make the limit configurable via env instead of a constant if you prefer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788749604&installation_model_id=11126&pr_number=4270&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4270&signature=7194ebbf72d87254b6cba5b790e74a6ec2b55535fff6a053f35cc134be55251a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit redirect following in `safeFetch` to 20 to align with browser caps, reduce risk of long redirect chains exhausting workers, and surface broken loops sooner. Typical scrapes remain unchanged.

<sup>Written for commit 0f639273c56558a564bd88c702fb2745a4697d74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

