### PR TITLE
billing: make research paper endpoints zero-credit (research index)

### DIFF
--- a/apps/api/src/__tests__/snips/v2/research.test.ts
+++ b/apps/api/src/__tests__/snips/v2/research.test.ts
@@ -173,7 +173,7 @@ describeIf(HAS_RESEARCH)("Research API", () => {
   });
 
   describeIf(TEST_PRODUCTION)("research billing", () => {
-    it("bills read-paper as one scrape-like credit", async () => {
+    it("research read-paper remains zero-credit", async () => {
       const identity = await idmux({
         name: "research/bills read paper",
         credits: 100,
@@ -193,7 +193,7 @@ describeIf(HAS_RESEARCH)("Research API", () => {
       expect(before - after).toBe(0);
     }, 180000);
 
-    it("bills search-like endpoints by returned result count", async () => {
+    it("research search-like endpoints remain zero-credit", async () => {
       const identity = await idmux({
         name: "research/bills search papers",
         credits: 100,

--- a/apps/api/src/__tests__/snips/v2/research.test.ts
+++ b/apps/api/src/__tests__/snips/v2/research.test.ts
@@ -190,7 +190,7 @@ describeIf(HAS_RESEARCH)("Research API", () => {
 
       await sleepForBilling();
       const after = (await creditUsage(identity)).remainingCredits;
-      expect(before - after).toBe(1);
+      expect(before - after).toBe(0);
     }, 180000);
 
     it("bills search-like endpoints by returned result count", async () => {
@@ -212,7 +212,7 @@ describeIf(HAS_RESEARCH)("Research API", () => {
 
       await sleepForBilling();
       const after = (await creditUsage(identity)).remainingCredits;
-      expect(before - after).toBe(expectedCredits);
+      expect(before - after).toBe(0);
     }, 180000);
   });
 });

--- a/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
@@ -175,7 +175,7 @@ describe("developer category code_searches ledger", () => {
     expect(row.team_id).toBe(TEAM_ID);
     expect(row.target).toBe("vector database client");
     expect(row.num_results).toBe(2);
-    expect(row.credits_cost).toBe(0);
+    expect(row.credits_cost).toBe(2);
     expect(row.is_successful).toBe(true);
     expect(row.options.origin).toBe("sdk");
     expect(row.options.integration).toBe("cli");

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -201,6 +201,17 @@ function creditsFor(
   body: any,
   req: RequestWithAuth<any, any, any>,
 ) {
+  // Make certain research index accesses free (AI/ML & life-sciences indices).
+  // Research paper endpoints should have no credit cost. Explicit exceptions
+  // remain billable: GitHub search and developer/code search.
+  const freeResearchKinds = new Set([
+    "research_paper_search",
+    "research_related_papers",
+    "research_paper_read",
+    "research_paper_inspect",
+  ]);
+  if (freeResearchKinds.has(config.kind)) return 0;
+
   if (config.billAs === "scrape") return 1;
   const forcedKind = getSearchForcedKind(req.acuc?.flags);
   const perTen =

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -301,7 +301,9 @@ export async function searchController(
         time_taken: timeTakenInSeconds,
         team_id: req.auth.team_id,
         options: req.body,
-        credits_cost: shouldBill ? result.searchCredits : 0,
+        // Don't record preview tokens as billed in the ledger — only record
+        // credits when billing is actually applied.
+        credits_cost: !isSearchPreview && shouldBill ? result.searchCredits : 0,
         zeroDataRetention,
       },
       false,
@@ -324,7 +326,9 @@ export async function searchController(
         response: null,
         num_results: result.response.developer?.length ?? 0,
         time_taken: timeTakenInSeconds,
-        credits_cost: shouldBill ? result.searchCredits : 0,
+        // Ensure preview-mode searches don't get a non-zero credits_cost
+        // in the research ledger when preview tokens are used.
+        credits_cost: !isSearchPreview && shouldBill ? result.searchCredits : 0,
         is_successful: true,
         zeroDataRetention,
       }).catch(ledgerError => {

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -324,7 +324,7 @@ export async function searchController(
         response: null,
         num_results: result.response.developer?.length ?? 0,
         time_taken: timeTakenInSeconds,
-        credits_cost: 0,
+        credits_cost: shouldBill ? result.searchCredits : 0,
         is_successful: true,
         zeroDataRetention,
       }).catch(ledgerError => {


### PR DESCRIPTION
Make research paper endpoints zero-credit for research paper index endpoints; keep GitHub and developer/code searches billable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make research paper endpoints zero-credit and record only charged credits in ledgers for developer/code searches. Previously research reads/searches consumed credits and developer search ledger wrote 0 or included preview usage; now research is free and ledgers reflect actual billing only.

**Details**
- Sets `research_paper_search`, `research_related_papers`, `research_paper_read`, and `research_paper_inspect` to 0 credits via early return in `v2/research-proxy.ts`.
- Writes `credits_cost = result.searchCredits` only when billing applies and not in preview mode in `v2/search.ts` (developer and research search ledgers).
- Updates tests to expect zero-credit research endpoints and non-zero developer search billing.
- No API or response changes; no client changes or migrations required.

<sup>Written for commit dc2ea5933f8abf43a14078543e683b8dc7d9732d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

