### PR TITLE
chore(api): bump anydoc to 0.2.0

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-anydoc = "0.1.9"
+anydoc = "0.2.0"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"


### PR DESCRIPTION
Updates the `anydoc` dependency in `apps/api/native` from 0.1.9 to 0.2.0. Verified locally with `cargo check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `anydoc` in `apps/api/native` from 0.1.9 to 0.2.0 to pull in upstream fixes and improvements.

- Only `Cargo.toml` changed; no application code changes.
- Review: run `cargo build` or `cargo check` and smoke-test paths that use `anydoc`.

<sup>Written for commit 3817328cc0468dece979cd1c4a69ded0f3ae0c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

