### PR TITLE
fix(scrape-worker): clear extendLockInterval when addJobPriority throws

### DIFF
--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -1241,8 +1241,8 @@ async function processJobWithTracing(job: NuQJob<ScrapeJobData>, logger: any) {
         }, jobLockExtendInterval);
       }
 
-      await addJobPriority(job.data.team_id, job.id);
       try {
+        await addJobPriority(job.data.team_id, job.id);
         if (job.data.mode === "kickoff") {
           const result = await processKickoffJob(
             job as NuQJob<ScrapeJobKickoff>,


### PR DESCRIPTION
## Summary

Fixes #4246

In `processJobWithTracing` (scrape-worker.ts), `extendLockInterval` is created and `addJobPriority` is called before the inner `try` block whose `finally` calls `clearInterval`. If `addJobPriority` (a Redis operation) throws, control jumps past that `finally` and the interval keeps firing `pushConcurrencyLimitActiveJob` for a job that no longer exists.

### Change
Moved `await addJobPriority(...)` inside the guarded `try` block so the `finally` that clears the interval always runs, even when the Redis call throws.

### Verification
- `tsc --noEmit` shows no errors in `scrape-worker.ts` (remaining repo errors are from a pre-existing missing native `@mendable/firecrawl-rs` module in this environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `extendLockInterval` from leaking in the scrape worker when `addJobPriority` throws. Moved the `addJobPriority` call inside the inner try/finally in `processJobWithTracing` so the interval is always cleared.

<sup>Written for commit 3f78984e27688fa2f0fa99f71993852b1b3239d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

