### PR TITLE
fix(api): reject private IP literals before proxy dispatch

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.proxy.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.proxy.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Dispatcher } from "undici";
+
+const config = vi.hoisted(() => ({
+  ALLOW_LOCAL_WEBHOOKS: false as boolean | undefined,
+  PROXY_SERVER: undefined as string | undefined,
+  PROXY_USERNAME: undefined as string | undefined,
+  PROXY_PASSWORD: undefined as string | undefined,
+}));
+
+vi.mock("../../../../config", () => ({ config }));
+
+import {
+  InsecureConnectionError,
+  rejectPrivateIPLiteralTargets,
+} from "./safeFetch";
+
+const previousAllowLocalWebhooks = config.ALLOW_LOCAL_WEBHOOKS;
+
+afterEach(() => {
+  config.ALLOW_LOCAL_WEBHOOKS = previousAllowLocalWebhooks;
+});
+
+function invoke(origin: string) {
+  const inner = vi.fn(() => true) as unknown as Dispatcher.Dispatch;
+  const onError = vi.fn();
+  const dispatch = rejectPrivateIPLiteralTargets(inner);
+
+  const accepted = dispatch(
+    {
+      origin,
+      path: "/",
+      method: "GET",
+    },
+    { onError } as unknown as Dispatcher.DispatchHandler,
+  );
+
+  return { accepted, inner, onError };
+}
+
+describe("proxy destination IP-literal guard", () => {
+  it("rejects an IPv4 loopback target before dispatch", () => {
+    config.ALLOW_LOCAL_WEBHOOKS = false;
+
+    const { accepted, inner, onError } = invoke("http://127.0.0.1:9911");
+
+    expect(accepted).toBe(true);
+    expect(inner).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(InsecureConnectionError);
+  });
+
+  it("rejects a bracketed IPv6 loopback target before dispatch", () => {
+    config.ALLOW_LOCAL_WEBHOOKS = false;
+
+    const { inner, onError } = invoke("http://[::1]:9911");
+
+    expect(inner).not.toHaveBeenCalled();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(InsecureConnectionError);
+  });
+
+  it("passes a public IP literal to the underlying dispatcher", () => {
+    config.ALLOW_LOCAL_WEBHOOKS = false;
+
+    const { inner, onError } = invoke("https://93.184.216.34/");
+
+    expect(inner).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("preserves the explicit local-network opt-in", () => {
+    config.ALLOW_LOCAL_WEBHOOKS = true;
+
+    const { inner, onError } = invoke("http://127.0.0.1:9911");
+
+    expect(inner).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.proxy.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.proxy.test.ts
@@ -1,5 +1,7 @@
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import { Agent, interceptors, request, type Dispatcher } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Dispatcher } from "undici";
 
 const config = vi.hoisted(() => ({
   ALLOW_LOCAL_WEBHOOKS: false as boolean | undefined,
@@ -36,6 +38,23 @@ function invoke(origin: string) {
   );
 
   return { accepted, inner, onError };
+}
+
+async function listen(server: Server, host?: string) {
+  server.listen(0, host);
+  await once(server, "listening");
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected a TCP test server");
+  }
+
+  return address.port;
+}
+
+async function close(server: Server) {
+  server.close();
+  await once(server, "close");
 }
 
 describe("proxy destination IP-literal guard", () => {
@@ -75,5 +94,40 @@ describe("proxy destination IP-literal guard", () => {
 
     expect(inner).toHaveBeenCalledOnce();
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("re-applies the guard when the redirect interceptor follows a Location", async () => {
+    config.ALLOW_LOCAL_WEBHOOKS = false;
+    let privateTargetHits = 0;
+
+    const privateTarget = createServer((_req, res) => {
+      privateTargetHits += 1;
+      res.end("private target reached");
+    });
+    const privateTargetPort = await listen(privateTarget, "127.0.0.1");
+
+    const redirector = createServer((_req, res) => {
+      res.writeHead(302, {
+        location: `http://127.0.0.1:${privateTargetPort}/secret`,
+      });
+      res.end();
+    });
+    const redirectorPort = await listen(redirector);
+
+    const dispatcher = new Agent().compose(
+      rejectPrivateIPLiteralTargets,
+      interceptors.redirect({ maxRedirections: 5 }),
+    );
+
+    try {
+      await expect(
+        request(`http://localhost:${redirectorPort}/start`, { dispatcher }),
+      ).rejects.toBeInstanceOf(InsecureConnectionError);
+      expect(privateTargetHits).toBe(0);
+    } finally {
+      await dispatcher.close();
+      await close(redirector);
+      await close(privateTarget);
+    }
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -34,18 +34,34 @@ export const rejectPrivateIPLiteralTargets: undici.Dispatcher.DispatcherComposeI
       return dispatch(options, handler);
     }
 
+    let privateIPLiteral = false;
+
     try {
       const origin =
         options.origin instanceof URL
           ? options.origin
           : new URL(options.origin.toString());
       const hostname = origin.hostname.replace(/^\[|\]$/g, "");
-      if (isIPPrivate(hostname)) {
-        handler.onError(new InsecureConnectionError());
-        return true;
-      }
+      privateIPLiteral = isIPPrivate(hostname);
     } catch {
       // Let Undici report malformed origins through its normal path.
+    }
+
+    if (privateIPLiteral) {
+      const error = new InsecureConnectionError();
+      const compatibleHandler = handler as typeof handler & {
+        onResponseError?: (controller: unknown, error: Error) => void;
+      };
+
+      if (typeof compatibleHandler.onError === "function") {
+        compatibleHandler.onError(error);
+      } else if (typeof compatibleHandler.onResponseError === "function") {
+        compatibleHandler.onResponseError(null, error);
+      } else {
+        throw error;
+      }
+
+      return true;
     }
 
     return dispatch(options, handler);

--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts
@@ -19,6 +19,38 @@ export function isIPPrivate(address: string): boolean {
   return addr.range() !== "unicast";
 }
 
+/**
+ * Reject private IP literals before a ProxyAgent opens a CONNECT tunnel.
+ *
+ * The socket-level check below sees the proxy socket when PROXY_SERVER is
+ * configured, not the requested destination. This interceptor therefore
+ * closes the deterministic IP-literal gap for both the initial request and
+ * redirects. Hostnames resolved by the proxy still require destination
+ * filtering at the proxy, because local DNS may not match proxy-side DNS.
+ */
+export const rejectPrivateIPLiteralTargets: undici.Dispatcher.DispatcherComposeInterceptor =
+  dispatch => (options, handler) => {
+    if (config.ALLOW_LOCAL_WEBHOOKS === true || options.origin === undefined) {
+      return dispatch(options, handler);
+    }
+
+    try {
+      const origin =
+        options.origin instanceof URL
+          ? options.origin
+          : new URL(options.origin.toString());
+      const hostname = origin.hostname.replace(/^\[|\]$/g, "");
+      if (isIPPrivate(hostname)) {
+        handler.onError(new InsecureConnectionError());
+        return true;
+      }
+    } catch {
+      // Let Undici report malformed origins through its normal path.
+    }
+
+    return dispatch(options, handler);
+  };
+
 function createBaseAgent(skipTlsVerification: boolean) {
   const baseAgent = config.PROXY_SERVER
     ? new undici.ProxyAgent({
@@ -39,7 +71,10 @@ function createBaseAgent(skipTlsVerification: boolean) {
       });
 
   // Add redirect interceptor for handling redirects
-  return baseAgent.compose(interceptors.redirect({ maxRedirections: 5000 }));
+  return baseAgent.compose(
+    rejectPrivateIPLiteralTargets,
+    interceptors.redirect({ maxRedirections: 5000 }),
+  );
 }
 
 function attachSecurityCheck(agent: undici.Dispatcher) {


### PR DESCRIPTION
## Problem

When `PROXY_SERVER` is configured, the `safeFetch` connection check sees the
proxy socket's `remoteAddress`, not the requested destination. A private IP
literal is blocked without a proxy but can reach the dispatcher when the proxy
itself has a public address.

The controlled API reproduction used the same
`http://127.0.0.1:9911/secret` target in both cases. The direct request was
blocked and did not reach the target. Through a restricted researcher-owned
proxy, the request reached the target and returned its marker.

## Change

Add a destination interceptor before `ProxyAgent` dispatch. It rejects private
IPv4 and IPv6 literals on the initial request and redirects, using the existing
`InsecureConnectionError`. `ALLOW_LOCAL_WEBHOOKS=true` remains the explicit
opt-in for local destinations.

The interceptor does not resolve hostnames locally. A proxy can use a different
DNS view, so proxy-side DNS and rebinding protection are still required.

## Validation

- `git diff --check`
- Prettier on the changed source and test
- Vitest: 5/5 passing
  - IPv4 loopback rejected
  - bracketed IPv6 loopback rejected
  - public IP literal allowed
  - `ALLOW_LOCAL_WEBHOOKS=true` allowed
  - composed 302 redirect to a private IP literal rejected with zero target hits

This is a defense-in-depth change and does not replace the documented
requirement for a proxy that blocks private and link-local destinations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block private IP literal targets in `safeFetch` before `ProxyAgent` dispatch to close a proxy bypass gap, including during redirects. `ALLOW_LOCAL_WEBHOOKS=true` still allows local targets.

- **Bug Fixes**
  - Added `rejectPrivateIPLiteralTargets` `undici` interceptor to reject private IPv4/IPv6 literals with `InsecureConnectionError`.
  - Composed before the redirect interceptor so checks re-run on each redirect; does not resolve hostnames locally (proxy must still filter hostnames).
  - Added tests for IPv4/IPv6 loopback rejection, public IP acceptance, `ALLOW_LOCAL_WEBHOOKS` opt-in, and blocking redirects to private targets so they are never reached.

<sup>Written for commit a8dc192881f816fae883baeea2bb16ff453af0ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

