### PR TITLE
developer-search: tolerate removal of internal response fields

### DIFF
--- a/apps/api/src/__tests__/snips/v2/developer.test.ts
+++ b/apps/api/src/__tests__/snips/v2/developer.test.ts
@@ -15,8 +15,6 @@ const CANONICAL_PATH = "/v2/search/developer";
 const LEGACY_PATH = "/v2/developer/search";
 const SERVING_PATHS = [CANONICAL_PATH, LEGACY_PATH];
 
-const COVERAGE_STATUSES = ["ok", "degraded", "unavailable", "skipped"];
-
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 const sleepForBilling = () => sleep(40000);
 
@@ -51,17 +49,10 @@ describeIf(HAS_RESEARCH)("Developer Search API", () => {
       expect(res.statusCode).toBe(200);
       expect(res.body.success).toBe(true);
       expect(Array.isArray(res.body.results)).toBe(true);
-      for (const type of ["doc", "issue", "pull_request", "readme"]) {
-        expect(COVERAGE_STATUSES).toContain(res.body.coverage[type]);
-      }
-      expect(typeof res.body.reranked).toBe("boolean");
 
       for (const result of res.body.results) {
         expect(typeof result.id).toBe("string");
         expect(typeof result.url).toBe("string");
-        expect(["doc", "issue", "pull_request", "readme"]).toContain(
-          result.type,
-        );
         expect(Array.isArray(result.passages)).toBe(true);
         expect(result.license).toBeUndefined();
       }
@@ -82,11 +73,6 @@ describeIf(HAS_RESEARCH)("Developer Search API", () => {
       expect(res.statusCode).toBe(200);
       expect(res.body.success).toBe(true);
       expect(Array.isArray(res.body.results)).toBe(true);
-      for (const result of res.body.results) {
-        expect(["issue", "readme"]).toContain(result.type);
-      }
-      expect(res.body.coverage.doc).toBe("skipped");
-      expect(res.body.coverage.pull_request).toBe("skipped");
     }, 120000);
   });
 

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -1459,7 +1459,7 @@ export interface GitHubScoreBreakdown {
 }
 
 export interface GitHubSearchItem {
-  resultType: "github_history" | "repo_readme" | "web";
+  resultType?: "github_history" | "repo_readme" | "web";
   /** `owner/name`; empty for web results whose URL is not a repo page. */
   repo: string;
   url: string;


### PR DESCRIPTION
The developer-search service stops serving internal diagnostic response fields. This change makes the consumers here tolerant before the server change deploys.

## What
- API snapshot test: drop required expectations for the removed top-level diagnostic fields and the per-result `type` field.
- JS SDK: `GitHubSearchItem.resultType` becomes optional.
- Python SDK: no change needed — its research results are untyped dictionaries and its developer models do not require these fields.

## Order of operations
This merges before the server removal deploys, so strict test expectations and SDK types never break on absence.

## Not touched
Scrape, crawl, map, and web-search surfaces.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make developer-search clients resilient to the removal of internal response fields by relaxing assertions and types. This prevents breaks when the server stops returning diagnostics.

- **Refactors**
  - API tests: stop asserting top-level diagnostics (coverage, reranked) and per-result type.
  - JS SDK: `GitHubSearchItem.resultType` is now optional.
  - Python SDK: no change.

- **Migration**
  - No action needed. Ships before the server change to avoid test and type failures.

<sup>Written for commit 7cceacea1fa0880b4956dd0f1515e701f7cdc20b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

