### PR TITLE
fix(js-sdk): don't paginate while waiting on crawl/batch jobs

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, jest } from "@jest/globals";
+import { startCrawl, waitForCrawlCompletion } from "../../../v2/methods/crawl";
+import { waitForBatchCompletion } from "../../../v2/methods/batch";
+
+describe("v2.crawl unit", () => {
+  test("startCrawl forwards ignoreRobotsTxt in request payload", async () => {
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { success: true, id: "crawl-job", url: "https://api.firecrawl.dev/v2/crawl/crawl-job" },
+    });
+
+    await startCrawl({ post } as any, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+
+    expect(post).toHaveBeenCalledWith("/v2/crawl", {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+    });
+  });
+
+  test("waitForCrawlCompletion paginates only after the job completes", async () => {
+    const get = jest.fn(async (url: string) => {
+      if (String(url).includes("/v2/crawl/")) {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            status: "completed",
+            completed: 1,
+            total: 2,
+            next: "https://api/n1",
+            data: [{ markdown: "a" }],
+          },
+        };
+      }
+      return {
+        status: 200,
+        data: { success: true, next: null, data: [{ markdown: "b" }] },
+      };
+    });
+
+    const res = await waitForCrawlCompletion({ get } as any, "job1");
+    expect(res.data.map((d) => d.markdown)).toEqual(["a", "b"]);
+    expect(res.next).toBeNull();
+    expect(get.mock.calls.map((c) => c[0])).toEqual([
+      "/v2/crawl/job1",
+      "https://api/n1",
+    ]);
+  });
+
+  test("waitForBatchCompletion paginates only after the job completes", async () => {
+    const get = jest.fn(async (url: string) => {
+      if (String(url).includes("/v2/batch/scrape/")) {
+        return {
+          status: 200,
+          data: {
+            success: true,
+            status: "completed",
+            completed: 1,
+            total: 2,
+            next: "https://api/b1",
+            data: [{ markdown: "a" }],
+          },
+        };
+      }
+      return {
+        status: 200,
+        data: { success: true, next: null, data: [{ markdown: "b" }] },
+      };
+    });
+
+    const res = await waitForBatchCompletion({ get } as any, "jobB");
+    expect(res.data.map((d) => d.markdown)).toEqual(["a", "b"]);
+    expect(res.next).toBeNull();
+    expect(get.mock.calls.map((c) => c[0])).toEqual([
+      "/v2/batch/scrape/jobB",
+      "https://api/b1",
+    ]);
+  });
+});

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -21,16 +21,19 @@ describe("v2.crawl unit", () => {
   });
 
   test("waitForCrawlCompletion paginates only after the job completes", async () => {
+    const nextUrl = "https://api/n1";
+    let polls = 0;
     const get = jest.fn(async (url: string) => {
       if (String(url).includes("/v2/crawl/")) {
+        polls += 1;
         return {
           status: 200,
           data: {
             success: true,
-            status: "completed",
-            completed: 1,
+            status: polls === 1 ? "scraping" : "completed",
+            completed: polls === 1 ? 1 : 2,
             total: 2,
-            next: "https://api/n1",
+            next: nextUrl,
             data: [{ markdown: "a" }],
           },
         };
@@ -41,26 +44,30 @@ describe("v2.crawl unit", () => {
       };
     });
 
-    const res = await waitForCrawlCompletion({ get } as any, "job1");
+    const res = await waitForCrawlCompletion({ get } as any, "job1", 0);
     expect(res.data.map((d) => d.markdown)).toEqual(["a", "b"]);
     expect(res.next).toBeNull();
     expect(get.mock.calls.map((c) => c[0])).toEqual([
       "/v2/crawl/job1",
-      "https://api/n1",
+      "/v2/crawl/job1",
+      nextUrl,
     ]);
   });
 
-  test("waitForBatchCompletion paginates only after the job completes", async () => {
+  test("waitForBatchCompletion paginates after failed jobs that still have a next page", async () => {
+    const nextUrl = "https://api/b1";
+    let polls = 0;
     const get = jest.fn(async (url: string) => {
       if (String(url).includes("/v2/batch/scrape/")) {
+        polls += 1;
         return {
           status: 200,
           data: {
             success: true,
-            status: "completed",
+            status: polls === 1 ? "scraping" : "failed",
             completed: 1,
             total: 2,
-            next: "https://api/b1",
+            next: nextUrl,
             data: [{ markdown: "a" }],
           },
         };
@@ -71,12 +78,14 @@ describe("v2.crawl unit", () => {
       };
     });
 
-    const res = await waitForBatchCompletion({ get } as any, "jobB");
+    const res = await waitForBatchCompletion({ get } as any, "jobB", 0);
+    expect(res.status).toBe("failed");
     expect(res.data.map((d) => d.markdown)).toEqual(["a", "b"]);
     expect(res.next).toBeNull();
     expect(get.mock.calls.map((c) => c[0])).toEqual([
       "/v2/batch/scrape/jobB",
-      "https://api/b1",
+      "/v2/batch/scrape/jobB",
+      nextUrl,
     ]);
   });
 });

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -180,7 +180,7 @@ export async function waitForBatchCompletion(
       const status = await getBatchScrapeStatus(http, jobId, { autoPaginate: false });
 
       if (["completed", "failed", "cancelled"].includes(status.status)) {
-        if (status.status === "completed" && status.next) {
+        if (status.next) {
           const data = await fetchAllPages(http, status.next, status.data);
           return { ...status, next: null, data };
         }

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -177,9 +177,13 @@ export async function waitForBatchCompletion(
 
   while (true) {
     try {
-      const status = await getBatchScrapeStatus(http, jobId);
+      const status = await getBatchScrapeStatus(http, jobId, { autoPaginate: false });
 
       if (["completed", "failed", "cancelled"].includes(status.status)) {
+        if (status.status === "completed" && status.next) {
+          const data = await fetchAllPages(http, status.next, status.data);
+          return { ...status, next: null, data };
+        }
         return status;
       }
     } catch (err: any) {

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -127,7 +127,7 @@ export async function waitForCrawlCompletion(http: HttpClient, jobId: string, po
       const status = await getCrawlStatus(http, jobId, { autoPaginate: false });
 
       if (["completed", "failed", "cancelled"].includes(status.status)) {
-        if (status.status === "completed" && status.next) {
+        if (status.next) {
           const data = await fetchAllPages(http, status.next, status.data);
           return { ...status, next: null, data };
         }

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -27,6 +27,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.includePaths) data.includePaths = request.includePaths;
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
@@ -123,9 +124,13 @@ export async function waitForCrawlCompletion(http: HttpClient, jobId: string, po
   
   while (true) {
     try {
-      const status = await getCrawlStatus(http, jobId);
-      
+      const status = await getCrawlStatus(http, jobId, { autoPaginate: false });
+
       if (["completed", "failed", "cancelled"].includes(status.status)) {
+        if (status.status === "completed" && status.next) {
+          const data = await fetchAllPages(http, status.next, status.data);
+          return { ...status, next: null, data };
+        }
         return status;
       }
     } catch (err: any) {


### PR DESCRIPTION
`waitForCrawlCompletion` and `waitForBatchCompletion` call status with the default `autoPaginate: true`, so every poll downloads the full result set just to see if the job is done.

Poll with `autoPaginate: false` and only follow `next` once the job completes. Also put `ignoreRobotsTxt` in the crawl payload — it's on `CrawlOptions` and in the Python SDK, but the JS client was dropping it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-pagination while polling crawl and batch jobs; only paginate after a terminal status. Previously polls fetched full result sets on every request; now they poll with autoPaginate: false and fetch remaining pages once the job is completed, failed, or cancelled, reducing bandwidth while preserving combined results.

- waitForCrawlCompletion and waitForBatchCompletion poll with autoPaginate: false and, on any terminal status with next, fetch remaining pages, merge data, and return next: null.
- External behavior of the wait functions is unchanged (combined results on completion/termination), but polling uses less bandwidth.
- startCrawl forwards ignoreRobotsTxt in the request payload for SDK parity.
- Adds unit tests for pagination-after-termination and payload forwarding.

<sup>Written for commit 490b78a9caf77fe23a9bd26dcff8151581892ce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

