### PR TITLE
fix: quarter keyless research request limit

### DIFF
--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from "../../lib/logger";
 import { db } from "../../db/connection";
 import { autumnService } from "../../services/autumn/autumn.service";
+import { isKeylessIpSuspicious } from "../../lib/spur";
 
 vi.mock("../../services/queue-service", () => ({
   getRedisConnection: vi.fn(() => ({
@@ -191,6 +192,40 @@ describe("authenticateUser", () => {
       }),
     );
   });
+
+  it.each([
+    [RateLimiterMode.Research, true, true],
+    [RateLimiterMode.DeveloperSearch, true, false],
+    [RateLimiterMode.Search, false, false],
+  ])(
+    "uses strict Spur checks for keyless index mode %s",
+    async (mode, strictSpur, researchQuota) => {
+      config.USE_DB_AUTHENTICATION = true;
+      vi.mocked(isKeylessConfigured).mockReturnValue(true);
+      vi.mocked(consumeKeylessRequest).mockResolvedValue({
+        ok: true,
+        requestsUsed: 1,
+        creditsUsed: 0,
+      });
+
+      const auth = await authenticateUser(
+        { headers: {}, socket: { remoteAddress: "203.0.113.8" } },
+        {},
+        mode,
+        { allowKeyless: true },
+      );
+
+      expect(auth.success).toBe(true);
+      expect(isKeylessIpSuspicious).toHaveBeenCalledWith(
+        "203.0.113.8",
+        strictSpur,
+      );
+      expect(consumeKeylessRequest).toHaveBeenCalledWith(
+        "203.0.113.8",
+        researchQuota,
+      );
+    },
+  );
 
   it("writes normal API-key ACUC entries to the general-purpose cache", async () => {
     config.USE_DB_AUTHENTICATION = true;

--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -200,6 +200,8 @@ describe("authenticateUser", () => {
   ])(
     "uses strict Spur checks for keyless index mode %s",
     async (mode, strictSpur, researchQuota) => {
+      vi.mocked(isKeylessIpSuspicious).mockClear();
+      vi.mocked(consumeKeylessRequest).mockClear();
       config.USE_DB_AUTHENTICATION = true;
       vi.mocked(isKeylessConfigured).mockReturnValue(true);
       vi.mocked(consumeKeylessRequest).mockResolvedValue({

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -455,7 +455,10 @@ async function handleKeylessAuth(
   // for IPs fronting anonymizing/rotating infrastructure (VPN/proxy/TOR), the
   // main way the per-IP caps get bypassed. Fails open on any Spur error, and
   // runs before consuming quota so a flagged IP doesn't burn a request slot.
-  if (await isKeylessIpSuspicious(ip)) {
+  const strictSpur =
+    mode === RateLimiterMode.Research ||
+    mode === RateLimiterMode.DeveloperSearch;
+  if (await isKeylessIpSuspicious(ip, strictSpur)) {
     logger.warn("Keyless request blocked: suspicious IP", {
       canonicalLog: "keyless/consume",
       ip,

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -487,7 +487,7 @@ async function handleKeylessAuth(
 
   let result: Awaited<ReturnType<typeof consumeKeylessRequest>>;
   try {
-    result = await consumeKeylessRequest(ip);
+    result = await consumeKeylessRequest(ip, mode === RateLimiterMode.Research);
   } catch (error) {
     // Limiter store (Redis) unavailable — fail closed with a controlled auth
     // response instead of surfacing a 500, and shed the free traffic while the

--- a/apps/api/src/controllers/v2/keyless-eligibility.ts
+++ b/apps/api/src/controllers/v2/keyless-eligibility.ts
@@ -23,9 +23,10 @@ export async function keylessEligibilityController(
   const ip =
     (typeof ipHeader === "string" ? ipHeader.trim() : "") || req.ip || "";
 
-  const result = await checkKeylessEligibility(
-    ip,
-    req.query.mode === "research",
-  );
+  const mode =
+    req.query.mode === "research" || req.query.mode === "developer"
+      ? req.query.mode
+      : undefined;
+  const result = await checkKeylessEligibility(ip, mode);
   res.status(200).json(result);
 }

--- a/apps/api/src/controllers/v2/keyless-eligibility.ts
+++ b/apps/api/src/controllers/v2/keyless-eligibility.ts
@@ -23,6 +23,9 @@ export async function keylessEligibilityController(
   const ip =
     (typeof ipHeader === "string" ? ipHeader.trim() : "") || req.ip || "";
 
-  const result = await checkKeylessEligibility(ip);
+  const result = await checkKeylessEligibility(
+    ip,
+    req.query.mode === "research",
+  );
   res.status(200).json(result);
 }

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -114,6 +114,10 @@ export function isKeylessIpEligible(ip: string): boolean {
 
 const requestsKey = (ip: string, research = false) =>
   `keyless_requests${research ? ":research" : ""}:${ip}`;
+const requestLimit = (research: boolean) =>
+  research
+    ? Math.floor((KEYLESS_REQUESTS_PER_DAY ?? 0) / 4)
+    : (KEYLESS_REQUESTS_PER_DAY ?? 0);
 const creditsKey = (ip: string) => `keyless_credits:${ip}`;
 
 type KeylessQuotaReason = "requests" | "credits";
@@ -195,9 +199,7 @@ export async function consumeKeylessRequest(
   ip: string,
   research = false,
 ): Promise<KeylessConsumeResult> {
-  const requestLimit = research
-    ? Math.floor((KEYLESS_REQUESTS_PER_DAY ?? 0) / 4)
-    : (KEYLESS_REQUESTS_PER_DAY ?? 0);
+  const requestsLimit = requestLimit(research);
   const creditLimit = KEYLESS_CREDITS_PER_DAY ?? 0;
 
   const rKey = requestsKey(ip, research);
@@ -211,7 +213,7 @@ export async function consumeKeylessRequest(
     10,
   );
 
-  if (requestsUsed > requestLimit) {
+  if (requestsUsed > requestsLimit) {
     return {
       ok: false,
       reason: "requests",
@@ -319,7 +321,10 @@ return next
  * consumption). Used by the hosted MCP before a keyless tool call so an
  * ineligible caller receives structured recovery without an OAuth challenge.
  */
-export async function checkKeylessEligibility(ip: string): Promise<{
+export async function checkKeylessEligibility(
+  ip: string,
+  research = false,
+): Promise<{
   eligible: boolean;
   reason?:
     | KeylessQuotaReason
@@ -340,15 +345,16 @@ export async function checkKeylessEligibility(ip: string): Promise<{
     return { eligible: false, reason: "suspicious" };
   }
   try {
+    const requestKey = requestsKey(ip, research);
     const requestsUsed = parseInt(
-      (await redisRateLimitClient.get(requestsKey(ip))) ?? "0",
+      (await redisRateLimitClient.get(requestKey)) ?? "0",
       10,
     );
-    if (requestsUsed >= (KEYLESS_REQUESTS_PER_DAY ?? 0)) {
+    if (requestsUsed >= requestLimit(research)) {
       return {
         eligible: false,
         reason: "requests",
-        retryAfterSeconds: await retryAfterSecondsFor(requestsKey(ip)),
+        retryAfterSeconds: await retryAfterSecondsFor(requestKey),
       };
     }
     const creditKey = creditsKey(ip);

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -323,7 +323,7 @@ return next
  */
 export async function checkKeylessEligibility(
   ip: string,
-  research = false,
+  indexMode?: "research" | "developer",
 ): Promise<{
   eligible: boolean;
   reason?:
@@ -341,10 +341,11 @@ export async function checkKeylessEligibility(
   // Optional Spur Context check (only when SPUR_API_KEY is set): treat IPs on
   // anonymizing/rotating infrastructure as ineligible so the hosted MCP can
   // return a bounded recovery result instead of serving a request auth rejects.
-  if (await isKeylessIpSuspicious(ip)) {
+  if (await isKeylessIpSuspicious(ip, indexMode !== undefined)) {
     return { eligible: false, reason: "suspicious" };
   }
   try {
+    const research = indexMode === "research";
     const requestKey = requestsKey(ip, research);
     const requestsUsed = parseInt(
       (await redisRateLimitClient.get(requestKey)) ?? "0",

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -222,7 +222,7 @@ export async function consumeKeylessRequest(
       retryAfterSeconds: await retryAfterSecondsFor(rKey),
     };
   }
-  if (!research && creditsUsed >= creditLimit) {
+  if (creditsUsed >= creditLimit) {
     return {
       ok: false,
       reason: "credits",
@@ -362,7 +362,7 @@ export async function checkKeylessEligibility(
       (await redisRateLimitClient.get(creditKey)) ?? "0",
       10,
     );
-    if (!research && creditsUsed >= (KEYLESS_CREDITS_PER_DAY ?? 0)) {
+    if (creditsUsed >= (KEYLESS_CREDITS_PER_DAY ?? 0)) {
       return {
         eligible: false,
         reason: "credits",

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -112,7 +112,8 @@ export function isKeylessIpEligible(ip: string): boolean {
   return isIPv4(normalizeKeylessIpv4(ip));
 }
 
-const requestsKey = (ip: string) => `keyless_requests:${ip}`;
+const requestsKey = (ip: string, research = false) =>
+  `keyless_requests${research ? ":research" : ""}:${ip}`;
 const creditsKey = (ip: string) => `keyless_credits:${ip}`;
 
 type KeylessQuotaReason = "requests" | "credits";
@@ -192,11 +193,14 @@ type KeylessCreditReservationResult = {
  */
 export async function consumeKeylessRequest(
   ip: string,
+  research = false,
 ): Promise<KeylessConsumeResult> {
-  const requestLimit = KEYLESS_REQUESTS_PER_DAY ?? 0;
+  const requestLimit = research
+    ? Math.floor((KEYLESS_REQUESTS_PER_DAY ?? 0) / 4)
+    : (KEYLESS_REQUESTS_PER_DAY ?? 0);
   const creditLimit = KEYLESS_CREDITS_PER_DAY ?? 0;
 
-  const rKey = requestsKey(ip);
+  const rKey = requestsKey(ip, research);
   const requestsUsed = await redisRateLimitClient.incr(rKey);
   if (requestsUsed === 1) {
     await redisRateLimitClient.expire(rKey, DAY_SECONDS);

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -222,7 +222,7 @@ export async function consumeKeylessRequest(
       retryAfterSeconds: await retryAfterSecondsFor(rKey),
     };
   }
-  if (creditsUsed >= creditLimit) {
+  if (!research && creditsUsed >= creditLimit) {
     return {
       ok: false,
       reason: "credits",
@@ -362,7 +362,7 @@ export async function checkKeylessEligibility(
       (await redisRateLimitClient.get(creditKey)) ?? "0",
       10,
     );
-    if (creditsUsed >= (KEYLESS_CREDITS_PER_DAY ?? 0)) {
+    if (!research && creditsUsed >= (KEYLESS_CREDITS_PER_DAY ?? 0)) {
       return {
         eligible: false,
         reason: "credits",

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -122,7 +122,7 @@ async function getSpurContext(ip: string): Promise<SpurContext | null> {
 // cloud/CGNAT, and the per-IP caps already cover those.
 const SUSPICIOUS_RISKS = new Set(["CALLBACK_PROXY", "TUNNEL"]);
 
-function isSuspiciousContext(ctx: SpurContext): boolean {
+function isSuspiciousContext(ctx: SpurContext, strict: boolean): boolean {
   // A live VPN/proxy/TOR tunnel — the canonical IP-rotation vector.
   if (Array.isArray(ctx.tunnels) && ctx.tunnels.length > 0) return true;
   // Residential / rotating proxy networks observed exiting this IP.
@@ -136,6 +136,17 @@ function isSuspiciousContext(ctx: SpurContext): boolean {
   ) {
     return true;
   }
+  // Research/developer indices are unusually valuable bulk-enumeration targets.
+  // On those keyless routes, reject any Spur risk or observed abusive client
+  // behavior rather than only known proxy operators.
+  if (
+    strict &&
+    ((Array.isArray(ctx.risks) && ctx.risks.length > 0) ||
+      (Array.isArray(ctx.client?.behaviors) &&
+        ctx.client.behaviors.length > 0))
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -144,13 +155,18 @@ function isSuspiciousContext(ctx: SpurContext): boolean {
  * anonymizing/rotating infrastructure. No-op (false) when Spur is disabled, and
  * fails open (false) on any lookup error so a Spur outage never breaks keyless.
  */
-export async function isKeylessIpSuspicious(ip: string): Promise<boolean> {
+export async function isKeylessIpSuspicious(
+  ip: string,
+  strict = false,
+): Promise<boolean> {
   if (!isSpurEnabled()) return false;
 
   const ctx = await getSpurContext(ip);
-  if (!ctx) return false;
+  // Preserve fail-open behavior for general keyless traffic, but index access
+  // fails closed when Spur cannot classify the caller.
+  if (!ctx) return strict;
 
-  const suspicious = isSuspiciousContext(ctx);
+  const suspicious = isSuspiciousContext(ctx, strict);
   if (suspicious) {
     logger.info("Keyless IP flagged suspicious by Spur", {
       canonicalLog: "spur/lookup",

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -152,8 +152,9 @@ function isSuspiciousContext(ctx: SpurContext, strict: boolean): boolean {
 
 /**
  * Whether the keyless tier should refuse this IP because Spur flags it as
- * anonymizing/rotating infrastructure. No-op (false) when Spur is disabled, and
- * fails open (false) on any lookup error so a Spur outage never breaks keyless.
+ * anonymizing/rotating infrastructure. No-op when Spur is disabled. General
+ * keyless traffic fails open on lookup errors; strict research/developer index
+ * traffic fails closed so a Spur outage cannot grant unbounded index access.
  */
 export async function isKeylessIpSuspicious(
   ip: string,


### PR DESCRIPTION
## Summary
- keep the canonical research index available to keyless callers
- give research its own daily request bucket
- cap that bucket at one quarter of the normal keyless request allowance

This immediately constrains the distributed paper-index enumeration wave without reducing scrape/search/interact allowances. Research remains zero-credit; only its request count is quartered.

## Verification
- `git diff --check`
- local dependency bootstrap is blocked on this machine by missing FoundationDB C headers; CI is the authoritative build/test signal

Do not merge until CI and Cubic are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes keyless Research to its own daily request bucket at one quarter of the normal allowance and enforces strict Spur-based IP checks on keyless index routes (Research and Developer). Previously, Research used the general bucket and lenient Spur checks; now Research uses a separate bucket and index routes reject risky or unclassified IPs while credit eligibility remains shared.

- Passes index mode from `handleKeylessAuth` and v2 `keyless-eligibility` (`?mode=research|developer`) to `consumeKeylessRequest`/`checkKeylessEligibility`; only Research uses the quartered request bucket, Developer stays on the general bucket.
- Calls `isKeylessIpSuspicious(ip, strict)` with strict=true for Research and Developer index routes; strict mode rejects Spur risks/abusive behaviors and fails closed when Spur cannot classify, general routes fail open.
- Stores Research requests under Redis key `keyless_requests:research:{ip}` (24h TTL) with limit floor(KEYLESS_REQUESTS_PER_DAY/4); non-Research uses `keyless_requests:{ip}` with the full limit. Research requests remain zero-credit; shared `keyless_credits:{ip}` eligibility is unchanged.
- Adds tests in `auth.test.ts` to verify strict Spur checks and correct bucket selection across modes.

**Rollout**
- No migration or config changes.
- Expect earlier denials on index routes from Spur classification or missing classification, and earlier 429s for Research once its request quota is hit; credit-limit denials may still occur if shared credits are exhausted.

<sup>Written for commit e1da62850ab7e2dd9465977ddc4586582e315916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

