### PR TITLE
fix(api): bill browser sessions at logical release

### DIFF
--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -96,6 +96,7 @@ interface BrowserDeleteResponse {
   success: boolean;
   sessionDurationMs?: number;
   creditsBilled?: number;
+  cleanupQueued?: boolean;
   error?: string;
 }
 
@@ -194,6 +195,7 @@ interface BrowserServiceExecResponse {
 interface BrowserServiceDeleteResponse {
   ok: boolean;
   sessionDurationMs: number;
+  cleanupQueued: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -583,20 +585,39 @@ export async function browserDeleteController(
 
   logger.info("Deleting browser session");
 
-  // Release the browser session via the browser service
-  let sessionDurationMs: number | undefined;
+  let deleteResult: BrowserServiceDeleteResponse;
   try {
-    const deleteResult =
-      await browserServiceRequest<BrowserServiceDeleteResponse>(
-        "DELETE",
-        `/browsers/${session.browser_id}`,
-      );
-    sessionDurationMs = deleteResult?.sessionDurationMs;
+    deleteResult = await browserServiceRequest<BrowserServiceDeleteResponse>(
+      "DELETE",
+      `/browsers/${session.browser_id}`,
+    );
   } catch (err) {
-    logger.warn("Failed to delete browser session via browser service", {
+    logger.error("Browser service did not confirm session release", {
       error: err,
     });
+    return res.status(502).json({
+      success: false,
+      error: "Browser session release was not confirmed.",
+    });
   }
+
+  if (
+    !deleteResult ||
+    !deleteResult.ok ||
+    !deleteResult.cleanupQueued ||
+    !Number.isFinite(deleteResult.sessionDurationMs) ||
+    deleteResult.sessionDurationMs < 0
+  ) {
+    logger.error("Browser service returned an invalid release confirmation", {
+      deleteResult,
+    });
+    return res.status(502).json({
+      success: false,
+      error: "Browser session release was not confirmed.",
+    });
+  }
+
+  const durationMs = deleteResult.sessionDurationMs;
 
   const claimed = await claimBrowserSessionDestroyed(session.id);
 
@@ -620,14 +641,10 @@ export async function browserDeleteController(
     });
     return res.status(200).json({
       success: true,
+      sessionDurationMs: durationMs,
+      cleanupQueued: true,
     });
   }
-
-  const wallClockMs = Date.now() - new Date(session.created_at).getTime();
-  const durationMs =
-    sessionDurationMs && sessionDurationMs > 0
-      ? sessionDurationMs
-      : wallClockMs;
 
   const usedPrompt = await didBrowserSessionUsePrompt(session.id);
   const rate = usedPrompt
@@ -667,6 +684,7 @@ export async function browserDeleteController(
     success: true,
     sessionDurationMs: durationMs,
     creditsBilled,
+    cleanupQueued: true,
   });
 }
 
@@ -733,9 +751,18 @@ export async function browserWebhookDestroyedController(
     return res.status(401).json({ error: "Unauthorized" });
   }
 
-  const { sessionId } = req.body as { sessionId?: string };
+  const { sessionId, sessionDurationMs } = req.body as {
+    sessionId?: string;
+    sessionDurationMs?: number;
+  };
   if (!sessionId) {
     return res.status(400).json({ error: "Missing browserId" });
+  }
+  if (
+    !Number.isFinite(sessionDurationMs) ||
+    (sessionDurationMs as number) < 0
+  ) {
+    return res.status(400).json({ error: "Missing sessionDurationMs" });
   }
   let browserId = sessionId;
 
@@ -769,7 +796,7 @@ export async function browserWebhookDestroyedController(
     return res.status(200).json({ ok: true });
   }
 
-  const durationMs = Date.now() - new Date(session.created_at).getTime();
+  const durationMs = sessionDurationMs as number;
 
   const usedPrompt = await didBrowserSessionUsePrompt(session.id);
   const rate = usedPrompt

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -117,6 +117,7 @@ interface BrowserDeleteResponse {
   success: boolean;
   sessionDurationMs?: number;
   creditsBilled?: number;
+  cleanupQueued?: boolean;
   error?: string;
 }
 
@@ -417,19 +418,39 @@ export async function scrapeStopInteractiveBrowserController(
   });
   logger.info("Deleting browser session");
 
-  let sessionDurationMs: number | undefined;
+  let deleteResult: BrowserServiceDeleteResponse;
   try {
-    const deleteResult =
-      await browserServiceRequest<BrowserServiceDeleteResponse>(
-        "DELETE",
-        `/browsers/${session.browser_id}`,
-      );
-    sessionDurationMs = deleteResult?.sessionDurationMs;
+    deleteResult = await browserServiceRequest<BrowserServiceDeleteResponse>(
+      "DELETE",
+      `/browsers/${session.browser_id}`,
+    );
   } catch (err) {
-    logger.warn("Failed to delete browser session via browser service", {
+    logger.error("Browser service did not confirm session release", {
       error: err,
     });
+    return res.status(502).json({
+      success: false,
+      error: "Browser session release was not confirmed.",
+    });
   }
+
+  if (
+    !deleteResult ||
+    !deleteResult.ok ||
+    !deleteResult.cleanupQueued ||
+    !Number.isFinite(deleteResult.sessionDurationMs) ||
+    deleteResult.sessionDurationMs < 0
+  ) {
+    logger.error("Browser service returned an invalid release confirmation", {
+      deleteResult,
+    });
+    return res.status(502).json({
+      success: false,
+      error: "Browser session release was not confirmed.",
+    });
+  }
+
+  const durationMs = deleteResult.sessionDurationMs;
 
   const claimed = await claimBrowserSessionDestroyed(session.id);
 
@@ -449,14 +470,12 @@ export async function scrapeStopInteractiveBrowserController(
     logger.info("Session already destroyed by another path, skipping billing", {
       sessionId: session.id,
     });
-    return res.status(200).json({ success: true });
+    return res.status(200).json({
+      success: true,
+      sessionDurationMs: durationMs,
+      cleanupQueued: true,
+    });
   }
-
-  const wallClockMs = Date.now() - new Date(session.created_at).getTime();
-  const durationMs =
-    sessionDurationMs && sessionDurationMs > 0
-      ? sessionDurationMs
-      : wallClockMs;
 
   const usedPrompt = await didBrowserSessionUsePrompt(session.id);
   const rate = usedPrompt
@@ -505,6 +524,7 @@ export async function scrapeStopInteractiveBrowserController(
     success: true,
     sessionDurationMs: durationMs,
     creditsBilled,
+    cleanupQueued: true,
   });
 }
 

--- a/apps/api/src/lib/scrape-interact/browser-service-client.ts
+++ b/apps/api/src/lib/scrape-interact/browser-service-client.ts
@@ -23,7 +23,8 @@ export interface BrowserServiceExecResponse {
 
 export interface BrowserServiceDeleteResponse {
   ok: boolean;
-  sessionDurationMs?: number;
+  sessionDurationMs: number;
+  cleanupQueued: boolean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require browser-service confirmation that cleanup was durably queued
- bill from the frozen logical-session duration
- remove wall-clock teardown time from browser billing

## Validation
- `pnpm run build` in `apps/api`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bill browser sessions at the logical release confirmed by the browser service and remove wall‑clock teardown from billing. Delete flows now require durable cleanup confirmation; without it the API returns 502 and does not bill.

**Behavior changes**
- Delete controllers now require `ok`, `cleanupQueued: true`, and a finite `sessionDurationMs`; otherwise they return 502 with "Browser session release was not confirmed."
- Successful delete responses include `sessionDurationMs` and `cleanupQueued: true`; if already destroyed, we return those fields and skip billing.
- The destroyed webhook requires `sessionDurationMs` and uses it for billing; missing/invalid values return 400.

**Migration for browser service**
- Delete response must include `{ ok: true, sessionDurationMs: number, cleanupQueued: true }`.
- Destroyed webhook payload must include `sessionDurationMs` with the `sessionId`.

<sup>Written for commit c8ae4426b9affb1f7309caa1c6ee875bc173d75f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

