### PR TITLE
fix(api): point keyless recovery at API keys

### DIFF
--- a/apps/api/src/__tests__/snips/v2/keyless.test.ts
+++ b/apps/api/src/__tests__/snips/v2/keyless.test.ts
@@ -106,8 +106,12 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
     expect(response.body.error).toContain(
       "not supported by the keyless free tier",
     );
-    expect(response.body.error).toContain("https://www.firecrawl.dev/signin");
-    expect(response.body.error).toContain("Authorization: Bearer YOUR_API_KEY");
+    expect(response.body.error).toContain(
+      "https://www.firecrawl.dev/app/api-keys",
+    );
+    expect(response.body.error).toContain("Authorization: Bearer header");
+    expect(response.body.error).toContain("Do not share the API key in chat");
+    expect(response.body.error).toContain("put it in a URL");
   });
 
   it(
@@ -157,8 +161,12 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
     expect(blocked.statusCode).toBe(429);
     expect(blocked.body.error).toContain("keyless free tier rate limit");
-    expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
-    expect(blocked.body.error).toContain("Authorization: Bearer YOUR_API_KEY");
+    expect(blocked.body.error).toContain(
+      "https://www.firecrawl.dev/app/api-keys",
+    );
+    expect(blocked.body.error).toContain("Authorization: Bearer header");
+    expect(blocked.body.error).toContain("Do not share the API key in chat");
+    expect(blocked.body.error).toContain("put it in a URL");
     // Out of quota → emit the OAuth-discovery header so agents find the key flow.
     expect(blocked.headers["www-authenticate"]).toContain("resource_metadata");
   });
@@ -182,8 +190,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
     expect(blocked.statusCode).toBe(429);
     expect(blocked.body.error).toContain("keyless free tier rate limit");
-    expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
-    expect(blocked.body.error).toContain("Authorization: Bearer YOUR_API_KEY");
+    expect(blocked.body.error).toContain(
+      "https://www.firecrawl.dev/app/api-keys",
+    );
+    expect(blocked.body.error).toContain("Authorization: Bearer header");
   });
 
   it("enforces the daily credit cap on parse (429)", async () => {
@@ -211,8 +221,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
     expect(blocked.statusCode).toBe(429);
     expect(blocked.body.error).toContain("keyless free tier rate limit");
-    expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
-    expect(blocked.body.error).toContain("Authorization: Bearer YOUR_API_KEY");
+    expect(blocked.body.error).toContain(
+      "https://www.firecrawl.dev/app/api-keys",
+    );
+    expect(blocked.body.error).toContain("Authorization: Bearer header");
   });
 
   it(
@@ -254,10 +266,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.reason).toBe("credits");
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
       expect(blocked.headers["www-authenticate"]).toContain(
         "resource_metadata",
       );
@@ -299,10 +311,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.reason).toBe("credits");
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
       expect(blocked.headers["www-authenticate"]).toContain(
         "resource_metadata",
       );
@@ -341,10 +353,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
       expect(blocked.headers["www-authenticate"]).toContain(
         "resource_metadata",
       );
@@ -471,10 +483,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
       expect(blocked.headers["www-authenticate"]).toContain(
         "resource_metadata",
       );
@@ -510,10 +522,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
       expect(blocked.headers["www-authenticate"]).toContain(
         "resource_metadata",
       );
@@ -561,10 +573,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
         .send({ origin: "mcp" });
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
 
       // Without the secret, the forwarded IP is ignored (keyed on the real IP).
       const allowed = await request(TEST_API_URL)
@@ -684,10 +696,10 @@ describeIf(KEYLESS_ENABLED)("Keyless free tier", () => {
 
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body.error).toContain("keyless free tier rate limit");
-      expect(blocked.body.error).toContain("https://www.firecrawl.dev/signin");
       expect(blocked.body.error).toContain(
-        "Authorization: Bearer YOUR_API_KEY",
+        "https://www.firecrawl.dev/app/api-keys",
       );
+      expect(blocked.body.error).toContain("Authorization: Bearer header");
       expect(blocked.headers["www-authenticate"]).toContain(
         "resource_metadata",
       );

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -385,10 +385,9 @@ export async function clearACUCTeam(team_id: string): Promise<void> {
   await deleteKey(`acuc_team_${team_id}`);
 }
 
-const KEYLESS_ENDPOINT_NOT_AVAILABLE_MESSAGE = `This endpoint is not supported by the keyless free tier. Sign up for a free API key at https://www.firecrawl.dev/signin for more endpoints, more usage, and higher rate limits.
+const KEYLESS_ENDPOINT_NOT_AVAILABLE_MESSAGE = `This endpoint is not supported by the keyless free tier. Sign up for a free API key at https://www.firecrawl.dev/app/api-keys for more endpoints, more usage, and higher rate limits.
 
-Then authenticate with:
-Authorization: Bearer YOUR_API_KEY`;
+Then configure your client to send it as an Authorization: Bearer header. Do not share the API key in chat or put it in a URL.`;
 
 const KEYLESS_SUSPICIOUS_IP_MESSAGE = `Unfortunately, your IP address looks suspicious, so Firecrawl can't be used without an API key from here. Sign up for a free API key at https://firecrawl.dev for 1000 credits and higher rate limits for free. (If you're an agent, you can also use https://firecrawl.dev/auth.md)`;
 

--- a/apps/api/src/lib/keyless.conversion.test.ts
+++ b/apps/api/src/lib/keyless.conversion.test.ts
@@ -7,6 +7,7 @@ import { config } from "../config";
 import { logger } from "./logger";
 import {
   KEYLESS_CONVERSION_COHORT_VERSION,
+  KEYLESS_FREE_TIER_LIMIT_MESSAGE,
   keylessConversionCohort,
   keylessExhaustionTelemetry,
   keylessLimitBody,
@@ -51,6 +52,25 @@ describe("keyless conversion cohort telemetry", () => {
 
     expect(keylessConversionCohort("   ")).toBeUndefined();
     expect(keylessExhaustionTelemetry("   ")).toEqual({});
+  });
+
+  it("points quota recovery at API keys without asking for chat credential sharing", () => {
+    expect(KEYLESS_FREE_TIER_LIMIT_MESSAGE).toContain(
+      "https://www.firecrawl.dev/app/api-keys",
+    );
+    expect(KEYLESS_FREE_TIER_LIMIT_MESSAGE).not.toContain(
+      "https://www.firecrawl.dev/signin",
+    );
+    expect(KEYLESS_FREE_TIER_LIMIT_MESSAGE).not.toContain(
+      "Authorization: Bearer YOUR_API_KEY",
+    );
+    expect(KEYLESS_FREE_TIER_LIMIT_MESSAGE).toContain(
+      "Authorization: Bearer header",
+    );
+    expect(KEYLESS_FREE_TIER_LIMIT_MESSAGE).toContain(
+      "Do not share the API key in chat",
+    );
+    expect(KEYLESS_FREE_TIER_LIMIT_MESSAGE).toContain("put it in a URL");
   });
 
   it("adds the cohort to reservation-limit exhaustion telemetry", async () => {

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -20,10 +20,9 @@ const KEYLESS_REQUESTS_PER_DAY = config.KEYLESS_REQUESTS_PER_DAY;
 const KEYLESS_CREDITS_PER_DAY = config.KEYLESS_CREDITS_PER_DAY;
 
 // Shared 429 copy for both keyless request-cap and credit-cap failures.
-export const KEYLESS_FREE_TIER_LIMIT_MESSAGE = `You've hit Firecrawl's keyless free tier rate limit. To continue now, create a free API key at https://www.firecrawl.dev/signin.
+export const KEYLESS_FREE_TIER_LIMIT_MESSAGE = `You've hit Firecrawl's keyless free tier rate limit. To continue now, create a free API key at https://www.firecrawl.dev/app/api-keys.
 
-Then authenticate with:
-Authorization: Bearer YOUR_API_KEY`;
+Then configure your client to send it as an Authorization: Bearer header. Do not share the API key in chat or put it in a URL.`;
 
 // The tier is "configured" when BOTH limits are set — even to 0. Unset means the
 // feature is off (callers get a plain Unauthorized); 0 means it's on but the


### PR DESCRIPTION
## Why

Keyless API recovery messages pointed users at the generic sign-in page and included a raw `Authorization: Bearer YOUR_API_KEY` template in model-visible text. Agent-mediated callers can repeat that template into chat or invite users to provide a credential there.

## What changed

- Points keyless quota and unsupported-endpoint recovery at `https://www.firecrawl.dev/app/api-keys`
- Keeps the post-login destination through the existing sign-in redirect
- Replaces the copyable bearer-token template with client-configuration guidance
- Explicitly says not to share API keys in chat or put them in URLs
- Adds regression coverage for the destination and credential-safety wording

## Validation

- `pnpm exec prettier --check src/lib/keyless.ts src/controllers/auth.ts src/lib/keyless.conversion.test.ts src/__tests__/snips/v2/keyless.test.ts`
- `TEST_SUITE_WEBSITE=https://example.com pnpm exec vitest run src/lib/keyless.conversion.test.ts src/__tests__/snips/v2/keyless.test.ts` (5 passed, 27 environment-gated skipped)
- `pnpm exec tsc --noEmit`
- Verified logged-out `https://www.firecrawl.dev/app/api-keys` redirects to `/signin?redirect=%2Fapp%2Fapi-keys`


## CI note

All functional CI jobs passed. The dependency audit reports existing `nanoid` advisories that also fail on the scheduled `main` audit: https://github.com/firecrawl/firecrawl/actions/runs/31268679603


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Directs keyless recovery messages to the API Keys page and removes copyable token templates to reduce credential leakage in chats. Fixes misleading sign-in links and clarifies safe client configuration.

- **Bug Fixes**
  - Link quota and unsupported-endpoint errors to https://www.firecrawl.dev/app/api-keys and keep post-login redirect.
  - Replace raw "Authorization: Bearer YOUR_API_KEY" with guidance to use an Authorization: Bearer header; warn not to share keys in chat or put them in URLs.
  - Update tests to assert the new link and safety wording, adding regression coverage.

<sup>Written for commit 0d42c27b3ac4238a04c9bf54a2f56f84fa52b3fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


