### PR TITLE
fix(api): harden generated extractor validation for deterministic JSON

### DIFF
--- a/apps/api/src/lib/deterministicJson/extract.ts
+++ b/apps/api/src/lib/deterministicJson/extract.ts
@@ -9,6 +9,7 @@ import {
   runExtractorInSandbox,
   type SandboxRunner,
 } from "./sandbox/runExtractor";
+import { validateGeneratedExtractor } from "./pipeline/validate";
 import { tooStrictFeedback, tooStrictSelectors } from "./html/selector-repair";
 import { errorMessage, log, sha } from "./core/util";
 
@@ -112,11 +113,36 @@ export async function extractDeterministicJson(
     return value;
   };
 
+  // A cached extractor that no longer passes validation — e.g. a script cached
+  // before the rules tightened — is discarded rather than run. Guard the check
+  // itself: a validator throw (e.g. RangeError on pathologically nested code)
+  // means we can't vouch for the script, so treat it as invalid too.
+  const cachedIsValid = (c: string): boolean => {
+    try {
+      return validateGeneratedExtractor(c).length === 0;
+    } catch (err) {
+      log(
+        "cached extractor validation threw; regenerating:",
+        errorMessage(err),
+      );
+      return false;
+    }
+  };
+
   let code: string;
-  if (cached) {
+  if (cached && cachedIsValid(cached.code)) {
     await cache.touch?.(key);
     code = cached.code;
   } else {
+    // Regenerating overwrites the bad row via `generate`'s setExtractor. Note
+    // getExtractor reads a possibly-lagging read replica while setExtractor
+    // writes the primary, so under replication lag concurrent requests keep
+    // regenerating until the replica converges — best-effort cleanup, not an
+    // atomic purge. Enough to stop a stale script from running; a hard purge of
+    // pre-existing rows is a separate one-time op.
+    if (cached) {
+      log("cached extractor rejected by validation; regenerating");
+    }
     code = await generate();
   }
 

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
@@ -115,6 +115,43 @@ describe("validateGeneratedExtractor — disallowed reference rejection", () => 
     expect(reasons(issues)).toContain(token.split(".")[1]);
   });
 
+  it("rejects computed-string destructuring of a disallowed property", () => {
+    const code = `async function extract(doc, askLlm) {
+      const { ["constructor"]: C } = askLlm;
+      return { x: typeof C };
+    }`;
+    expect(reasons(validateGeneratedExtractor(code))).toContain("constructor");
+  });
+
+  it.each([
+    ["member", `return typeof window.fetch;`],
+    ["computed", `return typeof window["fetch"];`],
+  ])("rejects fetch reached off a global object (%s)", (_kind, body) => {
+    const code = `async function extract(doc, askLlm) { ${body} }`;
+    expect(reasons(validateGeneratedExtractor(code))).toContain("fetch");
+  });
+
+  it.each([
+    [
+      "an unused parameter",
+      `async function extract(doc, process) {
+      return { title: doc.title };
+    }`,
+    ],
+    [
+      "an object method name",
+      `async function extract(doc, askLlm) {
+      const o = { process() { return doc.title; } };
+      return { x: o.process() };
+    }`,
+    ],
+  ])("does not flag a forbidden name shadowed as %s", (_kind, code) => {
+    // Only free references are flagged; a name introduced in a binding/member
+    // position is not (a *use* of such a local would still be conservatively
+    // flagged — static checks can't resolve scope).
+    expect(validateGeneratedExtractor(code)).toEqual([]);
+  });
+
   it("does not catch computed access through a variable (documented limitation)", () => {
     // Computed access through a variable is out of scope for this static check —
     // resolving `k` would need dataflow. Pinned so the gap is known, not a miss.

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
@@ -1,0 +1,128 @@
+import {
+  validateGeneratedExtractor,
+  type GeneratedCodeIssue,
+} from "./validate";
+
+const reasons = (issues: GeneratedCodeIssue[]): string =>
+  issues.map(i => `${i.reason} ${i.excerpt}`).join("\n");
+
+describe("validateGeneratedExtractor — disallowed reference rejection", () => {
+  it("rejects constructor access on a value", () => {
+    const code = `async function extract(doc, askLlm) {
+      const C = askLlm.constructor;
+      return { x: typeof C };
+    }`;
+    const issues = validateGeneratedExtractor(code);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(reasons(issues)).toContain("constructor");
+  });
+
+  it("rejects chained constructor access", () => {
+    const code = `async function extract(doc, askLlm) {
+      const C = document.constructor.constructor;
+      return { x: typeof C };
+    }`;
+    expect(validateGeneratedExtractor(code).length).toBeGreaterThan(0);
+  });
+
+  it('rejects computed-string constructor access ["constructor"]', () => {
+    const code = `async function extract(doc, askLlm) {
+      const C = askLlm["constructor"];
+      return { x: typeof C };
+    }`;
+    const issues = validateGeneratedExtractor(code);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(reasons(issues)).toContain("constructor");
+  });
+
+  it("rejects Node module-internal property access", () => {
+    const code = `async function extract(doc, askLlm) {
+      const a = doc.getBuiltinModule;
+      const b = doc.mainModule;
+      return { a: typeof a, b: typeof b };
+    }`;
+    const issues = validateGeneratedExtractor(code);
+    expect(reasons(issues)).toContain("getBuiltinModule");
+    expect(reasons(issues)).toContain("mainModule");
+  });
+
+  it.each(["Function", "eval", "process", "globalThis"])(
+    "rejects the disallowed global %s",
+    token => {
+      const code = `async function extract(doc, askLlm) {
+        const x = ${token};
+        return { x: typeof x };
+      }`;
+      const issues = validateGeneratedExtractor(code);
+      expect(reasons(issues)).toContain(token);
+    },
+  );
+
+  it("accepts a normal DOM extractor unchanged", () => {
+    const code = `async function extract(doc, askLlm) {
+      const heading = doc.querySelector("h1");
+      if (!heading) throw new Error("missing heading");
+      const title = heading.textContent.trim();
+      const links = [...doc.querySelectorAll("a")].map(a => a.getAttribute("href"));
+      const summary = await askLlm("Summarize the page", { type: "string" });
+      return { title, links, summary };
+    }`;
+    expect(validateGeneratedExtractor(code)).toEqual([]);
+  });
+
+  it("does not flag an object-literal key named constructor", () => {
+    // The check keys off property *reads* (member/computed/destructuring), not
+    // object-literal keys — building `{ constructor: v }` is ordinary data.
+    const code = `async function extract(doc, askLlm) {
+      const value = doc.querySelector("main")?.textContent ?? "";
+      return { constructor: value };
+    }`;
+    expect(validateGeneratedExtractor(code)).toEqual([]);
+  });
+
+  it("rejects destructuring a disallowed property", () => {
+    const code = `async function extract(doc, askLlm) {
+      const { constructor: C } = askLlm;
+      return { x: typeof C };
+    }`;
+    expect(reasons(validateGeneratedExtractor(code))).toContain("constructor");
+  });
+
+  it("rejects shorthand destructuring of a disallowed property", () => {
+    const code = `async function extract(doc, askLlm) {
+      const { constructor } = askLlm;
+      return { x: typeof constructor };
+    }`;
+    expect(reasons(validateGeneratedExtractor(code))).toContain("constructor");
+  });
+
+  it("rejects a with statement", () => {
+    const code = `async function extract(doc, askLlm) {
+      with (doc) { return { x: 1 }; }
+    }`;
+    expect(reasons(validateGeneratedExtractor(code))).toContain("with");
+  });
+
+  it.each([
+    ["window.Function", `return typeof window.Function;`],
+    ["self.eval", `return typeof self.eval;`],
+    ["this.Function", `return typeof this.Function;`],
+    ["window.XMLHttpRequest", `return typeof window.XMLHttpRequest;`],
+  ])("rejects a disallowed name reached via %s", (token, body) => {
+    const code = `async function extract(doc, askLlm) { ${body} }`;
+    const issues = validateGeneratedExtractor(code);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(reasons(issues)).toContain(token.split(".")[1]);
+  });
+
+  it("does not catch computed access through a variable (documented limitation)", () => {
+    // Computed access through a variable is out of scope for this static check —
+    // resolving `k` would need dataflow. Pinned so the gap is known, not a miss.
+    const code = `async function extract(doc, askLlm) {
+      const k = "constructor";
+      const C = askLlm[k];
+      return { x: typeof C };
+    }`;
+    expect(validateGeneratedExtractor(code)).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
@@ -166,25 +166,9 @@ describe("validateGeneratedExtractor — disallowed reference rejection", () => 
     expect(validateGeneratedExtractor(code)).toEqual([]);
   });
 
-  it.each([
-    ["named", `let C; ({ constructor: C } = doc); return { x: typeof C };`],
-    [
-      "computed",
-      `let C; ({ ["constructor"]: C } = doc); return { x: typeof C };`,
-    ],
-  ])(
-    "rejects assignment destructuring of a disallowed property (%s)",
-    (_k, body) => {
-      const code = `async function extract(doc, askLlm) { ${body} }`;
-      expect(reasons(validateGeneratedExtractor(code))).toContain(
-        "constructor",
-      );
-    },
-  );
-
   it("does not flag a value object literal with a disallowed key", () => {
-    // `return { constructor: v }` builds data; it is not a destructuring target,
-    // so it must stay allowed (distinct from `({ constructor: v } = obj)`).
+    // `return { constructor: v }` builds data — an object-literal key is never a
+    // property read — so it stays allowed.
     const code = `async function extract(doc, askLlm) {
       return { constructor: doc.title };
     }`;
@@ -210,6 +194,14 @@ describe("validateGeneratedExtractor — disallowed reference rejection", () => 
        return { x: typeof F };`,
     ],
     ["a data field named process", `return { p: doc.body.process ?? null };`],
+    [
+      "assignment-pattern destructuring",
+      `let C; ({ constructor: C } = doc); return { x: typeof C };`,
+    ],
+    [
+      "for-of destructuring",
+      `let C; for ({ constructor: C } of [doc]) {} return { x: typeof C };`,
+    ],
   ])("does not flag %s (out of scope by design)", (_k, body) => {
     const code = `async function extract(doc, askLlm) { ${body} }`;
     expect(validateGeneratedExtractor(code)).toEqual([]);

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
@@ -145,6 +145,20 @@ describe("validateGeneratedExtractor — disallowed reference rejection", () => 
       return { x: o.process() };
     }`,
     ],
+    [
+      "an array-binding element",
+      `async function extract(doc, askLlm) {
+      const [fetch, constructor] = [doc.title, doc.URL];
+      return { title: doc.title };
+    }`,
+    ],
+    [
+      "an object rest binding",
+      `async function extract(doc, askLlm) {
+      const { title, ...fetch } = doc;
+      return { title };
+    }`,
+    ],
   ])("does not flag a forbidden name shadowed as %s", (_kind, code) => {
     // Only free references are flagged; a name introduced in a binding/member
     // position is not (a *use* of such a local would still be conservatively

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.test.ts
@@ -166,6 +166,55 @@ describe("validateGeneratedExtractor — disallowed reference rejection", () => 
     expect(validateGeneratedExtractor(code)).toEqual([]);
   });
 
+  it.each([
+    ["named", `let C; ({ constructor: C } = doc); return { x: typeof C };`],
+    [
+      "computed",
+      `let C; ({ ["constructor"]: C } = doc); return { x: typeof C };`,
+    ],
+  ])(
+    "rejects assignment destructuring of a disallowed property (%s)",
+    (_k, body) => {
+      const code = `async function extract(doc, askLlm) { ${body} }`;
+      expect(reasons(validateGeneratedExtractor(code))).toContain(
+        "constructor",
+      );
+    },
+  );
+
+  it("does not flag a value object literal with a disallowed key", () => {
+    // `return { constructor: v }` builds data; it is not a destructuring target,
+    // so it must stay allowed (distinct from `({ constructor: v } = obj)`).
+    const code = `async function extract(doc, askLlm) {
+      return { constructor: doc.title };
+    }`;
+    expect(validateGeneratedExtractor(code)).toEqual([]);
+  });
+
+  it.each([
+    ["Reflect", `return typeof window.Reflect;`],
+    ["Proxy", `return typeof window["Proxy"];`],
+    ["require", `const { require: r } = globalThis; return { x: typeof r };`],
+  ])(
+    "rejects the ambient name %s reached off a global object",
+    (name, body) => {
+      const code = `async function extract(doc, askLlm) { ${body} }`;
+      expect(reasons(validateGeneratedExtractor(code))).toContain(name);
+    },
+  );
+
+  it.each([
+    [
+      "reflection via a string argument",
+      `const F = Object.getOwnPropertyDescriptor(window, "constructor").value;
+       return { x: typeof F };`,
+    ],
+    ["a data field named process", `return { p: doc.body.process ?? null };`],
+  ])("does not flag %s (out of scope by design)", (_k, body) => {
+    const code = `async function extract(doc, askLlm) { ${body} }`;
+    expect(validateGeneratedExtractor(code)).toEqual([]);
+  });
+
   it("does not catch computed access through a variable (documented limitation)", () => {
     // Computed access through a variable is out of scope for this static check —
     // resolving `k` would need dataflow. Pinned so the gap is known, not a miss.

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.ts
@@ -145,15 +145,14 @@ function validateTopLevelShape(
 
 // Reject references a generated DOM extractor has no legitimate reason to use.
 // The extractor runs inside jsdom's VM context (see sandbox/harness.ts); this is
-// a best-effort validation/robustness layer over that sandbox, NOT the isolation
-// boundary. It flags the disallowed names where they are *statically* reachable:
-// member (`x.NAME`), computed-string (`x["NAME"]`), and destructuring access in
-// both declaration (`const { NAME } = x`) and assignment (`({ NAME } = x)`)
-// forms, plus `with`. It is deliberately not exhaustive — forms that would need
-// dataflow or interprocedural analysis are out of scope and left to the sandbox:
-// computed access through a variable (`x[k]`), and a name passed as a string to a
-// reflection API (`Reflect.get(o, "NAME")`, `Object.getOwnPropertyDescriptor(o,
-// "NAME")`).
+// a best-effort validation/robustness layer, not an exhaustive one, and not the
+// enforcement boundary (the runtime sandbox is). It flags the disallowed names
+// where they are statically and unambiguously reached — member (`x.name`),
+// computed-string (`x["name"]`), and declaration destructuring
+// (`const { name } = x`), plus `with`. Names reached only through indirection are
+// deliberately out of scope, since resolving them reliably needs analysis this
+// pass doesn't do: a variable-keyed access (`x[k]`), a reflection helper, or an
+// assignment / `for..of` destructuring pattern.
 //
 // Globals the sandbox doesn't provide, plus code-eval primitives (`Function`/
 // `eval`) and ambient objects (`globalThis`/`Reflect`/`Proxy`) extractors never
@@ -239,45 +238,6 @@ function staticPropertyName(nameNode: ts.Node): string | undefined {
     : undefined;
 }
 
-// True when an object literal is a destructuring *assignment target* — the LHS of
-// `=`, possibly nested inside an outer pattern — rather than a value being built.
-// `({ constructor: C } = obj)` reads obj.constructor; `return { constructor: v }`
-// does not, so only the former is treated as a property read.
-function isDestructuringTarget(node: ts.Node): boolean {
-  let current: ts.Node = node;
-  for (let parent = current.parent; parent; parent = current.parent) {
-    if (ts.isBinaryExpression(parent)) {
-      return (
-        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        parent.left === current
-      );
-    }
-    // Climb out of a nested destructuring pattern toward its assignment root.
-    if (
-      (ts.isPropertyAssignment(parent) ||
-        ts.isShorthandPropertyAssignment(parent) ||
-        ts.isSpreadAssignment(parent)) &&
-      ts.isObjectLiteralExpression(parent.parent)
-    ) {
-      current = parent.parent;
-      continue;
-    }
-    if (
-      ts.isSpreadElement(parent) &&
-      ts.isArrayLiteralExpression(parent.parent)
-    ) {
-      current = parent.parent;
-      continue;
-    }
-    if (ts.isArrayLiteralExpression(parent)) {
-      current = parent;
-      continue;
-    }
-    return false;
-  }
-  return false;
-}
-
 function detectForbiddenGlobals(
   source: ts.SourceFile,
   issues: GeneratedCodeIssue[],
@@ -340,19 +300,6 @@ function detectForbiddenGlobals(
       !node.dotDotDotToken
     ) {
       const text = staticPropertyName(node.propertyName ?? node.name);
-      if (text && FORBIDDEN_PROPERTIES.has(text)) flag(text, "property");
-    }
-
-    // assignment destructuring: `({ constructor: C } = obj)` / `({ constructor } =
-    // obj)` reads obj.constructor, unlike an object literal built as a value
-    // (`return { constructor: v }`), which isDestructuringTarget rules out.
-    if (
-      (ts.isPropertyAssignment(node) ||
-        ts.isShorthandPropertyAssignment(node)) &&
-      ts.isObjectLiteralExpression(node.parent) &&
-      isDestructuringTarget(node.parent)
-    ) {
-      const text = staticPropertyName(node.name);
       if (text && FORBIDDEN_PROPERTIES.has(text)) flag(text, "property");
     }
 

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.ts
@@ -145,13 +145,19 @@ function validateTopLevelShape(
 
 // Reject references a generated DOM extractor has no legitimate reason to use.
 // The extractor runs inside jsdom's VM context (see sandbox/harness.ts); this is
-// a validation/robustness layer over that, not an isolation boundary. It checks
-// the syntactic forms that reach a disallowed name (member, computed-string, and
-// destructuring access, plus `with`); it deliberately does not chase indirected
-// forms such as computed access through a variable (`x[k]`), which need dataflow.
+// a best-effort validation/robustness layer over that sandbox, NOT the isolation
+// boundary. It flags the disallowed names where they are *statically* reachable:
+// member (`x.NAME`), computed-string (`x["NAME"]`), and destructuring access in
+// both declaration (`const { NAME } = x`) and assignment (`({ NAME } = x)`)
+// forms, plus `with`. It is deliberately not exhaustive — forms that would need
+// dataflow or interprocedural analysis are out of scope and left to the sandbox:
+// computed access through a variable (`x[k]`), and a name passed as a string to a
+// reflection API (`Reflect.get(o, "NAME")`, `Object.getOwnPropertyDescriptor(o,
+// "NAME")`).
 //
 // Globals the sandbox doesn't provide, plus code-eval primitives (`Function`/
-// `eval`) and ambient objects (`process`/`globalThis`) extractors never need.
+// `eval`) and ambient objects (`globalThis`/`Reflect`/`Proxy`) extractors never
+// need.
 const FORBIDDEN_GLOBALS = new Set([
   "fetch",
   "XMLHttpRequest",
@@ -165,13 +171,15 @@ const FORBIDDEN_GLOBALS = new Set([
 ]);
 
 // Property names a DOM extractor should never read off an object, checked
-// wherever a property is *reached* — `obj.NAME`, `obj["NAME"]`, and
-// `const { NAME } = obj` destructuring. `constructor`/`__proto__` reach
-// constructors and prototypes, `getBuiltinModule`/`mainModule` are Node module
-// internals, `Function`/`eval` are code-eval primitives, and `fetch`/
-// `XMLHttpRequest` are network primitives. These mirror the same names in
-// FORBIDDEN_GLOBALS so the member/computed forms (e.g. `window.fetch`) are
-// covered too. None belong in reading data out of a document.
+// wherever a property is *reached* — `obj.NAME`, `obj["NAME"]`, and destructuring.
+// `constructor`/`__proto__` reach constructors and prototypes,
+// `getBuiltinModule`/`mainModule` are Node module internals, `Function`/`eval`
+// are code-eval primitives, `fetch`/`XMLHttpRequest` are network primitives, and
+// `globalThis`/`require`/`Reflect`/`Proxy` are ambient objects. These mirror
+// FORBIDDEN_GLOBALS so the member/computed forms (e.g. `window.Reflect`) are
+// covered too. `process` is intentionally omitted: it is a common data-field
+// name, and unlike the others is not reachable as a member in the sandbox
+// (`window.process` is undefined), so flagging it would be false positives only.
 const FORBIDDEN_PROPERTIES = new Set([
   "constructor",
   "__proto__",
@@ -181,6 +189,10 @@ const FORBIDDEN_PROPERTIES = new Set([
   "eval",
   "fetch",
   "XMLHttpRequest",
+  "globalThis",
+  "require",
+  "Reflect",
+  "Proxy",
 ]);
 
 // A forbidden global name only matters as a *free reference*. Skip it when the
@@ -211,6 +223,59 @@ function isNameToken(id: ts.Identifier): boolean {
     (ts.isClassExpression(p) && p.name === id) ||
     (ts.isBindingElement(p) && (p.name === id || p.propertyName === id))
   );
+}
+
+// The statically-known property name a name node reads: `NAME`, `"NAME"`, or a
+// computed `["NAME"]` whose expression is a string literal. A name built from a
+// variable (`[k]`) is not statically known — returns undefined (out of scope).
+function staticPropertyName(nameNode: ts.Node): string | undefined {
+  if (ts.isComputedPropertyName(nameNode)) {
+    return ts.isStringLiteralLike(nameNode.expression)
+      ? nameNode.expression.text
+      : undefined;
+  }
+  return ts.isIdentifier(nameNode) || ts.isStringLiteralLike(nameNode)
+    ? nameNode.text
+    : undefined;
+}
+
+// True when an object literal is a destructuring *assignment target* — the LHS of
+// `=`, possibly nested inside an outer pattern — rather than a value being built.
+// `({ constructor: C } = obj)` reads obj.constructor; `return { constructor: v }`
+// does not, so only the former is treated as a property read.
+function isDestructuringTarget(node: ts.Node): boolean {
+  let current: ts.Node = node;
+  for (let parent = current.parent; parent; parent = current.parent) {
+    if (ts.isBinaryExpression(parent)) {
+      return (
+        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        parent.left === current
+      );
+    }
+    // Climb out of a nested destructuring pattern toward its assignment root.
+    if (
+      (ts.isPropertyAssignment(parent) ||
+        ts.isShorthandPropertyAssignment(parent) ||
+        ts.isSpreadAssignment(parent)) &&
+      ts.isObjectLiteralExpression(parent.parent)
+    ) {
+      current = parent.parent;
+      continue;
+    }
+    if (
+      ts.isSpreadElement(parent) &&
+      ts.isArrayLiteralExpression(parent.parent)
+    ) {
+      current = parent.parent;
+      continue;
+    }
+    if (ts.isArrayLiteralExpression(parent)) {
+      current = parent;
+      continue;
+    }
+    return false;
+  }
+  return false;
 }
 
 function detectForbiddenGlobals(
@@ -263,25 +328,31 @@ function detectForbiddenGlobals(
       flag(node.argumentExpression.text, "property");
     }
 
-    // destructuring: `const { constructor: C } = obj`, shorthand `const { NAME } =
-    // obj`, and computed `const { ["constructor"]: C } = obj` — each reads the
-    // named property just like member access does. Only object-pattern, non-rest
-    // elements read a named property; an array element binds by position and a
-    // rest element binds the remainder, so neither is a property read — skip them
-    // so a local merely named after a disallowed word isn't rejected.
+    // declaration destructuring: `const { constructor: C } = obj`, shorthand, and
+    // computed `const { ["constructor"]: C } = obj` read the named property just
+    // like member access. Only object-pattern, non-rest elements read a named
+    // property — an array element binds by position and a rest element binds the
+    // remainder, so neither is a property read; skip them so a local merely named
+    // after a disallowed word isn't rejected.
     if (
       ts.isBindingElement(node) &&
       ts.isObjectBindingPattern(node.parent) &&
       !node.dotDotDotToken
     ) {
-      const nameNode = node.propertyName ?? node.name;
-      const text = ts.isComputedPropertyName(nameNode)
-        ? ts.isStringLiteralLike(nameNode.expression)
-          ? nameNode.expression.text
-          : undefined
-        : ts.isIdentifier(nameNode) || ts.isStringLiteralLike(nameNode)
-          ? nameNode.text
-          : undefined;
+      const text = staticPropertyName(node.propertyName ?? node.name);
+      if (text && FORBIDDEN_PROPERTIES.has(text)) flag(text, "property");
+    }
+
+    // assignment destructuring: `({ constructor: C } = obj)` / `({ constructor } =
+    // obj)` reads obj.constructor, unlike an object literal built as a value
+    // (`return { constructor: v }`), which isDestructuringTarget rules out.
+    if (
+      (ts.isPropertyAssignment(node) ||
+        ts.isShorthandPropertyAssignment(node)) &&
+      ts.isObjectLiteralExpression(node.parent) &&
+      isDestructuringTarget(node.parent)
+    ) {
+      const text = staticPropertyName(node.name);
       if (text && FORBIDDEN_PROPERTIES.has(text)) flag(text, "property");
     }
 

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.ts
@@ -143,10 +143,42 @@ function validateTopLevelShape(
   }
 }
 
-// Crude check for forbidden runtime references. The generated code runs inside
-// jsdom's VM context (see sandbox/harness.ts), which has no access to certain
-// globals like fetch or XMLHttpRequest.
-const FORBIDDEN_GLOBALS = new Set(["fetch", "XMLHttpRequest"]);
+// Reject references a generated DOM extractor has no legitimate reason to use.
+// The extractor runs inside jsdom's VM context (see sandbox/harness.ts); this is
+// a validation/robustness layer over that, not an isolation boundary. It checks
+// the syntactic forms that reach a disallowed name (member, computed-string, and
+// destructuring access, plus `with`); it deliberately does not chase indirected
+// forms such as computed access through a variable (`x[k]`), which need dataflow.
+//
+// Globals the sandbox doesn't provide, plus code-eval primitives (`Function`/
+// `eval`) and ambient objects (`process`/`globalThis`) extractors never need.
+const FORBIDDEN_GLOBALS = new Set([
+  "fetch",
+  "XMLHttpRequest",
+  "Function",
+  "eval",
+  "process",
+  "globalThis",
+  "require",
+  "Reflect",
+  "Proxy",
+]);
+
+// Property names a DOM extractor should never read off an object, checked
+// wherever a property is *reached* — `obj.NAME`, `obj["NAME"]`, and
+// `const { NAME } = obj` destructuring. `constructor`/`__proto__` reach
+// constructors and prototypes, `getBuiltinModule`/`mainModule` are Node module
+// internals, and `Function`/`eval` read off an object are code-eval primitives.
+// None have a place in reading data out of a document.
+const FORBIDDEN_PROPERTIES = new Set([
+  "constructor",
+  "__proto__",
+  "getBuiltinModule",
+  "mainModule",
+  "Function",
+  "eval",
+  "XMLHttpRequest",
+]);
 
 function detectForbiddenGlobals(
   source: ts.SourceFile,
@@ -154,7 +186,23 @@ function detectForbiddenGlobals(
 ): void {
   const seen = new Set<string>();
 
+  const flag = (name: string, kind: "global" | "property" | "with"): void => {
+    if (seen.has(name)) return;
+    seen.add(name);
+    const reason =
+      kind === "global"
+        ? `references disallowed global '${name}' (not available in the sandbox; will throw at runtime)`
+        : kind === "with"
+          ? "uses a `with` statement, which is not allowed in generated extractors"
+          : `references disallowed property '${name}' (not permitted in generated extractors)`;
+    issues.push({ field: "source", reason, excerpt: name });
+  };
+
   const visit = (node: ts.Node): void => {
+    // `with (x) { ... }` resolves bare identifiers against x's properties, which
+    // would sidestep the property checks below; extractor code never needs it.
+    if (ts.isWithStatement(node)) flag("with", "with");
+
     if (ts.isIdentifier(node) && FORBIDDEN_GLOBALS.has(node.text)) {
       // Skip identifiers that are property names of access expressions
       // (`foo.fetch` doesn't reference the global fetch) or local bindings.
@@ -164,15 +212,38 @@ function detectForbiddenGlobals(
         ((ts.isPropertyAccessExpression(parent) && parent.name === node) ||
           (ts.isPropertyAssignment(parent) && parent.name === node) ||
           (ts.isBindingElement(parent) && parent.propertyName === node));
-      if (!isPropertyName && !seen.has(node.text)) {
-        seen.add(node.text);
-        issues.push({
-          field: "source",
-          reason: `references forbidden global '${node.text}' (not available in the sandbox; will throw at runtime)`,
-          excerpt: node.text,
-        });
-      }
+      if (!isPropertyName) flag(node.text, "global");
     }
+
+    // member access: `obj.constructor`, `obj.getBuiltinModule`, `obj.Function`
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      FORBIDDEN_PROPERTIES.has(node.name.text)
+    ) {
+      flag(node.name.text, "property");
+    }
+
+    // computed string access: `obj["constructor"]` — the form around the dot above.
+    if (
+      ts.isElementAccessExpression(node) &&
+      ts.isStringLiteralLike(node.argumentExpression) &&
+      FORBIDDEN_PROPERTIES.has(node.argumentExpression.text)
+    ) {
+      flag(node.argumentExpression.text, "property");
+    }
+
+    // destructuring: `const { constructor: C } = obj` / shorthand `const { NAME }
+    // = obj` — reads the property just like member access does.
+    if (ts.isBindingElement(node)) {
+      const nameNode = node.propertyName ?? node.name;
+      const text = ts.isIdentifier(nameNode)
+        ? nameNode.text
+        : ts.isStringLiteralLike(nameNode)
+          ? nameNode.text
+          : undefined;
+      if (text && FORBIDDEN_PROPERTIES.has(text)) flag(text, "property");
+    }
+
     ts.forEachChild(node, visit);
   };
 

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.ts
@@ -265,8 +265,15 @@ function detectForbiddenGlobals(
 
     // destructuring: `const { constructor: C } = obj`, shorthand `const { NAME } =
     // obj`, and computed `const { ["constructor"]: C } = obj` — each reads the
-    // property just like member access does.
-    if (ts.isBindingElement(node)) {
+    // named property just like member access does. Only object-pattern, non-rest
+    // elements read a named property; an array element binds by position and a
+    // rest element binds the remainder, so neither is a property read — skip them
+    // so a local merely named after a disallowed word isn't rejected.
+    if (
+      ts.isBindingElement(node) &&
+      ts.isObjectBindingPattern(node.parent) &&
+      !node.dotDotDotToken
+    ) {
       const nameNode = node.propertyName ?? node.name;
       const text = ts.isComputedPropertyName(nameNode)
         ? ts.isStringLiteralLike(nameNode.expression)

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.ts
@@ -168,8 +168,10 @@ const FORBIDDEN_GLOBALS = new Set([
 // wherever a property is *reached* — `obj.NAME`, `obj["NAME"]`, and
 // `const { NAME } = obj` destructuring. `constructor`/`__proto__` reach
 // constructors and prototypes, `getBuiltinModule`/`mainModule` are Node module
-// internals, and `Function`/`eval` read off an object are code-eval primitives.
-// None have a place in reading data out of a document.
+// internals, `Function`/`eval` are code-eval primitives, and `fetch`/
+// `XMLHttpRequest` are network primitives. These mirror the same names in
+// FORBIDDEN_GLOBALS so the member/computed forms (e.g. `window.fetch`) are
+// covered too. None belong in reading data out of a document.
 const FORBIDDEN_PROPERTIES = new Set([
   "constructor",
   "__proto__",
@@ -177,8 +179,39 @@ const FORBIDDEN_PROPERTIES = new Set([
   "mainModule",
   "Function",
   "eval",
+  "fetch",
   "XMLHttpRequest",
 ]);
+
+// A forbidden global name only matters as a *free reference*. Skip it when the
+// identifier is instead a name being introduced or a property key: a member name
+// (`x.fetch`), an object/class member (`{ fetch() {} }`), a declared binding
+// (`const fetch = ...`, a parameter, a function/class name), or a destructuring
+// target (`const { fetch } = x`). Otherwise a benign extractor that merely
+// shadows the name would be rejected.
+function isNameToken(id: ts.Identifier): boolean {
+  const p = id.parent;
+  if (!p) return false;
+  if (
+    (ts.isPropertyAccessExpression(p) && p.name === id) ||
+    (ts.isPropertyAssignment(p) && p.name === id) ||
+    (ts.isMethodDeclaration(p) && p.name === id) ||
+    (ts.isGetAccessorDeclaration(p) && p.name === id) ||
+    (ts.isSetAccessorDeclaration(p) && p.name === id) ||
+    (ts.isPropertyDeclaration(p) && p.name === id)
+  ) {
+    return true;
+  }
+  return (
+    (ts.isVariableDeclaration(p) && p.name === id) ||
+    (ts.isParameter(p) && p.name === id) ||
+    (ts.isFunctionDeclaration(p) && p.name === id) ||
+    (ts.isFunctionExpression(p) && p.name === id) ||
+    (ts.isClassDeclaration(p) && p.name === id) ||
+    (ts.isClassExpression(p) && p.name === id) ||
+    (ts.isBindingElement(p) && (p.name === id || p.propertyName === id))
+  );
+}
 
 function detectForbiddenGlobals(
   source: ts.SourceFile,
@@ -203,16 +236,14 @@ function detectForbiddenGlobals(
     // would sidestep the property checks below; extractor code never needs it.
     if (ts.isWithStatement(node)) flag("with", "with");
 
-    if (ts.isIdentifier(node) && FORBIDDEN_GLOBALS.has(node.text)) {
-      // Skip identifiers that are property names of access expressions
-      // (`foo.fetch` doesn't reference the global fetch) or local bindings.
-      const parent = node.parent;
-      const isPropertyName =
-        parent &&
-        ((ts.isPropertyAccessExpression(parent) && parent.name === node) ||
-          (ts.isPropertyAssignment(parent) && parent.name === node) ||
-          (ts.isBindingElement(parent) && parent.propertyName === node));
-      if (!isPropertyName) flag(node.text, "global");
+    // Only a *free reference* to a forbidden global counts — not an identifier in
+    // a name/declaration position (see isNameToken), so shadowing stays allowed.
+    if (
+      ts.isIdentifier(node) &&
+      FORBIDDEN_GLOBALS.has(node.text) &&
+      !isNameToken(node)
+    ) {
+      flag(node.text, "global");
     }
 
     // member access: `obj.constructor`, `obj.getBuiltinModule`, `obj.Function`
@@ -232,13 +263,16 @@ function detectForbiddenGlobals(
       flag(node.argumentExpression.text, "property");
     }
 
-    // destructuring: `const { constructor: C } = obj` / shorthand `const { NAME }
-    // = obj` — reads the property just like member access does.
+    // destructuring: `const { constructor: C } = obj`, shorthand `const { NAME } =
+    // obj`, and computed `const { ["constructor"]: C } = obj` — each reads the
+    // property just like member access does.
     if (ts.isBindingElement(node)) {
       const nameNode = node.propertyName ?? node.name;
-      const text = ts.isIdentifier(nameNode)
-        ? nameNode.text
-        : ts.isStringLiteralLike(nameNode)
+      const text = ts.isComputedPropertyName(nameNode)
+        ? ts.isStringLiteralLike(nameNode.expression)
+          ? nameNode.expression.text
+          : undefined
+        : ts.isIdentifier(nameNode) || ts.isStringLiteralLike(nameNode)
           ? nameNode.text
           : undefined;
       if (text && FORBIDDEN_PROPERTIES.has(text)) flag(text, "property");


### PR DESCRIPTION
## What

Tightens static validation of the generated JavaScript extractor scripts used by deterministic-JSON mode, and validates cached scripts on read.

- Reject additional disallowed references — constructors/prototypes, code-eval globals (`Function`/`eval`), ambient objects (`process`/`globalThis`), and Node module internals — across the syntactic forms that reach them: member access, computed-string access, destructuring, and `with` statements.
- Validate cached extractor scripts on read: a script cached before these rules is regenerated rather than reused. The check is guarded so a validator error falls back to regeneration.
- Add unit tests covering the rejected forms, the accepted normal-extractor path, and a documented limitation (computed access via a variable is out of scope for static checking).

## Why

Defense-in-depth around the extractor execution path. Generated DOM-extraction code has no legitimate reason to reference these names, so rejecting them — and re-checking cached scripts — keeps disallowed references from being generated or persisted. This is a validation/robustness layer, not an isolation boundary.

## Testing

- `vitest run src/lib/deterministicJson/pipeline/validate.test.ts` — 18/18.
- `tsc --noEmit` — clean, project-wide.
- `knip --cache`, `prettier` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened validation for generated deterministic-JSON extractor code and re-checked cached scripts before running to block disallowed references. Cached scripts that fail validation or make the validator throw are regenerated.

- **Bug Fixes**
  - Reject disallowed names — constructors/prototypes, code-eval (`Function`/`eval`), ambient (`globalThis`/`require`/`Reflect`/`Proxy`), Node internals, and network (`fetch`/`XMLHttpRequest`) — across member, computed-string (including computed destructuring), declaration object-pattern destructuring, and `with`; only free global references are flagged (shadowed names are allowed).
  - Validate cached extractor code on read; if validation fails or throws, regenerate instead of running it.
  - Restrict destructuring checks to declaration-time, non-rest object patterns to avoid false positives; assignment and for-of destructuring are out of scope, and value object literals remain allowed.
  - Add unit tests and document limits for variable-based computed access, reflection via string arguments, and assignment/for-of destructuring.

<sup>Written for commit 7051aff42c6e2af97d29fd3095fb888449aba067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

