### PR TITLE
fix(api): don't drop the first sitemap URL in /map (#4337)

### DIFF
--- a/apps/api/src/__tests__/snips/mocks/map-sitemap-all-urls.json
+++ b/apps/api/src/__tests__/snips/mocks/map-sitemap-all-urls.json
@@ -1,0 +1,18 @@
+[
+  {
+    "time": 1740000000000,
+    "options": {
+      "url": "https://www.hfea.gov.uk/sitemap.xml",
+      "method": "GET",
+      "ignoreResponse": false,
+      "ignoreFailure": false,
+      "tryCount": 1
+    },
+    "result": {
+      "url": "https://www.hfea.gov.uk/sitemap.xml",
+      "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url><loc>https://www.hfea.gov.uk/first-page</loc></url>\n  <url><loc>https://www.hfea.gov.uk/second-page</loc></url>\n  <url><loc>https://www.hfea.gov.uk/third-page</loc></url>\n</urlset>\n",
+      "status": 200,
+      "headers": [["content-type", "text/xml; charset=utf-8"]]
+    }
+  }
+]

--- a/apps/api/src/__tests__/snips/v2/map.test.ts
+++ b/apps/api/src/__tests__/snips/v2/map.test.ts
@@ -78,6 +78,53 @@ describe("Map tests", () => {
     60000,
   );
 
+  it.concurrent(
+    "sitemap=only returns every URL of the sitemap",
+    async () => {
+      const response = await map(
+        {
+          url: "https://www.hfea.gov.uk",
+          sitemap: "only",
+          useMock: "map-sitemap-all-urls",
+          ignoreCache: true,
+        },
+        identity,
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.success).toBe(true);
+
+      // The first URL the sitemap yields used to be discarded, so
+      // /first-page never made it into the response.
+      const urls = response.body.links.map(x => x.url);
+      expect(urls).toContain("https://www.hfea.gov.uk/first-page");
+      expect(urls).toContain("https://www.hfea.gov.uk/second-page");
+      expect(urls).toContain("https://www.hfea.gov.uk/third-page");
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "sitemap=only still respects a limit smaller than the sitemap",
+    async () => {
+      const response = await map(
+        {
+          url: "https://www.hfea.gov.uk",
+          sitemap: "only",
+          useMock: "map-sitemap-all-urls",
+          ignoreCache: true,
+          limit: 2,
+        },
+        identity,
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.links.length).toBe(2);
+    },
+    60000,
+  );
+
   concurrentIf(ALLOW_TEST_SUITE_WEBSITE)(
     "sitemap=only respects limit",
     async () => {

--- a/apps/api/src/lib/map-utils.ts
+++ b/apps/api/src/lib/map-utils.ts
@@ -181,7 +181,6 @@ export async function getMapResults({
 
     if (sitemap > 0) {
       mapResults = mapResults
-        .slice(1)
         .map(x => {
           try {
             return {


### PR DESCRIPTION
## Summary

Fixes #4337. With `sitemap: "only"`, `/v2/map` dropped the first URL the sitemap yielded. This removes the `.slice(1)` that was doing it.

## Root cause

The slice is a leftover from a time when the list it operated on started with a placeholder.

- `3c1b1909f` (2024-11-14) added `links.slice(1, limit)` to v1 `/map`. Back then `links` was seeded with `let links: string[] = [url];`, so the slice removed that seed. Correct at the time.
- `fa36ad664` (2025-08-10) merged `links` and `mapResults` into a single `mapResults: MapDocument[] = []` in v2 and dropped the seed.
- `33fb6bb81` (same day) restored the sitemap-only branch without the seed but kept the slice.
- `4e9eda765` (2025-09-27) moved the code to `lib/map-utils.ts`, where it is today.

In the current code `mapResults` starts empty and, in this branch, is only ever filled by the `tryGetSitemap` callback, so element 0 is always a real sitemap URL.

The slice is not compensating for the requested URL that `tryGetSitemap` appends either. That append arrived later, in `0421f8102` (2024-12-27), and it runs *after* all sitemap sources are fetched (`crawler.ts:686-693`), so it is never at index 0.

v1 `/map` is untouched: it still seeds `links` with the requested URL, so its slice keeps doing the job it was written for.

## Behavior change

Against a mocked sitemap of `/first-page`, `/second-page`, `/third-page`:

```
before:  /second-page, /third-page, <requested url>          (3)
after:   /first-page, /second-page, /third-page, <requested url>   (4)
```

`/v1/map` with `sitemapOnly: true` already returned all four for the same input, so this brings v2 in line with v1 rather than inventing a new shape.

Two things had been masking the loss: the count stayed plausible because the slice removed one entry while `tryGetSitemap` appended one, and the existing `map-query-params` fixture holds 48,513 `<loc>` entries that collapse to 899 after query-parameter stripping and deduplication, so the sliced entry was almost always a duplicate of a surviving one.

## Tests

Added `map-sitemap-all-urls`, a small fixture whose sitemap has three distinct URLs, and two snips in `v2/map.test.ts`:

- `sitemap=only returns every URL of the sitemap` — fails on `main` (`expected [ …(3) ] to include 'https://www.hfea.gov.uk/first-page'`), passes with this change.
- `sitemap=only still respects a limit smaller than the sitemap` — guards the `limit` path, which the extra URL could otherwise push past.

Ran locally against a self-hosted harness:

```
pnpm exec vitest run src/__tests__/snips/v2/map.test.ts
  6 passed | 2 failed
pnpm exec vitest run src/__tests__/snips/v1/map.test.ts src/__tests__/snips/v2/types-validation.test.ts
  123 passed
```

The two failures are `basic map succeeds` and `sitemap=only respects limit`. Both depend on `TEST_SUITE_WEBSITE`, which my environment cannot reach, and both fail identically on `main` with the change stashed. Everything else in the file passes.

## Notes

With the slice gone, the `map()` inside the `if (sitemap > 0)` block only normalizes URLs, which the tail of `getMapResults` already does for every entry — so the block now looks redundant. I left it alone to keep this change to one line; removing it would also leave `const sitemap` unused.

## Deployment impact

None. No configuration, migration, or schema change. `/v2/map` with `sitemap: "only"` returns one more URL than before, which is the point of the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `/v2/map` with `sitemap: "only"` from dropping the first sitemap URL. Before: the first sitemap entry was discarded; after: all sitemap URLs are included, and the requested URL is still appended at the end.

- Removes the `.slice(1)` in `getMapResults` for the sitemap-only branch; limit enforcement remains unchanged.
- Adds a small mock sitemap and two tests to verify inclusion of all URLs and limit behavior.
- `/v1/map` is unchanged and continues to slice its seeded list.
- No config or migration required; responses may include one additional URL in sitemap-only mode.

<sup>Written for commit 18e7d2bca68900a2f49443f8e2e307001f962872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

