### PR TITLE
feat(api): add rawBase64 scrape format for image URLs

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-raw-base64.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-raw-base64.test.ts
@@ -1,0 +1,115 @@
+import { describeIf, TEST_PRODUCTION } from "../lib";
+import {
+  scrape,
+  scrapeRaw,
+  scrapeTimeout,
+  crawl,
+  idmux,
+  Identity,
+} from "./lib";
+
+let identity: Identity;
+
+beforeAll(async () => {
+  identity = await idmux({
+    name: "scrape-raw-base64",
+    concurrency: 100,
+    credits: 1000000,
+  });
+}, 10000 + scrapeTimeout);
+
+// A stable, Firecrawl-controlled image asset served with an image/* content-type.
+const IMAGE_URL = "https://firecrawl-test-site.vercel.app/declared-logo.png";
+// A regular HTML page on the same test site.
+const HTML_URL = "https://firecrawl-test-site.vercel.app/";
+
+// Fetching a real image URL depends on production scraping engines.
+describeIf(TEST_PRODUCTION)("Scrape rawBase64 format", () => {
+  it.concurrent(
+    "returns image bytes as a base64 data URI",
+    async () => {
+      const response = await scrape(
+        {
+          url: IMAGE_URL,
+          formats: ["rawBase64"],
+        },
+        identity,
+      );
+
+      expect(response.rawBase64).toBeDefined();
+      expect(typeof response.rawBase64).toBe("string");
+      expect(response.rawBase64!.startsWith("data:image/")).toBe(true);
+      expect(response.rawBase64).toContain(";base64,");
+
+      // The payload after the comma must decode to non-empty bytes.
+      const b64 = response.rawBase64!.split(",")[1];
+      expect(b64.length).toBeGreaterThan(0);
+      const buffer = Buffer.from(b64, "base64");
+      expect(buffer.length).toBeGreaterThan(0);
+
+      expect(response.metadata?.contentType?.startsWith("image/")).toBe(true);
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
+    "errors on an image URL without the format, hinting at rawBase64",
+    async () => {
+      const raw = await scrapeRaw(
+        {
+          url: IMAGE_URL,
+        },
+        identity,
+      );
+
+      expect(raw.statusCode).not.toBe(200);
+      expect(raw.body.success).toBe(false);
+      expect(raw.body.code).toBe("SCRAPE_UNSUPPORTED_FILE_ERROR");
+      expect(raw.body.error).toContain("rawBase64");
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
+    "omits rawBase64 (no error) when the URL is not an image",
+    async () => {
+      const response = await scrape(
+        {
+          url: HTML_URL,
+          formats: ["markdown", "rawBase64"],
+        },
+        identity,
+      );
+
+      expect(response.markdown).toBeDefined();
+      expect(typeof response.markdown).toBe("string");
+      expect(response.rawBase64).toBeUndefined();
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
+    "returns base64 for images when rawBase64 is in crawl scrapeOptions",
+    async () => {
+      const response = await crawl(
+        {
+          url: IMAGE_URL,
+          limit: 1,
+          scrapeOptions: {
+            formats: ["rawBase64"],
+          },
+        },
+        identity,
+      );
+
+      expect(response.status).toBe("completed");
+      expect(Array.isArray(response.data)).toBe(true);
+      expect(response.data.length).toBeGreaterThan(0);
+
+      const doc = response.data[0];
+      expect(doc.rawBase64).toBeDefined();
+      expect(doc.rawBase64!.startsWith("data:image/")).toBe(true);
+    },
+    scrapeTimeout * 2,
+  );
+});

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -472,7 +472,8 @@ export type FormatObject =
   | { type: "product" }
   | { type: "menu" }
   | { type: "audio" }
-  | { type: "video" };
+  | { type: "video" }
+  | { type: "rawBase64" };
 
 const pdfModeSchema = z.enum(["fast", "auto", "ocr"]);
 
@@ -661,6 +662,7 @@ const baseScrapeOptions = z.strictObject({
           queryFormatWithOptions,
           z.strictObject({ type: z.literal("audio") }),
           z.strictObject({ type: z.literal("video") }),
+          z.strictObject({ type: z.literal("rawBase64") }),
         ])
         .array()
         .optional()
@@ -1246,6 +1248,8 @@ export type Document = {
   rawHtml?: string;
   links?: string[];
   images?: string[];
+  /** Raw bytes of a scraped image URL, as a base64 data URI. Requested via the `rawBase64` format. */
+  rawBase64?: string;
   screenshot?: string;
   audio?: string;
   video?: string;

--- a/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fetch/index.ts
@@ -3,6 +3,7 @@ import { EngineScrapeResult } from "..";
 import { Meta } from "../..";
 import { SSLError } from "../../error";
 import { specialtyScrapeCheck } from "../utils/specialtyHandler";
+import { hasFormatOfType } from "../../../../lib/format-utils";
 import {
   getSecureDispatcher,
   InsecureConnectionError,
@@ -214,6 +215,8 @@ export async function scrapeURLWithFetch(
   await specialtyScrapeCheck(
     meta.logger.child({ method: "scrapeURLWithFetch/specialtyScrapeCheck" }),
     Object.fromEntries(response.headers as any),
+    undefined,
+    hasFormatOfType(meta.options.formats, "rawBase64") !== undefined,
   );
 
   return {

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -201,6 +201,7 @@ async function performFireEngineScrape<
       }),
       status.responseHeaders,
       status,
+      hasFormatOfType(meta.options.formats, "rawBase64") !== undefined,
     );
 
     const contentType =

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -1,7 +1,7 @@
 import { Meta } from "../..";
 import { EngineScrapeResult } from "..";
 import { fetchFileToBuffer } from "../utils/downloadFile";
-import { readFile, unlink } from "node:fs/promises";
+import { readFile, stat, unlink } from "node:fs/promises";
 import { EngineUnsuccessfulError, UnsupportedFileError } from "../../error";
 
 // Base64 inflates the payload by ~33%, so cap the download to bound memory and
@@ -33,11 +33,13 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
   if (meta.imagePrefetch !== undefined && meta.imagePrefetch !== null) {
     const filePath = meta.imagePrefetch.filePath;
     try {
-      const buffer = await readFile(filePath);
-      // Enforce the same size cap on prefetched bytes as on direct downloads.
-      if (buffer.length > IMAGE_DOWNLOAD_MAX_FILE_SIZE) {
+      // Enforce the size cap before reading, so an oversized prefetch never
+      // loads its full payload into worker memory.
+      const { size } = await stat(filePath);
+      if (size > IMAGE_DOWNLOAD_MAX_FILE_SIZE) {
         throw new UnsupportedFileError("File exceeds size limit");
       }
+      const buffer = await readFile(filePath);
       const contentType = meta.imagePrefetch.contentType;
       return {
         url: meta.imagePrefetch.url ?? meta.rewrittenUrl ?? meta.url,

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -1,8 +1,8 @@
 import { Meta } from "../..";
 import { EngineScrapeResult } from "..";
 import { fetchFileToBuffer } from "../utils/downloadFile";
-import { readFile } from "node:fs/promises";
-import { EngineUnsuccessfulError } from "../../error";
+import { readFile, unlink } from "node:fs/promises";
+import { EngineUnsuccessfulError, UnsupportedFileError } from "../../error";
 
 // Base64 inflates the payload by ~33%, so cap the download to bound memory and
 // response size. Kept in line with the PDF download cap for consistency.
@@ -10,6 +10,11 @@ const IMAGE_DOWNLOAD_MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 export function imageMaxReasonableTime(_meta: Meta): number {
   return 60000;
+}
+
+function isImageContentType(contentType: string | undefined): boolean {
+  // HTTP media types are case-insensitive (RFC 9110), so normalize before test.
+  return contentType?.toLowerCase().startsWith("image/") ?? false;
 }
 
 function toDataUri(contentType: string | undefined, buffer: Buffer): string {
@@ -26,18 +31,28 @@ function toDataUri(contentType: string | undefined, buffer: Buffer): string {
  */
 export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
   if (meta.imagePrefetch !== undefined && meta.imagePrefetch !== null) {
-    const buffer = await readFile(meta.imagePrefetch.filePath);
-    const contentType = meta.imagePrefetch.contentType;
-    return {
-      url: meta.imagePrefetch.url ?? meta.rewrittenUrl ?? meta.url,
-      statusCode: meta.imagePrefetch.status,
+    const filePath = meta.imagePrefetch.filePath;
+    try {
+      const buffer = await readFile(filePath);
+      // Enforce the same size cap on prefetched bytes as on direct downloads.
+      if (buffer.length > IMAGE_DOWNLOAD_MAX_FILE_SIZE) {
+        throw new UnsupportedFileError("File exceeds size limit");
+      }
+      const contentType = meta.imagePrefetch.contentType;
+      return {
+        url: meta.imagePrefetch.url ?? meta.rewrittenUrl ?? meta.url,
+        statusCode: meta.imagePrefetch.status,
 
-      html: "",
-      rawBase64: toDataUri(contentType, buffer),
+        html: "",
+        rawBase64: toDataUri(contentType, buffer),
 
-      contentType,
-      proxyUsed: meta.imagePrefetch.proxyUsed,
-    };
+        contentType,
+        proxyUsed: meta.imagePrefetch.proxyUsed,
+      };
+    } finally {
+      // Don't leave the prefetched payload behind in os.tmpdir().
+      await unlink(filePath).catch(() => {});
+    }
   }
 
   const file = await fetchFileToBuffer(
@@ -56,7 +71,7 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
   // means the URL wasn't actually an image (e.g. content-type changed between
   // detection and download); let the waterfall report failure rather than
   // return arbitrary bytes.
-  if (!contentType || !contentType.startsWith("image/")) {
+  if (!isImageContentType(contentType)) {
     throw new EngineUnsuccessfulError("image");
   }
 

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -1,0 +1,73 @@
+import { Meta } from "../..";
+import { EngineScrapeResult } from "..";
+import { fetchFileToBuffer } from "../utils/downloadFile";
+import { readFile } from "node:fs/promises";
+import { EngineUnsuccessfulError } from "../../error";
+
+// Base64 inflates the payload by ~33%, so cap the download to bound memory and
+// response size. Kept in line with the PDF download cap for consistency.
+const IMAGE_DOWNLOAD_MAX_FILE_SIZE = 50 * 1024 * 1024;
+
+export function imageMaxReasonableTime(_meta: Meta): number {
+  return 60000;
+}
+
+function toDataUri(contentType: string | undefined, buffer: Buffer): string {
+  const mime = contentType?.split(";")[0]?.trim() || "application/octet-stream";
+  return `data:${mime};base64,${buffer.toString("base64")}`;
+}
+
+/**
+ * Returns the raw bytes of an image URL as a base64 data URI. Selected only
+ * when the `image` feature flag is active, which is added when the `rawBase64`
+ * format is requested and the scraped resource is an image. Mirrors the PDF
+ * engine's "no parse" path: read the prefetched bytes if an engine already
+ * fetched them, otherwise download directly.
+ */
+export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
+  if (meta.imagePrefetch !== undefined && meta.imagePrefetch !== null) {
+    const buffer = await readFile(meta.imagePrefetch.filePath);
+    const contentType = meta.imagePrefetch.contentType;
+    return {
+      url: meta.imagePrefetch.url ?? meta.rewrittenUrl ?? meta.url,
+      statusCode: meta.imagePrefetch.status,
+
+      html: "",
+      rawBase64: toDataUri(contentType, buffer),
+
+      contentType,
+      proxyUsed: meta.imagePrefetch.proxyUsed,
+    };
+  }
+
+  const file = await fetchFileToBuffer(
+    meta.rewrittenUrl ?? meta.url,
+    meta.options.skipTlsVerification,
+    {
+      headers: meta.options.headers,
+      signal: meta.abort.asSignal(),
+    },
+    IMAGE_DOWNLOAD_MAX_FILE_SIZE,
+  );
+
+  const contentType = file.response.headers.get("content-type") ?? undefined;
+
+  // Only serve genuine image content as rawBase64. A non-image response here
+  // means the URL wasn't actually an image (e.g. content-type changed between
+  // detection and download); let the waterfall report failure rather than
+  // return arbitrary bytes.
+  if (!contentType || !contentType.startsWith("image/")) {
+    throw new EngineUnsuccessfulError("image");
+  }
+
+  return {
+    url: file.response.url,
+    statusCode: file.response.status,
+
+    html: "",
+    rawBase64: toDataUri(contentType, file.buffer),
+
+    contentType,
+    proxyUsed: "basic",
+  };
+}

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -612,9 +612,6 @@ export function shouldUseIndex(meta: Meta) {
     config.FIRECRAWL_INDEX_WRITE_ONLY !== true &&
     !hasFormatOfType(meta.options.formats, "changeTracking") &&
     !hasFormatOfType(meta.options.formats, "branding") &&
-    // The index serves cached HTML/markdown documents, which never carry the
-    // raw image bytes — so a rawBase64 request must fetch the image directly.
-    !hasFormatOfType(meta.options.formats, "rawBase64") &&
     // The URL index does not yet persist physical-page capability metadata.
     !getPDFPageMarkdown(meta.options.parsers) &&
     !hasCustomScreenshotSettings &&

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -536,9 +536,14 @@ const engineOptions: {
       atsv: false,
       location: false,
       mobile: false,
-      skipTlsVerification: false,
+      // The direct-download path uses a basic fetch that honors
+      // skipTlsVerification. When an image is prefetched by an upstream engine
+      // (incl. stealth), that engine already applied the proxy and the prefetch
+      // carries the real proxyUsed — so the image engine itself only advertises
+      // what its own download does.
+      skipTlsVerification: true,
       useFastMode: true,
-      stealthProxy: true, // kinda...
+      stealthProxy: false,
       branding: false,
       disableAdblock: true,
       image: true,
@@ -607,6 +612,9 @@ export function shouldUseIndex(meta: Meta) {
     config.FIRECRAWL_INDEX_WRITE_ONLY !== true &&
     !hasFormatOfType(meta.options.formats, "changeTracking") &&
     !hasFormatOfType(meta.options.formats, "branding") &&
+    // The index serves cached HTML/markdown documents, which never carry the
+    // raw image bytes — so a rawBase64 request must fetch the image directly.
+    !hasFormatOfType(meta.options.formats, "rawBase64") &&
     // The URL index does not yet persist physical-page capability metadata.
     !getPDFPageMarkdown(meta.options.parsers) &&
     !hasCustomScreenshotSettings &&

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./fire-engine";
 import { exchangeMaxReasonableTime, scrapeURLWithExchange } from "./exchange";
 import { pdfMaxReasonableTime, scrapePDF } from "./pdf";
+import { imageMaxReasonableTime, scrapeImage } from "./image";
 import { fetchMaxReasonableTime, scrapeURLWithFetch } from "./fetch";
 import {
   playwrightMaxReasonableTime,
@@ -49,6 +50,7 @@ export type Engine =
   | "fetch"
   | "pdf"
   | "document"
+  | "image"
   | "index"
   | "index;documents"
   | "wikipedia"
@@ -87,6 +89,7 @@ const engines: Engine[] = [
   "fetch",
   "pdf",
   "document",
+  "image",
 ];
 
 const featureFlags = [
@@ -106,6 +109,7 @@ const featureFlags = [
   "stealthProxy",
   "branding",
   "disableAdblock",
+  "image",
 ] as const;
 
 export type FeatureFlag = (typeof featureFlags)[number];
@@ -131,6 +135,7 @@ const featureFlagOptions: {
   stealthProxy: { priority: 20 },
   branding: { priority: 20 }, // Requires CDP executeJavascript
   disableAdblock: { priority: 10 },
+  image: { priority: 100 },
 } as const;
 
 export type EngineScrapeResult = {
@@ -144,6 +149,7 @@ export type EngineScrapeResult = {
   error?: string;
 
   screenshot?: string;
+  rawBase64?: string;
   actions?: {
     screenshots: string[];
     scrapes: ScrapeActionContent[];
@@ -189,6 +195,7 @@ const engineHandlers: {
   fetch: scrapeURLWithFetch,
   pdf: scrapePDF,
   document: scrapeDocument,
+  image: scrapeImage,
   wikipedia: scrapeURLWithWikipedia,
   "x-twitter": scrapeURLWithXTwitter,
 };
@@ -215,6 +222,7 @@ const engineMRTs: {
   fetch: fetchMaxReasonableTime,
   pdf: pdfMaxReasonableTime,
   document: documentMaxReasonableTime,
+  image: imageMaxReasonableTime,
   wikipedia: wikipediaMaxReasonableTime,
   "x-twitter": xTwitterMaxReasonableTime,
 };
@@ -247,6 +255,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: false,
       disableAdblock: false,
+      image: false,
     },
     quality: 2000,
   },
@@ -268,6 +277,7 @@ const engineOptions: {
       stealthProxy: true,
       branding: false,
       disableAdblock: true,
+      image: false,
     },
     quality: 1000, // index should always be tried first
   },
@@ -289,6 +299,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: true,
       disableAdblock: false,
+      image: false,
     },
     quality: 50,
   },
@@ -310,6 +321,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: true,
       disableAdblock: false,
+      image: false,
     },
     quality: 45,
   },
@@ -331,6 +343,7 @@ const engineOptions: {
       stealthProxy: true,
       branding: false,
       disableAdblock: false,
+      image: false,
     },
     quality: -1,
   },
@@ -352,6 +365,7 @@ const engineOptions: {
       stealthProxy: true,
       branding: true,
       disableAdblock: false,
+      image: false,
     },
     quality: -2,
   },
@@ -373,6 +387,7 @@ const engineOptions: {
       stealthProxy: true,
       branding: true,
       disableAdblock: false,
+      image: false,
     },
     quality: -5,
   },
@@ -394,6 +409,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: false,
       disableAdblock: false,
+      image: false,
     },
     quality: 20,
   },
@@ -415,6 +431,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: false,
       disableAdblock: false,
+      image: false,
     },
     quality: 10,
   },
@@ -436,6 +453,7 @@ const engineOptions: {
       stealthProxy: true,
       branding: false,
       disableAdblock: false,
+      image: false,
     },
     quality: -15,
   },
@@ -457,6 +475,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: false,
       disableAdblock: false,
+      image: false,
     },
     quality: 5,
   },
@@ -478,6 +497,7 @@ const engineOptions: {
       stealthProxy: true, // kinda...
       branding: false,
       disableAdblock: true,
+      image: false,
     },
     quality: -20,
   },
@@ -499,6 +519,29 @@ const engineOptions: {
       stealthProxy: true, // kinda...
       branding: false,
       disableAdblock: true,
+      image: false,
+    },
+    quality: -20,
+  },
+  image: {
+    features: {
+      actions: false,
+      waitFor: false,
+      screenshot: false,
+      "screenshot@fullScreen": false,
+      pdf: false,
+      document: false,
+      audio: false,
+      video: false,
+      atsv: false,
+      location: false,
+      mobile: false,
+      skipTlsVerification: false,
+      useFastMode: true,
+      stealthProxy: true, // kinda...
+      branding: false,
+      disableAdblock: true,
+      image: true,
     },
     quality: -20,
   },
@@ -520,6 +563,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: false,
       disableAdblock: true,
+      image: false,
     },
     quality: 500, // below index (1000) so cache is tried first, above fire-engine (50)
   },
@@ -541,6 +585,7 @@ const engineOptions: {
       stealthProxy: false,
       branding: false,
       disableAdblock: true,
+      image: false,
     },
     quality: 1500,
   },

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -41,6 +41,21 @@ async function feResToPdfPrefetch(
   return feResToFilePrefetch(logger, feRes, "pdf", "pdf");
 }
 
+async function feResToImagePrefetch(
+  logger: Logger,
+  feRes: FireEngineCheckStatusSuccess | undefined,
+  contentType: string,
+): Promise<Meta["imagePrefetch"]> {
+  // Extension is only used for the temp filename, so a best-effort derivation
+  // from the mime subtype (e.g. image/svg+xml -> "svg") is sufficient.
+  const extension =
+    contentType
+      .split("/")[1]
+      ?.split(/[;+]/)[0]
+      ?.replace(/[^a-z0-9]/gi, "") || "img";
+  return feResToFilePrefetch(logger, feRes, extension, "image", contentType);
+}
+
 async function feResToDocumentPrefetch(
   logger: Logger,
   feRes: FireEngineCheckStatusSuccess | undefined,
@@ -57,6 +72,7 @@ export async function specialtyScrapeCheck(
   logger: Logger,
   headers: Record<string, string> | undefined,
   feRes?: FireEngineCheckStatusSuccess,
+  allowImageBase64?: boolean,
 ) {
   const contentType = (Object.entries(headers ?? {}).find(
     x => x[0].toLowerCase() === "content-type",
@@ -130,6 +146,18 @@ export async function specialtyScrapeCheck(
       feRes?.content.startsWith("%PDF-"))
   ) {
     throw new AddFeatureError(["pdf"], await feResToPdfPrefetch(logger, feRes));
+  }
+
+  // Images: when the caller opted into the rawBase64 format, route to the image
+  // engine (which returns the raw bytes as a base64 data URI) instead of
+  // rejecting. Any other binary type still falls through to the rejection below.
+  if (allowImageBase64 && contentType.startsWith("image/")) {
+    throw new AddFeatureError(
+      ["image"],
+      undefined,
+      undefined,
+      await feResToImagePrefetch(logger, feRes, contentType),
+    );
   }
 
   // Reject unsupported binary content types (images, video, audio, archives, etc.)

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -151,7 +151,8 @@ export async function specialtyScrapeCheck(
   // Images: when the caller opted into the rawBase64 format, route to the image
   // engine (which returns the raw bytes as a base64 data URI) instead of
   // rejecting. Any other binary type still falls through to the rejection below.
-  if (allowImageBase64 && contentType.startsWith("image/")) {
+  // HTTP media types are case-insensitive (RFC 9110), so normalize before test.
+  if (allowImageBase64 && contentType.toLowerCase().startsWith("image/")) {
     throw new AddFeatureError(
       ["image"],
       undefined,

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -65,16 +65,19 @@ export class AddFeatureError extends Error {
   public featureFlags: FeatureFlag[];
   public pdfPrefetch: Meta["pdfPrefetch"];
   public documentPrefetch: Meta["documentPrefetch"];
+  public imagePrefetch: Meta["imagePrefetch"];
 
   constructor(
     featureFlags: FeatureFlag[],
     pdfPrefetch?: Meta["pdfPrefetch"],
     documentPrefetch?: Meta["documentPrefetch"],
+    imagePrefetch?: Meta["imagePrefetch"],
   ) {
     super("New feature flags have been discovered: " + featureFlags.join(", "));
     this.featureFlags = featureFlags;
     this.pdfPrefetch = pdfPrefetch;
     this.documentPrefetch = documentPrefetch;
+    this.imagePrefetch = imagePrefetch;
   }
 }
 
@@ -229,7 +232,10 @@ export class UnsupportedFileError extends TransportableError {
   constructor(public reason: string) {
     super(
       "SCRAPE_UNSUPPORTED_FILE_ERROR",
-      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Binary files like images, videos, executables, and archives are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
+      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Binary files like images, videos, executables, and archives are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.` +
+        (reason.startsWith("image/")
+          ? ` To fetch the raw image bytes as a base64 data URI, add the "rawBase64" format to your request.`
+          : ""),
     );
   }
 

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -233,7 +233,7 @@ export class UnsupportedFileError extends TransportableError {
     super(
       "SCRAPE_UNSUPPORTED_FILE_ERROR",
       `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Binary files like images, videos, executables, and archives are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.` +
-        (reason.startsWith("image/")
+        (reason.toLowerCase().startsWith("image/")
           ? ` To fetch the raw image bytes as a base64 data URI, add the "rawBase64" format to your request.`
           : ""),
     );

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -605,6 +605,10 @@ async function scrapeURLLoopIter(
 
     // Success factors
     const isLongEnough = checkMarkdown.trim().length > 0;
+    // Binary formats (e.g. rawBase64 for images) carry no markdown/html, so the
+    // length-based check above never passes for them. Treat their presence as a
+    // success signal so the engine result isn't rejected.
+    const hasBinaryContent = engineResult.rawBase64 !== undefined;
     const isGoodStatusCode =
       (engineResult.statusCode >= 200 && engineResult.statusCode < 300) ||
       engineResult.statusCode === 304;
@@ -634,9 +638,14 @@ async function scrapeURLLoopIter(
     // NOTE: TODO: what to do when status code is bad is tough...
     // we cannot just rely on text because error messages can be brief and not hit the limit
     // should we just use all the fallbacks and pick the one with the longest text? - mogery
-    if (isLongEnough || !isGoodStatusCode) {
+    if (isLongEnough || !isGoodStatusCode || hasBinaryContent) {
       meta.logger.info("Scrape via " + engine + " deemed successful.", {
-        factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
+        factors: {
+          isLongEnough,
+          isGoodStatusCode,
+          hasNoPageError,
+          hasBinaryContent,
+        },
       });
       return engineResult;
     } else {

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -164,6 +164,16 @@ export type Meta = {
       }
     | null
     | undefined; // undefined: no prefetch yet, null: prefetch came back empty
+  imagePrefetch:
+    | {
+        filePath: string;
+        url?: string;
+        status: number;
+        proxyUsed: "basic" | "stealth";
+        contentType?: string;
+      }
+    | null
+    | undefined; // undefined: no prefetch yet, null: prefetch came back empty
   fetchPrefetch:
     | {
         url?: string;
@@ -362,6 +372,7 @@ async function buildMetaObject(
 
   let pdfPrefetch: Meta["pdfPrefetch"] = undefined;
   let documentPrefetch: Meta["documentPrefetch"] = undefined;
+  let imagePrefetch: Meta["imagePrefetch"] = undefined;
   let fetchPrefetch: Meta["fetchPrefetch"] = undefined;
 
   if (internalOptions.uploadedFile) {
@@ -441,6 +452,7 @@ async function buildMetaObject(
         : null,
     pdfPrefetch,
     documentPrefetch,
+    imagePrefetch,
     fetchPrefetch,
     costTracking,
     threatDecisions: [],
@@ -987,6 +999,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
       pages: engineResult.pages,
       rawHtml: engineResult.html,
       json: engineResult.json,
+      rawBase64: engineResult.rawBase64,
       screenshot: engineResult.screenshot,
       actions: engineResult.actions,
       branding: engineResult.branding,
@@ -1247,6 +1260,9 @@ export async function scrapeURL(
             }
             if (error.documentPrefetch) {
               meta.documentPrefetch = error.documentPrefetch;
+            }
+            if (error.imagePrefetch) {
+              meta.imagePrefetch = error.imagePrefetch;
             }
           } else if (
             error instanceof RemoveFeatureError &&

--- a/apps/api/src/scraper/scrapeURL/transformers/index.ts
+++ b/apps/api/src/scraper/scrapeURL/transformers/index.ts
@@ -369,6 +369,7 @@ function coerceFieldsToFormats(meta: Meta, document: Document): Document {
   const hasHtml = hasFormatOfType(meta.options.formats, "html");
   const hasLinks = hasFormatOfType(meta.options.formats, "links");
   const hasImages = hasFormatOfType(meta.options.formats, "images");
+  const hasRawBase64 = hasFormatOfType(meta.options.formats, "rawBase64");
   const hasChangeTracking = hasFormatOfType(
     meta.options.formats,
     "changeTracking",
@@ -448,6 +449,14 @@ function coerceFieldsToFormats(meta: Meta, document: Document): Document {
       "Request had format: images, but there was no images field in the result.",
       { hasImages, hasImagesField: document.images !== undefined },
     );
+  }
+
+  // rawBase64 is only populated when the scraped URL is an image. When the
+  // format wasn't requested, drop it. When it was requested but the URL wasn't
+  // an image, the field is simply absent -- this is expected (graceful), so we
+  // don't warn like the other formats do.
+  if (!hasRawBase64 && document.rawBase64 !== undefined) {
+    delete document.rawBase64;
   }
 
   // Handle v1 backward compatibility - don't delete fields based on v1OriginalFormat

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -16,7 +16,8 @@ export type FormatString =
   | "product"
   | "menu"
   | "audio"
-  | "video";
+  | "video"
+  | "rawBase64";
 
 export interface Viewport {
   width: number;
@@ -90,7 +91,7 @@ export type FormatOption =
 
 export type ParseFormatString = Exclude<
   FormatString,
-  "screenshot" | "changeTracking" | "branding" | "audio" | "video"
+  "screenshot" | "changeTracking" | "branding" | "audio" | "video" | "rawBase64"
 >;
 
 export interface ParseFormat {
@@ -631,6 +632,8 @@ export interface Document {
   metadata?: DocumentMetadata;
   links?: string[];
   images?: string[];
+  /** Raw bytes of a scraped image URL, as a base64 data URI. Requested via the `rawBase64` format. */
+  rawBase64?: string;
   screenshot?: string;
   audio?: string;
   video?: string;

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -450,6 +450,7 @@ class Document(BaseModel):
     metadata: Optional[DocumentMetadata] = None
     links: Optional[List[str]] = None
     images: Optional[List[str]] = None
+    raw_base64: Optional[str] = None
     screenshot: Optional[str] = None
     audio: Optional[str] = None
     video: Optional[str] = None
@@ -609,9 +610,11 @@ FormatString = Literal[
     "query",
     "audio",
     "video",
+    "rawBase64",
     # snake_case versions (user-friendly)
     "raw_html",
     "change_tracking",
+    "raw_base64",
 ]
 
 

--- a/apps/python-sdk/firecrawl/v2/utils/normalize.py
+++ b/apps/python-sdk/firecrawl/v2/utils/normalize.py
@@ -84,6 +84,9 @@ def normalize_document_input(doc: Dict[str, Any]) -> Dict[str, Any]:
     if "changeTracking" in normalized and "change_tracking" not in normalized:
         normalized["change_tracking"] = normalized.pop("changeTracking")
 
+    if "rawBase64" in normalized and "raw_base64" not in normalized:
+        normalized["raw_base64"] = normalized.pop("rawBase64")
+
     md = normalized.get("metadata")
     if isinstance(md, dict):
         mapped = _map_metadata_keys(md)

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -19,6 +19,7 @@ def _convert_format_string(format_str: str) -> str:
     format_mapping = {
         "raw_html": "rawHtml",
         "change_tracking": "changeTracking",
+        "raw_base64": "rawBase64",
         "screenshot_full_page": "screenshot@fullPage"
     }
     return format_mapping.get(format_str, format_str)


### PR DESCRIPTION
## What

Scraping a direct image URL (an `image/*` content-type) previously failed with `SCRAPE_UNSUPPORTED_FILE_ERROR`, with no way to get the bytes back. This adds an opt-in **`rawBase64`** scrape format that returns the raw image bytes as a base64 **data URI**.

```jsonc
POST /v2/scrape
{ "url": "https://example.com/logo.png", "formats": ["rawBase64"] }

// -> data.rawBase64 = "data:image/png;base64,iVBORw0KGgo..."
//    data.metadata.contentType = "image/png"
```

## Design

- New `rawBase64` format in the v2 `formats` union + a `Document.rawBase64` field. Modeled as a **format** (like `audio`/`video`/`screenshot`) rather than a `parsers`-style toggle, since a raw image has no text/markdown representation to switch between.
- Routed through a dedicated `image` engine that mirrors the PDF "no parse" path: use the prefetched bytes when a scraping engine already fetched them, otherwise download directly. Download is capped at 50MB (PDF parity) so oversize images fail cleanly.
- Gated behind an `image` feature flag added only when `rawBase64` is requested **and** the resource is actually an image, so **default behavior is unchanged** — a bare scrape of an image still errors.
- `UnsupportedFileError` now appends a hint pointing at `rawBase64` for `image/*` content types.
- Output shape is a data URI so it's self-describing and directly usable; the real mime is also on `metadata.contentType`.

## Behavior notes

- **Non-image URL + `rawBase64`**: the field is simply omitted (no error); other formats work normally.
- **Crawl / batch**: works via the shared `scrapeOptions` — any scraped URL that is an image returns bytes. Crawl still does **not** follow image links; only a scraped image URL yields bytes.
- **Billing**: bills as a normal 1-credit scrape (these requests previously errored and billed nothing).

## SDKs

- TS: `rawBase64` added to the format union + `Document.rawBase64`.
- Python: `rawBase64`/`raw_base64` format literals, `Document.raw_base64`, and camel/snake normalization both directions.

## Tests

E2E snips (`scrape-raw-base64.test.ts`), gated to production engines:
- image URL + `rawBase64` -> data URI + `image/*` contentType
- image URL without the format -> error whose message hints at `rawBase64`
- HTML page + `["markdown", "rawBase64"]` -> markdown present, `rawBase64` absent, no error
- crawl with `rawBase64` in `scrapeOptions` -> base64 for the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in rawBase64 scrape format that returns image bytes as a base64 data URI for direct image URLs. Previously these errored with SCRAPE_UNSUPPORTED_FILE_ERROR; default behavior is unchanged unless you request rawBase64.

- API: adds 'rawBase64' to the v2 formats union and Document.rawBase64 (data URI; actual mime in metadata.contentType).
- Engine/routing: new 'image' engine behind a feature flag, activated only when formats include 'rawBase64' and content-type is image/* (case-insensitive). Uses prefetch when available with a 50MB cap checked before reading and temp file cleanup; otherwise direct download with the same cap. Honors skipTlsVerification; proxyUsed from prefetch is preserved. No blanket index-cache bypass; image results are never indexed, and cached HTML pages continue to serve from cache with rawBase64 omitted.
- Behavior/billing: image URL without 'rawBase64' still errors (now hints at 'rawBase64'); non-image + 'rawBase64' omits Document.rawBase64 (no error); presence of rawBase64 counts as a waterfall success even without markdown; crawl works via scrapeOptions and still does not follow image links. Bills 1 credit per scrape.
- SDKs/tests: TypeScript and Python add the format and Document fields (Python also supports 'raw_base64'). E2E tests cover image success, image without format (hinted error), HTML + rawBase64 (omitted), and crawl with scrapeOptions.

Required action for clients who need image bytes: add 'rawBase64' to formats.

<sup>Written for commit 880721bcd2a7e25a4ddcdd2dbace523b003c4e86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

