### PR TITLE
feat(api): add OrcaRouter OpenAI-compatible provider

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -60,6 +60,8 @@ RATE_LIMIT_TEST_API_KEY_CRAWL=
 SCRAPING_BEE_API_KEY=
 # add for LLM dependent features (image alt generation, etc.)
 OPENAI_API_KEY=
+# add for LLM dependent features via OrcaRouter (OpenAI-compatible model routing gateway)
+ORCAROUTER_API_KEY=
 BULL_AUTH_KEY=@
 # set if you have a llamaparse key you'd like to use to parse pdfs
 LLAMAPARSE_API_KEY=

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -112,6 +112,7 @@ const configSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
+  ORCAROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/apps/api/src/lib/generic-ai.test.ts
+++ b/apps/api/src/lib/generic-ai.test.ts
@@ -1,0 +1,116 @@
+import { vi, describe, it, expect } from "vitest";
+
+// A callable provider stub (AI SDK providers are callable: provider("model-id")
+// is shorthand for provider.chat("model-id")) with .chat/.embedding methods.
+const { createOpenRouterMock } = vi.hoisted(() => {
+  const makeProvider = () => {
+    const chat = vi.fn((id: string) => ({ id }));
+    const embedding = vi.fn((id: string) => ({ id }));
+    const provider: any = vi.fn((id: string) => chat(id));
+    provider.chat = chat;
+    provider.embedding = embedding;
+    return provider;
+  };
+  return { createOpenRouterMock: vi.fn((_opts: unknown) => makeProvider()) };
+});
+
+// generic-ai.ts instantiates every provider at module load; stub them all so
+// the orcarouter wiring can be asserted in isolation.
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => ({ chat: vi.fn(), embedding: vi.fn() })),
+}));
+vi.mock("ollama-ai-provider-v2", () => ({
+  createOllama: vi.fn(() => ({ chat: vi.fn(), embedding: vi.fn() })),
+}));
+vi.mock("@ai-sdk/anthropic", () => ({
+  anthropic: { chat: vi.fn(), embedding: vi.fn() },
+}));
+vi.mock("@ai-sdk/groq", () => ({
+  groq: { chat: vi.fn(), embedding: vi.fn() },
+}));
+vi.mock("@ai-sdk/google", () => ({
+  google: { chat: vi.fn(), embedding: vi.fn() },
+}));
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: createOpenRouterMock,
+}));
+vi.mock("@ai-sdk/fireworks", () => ({
+  fireworks: { chat: vi.fn(), embedding: vi.fn() },
+}));
+vi.mock("@ai-sdk/deepinfra", () => ({
+  deepinfra: { chat: vi.fn(), embedding: vi.fn() },
+}));
+vi.mock("@ai-sdk/google-vertex", () => ({
+  createVertex: vi.fn(() => ({ chat: vi.fn(), embedding: vi.fn() })),
+}));
+vi.mock("../config", () => ({
+  config: {
+    OLLAMA_BASE_URL: undefined,
+    OPENAI_API_KEY: undefined,
+    OPENAI_BASE_URL: undefined,
+    OPENROUTER_API_KEY: undefined,
+    ORCAROUTER_API_KEY: "sk-orca-test",
+    MODEL_NAME: undefined,
+    MODEL_EMBEDDING_NAME: undefined,
+    VERTEX_CREDENTIALS: undefined,
+  },
+}));
+
+import { getModel, getEmbeddingModel } from "./generic-ai";
+
+describe("generic-ai orcarouter provider", () => {
+  it("registers an orcarouter provider pointing at api.orcarouter.ai", () => {
+    const callIndex = createOpenRouterMock.mock.calls.findIndex(
+      ([opts]) =>
+        (opts as { baseURL?: string }).baseURL ===
+        "https://api.orcarouter.ai/v1",
+    );
+    expect(callIndex).toBeGreaterThan(-1);
+
+    const opts = createOpenRouterMock.mock.calls[callIndex][0] as {
+      apiKey?: string;
+      baseURL?: string;
+      compatibility?: string;
+    };
+    expect(opts).toMatchObject({
+      apiKey: "sk-orca-test",
+      baseURL: "https://api.orcarouter.ai/v1",
+      compatibility: "compatible",
+    });
+  });
+
+  it("routes getModel requests through the orcarouter provider", () => {
+    const callIndex = createOpenRouterMock.mock.calls.findIndex(
+      ([opts]) =>
+        (opts as { baseURL?: string }).baseURL ===
+        "https://api.orcarouter.ai/v1",
+    );
+    const orcaProvider = createOpenRouterMock.mock.results[callIndex]
+      .value as any;
+
+    const model = getModel("openai/gpt-5.5", "orcarouter");
+
+    expect(orcaProvider.chat).toHaveBeenCalledWith("openai/gpt-5.5");
+    expect(model).toEqual({ id: "openai/gpt-5.5" });
+  });
+
+  it("routes getEmbeddingModel requests through the orcarouter provider", () => {
+    const callIndex = createOpenRouterMock.mock.calls.findIndex(
+      ([opts]) =>
+        (opts as { baseURL?: string }).baseURL ===
+        "https://api.orcarouter.ai/v1",
+    );
+    const orcaProvider = createOpenRouterMock.mock.results[callIndex]
+      .value as any;
+
+    const embedding = getEmbeddingModel(
+      "openai/text-embedding-3-small",
+      "orcarouter",
+    );
+
+    expect(orcaProvider.embedding).toHaveBeenCalledWith(
+      "openai/text-embedding-3-small",
+    );
+    expect(embedding).toEqual({ id: "openai/text-embedding-3-small" });
+  });
+});

--- a/apps/api/src/lib/generic-ai.ts
+++ b/apps/api/src/lib/generic-ai.ts
@@ -16,6 +16,7 @@ type Provider =
   | "groq"
   | "google"
   | "openrouter"
+  | "orcarouter"
   | "fireworks"
   | "deepinfra"
   | "vertex";
@@ -34,6 +35,11 @@ const providerList: Record<Provider, any> = {
   google, //GOOGLE_GENERATIVE_AI_API_KEY
   openrouter: createOpenRouter({
     apiKey: config.OPENROUTER_API_KEY,
+  }),
+  orcarouter: createOpenRouter({
+    apiKey: config.ORCAROUTER_API_KEY,
+    baseURL: "https://api.orcarouter.ai/v1",
+    compatibility: "compatible",
   }),
   fireworks, //FIREWORKS_API_KEY
   deepinfra, //DEEPINFRA_API_KEY


### PR DESCRIPTION
## Summary

Adds a named `orcarouter` provider to the API's generic AI layer ([OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway). It mirrors the existing `openrouter` entry but points at `https://api.orcarouter.ai/v1`, so self-hosted users can route LLM-dependent features (image alt generation, branding, etc.) through OrcaRouter by setting `ORCAROUTER_API_KEY` and selecting the `orcarouter` provider.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Changes

- `apps/api/src/lib/generic-ai.ts`: register `orcarouter` in the `Provider` union and provider list, using `createOpenRouter` with `baseURL: "https://api.orcarouter.ai/v1"` and `compatibility: "compatible"`.
- `apps/api/src/config.ts`: add optional `ORCAROUTER_API_KEY`.
- `apps/api/.env.example`: document `ORCAROUTER_API_KEY`.
- `apps/api/src/lib/generic-ai.test.ts`: unit tests asserting the provider wiring (base URL, compatibility mode, API key passthrough, chat/embedding routing).

## Usage

1. Get an API key from https://www.orcarouter.ai/console.
2. Set `ORCAROUTER_API_KEY` in `apps/api/.env`.
3. Select the `orcarouter` provider where the generic AI layer is configured, e.g. `getModel("openai/gpt-5.5", "orcarouter")`.

## Verification

- Unit tests: 3 passed (`pnpm vitest run src/lib/generic-ai.test.ts`).
- Live against OrcaRouter: non-stream and stream chat via `https://api.orcarouter.ai/v1/chat/completions` returned 200; invalid key returned 401; `getModel("openai/gpt-5.5", "orcarouter")` -> `generateText` returned `ORCA-OK`.
- `tsc --noEmit` reports no errors for the changed files (pre-existing `@mendable/firecrawl-rs` native-binding errors are unrelated and are resolved by the CI native build step).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `orcarouter` provider to the generic AI layer so OpenAI‑compatible chat and embedding requests can route through OrcaRouter. Previously there was no `orcarouter` option; now users can opt in by setting `ORCAROUTER_API_KEY` and selecting `orcarouter`, with no impact to existing providers.

- Registers `orcarouter` in `generic-ai.ts` (Provider union and provider list) using `createOpenRouter` with baseURL `https://api.orcarouter.ai/v1` and `compatibility: "compatible"`.
- Adds optional `ORCAROUTER_API_KEY` to config and documents it in `.env.example`.
- Adds unit tests verifying base URL, compatibility, API key passthrough, and chat/embedding routing.
- No behavior change unless `orcarouter` is selected. To use, set `ORCAROUTER_API_KEY` and call `getModel("<model>", "orcarouter")` or `getEmbeddingModel("<model>", "orcarouter")`.

<sup>Written for commit 216f5d13c5daaa2e205430c096b928b0481924ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

