### PR TITLE
feat: implement production-grade liveness and readiness probes

### DIFF
--- a/apps/api/src/controllers/v0/liveness.ts
+++ b/apps/api/src/controllers/v0/liveness.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from "express";
+import { redisRateLimitClient } from "../../services/rate-limiter";
 
 export async function livenessController(req: Request, res: Response) {
-  //TODO: add checks if the application is live and healthy like checking the redis connection
+  if (redisRateLimitClient.status === 'end') {
+     return res.status(503).json({ status: "error", message: "Redis connection has ended fatally" });
+  }
+
   res.status(200).json({ status: "ok" });
 }

--- a/apps/api/src/controllers/v0/liveness.ts
+++ b/apps/api/src/controllers/v0/liveness.ts
@@ -2,8 +2,17 @@ import { Request, Response } from "express";
 import { redisRateLimitClient } from "../../services/rate-limiter";
 
 export async function livenessController(req: Request, res: Response) {
-  if (redisRateLimitClient.status === 'end') {
-     return res.status(503).json({ status: "error", message: "Redis connection has ended fatally" });
+  try {
+    if (redisRateLimitClient.status !== 'ready') {
+      return res.status(503).json({ status: "error", message: "Redis connection is not ready" });
+    }
+    // Set a short timeout to prevent the ping from hanging indefinitely
+    await Promise.race([
+      redisRateLimitClient.ping(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("Redis ping timed out")), 2000))
+    ]);
+  } catch (error) {
+    return res.status(503).json({ status: "error", message: "Redis connection check failed" });
   }
 
   res.status(200).json({ status: "ok" });

--- a/apps/api/src/controllers/v0/liveness.ts
+++ b/apps/api/src/controllers/v0/liveness.ts
@@ -6,11 +6,14 @@ export async function livenessController(req: Request, res: Response) {
     if (redisRateLimitClient.status !== 'ready') {
       return res.status(503).json({ status: "error", message: "Redis connection is not ready" });
     }
-    // Set a short timeout to prevent the ping from hanging indefinitely
+    
+    let timer: NodeJS.Timeout;
     await Promise.race([
       redisRateLimitClient.ping(),
-      new Promise((_, reject) => setTimeout(() => reject(new Error("Redis ping timed out")), 2000))
-    ]);
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error("Redis ping timed out")), 2000);
+      })
+    ]).finally(() => clearTimeout(timer));
   } catch (error) {
     return res.status(503).json({ status: "error", message: "Redis connection check failed" });
   }

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -33,8 +33,7 @@ export async function readinessController(req: Request, res: Response) {
     logger.error("Readiness probe failed", { error: error instanceof Error ? error.message : error });
     res.status(503).json({ 
       status: "error", 
-      message: "Service is not ready",
-      detail: error instanceof Error ? error.message : "Unknown error"
+      message: "Service is not ready"
     });
   }
 }

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -7,10 +7,11 @@ import { logger } from "../../lib/logger";
 import { config } from "../../config";
 
 const withTimeout = <T>(promise: Promise<T>, timeoutMs: number, name: string): Promise<T> => {
-  return Promise.race([
-    promise,
-    new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${name} check timed out after ${timeoutMs}ms`)), timeoutMs))
-  ]);
+  let timer: NodeJS.Timeout;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${name} check timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer));
 };
 
 export async function readinessController(req: Request, res: Response) {

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -1,6 +1,40 @@
 import { Request, Response } from "express";
+import { sql } from "drizzle-orm";
+import { db, dbRr } from "../../db/connection";
+import { getRedisConnection } from "../../services/queue-service";
+import { redisRateLimitClient } from "../../services/rate-limiter";
+import { logger } from "../../lib/logger";
 
 export async function readinessController(req: Request, res: Response) {
-  // TODO: add checks when the application is ready to serve traffic
-  res.status(200).json({ status: "ok" });
+  try {
+    // 1. Check Redis Rate Limiter Connection
+    if (redisRateLimitClient.status !== 'ready') {
+       throw new Error("Redis rate limiter client is not ready");
+    }
+    await redisRateLimitClient.ping();
+
+    // 2. Check Redis Queue Connection
+    const queueRedis = getRedisConnection();
+    if (queueRedis.status !== 'ready') {
+       throw new Error("Redis queue client is not ready");
+    }
+    await queueRedis.ping();
+
+    // 3. Check Postgres Connections (Main and Replica)
+    if (db) {
+      await db.execute(sql`SELECT 1`);
+    }
+    if (dbRr) {
+      await dbRr.execute(sql`SELECT 1`);
+    }
+
+    res.status(200).json({ status: "ok", message: "Application is ready to serve traffic" });
+  } catch (error) {
+    logger.error("Readiness probe failed", { error: error instanceof Error ? error.message : error });
+    res.status(503).json({ 
+      status: "error", 
+      message: "Service is not ready",
+      detail: error instanceof Error ? error.message : "Unknown error"
+    });
+  }
 }

--- a/apps/api/src/controllers/v0/readiness.ts
+++ b/apps/api/src/controllers/v0/readiness.ts
@@ -4,28 +4,36 @@ import { db, dbRr } from "../../db/connection";
 import { getRedisConnection } from "../../services/queue-service";
 import { redisRateLimitClient } from "../../services/rate-limiter";
 import { logger } from "../../lib/logger";
+import { config } from "../../config";
+
+const withTimeout = <T>(promise: Promise<T>, timeoutMs: number, name: string): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${name} check timed out after ${timeoutMs}ms`)), timeoutMs))
+  ]);
+};
 
 export async function readinessController(req: Request, res: Response) {
   try {
+    const TIMEOUT_MS = 3000;
+
     // 1. Check Redis Rate Limiter Connection
     if (redisRateLimitClient.status !== 'ready') {
        throw new Error("Redis rate limiter client is not ready");
     }
-    await redisRateLimitClient.ping();
+    await withTimeout(redisRateLimitClient.ping(), TIMEOUT_MS, "Redis rate limiter");
 
     // 2. Check Redis Queue Connection
     const queueRedis = getRedisConnection();
     if (queueRedis.status !== 'ready') {
        throw new Error("Redis queue client is not ready");
     }
-    await queueRedis.ping();
+    await withTimeout(queueRedis.ping(), TIMEOUT_MS, "Redis queue");
 
-    // 3. Check Postgres Connections (Main and Replica)
-    if (db) {
-      await db.execute(sql`SELECT 1`);
-    }
-    if (dbRr) {
-      await dbRr.execute(sql`SELECT 1`);
+    // 3. Check Postgres Connections (Main and Replica) if configured
+    if (config.USE_DB_AUTHENTICATION) {
+      await withTimeout(db.execute(sql`SELECT 1`), TIMEOUT_MS, "Main DB");
+      await withTimeout(dbRr.execute(sql`SELECT 1`), TIMEOUT_MS, "Replica DB");
     }
 
     res.status(200).json({ status: "ok", message: "Application is ready to serve traffic" });


### PR DESCRIPTION
Resolves #4291

This PR implements the feature requested in the associated issue.

It implements production-grade readiness and liveness probes in `src/controllers/v0/readiness.ts` and `src/controllers/v0/liveness.ts` that actively verify connections to Postgres and Redis before returning `200 OK`. This resolves existing TODOs in those files and ensures that orchestration systems like Kubernetes only route traffic to fully healthy pods.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production-grade liveness and readiness probes so orchestrators route traffic only to healthy pods. Previously both endpoints returned 200 without checks; now liveness verifies the rate limiter Redis is responsive, and readiness verifies rate limiter Redis, queue Redis, and optionally Postgres before advertising readiness.

Liveness returns 503 if the rate limiter Redis client is not ready or its PING exceeds 2s; timers are cleared in finally to prevent leaks. Readiness requires both Redis clients to be ready and respond within 3s; when `config.USE_DB_AUTHENTICATION` is true, it runs SELECT 1 on main and replica via `drizzle-orm`. On failure, it logs the error and returns 503 with "Service is not ready" and no internal details.

- Rollout: Update orchestration health checks to the v0 liveness/readiness endpoints; pods can remain Unready until Redis and Postgres are available.

<sup>Written for commit 39852290fabf66ef85c3972259edb4fcec8821b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

