### PR TITLE
fix(python-sdk): avoid paginating every batch status poll in wait loops

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -4,6 +4,7 @@ Unit tests for Firecrawl v2 pagination functionality.
 
 import pytest
 import time
+import asyncio
 from unittest.mock import Mock, patch, AsyncMock
 from typing import Dict, Any, List
 
@@ -15,7 +16,12 @@ from firecrawl.v2.types import (
     DocumentMetadata
 )
 from firecrawl.v2.methods.crawl import get_crawl_status, get_crawl_status_page, _fetch_all_pages
-from firecrawl.v2.methods.batch import get_batch_scrape_status, get_batch_scrape_status_page, _fetch_all_batch_pages
+from firecrawl.v2.methods.batch import (
+    get_batch_scrape_status,
+    get_batch_scrape_status_page,
+    _fetch_all_batch_pages,
+    wait_for_batch_completion,
+)
 from firecrawl.v2.methods.aio.crawl import (
     get_crawl_status as get_crawl_status_async,
     get_crawl_status_page as get_crawl_status_page_async,
@@ -481,6 +487,74 @@ class TestBatchScrapePagination:
         assert result.next is None  # Should be None when auto_paginate=True
         assert len(result.data) == 2
         assert self.mock_client.get.call_count == 2
+
+    def test_wait_for_batch_completion_does_not_paginate_polls(self):
+        """Status polls must be cheap (no pagination); the full result set is
+        only materialized once the job has completed."""
+        import firecrawl.v2.methods.batch as batch_module
+
+        # Poll 1: job still running
+        in_progress = Mock()
+        in_progress.ok = True
+        in_progress.json.return_value = {
+            "success": True,
+            "status": "scraping",
+            "completed": 5,
+            "total": 10,
+            "creditsUsed": 2,
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "next": "https://api.firecrawl.dev/v2/batch/scrape/test-batch-123?page=2",
+            "data": [],
+        }
+
+        # Poll 2: completed, first page of results
+        completed_page1 = Mock()
+        completed_page1.ok = True
+        completed_page1.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 10,
+            "total": 10,
+            "creditsUsed": 4,
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "next": "https://api.firecrawl.dev/v2/batch/scrape/test-batch-123?page=2",
+            "data": [self.sample_doc],
+        }
+
+        # Second page of the completed job
+        completed_page2 = Mock()
+        completed_page2.ok = True
+        completed_page2.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 10,
+            "total": 10,
+            "creditsUsed": 4,
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "next": None,
+            "data": [self.sample_doc],
+        }
+
+        self.mock_client.get.side_effect = [in_progress, completed_page1, completed_page1, completed_page2]
+
+        configs_seen = []
+        real_get = batch_module.get_batch_scrape_status
+
+        def tracking_get(client, job_id, pagination_config=None):
+            configs_seen.append(pagination_config)
+            return real_get(client, job_id, pagination_config)
+
+        with patch.object(batch_module, "get_batch_scrape_status", side_effect=tracking_get), \
+                patch.object(batch_module.time, "sleep"):
+            result = wait_for_batch_completion(self.mock_client, self.job_id)
+
+        # All status polls used auto_paginate=False (cheap status checks)
+        assert all(c is not None and c.auto_paginate is False for c in configs_seen[:-1])
+        # The final completed fetch used auto_paginate=True (full result set)
+        assert configs_seen[-1].auto_paginate is True
+        # Callers still receive the full result set
+        assert result.status == "completed"
+        assert len(result.data) == 2
     
     def test_fetch_all_batch_pages_limits(self):
         """Test _fetch_all_batch_pages with various limits."""
@@ -703,6 +777,78 @@ class TestAsyncPagination:
         assert result.next is None
         assert len(result.data) == 2
         assert self.mock_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_batch_scrape_does_not_paginate_polls(self):
+        """Async wait polls must be cheap (no pagination); the full result set
+        is only materialized once the job has completed."""
+        from firecrawl.v2.client_async import AsyncFirecrawlClient, async_batch
+
+        app = AsyncFirecrawlClient(api_key="test")
+        app.async_http_client = self.mock_client
+
+        # Poll 1: job still running
+        in_progress = Mock()
+        in_progress.status_code = 200
+        in_progress.json.return_value = {
+            "success": True,
+            "status": "scraping",
+            "completed": 5,
+            "total": 10,
+            "creditsUsed": 2,
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "next": "https://api.firecrawl.dev/v2/batch/scrape/test-async-123?page=2",
+            "data": [],
+        }
+
+        # Poll 2: completed, first page of results
+        completed_page1 = Mock()
+        completed_page1.status_code = 200
+        completed_page1.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 10,
+            "total": 10,
+            "creditsUsed": 4,
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "next": "https://api.firecrawl.dev/v2/batch/scrape/test-async-123?page=2",
+            "data": [self.sample_doc],
+        }
+
+        # Second page of the completed job
+        completed_page2 = Mock()
+        completed_page2.status_code = 200
+        completed_page2.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 10,
+            "total": 10,
+            "creditsUsed": 4,
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "next": None,
+            "data": [self.sample_doc],
+        }
+
+        self.mock_client.get.side_effect = [in_progress, completed_page1, completed_page1, completed_page2]
+
+        configs_seen = []
+        real_get = async_batch.get_batch_scrape_status
+
+        async def tracking_get(client, job_id, pagination_config=None):
+            configs_seen.append(pagination_config)
+            return await real_get(client, job_id, pagination_config)
+
+        with patch.object(async_batch, "get_batch_scrape_status", new=AsyncMock(side_effect=tracking_get)), \
+                patch.object(asyncio, "sleep", new=AsyncMock()):
+            result = await app.wait_batch_scrape("test-async-123")
+
+        # All status polls used auto_paginate=False (cheap status checks)
+        assert all(c is not None and c.auto_paginate is False for c in configs_seen[:-1])
+        # The final completed fetch used auto_paginate=True (full result set)
+        assert configs_seen[-1].auto_paginate is True
+        # Callers still receive the full result set
+        assert result.status == "completed"
+        assert len(result.data) == 2
 
     @pytest.mark.asyncio
     async def test_get_batch_scrape_status_page_async(self):

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -534,8 +534,21 @@ class AsyncFirecrawlClient:
     async def wait_batch_scrape(self, job_id: str, poll_interval: int = 2, timeout: Optional[int] = None) -> Any:
         start = asyncio.get_event_loop().time()
         while True:
-            status = await async_batch.get_batch_scrape_status(self.async_http_client, job_id)
+            # Poll cheaply: do not paginate on status checks. Materializing
+            # every page of the batch on each poll is wasted work, since
+            # intermediate results are discarded on the next poll.
+            status = await async_batch.get_batch_scrape_status(
+                self.async_http_client, job_id,
+                pagination_config=PaginationConfig(auto_paginate=False),
+            )
             if status.status in ["completed", "failed", "cancelled"]:
+                if status.status == "completed":
+                    # Final fetch with pagination so callers still receive the
+                    # full result set once the job has finished.
+                    return await async_batch.get_batch_scrape_status(
+                        self.async_http_client, job_id,
+                        pagination_config=PaginationConfig(auto_paginate=True),
+                    )
                 return status
             if timeout and (asyncio.get_event_loop().time() - start) > timeout:
                 raise TimeoutError("Batch wait timed out")

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -319,10 +319,21 @@ def wait_for_batch_completion(
     start_time = time.monotonic()
     
     while True:
-        status_job = get_batch_scrape_status(client, job_id)
+        # Poll cheaply: do not paginate on status checks. Materializing every
+        # page of the batch on each poll is wasted work, since intermediate
+        # results are discarded as soon as the next poll happens.
+        status_job = get_batch_scrape_status(
+            client, job_id, pagination_config=PaginationConfig(auto_paginate=False)
+        )
         
         # Check if job is complete
         if status_job.status in ["completed", "failed", "cancelled"]:
+            if status_job.status == "completed":
+                # Final fetch with pagination so callers still receive the
+                # full result set once the job has finished.
+                return get_batch_scrape_status(
+                    client, job_id, pagination_config=PaginationConfig(auto_paginate=True)
+                )
             return status_job
         
         # Check timeout


### PR DESCRIPTION
## What

Fixes the Python SDK's batch-scrape wait loops paginating (and materializing) the **entire** batch result set on **every** status poll, only to discard it on the next poll.

Closes #4107

## Root cause

`get_batch_scrape_status()` defaults `auto_paginate=True` when no `PaginationConfig` is supplied:

```python
auto_paginate = pagination_config.auto_paginate if pagination_config else True
```

The wait loops were calling it with no config:

- sync: `wait_for_batch_completion()` in `firecrawl/v2/methods/batch.py`
- async: `wait_batch_scrape()` in `firecrawl/v2/client_async.py`

So a batch of N pages was fetching 1 + N requests every poll interval, for the full duration of the job. For large batches (thousands of URLs) that is a lot of wasted work, and the intermediate results are never even returned to the caller.

## Fix

Poll cheaply: pass `PaginationConfig(auto_paginate=False)` so status checks only fetch the first page. Once the job reaches `completed`, do a single final fetch with `auto_paginate=True` so callers still receive the full result set — the public behavior of `batch_scrape()` / `wait_batch_scrape()` is unchanged.

Both sync and async paths are fixed, with regression tests that assert:

- every status poll used `auto_paginate=False`
- the terminal completed fetch used `auto_paginate=True`
- callers still get the complete data

## Related

The async `wait_crawl()` loop has the same pattern and may deserve the same treatment; keeping this PR scoped to batch scrape as per the issue.

## Tests

```bash
python -m pytest firecrawl/__tests__/unit/v2/methods/test_pagination.py -k "batch or wait"
# 11 passed
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make batch-scrape wait loops poll cheaply by not auto-paginating during status checks; only paginate once on completion. This reduces request load for large batches without changing SDK behavior.

- **Bug Fixes**
  - Use `PaginationConfig(auto_paginate=False)` for each poll in `wait_for_batch_completion()` and `AsyncFirecrawlClient.wait_batch_scrape()`.
  - After completion, perform one fetch with `auto_paginate=True` to return the full result set.

<sup>Written for commit 1c9637d419940e6f73af576f22819f3002202f8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

