### PR TITLE
feat(agent): default to spark-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,11 +384,12 @@ result = app.agent(
 
 #### Model Selection
 
-Choose between two models based on your needs:
+Choose a model based on your needs:
 
 | Model | Cost | Best For |
 |-------|------|----------|
-| `spark-1-mini` (default) | 60% cheaper | Most tasks |
+| `spark-2` (default) | See [pricing](https://docs.firecrawl.dev/features/agent) | Most tasks |
+| `spark-1-mini` | 60% cheaper than `spark-1-pro` | Cost-sensitive tasks |
 | `spark-1-pro` | Standard | Complex research, critical data gathering |
 ```python
 result = app.agent(

--- a/apps/api/src/controllers/v2/agent-schema.test.ts
+++ b/apps/api/src/controllers/v2/agent-schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { agentRequestSchema } from "./types";
+
+describe("agentRequestSchema model", () => {
+  it("defaults to spark-2 when no model is given", () => {
+    expect(
+      agentRequestSchema.parse({ prompt: "Find the pricing page" }).model,
+    ).toBe("spark-2");
+  });
+
+  it("keeps an explicitly requested model", () => {
+    for (const model of ["spark-1-pro", "spark-1-mini", "spark-2"] as const) {
+      expect(
+        agentRequestSchema.parse({ prompt: "Find the pricing page", model })
+          .model,
+      ).toBe(model);
+    }
+  });
+
+  it("rejects an unknown model", () => {
+    expect(() =>
+      agentRequestSchema.parse({
+        prompt: "Find the pricing page",
+        model: "spark-3",
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/api/src/controllers/v2/agent-status.ts
+++ b/apps/api/src/controllers/v2/agent-status.ts
@@ -25,6 +25,9 @@ export async function agentStatusController(
 
   const agent = await supabaseGetAgentByIdDirect(req.params.jobId);
 
+  // Jobs whose stored options carry no model predate the model option and ran
+  // on spark-1-pro, so the fallback here stays spark-1-pro even though the
+  // agent request schema now defaults new jobs to spark-2.
   let model: "spark-1-pro" | "spark-1-mini" | "spark-2";
   if (agent) {
     model = (agent.options?.model ?? "spark-1-pro") as
@@ -52,7 +55,7 @@ export async function agentStatusController(
           module: "api/v2",
           text: await optionsRequest.text(),
         });
-        model = "spark-1-pro"; // fall back to this value
+        model = "spark-1-pro"; // fall back to the pre-model-option default
       } else {
         model = ((await optionsRequest.json()).model ?? "spark-1-pro") as
           | "spark-1-pro"
@@ -66,7 +69,7 @@ export async function agentStatusController(
         module: "api/v2",
         extractId: req.params.jobId,
       });
-      model = "spark-1-pro"; // fall back to this value
+      model = "spark-1-pro"; // fall back to the pre-model-option default
     }
   }
 

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1005,9 +1005,7 @@ export const agentRequestSchema = z.strictObject({
   webhook: agentWebhookSchema.optional(),
 
   overrideWhitelist: z.string().optional(),
-  model: z
-    .enum(["spark-1-pro", "spark-1-mini", "spark-2"])
-    .default("spark-1-pro"),
+  model: z.enum(["spark-1-pro", "spark-1-mini", "spark-2"]).default("spark-2"),
   threatProtection: threatProtectionOverrideSchema.optional(),
   auditMetadata: auditMetadataSchema.optional(),
 });


### PR DESCRIPTION
Makes `spark-2` the default model for `/v2/agent`.

## Changes

- **`apps/api/src/controllers/v2/types.ts`** — `agentRequestSchema.model` default flipped `spark-1-pro` → `spark-2`. This is the only place the default is applied; `agentController` forwards `req.body.model` verbatim to the upstream agent service, so requests that omit `model` now run spark-2. `spark-2` was already in the enum, so explicit selection is unchanged.
- **`apps/api/src/controllers/v2/agent-schema.test.ts`** (new) — asserts the default is `spark-2`, that an explicit `spark-1-pro` / `spark-1-mini` / `spark-2` is preserved, and that an unknown model is rejected.
- **`apps/api/src/controllers/v2/agent-status.ts`** — comment only. The status controller's `?? "spark-1-pro"` fallbacks only fire for jobs whose stored options carry no model at all — jobs predating the model option, which really did run spark-1-pro. Left as-is on purpose (changing them would misreport historical jobs); commented so the divergence from the new request default doesn't read as an oversight.
- **`README.md`** — the model table claimed `spark-1-mini` was the default, which was already wrong. Now lists `spark-2` as the default. No cost figures invented for spark-2 (that cell points at the pricing docs), and `spark-1-mini`'s "60% cheaper" is now explicit about its baseline since the row order changed.

## Testing

- `vitest run src/controllers/v2/agent-schema.test.ts src/controllers/v2/__tests__/agent-status.test.ts` → 5 passed
- `knip` exits 0
- `tsc --noEmit` clean apart from pre-existing `@mendable/firecrawl-rs` module-not-found errors (local env: the native package isn't built in this worktree)

No agent E2E snip exists — the endpoint proxies to the `EXTRACT_V3_BETA_URL` service, which isn't reachable from `pnpm harness` — so the schema-level test is where the win condition is asserted.

## Not included

The SDK type unions still only allow `spark-1-pro` / `spark-1-mini` (`apps/js-sdk/firecrawl/src/v2/types.ts`, `apps/js-sdk/.../methods/agent.ts`, several `apps/python-sdk/firecrawl/v2/**` `Literal[...]`, `apps/rust-sdk/src/types.rs`). SDK users get spark-2 by default (they omit the field), but can't explicitly *select* it. That's a separate change across four SDKs plus their tests — happy to do it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default model for `/v2/agent` requests changes from `spark-1-pro` to `spark-2`. Requests that omit `model` now run on `spark-2`; explicit model selection is unchanged. The status controller still falls back to `spark-1-pro` only for legacy jobs with no stored model to avoid misreporting historical runs.

**Review and rollout**
- Update lives in the request schema; the controller forwards `req.body.model` unchanged, so omission now selects `spark-2`. README model table now lists `spark-2` as the default.
- Status controller fallbacks stay on `spark-1-pro` for legacy jobs; code comment explains the divergence from the new request default.
- Validation rejects unknown models; tests cover defaulting, pass-through of explicit models, and rejection.
- SDKs: omitting `model` yields `spark-2`, but explicit `spark-2` selection is not yet supported in type unions. To keep prior behavior, set `model: "spark-1-pro"` explicitly.

<sup>Written for commit 6df6b07f53acb12c4a3884c82968030e2ea34b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

