### PR TITLE
chore(api): bump pdf-inspector to 1.14.2

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -13,7 +13,7 @@ anydoc = "0.1.6"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = "0.1.0"
+pdf-inspector = "1.14.2"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"
 nodesig = { git = "https://github.com/firecrawl/nodesig" }


### PR DESCRIPTION
## Summary
- Bump the native scrape-PDF dependency from pdf-inspector **0.1.0 → 1.14.2**.
- This is the crate behind `detectPdf` / `processPdf` in `apps/api/src/scraper/scrapeURL/engines/pdf/index.ts`.
- Leaves `anydoc` at `0.1.6` (document converter). That bump is https://github.com/firecrawl/firecrawl/pull/4303.

Picks up [pdf-inspector 1.14.2](https://github.com/firecrawl/pdf-inspector/releases/tag/v1.14.2): parser resource bounds, Form XObject operators, and small-caps table merging. `PdfOptions` / `process_pdf_with_options` are unchanged.

## Test plan
- [x] `cargo check` in `apps/api/native`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the native PDF parser `pdf-inspector` from 0.1.0 to 1.14.2 to improve parsing correctness and stability for `detectPdf`/`processPdf`. The old parser lacked resource bounds and some operator support; the new version adds parser resource limits, Form XObject operators, and better small-caps table merging without API changes.

- Changes limited to `apps/api/native/Cargo.toml`; `anydoc` stays at 0.1.6.
- Expect improved extraction; minor output diffs on some PDFs are possible.
- No TS API or option changes; no migration required.
- Build sanity check: `cargo check` passes.

<sup>Written for commit 41cbccdf75b5fd775ac8da429e08784f762abf84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

