### PR TITLE
Run deterministicJson extractors via the sandbox runtime

### DIFF
--- a/apps/api/src/lib/deterministicJson/config.ts
+++ b/apps/api/src/lib/deterministicJson/config.ts
@@ -6,7 +6,7 @@ export const LIGHT_MODEL = config.EXTRACT_LIGHT_MODEL;
 export const CODE_SANDBOX_URL = config.CODE_SANDBOX_URL;
 
 // Bump to invalidate every cached extractor at once.
-export const CACHE_VERSION = 1;
+export const CACHE_VERSION = 2;
 
 export const MARKDOWN_BUDGET = 50_000;
 export const HTML_BUDGET = 40_000;

--- a/apps/api/src/lib/deterministicJson/llm/prompts.ts
+++ b/apps/api/src/lib/deterministicJson/llm/prompts.ts
@@ -39,7 +39,8 @@ const EXTRACTOR_SYSTEM = `You write one reusable JavaScript function:
 
     async function extract(doc, askLlm) { ... }
 
-- \`doc\` is a standard DOM Document: querySelector, querySelectorAll, document.evaluate, textContent, getAttribute, etc.
+- \`doc\` is a DOM Document read through querySelector, querySelectorAll, textContent, innerText, getAttribute, and the usual element/attribute traversal.
+- There is no XPath (\`document.evaluate\` does not exist) and no layout engine (\`getComputedStyle\` returns empty; no element sizes or positions). To match by text, select candidate elements with CSS selectors, then filter in JS.
 - \`askLlm(prompt)\` returns a string.
 - \`askLlm(prompt, jsonSchema)\` returns a value of that schema shape. It may return null, so guard its result.
 

--- a/apps/api/src/lib/deterministicJson/pipeline/validate.ts
+++ b/apps/api/src/lib/deterministicJson/pipeline/validate.ts
@@ -144,7 +144,7 @@ function validateTopLevelShape(
 }
 
 // Crude check for forbidden runtime references. The generated code runs inside
-// jsdom's VM context (see sandbox/harness.ts), which has no access to certain
+// the extractor runtime (see sandbox/harness.ts), which has no access to certain
 // globals like fetch or XMLHttpRequest.
 const FORBIDDEN_GLOBALS = new Set(["fetch", "XMLHttpRequest"]);
 

--- a/apps/api/src/lib/deterministicJson/sandbox/harness.ts
+++ b/apps/api/src/lib/deterministicJson/sandbox/harness.ts
@@ -1,45 +1,5 @@
 // Runs as the body of `async (input, host, require) => { ... }` in the
-// code-sandbox jail. input is { code, html, url }: build a jsdom Document, run the
-// generated extract(doc, askLlm) in jsdom's VM context, and bridge askLlm back to
-// the API worker over host().
+// code-sandbox jail. The jail image provides the extractor runtime.
 export const EXTRACTOR_HARNESS = String.raw`
-const { JSDOM, VirtualConsole } = require("jsdom");
-const vm = require("node:vm");
-
-const dom = new JSDOM(input.html, {
-  url: input.url || "https://example.invalid/",
-  runScripts: "outside-only", // page scripts don't run; ours can.
-  pretendToBeVisual: true,     // enables getComputedStyle, requestAnimationFrame.
-  virtualConsole: new VirtualConsole(),
-});
-
-// jsdom doesn't implement innerText (it needs layout). Models reach for it
-// constantly; alias it to textContent so those reads don't crash.
-const proto = dom.window.HTMLElement.prototype;
-if (!Object.getOwnPropertyDescriptor(proto, "innerText")) {
-  Object.defineProperty(proto, "innerText", {
-    get() { return this.textContent; },
-    set(value) { this.textContent = value == null ? "" : String(value); },
-    configurable: true,
-  });
-}
-
-const context = dom.getInternalVMContext();
-
-// Bridge askLlm back through the sandbox host-callback to the API worker.
-dom.window.askLlm = (prompt, schema) =>
-  Promise.resolve()
-    .then(() => host("askLlm", { prompt: String(prompt == null ? "" : prompt), schema: schema == null ? null : schema }))
-    .catch(() => null);
-
-// Stringify inside the context so the result crosses the realm boundary as a
-// plain primitive, and a non-JSON return (DOM node, circular ref) throws here.
-const wrapped =
-  "(async () => {\n" + input.code + "\n" +
-  "  const __value = await extract(document, askLlm);\n" +
-  "  return JSON.stringify(__value === undefined ? null : __value);\n" +
-  "})()";
-
-const json = await new vm.Script(wrapped).runInContext(context);
-return JSON.parse(typeof json === "string" ? json : "null");
+return require("/opt/extractor-runtime.cjs")(input, host);
 `;


### PR DESCRIPTION
## Summary
- Point the deterministic JSON harness at the extractor runtime shipped by the code-sandbox image (`/opt/extractor-runtime.cjs`).
- Bump the extractor cache version so cached scripts are rebuilt against that runtime.

Depends on the code-sandbox image that includes `/opt/extractor-runtime.cjs`. Deploy that image before this.

## Test plan
- [ ] Confirm the new code-sandbox image is live
- [ ] `formats: [{ type: "deterministicJson", ... }]` still returns schema-shaped `json`
- [ ] Fields that use `askLlm` still populate
- [ ] A cached extractor for a previously scraped URL is regenerated once, then reused


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs `deterministicJson` extractors via the `code-sandbox` extractor runtime instead of the inline `jsdom`/`vm` harness. Updates the codegen prompt to match the runtime DOM surface (no XPath, no layout) and bumps the extractor cache to rebuild scripts.

- Old: Build a `jsdom` document, inject `askLlm`, and run in a VM context.
- New: Delegate to `/opt/extractor-runtime.cjs` with `(input, host)`.
- Side effects: `CACHE_VERSION` -> 2 triggers a one-time extractor regeneration; forbidden globals and `askLlm` behavior are unchanged.

**Rollout**
- Deploy the `code-sandbox` image that includes `/opt/extractor-runtime.cjs` before merging.
- Expect a one-time cache miss per extractor as cached scripts rebuild; subsequent runs reuse the cache.

**Reviewer notes**
- `harness.ts` now calls `require("/opt/extractor-runtime.cjs")(input, host)`.
- `prompts.ts` clarifies: use CSS selectors + JS filtering; no `document.evaluate`; `getComputedStyle` returns empty.
- `validate.ts` comments reference the extractor runtime; no validation behavior changes.

<sup>Written for commit ce7366034ecb4cc7e23195632c0ae3f07ba91638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

