### PR TITLE
Add Redis health check with fail-fast timeout to liveness endpoint

### DIFF
--- a/apps/api/src/controllers/v0/liveness.ts
+++ b/apps/api/src/controllers/v0/liveness.ts
@@ -1,6 +1,29 @@
 import { Request, Response } from "express";
+import { redisRateLimitClient } from "../../services/rate-limiter";
+import { logger } from "../../lib/logger";
+
+const REDIS_PING_TIMEOUT_MS = 2000;
 
 export async function livenessController(req: Request, res: Response) {
-  //TODO: add checks if the application is live and healthy like checking the redis connection
-  res.status(200).json({ status: "ok" });
+  try {
+    // Verify the application can reach Redis by issuing a PING.
+    // Fail fast if Redis does not respond in time, rather than waiting for
+    // ioredis to reconnect.
+    const pong = await Promise.race([
+      redisRateLimitClient.ping(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Redis PING timed out")),
+          REDIS_PING_TIMEOUT_MS,
+        ),
+      ),
+    ]);
+    if (pong !== "PONG") {
+      throw new Error(`Unexpected Redis PING response: ${pong}`);
+    }
+    res.status(200).json({ status: "ok" });
+  } catch (error) {
+    logger.error("Liveness check failed: Redis is unreachable", { error });
+    res.status(503).json({ status: "error", error: "Redis is unreachable" });
+  }
 }


### PR DESCRIPTION
Resolves the liveness TODO by pinging the existing redisRateLimitClient connection, returning 503 if unreachable. Adds a 2s timeout so the check fails fast instead of waiting on ioredis reconnection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Redis health check to the liveness endpoint that pings Redis with a 2s timeout to fail fast instead of waiting on `ioredis` reconnects. Returns 503 and logs an error when Redis is unreachable; returns 200 when healthy.

<sup>Written for commit c0f1facd2cb244414ada4993690e9cbd27691bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

