### PR TITLE
fix(self-host): make FoundationDB init idempotent

### DIFF
--- a/apps/api/src/harness.ts
+++ b/apps/api/src/harness.ts
@@ -748,7 +748,7 @@ async function setupFdb(): Promise<Services["fdb"]> {
   // configured" failure and surface any real configure error.
   const configure = execForward(
     `${runtime}@fdb-configure`,
-    `${runtime} exec ${containerName} sh -c 'out=$(fdbcli --exec "configure new single memory" 2>&1); status=$?; printf "%s\\n" "$out"; if [ "$status" -eq 0 ]; then exit 0; fi; printf "%s\\n" "$out" | grep -Eiq "already.*configured|database.*configured"'`,
+    `${runtime} exec ${containerName} sh -c 'out=$(fdbcli --exec "configure new single memory" 2>&1); status=$?; printf "%s\\n" "$out"; if [ "$status" -eq 0 ]; then exit 0; fi; printf "%s\\n" "$out" | grep -Eiq "already.*configured|database.*configured|database.*already exists"'`,
   );
   await configure.promise;
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -203,7 +203,7 @@ services:
     entrypoint:
       - /bin/bash
       - -c
-      - "sleep 5 && out=$(fdbcli -C /var/fdb/fdb.cluster --exec 'configure new single ssd' 2>&1); status=$$?; printf '%s\n' \"$$out\"; if [ \"$$status\" -eq 0 ]; then exit 0; fi; printf '%s\n' \"$$out\" | grep -Eiq 'already.*configured|database.*configured'"
+      - "sleep 5 && out=$(fdbcli -C /var/fdb/fdb.cluster --exec 'configure new single ssd' 2>&1); status=$$?; printf '%s\n' \"$$out\"; if [ \"$$status\" -eq 0 ]; then exit 0; fi; printf '%s\n' \"$$out\" | grep -Eiq 'already.*configured|database.*configured|database.*already exists'"
     volumes:
       - fdb-cluster-file:/var/fdb
     networks:


### PR DESCRIPTION
Fixes #4265

## Problem

`foundationdb-init` is intended to be a one-shot service that becomes a no-op
after first boot. With FoundationDB 7.3.63 and a persistent volume, the second
identical invocation returns:

```text
ERROR: Database already exists! To change configuration, don't say `new'
```

The current allowlist accepts `already ... configured` and
`database ... configured`, but not the actual `Database already exists`
response. The second invocation exits 1 even though the database is valid.

## Change

Accept `database.*already exists` in both FoundationDB startup paths:

- `docker-compose.yaml`
- `apps/api/src/harness.ts`

Other nonzero `fdbcli` errors still propagate.

## Validation

The same two-invocation experiment was run before and after the patch on fresh
named volumes:

| State | First init | Second init |
|---|---:|---:|
| Before | 0 | 1 |
| After | 0 | 0 |

Also checked:

- patch applies cleanly to current `main`
- `git diff --check`
- `docker compose config -q`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make FoundationDB init idempotent for self-hosted installs. Repeated runs no longer fail when the database already exists on FDB 7.3.63 with persistent volumes.

- **Bug Fixes**
  - Treat “database.*already exists” as a successful init in both startup paths (docker-compose init and API `setupFdb`), while still surfacing real `fdbcli` errors.

<sup>Written for commit 56b092ec2bc7be13e23a74e125e12e8385c95115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

