### PR TITLE
feat(api): expose fire-pdf typed blocks via parsers[].blocks

### DIFF
--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { protocolIncluded, checkUrl } from "../../lib/validateUrl";
 import { hasReachableHost } from "../../lib/url-utils";
 import { countries } from "../../lib/validate-country";
+import type { PdfPageBlocks } from "../../scraper/scrapeURL/engines/pdf/types";
 import {
   ExtractorOptions,
   PageOptions,
@@ -1007,6 +1008,9 @@ export type Document = {
   markdown?: string;
   /** Physical PDF pages, populated by the v2 pageMarkdown parser option. */
   pages?: Array<{ pageNumber: number; markdown: string }>;
+  /** Typed PDF layout blocks with bounding boxes, populated by the v2
+   * `blocks` parser option. */
+  blocks?: PdfPageBlocks[];
   html?: string;
   rawHtml?: string;
   links?: string[];

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -18,6 +18,7 @@ import {
   ScrapeOptions as V1ScrapeOptions,
 } from "../v1/types";
 import type { InternalOptions } from "../../scraper/scrapeURL";
+import type { PdfPageBlocks } from "../../scraper/scrapeURL/engines/pdf/types";
 import { ErrorCodes } from "../../lib/error";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
@@ -484,6 +485,9 @@ const pdfParserWithOptions = z.strictObject({
   maxPages: z.int().positive().finite().max(10000).optional(),
   /** Include physical per-page markdown alongside document markdown. */
   pageMarkdown: z.boolean().optional(),
+  /** Include per-page typed layout blocks (bounding boxes, block types,
+   * reading order) alongside document markdown. */
+  blocks: z.boolean().optional(),
   // Experimental: route this request through the fire-pdf async pipeline
   // (POST /jobs + poll) instead of the sync POST /ocr endpoint. Falls back
   // to sync on any async-path failure, so user-visible behavior is unchanged
@@ -538,6 +542,16 @@ export function getPDFPageMarkdown(parsers?: Parsers): boolean {
   for (const parser of parsers) {
     if (typeof parser === "object" && parser.type === "pdf") {
       return parser.pageMarkdown === true;
+    }
+  }
+  return false;
+}
+
+export function getPDFBlocks(parsers?: Parsers): boolean {
+  if (!parsers) return false;
+  for (const parser of parsers) {
+    if (typeof parser === "object" && parser.type === "pdf") {
+      return parser.blocks === true;
     }
   }
   return false;
@@ -1242,6 +1256,9 @@ export type Document = {
   markdown?: string;
   /** Physical PDF pages, present only for `parsers[].pageMarkdown`. */
   pages?: Array<{ pageNumber: number; markdown: string }>;
+  /** Typed PDF layout blocks with bounding boxes, present only for
+   * `parsers[].blocks`. */
+  blocks?: PdfPageBlocks[];
   html?: string;
   rawHtml?: string;
   links?: string[];

--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "@google-cloud/storage";
+import type { FirePdfPageBlocks } from "../scraper/scrapeURL/engines/pdf/types";
 import { logger } from "./logger";
 import { config } from "../config";
 import crypto from "crypto";
@@ -15,6 +16,9 @@ type CachedPdfResult = {
   pagesProcessed?: number;
   /** Physical page markdown; present only in page-capable cache variants. */
   pageMarkdown?: Array<{ page: number; markdown: string }>;
+  /** Typed layout blocks (fire-pdf wire shape); present only in
+   * block-capable cache variants. */
+  blocks?: FirePdfPageBlocks[];
 };
 
 const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -680,6 +680,17 @@ export async function buildFallbackList(meta: Meta): Promise<
     _engines.push(...indexEngines);
     meta.internalOptions.forceEngine = indexEngines;
   } else if (meta.internalOptions.agentIndexOnly) {
+    // Index documents carry no physical-page or typed-block payloads, so an
+    // index-only request that demands them can only be answered wrong. Fail
+    // loud instead of silently serving a document without the capability.
+    if (
+      getPDFPageMarkdown(meta.options.parsers) ||
+      getPDFBlocks(meta.options.parsers)
+    ) {
+      throw new Error(
+        "PDF pageMarkdown/blocks cannot be served from the URL index (agentIndexOnly request)",
+      );
+    }
     const indexEngines: Engine[] = useIndex ? ["index", "index;documents"] : [];
     _engines.length = 0;
     _engines.push(...indexEngines);

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -27,8 +27,11 @@ import {
 } from "./x-twitter";
 import { queryEngpickerVerdict, useIndex } from "../../../services";
 import { hasFormatOfType } from "../../../lib/format-utils";
-import { getPDFPageMarkdown } from "../../../controllers/v2/types";
-import type { PdfMetadata } from "./pdf/types";
+import {
+  getPDFBlocks,
+  getPDFPageMarkdown,
+} from "../../../controllers/v2/types";
+import type { PdfMetadata, PdfPageBlocks } from "./pdf/types";
 import { BrandingProfile } from "../../../types/branding";
 import { BrandingNotSupportedError } from "../error";
 import { isUrlBlocked } from "../../WebScraper/utils/blocklist";
@@ -139,6 +142,7 @@ export type EngineScrapeResult = {
   html: string;
   markdown?: string;
   pages?: Array<{ pageNumber: number; markdown: string }>;
+  blocks?: PdfPageBlocks[];
   json?: unknown;
   statusCode: number;
   error?: string;
@@ -562,8 +566,10 @@ export function shouldUseIndex(meta: Meta) {
     config.FIRECRAWL_INDEX_WRITE_ONLY !== true &&
     !hasFormatOfType(meta.options.formats, "changeTracking") &&
     !hasFormatOfType(meta.options.formats, "branding") &&
-    // The URL index does not yet persist physical-page capability metadata.
+    // The URL index does not yet persist physical-page or typed-block
+    // capability metadata.
     !getPDFPageMarkdown(meta.options.parsers) &&
+    !getPDFBlocks(meta.options.parsers) &&
     !hasCustomScreenshotSettings &&
     meta.options.maxAge !== 0 &&
     (meta.options.headers === undefined ||

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -33,7 +33,7 @@ import {
 } from "../../../controllers/v2/types";
 import type { PdfMetadata, PdfPageBlocks } from "./pdf/types";
 import { BrandingProfile } from "../../../types/branding";
-import { BrandingNotSupportedError } from "../error";
+import { AgentIndexOnlyError, BrandingNotSupportedError } from "../error";
 import { isUrlBlocked } from "../../WebScraper/utils/blocklist";
 import {
   canUseExchangeForRequest,
@@ -682,14 +682,18 @@ export async function buildFallbackList(meta: Meta): Promise<
   } else if (meta.internalOptions.agentIndexOnly) {
     // Index documents carry no physical-page or typed-block payloads, so an
     // index-only request that demands them can only be answered wrong. Fail
-    // loud instead of silently serving a document without the capability.
+    // loud with the canonical index-only error (maps to a clean 4xx and
+    // tells the caller how to unlock live scraping) instead of silently
+    // serving a document without the capability.
     if (
       getPDFPageMarkdown(meta.options.parsers) ||
       getPDFBlocks(meta.options.parsers)
     ) {
-      throw new Error(
-        "PDF pageMarkdown/blocks cannot be served from the URL index (agentIndexOnly request)",
+      meta.logger.warn(
+        "agentIndexOnly request demands pageMarkdown/blocks, which the URL index cannot serve",
+        { parsers: meta.options.parsers },
       );
+      throw new AgentIndexOnlyError();
     }
     const indexEngines: Engine[] = useIndex ? ["index", "index;documents"] : [];
     _engines.length = 0;

--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -37,6 +37,7 @@ import {
   NoCachedDataError,
 } from "../../error";
 import {
+  getPDFBlocks,
   getPDFMaxPages,
   getPDFPageMarkdown,
   shouldParsePDF,
@@ -60,10 +61,11 @@ export async function sendDocumentToIndex(meta: Meta, document: Document) {
     // every access must go through the Exchange and its ledger.
     meta.winnerEngine !== "exchange" &&
     !(meta.winnerEngine === "pdf" && !shouldParsePDF(meta.options.parsers)) &&
-    // Page-aware results are capability-specific and are not represented in
-    // the URL index schema yet. Do not write an entry that could later be
-    // served without its required pages payload.
+    // Page-aware and block-aware results are capability-specific and are not
+    // represented in the URL index schema yet. Do not write an entry that
+    // could later be served without its required pages/blocks payload.
     !getPDFPageMarkdown(meta.options.parsers) &&
+    !getPDFBlocks(meta.options.parsers) &&
     !meta.options.parsers?.some(parser => {
       if (
         typeof parser === "object" &&

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDF.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDF.test.ts
@@ -133,3 +133,81 @@ describe("scrapePDFWithFirePDF page markdown", () => {
     ).rejects.toThrow(/did not include requested physical page markdown/);
   });
 });
+
+describe("scrapePDFWithFirePDF typed blocks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests and returns the block payload", async () => {
+    const blocks = [
+      {
+        page: 1,
+        width: 800,
+        height: 1100,
+        status: "ok",
+        items: [
+          {
+            id: "p1.b0",
+            type: "title",
+            label: "doc_title",
+            bbox: [0.1, 0.05, 0.9, 0.1],
+            content: "# Annual Report",
+            markdown_span: [0, 15],
+            reading_order: 0,
+            source: "native_text",
+            confidence: { layout: 0.97, ocr: null },
+          },
+        ],
+      },
+    ];
+    mockedRobustFetch.mockResolvedValue({
+      markdown: "# Annual Report",
+      failed_pages: null,
+      pages_processed: 1,
+      blocks,
+    } as any);
+
+    const result = await scrapePDFWithFirePDF(
+      makeMeta(),
+      "BASE64",
+      undefined,
+      undefined,
+      "auto",
+      false,
+      true,
+    );
+
+    expect(mockedRobustFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ include_blocks: true }),
+      }),
+    );
+    expect(
+      ((mockedRobustFetch.mock.calls[0][0] as any).body as any)
+        .include_page_markdown,
+    ).toBeUndefined();
+    expect(result.blocks).toEqual(blocks);
+    expect(result.pageMarkdown).toBeUndefined();
+  });
+
+  it("rejects block-less FirePDF responses for block-aware requests", async () => {
+    mockedRobustFetch.mockResolvedValue({
+      markdown: "document only",
+      failed_pages: null,
+      pages_processed: 1,
+    } as any);
+
+    await expect(
+      scrapePDFWithFirePDF(
+        makeMeta(),
+        "BASE64",
+        undefined,
+        undefined,
+        "auto",
+        false,
+        true,
+      ),
+    ).rejects.toThrow(/did not include requested typed blocks/);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -348,6 +348,125 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect(error.reason).toBe("http_5xx");
   });
 
+  it("requests and returns typed blocks, tolerating the legacy pages alias", async () => {
+    const blocks = [
+      {
+        page: 1,
+        width: 800,
+        height: 1100,
+        status: "ok",
+        items: [
+          {
+            id: "p1.b0",
+            type: "text",
+            label: "text",
+            bbox: [0.1, 0.1, 0.9, 0.2],
+            content: "hello",
+            markdown_span: [0, 5],
+            reading_order: 0,
+            source: "native_text",
+            confidence: { layout: 0.97, ocr: null },
+          },
+        ],
+      },
+    ];
+    const { fetchImpl, calls } = makeFetchFromSequence([
+      {
+        matchUrl: /\/jobs$/,
+        matchMethod: "POST",
+        response: {
+          status: 200,
+          body: {
+            scrape_id: "scrape-id-test",
+            status: "done",
+            lane: "fast",
+          },
+        },
+      },
+      {
+        matchUrl: /\/jobs\/scrape-id-test\/result$/,
+        matchMethod: "GET",
+        response: {
+          status: 200,
+          body: {
+            schema_version: 2,
+            markdown: "hello",
+            blocks,
+            // Block-only jobs return `pages` as the legacy block alias
+            // (no per-page markdown). The result parser must drop it
+            // rather than fail the whole response.
+            pages: [
+              { page: 1, width: 800, height: 1100, status: "ok", blocks: [] },
+            ],
+            pages_processed: 1,
+          },
+        },
+      },
+    ]);
+
+    const result = await scrapePDFWithFirePDFAsync(
+      makeMeta(),
+      "BASE64",
+      undefined,
+      undefined,
+      "auto",
+      { fetchImpl, sleepImpl: noopSleep },
+      false,
+      true,
+    );
+
+    expect((calls[0].body as any).options.include_blocks).toBe(true);
+    expect((calls[0].body as any).options.include_page_markdown).toBe(
+      undefined,
+    );
+    expect(result.markdown).toBe("hello");
+    expect(result.blocks).toEqual(blocks);
+    expect(result.pageMarkdown).toBeUndefined();
+  });
+
+  it("fails a block-aware request when FirePDF omits the block payload", async () => {
+    const { fetchImpl } = makeFetchFromSequence([
+      {
+        matchUrl: /\/jobs$/,
+        matchMethod: "POST",
+        response: {
+          status: 200,
+          body: {
+            scrape_id: "scrape-id-test",
+            status: "done",
+            lane: "fast",
+          },
+        },
+      },
+      {
+        matchUrl: /\/jobs\/scrape-id-test\/result$/,
+        matchMethod: "GET",
+        response: {
+          status: 200,
+          body: {
+            schema_version: 1,
+            markdown: "document only",
+            pages_processed: 1,
+          },
+        },
+      },
+    ]);
+
+    const error = await scrapePDFWithFirePDFAsync(
+      makeMeta(),
+      "BASE64",
+      undefined,
+      undefined,
+      "auto",
+      { fetchImpl, sleepImpl: noopSleep },
+      false,
+      true,
+    ).catch(error => error);
+
+    expect(error).toBeInstanceOf(FirePdfAsyncFailure);
+    expect(error.reason).toBe("http_5xx");
+  });
+
   it("submits without team context when the snapshot is absent", async () => {
     const { fetchImpl, calls } = makeFetchFromSequence([
       {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
@@ -363,9 +363,16 @@ describe("FirePDF page-markdown cache capabilities", () => {
         blocks: "not-an-array" as never,
       })
       .mockResolvedValueOnce({
+        markdown: "wrong page",
+        html: "<p>wrong page</p>",
+        blocks: [{ page: 0, items: null }] as never,
+      })
+      .mockResolvedValueOnce({
         markdown: "wrong item",
         html: "<p>wrong item</p>",
-        blocks: [{ page: 0, items: null }] as never,
+        blocks: [
+          { page: 1, width: 800, height: 1100, status: "ok", items: [null] },
+        ] as never,
       });
 
     const result = await tryGetCached(

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
@@ -35,18 +35,69 @@ describe("FirePDF page-markdown cache capabilities", () => {
   });
 
   it("uses versioned page-capable variants", () => {
-    expect(cacheKeyShape("auto", undefined, true)).toMatchObject({
+    expect(cacheKeyShape("auto", undefined, true, false)).toMatchObject({
       cacheable: true,
       ownVariant: "page-markdown-v1",
-      lookupVariants: ["page-markdown-v1", "ocr-page-markdown-v1"],
+      lookupVariants: [
+        "page-markdown-v1",
+        "page-markdown-blocks-v1",
+        "ocr-page-markdown-v1",
+        "ocr-page-markdown-blocks-v1",
+      ],
     });
-    expect(cacheKeyShape("ocr", undefined, true)).toMatchObject({
+    expect(cacheKeyShape("ocr", undefined, true, false)).toMatchObject({
       cacheable: true,
       ownVariant: "ocr-page-markdown-v1",
-      lookupVariants: ["ocr-page-markdown-v1"],
+      lookupVariants: ["ocr-page-markdown-v1", "ocr-page-markdown-blocks-v1"],
     });
-    expect(cacheKeyShape("fast", undefined, true).cacheable).toBe(false);
-    expect(cacheKeyShape("auto", 5, true).cacheable).toBe(false);
+    expect(cacheKeyShape("fast", undefined, true, false).cacheable).toBe(false);
+    expect(cacheKeyShape("auto", 5, true, false).cacheable).toBe(false);
+  });
+
+  it("uses versioned block-capable variants", () => {
+    expect(cacheKeyShape("auto", undefined, false, true)).toMatchObject({
+      cacheable: true,
+      ownVariant: "blocks-v1",
+      lookupVariants: [
+        "blocks-v1",
+        "page-markdown-blocks-v1",
+        "ocr-blocks-v1",
+        "ocr-page-markdown-blocks-v1",
+      ],
+    });
+    expect(cacheKeyShape("ocr", undefined, false, true)).toMatchObject({
+      cacheable: true,
+      ownVariant: "ocr-blocks-v1",
+      lookupVariants: ["ocr-blocks-v1", "ocr-page-markdown-blocks-v1"],
+    });
+    expect(cacheKeyShape("auto", undefined, true, true)).toMatchObject({
+      cacheable: true,
+      ownVariant: "page-markdown-blocks-v1",
+      lookupVariants: [
+        "page-markdown-blocks-v1",
+        "ocr-page-markdown-blocks-v1",
+      ],
+    });
+    expect(cacheKeyShape("fast", undefined, false, true).cacheable).toBe(false);
+    expect(cacheKeyShape("auto", 5, false, true).cacheable).toBe(false);
+  });
+
+  it("keeps the historical probe list for plain requests", () => {
+    expect(cacheKeyShape("auto", undefined, false, false)).toMatchObject({
+      cacheable: true,
+      ownVariant: undefined,
+      lookupVariants: [
+        undefined,
+        "page-markdown-v1",
+        "ocr",
+        "ocr-page-markdown-v1",
+      ],
+    });
+    expect(cacheKeyShape("ocr", undefined, false, false)).toMatchObject({
+      cacheable: true,
+      ownVariant: "ocr",
+      lookupVariants: ["ocr", "ocr-page-markdown-v1"],
+    });
   });
 
   it("never serves a document-only cache entry to a page-aware request", async () => {
@@ -62,14 +113,22 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       2,
       true,
+      false,
     );
 
     expect(result).toBeNull();
-    expect(getCached).toHaveBeenCalledOnce();
-    expect(getCached).toHaveBeenCalledWith(
+    expect(getCached).toHaveBeenCalledTimes(2);
+    expect(getCached).toHaveBeenNthCalledWith(
+      1,
       "BASE64",
       "firepdf",
       "ocr-page-markdown-v1",
+    );
+    expect(getCached).toHaveBeenNthCalledWith(
+      2,
+      "BASE64",
+      "firepdf",
+      "ocr-page-markdown-blocks-v1",
     );
   });
 
@@ -93,10 +152,11 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       2,
       true,
+      false,
     );
 
     expect(result).toBeNull();
-    expect(getCached).toHaveBeenCalledTimes(2);
+    expect(getCached).toHaveBeenCalledTimes(4);
   });
 
   it("rejects page-capable variants missing required document fields", async () => {
@@ -117,10 +177,11 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       1,
       true,
+      false,
     );
 
     expect(result).toBeNull();
-    expect(getCached).toHaveBeenCalledTimes(2);
+    expect(getCached).toHaveBeenCalledTimes(4);
   });
 
   it("accepts an explicitly empty cached markdown string", async () => {
@@ -137,6 +198,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       1,
       true,
+      false,
     );
 
     expect(result).toMatchObject({ markdown: "", html: "" });
@@ -164,10 +226,11 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       1,
       true,
+      false,
     );
 
     expect(result).toBeNull();
-    expect(getCached).toHaveBeenCalledTimes(2);
+    expect(getCached).toHaveBeenCalledTimes(4);
   });
 
   it("serves page-capable entries and preserves the page-count fallback", async () => {
@@ -187,6 +250,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       2,
       true,
+      false,
     );
 
     expect(result?.pageMarkdown).toHaveLength(2);
@@ -210,6 +274,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       undefined,
       2,
       false,
+      false,
     );
 
     expect(result).toMatchObject({
@@ -226,6 +291,97 @@ describe("FirePDF page-markdown cache capabilities", () => {
     );
   });
 
+  it("never serves a block-less cache entry to a block-aware request", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "no blocks",
+      html: "<p>no blocks</p>",
+    });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      true,
+    );
+
+    expect(result).toBeNull();
+    expect(getCached).toHaveBeenCalledTimes(2);
+    expect(getCached).toHaveBeenNthCalledWith(
+      1,
+      "BASE64",
+      "firepdf",
+      "ocr-blocks-v1",
+    );
+    expect(getCached).toHaveBeenNthCalledWith(
+      2,
+      "BASE64",
+      "firepdf",
+      "ocr-page-markdown-blocks-v1",
+    );
+  });
+
+  it("serves block-capable entries and strips payloads the request skipped", async () => {
+    const blocks = [
+      { page: 1, width: 800, height: 1100, status: "ok", items: [] },
+    ];
+    getCached.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      markdown: "whole",
+      html: "<p>whole</p>",
+      pagesProcessed: 1,
+      pageMarkdown: [{ page: 1, markdown: "one" }],
+      blocks,
+    });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "auto",
+      undefined,
+      1,
+      false,
+      true,
+    );
+
+    expect(getCached).toHaveBeenNthCalledWith(
+      2,
+      "BASE64",
+      "firepdf",
+      "page-markdown-blocks-v1",
+    );
+    expect(result?.blocks).toEqual(blocks);
+    expect(result?.pageMarkdown).toBeUndefined();
+  });
+
+  it("rejects malformed block payloads in block-capable variants", async () => {
+    getCached
+      .mockResolvedValueOnce({
+        markdown: "wrong type",
+        html: "<p>wrong type</p>",
+        blocks: "not-an-array" as never,
+      })
+      .mockResolvedValueOnce({
+        markdown: "wrong item",
+        html: "<p>wrong item</p>",
+        blocks: [{ page: 0, items: null }] as never,
+      });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "auto",
+      undefined,
+      1,
+      false,
+      true,
+    );
+
+    expect(result).toBeNull();
+    expect(getCached).toHaveBeenCalledTimes(4);
+  });
+
   it("writes an enriched sidecar plus a compact legacy entry", async () => {
     const pageMarkdown = [
       { page: 1, markdown: "one" },
@@ -238,6 +394,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       mode: "auto",
       maxPages: undefined,
       includePageMarkdown: true,
+      includeBlocks: false,
       result: {
         markdown: "whole",
         html: "<p>whole</p>",
@@ -276,6 +433,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       mode: "auto",
       maxPages: undefined,
       includePageMarkdown: true,
+      includeBlocks: false,
       result: {
         markdown: "whole",
         html: "<p>whole</p>",
@@ -294,6 +452,49 @@ describe("FirePDF page-markdown cache capabilities", () => {
       expect.objectContaining({ pageMarkdown: expect.any(Array) }),
       "firepdf",
       "page-markdown-v1",
+    );
+  });
+
+  it("writes a block sidecar plus a compact legacy entry", async () => {
+    const blocks = [
+      {
+        page: 1,
+        width: 800,
+        height: 1100,
+        status: "ok",
+        items: [],
+      },
+    ];
+
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: false,
+      includeBlocks: true,
+      result: {
+        markdown: "whole",
+        html: "<p>whole</p>",
+        pagesProcessed: 1,
+        blocks,
+      },
+    });
+
+    expect(saveCached).toHaveBeenCalledTimes(2);
+    expect(saveCached).toHaveBeenNthCalledWith(
+      1,
+      "BASE64",
+      expect.objectContaining({ blocks }),
+      "firepdf",
+      "blocks-v1",
+    );
+    expect(saveCached).toHaveBeenNthCalledWith(
+      2,
+      "BASE64",
+      expect.not.objectContaining({ blocks: expect.anything() }),
+      "firepdf",
+      undefined,
     );
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/indexPageMarkdown.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/indexPageMarkdown.test.ts
@@ -33,6 +33,15 @@ describe("PDF page-markdown URL index policy", () => {
           },
         }),
       ).toBe(false);
+      expect(
+        shouldUseIndex({
+          ...baseMeta,
+          options: {
+            ...baseMeta.options,
+            parsers: [{ type: "pdf", blocks: true }],
+          },
+        }),
+      ).toBe(false);
     } finally {
       (
         config as { FIRECRAWL_INDEX_WRITE_ONLY?: boolean }
@@ -55,6 +64,36 @@ describe("PDF page-markdown URL index policy", () => {
       options: {
         storeInCache: true,
         parsers: [{ type: "pdf", pageMarkdown: true }],
+      },
+      internalOptions: {
+        isParse: false,
+        zeroDataRetention: false,
+      },
+    } as any;
+
+    const result = await sendDocumentToIndex(meta, document);
+
+    expect(result).toBe(document);
+    expect(result.metadata.indexId).toBeUndefined();
+  });
+
+  it("does not write block-aware results to the document-only URL index", async () => {
+    const document = {
+      markdown: "whole document",
+      blocks: [
+        { pageNumber: 1, width: 800, height: 1100, status: "ok", items: [] },
+      ],
+      rawHtml: "<p>whole document</p>",
+      metadata: {
+        sourceURL: "https://example.com/file.pdf",
+      },
+    } as any;
+    const meta = {
+      url: "https://example.com/file.pdf",
+      winnerEngine: "pdf",
+      options: {
+        storeInCache: true,
+        parsers: [{ type: "pdf", blocks: true }],
       },
       internalOptions: {
         isParse: false,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/blocks.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/blocks.ts
@@ -1,0 +1,27 @@
+import type { FirePdfPageBlocks, PdfPageBlocks } from "./types";
+
+/**
+ * Project fire-pdf's snake_case block wire shape onto the camelCase shape
+ * surfaced on `Document.blocks`. Pure adapter — keeps the provider contract
+ * translation out of the engine orchestration and next to the wire schema
+ * it mirrors (fire-pdf/schema.ts).
+ */
+export function toPublicBlocks(blocks: FirePdfPageBlocks[]): PdfPageBlocks[] {
+  return blocks.map(page => ({
+    pageNumber: page.page,
+    width: page.width,
+    height: page.height,
+    status: page.status,
+    items: page.items.map(item => ({
+      id: item.id,
+      type: item.type,
+      label: item.label,
+      bbox: item.bbox,
+      content: item.content,
+      markdownSpan: item.markdown_span,
+      readingOrder: item.reading_order,
+      source: item.source,
+      confidence: item.confidence,
+    })),
+  }));
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -38,6 +38,7 @@ export async function scrapePDFWithFirePDFAsync(
   mode?: PDFMode,
   deps: FirePdfAsyncDeps = {},
   includePageMarkdown = false,
+  includeBlocks = false,
 ): Promise<PDFProcessorResult> {
   const fetchImpl = deps.fetchImpl ?? undiciFetch;
   const fallbackImpl = deps.fallbackImpl ?? scrapePDFWithFirePDF;
@@ -55,6 +56,7 @@ export async function scrapePDFWithFirePDFAsync(
       pagesProcessed,
       mode,
       includePageMarkdown,
+      includeBlocks,
     );
   }
 
@@ -65,6 +67,7 @@ export async function scrapePDFWithFirePDFAsync(
     maxPages,
     pagesProcessed,
     includePageMarkdown,
+    includeBlocks,
   );
   if (cached) return cached;
 
@@ -89,6 +92,7 @@ export async function scrapePDFWithFirePDFAsync(
       pagesProcessed,
       mode,
       includePageMarkdown,
+      includeBlocks,
     );
   }
 
@@ -122,6 +126,7 @@ export async function scrapePDFWithFirePDFAsync(
       pagesProcessed,
       mode,
       includePageMarkdown,
+      includeBlocks,
       deadlineAt,
       teamConcurrency,
       fetchImpl,
@@ -182,6 +187,11 @@ export async function scrapePDFWithFirePDFAsync(
       note: "FirePDF result omitted requested physical page markdown",
     });
   }
+  if (includeBlocks && fetched.blocks === undefined) {
+    failAsync(meta, "http_5xx", {
+      note: "FirePDF result omitted requested typed blocks",
+    });
+  }
   const durationMs = now() - overallStartedAt;
   firePdfAsyncTotalDurationSeconds.observe(durationMs / 1000);
 
@@ -191,6 +201,7 @@ export async function scrapePDFWithFirePDFAsync(
     markdownLength: fetched.markdown.length,
     pagesProcessed: pages,
     pageMarkdownPages: fetched.pages?.length,
+    blockPages: fetched.blocks?.length,
     failedPages: fetched.failed_pages,
     partialPages: fetched.partial_pages,
     pollCount: polled.pollCount,
@@ -201,6 +212,7 @@ export async function scrapePDFWithFirePDFAsync(
     html: await safeMarkdownToHtml(fetched.markdown, meta.logger, meta.id),
     pagesProcessed: pages,
     ...(fetched.pages ? { pageMarkdown: fetched.pages } : {}),
+    ...(fetched.blocks ? { blocks: fetched.blocks } : {}),
   };
 
   await maybeSaveResult({
@@ -209,6 +221,7 @@ export async function scrapePDFWithFirePDFAsync(
     mode,
     maxPages,
     includePageMarkdown,
+    includeBlocks,
     result: processorResult,
   });
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
@@ -5,6 +5,7 @@ import {
   getPdfResultFromCache,
   savePdfResultToCache,
 } from "../../../../../lib/gcs-pdf-cache";
+import { firePdfBlockPagesSchema } from "./schema";
 
 // Cache layout mirrors the sync `scrapePDFWithFirePDF` so async/sync share
 // entries. `fast` mode bypasses entirely (hard cost ceiling — must fail on
@@ -52,35 +53,13 @@ function isValidPageMarkdown(
   );
 }
 
+// Cached block sidecars must satisfy the full wire contract before being
+// served — a malformed or stale GCS artifact is skipped (and regenerated)
+// rather than surfaced as invalid public block data.
 function isValidBlocks(
   value: unknown,
 ): value is NonNullable<PDFProcessorResult["blocks"]> {
-  return (
-    Array.isArray(value) &&
-    value.every(
-      page =>
-        typeof page === "object" &&
-        page !== null &&
-        Number.isInteger((page as { page?: unknown }).page) &&
-        Number((page as { page: number }).page) > 0 &&
-        Array.isArray((page as { items?: unknown }).items) &&
-        (page as { items: unknown[] }).items.every(item => {
-          if (typeof item !== "object" || item === null) return false;
-          const block = item as {
-            id?: unknown;
-            type?: unknown;
-            content?: unknown;
-            reading_order?: unknown;
-          };
-          return (
-            typeof block.id === "string" &&
-            typeof block.type === "string" &&
-            typeof block.content === "string" &&
-            typeof block.reading_order === "number"
-          );
-        }),
-    )
-  );
+  return firePdfBlockPagesSchema.safeParse(value).success;
 }
 
 export function cacheKeyShape(

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
@@ -63,7 +63,22 @@ function isValidBlocks(
         page !== null &&
         Number.isInteger((page as { page?: unknown }).page) &&
         Number((page as { page: number }).page) > 0 &&
-        Array.isArray((page as { items?: unknown }).items),
+        Array.isArray((page as { items?: unknown }).items) &&
+        (page as { items: unknown[] }).items.every(item => {
+          if (typeof item !== "object" || item === null) return false;
+          const block = item as {
+            id?: unknown;
+            type?: unknown;
+            content?: unknown;
+            reading_order?: unknown;
+          };
+          return (
+            typeof block.id === "string" &&
+            typeof block.type === "string" &&
+            typeof block.content === "string" &&
+            typeof block.reading_order === "number"
+          );
+        }),
     )
   );
 }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
@@ -12,6 +12,10 @@ import {
 // `maxPages` (the cached entry may have been written with a different cap).
 const PAGE_MARKDOWN_VARIANT = "page-markdown-v1";
 const OCR_PAGE_MARKDOWN_VARIANT = "ocr-page-markdown-v1";
+const BLOCKS_VARIANT = "blocks-v1";
+const OCR_BLOCKS_VARIANT = "ocr-blocks-v1";
+const PAGE_MARKDOWN_BLOCKS_VARIANT = "page-markdown-blocks-v1";
+const OCR_PAGE_MARKDOWN_BLOCKS_VARIANT = "ocr-page-markdown-blocks-v1";
 
 function isValidCachedDocument(
   value: unknown,
@@ -48,28 +52,76 @@ function isValidPageMarkdown(
   );
 }
 
+function isValidBlocks(
+  value: unknown,
+): value is NonNullable<PDFProcessorResult["blocks"]> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      page =>
+        typeof page === "object" &&
+        page !== null &&
+        Number.isInteger((page as { page?: unknown }).page) &&
+        Number((page as { page: number }).page) > 0 &&
+        Array.isArray((page as { items?: unknown }).items),
+    )
+  );
+}
+
 export function cacheKeyShape(
   mode: PDFMode | undefined,
   maxPages: number | undefined,
   includePageMarkdown: boolean,
+  includeBlocks: boolean,
 ) {
   const cacheable = mode !== "fast" && !maxPages;
-  const baseVariant: string | undefined = mode === "ocr" ? "ocr" : undefined;
-  const ownVariant: string | undefined = includePageMarkdown
-    ? mode === "ocr"
-      ? OCR_PAGE_MARKDOWN_VARIANT
-      : PAGE_MARKDOWN_VARIANT
-    : baseVariant;
+  const isOcr = mode === "ocr";
+  const baseVariant: string | undefined = isOcr ? "ocr" : undefined;
+  const ownVariant: string | undefined =
+    includePageMarkdown && includeBlocks
+      ? isOcr
+        ? OCR_PAGE_MARKDOWN_BLOCKS_VARIANT
+        : PAGE_MARKDOWN_BLOCKS_VARIANT
+      : includeBlocks
+        ? isOcr
+          ? OCR_BLOCKS_VARIANT
+          : BLOCKS_VARIANT
+        : includePageMarkdown
+          ? isOcr
+            ? OCR_PAGE_MARKDOWN_VARIANT
+            : PAGE_MARKDOWN_VARIANT
+          : baseVariant;
 
-  // Page-aware requests may only consume page-capable artifacts. Legacy
-  // requests prefer their compact entry but can reuse an enriched sidecar.
-  const lookupVariants: (string | undefined)[] = includePageMarkdown
-    ? mode === "ocr"
-      ? [OCR_PAGE_MARKDOWN_VARIANT]
-      : [PAGE_MARKDOWN_VARIANT, OCR_PAGE_MARKDOWN_VARIANT]
-    : mode === "ocr"
-      ? ["ocr", OCR_PAGE_MARKDOWN_VARIANT]
-      : [undefined, PAGE_MARKDOWN_VARIANT, "ocr", OCR_PAGE_MARKDOWN_VARIANT];
+  // Capability rule: a request may only consume artifacts carrying every
+  // capability it asked for (pages/blocks), but can reuse a richer sidecar.
+  // Compact entries are preferred, and `auto` may fall back to ocr-written
+  // artifacts. Plain requests keep the historical 4-variant probe list —
+  // the hot path is not taxed with block-sidecar lookups.
+  const lookupVariants: (string | undefined)[] = includeBlocks
+    ? includePageMarkdown
+      ? isOcr
+        ? [OCR_PAGE_MARKDOWN_BLOCKS_VARIANT]
+        : [PAGE_MARKDOWN_BLOCKS_VARIANT, OCR_PAGE_MARKDOWN_BLOCKS_VARIANT]
+      : isOcr
+        ? [OCR_BLOCKS_VARIANT, OCR_PAGE_MARKDOWN_BLOCKS_VARIANT]
+        : [
+            BLOCKS_VARIANT,
+            PAGE_MARKDOWN_BLOCKS_VARIANT,
+            OCR_BLOCKS_VARIANT,
+            OCR_PAGE_MARKDOWN_BLOCKS_VARIANT,
+          ]
+    : includePageMarkdown
+      ? isOcr
+        ? [OCR_PAGE_MARKDOWN_VARIANT, OCR_PAGE_MARKDOWN_BLOCKS_VARIANT]
+        : [
+            PAGE_MARKDOWN_VARIANT,
+            PAGE_MARKDOWN_BLOCKS_VARIANT,
+            OCR_PAGE_MARKDOWN_VARIANT,
+            OCR_PAGE_MARKDOWN_BLOCKS_VARIANT,
+          ]
+      : isOcr
+        ? ["ocr", OCR_PAGE_MARKDOWN_VARIANT]
+        : [undefined, PAGE_MARKDOWN_VARIANT, "ocr", OCR_PAGE_MARKDOWN_VARIANT];
   return { cacheable, ownVariant, baseVariant, lookupVariants };
 }
 
@@ -80,12 +132,14 @@ export async function tryGetCached(
   maxPages: number | undefined,
   pagesProcessed: number | undefined,
   includePageMarkdown: boolean,
+  includeBlocks: boolean,
 ): Promise<PDFProcessorResult | null> {
   if (meta.internalOptions.zeroDataRetention) return null;
   const { cacheable, lookupVariants } = cacheKeyShape(
     mode,
     maxPages,
     includePageMarkdown,
+    includeBlocks,
   );
   if (!cacheable) return null;
 
@@ -99,7 +153,8 @@ export async function tryGetCached(
       if (cached) {
         if (
           !isValidCachedDocument(cached) ||
-          (includePageMarkdown && !isValidPageMarkdown(cached.pageMarkdown))
+          (includePageMarkdown && !isValidPageMarkdown(cached.pageMarkdown)) ||
+          (includeBlocks && !isValidBlocks(cached.blocks))
         ) {
           // Defense in depth: variant names are the capability boundary, but
           // never let a malformed/old artifact satisfy a cache lookup.
@@ -110,15 +165,13 @@ export async function tryGetCached(
           requestedMode: mode,
           cacheVariant: variant ?? "base",
         });
-        if (!includePageMarkdown) {
-          const { pageMarkdown: _pageMarkdown, ...compactCached } = cached;
-          return {
-            ...compactCached,
-            pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
-          };
-        }
+        // Strip payloads the request didn't ask for so a richer sidecar
+        // serves a poorer request without leaking extra capabilities.
+        const { pageMarkdown, blocks, ...compactCached } = cached;
         return {
-          ...cached,
+          ...compactCached,
+          ...(includePageMarkdown ? { pageMarkdown } : {}),
+          ...(includeBlocks ? { blocks } : {}),
           pagesProcessed: cached.pagesProcessed ?? pagesProcessed,
         };
       }
@@ -138,33 +191,46 @@ export async function maybeSaveResult(args: {
   mode: PDFMode | undefined;
   maxPages: number | undefined;
   includePageMarkdown: boolean;
+  includeBlocks: boolean;
   result: PDFProcessorResult & { markdown: string };
 }): Promise<void> {
-  const { meta, base64Content, mode, maxPages, includePageMarkdown, result } =
-    args;
+  const {
+    meta,
+    base64Content,
+    mode,
+    maxPages,
+    includePageMarkdown,
+    includeBlocks,
+    result,
+  } = args;
   if (meta.internalOptions.zeroDataRetention) return;
   const { cacheable, ownVariant, baseVariant } = cacheKeyShape(
     mode,
     maxPages,
     includePageMarkdown,
+    includeBlocks,
   );
   if (!cacheable) return;
 
   try {
     await savePdfResultToCache(base64Content, result, "firepdf", ownVariant);
-    // A page-capable parse is also a valid legacy result. Populate the compact
-    // base key when it is missing so a later legacy request never repeats the
-    // conversion. A page-sidecar miss can coexist with a warm legacy key during
-    // rollout, so avoid rewriting that object. Strip the page payload to keep
-    // the hot-path cache object small.
-    if (includePageMarkdown && ownVariant !== baseVariant) {
+    // An enriched (page/block-capable) parse is also a valid legacy result.
+    // Populate the compact base key when it is missing so a later legacy
+    // request never repeats the conversion. A sidecar miss can coexist with
+    // a warm legacy key during rollout, so avoid rewriting that object.
+    // Strip the enriched payloads to keep the hot-path cache object small.
+    if ((includePageMarkdown || includeBlocks) && ownVariant !== baseVariant) {
       const existingBase = await getPdfResultFromCache(
         base64Content,
         "firepdf",
         baseVariant,
       );
       if (!existingBase || !isValidCachedDocument(existingBase)) {
-        const { pageMarkdown: _pageMarkdown, ...baseResult } = result;
+        const {
+          pageMarkdown: _pageMarkdown,
+          blocks: _blocks,
+          ...baseResult
+        } = result;
         await savePdfResultToCache(
           base64Content,
           baseResult,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -51,48 +51,63 @@ export const pollResponseSchema = z.object({
  * Physical page markdown payload, shared by the sync `/ocr` and async
  * `/jobs/:id/result` response schemas. When `include_blocks` is requested
  * without `include_page_markdown`, fire-pdf returns `pages` in a legacy
- * block-alias shape (`{page, width, height, status, blocks}` — no markdown);
- * `.catch(undefined)` drops that alias instead of failing the whole response
- * parse. The callers' "requested page markdown missing" checks still fire
- * when page markdown was actually requested but came back malformed.
+ * block-alias shape (`{page, width, height, status, blocks}` — no markdown).
+ * The union matches that alias explicitly and drops it to `undefined`, so
+ * genuine protocol corruption still fails the response parse, and the
+ * callers' "requested page markdown missing" checks still fire when page
+ * markdown was requested but absent.
  */
 export const firePdfPagesSchema = z
-  .array(z.object({ page: z.number().int().positive(), markdown: z.string() }))
-  .optional()
-  .catch(undefined);
+  .union([
+    z.array(
+      z.object({ page: z.number().int().positive(), markdown: z.string() }),
+    ),
+    z
+      .array(
+        z.object({
+          page: z.number().int().positive(),
+          blocks: z.array(z.unknown()),
+        }),
+      )
+      .transform((): undefined => undefined),
+  ])
+  .optional();
 
 /** Typed layout blocks (fire-pdf docs/blocks-schema.md), present only when
- * the request set `include_blocks`. Wire shape — snake_case passthrough. */
-export const firePdfBlocksSchema = z
-  .array(
-    z.object({
-      page: z.number().int().positive(),
-      width: z.number().nullable(),
-      height: z.number().nullable(),
-      // Documented values: ok | partial | failed. Kept open so a new
-      // page status never fails an otherwise-valid scrape.
-      status: z.string(),
-      items: z.array(
-        z.object({
-          id: z.string(),
-          type: z.string(),
-          label: z.string().nullable(),
-          bbox: z
-            .tuple([z.number(), z.number(), z.number(), z.number()])
-            .nullable(),
-          content: z.string(),
-          markdown_span: z.tuple([z.number(), z.number()]).nullable(),
-          reading_order: z.number(),
-          source: z.string().nullable(),
-          confidence: z.object({
-            layout: z.number().nullable(),
-            ocr: z.number().nullable(),
-          }),
+ * the request set `include_blocks`. Wire shape — snake_case passthrough.
+ * Single source of truth for the block contract: the response parsers and
+ * the GCS cache validator both use it, and the wire TS types are inferred
+ * from it. */
+export const firePdfBlockPagesSchema = z.array(
+  z.object({
+    page: z.number().int().positive(),
+    width: z.number().nullable(),
+    height: z.number().nullable(),
+    // Documented values: ok | partial | failed. Kept open so a new
+    // page status never fails an otherwise-valid scrape.
+    status: z.string(),
+    items: z.array(
+      z.object({
+        id: z.string(),
+        type: z.string(),
+        label: z.string().nullable(),
+        bbox: z
+          .tuple([z.number(), z.number(), z.number(), z.number()])
+          .nullable(),
+        content: z.string(),
+        markdown_span: z.tuple([z.number(), z.number()]).nullable(),
+        reading_order: z.number(),
+        source: z.string().nullable(),
+        confidence: z.object({
+          layout: z.number().nullable(),
+          ocr: z.number().nullable(),
         }),
-      ),
-    }),
-  )
-  .optional();
+      }),
+    ),
+  }),
+);
+
+export const firePdfBlocksSchema = firePdfBlockPagesSchema.optional();
 
 export const resultResponseSchema = z.object({
   schema_version: z

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -64,8 +64,14 @@ export const firePdfPagesSchema = z
     ),
     z
       .array(
+        // Full documented alias shape (LegacyPageBlocks) — requiring every
+        // field keeps the union discriminating: a payload that is neither
+        // valid page markdown nor a complete alias fails the parse.
         z.object({
           page: z.number().int().positive(),
+          width: z.number().nullable(),
+          height: z.number().nullable(),
+          status: z.string(),
           blocks: z.array(z.unknown()),
         }),
       )

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -47,16 +47,60 @@ export const pollResponseSchema = z.object({
   error_message: z.string().optional(),
 });
 
+/**
+ * Physical page markdown payload, shared by the sync `/ocr` and async
+ * `/jobs/:id/result` response schemas. When `include_blocks` is requested
+ * without `include_page_markdown`, fire-pdf returns `pages` in a legacy
+ * block-alias shape (`{page, width, height, status, blocks}` — no markdown);
+ * `.catch(undefined)` drops that alias instead of failing the whole response
+ * parse. The callers' "requested page markdown missing" checks still fire
+ * when page markdown was actually requested but came back malformed.
+ */
+export const firePdfPagesSchema = z
+  .array(z.object({ page: z.number().int().positive(), markdown: z.string() }))
+  .optional()
+  .catch(undefined);
+
+/** Typed layout blocks (fire-pdf docs/blocks-schema.md), present only when
+ * the request set `include_blocks`. Wire shape — snake_case passthrough. */
+export const firePdfBlocksSchema = z
+  .array(
+    z.object({
+      page: z.number().int().positive(),
+      width: z.number().nullable(),
+      height: z.number().nullable(),
+      // Documented values: ok | partial | failed. Kept open so a new
+      // page status never fails an otherwise-valid scrape.
+      status: z.string(),
+      items: z.array(
+        z.object({
+          id: z.string(),
+          type: z.string(),
+          label: z.string().nullable(),
+          bbox: z
+            .tuple([z.number(), z.number(), z.number(), z.number()])
+            .nullable(),
+          content: z.string(),
+          markdown_span: z.tuple([z.number(), z.number()]).nullable(),
+          reading_order: z.number(),
+          source: z.string().nullable(),
+          confidence: z.object({
+            layout: z.number().nullable(),
+            ocr: z.number().nullable(),
+          }),
+        }),
+      ),
+    }),
+  )
+  .optional();
+
 export const resultResponseSchema = z.object({
   schema_version: z
     .union([z.literal(1), z.literal(2), z.literal(3)])
     .optional(),
   markdown: z.string(),
-  pages: z
-    .array(
-      z.object({ page: z.number().int().positive(), markdown: z.string() }),
-    )
-    .optional(),
+  pages: firePdfPagesSchema,
+  blocks: firePdfBlocksSchema,
   pages_processed: z.number().optional(),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
@@ -20,6 +20,7 @@ type SubmitArgs = {
   pagesProcessed: number | undefined;
   mode: PDFMode | undefined;
   includePageMarkdown: boolean;
+  includeBlocks: boolean;
   deadlineAt: string;
   /** Team's sold concurrency from the ACUC (ENG-5049 account context).
    * Optional: entitlement lookup must never block or fail a scrape. */
@@ -60,6 +61,7 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
     pagesProcessed,
     mode,
     includePageMarkdown,
+    includeBlocks,
     deadlineAt,
     teamConcurrency,
     fetchImpl,
@@ -89,6 +91,7 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
       ...(maxPages !== undefined && { max_pages: maxPages }),
       ...(mode !== undefined && { mode }),
       ...(includePageMarkdown && { include_page_markdown: true }),
+      ...(includeBlocks && { include_blocks: true }),
     },
   };
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -7,6 +7,7 @@ import type { PDFMode } from "../../../../controllers/v2/types";
 import { safeMarkdownToHtml } from "./markdownToHtml";
 import { createPdfCacheKey } from "../../../../lib/gcs-pdf-cache";
 import { maybeSaveResult, tryGetCached } from "./fire-pdf/cache";
+import { firePdfBlocksSchema, firePdfPagesSchema } from "./fire-pdf/schema";
 
 /**
  * Reconcile an existing page count with what fire-pdf reported.
@@ -45,6 +46,7 @@ export async function scrapePDFWithFirePDF(
   pagesProcessed?: number,
   mode?: PDFMode,
   includePageMarkdown = false,
+  includeBlocks = false,
 ): Promise<PDFProcessorResult> {
   const logger = meta.logger;
 
@@ -70,6 +72,7 @@ export async function scrapePDFWithFirePDF(
         maxPages,
         pagesProcessed,
         includePageMarkdown,
+        includeBlocks,
       )
     : null;
   if (cached) return cached;
@@ -120,6 +123,7 @@ export async function scrapePDFWithFirePDF(
       ...(maxPages !== undefined && { max_pages: maxPages }),
       ...(mode !== undefined && { mode }),
       ...(includePageMarkdown && { include_page_markdown: true }),
+      ...(includeBlocks && { include_blocks: true }),
       // Enrichment for the fire-pdf jobs DB / dashboard. fire-pdf treats
       // these as optional — older fire-pdf builds will ignore unknown fields.
       team_id: meta.internalOptions.teamId,
@@ -137,11 +141,8 @@ export async function scrapePDFWithFirePDF(
       markdown: z.string(),
       failed_pages: z.array(z.number()).nullable(),
       pages_processed: z.number().optional(),
-      pages: z
-        .array(
-          z.object({ page: z.number().int().positive(), markdown: z.string() }),
-        )
-        .optional(),
+      pages: firePdfPagesSchema,
+      blocks: firePdfBlocksSchema,
     }),
     mock: meta.mock,
     abort: meta.abort.asSignal(),
@@ -152,6 +153,9 @@ export async function scrapePDFWithFirePDF(
     throw new Error(
       "FirePDF response did not include requested physical page markdown",
     );
+  }
+  if (includeBlocks && resp.blocks === undefined) {
+    throw new Error("FirePDF response did not include requested typed blocks");
   }
   const pages = resp.pages_processed ?? pagesProcessed;
 
@@ -170,6 +174,7 @@ export async function scrapePDFWithFirePDF(
     html: await safeMarkdownToHtml(resp.markdown, logger, meta.id),
     pagesProcessed: pages,
     ...(resp.pages ? { pageMarkdown: resp.pages } : {}),
+    ...(resp.blocks ? { blocks: resp.blocks } : {}),
   };
 
   if (cacheable) {
@@ -179,6 +184,7 @@ export async function scrapePDFWithFirePDF(
       mode,
       maxPages,
       includePageMarkdown,
+      includeBlocks,
       result: processorResult,
     });
   }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -19,6 +19,7 @@ import {
   getPDFMaxPages,
   getPDFMode,
   getPDFPageMarkdown,
+  getPDFBlocks,
   getFirePdfAsync,
 } from "../../../../controllers/v2/types";
 import type { PDFMode } from "../../../../controllers/v2/types";
@@ -61,10 +62,17 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
   const maxPages = getPDFMaxPages(meta.options.parsers);
   const mode: PDFMode = getPDFMode(meta.options.parsers);
   const includePageMarkdown = getPDFPageMarkdown(meta.options.parsers);
+  const includeBlocks = getPDFBlocks(meta.options.parsers);
 
   if (includePageMarkdown && !config.FIRE_PDF_BASE_URL) {
     throw new Error(
       "Physical page markdown is unavailable because FirePDF is not configured",
+    );
+  }
+
+  if (includeBlocks && !config.FIRE_PDF_BASE_URL) {
+    throw new Error(
+      "Typed blocks are unavailable because FirePDF is not configured",
     );
   }
 
@@ -178,7 +186,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     let shadowPagesNeedingOcr: number[] | undefined;
 
     const forceFirePDF =
-      (!!meta.options.__forceFirePDF || includePageMarkdown) &&
+      (!!meta.options.__forceFirePDF || includePageMarkdown || includeBlocks) &&
       !!config.FIRE_PDF_BASE_URL;
     const rustEnabled = !!config.PDF_RUST_EXTRACT_ENABLE;
     const logger = meta.logger.child({ method: "scrapePDF/processPdf" });
@@ -461,17 +469,18 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
                 mode,
                 undefined,
                 includePageMarkdown,
+                includeBlocks,
               );
             } catch (error) {
               if (
-                !includePageMarkdown ||
+                (!includePageMarkdown && !includeBlocks) ||
                 error instanceof RemoveFeatureError ||
                 error instanceof AbortManagerThrownError
               ) {
                 throw error;
               }
               meta.logger.warn(
-                "FirePDF async page markdown failed -- retrying synchronously",
+                "FirePDF async page markdown/blocks failed -- retrying synchronously",
                 {
                   method: "scrapePDF/firePDFFallback",
                   error,
@@ -490,7 +499,8 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
                 maxPages,
                 effectivePageCount,
                 mode,
-                true,
+                includePageMarkdown,
+                includeBlocks,
               );
             }
           } else {
@@ -501,6 +511,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
               effectivePageCount,
               mode,
               includePageMarkdown,
+              includeBlocks,
             );
           }
           effectivePageCount = reconcilePageCountWithFirePdf(
@@ -687,6 +698,27 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             pages: result.pageMarkdown.map(page => ({
               pageNumber: page.page,
               markdown: page.markdown,
+            })),
+          }
+        : {}),
+      ...(includeBlocks && result?.blocks
+        ? {
+            blocks: result.blocks.map(page => ({
+              pageNumber: page.page,
+              width: page.width,
+              height: page.height,
+              status: page.status,
+              items: page.items.map(item => ({
+                id: item.id,
+                type: item.type,
+                label: item.label,
+                bbox: item.bbox,
+                content: item.content,
+                markdownSpan: item.markdown_span,
+                readingOrder: item.reading_order,
+                source: item.source,
+                confidence: item.confidence,
+              })),
             })),
           }
         : {}),

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -41,6 +41,7 @@ import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
 import { scrapePDFWithFirePDFAsync } from "./fire-pdf/async";
 import { decideFirePdfAsyncRoute } from "./fire-pdf/routing";
 import { scrapePDFWithParsePDF } from "./pdfParse";
+import { toPublicBlocks } from "./blocks";
 import { captureExceptionWithZdrCheck } from "../../../../services/sentry";
 import { isPdfBuffer, PDF_SNIFF_WINDOW } from "./pdfUtils";
 import { comparePdfOutputs } from "./shadowComparison";
@@ -702,25 +703,7 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           }
         : {}),
       ...(includeBlocks && result?.blocks
-        ? {
-            blocks: result.blocks.map(page => ({
-              pageNumber: page.page,
-              width: page.width,
-              height: page.height,
-              status: page.status,
-              items: page.items.map(item => ({
-                id: item.id,
-                type: item.type,
-                label: item.label,
-                bbox: item.bbox,
-                content: item.content,
-                markdownSpan: item.markdown_span,
-                readingOrder: item.reading_order,
-                source: item.source,
-                confidence: item.confidence,
-              })),
-            })),
-          }
+        ? { blocks: toPublicBlocks(result.blocks) }
         : {}),
       pdfMetadata: {
         numPages: effectivePageCount,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -1,43 +1,16 @@
+import type { z } from "zod";
+import type { firePdfBlockPagesSchema } from "./fire-pdf/schema";
+
 export type PdfPageMarkdown = {
   /** 1-based physical PDF page number returned by fire-pdf. */
   page: number;
   markdown: string;
 };
 
-/** Typed layout block as fire-pdf returns it (snake_case wire shape,
- * fire-pdf docs/blocks-schema.md). Cached artifacts store this shape. */
-export type FirePdfBlock = {
-  /** Stable within a response: p<page>.b<index in reading order>. */
-  id: string;
-  /** Public block taxonomy: title, section_header, text, table, formula,
-   * figure, caption, page_number, ... New types may appear over time. */
-  type: string;
-  /** Raw layout-model label, passthrough for forward compatibility. */
-  label: string | null;
-  /** [x0,y0,x1,y1] normalized 0-1 to page dims; null when the page has no
-   * known dims and the raw bbox isn't already normalized. */
-  bbox: [number, number, number, number] | null;
-  /** Markdown fragment this block contributed. */
-  content: string;
-  /** [start,end) char offsets into the document markdown; null when a
-   * post-join transform rewrote the fragment. */
-  markdown_span: [number, number] | null;
-  reading_order: number;
-  source: string | null;
-  confidence: { layout: number | null; ocr: number | null };
-};
-
-export type FirePdfPageBlocks = {
-  /** 1-based, matches `<!-- page N -->` markers in the document markdown. */
-  page: number;
-  /** Render dims in px — the bbox denormalization anchor. Null for pages
-   * that never rendered (direct-extraction-only pages). */
-  width: number | null;
-  height: number | null;
-  /** Page-level rollup: "ok" | "partial" | "failed" (open set). */
-  status: string;
-  items: FirePdfBlock[];
-};
+/** Typed layout blocks as fire-pdf returns them (snake_case wire shape,
+ * fire-pdf docs/blocks-schema.md). Inferred from the zod wire schema so the
+ * contract lives in exactly one place. Cached artifacts store this shape. */
+export type FirePdfPageBlocks = z.infer<typeof firePdfBlockPagesSchema>[number];
 
 /** Public camelCase shape surfaced on `Document.blocks`. */
 export type PdfBlockItem = {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/types.ts
@@ -4,10 +4,69 @@ export type PdfPageMarkdown = {
   markdown: string;
 };
 
+/** Typed layout block as fire-pdf returns it (snake_case wire shape,
+ * fire-pdf docs/blocks-schema.md). Cached artifacts store this shape. */
+export type FirePdfBlock = {
+  /** Stable within a response: p<page>.b<index in reading order>. */
+  id: string;
+  /** Public block taxonomy: title, section_header, text, table, formula,
+   * figure, caption, page_number, ... New types may appear over time. */
+  type: string;
+  /** Raw layout-model label, passthrough for forward compatibility. */
+  label: string | null;
+  /** [x0,y0,x1,y1] normalized 0-1 to page dims; null when the page has no
+   * known dims and the raw bbox isn't already normalized. */
+  bbox: [number, number, number, number] | null;
+  /** Markdown fragment this block contributed. */
+  content: string;
+  /** [start,end) char offsets into the document markdown; null when a
+   * post-join transform rewrote the fragment. */
+  markdown_span: [number, number] | null;
+  reading_order: number;
+  source: string | null;
+  confidence: { layout: number | null; ocr: number | null };
+};
+
+export type FirePdfPageBlocks = {
+  /** 1-based, matches `<!-- page N -->` markers in the document markdown. */
+  page: number;
+  /** Render dims in px — the bbox denormalization anchor. Null for pages
+   * that never rendered (direct-extraction-only pages). */
+  width: number | null;
+  height: number | null;
+  /** Page-level rollup: "ok" | "partial" | "failed" (open set). */
+  status: string;
+  items: FirePdfBlock[];
+};
+
+/** Public camelCase shape surfaced on `Document.blocks`. */
+export type PdfBlockItem = {
+  id: string;
+  type: string;
+  label: string | null;
+  bbox: [number, number, number, number] | null;
+  content: string;
+  markdownSpan: [number, number] | null;
+  readingOrder: number;
+  source: string | null;
+  confidence: { layout: number | null; ocr: number | null };
+};
+
+export type PdfPageBlocks = {
+  pageNumber: number;
+  width: number | null;
+  height: number | null;
+  status: string;
+  items: PdfBlockItem[];
+};
+
 export type PDFProcessorResult = {
   html: string;
   markdown?: string;
   pageMarkdown?: PdfPageMarkdown[];
+  /** Typed layout blocks (fire-pdf wire shape); present only when the
+   * request set the `blocks` parser option. */
+  blocks?: FirePdfPageBlocks[];
   /**
    * Pages the underlying engine actually processed for this request.
    * Currently populated only by fire-pdf (via OcrSuccessBody.pages_processed).

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -985,6 +985,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
     let document: Document = {
       markdown: engineResult.markdown,
       pages: engineResult.pages,
+      blocks: engineResult.blocks,
       rawHtml: engineResult.html,
       json: engineResult.json,
       screenshot: engineResult.screenshot,


### PR DESCRIPTION
## What

Adds a `blocks: true` option to the PDF parser object, available everywhere `parsers` is accepted (v2 scrape / parse / crawl / batch):

```json
{ "url": "https://example.com/doc.pdf", "parsers": [{ "type": "pdf", "blocks": true }] }
```

When set, the request is pinned to fire-pdf with `include_blocks`, and the document carries a `blocks` array — per-page typed layout blocks that fire-pdf already computes (shipped there in July, never exposed here):

```jsonc
"blocks": [
  {
    "pageNumber": 1,
    "width": 1700, "height": 2200,        // render px — bbox denormalization anchor
    "status": "ok",                        // ok | partial | failed
    "items": [
      {
        "id": "p1.b0",
        "type": "title",                   // title | section_header | text | table | formula | figure | ...
        "label": "doc_title",              // raw layout-model label passthrough
        "bbox": [0.118, 0.054, 0.882, 0.092],  // [x0,y0,x1,y1] normalized 0-1
        "content": "# Annual Report 2025",
        "markdownSpan": [0, 21],           // [start,end) offsets into document markdown
        "readingOrder": 0,
        "source": "native_text",
        "confidence": { "layout": 0.97, "ocr": null }
      }
    ]
  }
]
```

API only — no SDK changes in this PR.

## How

Mirrors the `pageMarkdown` parser option end to end:

- **Engine routing**: `blocks` forces the fire-pdf route (like `pageMarkdown`); errors clearly if fire-pdf isn't configured. Async path requests `options.include_blocks` and falls back to the sync `/ocr` path on failure.
- **Wire contract**: one zod schema (`firePdfBlockPagesSchema`) is the single source of truth — response parsing (sync + async), GCS cache validation, and the inferred TS wire types all use it. A pure adapter (`toPublicBlocks`) projects the snake_case wire shape onto the camelCase public shape.
- **Legacy `pages` alias**: block-only fire-pdf jobs return `pages` in a legacy block-alias shape (no per-page markdown). The `pages` schema now matches that alias explicitly and drops it, so genuine protocol corruption still fails the parse.
- **Content cache**: four new block-capable variants (`blocks-v1`, `ocr-blocks-v1`, `page-markdown-blocks-v1`, `ocr-page-markdown-blocks-v1`). Block-aware requests only consume block-capable artifacts (validated against the full wire contract before serving); richer sidecars serve poorer requests with payload stripping; **plain requests keep the historical 4-variant probe list** so the hot path gains no extra GCS lookups.
- **URL index**: block-aware requests bypass index reads and never write entries, mirroring the `pageMarkdown` policy (the index schema has no capability metadata).

## Consciously deferred (raised by local review)

- Modeling cache variants as a typed capability set and resolving PDF parser options into a single config object: both would restructure the pre-existing `pageMarkdown` plumbing too; the explicit variant lists are pinned by tests for every mode/capability combination. Worth doing if/when a third per-request payload lands.

## Testing

- `tsc --noEmit` clean
- 97 tests across the PDF engine suites pass, including new coverage: sync + async block request/response, missing-payload failures, legacy `pages` alias tolerance, cache variant selection/validation/stripping/backfill, URL-index read+write gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes typed PDF layout blocks via the `parsers[].blocks` option and returns them on `Document.blocks`. Previously only document/page markdown was exposed; now block-aware requests get per-page typed blocks, and index-only requests that demand pages/blocks fail with `AgentIndexOnlyError` instead of serving document-only content.

- Engine routing: `blocks: true` pins the fire-pdf route and errors if fire-pdf is not configured; async requests include `include_blocks` and fall back to sync on failure.
- Wire/schema: one zod schema validates sync/async responses and cached sidecars; the legacy `pages` block-alias is matched explicitly and dropped; cached block items are validated before serving.
- Cache: new variants `blocks-v1`, `ocr-blocks-v1`, `page-markdown-blocks-v1`, `ocr-page-markdown-blocks-v1`; richer sidecars serve poorer requests with payload stripping; plain requests keep the historical probe list.
- URL index: block-aware requests bypass reads and do not write entries, mirroring `pageMarkdown`; `agentIndexOnly` requests that require `pageMarkdown`/`blocks` now throw `AgentIndexOnlyError` (clean 4xx).
- Public shape: fire-pdf’s snake_case blocks are adapted to camelCase on `Document.blocks`; `Document` types in v1/v2 include optional `blocks`.

**Usage**
- To receive blocks, set `{"type":"pdf","blocks":true}` in `parsers` (can be combined with `pageMarkdown`). No SDK changes required.

<sup>Written for commit e28588e55b558e84c34ff36b9db7d49fffb47196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

