### PR TITLE
feat(sdks): add parsers[].pages for per-page PDF markdown

### DIFF
--- a/apps/dot-net-sdk/Firecrawl.Tests/ModelsTests.cs
+++ b/apps/dot-net-sdk/Firecrawl.Tests/ModelsTests.cs
@@ -146,6 +146,30 @@ public class ModelsTests
     }
 
     [Fact]
+    public void Document_DeserializesPagesCorrectly()
+    {
+        var json = """
+        {
+            "markdown": "# Annual Report 2025",
+            "pages": [
+                { "pageNumber": 1, "markdown": "# Cover" },
+                { "pageNumber": 2, "markdown": "## Intro" }
+            ]
+        }
+        """;
+
+        var doc = JsonSerializer.Deserialize<Document>(json, JsonOptions);
+        Assert.NotNull(doc);
+        Assert.Equal("# Annual Report 2025", doc.Markdown);
+        Assert.NotNull(doc.Pages);
+        Assert.Equal(2, doc.Pages.Count);
+        Assert.Equal(1, doc.Pages[0].PageNumber);
+        Assert.Equal("# Cover", doc.Pages[0].Markdown);
+        Assert.Equal(2, doc.Pages[1].PageNumber);
+        Assert.Equal("## Intro", doc.Pages[1].Markdown);
+    }
+
+    [Fact]
     public void Document_DeserializesBlocksCorrectly()
     {
         var json = """

--- a/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
+++ b/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>firecrawl-sdk</PackageId>
-    <Version>1.11.0</Version>
+    <Version>1.12.0</Version>
     <Authors>Firecrawl</Authors>
     <Company>Firecrawl</Company>
     <Description>.NET SDK for the Firecrawl API - web scraping, crawling, and data extraction</Description>

--- a/apps/dot-net-sdk/Firecrawl/FirecrawlClient.cs
+++ b/apps/dot-net-sdk/Firecrawl/FirecrawlClient.cs
@@ -714,7 +714,7 @@ public class FirecrawlClient
     // INTERNAL UTILITIES
     // ================================================================
 
-    private const string SdkOrigin = "dotnet-sdk@1.11.0";
+    private const string SdkOrigin = "dotnet-sdk@1.12.0";
 
     private static Dictionary<string, object> BuildBody(object? options)
     {

--- a/apps/dot-net-sdk/Firecrawl/Models/Document.cs
+++ b/apps/dot-net-sdk/Firecrawl/Models/Document.cs
@@ -65,6 +65,12 @@ public class Document
     public MenuProfile? Menu { get; set; }
 
     /// <summary>
+    /// Physical PDF pages, present only when parsers[].pages is true.
+    /// </summary>
+    [JsonPropertyName("pages")]
+    public List<PdfPage>? Pages { get; set; }
+
+    /// <summary>
     /// Typed PDF layout blocks, present only when parsers[].blocks is true.
     /// </summary>
     [JsonPropertyName("blocks")]

--- a/apps/dot-net-sdk/Firecrawl/Models/PdfBlocks.cs
+++ b/apps/dot-net-sdk/Firecrawl/Models/PdfBlocks.cs
@@ -3,6 +3,18 @@ using System.Text.Json.Serialization;
 namespace Firecrawl.Models;
 
 /// <summary>
+/// Physical markdown for a single PDF page.
+/// </summary>
+public class PdfPage
+{
+    [JsonPropertyName("pageNumber")]
+    public int PageNumber { get; set; }
+
+    [JsonPropertyName("markdown")]
+    public string Markdown { get; set; } = "";
+}
+
+/// <summary>
 /// Layout and OCR confidence scores for a PDF block.
 /// </summary>
 public class PdfBlockConfidence

--- a/apps/go-sdk/models.go
+++ b/apps/go-sdk/models.go
@@ -24,17 +24,25 @@ type Document struct {
 	Branding       map[string]interface{}   `json:"branding,omitempty"`
 	Product        *ProductProfile          `json:"product,omitempty"`
 	Menu           *MenuProfile             `json:"menu,omitempty"`
+	// Pages is per-page PDF markdown, present only when parsers[].pages is true.
+	Pages []PdfPage `json:"pages,omitempty"`
 	// Blocks is typed PDF layout data, present only when parsers[].blocks is true.
 	Blocks []PdfPageBlocks `json:"blocks,omitempty"`
 }
 
 // PDFParser configures PDF parsing. Use in ScrapeOptions.Parsers / ParseOptions.Parsers.
 type PDFParser struct {
-	Type         string `json:"type"`
-	Mode         string `json:"mode,omitempty"`
-	MaxPages     *int   `json:"maxPages,omitempty"`
-	PageMarkdown *bool  `json:"pageMarkdown,omitempty"`
-	Blocks       *bool  `json:"blocks,omitempty"`
+	Type     string `json:"type"`
+	Mode     string `json:"mode,omitempty"`
+	MaxPages *int   `json:"maxPages,omitempty"`
+	Pages    *bool  `json:"pages,omitempty"`
+	Blocks   *bool  `json:"blocks,omitempty"`
+}
+
+// PdfPage is physical markdown for a single PDF page.
+type PdfPage struct {
+	PageNumber int    `json:"pageNumber"`
+	Markdown   string `json:"markdown"`
 }
 
 // PdfBlockConfidence is layout and OCR confidence for a PDF block.

--- a/apps/go-sdk/options_test.go
+++ b/apps/go-sdk/options_test.go
@@ -64,20 +64,45 @@ func TestScrapeOptionsPreservesStringFormats(t *testing.T) {
 	}
 }
 
-func TestScrapeOptionsSerializesPDFParserBlocks(t *testing.T) {
+func TestScrapeOptionsSerializesPDFParserPagesAndBlocks(t *testing.T) {
+	pages := true
 	blocks := true
 	payload, err := json.Marshal(ScrapeOptions{
 		Parsers: []interface{}{
-			PDFParser{Type: "pdf", Mode: "auto", Blocks: &blocks},
+			PDFParser{Type: "pdf", Mode: "auto", Pages: &pages, Blocks: &blocks},
 		},
 	})
 	if err != nil {
 		t.Fatalf("Marshal ScrapeOptions: %v", err)
 	}
 
-	want := `"parsers":[{"type":"pdf","mode":"auto","blocks":true}]`
+	want := `"parsers":[{"type":"pdf","mode":"auto","pages":true,"blocks":true}]`
 	if !strings.Contains(string(payload), want) {
 		t.Fatalf("serialized parsers = %s, want to contain %s", payload, want)
+	}
+}
+
+func TestDocumentDeserializesPages(t *testing.T) {
+	raw := []byte(`{
+		"markdown": "# Annual Report 2025",
+		"pages": [
+			{"pageNumber": 1, "markdown": "# Cover"},
+			{"pageNumber": 2, "markdown": "## Intro"}
+		]
+	}`)
+
+	var doc Document
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("Unmarshal Document: %v", err)
+	}
+	if len(doc.Pages) != 2 {
+		t.Fatalf("pages len = %d, want 2", len(doc.Pages))
+	}
+	if doc.Pages[0].PageNumber != 1 || doc.Pages[0].Markdown != "# Cover" {
+		t.Fatalf("page 0 = %+v", doc.Pages[0])
+	}
+	if doc.Pages[1].PageNumber != 2 || doc.Pages[1].Markdown != "## Intro" {
+		t.Fatalf("page 1 = %+v", doc.Pages[1])
 	}
 }
 

--- a/apps/go-sdk/version.go
+++ b/apps/go-sdk/version.go
@@ -9,4 +9,4 @@ package firecrawl
 // Bump this when preparing a new release. The publish-go-sdk GitHub workflow
 // reads this value and creates the corresponding monorepo-prefixed tag on
 // merge to main.
-const Version = "1.10.0"
+const Version = "1.11.0"

--- a/apps/java-sdk/build.gradle.kts
+++ b/apps/java-sdk/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.firecrawl"
-version = "1.13.0"
+version = "1.14.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ForkJoinPool;
 public class FirecrawlClient {
 
     private static final String DEFAULT_API_URL = "https://api.firecrawl.dev";
-    private static final String SDK_ORIGIN = "java-sdk@1.13.0";
+    private static final String SDK_ORIGIN = "java-sdk@1.14.0";
     private static final long DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
     private static final int DEFAULT_MAX_RETRIES = 3;
     private static final double DEFAULT_BACKOFF_FACTOR = 0.5;

--- a/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java
@@ -30,6 +30,8 @@ public class Document {
     private Map<String, Object> branding;
     private Product product;
     private Menu menu;
+    /** Physical PDF pages, present only when parsers[].pages is true. */
+    private List<PdfPage> pages;
     /** Typed PDF layout blocks, present only when parsers[].blocks is true. */
     private List<PdfPageBlocks> blocks;
 
@@ -53,6 +55,7 @@ public class Document {
     public Map<String, Object> getBranding() { return branding; }
     public Product getProduct() { return product; }
     public Menu getMenu() { return menu; }
+    public List<PdfPage> getPages() { return pages; }
     public List<PdfPageBlocks> getBlocks() { return blocks; }
 
     @Override

--- a/apps/java-sdk/src/main/java/com/firecrawl/models/PdfPage.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/models/PdfPage.java
@@ -1,0 +1,22 @@
+package com.firecrawl.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Physical markdown for a single PDF page, returned when
+ * {@code parsers} includes {@code {type: "pdf", pages: true}}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PdfPage {
+
+    private int pageNumber;
+    private String markdown;
+
+    public int getPageNumber() { return pageNumber; }
+    public String getMarkdown() { return markdown; }
+
+    @Override
+    public String toString() {
+        return "PdfPage{pageNumber=" + pageNumber + "}";
+    }
+}

--- a/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java
@@ -145,7 +145,7 @@ public class ScrapeOptions {
         /** Scrape as a mobile device. */
         public Builder mobile(Boolean mobile) { this.mobile = mobile; return this; }
 
-        /** Parsers to use (e.g., "pdf" or {"type": "pdf", "maxPages": 10, "blocks": true}). */
+        /** Parsers to use (e.g., "pdf" or {"type": "pdf", "maxPages": 10, "pages": true, "blocks": true}). */
         public Builder parsers(List<Object> parsers) { this.parsers = parsers; return this; }
 
         /** Actions to execute before/during scraping. */

--- a/apps/java-sdk/src/test/java/com/firecrawl/FirecrawlClientTest.java
+++ b/apps/java-sdk/src/test/java/com/firecrawl/FirecrawlClientTest.java
@@ -262,6 +262,24 @@ class FirecrawlClientTest {
     }
 
     @Test
+    void testDocumentDeserializesPages() throws Exception {
+        String json = "{\"markdown\":\"# Annual Report 2025\",\"pages\":["
+                + "{\"pageNumber\":1,\"markdown\":\"# Cover\"},"
+                + "{\"pageNumber\":2,\"markdown\":\"## Intro\"}]}";
+
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        Document doc = mapper.readValue(json, Document.class);
+
+        assertEquals("# Annual Report 2025", doc.getMarkdown());
+        assertNotNull(doc.getPages());
+        assertEquals(2, doc.getPages().size());
+        assertEquals(1, doc.getPages().get(0).getPageNumber());
+        assertEquals("# Cover", doc.getPages().get(0).getMarkdown());
+        assertEquals(2, doc.getPages().get(1).getPageNumber());
+        assertEquals("## Intro", doc.getPages().get(1).getMarkdown());
+    }
+
+    @Test
     void testDocumentDeserializesBlocks() throws Exception {
         String json = "{\"markdown\":\"# Annual Report 2025\",\"blocks\":[{"
                 + "\"pageNumber\":1,\"width\":1700,\"height\":2200,\"status\":\"ok\","

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.33.0",
+  "version": "4.34.0",
   "description": "JavaScript SDK for the Firecrawl API: web scraping, crawling, web search, and scientific literature search over a research paper index of PubMed, bioRxiv, medRxiv and arXiv abstracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/validation.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/validation.test.ts
@@ -89,16 +89,16 @@ describe("v2 utils: validation", () => {
     expect(options.parsers).toEqual(before);
   });
 
-  test("ensureValidScrapeOptions: leaves PDF parser blocks option untouched", () => {
+  test("ensureValidScrapeOptions: leaves PDF parser pages and blocks options untouched", () => {
     const options = {
-      parsers: [{ type: "pdf", mode: "auto", blocks: true, pageMarkdown: true }],
+      parsers: [{ type: "pdf", mode: "auto", blocks: true, pages: true }],
     } as any;
     expect(() => ensureValidScrapeOptions(options)).not.toThrow();
     expect(options.parsers[0]).toEqual({
       type: "pdf",
       mode: "auto",
       blocks: true,
-      pageMarkdown: true,
+      pages: true,
     });
   });
 

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -191,11 +191,20 @@ export type PDFParser = {
   type: "pdf";
   mode?: "fast" | "auto" | "ocr";
   maxPages?: number;
-  /** Include physical per-page markdown alongside document markdown. */
+  /** Include physical per-page markdown alongside document markdown. Populates `document.pages`. */
+  pages?: boolean;
+  /**
+   * @deprecated Renamed to `pages`. The API still accepts this as a silent alias.
+   */
   pageMarkdown?: boolean;
   /** Include per-page typed layout blocks (bounding boxes, block types, reading order). */
   blocks?: boolean;
 };
+
+export interface PdfPage {
+  pageNumber: number;
+  markdown: string;
+}
 
 export interface PdfBlockConfidence {
   layout: number | null;
@@ -680,6 +689,8 @@ export interface Document {
   branding?: BrandingProfile;
   product?: ProductProfile;
   menu?: MenuProfile;
+  /** Physical PDF pages, present only when `parsers[].pages` is true. */
+  pages?: PdfPage[];
   /** Typed PDF layout blocks, present only when `parsers[].blocks` is true. */
   blocks?: PdfPageBlocks[];
 }

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Firecrawl PHP SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-08-19
+
+### Added
+- PDF parser `pages` option and `Document::getPages()` for per-page markdown.
+
 ## [1.11.0] - 2026-08-19
 
 ### Added

--- a/apps/php-sdk/src/Models/Document.php
+++ b/apps/php-sdk/src/Models/Document.php
@@ -14,6 +14,7 @@ final class Document
      * @param array<string, mixed>|null               $actions
      * @param array<string, mixed>|null               $changeTracking
      * @param array<string, mixed>|null               $branding
+     * @param list<array<string, mixed>>|null         $pages
      * @param list<array<string, mixed>>|null         $blocks
      */
     public function __construct(
@@ -37,6 +38,7 @@ final class Document
         private readonly ?array $branding = null,
         private readonly ?Product $product = null,
         private readonly ?Menu $menu = null,
+        private readonly ?array $pages = null,
         private readonly ?array $blocks = null,
     ) {}
 
@@ -67,6 +69,9 @@ final class Document
                 : null,
             menu: isset($data['menu']) && is_array($data['menu'])
                 ? Menu::fromArray($data['menu'])
+                : null,
+            pages: isset($data['pages']) && is_array($data['pages'])
+                ? $data['pages']
                 : null,
             blocks: isset($data['blocks']) && is_array($data['blocks'])
                 ? $data['blocks']
@@ -179,6 +184,16 @@ final class Document
     public function getMenu(): ?Menu
     {
         return $this->menu;
+    }
+
+    /**
+     * Physical PDF pages, present only when parsers[].pages is true.
+     *
+     * @return list<array<string, mixed>>|null
+     */
+    public function getPages(): ?array
+    {
+        return $this->pages;
     }
 
     /**

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.11.0';
+    public const SDK_VERSION = '1.12.0';
 }

--- a/apps/php-sdk/tests/Unit/ModelsTest.php
+++ b/apps/php-sdk/tests/Unit/ModelsTest.php
@@ -103,6 +103,21 @@ it('preserves null creditsUsed in CrawlJob', function (): void {
     expect($job->getCreditsUsed())->toBeNull();
 });
 
+it('hydrates PDF pages in Document', function (): void {
+    $doc = Document::fromArray([
+        'markdown' => '# Annual Report 2025',
+        'pages' => [
+            ['pageNumber' => 1, 'markdown' => '# Cover'],
+            ['pageNumber' => 2, 'markdown' => '## Intro'],
+        ],
+    ]);
+
+    expect($doc->getMarkdown())->toBe('# Annual Report 2025');
+    expect($doc->getPages())->toHaveCount(2);
+    expect($doc->getPages()[0]['pageNumber'])->toBe(1);
+    expect($doc->getPages()[0]['markdown'])->toBe('# Cover');
+});
+
 it('hydrates PDF blocks in Document', function (): void {
     $doc = Document::fromArray([
         'markdown' => '# Annual Report 2025',

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -18,7 +18,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.36.0"
+__version__ = "4.37.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_document_blocks.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_document_blocks.py
@@ -1,4 +1,4 @@
-from firecrawl.v2.types import Document, PdfPageBlocks
+from firecrawl.v2.types import Document, PdfPage, PdfPageBlocks
 from firecrawl.v2.utils.normalize import normalize_document_input
 
 
@@ -48,3 +48,24 @@ class TestDocumentBlocks:
     def test_blocks_absent_when_not_requested(self):
         doc = Document(**normalize_document_input({"markdown": "# Hello"}))
         assert doc.blocks is None
+        assert doc.pages is None
+
+
+class TestDocumentPages:
+    def test_pages_hydrate_from_api_camel_case(self):
+        raw = {
+            "markdown": "# Annual Report 2025",
+            "pages": [
+                {"pageNumber": 1, "markdown": "# Cover"},
+                {"pageNumber": 2, "markdown": "## Intro"},
+            ],
+        }
+
+        doc = Document(**normalize_document_input(raw))
+        assert doc.pages is not None
+        assert len(doc.pages) == 2
+        assert isinstance(doc.pages[0], PdfPage)
+        assert doc.pages[0].page_number == 1
+        assert doc.pages[0].markdown == "# Cover"
+        assert doc.pages[1].page_number == 2
+        assert doc.pages[1].markdown == "## Intro"

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -389,9 +389,9 @@ class TestPrepareScrapeOptions:
 
         assert result["parsers"][0]["maxPages"] == 5
 
-    def test_prepare_parsers_blocks_and_page_markdown(self):
-        """PDF parser blocks and page_markdown are sent in API camelCase."""
-        parser = PDFParser(mode="auto", page_markdown=True, blocks=True)
+    def test_prepare_parsers_blocks_and_pages(self):
+        """PDF parser blocks and pages are forwarded to the API."""
+        parser = PDFParser(mode="auto", pages=True, blocks=True)
         options = ScrapeOptions(parsers=[parser])
 
         result = prepare_scrape_options(options)
@@ -399,7 +399,7 @@ class TestPrepareScrapeOptions:
         assert result["parsers"][0] == {
             "type": "pdf",
             "mode": "auto",
-            "pageMarkdown": True,
+            "pages": True,
             "blocks": True,
         }
 
@@ -407,9 +407,10 @@ class TestPrepareScrapeOptions:
             parsers=[{"type": "pdf", "page_markdown": True, "blocks": True}]
         )
         dict_result = prepare_scrape_options(dict_options)
-        assert dict_result["parsers"][0]["pageMarkdown"] is True
+        assert dict_result["parsers"][0]["pages"] is True
         assert dict_result["parsers"][0]["blocks"] is True
         assert "page_markdown" not in dict_result["parsers"][0]
+        assert "pageMarkdown" not in dict_result["parsers"][0]
 
     def test_prepare_min_age_maps_to_camel_case(self):
         """min_age must be sent as minAge; the server drops the snake_case key."""

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -412,6 +412,13 @@ class TestPrepareScrapeOptions:
         assert "page_markdown" not in dict_result["parsers"][0]
         assert "pageMarkdown" not in dict_result["parsers"][0]
 
+        camel_options = ScrapeOptions(
+            parsers=[{"type": "pdf", "pageMarkdown": True}]
+        )
+        camel_result = prepare_scrape_options(camel_options)
+        assert camel_result["parsers"][0]["pages"] is True
+        assert "pageMarkdown" not in camel_result["parsers"][0]
+
     def test_prepare_min_age_maps_to_camel_case(self):
         """min_age must be sent as minAge; the server drops the snake_case key."""
         options = ScrapeOptions(min_age=1000, max_age=5000)

--- a/apps/python-sdk/firecrawl/types.py
+++ b/apps/python-sdk/firecrawl/types.py
@@ -15,6 +15,7 @@ from .v2.types import (
     PdfBlockConfidence,
     PdfBlockItem,
     PdfPageBlocks,
+    PdfPage,
     
     # Scrape types
     ScrapeFormats,
@@ -103,6 +104,7 @@ __all__ = [
     'PdfBlockConfidence',
     'PdfBlockItem',
     'PdfPageBlocks',
+    'PdfPage',
     
     # Scrape types
     'ScrapeFormats',

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -476,6 +476,15 @@ class PdfPageBlocks(BaseModel):
     items: List[PdfBlockItem] = Field(default_factory=list)
 
 
+class PdfPage(BaseModel):
+    """Physical PDF page markdown, present when parsers[].pages is true."""
+
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+    page_number: int = Field(alias="pageNumber")
+    markdown: str
+
+
 class Document(BaseModel):
     """A scraped document."""
 
@@ -498,6 +507,7 @@ class Document(BaseModel):
     branding: Optional[BrandingProfile] = None
     product: Optional[ProductProfile] = None
     menu: Optional[MenuProfile] = None
+    pages: Optional[List[PdfPage]] = None
     blocks: Optional[List[PdfPageBlocks]] = None
 
     @property
@@ -1656,7 +1666,7 @@ class PDFParser(BaseModel):
     type: Literal["pdf"] = "pdf"
     mode: Optional[Literal["fast", "auto", "ocr"]] = None
     max_pages: Optional[int] = None
-    page_markdown: Optional[bool] = None
+    pages: Optional[bool] = None
     blocks: Optional[bool] = None
 
 

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1669,6 +1669,20 @@ class PDFParser(BaseModel):
     pages: Optional[bool] = None
     blocks: Optional[bool] = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _fold_deprecated_page_markdown(cls, data: Any) -> Any:
+        """Accept the pre-rename pageMarkdown alias and fold it into pages."""
+        if not isinstance(data, dict):
+            return data
+        folded = dict(data)
+        alias = folded.pop("page_markdown", None)
+        if alias is None:
+            alias = folded.pop("pageMarkdown", None)
+        if folded.get("pages") is None and alias is not None:
+            folded["pages"] = alias
+        return folded
+
 
 # Location types
 class Location(BaseModel):

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -790,8 +790,11 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                         parser_data = dict(parser)
                         if "max_pages" in parser_data:
                             parser_data["maxPages"] = parser_data.pop("max_pages")
+                        # Deprecated alias from the pre-rename pageMarkdown option.
                         if "page_markdown" in parser_data:
-                            parser_data["pageMarkdown"] = parser_data.pop("page_markdown")
+                            parser_data.setdefault("pages", parser_data.pop("page_markdown"))
+                        if "pageMarkdown" in parser_data:
+                            parser_data.setdefault("pages", parser_data.pop("pageMarkdown"))
                         converted_parsers.append(parser_data)
                     else:
                         parser_data = parser.model_dump(exclude_none=True)
@@ -799,7 +802,9 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                         if "max_pages" in parser_data:
                             parser_data["maxPages"] = parser_data.pop("max_pages")
                         if "page_markdown" in parser_data:
-                            parser_data["pageMarkdown"] = parser_data.pop("page_markdown")
+                            parser_data.setdefault("pages", parser_data.pop("page_markdown"))
+                        if "pageMarkdown" in parser_data:
+                            parser_data.setdefault("pages", parser_data.pop("pageMarkdown"))
                         converted_parsers.append(parser_data)
                 scrape_data["parsers"] = converted_parsers
             elif key == "location":

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -801,10 +801,6 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
                         # Convert snake_case to camelCase for API
                         if "max_pages" in parser_data:
                             parser_data["maxPages"] = parser_data.pop("max_pages")
-                        if "page_markdown" in parser_data:
-                            parser_data.setdefault("pages", parser_data.pop("page_markdown"))
-                        if "pageMarkdown" in parser_data:
-                            parser_data.setdefault("pages", parser_data.pop("pageMarkdown"))
                         converted_parsers.append(parser_data)
                 scrape_data["parsers"] = converted_parsers
             elif key == "location":

--- a/apps/ruby-sdk/lib/firecrawl/models/document.rb
+++ b/apps/ruby-sdk/lib/firecrawl/models/document.rb
@@ -8,7 +8,7 @@ module Firecrawl
                   :metadata, :links, :images, :screenshot, :audio,
                   :video, :attributes, :actions, :answer, :highlights,
                   :warning, :change_tracking, :branding, :product, :menu,
-                  :blocks
+                  :pages, :blocks
 
       def initialize(data)
         @markdown = data["markdown"]
@@ -31,6 +31,7 @@ module Firecrawl
         @branding = data["branding"]
         @product = data["product"] && ProductProfile.new(data["product"])
         @menu = data["menu"] && MenuProfile.new(data["menu"])
+        @pages = data["pages"]
         @blocks = data["blocks"]
       end
 

--- a/apps/ruby-sdk/lib/firecrawl/version.rb
+++ b/apps/ruby-sdk/lib/firecrawl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Firecrawl
-  VERSION = "1.12.0"
+  VERSION = "1.13.0"
 end

--- a/apps/ruby-sdk/test/firecrawl/client_test.rb
+++ b/apps/ruby-sdk/test/firecrawl/client_test.rb
@@ -85,6 +85,27 @@ class ClientTest < Minitest::Test
     assert_equal "Example", doc.metadata["title"]
   end
 
+  def test_scrape_hydrates_pdf_pages
+    stub_request(:post, "#{BASE_URL}/v2/scrape")
+      .to_return(
+        status: 200,
+        body: JSON.generate(data: {
+          markdown: "# Annual Report 2025",
+          pages: [
+            { pageNumber: 1, markdown: "# Cover" },
+            { pageNumber: 2, markdown: "## Intro" }
+          ]
+        }),
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    doc = @client.scrape("https://example.com/report.pdf")
+    assert_equal "# Annual Report 2025", doc.markdown
+    assert_equal 2, doc.pages.length
+    assert_equal 1, doc.pages[0]["pageNumber"]
+    assert_equal "# Cover", doc.pages[0]["markdown"]
+  end
+
   def test_scrape_hydrates_pdf_blocks
     stub_request(:post, "#{BASE_URL}/v2/scrape")
       .to_return(

--- a/apps/rust-sdk/CHANGELOG.md
+++ b/apps/rust-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGELOG
 
+## [2.14.0] - 2026-08-19
+
+### Added
+
+- Added `ParserConfig::Pdf.pages` to request per-page PDF markdown.
+- Added `Document.pages` (`PdfPage`) for physical page markdown.
+
 ## [2.13.0] - 2026-08-19
 
 ### Added

--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecrawl"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "mockito",
  "reqwest",

--- a/apps/rust-sdk/Cargo.toml
+++ b/apps/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecrawl"
-version = "2.13.0"
+version = "2.14.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://www.firecrawl.dev/"

--- a/apps/rust-sdk/src/scrape.rs
+++ b/apps/rust-sdk/src/scrape.rs
@@ -119,8 +119,8 @@ pub enum ParserConfig {
         mode: Option<String>,
         #[serde(rename = "maxPages", skip_serializing_if = "Option::is_none")]
         max_pages: Option<u32>,
-        #[serde(rename = "pageMarkdown", skip_serializing_if = "Option::is_none")]
-        page_markdown: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pages: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
         blocks: Option<bool>,
     },
@@ -531,7 +531,7 @@ mod tests {
                 parser_type: "pdf".to_string(),
                 mode: Some("auto".to_string()),
                 max_pages: None,
-                page_markdown: Some(true),
+                pages: Some(true),
                 blocks: Some(true),
             }]),
             ..Default::default()
@@ -543,7 +543,7 @@ mod tests {
             json!({
                 "type": "pdf",
                 "mode": "auto",
-                "pageMarkdown": true,
+                "pages": true,
                 "blocks": true
             })
         );

--- a/apps/rust-sdk/src/types.rs
+++ b/apps/rust-sdk/src/types.rs
@@ -690,8 +690,19 @@ pub struct Document {
     pub product: Option<Product>,
     /// Menu extraction result.
     pub menu: Option<Menu>,
+    /// Physical PDF page markdown, present only when `parsers[].pages` is true.
+    pub pages: Option<Vec<PdfPage>>,
     /// Typed PDF layout blocks, present only when `parsers[].blocks` is true.
     pub blocks: Option<Vec<PdfPageBlocks>>,
+}
+
+/// Physical markdown for a single PDF page.
+#[serde_with::skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PdfPage {
+    pub page_number: u32,
+    pub markdown: String,
 }
 
 /// Layout and OCR confidence scores for a PDF block.
@@ -1205,5 +1216,23 @@ mod tests {
         assert_eq!(pages[0].items[0].reading_order, 0);
         assert_eq!(pages[0].items[0].confidence.layout, Some(0.97));
         assert_eq!(pages[0].items[0].confidence.ocr, None);
+    }
+
+    #[test]
+    fn test_document_with_pages() {
+        let json = json!({
+            "markdown": "# Annual Report 2025",
+            "pages": [
+                { "pageNumber": 1, "markdown": "# Cover" },
+                { "pageNumber": 2, "markdown": "## Intro" }
+            ]
+        });
+        let doc: Document = serde_json::from_value(json).unwrap();
+        let pages = doc.pages.expect("pages should be present");
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].page_number, 1);
+        assert_eq!(pages[0].markdown, "# Cover");
+        assert_eq!(pages[1].page_number, 2);
+        assert_eq!(pages[1].markdown, "## Intro");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds the v2 PDF parser `pages` option (from #4352) to every first-party SDK, plus `Document.pages` for the per-page markdown response.

```json
{ "parsers": [{ "type": "pdf", "pages": true }] }
```

When set, scrape/parse/crawl/batch documents can include:

```jsonc
"pages": [
  { "pageNumber": 1, "markdown": "# Cover" },
  { "pageNumber": 2, "markdown": "## Intro" }
]
```

The old `pageMarkdown` / `page_markdown` request flag is still accepted as a deprecated silent alias (Python folds it to `pages`; JS keeps it on the typed parser as `@deprecated`).

## SDKs and version bumps

Versions are bumped so merge auto-publishes:

| SDK | Version |
| --- | --- |
| JS | 4.33.0 → **4.34.0** |
| Python | 4.36.0 → **4.37.0** |
| Go | 1.10.0 → **1.11.0** |
| Java | 1.13.0 → **1.14.0** |
| Ruby | 1.12.0 → **1.13.0** |
| PHP | 1.11.0 → **1.12.0** |
| Rust | 2.13.0 → **2.14.0** |
| .NET | 1.11.0 → **1.12.0** |

Elixir is unchanged: `parsers` is already an untyped list and responses are maps, so `pages` already passes through.

## Tests

Unit coverage for request serialization and document hydration in Python, JS, Go, Java, PHP, Ruby, Rust, and .NET.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a633706e-babf-4980-b886-12d8d972d3e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a633706e-babf-4980-b886-12d8d972d3e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the v2 PDF parser option parsers[].pages and Document.pages across all first‑party SDKs to return per‑page PDF markdown. Replaces the old pageMarkdown flag; the API still accepts it, but SDKs now prefer pages.

- Request/response: send { type: "pdf", pages: true } in parsers[]. Read Document.pages[] with pageNumber and markdown.
- Deprecated aliases: API accepts pageMarkdown/page_markdown. `@mendable/firecrawl-js` keeps a deprecated pageMarkdown field; Python accepts both aliases and folds them into pages; other typed SDKs replace the field with pages.
- Python fix: a model before‑validator now folds page_markdown/pageMarkdown into pages; removed redundant rewrite in prepare_scrape_options.
- Review focus: PDF parser request serialization and Document.pages hydration tests added in JS, Python, Go, Java, Ruby, PHP, Rust, and .NET.
- Release: Minor bumps publish the change — JS 4.34.0, Python 4.37.0, Go 1.11.0, Java 1.14.0, Ruby 1.13.0, PHP 1.12.0, Rust 2.14.0, .NET 1.12.0; Elixir unchanged (untyped pass‑through).

<sup>Written for commit 4ef919b685e4464e76fe1edaec201977796856e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

