### PR TITLE
chore(api): bump anydoc to 0.1.9

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -13,7 +13,7 @@ anydoc = "0.1.9"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = "1.14.2"
+pdf-inspector = "0.1.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"
 nodesig = { git = "https://github.com/firecrawl/nodesig" }

--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -9,11 +9,11 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-anydoc = "0.1.6"
+anydoc = "0.1.9"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = "0.1.0"
+pdf-inspector = "1.14.2"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"
 nodesig = { git = "https://github.com/firecrawl/nodesig" }


### PR DESCRIPTION
## Summary
- Bump the native document converter from anydoc **0.1.6 → 0.1.9**.
- Leaves the direct `pdf-inspector` pin at `0.1.0` (the scrape PDF `detectPdf` / `processPdf` path). That bump is a separate PR because it is a 0.1 → 1.14 jump on a live scrape path.

anydoc 0.1.9 already depends on pdf-inspector 1.14.2 for **docx/pptx/xlsx/… PDF-in-anydoc conversion**. Cargo will keep two inspector copies until the direct pin is bumped: `0.1.x` for `processPdf`/`detectPdf`, `1.14.2` inside anydoc.

## Test plan
- [x] `cargo check` in `apps/api/native`