### PR TITLE
fix(ci): restore GitHub-hosted image builds

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -69,10 +69,10 @@ jobs:
         include:
           - platform: linux/amd64
             platform_suffix: linux-amd64
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-24.04
           - platform: linux/arm64
             platform_suffix: linux-arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            runner: ubuntu-24.04-arm
     defaults:
       run:
         working-directory: './apps/api'
@@ -80,8 +80,8 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@main
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -91,7 +91,7 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: 'Build and Push Image'
-        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./apps/api
           push: true
@@ -125,7 +125,7 @@ jobs:
           '
 
   publish:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs:
       - version
       - build


### PR DESCRIPTION
## Summary

Restore the production API image release workflow to GitHub-hosted Ubuntu runners and the official Docker Buildx actions. Blacksmith's US West ARM storage outage causes its builder setup to fall back to the local Docker driver, which cannot export the configured registry cache; using GitHub's native x64 and ARM64 runners removes that dependency while preserving cache, image verification, and multi-arch publishing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the production API image build workflow to GitHub-hosted Ubuntu runners using official Docker Buildx actions. This replaces Blacksmith runners that were falling back to the local Docker driver, restoring registry cache export while keeping multi-arch publishing.

- Switches `runs-on` from Blacksmith (`blacksmith-*`) to `ubuntu-24.04` and `ubuntu-24.04-arm`.
- Replaces `useblacksmith/setup-docker-builder` with `docker/setup-buildx-action@v3`.
- Replaces `useblacksmith/build-push-action@v2` with `docker/build-push-action@v6`.
- Preserves the `linux/amd64` and `linux/arm64` matrix, registry cache, and existing tag/publish behavior; no migration required.

<sup>Written for commit a8630de0a20bffbffa53e64fe6a3689eeef21183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

