### PR TITLE
fix(api): scope the fetch cookie jar per request instead of per process

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.test.ts
@@ -1,0 +1,61 @@
+import http from "http";
+import type { AddressInfo } from "net";
+import * as undici from "undici";
+
+// The security check in safeFetch destroys sockets to private IPs unless
+// ALLOW_LOCAL_WEBHOOKS is set; the test server below listens on loopback.
+vi.mock("../../../../config", () => ({
+  config: {
+    ALLOW_LOCAL_WEBHOOKS: true,
+    PROXY_SERVER: undefined,
+    PROXY_USERNAME: undefined,
+    PROXY_PASSWORD: undefined,
+  },
+}));
+
+import { getSecureDispatcher } from "./safeFetch";
+
+describe("getSecureDispatcher cookie isolation", () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      if (req.url === "/set") {
+        res.setHeader("Set-Cookie", "session=user-a-token; Path=/");
+        res.end("set");
+        return;
+      }
+      res.end(req.headers.cookie ?? "");
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it("does not leak cookies between separately obtained dispatchers", async () => {
+    // "User A" scrapes a page that sets a cookie.
+    await undici.fetch(`${baseUrl}/set`, {
+      dispatcher: getSecureDispatcher(),
+    });
+
+    // "User B" scrapes the same origin with a freshly obtained dispatcher.
+    const res = await undici.fetch(`${baseUrl}/read`, {
+      dispatcher: getSecureDispatcher(),
+    });
+
+    expect(await res.text()).toBe("");
+  });
+
+  it("keeps cookies within a single dispatcher instance", async () => {
+    const dispatcher = getSecureDispatcher();
+
+    await undici.fetch(`${baseUrl}/set`, { dispatcher });
+    const res = await undici.fetch(`${baseUrl}/read`, { dispatcher });
+
+    expect(await res.text()).toBe("session=user-a-token");
+  });
+});


### PR DESCRIPTION
Fixes #4295

## Problem

`getSecureDispatcher()` in `apps/api/src/scraper/scrapeURL/engines/utils/safeFetch.ts` returned a module-level singleton whose `CookieJar` was created once at import and lived for the lifetime of the Node process. Any `Set-Cookie` received while scraping a domain for one team was stored in that shared jar and replayed on later scrapes of the same domain for every other team on the same worker — cross-tenant cookie leakage. This affects every caller: the fetch engine, `downloadFile`, the redirect resolver in `validateUrl`, and the DuckDuckGo search client.

## Fix

- Keep the base undici agents (connection pool, redirect interceptor, private-IP security check) as shared singletons.
- `getSecureDispatcher()` now composes a fresh `CookieJar` on every call. undici's `compose()` proxies the underlying agent, so pooling and the `connect` security check are unchanged; only the jar is per-call.
- Cookies still persist within a single dispatcher instance, so auth/redirect flows inside one scrape keep working. Existing callers already obtain the dispatcher per request, so no call-site changes were needed.
- `getSecureDispatcherNoCookies()` (webhooks) is untouched.

## Tests

New `safeFetch.test.ts` spins up a loopback HTTP server:
- sets a cookie via one dispatcher, then asserts a freshly obtained dispatcher does **not** send it (fails on `main`, passes with this change);
- asserts a single dispatcher instance still carries cookies across requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the fetch cookie jar to each request to prevent cross-tenant cookie leakage. Previously `getSecureDispatcher()` used a process-wide `CookieJar`; now each call returns a dispatcher with a fresh jar while base `undici` agents remain shared.

- Connection pooling, redirect interceptor, and private-IP security check stay shared; cookies still persist within a single dispatcher instance. No call-site changes; `getSecureDispatcherNoCookies()` is unchanged.
- Adds `safeFetch.test.ts` to verify no cookie leakage across separately obtained dispatchers and persistence within one dispatcher.

<sup>Written for commit c942022489637266e31837b658732460d11af032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

