### PR TITLE
docs: point agent instructions at vitest instead of jest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ When making changes to the API, here are the general steps you should take:
     - If it requires fire-engine: `!process.env.TEST_SUITE_SELF_HOSTED`
     - If it requires AI: `!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL`
 2. Write code to achieve your win conditions
-3. Run your tests using `pnpm harness jest ...`
+3. Run your tests using `pnpm harness pnpm exec vitest run ...`
   - `pnpm harness` is a command that gets the API server and workers up for you to run the tests. Don't try to `pnpm start` manually.
   - The full test suite takes a long time to run, so you should try to only execute the relevant tests locally, and let CI run the full test suite.
 4. Push to a branch, open a PR, and let CI run to verify your win condition.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ When making changes to the API, here are the general steps you should take:
     - If it requires fire-engine: `!process.env.TEST_SUITE_SELF_HOSTED`
     - If it requires AI: `!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL`
 2. Write code to achieve your win conditions
-3. Run your tests using `pnpm harness jest ...`
+3. Run your tests using `pnpm harness pnpm exec vitest run ...`
   - `pnpm harness` is a command that gets the API server and workers up for you to run the tests. Don't try to `pnpm start` manually.
   - The full test suite takes a long time to run, so you should try to only execute the relevant tests locally, and let CI run the full test suite.
 4. Push to a branch, open a PR, and let CI run to verify your win condition.


### PR DESCRIPTION
## What

`CLAUDE.md` and `AGENTS.md` both tell agents:

> 3. Run your tests using `pnpm harness jest ...`

The API test suite has since migrated to Vitest, so that command no longer resolves. `apps/api/package.json` has no jest dependency or script left (`test`, `test:snips`, `test:full`, `test:prod` all invoke `vitest run`), and there is a `apps/api/vitest.config.ts` with `globals: true` plus `vi.mock` usage throughout the test files.

## Change

Point both files at the same invocation `CONTRIBUTING.md` already documents:

```
pnpm harness pnpm exec vitest run path/to/test.ts
```

Docs only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update agent test-running instructions in `CLAUDE.md` and `AGENTS.md` to use `vitest` instead of `jest`, matching the API test suite. This replaces the broken `pnpm harness jest ...` guidance with the correct Vitest invocation.

- Use `pnpm harness pnpm exec vitest run ...` instead of `pnpm harness jest ...` (matches `CONTRIBUTING.md`).
- Docs only; no code, scripts, or CI changes.

<sup>Written for commit 0238ec4e457f6419c0aefa6ac0b0a33e41741ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

