### PR TITLE
docs: fix duplicate word in o1_job_recommender example

### DIFF
--- a/examples/o1_job_recommender/o1_job_recommender.py
+++ b/examples/o1_job_recommender/o1_job_recommender.py
@@ -44,7 +44,7 @@ Mendable
 Co-Founder @ Mendable.ai
 March 2022 - Present (2 years 7 months)
 San Francisco, California, United States
-- Built an AI powered search platform that that served millions of queries for
+- Built an AI powered search platform that served millions of queries for
 hundreds of customers (YC S22)
 - We were one of the first LLM powered apps adopted by industry leaders like
 Coinbase, Snap, DoorDash, and MongoDB


### PR DESCRIPTION
## Summary
- Fixed a duplicate word ("that that" → "that") in the `o1_job_recommender` example script.

## Why this helps
- Removes an obvious typo in an example file that users copy as a template.

## Test Plan
- [x] `git diff --check` clean
- [x] 1 file changed, 1 insertion, 1 deletion
- [x] Verified the typo is gone in the working tree


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicate word in the `examples/o1_job_recommender/o1_job_recommender.py` example to improve readability for users who copy it. The sentence “Built an AI powered search platform that that served…” now reads “that served…”; no behavior or API changes.

<sup>Written for commit f7203effab918c25376f2544ea3342fbedb44301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

