### PR TITLE
fix(api): return 404 for unknown v2 extract jobs

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/extract-status.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/extract-status.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getExtract: vi.fn(),
+  getExtractExpiry: vi.fn(),
+  getExtractResult: vi.fn(),
+  getJobFromGCS: vi.fn(),
+  supabaseGetAgentByIdDirect: vi.fn(),
+  supabaseGetExtractByIdDirect: vi.fn(),
+  supabaseGetExtractRequestByIdDirect: vi.fn(),
+}));
+
+vi.mock("../../../config", () => ({
+  config: {
+    USE_DB_AUTHENTICATION: false,
+    GCS_BUCKET_NAME: undefined,
+  },
+}));
+
+vi.mock("../../../lib/extract/extract-redis", () => ({
+  getExtract: mocks.getExtract,
+  getExtractExpiry: mocks.getExtractExpiry,
+  getExtractResult: mocks.getExtractResult,
+}));
+
+vi.mock("../../../lib/supabase-jobs", () => ({
+  supabaseGetAgentByIdDirect: mocks.supabaseGetAgentByIdDirect,
+  supabaseGetExtractByIdDirect: mocks.supabaseGetExtractByIdDirect,
+  supabaseGetExtractRequestByIdDirect:
+    mocks.supabaseGetExtractRequestByIdDirect,
+}));
+
+vi.mock("../../../lib/gcs-jobs", () => ({
+  getJobFromGCS: mocks.getJobFromGCS,
+}));
+
+vi.mock("../../../lib/logger", () => ({ logger: {} }));
+
+import { config } from "../../../config";
+import { extractStatusController } from "../extract-status";
+
+function responseMock() {
+  const res: any = {
+    status: vi.fn(),
+    json: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  return res;
+}
+
+describe("v2 extract status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    config.USE_DB_AUTHENTICATION = false;
+    mocks.getExtract.mockResolvedValue(null);
+  });
+
+  it("returns 404 for an unknown self-hosted job instead of dereferencing null", async () => {
+    const req: any = {
+      params: { jobId: "00000000-0000-4000-8000-000000000001" },
+      auth: { team_id: "bypass" },
+    };
+    const res = responseMock();
+
+    await extractStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: "Extract job not found",
+    });
+    expect(mocks.getExtractExpiry).not.toHaveBeenCalled();
+  });
+
+  it("retains the authenticated in-progress fallback for an owned request", async () => {
+    config.USE_DB_AUTHENTICATION = true;
+    mocks.supabaseGetExtractRequestByIdDirect.mockResolvedValue({
+      team_id: "team-a",
+      kind: "extract",
+      created_at: "2026-08-08T00:00:00.000Z",
+    });
+    mocks.supabaseGetExtractByIdDirect.mockResolvedValue(null);
+    const req: any = {
+      params: { jobId: "00000000-0000-4000-8000-000000000002" },
+      auth: { team_id: "team-a" },
+    };
+    const res = responseMock();
+
+    await extractStatusController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, status: "processing" }),
+    );
+  });
+});

--- a/apps/api/src/controllers/v2/extract-status.ts
+++ b/apps/api/src/controllers/v2/extract-status.ts
@@ -97,6 +97,13 @@ export async function extractStatusController(
       }
     }
 
+    if (!extractRequest) {
+      return res.status(404).json({
+        success: false,
+        error: "Extract job not found",
+      });
+    }
+
     // Fall back to extractRequest info
     return res.status(200).json({
       success: true,


### PR DESCRIPTION
## Problem

On a self-hosted deployment with `USE_DB_AUTHENTICATION=false`, a valid but
unknown UUID sent to `GET /v2/extract/:jobId` returns HTTP 500. With no Redis
job, `extractRequest` remains null and the controller dereferences
`extractRequest.created_at`.

The reproduced error was:

```text
TypeError: Cannot read properties of null (reading 'created_at')
```

The v1 controller already returns 404 for the same state.

## Change

Return the existing non-enumerating 404 response when neither Redis nor the
database provides an extract request:

```json
{ "success": false, "error": "Extract job not found" }
```

The authenticated in-progress fallback for a real owned request is unchanged.

## Validation

- unknown self-host job returns 404 without requesting an expiry
- authenticated owned request with no final database row retains the 200
  `processing` fallback
- Vitest: 2/2 passing
- Prettier: passing
- `git diff --check`: passing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 for unknown v2 extract job IDs in `GET /v2/extract/:jobId` instead of throwing a 500 on self-hosted setups. This aligns v2 with v1 behavior.

- **Bug Fixes**
  - Return `{ success: false, error: "Extract job not found" }` when neither Redis nor the database has the job.
  - Skip expiry lookups for unknown jobs.
  - Keep the 200 `processing` fallback for authenticated in-progress owned requests.
  - Add Vitest tests for unknown self-hosted jobs and the authenticated fallback.

<sup>Written for commit 7c88650a8db8babb479ae77031310e4e0a02e043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

