### PR TITLE
Handle a firebill refusal, and ramp by percentage instead of by allowlist

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -405,6 +405,12 @@ const configSchema = z.object({
   FIREBILL_URL: emptyStringAsUndefined(z.string().url()),
   FIREBILL_SECRET: emptyStringAsUndefined(z.string().trim().min(1)),
   FIREBILL_ORG_IDS: delimitedList(",").optional(),
+  // Sticky percentage ramp, on top of the allowlist above. The bucket is a
+  // hash of the org id, so an org that is in at 5 is still in at 30 — a ramp
+  // only ever adds, and never reshuffles who is on which path mid-rollout.
+  // 0 (the default) is also the kill switch: the allowlist still routes, and
+  // nothing else does.
+  FIREBILL_ROLLOUT_PERCENT: z.coerce.number().min(0).max(100).default(0),
 
   // Miscellaneous
   IDMUX_URL: z.string().optional(),

--- a/apps/api/src/lib/__tests__/rollout.test.ts
+++ b/apps/api/src/lib/__tests__/rollout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { sampled } from "../rollout";
+
+const orgs = Array.from({ length: 2000 }, (_, i) => `org-${i}`);
+
+describe("sampled", () => {
+  it("is off at 0 and on at 100", () => {
+    expect(orgs.some(o => sampled(o, 0))).toBe(false);
+    expect(orgs.every(o => sampled(o, 100))).toBe(true);
+  });
+
+  it("only ever adds as the percentage rises", () => {
+    // The property the whole ramp rests on: nobody is moved back off firebill
+    // by a later step, so each stage is a superset of the one before it.
+    const stages = [5, 10, 30, 60, 80, 100];
+    for (const org of orgs) {
+      let wasIn = false;
+      for (const percent of stages) {
+        const isIn = sampled(org, percent);
+        expect(!wasIn || isIn).toBe(true);
+        wasIn = isIn;
+      }
+    }
+  });
+
+  it("gives the same answer every call", () => {
+    for (const org of orgs.slice(0, 50)) {
+      const first = sampled(org, 37);
+      for (let i = 0; i < 5; i++) expect(sampled(org, 37)).toBe(first);
+    }
+  });
+
+  it("lands near the requested share", () => {
+    for (const percent of [5, 30, 60]) {
+      const hits = orgs.filter(o => sampled(o, percent)).length;
+      const share = (hits / orgs.length) * 100;
+      expect(Math.abs(share - percent)).toBeLessThan(5);
+    }
+  });
+});

--- a/apps/api/src/lib/rollout.ts
+++ b/apps/api/src/lib/rollout.ts
@@ -1,0 +1,23 @@
+/**
+ * Deterministic percentage sampling for gradual rollouts.
+ *
+ * The bucket is a pure function of the cohort key, so a cohort that is in at
+ * 5% is still in at 30% — a ramp only ever adds, never reshuffles. That is the
+ * property `Math.random() < percent` does not have, and the reason to prefer
+ * this wherever a cohort should stay on one side of a rollout: billing routes,
+ * anything a support question could be asked about, anything you want to
+ * compare before and after.
+ *
+ * FNV-1a over the key, mapped onto [0, 100).
+ */
+export function sampled(cohortKey: string, percent: number): boolean {
+  if (percent <= 0) return false;
+  if (percent >= 100) return true;
+
+  let hash = 2166136261;
+  for (let i = 0; i < cohortKey.length; i++) {
+    hash ^= cohortKey.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return ((hash >>> 0) / 0x1_0000_0000) * 100 < percent;
+}

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -9,6 +9,7 @@ import {
 import type { HighlightFailureReason } from "./highlight-model";
 import { config } from "../config";
 import { logger as rootLogger } from "../lib/logger";
+import { sampled } from "../lib/rollout";
 
 // How far back into the index we're willing to reach for highlight source text.
 const HIGHLIGHTS_INDEX_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -26,18 +27,6 @@ export function highlightsEnvReady(): boolean {
   return (
     useIndex && !!config.GCS_INDEX_BUCKET_NAME && !!config.HIGHLIGHT_MODEL_URL
   );
-}
-
-function sampled(cohortKey: string, percent: number): boolean {
-  if (percent <= 0) return false;
-  if (percent >= 100) return true;
-
-  let hash = 2166136261;
-  for (let i = 0; i < cohortKey.length; i++) {
-    hash ^= cohortKey.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  return ((hash >>> 0) / 0x1_0000_0000) * 100 < percent;
 }
 
 export function searchHighlightsMode(options: {

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -715,7 +715,7 @@ describe("firebill routing", () => {
     expect(String(url)).toBe("http://proxy.test/firebill/v1/track");
   });
 
-  it("sends a caller-supplied idempotency key to firebill, and omits the field otherwise", async () => {
+  it("sends a caller-supplied idempotency key to firebill, and mints one otherwise", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();
 
@@ -734,9 +734,14 @@ describe("firebill routing", () => {
       value: 5,
       properties: { source: "billTeam", endpoint: "search" },
     });
-    expect(
-      "idempotency_key" in JSON.parse(mockFetch.mock.calls[1]![1].body),
-    ).toBe(false);
+    // A key is always sent, even when the caller has none: firebillTrack retries
+    // once, and both attempts have to be the same event or an accepted-but-lost
+    // first attempt would be billed twice. firebill would have minted an
+    // equivalent UUID itself; minting it here is what makes it stable across
+    // the retry.
+    const minted = JSON.parse(mockFetch.mock.calls[1]![1].body).idempotency_key;
+    expect(minted).toEqual(expect.any(String));
+    expect(minted).not.toBe("fc:track:scrape:job-123");
   });
 
   it("a track/refund pair for one charge carries two distinct keys", async () => {
@@ -794,6 +799,9 @@ describe("firebill routing", () => {
       feature_id: "CREDITS",
       value: 42,
       properties: { source: "test", endpoint: "extract" },
+      // Minted when the caller has none, so the retry inside firebillTrack is
+      // the same event rather than a second charge.
+      idempotency_key: expect.any(String),
     });
   });
 

--- a/apps/api/src/services/autumn/__tests__/firebill.test.ts
+++ b/apps/api/src/services/autumn/__tests__/firebill.test.ts
@@ -16,6 +16,8 @@ vi.mock("../../../lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+// Built fresh per call: a Response body can only be read once, so a shared
+// instance would make the second attempt look like a transport failure.
 const ok = () =>
   new Response(JSON.stringify({ success: true }), { status: 200 });
 const refused = () =>
@@ -69,8 +71,8 @@ describe("firebillTrack", () => {
   it("retries a refusal and reports success if the retry lands", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(refused())
-      .mockResolvedValueOnce(ok());
+      .mockImplementationOnce(async () => refused())
+      .mockImplementationOnce(async () => ok());
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(firebillTrack(params)).resolves.toBe(true);
@@ -83,18 +85,72 @@ describe("firebillTrack", () => {
   });
 
   it("gives up after the attempt limit and reports false", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(refused());
+    const fetchMock = vi.fn().mockImplementation(async () => refused());
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(firebillTrack(params)).resolves.toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("reuses one key across attempts even when the caller supplies none", async () => {
+    // Without this the retry is a second event: firebill mints its own key per
+    // request, so an accepted-but-lost first attempt would be billed twice.
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockImplementationOnce(async () => ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await firebillTrack({ ...params, idempotencyKey: undefined });
+
+    const keys = fetchMock.mock.calls.map(
+      c => JSON.parse(c[1].body).idempotency_key,
+    );
+    expect(keys[0]).toBeTruthy();
+    expect(keys[0]).toBe(keys[1]);
+  });
+
+  it("mints a different key for each keyless call", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await firebillTrack({ ...params, idempotencyKey: undefined });
+    await firebillTrack({ ...params, idempotencyKey: undefined });
+
+    const [first, second] = fetchMock.mock.calls.map(
+      c => JSON.parse(c[1].body).idempotency_key,
+    );
+    expect(first).not.toBe(second);
+  });
+
+  it("separates an explicit refusal from an ambiguous transport failure", async () => {
+    const outcomes = async () =>
+      Object.fromEntries(
+        (await firebillTrackTotal.get()).values.map(v => [
+          v.labels.outcome,
+          v.value,
+        ]),
+      );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => refused()),
+    );
+    await firebillTrack(params);
+    expect(await outcomes()).toEqual({ refused: 1 });
+
+    firebillTrackTotal.reset();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
+    await firebillTrack(params);
+    // A timeout is not proof the usage was lost — firebill may have taken it.
+    expect(await outcomes()).toEqual({ ambiguous: 1 });
+  });
+
   it("retries a thrown error too", async () => {
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error("connection refused"))
-      .mockResolvedValueOnce(ok());
+      .mockImplementationOnce(async () => ok());
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(firebillTrack(params)).resolves.toBe(true);
@@ -102,7 +158,7 @@ describe("firebillTrack", () => {
   });
 
   it("sends a refund to /v1/refund with the value made positive", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(ok());
+    const fetchMock = vi.fn().mockImplementation(async () => ok());
     vi.stubGlobal("fetch", fetchMock);
 
     await firebillTrack({ ...params, value: -7 });

--- a/apps/api/src/services/autumn/__tests__/firebill.test.ts
+++ b/apps/api/src/services/autumn/__tests__/firebill.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { configState } = vi.hoisted(() => ({
+  configState: {
+    FIREBILL_URL: "https://firebill.test",
+    FIREBILL_SECRET: "secret",
+    FIREBILL_ORG_IDS: ["allow-listed-org"] as string[] | undefined,
+    FIREBILL_ROLLOUT_PERCENT: 0,
+  },
+}));
+
+vi.mock("../../../config", () => ({ config: configState }));
+vi.mock("../../../lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { firebillTrack, shouldRouteToFirebill } = await import("../firebill");
+const { firebillTrackTotal, firebillRetryTotal } = await import("../metrics");
+
+const ok = () =>
+  new Response(JSON.stringify({ success: true }), { status: 200 });
+const refused = () =>
+  new Response(JSON.stringify({ success: false }), { status: 200 });
+
+const params = {
+  customerId: "org-1",
+  entityId: "team-1",
+  featureId: "CREDITS",
+  value: 3,
+  properties: {},
+  idempotencyKey: "fc:track:scrape:job-1",
+};
+
+beforeEach(() => {
+  configState.FIREBILL_URL = "https://firebill.test";
+  configState.FIREBILL_SECRET = "secret";
+  configState.FIREBILL_ORG_IDS = ["allow-listed-org"];
+  configState.FIREBILL_ROLLOUT_PERCENT = 0;
+  firebillTrackTotal.reset();
+  firebillRetryTotal.reset();
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("shouldRouteToFirebill", () => {
+  it("routes the allowlist even at 0 percent", () => {
+    expect(shouldRouteToFirebill("allow-listed-org")).toBe(true);
+  });
+
+  it("routes nobody else at 0 percent — the kill switch", () => {
+    const others = Array.from({ length: 200 }, (_, i) => `other-${i}`);
+    expect(others.some(shouldRouteToFirebill)).toBe(false);
+  });
+
+  it("routes roughly the configured share once ramped", () => {
+    const orgs = Array.from({ length: 1000 }, (_, i) => `ramp-${i}`);
+    configState.FIREBILL_ROLLOUT_PERCENT = 30;
+    const share =
+      (orgs.filter(shouldRouteToFirebill).length / orgs.length) * 100;
+    expect(Math.abs(share - 30)).toBeLessThan(6);
+  });
+
+  it("stays off entirely when firebill is not configured", () => {
+    configState.FIREBILL_ROLLOUT_PERCENT = 100;
+    configState.FIREBILL_SECRET = "";
+    expect(shouldRouteToFirebill("allow-listed-org")).toBe(false);
+  });
+});
+
+describe("firebillTrack", () => {
+  it("retries a refusal and reports success if the retry lands", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(refused())
+      .mockResolvedValueOnce(ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(firebillTrack(params)).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Same key on both attempts, which is what makes the retry safe.
+    const keys = fetchMock.mock.calls.map(
+      c => JSON.parse(c[1].body).idempotency_key,
+    );
+    expect(keys).toEqual([params.idempotencyKey, params.idempotencyKey]);
+  });
+
+  it("gives up after the attempt limit and reports false", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(refused());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a thrown error too", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connection refused"))
+      .mockResolvedValueOnce(ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(firebillTrack(params)).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends a refund to /v1/refund with the value made positive", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await firebillTrack({ ...params, value: -7 });
+    expect(fetchMock.mock.calls[0][0]).toBe("https://firebill.test/v1/refund");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).value).toBe(7);
+  });
+});

--- a/apps/api/src/services/autumn/__tests__/firebill.test.ts
+++ b/apps/api/src/services/autumn/__tests__/firebill.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { firebillTrack, shouldRouteToFirebill } from "../firebill";
+import { firebillRetryTotal, firebillTrackTotal } from "../metrics";
 
 const { configState } = vi.hoisted(() => ({
   configState: {
@@ -13,9 +15,6 @@ vi.mock("../../../config", () => ({ config: configState }));
 vi.mock("../../../lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
-
-const { firebillTrack, shouldRouteToFirebill } = await import("../firebill");
-const { firebillTrackTotal, firebillRetryTotal } = await import("../metrics");
 
 const ok = () =>
   new Response(JSON.stringify({ success: true }), { status: 200 });

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -10,6 +10,7 @@ import {
   firebillTrack,
   shouldRouteToFirebill,
 } from "./firebill";
+import { billingRouteTotal } from "./metrics";
 import type {
   CreateEntityParams,
   CreateEntityResult,
@@ -238,13 +239,12 @@ export class AutumnService {
     properties,
     idempotencyKey,
   }: TrackParams): Promise<boolean> {
-    // Gradual firebill rollout: allowlisted orgs record usage via firebill (a
-    // durable store that forwards to Autumn) instead of calling Autumn
-    // directly. If the firebill call fails we must NOT fall back to Autumn —
-    // firebill may have durably recorded the event and will deliver it later,
-    // so a direct-Autumn fallback could double-bill the customer. firebillTrack
-    // returns false on failure, exactly like an Autumn track failure.
+    // Gradual rollout: allowlisted orgs, and those in the sticky
+    // FIREBILL_ROLLOUT_PERCENT bucket, bill through firebill. No fallback to
+    // Autumn on failure — firebill may already own the event, and the SDK sends
+    // no idempotency key, so the pair could not be deduped.
     if (shouldRouteToFirebill(customerId)) {
+      billingRouteTotal.labels("firebill").inc();
       return await firebillTrack({
         customerId,
         entityId,
@@ -254,6 +254,8 @@ export class AutumnService {
         idempotencyKey,
       });
     }
+
+    billingRouteTotal.labels("direct").inc();
 
     if (!autumnClient) return false;
 

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { config } from "../../config";
 import { logger } from "../../lib/logger";
 import { sampled } from "../../lib/rollout";
@@ -77,40 +78,57 @@ function firebillUrl(path: string): string {
  * took it: nothing is retrying, and the usage goes unbilled.
  */
 export async function firebillTrack(params: TrackParams): Promise<boolean> {
-  const path = params.value < 0 ? "/v1/refund" : "/v1/track";
+  const operation = params.value < 0 ? "refund" : "track";
+  const path = `/v1/${operation}`;
+  // Both attempts must be the same event. Without a caller key firebill mints
+  // one per request, so a retry after an accepted-but-lost first attempt would
+  // be a second charge; minting here instead keeps one identity per call while
+  // separate calls stay distinct, exactly as before.
+  const attempted = {
+    ...params,
+    idempotencyKey: params.idempotencyKey ?? randomUUID(),
+  };
 
-  for (let attempt = 1; attempt <= FIREBILL_ATTEMPTS; attempt++) {
-    const result = await firebillAttempt(path, params);
+  for (let attempt = 1; attempt < FIREBILL_ATTEMPTS; attempt++) {
+    const result = await firebillAttempt(path, attempted);
     if (result.ok) {
-      firebillTrackTotal.labels(path, "accepted").inc();
+      firebillTrackTotal.labels(operation, "accepted").inc();
       return true;
     }
+    firebillRetryTotal.labels(result.reason).inc();
+    await new Promise(resolve => setTimeout(resolve, FIREBILL_RETRY_DELAY_MS));
+  }
 
-    if (attempt < FIREBILL_ATTEMPTS) {
-      firebillRetryTotal.labels(result.reason).inc();
-      await new Promise(resolve =>
-        setTimeout(resolve, FIREBILL_RETRY_DELAY_MS),
-      );
-      continue;
-    }
+  const last = await firebillAttempt(path, attempted);
+  if (last.ok) {
+    firebillTrackTotal.labels(operation, "accepted").inc();
+    return true;
+  }
 
-    // Nobody owns this event now, so the usage is gone unless someone acts on
-    // it. A counter, not a throw: billing must not fail the customer's request,
-    // and a log alone is too quiet to alert on.
-    firebillTrackTotal.labels(path, "refused").inc();
-    logger.error("firebill refused a usage event; it will not be billed", {
+  // `refused` only for an explicit `success: false`, which is firebill saying it
+  // did not take the event. A transport failure is `ambiguous`: firebill may
+  // have accepted it and be delivering it right now, so this is not proof of
+  // lost usage. Either way the caller is told false and must not assume a
+  // charge landed. A counter rather than a throw: billing must not fail the
+  // customer's request, and a log alone is too quiet to alert on.
+  const outcome = last.reason === "not_success" ? "refused" : "ambiguous";
+  logger.error(
+    outcome === "refused"
+      ? "firebill refused a usage event; it will not be billed"
+      : "firebill did not answer; the event may or may not have been accepted",
+    {
       customerId: params.customerId,
       entityId: params.entityId,
       featureId: params.featureId,
       value: params.value,
-      idempotencyKey: params.idempotencyKey,
+      idempotencyKey: attempted.idempotencyKey,
+      callerSuppliedKey: params.idempotencyKey !== undefined,
       path,
       attempts: FIREBILL_ATTEMPTS,
-      reason: result.reason,
-    });
-    return false;
-  }
-
+      reason: last.reason,
+    },
+  );
+  firebillTrackTotal.labels(operation, outcome).inc();
   return false;
 }
 

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -1,6 +1,8 @@
 import { config } from "../../config";
 import { logger } from "../../lib/logger";
+import { sampled } from "../../lib/rollout";
 import type { TrackParams } from "./types";
+import { firebillRetryTotal, firebillTrackTotal } from "./metrics";
 
 /**
  * Outcome of a firebill `/v1/lock` call, mirroring firebill's three-state
@@ -17,6 +19,13 @@ type FirebillLockResult =
 // ~3.5s worst case, so this is deliberately looser than the 2s timeout on the
 // direct Autumn client.
 const FIREBILL_TIMEOUT_MS = 5000;
+
+// Safe to retry because the idempotency key is stable across attempts: if the
+// first attempt did land (ambiguous confirm timeout), Autumn dedupes the second.
+// Small because a caller may be waiting, and a firebill refusing events usually
+// cannot reach the broker — which more attempts will not fix.
+const FIREBILL_ATTEMPTS = 2;
+const FIREBILL_RETRY_DELAY_MS = 150;
 
 // FIREBILL_ORG_IDS is decoded once at startup by the config schema; the Set is
 // built lazily on first use and cached, keyed on the decoded array reference.
@@ -37,13 +46,15 @@ function firebillOrgIds(): Set<string> {
 }
 
 /**
- * Whether usage tracking for this org should be routed through firebill
- * instead of directly to Autumn. Requires firebill to be fully configured AND
- * the org to be on the rollout allowlist.
+ * Whether this org's usage goes through firebill rather than straight to Autumn.
+ * Needs firebill configured, then either the allowlist or the sticky percentage.
  */
 export function shouldRouteToFirebill(orgId: string): boolean {
   if (!config.FIREBILL_URL || !config.FIREBILL_SECRET) return false;
-  return firebillOrgIds().has(orgId);
+  // Always-on set: test orgs stay routed even at 0 percent.
+  if (firebillOrgIds().has(orgId)) return true;
+  // Sticky by org, so a ramp only ever adds and 0 is the kill switch.
+  return sampled(orgId, config.FIREBILL_ROLLOUT_PERCENT);
 }
 
 // Plain concatenation rather than new URL(path, base): a leading-slash path
@@ -53,26 +64,71 @@ function firebillUrl(path: string): string {
 }
 
 /**
- * Sends a usage event to firebill, which records it durably in Postgres and
- * forwards it to Autumn (replaying failed deliveries instead of losing them).
+ * Sends a usage event to firebill, which publishes it to a durable quorum queue
+ * and answers once the broker has confirmed it, then forwards it to Autumn from
+ * a consumer (retrying failed deliveries instead of losing them).
  *
  * A negative value is a refund (refundCredits negates before calling track);
  * firebill's /v1/refund endpoint expects the POSITIVE amount and negates it
  * itself, so the absolute value is sent either way.
  *
  * Returns true when firebill accepted the event, mirroring the boolean
- * contract of the direct Autumn track path. A `false` here means "not billed
- * yet" — firebill keeps retrying delivery on its side.
+ * contract of the direct Autumn track path. A `false` means firebill never
+ * took it: nothing is retrying, and the usage goes unbilled.
  */
-export async function firebillTrack({
-  customerId,
-  entityId,
-  featureId,
-  value,
-  properties,
-  idempotencyKey,
-}: TrackParams): Promise<boolean> {
-  const path = value < 0 ? "/v1/refund" : "/v1/track";
+export async function firebillTrack(params: TrackParams): Promise<boolean> {
+  const path = params.value < 0 ? "/v1/refund" : "/v1/track";
+
+  for (let attempt = 1; attempt <= FIREBILL_ATTEMPTS; attempt++) {
+    const result = await firebillAttempt(path, params);
+    if (result.ok) {
+      firebillTrackTotal.labels(path, "accepted").inc();
+      return true;
+    }
+
+    if (attempt < FIREBILL_ATTEMPTS) {
+      firebillRetryTotal.labels(result.reason).inc();
+      await new Promise(resolve =>
+        setTimeout(resolve, FIREBILL_RETRY_DELAY_MS),
+      );
+      continue;
+    }
+
+    // Nobody owns this event now, so the usage is gone unless someone acts on
+    // it. A counter, not a throw: billing must not fail the customer's request,
+    // and a log alone is too quiet to alert on.
+    firebillTrackTotal.labels(path, "refused").inc();
+    logger.error("firebill refused a usage event; it will not be billed", {
+      customerId: params.customerId,
+      entityId: params.entityId,
+      featureId: params.featureId,
+      value: params.value,
+      idempotencyKey: params.idempotencyKey,
+      path,
+      attempts: FIREBILL_ATTEMPTS,
+      reason: result.reason,
+    });
+    return false;
+  }
+
+  return false;
+}
+
+type AttemptResult =
+  | { ok: true }
+  | { ok: false; reason: "not_ok" | "not_success" | "exception" };
+
+async function firebillAttempt(
+  path: string,
+  {
+    customerId,
+    entityId,
+    featureId,
+    value,
+    properties,
+    idempotencyKey,
+  }: TrackParams,
+): Promise<AttemptResult> {
   const url = firebillUrl(path);
   try {
     const response = await fetch(url, {
@@ -90,17 +146,17 @@ export async function firebillTrack({
         feature_id: featureId,
         value: Math.abs(value),
         properties,
-        // Stable per-charge key: firebill makes it the intent row's primary
-        // key, so a caller retry (or a requeued job re-billing the same work)
-        // is answered from the existing row instead of charged again. Omitted
-        // → firebill mints a per-request UUID (dedupes only its own retries).
+        // firebill carries this to Autumn as the Idempotency-Key on every
+        // attempt, so a requeued job re-billing the same work is deduped rather
+        // than charged twice. Omitted → firebill mints a per-request UUID,
+        // which dedupes only its own retries.
         ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });
 
     if (!response.ok) {
-      logger.error("firebill track failed — non-OK response", {
+      logger.warn("firebill track attempt failed — non-OK response", {
         customerId,
         entityId,
         featureId,
@@ -108,19 +164,19 @@ export async function firebillTrack({
         path,
         status: response.status,
       });
-      return false;
+      return { ok: false, reason: "not_ok" };
     }
 
     const body = (await response.json()) as { success?: boolean };
     if (body.success !== true) {
-      logger.error("firebill track did not succeed", {
+      logger.warn("firebill track attempt did not succeed", {
         customerId,
         entityId,
         featureId,
         value,
         path,
       });
-      return false;
+      return { ok: false, reason: "not_success" };
     }
 
     logger.info("firebill track succeeded", {
@@ -130,14 +186,12 @@ export async function firebillTrack({
       value,
       path,
     });
-    return true;
+    return { ok: true };
   } catch (error) {
-    // DO NOT fall back to calling Autumn directly here: firebill may have
-    // durably recorded the event before this call failed and will deliver it
-    // to Autumn later, so a direct-Autumn fallback could double-bill the
-    // customer. A firebill failure (timeout, 5xx, connection refused) is
-    // treated exactly like an Autumn track failure: log and return false.
-    logger.error("firebill track failed — firebill may be unavailable", {
+    // DO NOT fall back to Autumn directly: firebill may have accepted the event
+    // before this failed, and the Autumn SDK sends no idempotency key, so the
+    // pair could not be deduped and the customer would be billed twice.
+    logger.warn("firebill track attempt failed — firebill may be unavailable", {
       customerId,
       entityId,
       featureId,
@@ -145,7 +199,7 @@ export async function firebillTrack({
       path,
       error,
     });
-    return false;
+    return { ok: false, reason: "exception" };
   }
 }
 

--- a/apps/api/src/services/autumn/metrics.ts
+++ b/apps/api/src/services/autumn/metrics.ts
@@ -13,14 +13,17 @@ export const billingRouteTotal = new Counter({
 });
 
 /**
- * What firebill said. `refused` is the one that matters: firebill answered
- * `success: false`, so it does NOT own the event and nobody else does either —
- * usage is being dropped. Alert on it.
+ * What firebill said. `refused` is an explicit `success: false` — firebill does
+ * not own the event and nobody else does, so usage is being dropped.
+ * `ambiguous` is a transport failure: firebill may have accepted it before the
+ * answer was lost. Both mean the caller was told false; only `refused` is proof
+ * the usage is gone. Alert on the pair.
  */
 export const firebillTrackTotal = new Counter({
   name: "firecrawl_firebill_track_total",
   help: "Outcomes of usage events sent to firebill",
-  labelNames: ["path", "outcome"] as const, // track|refund × accepted|refused
+  // operation: track|refund   outcome: accepted|refused|ambiguous
+  labelNames: ["operation", "outcome"] as const,
 });
 
 /** Retries of a firebill call that answered `false` or threw. */

--- a/apps/api/src/services/autumn/metrics.ts
+++ b/apps/api/src/services/autumn/metrics.ts
@@ -1,0 +1,31 @@
+import { Counter } from "prom-client";
+
+/**
+ * Which path a usage event took. The ratio of `firebill` to `direct` is the
+ * live read on the rollout percentage — during a ramp it is the first thing to
+ * look at, because a routing bug shows up here long before it shows up in a
+ * balance.
+ */
+export const billingRouteTotal = new Counter({
+  name: "firecrawl_billing_route_total",
+  help: "Usage events by the path they took to Autumn",
+  labelNames: ["route"] as const, // firebill | direct
+});
+
+/**
+ * What firebill said. `refused` is the one that matters: firebill answered
+ * `success: false`, so it does NOT own the event and nobody else does either —
+ * usage is being dropped. Alert on it.
+ */
+export const firebillTrackTotal = new Counter({
+  name: "firecrawl_firebill_track_total",
+  help: "Outcomes of usage events sent to firebill",
+  labelNames: ["path", "outcome"] as const, // track|refund × accepted|refused
+});
+
+/** Retries of a firebill call that answered `false` or threw. */
+export const firebillRetryTotal = new Counter({
+  name: "firecrawl_firebill_retry_total",
+  help: "Retried firebill calls, by why the previous attempt failed",
+  labelNames: ["reason"] as const, // not_ok | not_success | exception
+});

--- a/apps/api/src/services/billing/credit_billing.ts
+++ b/apps/api/src/services/billing/credit_billing.ts
@@ -53,9 +53,9 @@ export async function billTeam(
         if (await autumnService.isRoutedThroughFirebill(team_id)) {
           // No compensating refund on the firebill route: the tracked charge
           // is durable and correct, and a refund here poisons a retried
-          // request — its track would dedupe against the intent row (no new
-          // charge) while the ledger enqueue succeeds, leaving Autumn
-          // net-zero for billed work.
+          // request — its track would be deduped by Autumn against the same
+          // idempotency key (no new charge) while the ledger enqueue succeeds,
+          // leaving Autumn net-zero for billed work.
           logger?.warn(
             "billing enqueue failed on the firebill route; charge stands",
             { team_id, credits, billing },


### PR DESCRIPTION


## 1. Nothing acted on `false`

I audited every call site while checking the rollout gate: `trackedInRequest` is only ever read as a guard for compensation (`if (!result.success && trackedInRequest)`). **No branch anywhere responds to firebill answering `false`** — so an event firebill refused was dropped silently. Unbilled usage rather than a double charge, which is the less dangerous direction, but invisible either way.

`firebillTrack` now retries once and, if that fails too, counts it and logs at error.

Retrying is safe because the idempotency key is stable across attempts: if the first attempt *did* land (an ambiguous confirm timeout) the second is deduped by Autumn inside its 24h window rather than charged twice. That is not a guess — replaying a key against production Autumn left the balance untouched and produced `outcome="duplicate"`.

Deliberately **not** a throw, and deliberately **no fallback to Autumn**: firebill may already own the event, and the Autumn SDK sends no idempotency key, so the pair could not be deduped.

## 2. Nothing was observable

Three counters on the default prom-client registry, which the existing app and worker scrape configs already export:

| Metric | Use |
| --- | --- |
| `firecrawl_billing_route_total{route}` | firebill vs direct — **the ramp itself** |
| `firecrawl_firebill_track_total{path,outcome}` | `refused` is the one that means money |
| `firecrawl_firebill_retry_total{reason}` | blips that recovered |

The route ratio is what catches a broken gate in seconds. At 5% it should read ~0.05; 1.0 means everyone is routed and 0 means nobody is, and neither shows up in a customer balance for hours.

Note these increment mostly in the **worker**, since `scrape-worker` bills after the job — queries should aggregate across pods rather than pin to the api deployment.

## 3. `FIREBILL_ROLLOUT_PERCENT`

Sticky by org id, layered on top of the allowlist:

```ts
if (firebillOrgIds().has(orgId)) return true;              // always-on
return sampled(orgId, config.FIREBILL_ROLLOUT_PERCENT);    // sticky ramp
```

It reuses the FNV-1a bucketing `HIGHLIGHT_ROLLOUT_PERCENT` already uses, **extracted to `src/lib/rollout.ts`** so the two share one implementation — a second copy of a hash function is how two rollouts silently disagree. `highlights.ts` now imports it; its existing test still passes unchanged.

The property that matters, and that the tests pin: **a ramp only ever adds**. An org in the 5% bucket is still in it at 30%, so `5 → 10 → 30 → 60 → 80 → 100` never moves anyone back, and "is this org on firebill?" has one answer for the whole rollout. `0` is the kill switch and still routes the allowlist.

## Also: stale comments

Three comments still described the intent store — "records it durably in Postgres", "the intent row's primary key", "dedupe against the intent row". firebill has had no database since it moved to the queue; dedupe is Autumn's 24h window over the key firebill forwards. The conclusions were right, the mechanism named was gone.

## Verification

- **12 new tests**, all passing: sampling is off at 0 / on at 100, monotonic across the six ramp stages, deterministic per call, and lands within 5 points of the target share; allowlist beats 0 percent; nothing routes when firebill is unconfigured; retry-then-succeed, retry-then-give-up, retry-on-throw, and refunds hitting `/v1/refund` with the value made positive.
- **64 existing tests** in the three suites I touched (`autumn.service`, `highlights`, `credit_billing`) still pass.
- `tsc --noEmit` clean; prettier clean.

One environmental caveat: `pnpm install` fails here on the `foundationdb` native module, so I installed with `--ignore-scripts`. That leaves `@mendable/firecrawl-rs` unbuilt, and `tsc` reports it missing across ~15 unrelated files. Zero errors in anything I touched, and CI builds it properly.

## Ramp order once this and #451 are in

Alerts and dashboard first, then `FIREBILL_ROLLOUT_PERCENT: 5` and watch the route ratio, refused count, and parked depth before each step up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes billing through firebill by a sticky percentage and makes explicit refusals and transport failures visible. Previously a firebill false was ignored; now we retry once with a stable idempotency key (minted when absent), record outcomes, and never fall back to Autumn.

- Routing: `FIREBILL_ROLLOUT_PERCENT` (0–100) samples by org ID on top of the allowlist; 0 is the kill switch. Shared `sampled` lives in `src/lib/rollout.ts` and is used by highlights and firebill. `firecrawl_billing_route_total{route="firebill|direct"}` tracks the split.
- Failure handling: one retry with a short delay using the same idempotency key; we mint a key when callers do not provide one. On final failure, return false, count it, and log. Distinguish `refused` (explicit `success: false`) from `ambiguous` (non-OK or transport failures). Refunds go to `/v1/refund` with a positive value. No direct-Autumn fallback.
- Metrics: `firecrawl_firebill_track_total{operation="track|refund",outcome="accepted|refused|ambiguous"}` and `firecrawl_firebill_retry_total{reason}`; watch the firebill/direct ratio and refused+ambiguous during ramp. Aggregate across API and worker pods.
- Tests/build: adds rollout and firebill tests, including key-minting and retry paths; uses static imports to satisfy the build tsconfig. No other build/runtime changes.
- Required action: to ramp, set `FIREBILL_ROLLOUT_PERCENT` (e.g., 5) and increase gradually; keep 0 to route only the allowlist.

<sup>Written for commit 1efbb412b7d21dd58236a9031d73b553299898b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



