### PR TITLE
Merge branch 'main' of https://github.com/mendableai/firecrawl

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,9 +81,9 @@ services:
     cap_drop:
       - ALL
     # Resource limits for Docker Compose (not Swarm)
-    cpus: 2.0
-    mem_limit: 4G
-    memswap_limit: 4G
+    # cpus: 2.0
+    # mem_limit: 4G
+    # memswap_limit: 4G
     logging:
       driver: "json-file"
       options:
@@ -118,9 +118,9 @@ services:
     command: node dist/src/harness.js --start-docker
     # Resource limits for Docker Compose (not Swarm)
     # Increase if you have more CPU cores/RAM available
-    cpus: 4.0
-    mem_limit: 8G
-    memswap_limit: 8G
+    # cpus: 4.0
+    # mem_limit: 8G
+    # memswap_limit: 8G
 
   redis:
     # NOTE: If you want to use Valkey (open source) instead of Redis (source available),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes default CPU and memory limits from `docker-compose.yaml` to make local and small-host deployments run without manual tuning. Previously services were capped (2–4 CPUs, 4–8 GB); now no caps are set by default, so Docker uses available resources.

- Affects only Docker Compose; Swarm/Kubernetes limits are unchanged.
- If you need caps, re-enable `cpus`, `mem_limit`, and `memswap_limit` in an override file.
- Reviewer: verify services start and behave under load on constrained machines.

<sup>Written for commit 89c0dad76fc4a3b6cc2f1efd90c6b26549d6a8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

