### PR TITLE
fix(js-sdk): skip pagination while waiting on crawl and batch jobs

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { startCrawl } from "../../../v2/methods/crawl";
+
+function makeHttp(data: Record<string, unknown>) {
+  const post = jest.fn(async () => ({ status: 200, data }));
+  return {
+    post,
+    prepareHeaders: jest.fn(() => undefined),
+  } as any;
+}
+
+describe("v2 crawl payload", () => {
+  test("forwards ignoreRobotsTxt on startCrawl", async () => {
+    const http = makeHttp({ success: true, id: "job", url: "u" });
+    await startCrawl(http, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+      robotsUserAgent: "docs-bot",
+    });
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({
+        url: "https://example.com",
+        ignoreRobotsTxt: true,
+        robotsUserAgent: "docs-bot",
+      }),
+    );
+  });
+});

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, jest } from "@jest/globals";
-import { getCrawlStatus } from "../../../v2/methods/crawl";
-import { getBatchScrapeStatus } from "../../../v2/methods/batch";
+import { getCrawlStatus, waitForCrawlCompletion } from "../../../v2/methods/crawl";
+import { getBatchScrapeStatus, waitForBatchCompletion } from "../../../v2/methods/batch";
 import { getMonitorCheck } from "../../../v2/methods/monitor";
 
 describe("JS SDK v2 pagination", () => {
@@ -126,6 +126,56 @@ describe("JS SDK v2 pagination", () => {
       expect((http.get as jest.Mock).mock.calls.length).toBe(2);
     } finally {
       nowSpy.mockRestore();
+    }
+  });
+
+  test("crawl wait: does not paginate while scraping, then loads remaining pages once", async () => {
+    const scraping = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 3, next: "https://api/n1", data: [{ markdown: "a" }] } };
+    const done = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/n1", data: [{ markdown: "a" }] } };
+    const page2 = { status: 200, data: { success: true, next: null, data: [{ markdown: "b" }, { markdown: "c" }] } };
+    let polls = 0;
+    const http = makeHttp((url) => {
+      if (url.endsWith("n1")) return page2;
+      polls += 1;
+      return polls === 1 ? scraping : done;
+    });
+    const timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((fn: any) => {
+      fn();
+      return 0 as any;
+    });
+    try {
+      const res = await waitForCrawlCompletion(http, "job1", 1);
+      expect(res.status).toBe("completed");
+      expect(res.data.map((d: any) => d.markdown)).toEqual(["a", "b", "c"]);
+      const urls = (http.get as jest.Mock).mock.calls.map((c: string[]) => c[0]);
+      expect(urls.filter((u: string) => u.endsWith("n1")).length).toBe(1);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  test("batch wait: does not paginate while scraping, then loads remaining pages once", async () => {
+    const scraping = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 3, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const done = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const page2 = { status: 200, data: { success: true, next: null, data: [{ markdown: "b" }, { markdown: "c" }] } };
+    let polls = 0;
+    const http = makeHttp((url) => {
+      if (url.endsWith("b1")) return page2;
+      polls += 1;
+      return polls === 1 ? scraping : done;
+    });
+    const timeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation((fn: any) => {
+      fn();
+      return 0 as any;
+    });
+    try {
+      const res = await waitForBatchCompletion(http, "jobB", 1);
+      expect(res.status).toBe("completed");
+      expect(res.data.map((d: any) => d.markdown)).toEqual(["a", "b", "c"]);
+      const urls = (http.get as jest.Mock).mock.calls.map((c: string[]) => c[0]);
+      expect(urls.filter((u: string) => u.endsWith("b1")).length).toBe(1);
+    } finally {
+      timeoutSpy.mockRestore();
     }
   });
 });

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -177,9 +177,14 @@ export async function waitForBatchCompletion(
 
   while (true) {
     try {
-      const status = await getBatchScrapeStatus(http, jobId);
+      const status = await getBatchScrapeStatus(http, jobId, {
+        autoPaginate: false,
+      });
 
       if (["completed", "failed", "cancelled"].includes(status.status)) {
+        if (status.status === "completed" && status.next) {
+          return getBatchScrapeStatus(http, jobId);
+        }
         return status;
       }
     } catch (err: any) {

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -28,6 +28,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.maxDiscoveryDepth != null) data.maxDiscoveryDepth = request.maxDiscoveryDepth;
   if (request.sitemap != null) data.sitemap = request.sitemap;
   if (request.robotsUserAgent != null) data.robotsUserAgent = request.robotsUserAgent;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.ignoreQueryParameters != null) data.ignoreQueryParameters = request.ignoreQueryParameters;
   if (request.deduplicateSimilarURLs != null) data.deduplicateSimilarURLs = request.deduplicateSimilarURLs;
   if (request.limit != null) data.limit = request.limit;
@@ -123,9 +124,12 @@ export async function waitForCrawlCompletion(http: HttpClient, jobId: string, po
   
   while (true) {
     try {
-      const status = await getCrawlStatus(http, jobId);
-      
+      const status = await getCrawlStatus(http, jobId, { autoPaginate: false });
+
       if (["completed", "failed", "cancelled"].includes(status.status)) {
+        if (status.status === "completed" && status.next) {
+          return getCrawlStatus(http, jobId);
+        }
         return status;
       }
     } catch (err: any) {


### PR DESCRIPTION
`waitForCrawlCompletion` and `waitForBatchCompletion` were calling status with default pagination, so every poll downloaded every result page. Poll with `autoPaginate: false` and only load remaining pages once the job is done.

Also send `ignoreRobotsTxt` on `/v2/crawl`. It's on `CrawlOptions` (and in the Python SDK) but `prepareCrawlPayload` never copied it into the body.

Fixes #3940

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip auto-pagination while polling crawl and batch jobs to cut bandwidth during long runs. Previously the wait helpers fetched every result page on each poll; now they fetch the first page only and, once complete, load remaining pages once. Also forward ignoreRobotsTxt in crawl requests so serverside behavior matches options.

- Review notes:
  - `waitForCrawlCompletion`/`waitForBatchCompletion`: request status with `autoPaginate: false`; if status is `completed` and `next` is present, call status again to retrieve all pages.
  - `prepareCrawlPayload`: includes `ignoreRobotsTxt` when set.
  - Tests: new crawl payload test; pagination tests assert no pagination during polling and a single follow-up fetch on completion for both crawl and batch.
  - No API or migration changes; consumers still receive full results after completion.

<sup>Written for commit 2b6c834b740a85ce37519b39256ee96d89595d91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

