### PR TITLE
test(playwright): cover IPv4-mapped IPv6 SSRF handling

### DIFF
--- a/apps/playwright-service-ts/api.test.ts
+++ b/apps/playwright-service-ts/api.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import IPAddr from "ipaddr.js";
+
+const isUnicast = (address: string): boolean =>
+  IPAddr.process(address).range() === "unicast";
+
+test("IPv4-mapped IPv6 loopback is not considered unicast", () => {
+  assert.equal(isUnicast("::ffff:127.0.0.1"), false);
+});
+
+test("IPv4-mapped IPv6 private address is not considered unicast", () => {
+  assert.equal(isUnicast("::ffff:10.0.0.1"), false);
+});
+
+test("IPv4-mapped IPv6 public address remains unicast", () => {
+  assert.equal(isUnicast("::ffff:8.8.8.8"), true);
+});

--- a/apps/playwright-service-ts/api.test.ts
+++ b/apps/playwright-service-ts/api.test.ts
@@ -1,18 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import IPAddr from "ipaddr.js";
+import { isInternalHost } from "./api";
 
-const isUnicast = (address: string): boolean =>
-  IPAddr.process(address).range() === "unicast";
-
-test("IPv4-mapped IPv6 loopback is not considered unicast", () => {
-  assert.equal(isUnicast("::ffff:127.0.0.1"), false);
+test("IPv4-mapped IPv6 loopback is treated as internal", async () => {
+  assert.equal(await isInternalHost("::ffff:127.0.0.1"), true);
 });
 
-test("IPv4-mapped IPv6 private address is not considered unicast", () => {
-  assert.equal(isUnicast("::ffff:10.0.0.1"), false);
+test("IPv4-mapped IPv6 private address is treated as internal", async () => {
+  assert.equal(await isInternalHost("::ffff:10.0.0.1"), true);
 });
 
-test("IPv4-mapped IPv6 public address remains unicast", () => {
-  assert.equal(isUnicast("::ffff:8.8.8.8"), true);
+test("public IPv4-mapped IPv6 address remains external", async () => {
+  assert.equal(await isInternalHost("::ffff:8.8.8.8"), false);
 });

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -60,7 +60,7 @@ const isInternalHost = async (hostname: string): Promise<boolean> => {
   }
   return (
     addresses.length === 0 ||
-    addresses.some((a) => IPAddr.parse(a).range() !== 'unicast')
+    addresses.some((a) => IPAddr.process(a).range() !== 'unicast')
   );
 };
 

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -44,7 +44,7 @@ class InsecureConnectionError extends Error {
   }
 }
 
-const isInternalHost = async (hostname: string): Promise<boolean> => {
+export const isInternalHost = async (hostname: string): Promise<boolean> => {
   const host = hostname.toLowerCase().replace(/\.$/, '');
   if (!host) return true;
 
@@ -565,12 +565,12 @@ const start = async () => {
     console.log(`Server is running on port ${port}`);
   });
 };
-start().catch((error) => {
-  console.error('Failed to start server:', error);
-  process.exit(1);
-});
-
 if (require.main === module) {
+  start().catch((error) => {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  });
+
   process.on('SIGINT', () => {
     shutdownBrowser().then(() => {
       console.log('Browser closed');


### PR DESCRIPTION
## Summary

Adds regression coverage for IPv4-mapped IPv6 addresses used by the Playwright SSRF protection logic.

This covers the behavior introduced by using `IPAddr.process()` for IPv4-mapped IPv6 DNS results.

## Tests

- IPv4-mapped IPv6 loopback is not considered unicast
- IPv4-mapped IPv6 private address is not considered unicast
- IPv4-mapped IPv6 public address remains unicast

## Validation

- `pnpm exec tsx --test api.test.ts`
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSRF classification for IPv4-mapped IPv6 DNS results in the Playwright service and adds regression tests. Previously, `::ffff:127.0.0.1` and `::ffff:10.0.0.1` were treated as external/unicast; now they are internal and blocked. `::ffff:8.8.8.8` remains external.

- Normalize addresses with `IPAddr.process()` from `ipaddr.js` before range checks.
- Export `isInternalHost` and only start the server when `require.main === module` to avoid booting on import.
- Add `apps/playwright-service-ts/api.test.ts` covering mapped loopback, private, and public cases.

<sup>Written for commit 1aa4dfee9be701eedffa6e53734a7f395995bd12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

