### PR TITLE
fix(api): make crawl limit check in lockURL atomic

### DIFF
--- a/apps/api/src/lib/crawl-redis.test.ts
+++ b/apps/api/src/lib/crawl-redis.test.ts
@@ -1,4 +1,5 @@
-import { generateURLPermutations } from "./crawl-redis";
+import { generateURLPermutations, lockURL, StoredCrawl } from "./crawl-redis";
+import { redisEvictConnection } from "../services/redis";
 
 describe("generateURLPermutations", () => {
   it("generates permutations correctly", () => {
@@ -79,5 +80,39 @@ describe("generateURLPermutations", () => {
     expect(wwwHttp.includes("http://www.firecrawl.dev/")).toBe(true);
     expect(wwwHttp.includes("http://www.firecrawl.dev/index.html")).toBe(true);
     expect(wwwHttp.includes("http://www.firecrawl.dev/index.php")).toBe(true);
+  });
+});
+
+describe("lockURL", () => {
+  it("does not let concurrent callers exceed crawlerOptions.limit", async () => {
+    const id = "test-lockurl-concurrency-limit";
+    const limit = 5;
+    const concurrency = 20;
+    const sc = {
+      crawlerOptions: { limit },
+    } as StoredCrawl;
+
+    await redisEvictConnection.del(
+      "crawl:" + id + ":visited",
+      "crawl:" + id + ":visited_unique",
+    );
+
+    try {
+      const results = await Promise.all(
+        Array.from({ length: concurrency }, (_, i) =>
+          lockURL(id, sc, `https://firecrawl.dev/page-${i}`),
+        ),
+      );
+
+      expect(results.filter(Boolean).length).toBe(limit);
+      expect(
+        await redisEvictConnection.scard("crawl:" + id + ":visited_unique"),
+      ).toBe(limit);
+    } finally {
+      await redisEvictConnection.del(
+        "crawl:" + id + ":visited",
+        "crawl:" + id + ":visited_unique",
+      );
+    }
   });
 });

--- a/apps/api/src/lib/crawl-redis.test.ts
+++ b/apps/api/src/lib/crawl-redis.test.ts
@@ -115,4 +115,27 @@ describe("lockURL", () => {
       );
     }
   });
+
+  it("rejects all locks when crawlerOptions.limit is negative", async () => {
+    const id = "test-lockurl-negative-limit";
+    const sc = {
+      crawlerOptions: { limit: -1 },
+    } as StoredCrawl;
+
+    await redisEvictConnection.del(
+      "crawl:" + id + ":visited",
+      "crawl:" + id + ":visited_unique",
+    );
+
+    try {
+      const result = await lockURL(id, sc, "https://firecrawl.dev/page-0");
+
+      expect(result).toBe(false);
+    } finally {
+      await redisEvictConnection.del(
+        "crawl:" + id + ":visited",
+        "crawl:" + id + ":visited_unique",
+      );
+    }
+  });
 });

--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -532,7 +532,7 @@ export async function lockURL(
 
     const limit =
       typeof sc.crawlerOptions?.limit === "number"
-        ? sc.crawlerOptions.limit
+        ? Math.max(sc.crawlerOptions.limit, 0)
         : -1;
 
     const added = (await redisEvictConnection.eval(

--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -485,6 +485,33 @@ export function generateURLPermutations(url: string | URL): URL[] {
   return [...new Set(permutations.map(x => x.href))].map(x => new URL(x));
 }
 
+// Atomically checks the visited_unique limit and adds the URL to both sets.
+// Must be a single script: a separate SCARD check followed by SADD calls
+// leaves a TOCTOU window where concurrent workers can all pass the limit
+// check before any of them records their URL, overshooting the limit.
+const LOCK_URL_SCRIPT = `
+local visitedKey = KEYS[1]
+local uniqueKey = KEYS[2]
+local visitedMember = ARGV[1]
+local uniqueMember = ARGV[2]
+local limit = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+
+if limit >= 0 and redis.call("SCARD", uniqueKey) >= limit then
+  return -1
+end
+
+local added = redis.call("SADD", visitedKey, visitedMember)
+redis.call("EXPIRE", visitedKey, ttl)
+
+if added ~= 0 then
+  redis.call("SADD", uniqueKey, uniqueMember)
+  redis.call("EXPIRE", uniqueKey, ttl)
+end
+
+return added
+`;
+
 export async function lockURL(
   id: string,
   sc: StoredCrawl,
@@ -499,38 +526,31 @@ export async function lockURL(
       operation: "lock_url",
     });
 
-    if (typeof sc.crawlerOptions?.limit === "number") {
-      if (
-        (await redisEvictConnection.scard("crawl:" + id + ":visited_unique")) >=
-        sc.crawlerOptions.limit
-      ) {
-        setSpanAttributes(span, { "crawl.limit_reached": true });
-        return false;
-      }
+    const visitedMember = !sc.crawlerOptions?.deduplicateSimilarURLs
+      ? normalizedUrl
+      : generateURLPermutations(normalizedUrl)[0].href;
+
+    const limit =
+      typeof sc.crawlerOptions?.limit === "number"
+        ? sc.crawlerOptions.limit
+        : -1;
+
+    const added = (await redisEvictConnection.eval(
+      LOCK_URL_SCRIPT,
+      2,
+      "crawl:" + id + ":visited",
+      "crawl:" + id + ":visited_unique",
+      visitedMember,
+      normalizedUrl,
+      limit,
+      24 * 60 * 60,
+    )) as number;
+
+    const res = added > 0;
+
+    if (added === -1) {
+      setSpanAttributes(span, { "crawl.limit_reached": true });
     }
-
-    const pipeline = redisEvictConnection.pipeline();
-
-    if (!sc.crawlerOptions?.deduplicateSimilarURLs) {
-      pipeline.sadd("crawl:" + id + ":visited", normalizedUrl);
-    } else {
-      const permutation = generateURLPermutations(normalizedUrl)[0].href;
-      pipeline.sadd("crawl:" + id + ":visited", permutation);
-    }
-
-    pipeline.expire("crawl:" + id + ":visited", 24 * 60 * 60);
-
-    const results = await pipeline.exec();
-    const saddResult = results?.[0]?.[1] as number;
-    const res = saddResult !== 0;
-
-    if (res) {
-      const uniquePipeline = redisEvictConnection.pipeline();
-      uniquePipeline.sadd("crawl:" + id + ":visited_unique", normalizedUrl);
-      uniquePipeline.expire("crawl:" + id + ":visited_unique", 24 * 60 * 60);
-      await uniquePipeline.exec();
-    }
-
     setSpanAttributes(span, { "crawl.url_locked": res });
     return res;
   });


### PR DESCRIPTION
Fixes #4298.

## Bug

`lockURL()` in `apps/api/src/lib/crawl-redis.ts` checked the crawl `limit` with a non-atomic read (`SCARD` on `visited_unique`) and then added the URL with separate pipelines (`SADD` on `visited`, then `SADD` on `visited_unique`). The check and the adds were not connected atomically, so concurrent workers could all read a count below the limit, all pass the guard, and all add their URL — causing a crawl to exceed its configured `limit` by up to N (the number of concurrent workers hitting the race).

## Fix

Combined the limit check and both `SADD`s into a single Lua script (`LOCK_URL_SCRIPT`) executed via `redisEvictConnection.eval`. Redis executes Lua scripts atomically, so there's no window between checking the count and recording the URL. The script returns:
- `-1` if the limit is already reached (crawl.limit_reached span attribute set, url not locked)
- `0` if the URL was already visited (permutation/normalized-URL dedup, matching prior behavior)
- `1` if the URL was newly locked

This preserves existing semantics (`deduplicateSimilarURLs` permutation-based dedup on the `visited` set, `visited_unique` only updated when `visited` is newly added) while making the limit enforcement atomic.

## Testing

Added `apps/api/src/lib/crawl-redis.test.ts` › `lockURL` › "does not let concurrent callers exceed crawlerOptions.limit": fires 20 concurrent `lockURL` calls with distinct URLs against a real Redis instance with `crawlerOptions.limit = 5`, and asserts exactly 5 succeed and `visited_unique` cardinality is exactly 5.

Verified the test fails without the fix and passes with it:

```
# with `git checkout HEAD~1 -- apps/api/src/lib/crawl-redis.ts` (pre-fix code)
✗ does not let concurrent callers exceed crawlerOptions.limit
  AssertionError: expected 20 to be 5

# with the fix applied
✓ does not let concurrent callers exceed crawlerOptions.limit
```

Also ran:
- `pnpm exec tsc --noEmit` — no errors
- `pnpm knip --cache` — no new findings (pre-existing unrelated hint only)
- `pnpm exec prettier --check src/lib/crawl-redis.ts src/lib/crawl-redis.test.ts` — passes
- Full `crawl-redis.test.ts` suite — passes except a pre-existing, unrelated failure in `generateURLPermutations` (`expected 12 to be 16`) that reproduces identically on unmodified `main` and is untouched by this change.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude). The fix, tests, and this description were reviewed before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `crawlerOptions.limit` in `lockURL` atomically and restores negative-limit semantics to prevent overshooting under concurrency. Before: a non-atomic `SCARD` then `SADD`s let multiple workers exceed the limit; now: a single Redis Lua script checks the limit and writes to both sets atomically.

- Executes `LOCK_URL_SCRIPT` via `redisEvictConnection.eval`; returns -1 (limit reached), 0 (already visited), 1 (new). `lockURL` still returns a boolean and sets `crawl.limit_reached` and `crawl.url_locked` span attributes.
- Preserves dedup semantics: when `deduplicateSimilarURLs` is on, write the permutation to `visited`; only add the normalized URL to `visited_unique` when `visited` is newly added. TTLs remain 24h.
- Explicit negative `crawlerOptions.limit` now rejects all locks (clamped to 0), matching pre-rewrite behavior; omit/undefined still means “no limit.”
- Tests: add a concurrency test asserting exactly `limit` successes with 20 parallel calls, and a negative-limit test rejecting all locks. No migration required.

<sup>Written for commit 99b65e8b3370a17c9c268d3d3483a32132bd785e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

