### PR TITLE
fix(validateUrl): use the public suffix list for isSameDomain/isSameSubdomain

### DIFF
--- a/apps/api/src/lib/validateUrl.test.ts
+++ b/apps/api/src/lib/validateUrl.test.ts
@@ -17,6 +17,22 @@ describe("isSameDomain", () => {
     expect(result).toBe(false);
   });
 
+  it("should return false for different domains sharing a multi-part TLD", () => {
+    const result = isSameDomain(
+      "https://example.co.uk",
+      "https://attacker.co.uk",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("should return true for a subdomain on a multi-part TLD", () => {
+    const result = isSameDomain(
+      "https://sub.example.co.uk",
+      "https://example.co.uk",
+    );
+    expect(result).toBe(true);
+  });
+
   it("should return true for a subdomain with different protocols", () => {
     const result = isSameDomain(
       "https://sub.example.com",
@@ -70,6 +86,14 @@ describe("isSameSubdomain", () => {
     const result = isSameSubdomain(
       "http://docs.example.com",
       "http://blog.example.com",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("should return false for different domains sharing a multi-part TLD", () => {
+    const result = isSameSubdomain(
+      "https://a.example.co.uk",
+      "https://b.example.co.uk",
     );
     expect(result).toBe(false);
   });

--- a/apps/api/src/lib/validateUrl.ts
+++ b/apps/api/src/lib/validateUrl.ts
@@ -1,5 +1,6 @@
 import * as undici from "undici";
 import { getSecureDispatcher } from "../scraper/scrapeURL/engines/utils/safeFetch";
+import { parseHostname } from "./url-utils";
 
 export const protocolIncluded = (url: string) => {
   // if :// not in the start of the url assume http (maybe https?)
@@ -57,6 +58,24 @@ export const checkUrl = (url: string) => {
   return url;
 };
 
+// A leading "www." is treated as part of the registrable name, matching the
+// previous behavior where it was stripped before comparison.
+const stripWww = (hostname: string) =>
+  hostname.startsWith("www.") ? hostname.slice(4) : hostname;
+
+// Registrable domain via the public suffix list. The old split/slice logic
+// was wrong for multi-part TLDs: it collapsed example.co.uk to its suffix, so
+// example.co.uk and attacker.co.uk compared equal. Falls back to the bare
+// hostname for inputs with no registrable domain (IPs, localhost) so those
+// keep comparing by hostname.
+const registrableDomain = (hostname: string) => {
+  const cleaned = stripWww(hostname);
+  return parseHostname(cleaned).domain ?? cleaned;
+};
+
+const subdomainOf = (hostname: string) =>
+  parseHostname(stripWww(hostname)).subdomain ?? "";
+
 /**
  * Same domain check
  * It checks if the domain of the url is the same as the base url
@@ -73,21 +92,8 @@ export function isSameDomain(url: string, baseUrl: string) {
     return false;
   }
 
-  const typedUrlObj1 = urlObj1 as URL;
-  const typedUrlObj2 = urlObj2 as URL;
-
-  const cleanHostname = (hostname: string) => {
-    return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
-  };
-
-  const domain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-  const domain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
+  const domain1 = registrableDomain((urlObj1 as URL).hostname);
+  const domain2 = registrableDomain((urlObj2 as URL).hostname);
 
   return domain1 === domain2;
 }
@@ -100,33 +106,14 @@ export function isSameSubdomain(url: string, baseUrl: string) {
     return false;
   }
 
-  const typedUrlObj1 = urlObj1 as URL;
-  const typedUrlObj2 = urlObj2 as URL;
-
-  const cleanHostname = (hostname: string) => {
-    return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
-  };
-
-  const domain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-  const domain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-
-  const subdomain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(0, -2)
-    .join(".");
-  const subdomain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(0, -2)
-    .join(".");
+  const hostname1 = (urlObj1 as URL).hostname;
+  const hostname2 = (urlObj2 as URL).hostname;
 
   // Check if the domains are the same and the subdomains are the same
-  return domain1 === domain2 && subdomain1 === subdomain2;
+  return (
+    registrableDomain(hostname1) === registrableDomain(hostname2) &&
+    subdomainOf(hostname1) === subdomainOf(hostname2)
+  );
 }
 
 export const checkAndUpdateURLForMap = (


### PR DESCRIPTION
Fixes #4296.

`isSameDomain` extracted the registrable domain with `.split(".").slice(-2).join(".")`. That is wrong for any two-label TLD (`.co.uk`, `.com.au`, `.co.in`, ...). For `example.co.uk` it returns `co.uk`, and it returns the same for `attacker.co.uk`, so:

```ts
isSameDomain("https://example.co.uk", "https://attacker.co.uk") // => true (should be false)
```

`isSameSubdomain` has the same `slice(-2)` logic and the same flaw. Both feed the map link filters (`map.ts`, `map-utils.ts`), so a cross-domain link on a multi-label TLD passes the same-domain scope check.

The codebase already handles this correctly elsewhere: `url-utils.ts` exports `parseHostname`, which runs the hostname through the public suffix list (via `tldts`, already a dependency), and its own comment says to route registrable-domain lookups through it "so no call site can forget these." These two functions were the call sites that forgot. This change switches them to `parseHostname` and drops the hand-rolled slicing.

Behavior I made sure to preserve:
- A leading `www.` is still stripped, so the existing www tests pass.
- Hostnames with no registrable domain (IPs, `localhost`) fall back to comparing the bare hostname, so same-IP still counts as same domain.

I verified every existing case plus the new multi-part TLD cases against real `tldts` before writing it (existing subdomain/www/IP behavior unchanged, `example.co.uk` vs `attacker.co.uk` now `false`, `sub.example.co.uk` vs `example.co.uk` still `true`). Added tests for the multi-part TLD cases to `validateUrl.test.ts` for both functions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches isSameDomain/isSameSubdomain to Public Suffix List-backed parsing to correctly handle multi-part TLDs and close a scope-check gap in map link filters. Previously example.co.uk and attacker.co.uk compared equal; now they do not; www handling and IP/localhost fallbacks are unchanged.

- Replaces split/slice logic with parseHostname from url-utils (via `tldts`) and removes hand-rolled parsing.
- Adds helpers: stripWww, registrableDomain, subdomainOf; uses registrable domain when available, otherwise compares bare hostname.
- Adds tests for multi-part TLD cases in validateUrl.test.ts.
- No API changes; impact is limited to more accurate same-domain/subdomain checks on multi-part TLDs.

<sup>Written for commit 78d4c5fd30a96c6c0fbd9cf92facbf6a90e90fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

