### PR TITLE
docs: add dsh-firecrawl to integrations, resolves #4318

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,7 @@ print_r($results);
 - [Firecrawl CLI Skills](https://github.com/firecrawl/cli#agent-skills)
 - [Firecrawl Workflows](https://github.com/firecrawl/firecrawl-workflows)
 - [Firecrawl MCP](https://github.com/mendableai/firecrawl-mcp-server)
+- [dsh-firecrawl](https://github.com/zoahdev/dsh-firecrawl)
 
 **Platforms**
 - [Lovable](https://docs.lovable.dev/integrations/firecrawl)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `dsh-firecrawl` to the README Integrations list so users can discover and install the DSH integration. Previously it was missing; now it appears alongside other Firecrawl integrations with no behavior or build changes.

- Verify the new link renders correctly and points to https://github.com/zoahdev/dsh-firecrawl.
- No rollout or migration steps.

<sup>Written for commit 9134959a7de21435a8595b282952a2d472d445fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

