### PR TITLE
Add /exchange proxy routes and feature flag

### DIFF
--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1316,6 +1316,7 @@ export type TeamFlags = {
   researchBeta?: boolean;
   enrichBeta?: boolean;
   labsSearch?: boolean;
+  exchangeRetrieve?: boolean;
   professionalProfileCompanyDataBeta?: boolean;
   organizationDataSourceAccess?: Record<
     string,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -30,6 +30,7 @@ import { QueueFullError } from "./lib/queue-full-error";
 import { v7 as uuidv7 } from "uuid";
 import { cacheableLookup } from "./scraper/scrapeURL/lib/cacheableLookup";
 import { v2Router } from "./routes/v2";
+import { exchangeRouter } from "./routes/exchange";
 import { labsRouter } from "./routes/labs";
 import { registerMcpActionLogIngestRoute } from "./routes/mcp-action-logs";
 import { startMcpActionLogRetentionWorkerIfEnabled } from "./services/mcp/action-logs";
@@ -139,6 +140,7 @@ app.use(v0Router);
 app.use("/v1", v1Router);
 app.use("/v2", v2Router);
 app.use("/labs", labsRouter);
+app.use("/exchange", exchangeRouter);
 app.use(adminRouter);
 
 const DEFAULT_PORT = config.PORT;

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -1,0 +1,118 @@
+import express, { Request, Response } from "express";
+import { Agent, fetch } from "undici";
+import { config } from "../config";
+import { logger as rootLogger } from "../lib/logger";
+import type { RequestWithAuth } from "../controllers/v1/types";
+import { RateLimiterMode } from "../types";
+import { authMiddleware, wrap } from "./shared";
+
+const DISCOVER_TIMEOUT_MS = 10_000;
+const RETRIEVE_TIMEOUT_MS = 50_000;
+
+const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
+const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
+
+function dispatcherFor(timeout: number) {
+  return new Agent({
+    connectTimeout: timeout,
+    headersTimeout: timeout,
+    bodyTimeout: timeout,
+  });
+}
+
+function exchangeError(res: Response, status: number, error: string) {
+  return res.status(status).json({ success: false, error });
+}
+
+function upstreamBase(): string | null {
+  if (!config.FIRE_EXCHANGE_URL) return null;
+  return config.FIRE_EXCHANGE_URL.replace(/\/+$/, "");
+}
+
+function exchangeProxy(timeout: number) {
+  const dispatcher = dispatcherFor(timeout);
+
+  return async function controller(req: Request, res: Response) {
+    const authedReq = req as RequestWithAuth<any, any, any>;
+    const logger = rootLogger.child({
+      module: "api/exchange",
+      method: req.method,
+      path: req.path,
+      teamId: authedReq.auth.team_id,
+    });
+
+    const base = upstreamBase();
+    if (!base) {
+      return exchangeError(res, 503, "This endpoint is not available.");
+    }
+
+    if (!authedReq.acuc?.flags?.exchangeRetrieve) {
+      return exchangeError(
+        res,
+        403,
+        "This endpoint is not enabled for this team.",
+      );
+    }
+
+    const hasBody = req.method !== "GET";
+    const path = req.originalUrl.replace(/^\/exchange/, "/v1");
+
+    try {
+      const upstream = await fetch(base + path, {
+        method: req.method,
+        headers: {
+          ...Object.fromEntries(
+            FORWARDED_REQUEST_HEADERS.flatMap(h => {
+              const value = req.headers[h];
+              return typeof value === "string" ? [[h, value]] : [];
+            }),
+          ),
+          ...(hasBody ? { "content-type": "application/json" } : {}),
+          "x-exchange-team-id": authedReq.auth.team_id,
+        },
+        body: hasBody ? JSON.stringify(req.body ?? {}) : undefined,
+        signal: AbortSignal.timeout(timeout),
+        dispatcher,
+      });
+
+      for (const h of FORWARDED_RESPONSE_HEADERS) {
+        const value = upstream.headers.get(h);
+        if (value) res.setHeader(h, value);
+      }
+
+      const text = await upstream.text();
+      let body: unknown;
+      try {
+        body = text ? JSON.parse(text) : null;
+      } catch {
+        body = text;
+      }
+
+      if (body === null || typeof body === "string") {
+        return res.status(upstream.status).send(body ?? "");
+      }
+      return res.status(upstream.status).json(body);
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        logger.error("Exchange proxy timed out");
+        return exchangeError(res, 504, "The request timed out.");
+      }
+      logger.error("Exchange proxy error", { error });
+      return exchangeError(res, 502, "The request could not be completed.");
+    }
+  };
+}
+
+export const exchangeRouter = express.Router();
+
+exchangeRouter.get(
+  "/discover{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(DISCOVER_TIMEOUT_MS)),
+);
+
+exchangeRouter.post(
+  "/retrieve",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(RETRIEVE_TIMEOUT_MS)),
+);


### PR DESCRIPTION
Introduce an exchange proxy router that forwards /exchange/discover and /exchange/retrieve requests to an upstream FIRE_EXCHANGE_URL with timeouts and header forwarding. The router enforces auth, team-level exchangeRetrieve flag, and per-route timeouts/dispatchers. Register the router in the API entrypoint. Add TeamFlags.exchangeRetrieve to the v1 types so teams can be opted into this endpoint. Includes error handling for timeouts and upstream failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/exchange` proxy routes for `discover` and `retrieve`, forwarding to an upstream service with auth gating and per-route timeouts. Introduces the `exchangeRetrieve` team flag and registers the router.

- **New Features**
  - Proxies `/exchange/discover` and `/exchange/retrieve` to `FIRE_EXCHANGE_URL` (maps to `/v1` paths) with forwarded headers (`accept`, `x-request-id`) and response headers (`content-type`, `x-request-id`).
  - Enforces auth and `exchangeRetrieve` team flag; uses Labs rate limiter.
  - Timeouts: 10s for `discover`, 50s for `retrieve`; returns 504 on timeout, 502 on upstream failure, 503 if upstream not configured, 403 if flag disabled.

- **Migration**
  - Set `FIRE_EXCHANGE_URL` in the environment.
  - Enable `exchangeRetrieve` in team flags for teams that should access these endpoints.

<sup>Written for commit f0ba1cec00c897c846f2e6a9a0630d4a544a59ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

