### PR TITLE
Expose keyless and Spur launch metrics

### DIFF
--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from "../../lib/logger";
 import { db } from "../../db/connection";
 import { autumnService } from "../../services/autumn/autumn.service";
+import { keylessRequestsTotal } from "../../lib/keyless-metrics";
 
 vi.mock("../../services/queue-service", () => ({
   getRedisConnection: vi.fn(() => ({
@@ -78,6 +79,22 @@ vi.mock("../../services/autumn/autumn.service", () => ({
 vi.mock("../../services/agent-sponsor", () => ({
   getAgentSponsorStatus: vi.fn(),
 }));
+
+async function keylessMetricValue(
+  mode: string,
+  outcome: string,
+  reason: string,
+): Promise<number> {
+  const metric = await keylessRequestsTotal.get();
+  return (
+    metric.values.find(
+      value =>
+        value.labels.mode === mode &&
+        value.labels.outcome === outcome &&
+        value.labels.reason === reason,
+    )?.value ?? 0
+  );
+}
 
 describe("authenticateUser", () => {
   const originalUseDbAuth = config.USE_DB_AUTHENTICATION;
@@ -164,6 +181,11 @@ describe("authenticateUser", () => {
       retryAfterSeconds: 42,
     });
     const warn = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    const exhaustedBefore = await keylessMetricValue(
+      "scrape",
+      "exhausted",
+      "requests",
+    );
 
     const auth = await authenticateUser(
       {
@@ -189,6 +211,9 @@ describe("authenticateUser", () => {
         reason: "requests",
         conversionCohort: keylessConversionCohort("203.0.113.8"),
       }),
+    );
+    expect(await keylessMetricValue("scrape", "exhausted", "requests")).toBe(
+      exhaustedBefore + 1,
     );
   });
 

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -15,6 +15,7 @@ import {
   keylessTeamId,
 } from "../lib/keyless";
 import { isKeylessIpSuspicious } from "../lib/spur";
+import { recordKeylessRequest } from "../lib/keyless-metrics";
 import { checkIpRestriction } from "../lib/ip-restriction";
 import { checkKeyEndpointRestriction } from "../lib/key-restriction";
 import { deleteKey, getValue, setValue } from "../services/redis";
@@ -451,11 +452,23 @@ async function handleKeylessAuth(
   // usable as arbitrary limiter buckets. Anything else falls through to 401.
   if (!isKeylessIpEligible(ip)) return unauthorized;
 
+  const modeLabel =
+    mode === RateLimiterMode.Search
+      ? "search"
+      : mode === RateLimiterMode.Research
+        ? "research"
+        : mode === RateLimiterMode.DeveloperSearch
+          ? "developer"
+          : mode === RateLimiterMode.BrowserExecute
+            ? "interact"
+            : "scrape";
+
   // Optional Spur Context check (only when SPUR_API_KEY is set): refuse keyless
   // for IPs fronting anonymizing/rotating infrastructure (VPN/proxy/TOR), the
   // main way the per-IP caps get bypassed. Fails open on any Spur error, and
   // runs before consuming quota so a flagged IP doesn't burn a request slot.
   if (await isKeylessIpSuspicious(ip)) {
+    recordKeylessRequest(modeLabel, "suspicious", "suspicious");
     logger.warn("Keyless request blocked: suspicious IP", {
       canonicalLog: "keyless/consume",
       ip,
@@ -474,17 +487,6 @@ async function handleKeylessAuth(
   }
 
   const teamId = keylessTeamId(ip);
-  const modeLabel =
-    mode === RateLimiterMode.Search
-      ? "search"
-      : mode === RateLimiterMode.Research
-        ? "research"
-        : mode === RateLimiterMode.DeveloperSearch
-          ? "developer"
-          : mode === RateLimiterMode.BrowserExecute
-            ? "interact"
-            : "scrape";
-
   let result: Awaited<ReturnType<typeof consumeKeylessRequest>>;
   try {
     result = await consumeKeylessRequest(ip);
@@ -492,6 +494,7 @@ async function handleKeylessAuth(
     // Limiter store (Redis) unavailable — fail closed with a controlled auth
     // response instead of surfacing a 500, and shed the free traffic while the
     // limiter can't enforce quotas.
+    recordKeylessRequest(modeLabel, "error", "limiter");
     logger.warn("Keyless quota check failed", {
       canonicalLog: "keyless/consume",
       ip,
@@ -513,6 +516,7 @@ async function handleKeylessAuth(
   };
 
   if (!result.ok) {
+    recordKeylessRequest(modeLabel, "exhausted", result.reason);
     logger.warn("Keyless request blocked", {
       ...baseLog,
       blocked: true,
@@ -532,6 +536,7 @@ async function handleKeylessAuth(
     };
   }
 
+  recordKeylessRequest(modeLabel, "accepted");
   logger.debug("Keyless request consumed", { ...baseLog, blocked: false });
 
   // Tag as a preview team so billing (autumn isPreviewTeam) and GCS persistence

--- a/apps/api/src/lib/__tests__/spur.test.ts
+++ b/apps/api/src/lib/__tests__/spur.test.ts
@@ -3,6 +3,7 @@ import { isKeylessIpSuspicious } from "../spur";
 import { redisRateLimitClient } from "../../services/rate-limiter";
 import { config } from "../../config";
 import { logger } from "../logger";
+import { spurLookupsTotal } from "../keyless-metrics";
 
 vi.mock("../../config", () => ({
   config: { SPUR_API_KEY: "test-key" },
@@ -50,6 +51,13 @@ function mockFetch(impl: () => Promise<unknown>): Mock {
 }
 
 const okResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+async function spurMetricValue(outcome: string): Promise<number> {
+  const metric = await spurLookupsTotal.get();
+  return (
+    metric.values.find(value => value.labels.outcome === outcome)?.value ?? 0
+  );
+}
 
 describe("Spur keyless IP reputation", () => {
   let store: Map<string, string>;
@@ -119,11 +127,14 @@ describe("Spur keyless IP reputation", () => {
     expect(results).toEqual([false, false, false, false, false]);
   });
 
-  it("fails open on a non-200 Spur response and caches nothing", async () => {
+  it("fails open on a non-200 Spur response, records it, and caches nothing", async () => {
     const fetchFn = mockFetch(async () => ({ ok: false, status: 429 }));
+    const failuresBefore = await spurMetricValue("failed_open");
+
     expect(await isKeylessIpSuspicious("1.2.3.7")).toBe(false);
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(store.has("spur_context:1.2.3.7")).toBe(false);
+    expect(await spurMetricValue("failed_open")).toBe(failuresBefore + 1);
   });
 
   it("fails open when the Spur call throws, and releases the lock so a later call retries", async () => {

--- a/apps/api/src/lib/keyless-metrics.test.ts
+++ b/apps/api/src/lib/keyless-metrics.test.ts
@@ -1,0 +1,22 @@
+import { config, type ResearchPaperOperation } from "../config";
+import { researchKeylessDisabled } from "./keyless-metrics";
+
+const OPERATIONS: ResearchPaperOperation[] = [
+  "search",
+  "inspect",
+  "read",
+  "similar",
+];
+
+describe("keyless launch metrics", () => {
+  it("exports the configured Research Index kill-switch state per operation", async () => {
+    const metric = await researchKeylessDisabled.get();
+
+    for (const operation of OPERATIONS) {
+      expect(
+        metric.values.find(value => value.labels.operation === operation)
+          ?.value,
+      ).toBe(config.RESEARCH_KEYLESS_DISABLED.includes(operation) ? 1 : 0);
+    }
+  });
+});

--- a/apps/api/src/lib/keyless-metrics.ts
+++ b/apps/api/src/lib/keyless-metrics.ts
@@ -1,0 +1,89 @@
+import { Counter, Gauge } from "prom-client";
+import { config, type ResearchPaperOperation } from "../config";
+
+const KEYLESS_MODES = [
+  "scrape",
+  "search",
+  "research",
+  "developer",
+  "interact",
+] as const;
+const KEYLESS_OUTCOMES = [
+  "accepted",
+  "exhausted",
+  "suspicious",
+  "error",
+] as const;
+const KEYLESS_REASONS = [
+  "none",
+  "requests",
+  "credits",
+  "suspicious",
+  "limiter",
+] as const;
+const SPUR_OUTCOMES = ["clean", "suspicious", "failed_open"] as const;
+const RESEARCH_OPERATIONS: ResearchPaperOperation[] = [
+  "search",
+  "inspect",
+  "read",
+  "similar",
+];
+
+type KeylessMode = (typeof KEYLESS_MODES)[number];
+type KeylessOutcome = (typeof KEYLESS_OUTCOMES)[number];
+type KeylessReason = (typeof KEYLESS_REASONS)[number];
+type SpurOutcome = (typeof SPUR_OUTCOMES)[number];
+
+export const keylessRequestsTotal = new Counter({
+  name: "firecrawl_keyless_requests_total",
+  help: "Keyless authentication decisions by mode, outcome, and reason",
+  labelNames: ["mode", "outcome", "reason"] as const,
+});
+
+export const spurLookupsTotal = new Counter({
+  name: "firecrawl_spur_lookups_total",
+  help: "Keyless Spur reputation checks by caller-visible outcome",
+  labelNames: ["outcome"] as const,
+});
+
+export const researchKeylessDisabled = new Gauge({
+  name: "firecrawl_research_keyless_disabled",
+  help: "1 when keyless access to the named Research Index operation is disabled",
+  labelNames: ["operation"] as const,
+});
+
+// Publish stable zero-valued children before launch traffic. Alerts then read a
+// real zero instead of silently going absent on healthy, unused paths.
+for (const mode of KEYLESS_MODES) {
+  for (const outcome of KEYLESS_OUTCOMES) {
+    for (const reason of KEYLESS_REASONS) {
+      keylessRequestsTotal.labels(mode, outcome, reason);
+    }
+  }
+}
+for (const outcome of SPUR_OUTCOMES) spurLookupsTotal.labels(outcome);
+for (const operation of RESEARCH_OPERATIONS) {
+  researchKeylessDisabled
+    .labels(operation)
+    .set((config.RESEARCH_KEYLESS_DISABLED ?? []).includes(operation) ? 1 : 0);
+}
+
+export function normalizeKeylessMode(mode: string): KeylessMode {
+  if (mode.includes("research")) return "research";
+  if (mode.includes("search")) return "search";
+  if (mode.includes("developer")) return "developer";
+  if (mode.includes("browser") || mode.includes("interact")) return "interact";
+  return "scrape";
+}
+
+export function recordKeylessRequest(
+  mode: KeylessMode,
+  outcome: KeylessOutcome,
+  reason: KeylessReason = "none",
+): void {
+  keylessRequestsTotal.labels(mode, outcome, reason).inc();
+}
+
+export function recordSpurLookup(outcome: SpurOutcome): void {
+  spurLookupsTotal.labels(outcome).inc();
+}

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -7,6 +7,7 @@ import * as schema from "../db/schema";
 import { redisRateLimitClient } from "../services/rate-limiter";
 import { isKeylessIpSuspicious } from "./spur";
 import { logger } from "./logger";
+import { normalizeKeylessMode, recordKeylessRequest } from "./keyless-metrics";
 
 // Keyless free tier: scrape, search, and interact can be used without an API key
 // from the official MCP server, CLI, or SDKs. It's gated per-IP/day by TWO
@@ -162,6 +163,7 @@ export async function keylessLimitBody(
     // The reservation already proved the limit; missing TTL must not turn its
     // controlled 429 into a server error.
   }
+  recordKeylessRequest(normalizeKeylessMode(mode), "exhausted", "credits");
   logger.warn("Keyless request blocked", {
     canonicalLog: "keyless/consume",
     event: "keyless_exhausted",

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { config } from "../config";
 import { logger } from "./logger";
+import { recordSpurLookup } from "./keyless-metrics";
 import { redisRateLimitClient } from "../services/rate-limiter";
 
 // Optional Spur Context API integration for the keyless free tier. When
@@ -271,9 +272,13 @@ export async function isKeylessIpSuspicious(ip: string): Promise<boolean> {
   if (!isSpurEnabled()) return false;
 
   const ctx = await getSpurContext(ip);
-  if (!ctx) return false;
+  if (!ctx) {
+    recordSpurLookup("failed_open");
+    return false;
+  }
 
   const suspicious = isSuspiciousContext(ctx);
+  recordSpurLookup(suspicious ? "suspicious" : "clean");
   if (suspicious) {
     logger.info("Keyless IP flagged suspicious by Spur", {
       canonicalLog: "spur/lookup",


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Prometheus metrics for keyless auth decisions, Spur reputation checks, and the Research Index keyless kill switch. Previously we only logged these events; now we export alertable metrics without changing auth behavior or responses.

- Keyless decisions: firecrawl_keyless_requests_total{mode, outcome, reason} increments on accept/exhausted/error/suspicious across modes (scrape/search/research/developer/interact) with reasons (none/requests/credits/suspicious/limiter).
- Spur lookups: firecrawl_spur_lookups_total{outcome} records clean, suspicious, and failed_open (non-200/exception) results.
- Research kill switch: firecrawl_research_keyless_disabled{operation} is 1 when the operation is disabled via RESEARCH_KEYLESS_DISABLED; exported for search/inspect/read/similar.
- All label combinations are pre-created so unused paths read as zero, not missing. Metrics use the existing registry and the /admin/.../metrics scrape path.

**Rollout**
- No config or code migrations. Ensure Prometheus scrapes the existing endpoint.
- Add alert rules post-deploy for spikes in keyless exhausted/error/suspicious, Spur failed_open, and any unexpected flips in the research_keyless_disabled gauge.

<sup>Written for commit 98a235f5a258747073d24c17030a16dad772dfac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

