### PR TITLE
feat(api): rename PDF parser option pageMarkdown -> pages

### DIFF
--- a/apps/api/src/__tests__/pdf-parser-options.test.ts
+++ b/apps/api/src/__tests__/pdf-parser-options.test.ts
@@ -1,4 +1,13 @@
-import { getPDFBlocks, getPDFPageMarkdown } from "../controllers/v2/types";
+import {
+  getPDFBlocks,
+  getPDFPageMarkdown,
+  scrapeOptions,
+} from "../controllers/v2/types";
+
+function parsePdfParser(parser: Record<string, unknown>) {
+  const parsed = scrapeOptions.parse({ parsers: [parser] });
+  return parsed.parsers![0] as Record<string, unknown>;
+}
 
 describe("PDF parser option getters", () => {
   it("reads the public `pages` option", () => {
@@ -9,24 +18,26 @@ describe("PDF parser option getters", () => {
     expect(getPDFPageMarkdown(undefined)).toBe(false);
   });
 
-  it("accepts the deprecated `pageMarkdown` alias", () => {
-    expect(getPDFPageMarkdown([{ type: "pdf", pageMarkdown: true }])).toBe(
-      true,
-    );
-  });
-
-  it("prefers `pages` when both names are set", () => {
-    expect(
-      getPDFPageMarkdown([{ type: "pdf", pages: false, pageMarkdown: true }]),
-    ).toBe(false);
-    expect(
-      getPDFPageMarkdown([{ type: "pdf", pages: true, pageMarkdown: false }]),
-    ).toBe(true);
-  });
-
   it("reads the `blocks` option", () => {
     expect(getPDFBlocks([{ type: "pdf", blocks: true }])).toBe(true);
     expect(getPDFBlocks([{ type: "pdf" }])).toBe(false);
     expect(getPDFBlocks(undefined)).toBe(false);
+  });
+});
+
+describe("deprecated pageMarkdown alias", () => {
+  it("is folded into `pages` at the schema boundary", () => {
+    const parser = parsePdfParser({ type: "pdf", pageMarkdown: true });
+    expect(parser.pages).toBe(true);
+    expect("pageMarkdown" in parser).toBe(false);
+  });
+
+  it("loses to an explicit `pages` when both are set", () => {
+    expect(
+      parsePdfParser({ type: "pdf", pages: false, pageMarkdown: true }).pages,
+    ).toBe(false);
+    expect(
+      parsePdfParser({ type: "pdf", pages: true, pageMarkdown: false }).pages,
+    ).toBe(true);
   });
 });

--- a/apps/api/src/__tests__/pdf-parser-options.test.ts
+++ b/apps/api/src/__tests__/pdf-parser-options.test.ts
@@ -1,0 +1,32 @@
+import { getPDFBlocks, getPDFPageMarkdown } from "../controllers/v2/types";
+
+describe("PDF parser option getters", () => {
+  it("reads the public `pages` option", () => {
+    expect(getPDFPageMarkdown([{ type: "pdf", pages: true }])).toBe(true);
+    expect(getPDFPageMarkdown([{ type: "pdf", pages: false }])).toBe(false);
+    expect(getPDFPageMarkdown([{ type: "pdf" }])).toBe(false);
+    expect(getPDFPageMarkdown(["pdf"])).toBe(false);
+    expect(getPDFPageMarkdown(undefined)).toBe(false);
+  });
+
+  it("accepts the deprecated `pageMarkdown` alias", () => {
+    expect(getPDFPageMarkdown([{ type: "pdf", pageMarkdown: true }])).toBe(
+      true,
+    );
+  });
+
+  it("prefers `pages` when both names are set", () => {
+    expect(
+      getPDFPageMarkdown([{ type: "pdf", pages: false, pageMarkdown: true }]),
+    ).toBe(false);
+    expect(
+      getPDFPageMarkdown([{ type: "pdf", pages: true, pageMarkdown: false }]),
+    ).toBe(true);
+  });
+
+  it("reads the `blocks` option", () => {
+    expect(getPDFBlocks([{ type: "pdf", blocks: true }])).toBe(true);
+    expect(getPDFBlocks([{ type: "pdf" }])).toBe(false);
+    expect(getPDFBlocks(undefined)).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/snips/v2/parse.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parse.test.ts
@@ -618,7 +618,7 @@ describe("/v2/parse", () => {
             {
               options: {
                 formats: ["markdown"],
-                parsers: [{ type: "pdf", mode: "auto", pageMarkdown: true }],
+                parsers: [{ type: "pdf", mode: "auto", pages: true }],
               },
               file: {
                 content: pdfFixture!,

--- a/apps/api/src/__tests__/snips/v2/parsers-pdf-page-markdown.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parsers-pdf-page-markdown.test.ts
@@ -26,7 +26,7 @@ describeIf(SHOULD_RUN)("PDF physical page markdown", () => {
         {
           url: `${TEST_SUITE_WEBSITE}/example.pdf`,
           formats: ["markdown"],
-          parsers: [{ type: "pdf", mode: "auto", pageMarkdown: true }],
+          parsers: [{ type: "pdf", mode: "auto", pages: true }],
         },
         identity,
       );

--- a/apps/api/src/__tests__/snips/v2/parsers.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parsers.test.ts
@@ -388,12 +388,12 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
     );
 
     it.concurrent(
-      "rejects non-boolean pageMarkdown",
+      "rejects non-boolean pages",
       async () => {
         const raw = await scrapeRaw(
           {
             url: pdfUrl,
-            parsers: [{ type: "pdf", pageMarkdown: "yes" } as any],
+            parsers: [{ type: "pdf", pages: "yes" } as any],
           },
           identity,
         );

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -438,13 +438,29 @@ describe("V2 Types Validation", () => {
     it("should accept physical page markdown for PDF parsers", () => {
       const result = scrapeRequestSchema.parse({
         url: "https://example.com/file.pdf",
+        parsers: [{ type: "pdf", mode: "auto", pages: true }],
+      });
+
+      expect((result.parsers as any)[0].pages).toBe(true);
+    });
+
+    it("should fold the deprecated pageMarkdown alias into pages", () => {
+      const result = scrapeRequestSchema.parse({
+        url: "https://example.com/file.pdf",
         parsers: [{ type: "pdf", mode: "auto", pageMarkdown: true }],
       });
 
-      expect((result.parsers as any)[0].pageMarkdown).toBe(true);
+      expect((result.parsers as any)[0].pages).toBe(true);
+      expect("pageMarkdown" in (result.parsers as any)[0]).toBe(false);
     });
 
     it("should reject non-boolean physical page markdown", () => {
+      expect(() =>
+        scrapeRequestSchema.parse({
+          url: "https://example.com/file.pdf",
+          parsers: [{ type: "pdf", pages: "yes" }],
+        }),
+      ).toThrow();
       expect(() =>
         scrapeRequestSchema.parse({
           url: "https://example.com/file.pdf",

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -1006,7 +1006,7 @@ export type Document = {
   description?: string;
   url?: string;
   markdown?: string;
-  /** Physical PDF pages, populated by the v2 pageMarkdown parser option. */
+  /** Physical PDF pages, populated by the v2 `pages` parser option. */
   pages?: Array<{ pageNumber: number; markdown: string }>;
   /** Typed PDF layout blocks with bounding boxes, populated by the v2
    * `blocks` parser option. */

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -483,10 +483,18 @@ const pdfParserWithOptions = z.strictObject({
   type: z.literal("pdf"),
   mode: pdfModeSchema.optional(),
   maxPages: z.int().positive().finite().max(10000).optional(),
-  /** Include physical per-page markdown alongside document markdown. */
+  /** Include physical per-page markdown alongside document markdown —
+   * populates `document.pages`. */
+  pages: z.boolean().optional(),
+  /**
+   * @deprecated Renamed to `pages` (2026-08). Accepted as a silent alias for
+   * callers that adopted the option pre-rename; never documented. `pages`
+   * wins when both are set.
+   */
   pageMarkdown: z.boolean().optional(),
   /** Include per-page typed layout blocks (bounding boxes, block types,
-   * reading order) alongside document markdown. */
+   * reading order) alongside document markdown — populates
+   * `document.blocks`. */
   blocks: z.boolean().optional(),
   // Experimental: route this request through the fire-pdf async pipeline
   // (POST /jobs + poll) instead of the sync POST /ocr endpoint. Falls back
@@ -541,7 +549,9 @@ export function getPDFPageMarkdown(parsers?: Parsers): boolean {
   if (!parsers) return false;
   for (const parser of parsers) {
     if (typeof parser === "object" && parser.type === "pdf") {
-      return parser.pageMarkdown === true;
+      // `pages` is the public name; `pageMarkdown` is the deprecated
+      // pre-rename alias and only consulted when `pages` is unset.
+      return (parser.pages ?? parser.pageMarkdown) === true;
     }
   }
   return false;
@@ -1254,7 +1264,7 @@ export type Document = {
   description?: string;
   url?: string;
   markdown?: string;
-  /** Physical PDF pages, present only for `parsers[].pageMarkdown`. */
+  /** Physical PDF pages, present only for the `parsers[].pages` option. */
   pages?: Array<{ pageNumber: number; markdown: string }>;
   /** Typed PDF layout blocks with bounding boxes, present only for
    * `parsers[].blocks`. */

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -560,8 +560,14 @@ export function getPDFPageMarkdown(parsers?: Parsers): boolean {
   for (const parser of parsers) {
     if (typeof parser === "object" && parser.type === "pdf") {
       // The deprecated `pageMarkdown` alias is folded into `pages` at the
-      // schema boundary, so parsed parsers only carry the canonical name.
-      return parser.pages === true;
+      // schema boundary, so freshly parsed parsers only carry the canonical
+      // name. Serialized options bypass re-parsing (queued jobs and crawl
+      // option snapshots from before the rename), so read the legacy key
+      // defensively too; `pages` wins when both are present.
+      return (
+        (parser.pages ??
+          (parser as { pageMarkdown?: boolean }).pageMarkdown) === true
+      );
     }
   }
   return false;

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -479,29 +479,39 @@ const pdfModeSchema = z.enum(["fast", "auto", "ocr"]);
 
 export type PDFMode = z.infer<typeof pdfModeSchema>;
 
-const pdfParserWithOptions = z.strictObject({
-  type: z.literal("pdf"),
-  mode: pdfModeSchema.optional(),
-  maxPages: z.int().positive().finite().max(10000).optional(),
-  /** Include physical per-page markdown alongside document markdown —
-   * populates `document.pages`. */
-  pages: z.boolean().optional(),
-  /**
-   * @deprecated Renamed to `pages` (2026-08). Accepted as a silent alias for
-   * callers that adopted the option pre-rename; never documented. `pages`
-   * wins when both are set.
-   */
-  pageMarkdown: z.boolean().optional(),
-  /** Include per-page typed layout blocks (bounding boxes, block types,
-   * reading order) alongside document markdown — populates
-   * `document.blocks`. */
-  blocks: z.boolean().optional(),
-  // Experimental: route this request through the fire-pdf async pipeline
-  // (POST /jobs + poll) instead of the sync POST /ocr endpoint. Falls back
-  // to sync on any async-path failure, so user-visible behavior is unchanged
-  // beyond latency variance. Underscored to mark as internal/experimental.
-  __firePdfAsync: z.boolean().optional(),
-});
+const pdfParserWithOptions = z
+  .strictObject({
+    type: z.literal("pdf"),
+    mode: pdfModeSchema.optional(),
+    maxPages: z.int().positive().finite().max(10000).optional(),
+    /** Include physical per-page markdown alongside document markdown —
+     * populates `document.pages`. */
+    pages: z.boolean().optional(),
+    /**
+     * @deprecated Renamed to `pages` (2026-08). Accepted as a silent alias
+     * for callers that adopted the option pre-rename; never documented.
+     * Normalized into `pages` below — internal code never sees this field.
+     */
+    pageMarkdown: z.boolean().optional(),
+    /** Include per-page typed layout blocks (bounding boxes, block types,
+     * reading order) alongside document markdown — populates
+     * `document.blocks`. */
+    blocks: z.boolean().optional(),
+    // Experimental: route this request through the fire-pdf async pipeline
+    // (POST /jobs + poll) instead of the sync POST /ocr endpoint. Falls back
+    // to sync on any async-path failure, so user-visible behavior is unchanged
+    // beyond latency variance. Underscored to mark as internal/experimental.
+    __firePdfAsync: z.boolean().optional(),
+  })
+  .transform(({ pageMarkdown, pages, ...parser }) => {
+    // Fold the deprecated alias into the canonical name at the schema
+    // boundary; `pages` wins when both are set. Keep the key optional so
+    // plain `{ type: "pdf" }` parser literals stay assignable.
+    const normalized: typeof parser & { pages?: boolean } = { ...parser };
+    const effective = pages ?? pageMarkdown;
+    if (effective !== undefined) normalized.pages = effective;
+    return normalized;
+  });
 
 const parsersSchema = z
   .array(z.union([z.literal("pdf"), pdfParserWithOptions]))
@@ -549,9 +559,9 @@ export function getPDFPageMarkdown(parsers?: Parsers): boolean {
   if (!parsers) return false;
   for (const parser of parsers) {
     if (typeof parser === "object" && parser.type === "pdf") {
-      // `pages` is the public name; `pageMarkdown` is the deprecated
-      // pre-rename alias and only consulted when `pages` is unset.
-      return (parser.pages ?? parser.pageMarkdown) === true;
+      // The deprecated `pageMarkdown` alias is folded into `pages` at the
+      // schema boundary, so parsed parsers only carry the canonical name.
+      return parser.pages === true;
     }
   }
   return false;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/indexPageMarkdown.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/indexPageMarkdown.test.ts
@@ -29,6 +29,16 @@ describe("PDF page-markdown URL index policy", () => {
           ...baseMeta,
           options: {
             ...baseMeta.options,
+            parsers: [{ type: "pdf", pages: true }],
+          },
+        }),
+      ).toBe(false);
+      // Deprecated pre-rename alias must keep working.
+      expect(
+        shouldUseIndex({
+          ...baseMeta,
+          options: {
+            ...baseMeta.options,
             parsers: [{ type: "pdf", pageMarkdown: true }],
           },
         }),


### PR DESCRIPTION
## What

Renames the per-page-markdown parser option to match the response field it populates, completing the naming convention `blocks` established:

```json
{ "type": "pdf", "pages": true, "blocks": true }  →  document.pages, document.blocks
```

## Compatibility

`pageMarkdown` (shipped Aug 4) was never documented, never in the OpenAPI spec, and never typed in any SDK — only raw-JSON callers who read source could be using it. It stays accepted as a deprecated alias:

- **Schema boundary:** a zod transform folds `pageMarkdown` into `pages` at parse time (`pages` wins when both are set), so the internal `Parsers` type only carries the canonical name.
- **Serialized options:** queued jobs and crawl option snapshots written before this deploys bypass schema re-parsing, so the getter defensively reads the legacy key when `pages` is unset — no in-flight job silently loses its page output across the deploy.
- Internal plumbing (`includePageMarkdown`, fire-pdf's `include_page_markdown` wire field, `PDFProcessorResult.pageMarkdown`) intentionally keeps its names — this PR is the public request surface only.

## Testing

- New schema-boundary tests: alias folds into `pages` and disappears from parsed output, both precedence directions, rejection of non-boolean values under both names
- Snips happy paths flipped to the canonical `pages`; alias-fold coverage retained
- Index-policy tests cover both the canonical and legacy serialized shapes
- `tsc --noEmit` clean; 222 tests across affected suites pass

Docs/OpenAPI/SDKs will only ever document `pages` (follow-ups in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the PDF parser option `pageMarkdown` to `pages`, matching the response field `document.pages`. The legacy `pageMarkdown` alias remains accepted; `pages` wins when both are set.

- Schema: a zod transform folds `pageMarkdown` into `pages` at parse time, so internal types carry only `pages`.
- Back-compat: `getPDFPageMarkdown` reads legacy `pageMarkdown` on serialized options (e.g., queued jobs, crawl snapshots) when `pages` is unset.
- Scope: public request shape only; internal plumbing and wire fields keep existing names.
- Tests: added/updated to cover alias folding, precedence, validation errors for non-boolean values, and index-policy behavior.
- Migration: raw-JSON callers using `pageMarkdown` should switch to `pages`.

<sup>Written for commit 20c30b6cba77a3016f8251fb2109ec8542de0b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

