### PR TITLE
fix(api): enforce robots.txt denial in scrapeURL

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -1135,6 +1135,7 @@ export async function scrapeURL(
     }
 
     if (shouldCheckRobots(options, internalOptions)) {
+      let robotsError: CrawlDenialError | undefined;
       await withSpan("scrape.robots_check", async robotsSpan => {
         const urlToCheck = meta.rewrittenUrl || meta.url;
         meta.logger.info("Checking robots.txt", { url: urlToCheck });
@@ -1199,14 +1200,19 @@ export async function scrapeURL(
           }
         }
       }).catch(error => {
-        if (error.message === "URL blocked by robots.txt") {
-          return {
-            success: false,
-            error,
-          };
+        if (error instanceof CrawlDenialError) {
+          robotsError = error;
+          return;
         }
         throw error;
       });
+
+      if (robotsError) {
+        return {
+          success: false,
+          error: robotsError,
+        };
+      }
     }
 
     // Initialize retry tracker with configured limits

--- a/apps/api/src/scraper/scrapeURL/scrapeURL.robots.test.ts
+++ b/apps/api/src/scraper/scrapeURL/scrapeURL.robots.test.ts
@@ -1,44 +1,109 @@
 import "dotenv/config";
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "../../config";
 config.ENV = "test";
 
-vi.mock("../../lib/robots-txt", () => ({
-  fetchRobotsTxt: vi.fn(async () => ({
-    content: "User-agent: *\nDisallow: /blocked",
-    url: "https://firecrawl-test-site.vercel.app/robots.txt",
-  })),
-
-  createRobotsChecker: vi.fn(() => ({
-    robotsTxtUrl: "https://firecrawl-test-site.vercel.app/robots.txt",
-    robotsTxt: "User-agent: *\nDisallow: /blocked",
-    robots: {},
-  })),
-
-  isUrlAllowedByRobots: vi.fn(() => false),
+const mocks = vi.hoisted(() => ({
+  fetchRobotsTxt: vi.fn(),
+  createRobotsChecker: vi.fn(),
+  isUrlAllowedByRobots: vi.fn(),
+  scrapeURLWithEngine: vi.fn(),
 }));
+
+vi.mock("../../lib/robots-txt", () => ({
+  fetchRobotsTxt: mocks.fetchRobotsTxt,
+  createRobotsChecker: mocks.createRobotsChecker,
+  isUrlAllowedByRobots: mocks.isUrlAllowedByRobots,
+}));
+
+vi.mock("./engines", async importOriginal => {
+  const actual = await importOriginal<typeof import("./engines")>();
+
+  return {
+    ...actual,
+    scrapeURLWithEngine: mocks.scrapeURLWithEngine,
+  };
+});
 
 import { scrapeURL } from ".";
 import { scrapeOptions } from "../../controllers/v2/types";
 import { CostTracking } from "../../lib/cost-tracking";
+import { CrawlDenialError } from "../../lib/error";
+
+const TEST_URL = "https://firecrawl-test-site.vercel.app/page";
+
+async function runScrape(url = TEST_URL) {
+  return scrapeURL(
+    "test:robots",
+    url,
+    scrapeOptions.parse({}),
+    {
+      forceEngine: "fetch",
+      teamId: "test",
+      orgId: null,
+      teamFlags: {
+        checkRobotsOnScrape: true,
+      },
+    },
+    new CostTracking(),
+  );
+}
 
 describe("scrapeURL robots.txt enforcement", () => {
-  it("does not scrape a URL blocked by robots.txt", async () => {
-    const out = await scrapeURL(
-      "test:robots-blocked",
-      "https://firecrawl-test-site.vercel.app/blocked",
-      scrapeOptions.parse({}),
-      {
-        forceEngine: "fetch",
-        teamId: "test",
-        orgId: null,
-        teamFlags: {
-          checkRobotsOnScrape: true,
-        },
-      },
-      new CostTracking(),
-    );
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.fetchRobotsTxt.mockResolvedValue({
+      content: "User-agent: *\nDisallow: /blocked",
+      url: "https://firecrawl-test-site.vercel.app/robots.txt",
+    });
+
+    mocks.createRobotsChecker.mockReturnValue({
+      robotsTxtUrl: "https://firecrawl-test-site.vercel.app/robots.txt",
+      robotsTxt: "User-agent: *\nDisallow: /blocked",
+      robots: {},
+    });
+
+    mocks.scrapeURLWithEngine.mockResolvedValue({
+      url: TEST_URL,
+      html: "<html><body>scraped</body></html>",
+      markdown: "scraped",
+      statusCode: 200,
+      proxyUsed: "basic",
+    });
+  });
+
+  it("does not enter the scraping engine when robots.txt denies the URL", async () => {
+    mocks.isUrlAllowedByRobots.mockReturnValue(false);
+
+    const out = await runScrape();
 
     expect(out.success).toBe(false);
-  }, 30000);
+
+    if (!out.success) {
+      expect(out.error).toBeInstanceOf(CrawlDenialError);
+    }
+
+    expect(mocks.scrapeURLWithEngine).not.toHaveBeenCalled();
+  });
+
+  it("enters the scraping engine when robots.txt allows the URL", async () => {
+    mocks.isUrlAllowedByRobots.mockReturnValue(true);
+
+    const out = await runScrape();
+
+    expect(out.success).toBe(true);
+    expect(mocks.scrapeURLWithEngine).toHaveBeenCalled();
+  });
+
+  it("allows scraping when robots.txt cannot be fetched", async () => {
+    mocks.fetchRobotsTxt.mockRejectedValue(
+      new Error("Failed to fetch robots.txt"),
+    );
+
+    const out = await runScrape();
+
+    expect(out.success).toBe(true);
+    expect(mocks.scrapeURLWithEngine).toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/scraper/scrapeURL/scrapeURL.robots.test.ts
+++ b/apps/api/src/scraper/scrapeURL/scrapeURL.robots.test.ts
@@ -51,7 +51,7 @@ async function runScrape(url = TEST_URL) {
 
 describe("scrapeURL robots.txt enforcement", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
 
     mocks.fetchRobotsTxt.mockResolvedValue({
       content: "User-agent: *\nDisallow: /blocked",
@@ -104,6 +104,7 @@ describe("scrapeURL robots.txt enforcement", () => {
     const out = await runScrape();
 
     expect(out.success).toBe(true);
+    expect(mocks.isUrlAllowedByRobots).not.toHaveBeenCalled();
     expect(mocks.scrapeURLWithEngine).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/scraper/scrapeURL/scrapeURL.robots.test.ts
+++ b/apps/api/src/scraper/scrapeURL/scrapeURL.robots.test.ts
@@ -1,0 +1,44 @@
+import "dotenv/config";
+
+import { config } from "../../config";
+config.ENV = "test";
+
+vi.mock("../../lib/robots-txt", () => ({
+  fetchRobotsTxt: vi.fn(async () => ({
+    content: "User-agent: *\nDisallow: /blocked",
+    url: "https://firecrawl-test-site.vercel.app/robots.txt",
+  })),
+
+  createRobotsChecker: vi.fn(() => ({
+    robotsTxtUrl: "https://firecrawl-test-site.vercel.app/robots.txt",
+    robotsTxt: "User-agent: *\nDisallow: /blocked",
+    robots: {},
+  })),
+
+  isUrlAllowedByRobots: vi.fn(() => false),
+}));
+
+import { scrapeURL } from ".";
+import { scrapeOptions } from "../../controllers/v2/types";
+import { CostTracking } from "../../lib/cost-tracking";
+
+describe("scrapeURL robots.txt enforcement", () => {
+  it("does not scrape a URL blocked by robots.txt", async () => {
+    const out = await scrapeURL(
+      "test:robots-blocked",
+      "https://firecrawl-test-site.vercel.app/blocked",
+      scrapeOptions.parse({}),
+      {
+        forceEngine: "fetch",
+        teamId: "test",
+        orgId: null,
+        teamFlags: {
+          checkRobotsOnScrape: true,
+        },
+      },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(false);
+  }, 30000);
+});


### PR DESCRIPTION
Fixes #4241

## What changed

`scrapeURL` already detected URLs disallowed by `robots.txt` and threw a `CrawlDenialError`, but the `.catch()` on the robots check converted that error into `{ success: false, error }` without returning it from `scrapeURL`.

Because the result of the awaited expression was discarded, execution continued into the scraping pipeline and the blocked URL was scraped anyway.

This change:

* captures `CrawlDenialError` from the robots.txt check
* returns `{ success: false, error }` from `scrapeURL` before the retry tracker or scraping engines are reached
* uses `instanceof CrawlDenialError` instead of matching the error message string
* preserves the existing behavior of allowing a scrape when fetching or parsing `robots.txt` itself fails

## Regression test

Added `scrapeURL.robots.test.ts` with the robots.txt helpers mocked so the requested URL is explicitly disallowed.

Before the fix, the regression test reproduced the bug:

```text
URL blocked by robots.txt
Scraping URL "https://firecrawl-test-site.vercel.app/blocked"...
Scraping via fetch...
AssertionError: expected true to be false
```

After the fix:

```text
URL blocked by robots.txt
✓ scrapeURL.robots.test.ts (1 test)
Test Files  1 passed (1)
Tests       1 passed (1)
```

The scraping engine is no longer entered after the robots.txt denial.

## Tests

From `apps/api`:

```bash
pnpm harness pnpm exec vitest run \
  src/scraper/scrapeURL/scrapeURL.robots.test.ts
```

Result: **1 test passed**.

The harness also successfully builds the API with TypeScript before running the test.

## Impact

No configuration, migration, or deployment changes.

This only changes behavior when the existing robots.txt check is enabled: a URL explicitly denied by robots.txt now stops before entering the scraping pipeline instead of silently continuing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl/pr/4271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788767998&installation_model_id=11126&pr_number=4271&repository=firecrawl%2Ffirecrawl&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl%2Fpull%2F4271&signature=883e1acee6b18a03db1185da6f52d6c9d8523349129bcff3b39583af3fc71ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces robots.txt denial in `scrapeURL` so blocked URLs never reach the scraping engines. Fixes #4241.

- **Bug Fixes**
  - Return early from `scrapeURL` on `CrawlDenialError` to prevent scraping disallowed URLs.
  - Use `instanceof CrawlDenialError` instead of checking the message string.
  - Strengthen tests (`scrapeURL.robots.test.ts`): blocked URLs return `success: false` and engines are not called; allowed URLs proceed; on robots.txt fetch failure, the allow-check is skipped and scraping continues.

<sup>Written for commit de7887ee497b648756b9f334d38bd77befcfff2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

