### PR TITLE
fix(sdks): preserve api_url path prefix in python v2 client URLs

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_build_url.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_build_url.py
@@ -1,0 +1,21 @@
+from firecrawl.v2.utils.http_client import HttpClient
+
+
+class TestBuildUrlBasePath:
+    def test_preserves_base_path_prefix(self):
+        # Self-hosted behind a reverse proxy at a sub-path
+        client = HttpClient(api_key="fc-test", api_url="http://localhost:3002/firecrawl")
+        assert client._build_url("/v2/search") == "http://localhost:3002/firecrawl/v2/search"
+
+    def test_preserves_base_path_prefix_with_trailing_slash(self):
+        client = HttpClient(api_key="fc-test", api_url="http://localhost:3002/firecrawl/")
+        assert client._build_url("/v2/search") == "http://localhost:3002/firecrawl/v2/search"
+
+    def test_preserves_nested_base_path_prefix(self):
+        client = HttpClient(api_key="fc-test", api_url="https://example.com/api/firecrawl")
+        assert client._build_url("/v2/crawl") == "https://example.com/api/firecrawl/v2/crawl"
+
+    def test_root_base_url_is_unchanged(self):
+        # Default cloud URL has no path and must keep resolving exactly as before
+        client = HttpClient(api_key="fc-test", api_url="https://api.firecrawl.dev")
+        assert client._build_url("/v2/search") == "https://api.firecrawl.dev/v2/search"

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -47,7 +47,9 @@ class HttpClient:
             ep2 = urlparse(f"https:{endpoint}")
             path = ep2.path or "/"
             return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
-        return urljoin(base_str, endpoint)
+        # Drop the leading slash so a base path is kept: urljoin treats "/v2/x" as
+        # root-absolute and would discard a self-hosted prefix like /firecrawl
+        return urljoin(base_str, endpoint.lstrip("/"))
     
     def _prepare_headers(
         self,


### PR DESCRIPTION
Fixes #4339.

`HttpClient._build_url` appends a trailing slash to `api_url` and then calls `urljoin` with endpoints that are all root-absolute literals (`"/v2/search"`, `"/v2/crawl"`, ...). A reference beginning with `/` replaces the whole base path, so the slash it just added never gets a chance to matter:

```python
>>> urljoin("http://host/firecrawl/", "/v2/search")
'http://host/v2/search'
```

Self-hosting behind a reverse proxy on a sub-path therefore loses the prefix on every v2 request. Every endpoint constant under `firecrawl/v2` starts with `/`, so this affects all of them, not only search.

The async client already does the right thing here, because httpx concatenates `base_url` with a relative path:

```python
>>> httpx.AsyncClient(base_url="http://host/firecrawl")._merge_url("/v2/search")
URL('http://host/firecrawl/v2/search')
```

So the sync and async clients in this package currently disagree about the same call. This change brings the sync one in line with the async one rather than inventing new behaviour.

### Change

Strip the leading slash before `urljoin` so the base path survives. The protocol-relative (`//host/path`) and absolute-URL branches above are untouched.

### Tests

Added `__tests__/unit/v2/utils/test_http_client_build_url.py`: three sub-path cases (no trailing slash, trailing slash, nested prefix) plus a guard that a root `api_url` still resolves exactly as before. It fails 3 of 4 before the change and passes 4 of 4 after.

The rest of the suite is unaffected — `firecrawl/__tests__/unit` gives 40 failed / 422 passed on `main` at 66bc308 and 40 failed / 426 passed on this branch, with an identical failure list and the +4 coming from the new file. Those 40 pre-existing failures are async tests unrelated to this area.

An `api_url` with no path, including the default `https://api.firecrawl.dev`, resolves unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves api_url path prefixes in the Python v2 sync client so self-hosted sub-paths resolve correctly and behavior matches the async client. Previously, root-absolute endpoints like "/v2/search" via urljoin replaced the base path; now we strip the leading slash before joining, keeping the prefix. Cloud URLs without a path are unchanged.

- Review / Rollout
  - Code: Single-line change in apps/python-sdk/firecrawl/v2/utils/http_client.py to lstrip the endpoint before urljoin; async client already correct via `httpx`.
  - Impact: Self-hosted deployments behind a reverse proxy on a sub-path now work; no API changes or migration required; default cloud `api_url` unaffected.
  - Tests: Adds apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_build_url.py covering sub-path prefixes and root base URL.

<sup>Written for commit 84124a13d5ad9ddc9219983a0ab21d0253824569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

