### PR TITLE
Fix false-positive SSRF blocking for IPv4-mapped IPv6 DNS results

### DIFF
--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -60,7 +60,7 @@ const isInternalHost = async (hostname: string): Promise<boolean> => {
   }
   return (
     addresses.length === 0 ||
-    addresses.some((a) => IPAddr.parse(a).range() !== 'unicast')
+    addresses.some((a) => IPAddr.process(a).range() !== 'unicast')
   );
 };
 


### PR DESCRIPTION
## Summary

Fix a false-positive SSRF check in the Playwright service when DNS resolution returns public IPv4 addresses as IPv4-mapped IPv6 addresses.

### Related work

This PR is related to [PR #4273](https://github.com/firecrawl/firecrawl/pull/4273), which strengthens SSRF protection for private IP literals before proxy dispatch.

While investigating this issue, I found a separate case in the hostname validation path: DNS resolution can return IPv4-mapped IPv6 addresses such as `::ffff:<IPv4>` (e.g. `::ffff:104.20.23.154`). These addresses are currently passed to `IPAddr.parse()`, which preserves the mapped IPv6 representation and causes the subsequent `range() !== 'unicast'` check to reject otherwise public destinations.

Using `IPAddr.process()` normalizes IPv4-mapped IPv6 addresses before the range check, while retaining the existing protection against private/internal addresses.

The two changes address different cases and can complement each other: #4273 handles private IP literals at proxy dispatch, while this PR fixes false-positive blocking of public hostnames whose DNS results include IPv4-mapped IPv6 addresses.


## Problem

While following the [Self-hosting Firecrawl setup guide](https://docs.firecrawl.dev/contributing/self-host), I created the minimal `.env` configuration described in the documentation and ran the functional smoke test.

The scrape request failed with:

```text
SCRAPE_ALL_ENGINES_FAILED
```

The Playwright service logs showed that the request was reaching the service correctly, but the target URL was rejected with:

```text
Blocked insecure target URL "https://example.com":
resolves to a private/internal address
```

The relevant SSRF check in `apps/playwright-service-ts/api.ts` was:

```ts
addresses.some((a) => IPAddr.parse(a).range() !== 'unicast')
```

## Root cause

In my environment, Node's DNS resolver returns public IPv4 addresses both as regular IPv4 addresses and as IPv4-mapped IPv6 addresses.

For example:

```text
IPv4:
172.66.147.243
104.20.23.154

IPv6:
::ffff:172.66.147.243
::ffff:104.20.23.154
2606:4700:10::ac42:93f3
2606:4700:10::6814:179a
```

`IPAddr.parse()` preserves the IPv4-mapped IPv6 representation. Consequently, the mapped addresses can be classified as `ipv4Mapped` rather than `unicast`, causing the existing check to treat them as private/internal addresses.

This resulted in legitimate public websites being rejected by the SSRF protection.

## Fix

Use `IPAddr.process()` instead of `IPAddr.parse()` in `apps/playwright-service-ts/api.ts` (line 63) when classifying resolved addresses:

```ts
addresses.some((a) => IPAddr.process(a).range() !== 'unicast')
```

`IPAddr.process()` normalizes IPv4-mapped IPv6 addresses to their underlying IPv4 representation before performing the range check.

This preserves the existing SSRF protection while avoiding false positives for public IPv4 addresses returned in IPv4-mapped IPv6 form.

## Verification

Before the change, scraping `https://example.com` using this command:

```bash
curl -sS -X POST 'http://localhost:3002/v2/scrape' \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://example.com","formats":["markdown"],"timeout":30000}'
```

failed with:

```json
{
  "success": false,
  "code": "SCRAPE_ALL_ENGINES_FAILED",
  "error": "All scraping engines failed to retrieve content from ..."
}
```

After the change, the same self-hosted instance successfully returned:

```json
{
  "success": true,
  "data": {
    "markdown": "Example Domain ...",
    "metadata": {
      "title": "Example Domain",
      "url": "https://example.com",
      "statusCode": 200,
      "contentType": "text/html"
    }
  }
}
```

The response contained the expected Markdown content from Example Domain.

No Docker networking, DNS, proxy, or `PLAYWRIGHT_MICROSERVICE_URL` configuration changes were required.

## Testing

* Started the self-hosted Firecrawl stack using the documented minimal `.env` configuration.
* Verified that both `api` and `playwright-service` resolve `example.com` to public addresses.
* Reproduced the false-positive SSRF rejection.
* Changed `IPAddr.parse()` to `IPAddr.process()`.
* Rebuilt and restarted the Playwright service.
* Re-ran the functional smoke test from [Self-hosting Firecrawl setup guide](https://docs.firecrawl.dev/contributing/self-host)
* Confirmed a successful scrape with HTTP status `200`.

The change is intentionally limited to address normalization before the existing `unicast` check; local/private destinations remain subject to the existing SSRF protection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false-positive SSRF checks in the Playwright service when DNS returns IPv4-mapped IPv6 results (e.g., ::ffff:104.20.23.154). We now normalize resolved addresses with `IPAddr.process()` so public hosts pass while private/internal addresses remain blocked.

- **Bug Fixes**
  - In `apps/playwright-service-ts/api.ts`, replace `IPAddr.parse(a).range()` with `IPAddr.process(a).range()` to normalize IPv4-mapped IPv6 before the `unicast` check.
  - Prevents misclassifying mapped IPv6 as non-`unicast` and blocking valid targets.

<sup>Written for commit e77a16d23c8b119b729d81bda618489a6b4c61a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

