### PR TITLE
feat(pdf-cache): freshness window, degraded-result gate, and cache metrics

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -5,23 +5,28 @@ import { getMcpActionLogConfigErrors } from "./lib/mcp-action-log-config";
 /* Codecs */
 const delimitedList = (separator = ",") => {
   return z.codec(z.string(), z.array(z.string()), {
-    decode: (str) => (str ? str.split(separator).map((s) => s.trim()) : []),
-    encode: (arr) => arr.join(separator),
+    decode: str => (str ? str.split(separator).map(s => s.trim()) : []),
+    encode: arr => arr.join(separator),
   });
 };
 
 const emptyStringAsUndefined = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess((value) => (value === "" ? undefined : value), schema.optional());
+  z.preprocess(value => (value === "" ? undefined : value), schema.optional());
 
 const emptyStringAsDefault = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess((value) => (value === "" ? undefined : value), schema);
+  z.preprocess(value => (value === "" ? undefined : value), schema);
 
-const RESEARCH_PAPER_OPERATIONS = ["search", "inspect", "read", "similar"] as const;
+const RESEARCH_PAPER_OPERATIONS = [
+  "search",
+  "inspect",
+  "read",
+  "similar",
+] as const;
 
 export type ResearchPaperOperation = (typeof RESEARCH_PAPER_OPERATIONS)[number];
 
 const researchKeylessDisabled = z.preprocess(
-  (value) => {
+  value => {
     if (typeof value !== "string") return value;
     const raw = value.trim().toLowerCase();
     if (raw === "") return undefined;
@@ -31,10 +36,12 @@ const researchKeylessDisabled = z.preprocess(
     }
     return raw
       .split(",")
-      .map((operation) => operation.trim())
+      .map(operation => operation.trim())
       .filter(Boolean);
   },
-  z.array(z.enum(RESEARCH_PAPER_OPERATIONS)).default([...RESEARCH_PAPER_OPERATIONS]),
+  z
+    .array(z.enum(RESEARCH_PAPER_OPERATIONS))
+    .default([...RESEARCH_PAPER_OPERATIONS]),
 );
 
 const containsLoneSurrogate = (value: string): boolean => {
@@ -67,11 +74,11 @@ const configSchema = z.object({
   SUPPORT_AGENT_URL: z.string().url().optional(),
   SUPPORT_AGENT_VERCEL_BYPASS_SECRET: z.string().optional(),
   FIREBRAIN_TRACKS_URL: z.preprocess(
-    (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
+    v => (typeof v === "string" && v.trim() === "" ? undefined : v),
     z.string().url().optional(),
   ),
   FIREBRAIN_TRACKS_API_KEY: z.preprocess(
-    (v) => (typeof v === "string" && v.trim() === "" ? undefined : v),
+    v => (typeof v === "string" && v.trim() === "" ? undefined : v),
     z.string().trim().optional(),
   ),
   RESEARCH_PROXY_URL: z.string().url().optional(),
@@ -108,14 +115,21 @@ const configSchema = z.object({
   // Google Web Risk. An unset key disables the provider (lookups then fail
   // per the org's failurePolicy).
   GOOGLE_WEB_RISK_API_KEY: z.string().optional(),
-  GOOGLE_WEB_RISK_API_URL: z.string().url().default("https://webrisk.googleapis.com"),
+  GOOGLE_WEB_RISK_API_URL: z
+    .string()
+    .url()
+    .default("https://webrisk.googleapis.com"),
   // Google Web Risk Update API sync tuning. ZDR: "normal" mode checks run
   // against a locally synced hash-prefix database (threatLists:computeDiff)
   // instead of sending URLs to Google, and verdicts are never persisted.
   //
   // Floor for how often threatLists:computeDiff may run per list. Google's
   // recommendedNextDiff is respected when it is later than this floor.
-  THREAT_LIST_SYNC_MIN_INTERVAL_SECONDS: z.coerce.number().int().positive().default(60),
+  THREAT_LIST_SYNC_MIN_INTERVAL_SECONDS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(60),
   // A synced threat list older than this is treated as unavailable
   // (provider-failure semantics → the org's failurePolicy decides).
   THREAT_LIST_STALENESS_SECONDS: z.coerce
@@ -138,7 +152,9 @@ const configSchema = z.object({
 
   // API Keys & Authentication
   BULL_AUTH_KEY: z.string().optional(),
-  S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY: emptyStringAsUndefined(z.string().trim().min(1)),
+  S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY: emptyStringAsUndefined(
+    z.string().trim().min(1),
+  ),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
   OPENROUTER_API_KEY: z.string().optional(),
@@ -151,7 +167,11 @@ const configSchema = z.object({
   SEARCH_PREVIEW_TOKEN: z.string().optional(),
   SEARCH_SERVICE_API_SECRET: z.string().optional(),
   SEARCH_FEEDBACK_MAX_AGE_SEC: z.coerce.number().int().positive().default(120),
-  SEARCH_FEEDBACK_DAILY_CAP_CREDITS: z.coerce.number().int().nonnegative().default(100),
+  SEARCH_FEEDBACK_DAILY_CAP_CREDITS: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(100),
   FEEDBACK_MAX_AGE_SEC: z.coerce.number().int().positive().default(120),
   FEEDBACK_DAILY_CAP_CREDITS: z.coerce.number().int().nonnegative().default(50),
   FEEDBACK_REFUND_ENABLED: z.stringbool().default(true),
@@ -191,11 +211,38 @@ const configSchema = z.object({
   NUQ_RABBITMQ_URL: z.string().optional(),
   FDB_CLUSTER_FILE: emptyStringAsUndefined(z.string()),
   NUQ_BACKEND: emptyStringAsUndefined(z.enum(["pg", "fdb"])),
-  NUQ_FDB_READY_SHARDS: emptyStringAsDefault(z.coerce.number().int().positive().default(2048)),
+  NUQ_FDB_READY_SHARDS: emptyStringAsDefault(
+    z.coerce.number().int().positive().default(2048),
+  ),
   // 1 = strict (priority, FIFO) promotion order per team; raise for teams with
   // extreme finish rates at the cost of approximate cross-shard ordering
-  NUQ_FDB_TEAM_PENDING_SHARDS: emptyStringAsDefault(z.coerce.number().int().positive().default(1)),
-  NUQ_FDB_TIME_BUCKETS: emptyStringAsDefault(z.coerce.number().int().positive().default(16)),
+  NUQ_FDB_TEAM_PENDING_SHARDS: emptyStringAsDefault(
+    z.coerce.number().int().positive().default(1),
+  ),
+  NUQ_FDB_TIME_BUCKETS: emptyStringAsDefault(
+    z.coerce.number().int().positive().default(16),
+  ),
+
+  // PDF result cache (content-keyed, GCS). Entries older than the window are
+  // treated as misses and re-parsed, so parser improvements reach repeat
+  // documents. Lowering the window trades processing load for freshness.
+  PDF_CACHE_MAX_AGE_MS: emptyStringAsDefault(
+    z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .default(60 * 24 * 60 * 60 * 1000),
+  ),
+  // /v2/parse hard-codes maxAge: 0 to bypass the URL index; that value is not
+  // a customer freshness signal, so the parse path gets its own (tighter)
+  // window instead of a full bypass.
+  PARSE_PDF_CACHE_MAX_AGE_MS: emptyStringAsDefault(
+    z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .default(7 * 24 * 60 * 60 * 1000),
+  ),
 
   // Google Cloud Storage
   GCS_BUCKET_NAME: z.string().optional(),
@@ -417,10 +464,10 @@ const configSchema = z.object({
   EXTRACT_V3_BETA_URL: z.string().optional(),
   AGENT_INTEROP_SECRET: z
     .string()
-    .refine((value) => value.trim().length > 0, {
+    .refine(value => value.trim().length > 0, {
       error: "AGENT_INTEROP_SECRET must not be blank",
     })
-    .refine((value) => !containsLoneSurrogate(value), {
+    .refine(value => !containsLoneSurrogate(value), {
       error: "AGENT_INTEROP_SECRET must not contain lone surrogates",
     })
     .optional(),

--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -19,6 +19,11 @@ type CachedPdfResult = {
   /** Typed layout blocks (fire-pdf wire shape); present only in
    * block-capable cache variants. */
   blocks?: FirePdfPageBlocks[];
+  /** ISO timestamp of when this entry was parsed. Stamped into the body on
+   * save; reads on pre-existing entries fall back to the GCS object's
+   * timeCreated. Undefined only when that fallback also failed — callers
+   * enforcing a freshness window must treat that as expired. */
+  createdAt?: string;
 };
 
 const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {
@@ -47,9 +52,21 @@ export async function savePdfResultToCache(
     const bucket = storage.bucket(config.GCS_BUCKET_NAME);
     const blob = bucket.file(`${prefix}${objectKey}.json`);
 
+    // Only the firepdf tier enforces freshness windows; keep RunPod payloads
+    // unchanged so its callers (which return the cached object directly) never
+    // see cache bookkeeping fields.
+    const body = JSON.stringify(
+      provider === "firepdf"
+        ? ({
+            ...result,
+            createdAt: new Date().toISOString(),
+          } satisfies CachedPdfResult)
+        : result,
+    );
+
     for (let i = 0; i < 3; i++) {
       try {
-        await blob.save(JSON.stringify(result), {
+        await blob.save(body, {
           contentType: "application/json",
           metadata: {
             source: `${provider}_pdf_conversion`,
@@ -106,6 +123,31 @@ export async function getPdfResultFromCache(
 
     const [content] = await blob.download();
     const result = JSON.parse(content.toString());
+
+    // Entries written before createdAt was stamped into the body: recover the
+    // parse time from the object itself so freshness windows apply to the
+    // whole corpus, not just new writes. On failure createdAt stays undefined
+    // and window-enforcing callers treat the entry as expired (fail-fresh).
+    // Only the firepdf tier enforces freshness — don't tax the legacy RunPod
+    // path with an extra metadata request it never uses. The extra HEAD on
+    // unstamped firepdf hits is transient by construction: every legacy entry
+    // either expires within the freshness window (and its re-parse writes a
+    // stamped body) or ages out entirely, and the sequential cost is dwarfed
+    // by the parse it avoids.
+    if (provider === "firepdf" && typeof result.createdAt !== "string") {
+      try {
+        const [objectMetadata] = await blob.getMetadata();
+        if (typeof objectMetadata.timeCreated === "string") {
+          result.createdAt = objectMetadata.timeCreated;
+        }
+      } catch (error) {
+        logger.warn(`Failed to read PDF cache entry metadata for age`, {
+          error,
+          cacheKey,
+          provider,
+        });
+      }
+    }
 
     logger.info(`Retrieved PDF result from GCS cache`, {
       cacheKey,

--- a/apps/api/src/lib/gcs-pdf-cache.ts
+++ b/apps/api/src/lib/gcs-pdf-cache.ts
@@ -24,6 +24,10 @@ type CachedPdfResult = {
    * timeCreated. Undefined only when that fallback also failed — callers
    * enforcing a freshness window must treat that as expired. */
   createdAt?: string;
+  /** fire-pdf parser quality version that produced this entry (firepdf tier
+   * only). Absent on entries written before fire-pdf surfaced it — readers
+   * treat absence as "old parser". */
+  parserVersion?: number;
 };
 
 const PROVIDER_PREFIXES: Record<PdfCacheProvider, string> = {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
@@ -16,16 +16,28 @@ vi.mock("../../../../../lib/gcs-pdf-cache", () => ({
 const getCached = vi.mocked(getPdfResultFromCache);
 const saveCached = vi.mocked(savePdfResultToCache);
 
-function makeMeta(zeroDataRetention = false) {
+function makeMeta(
+  zeroDataRetention = false,
+  { maxAge, isParse }: { maxAge?: number; isParse?: boolean } = {},
+) {
   return {
     id: "page-cache-test",
     logger: {
       info: vi.fn(),
       warn: vi.fn(),
     },
-    internalOptions: { zeroDataRetention },
+    options: { maxAge },
+    internalOptions: { zeroDataRetention, isParse },
   } as any;
 }
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// Served fixtures must carry a fresh createdAt — entries with no resolvable
+// age are deliberately treated as expired.
+const freshCreatedAt = () => new Date().toISOString();
 
 describe("FirePDF page-markdown cache capabilities", () => {
   beforeEach(() => {
@@ -189,6 +201,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       markdown: "",
       html: "",
       pageMarkdown: [{ page: 1, markdown: "" }],
+      createdAt: freshCreatedAt(),
     });
 
     const result = await tryGetCached(
@@ -241,6 +254,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
         { page: 1, markdown: "one" },
         { page: 2, markdown: "two" },
       ],
+      createdAt: freshCreatedAt(),
     });
 
     const result = await tryGetCached(
@@ -265,6 +279,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
         { page: 1, markdown: "one" },
         { page: 2, markdown: "two" },
       ],
+      createdAt: freshCreatedAt(),
     });
 
     const result = await tryGetCached(
@@ -333,6 +348,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       pagesProcessed: 1,
       pageMarkdown: [{ page: 1, markdown: "one" }],
       blocks,
+      createdAt: freshCreatedAt(),
     });
 
     const result = await tryGetCached(
@@ -432,6 +448,7 @@ describe("FirePDF page-markdown cache capabilities", () => {
       markdown: "existing",
       html: "<p>existing</p>",
       pagesProcessed: 2,
+      createdAt: freshCreatedAt(),
     });
 
     await maybeSaveResult({
@@ -503,5 +520,288 @@ describe("FirePDF page-markdown cache capabilities", () => {
       "firepdf",
       undefined,
     );
+  });
+});
+
+describe("FirePDF cache freshness window", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCached.mockResolvedValue(null);
+    saveCached.mockResolvedValue(null);
+  });
+
+  it("treats entries older than the default window as misses", async () => {
+    // Default PDF_CACHE_MAX_AGE_MS is 60d; a 100d-old entry must not serve.
+    getCached.mockResolvedValue({
+      markdown: "stale",
+      html: "<p>stale</p>",
+      createdAt: daysAgo(100),
+    });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toBeNull();
+    // Both ocr-path variants were probed and rejected on age.
+    expect(getCached).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats entries with no resolvable age as expired", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "unknown age",
+      html: "<p>unknown age</p>",
+    });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("serves entries within the default window", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "recent",
+      html: "<p>recent</p>",
+      createdAt: daysAgo(30),
+    });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toMatchObject({ markdown: "recent" });
+    expect(result).not.toHaveProperty("createdAt");
+  });
+
+  it("honors an explicit maxAge tighter than the default", async () => {
+    getCached.mockResolvedValue({
+      markdown: "week old",
+      html: "<p>week old</p>",
+      createdAt: daysAgo(7),
+    });
+
+    const result = await tryGetCached(
+      makeMeta(false, { maxAge: 24 * 60 * 60 * 1000 }),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("honors an explicit maxAge wider than the default", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "old but requested",
+      html: "<p>old but requested</p>",
+      createdAt: daysAgo(100),
+    });
+
+    const result = await tryGetCached(
+      makeMeta(false, { maxAge: 120 * 24 * 60 * 60 * 1000 }),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toMatchObject({ markdown: "old but requested" });
+  });
+
+  it("bypasses the cache entirely on maxAge: 0", async () => {
+    const result = await tryGetCached(
+      makeMeta(false, { maxAge: 0 }),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toBeNull();
+    expect(getCached).not.toHaveBeenCalled();
+  });
+
+  it("gives the parse path its own window instead of parse's synthetic maxAge: 0", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "parsed yesterday",
+      html: "<p>parsed yesterday</p>",
+      createdAt: daysAgo(1),
+    });
+
+    const result = await tryGetCached(
+      makeMeta(false, { maxAge: 0, isParse: true }),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toMatchObject({ markdown: "parsed yesterday" });
+  });
+
+  it("expires parse-path entries beyond the parse window", async () => {
+    // Default PARSE_PDF_CACHE_MAX_AGE_MS is 7d.
+    getCached.mockResolvedValue({
+      markdown: "too old for parse",
+      html: "<p>too old for parse</p>",
+      createdAt: daysAgo(10),
+    });
+
+    const result = await tryGetCached(
+      makeMeta(false, { maxAge: 0, isParse: true }),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rewrites an expired compact legacy entry during sidecar backfill", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "expired base",
+      html: "<p>expired base</p>",
+      createdAt: daysAgo(100),
+    });
+
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: true,
+      includeBlocks: false,
+      result: {
+        markdown: "whole",
+        html: "<p>whole</p>",
+        pagesProcessed: 2,
+        pageMarkdown: [
+          { page: 1, markdown: "one" },
+          { page: 2, markdown: "two" },
+        ],
+      },
+    });
+
+    expect(saveCached).toHaveBeenCalledTimes(2);
+    expect(saveCached).toHaveBeenNthCalledWith(
+      2,
+      "BASE64",
+      expect.not.objectContaining({ pageMarkdown: expect.anything() }),
+      "firepdf",
+      undefined,
+    );
+  });
+});
+
+describe("FirePDF cache degraded-result gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCached.mockResolvedValue(null);
+    saveCached.mockResolvedValue(null);
+  });
+
+  const result = {
+    markdown: "partial",
+    html: "<p>partial</p>",
+    pagesProcessed: 5,
+  };
+
+  it("does not persist results with failed pages", async () => {
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: false,
+      includeBlocks: false,
+      result,
+      failedPages: [3],
+    });
+
+    expect(saveCached).not.toHaveBeenCalled();
+  });
+
+  it("does not persist results with partial pages", async () => {
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: false,
+      includeBlocks: false,
+      result,
+      failedPages: null,
+      partialPages: [1, 2],
+    });
+
+    expect(saveCached).not.toHaveBeenCalled();
+  });
+
+  it("does not persist results whose block pages report degradation", async () => {
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: false,
+      includeBlocks: true,
+      result: {
+        ...result,
+        blocks: [
+          { page: 1, width: 800, height: 1100, status: "ok", items: [] },
+          { page: 2, width: 800, height: 1100, status: "partial", items: [] },
+        ],
+      },
+    });
+
+    expect(saveCached).not.toHaveBeenCalled();
+  });
+
+  it("persists clean results with empty/null degraded markers", async () => {
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: false,
+      includeBlocks: false,
+      result,
+      failedPages: [],
+      partialPages: null,
+    });
+
+    expect(saveCached).toHaveBeenCalledOnce();
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
@@ -572,6 +572,43 @@ describe("FirePDF cache freshness window", () => {
     expect(result).toBeNull();
   });
 
+  it("stamps parserVersion into cache writes and strips it on serve", async () => {
+    await maybeSaveResult({
+      meta: makeMeta(),
+      base64Content: "BASE64",
+      mode: "auto",
+      maxPages: undefined,
+      includePageMarkdown: false,
+      includeBlocks: false,
+      result: { markdown: "v7", html: "<p>v7</p>", pagesProcessed: 1 },
+      parserVersion: 7,
+    });
+    expect(saveCached).toHaveBeenCalledWith(
+      "BASE64",
+      expect.objectContaining({ parserVersion: 7 }),
+      "firepdf",
+      undefined,
+    );
+
+    getCached.mockResolvedValueOnce({
+      markdown: "v7",
+      html: "<p>v7</p>",
+      parserVersion: 7,
+      createdAt: freshCreatedAt(),
+    });
+    const served = await tryGetCached(
+      makeMeta(),
+      "BASE64",
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+    expect(served).toMatchObject({ markdown: "v7" });
+    expect(served).not.toHaveProperty("parserVersion");
+  });
+
   it("serves entries within the default window", async () => {
     getCached.mockResolvedValueOnce({
       markdown: "recent",

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -240,6 +240,7 @@ export async function scrapePDFWithFirePDFAsync(
     result: processorResult,
     failedPages,
     partialPages,
+    parserVersion: fetched.parser_version,
   });
 
   return processorResult;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -215,6 +215,21 @@ export async function scrapePDFWithFirePDFAsync(
     ...(fetched.blocks ? { blocks: fetched.blocks } : {}),
   };
 
+  // Degradation may be reported by the terminal poll, the result fetch, or
+  // both — union the markers so either source gates the cache write.
+  const failedPages = [
+    ...new Set([
+      ...(fetched.failed_pages ?? []),
+      ...(polled.poll.failed_pages ?? []),
+    ]),
+  ];
+  const partialPages = [
+    ...new Set([
+      ...(fetched.partial_pages ?? []),
+      ...(polled.poll.partial_pages ?? []),
+    ]),
+  ];
+
   await maybeSaveResult({
     meta,
     base64Content,
@@ -223,6 +238,8 @@ export async function scrapePDFWithFirePDFAsync(
     includePageMarkdown,
     includeBlocks,
     result: processorResult,
+    failedPages,
+    partialPages,
   });
 
   return processorResult;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
@@ -1,10 +1,16 @@
 import type { Meta } from "../../..";
 import type { PDFMode } from "../../../../../controllers/v2/types";
 import type { PDFProcessorResult } from "../types";
+import { config } from "../../../../../config";
 import {
   getPdfResultFromCache,
   savePdfResultToCache,
 } from "../../../../../lib/gcs-pdf-cache";
+import {
+  pdfCacheLookupCounter,
+  pdfCacheServedAgeDays,
+  pdfCacheWriteCounter,
+} from "./metrics";
 import { firePdfBlockPagesSchema } from "./schema";
 
 // Cache layout mirrors the sync `scrapePDFWithFirePDF` so async/sync share
@@ -119,6 +125,36 @@ export function cacheKeyShape(
   return { cacheable, ownVariant, baseVariant, lookupVariants };
 }
 
+/**
+ * Freshness window for PDF cache reads. Entries older than the window are
+ * treated as misses and re-parsed, which is how parser improvements reach
+ * documents that were first parsed long ago.
+ *
+ * - An explicit `maxAge` from the caller wins (and `maxAge: 0` is a true
+ *   bypass of this tier, matching the index tier's contract).
+ * - `/v2/parse` hard-codes `maxAge: 0` to skip the URL index — that value is
+ *   plumbing, not a customer freshness signal, so the parse path gets its own
+ *   configured window instead of an unintended full bypass.
+ */
+function resolveCacheWindowMs(meta: Meta): number {
+  if (meta.internalOptions.isParse) {
+    return config.PARSE_PDF_CACHE_MAX_AGE_MS;
+  }
+  if (meta.options?.maxAge !== undefined) {
+    return meta.options.maxAge;
+  }
+  return config.PDF_CACHE_MAX_AGE_MS;
+}
+
+function entryAgeMs(cached: { createdAt?: string }): number {
+  const createdAtMs = cached.createdAt ? Date.parse(cached.createdAt) : NaN;
+  // Unknown age (no body stamp and the GCS metadata fallback failed) reads as
+  // infinitely old: fail-fresh rather than serving an unbounded-staleness
+  // entry past the window.
+  if (!Number.isFinite(createdAtMs)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, Date.now() - createdAtMs);
+}
+
 export async function tryGetCached(
   meta: Meta,
   base64Content: string,
@@ -137,6 +173,13 @@ export async function tryGetCached(
   );
   if (!cacheable) return null;
 
+  const windowMs = resolveCacheWindowMs(meta);
+  if (windowMs <= 0) {
+    pdfCacheLookupCounter.inc({ outcome: "bypass" });
+    return null;
+  }
+
+  let sawExpired = false;
   for (const variant of lookupVariants) {
     try {
       const cached = await getPdfResultFromCache(
@@ -154,14 +197,28 @@ export async function tryGetCached(
           // never let a malformed/old artifact satisfy a cache lookup.
           continue;
         }
+        const ageMs = entryAgeMs(cached);
+        if (ageMs > windowMs) {
+          sawExpired = true;
+          continue;
+        }
+        pdfCacheLookupCounter.inc({ outcome: "hit" });
+        pdfCacheServedAgeDays.observe(ageMs / (24 * 60 * 60 * 1000));
         meta.logger.info("Using cached FirePDF result", {
           scrapeId: meta.id,
           requestedMode: mode,
           cacheVariant: variant ?? "base",
+          cacheAgeMs: Math.round(ageMs),
         });
         // Strip payloads the request didn't ask for so a richer sidecar
         // serves a poorer request without leaking extra capabilities.
-        const { pageMarkdown, blocks, ...compactCached } = cached;
+        // createdAt is cache bookkeeping, not document data.
+        const {
+          pageMarkdown,
+          blocks,
+          createdAt: _createdAt,
+          ...compactCached
+        } = cached;
         return {
           ...compactCached,
           ...(includePageMarkdown ? { pageMarkdown } : {}),
@@ -176,6 +233,7 @@ export async function tryGetCached(
       });
     }
   }
+  pdfCacheLookupCounter.inc({ outcome: sawExpired ? "expired" : "miss" });
   return null;
 }
 
@@ -187,6 +245,8 @@ export async function maybeSaveResult(args: {
   includePageMarkdown: boolean;
   includeBlocks: boolean;
   result: PDFProcessorResult & { markdown: string };
+  failedPages?: number[] | null;
+  partialPages?: number[] | null;
 }): Promise<void> {
   const {
     meta,
@@ -196,6 +256,8 @@ export async function maybeSaveResult(args: {
     includePageMarkdown,
     includeBlocks,
     result,
+    failedPages,
+    partialPages,
   } = args;
   if (meta.internalOptions.zeroDataRetention) return;
   const { cacheable, ownVariant, baseVariant } = cacheKeyShape(
@@ -206,12 +268,46 @@ export async function maybeSaveResult(args: {
   );
   if (!cacheable) return;
 
+  // Never persist a degraded parse: pages that failed or were cut short are a
+  // property of this request's conditions (fleet pressure, deadlines), not of
+  // the document. Serve the partial result, but let the next request re-parse
+  // instead of freezing the holes into the cache. Block sidecars carry their
+  // own per-page status, which can report degradation the marker arrays
+  // don't — gate on that independently.
+  const degradedBlockPages =
+    result.blocks?.filter(page => page.status !== "ok").length ?? 0;
+  if (
+    (failedPages?.length ?? 0) > 0 ||
+    (partialPages?.length ?? 0) > 0 ||
+    degradedBlockPages > 0
+  ) {
+    pdfCacheWriteCounter.inc({ outcome: "degraded_skip" });
+    meta.logger.info("Skipping FirePDF cache write for degraded result", {
+      scrapeId: meta.id,
+      failedPages: failedPages?.length ?? 0,
+      partialPages: partialPages?.length ?? 0,
+      degradedBlockPages,
+    });
+    return;
+  }
+
   try {
-    await savePdfResultToCache(base64Content, result, "firepdf", ownVariant);
+    const savedKey = await savePdfResultToCache(
+      base64Content,
+      result,
+      "firepdf",
+      ownVariant,
+    );
+    // savePdfResultToCache swallows storage errors and returns null — only
+    // count a save when an entry was actually written.
+    pdfCacheWriteCounter.inc({
+      outcome: savedKey !== null ? "saved" : "write_failed",
+    });
     // An enriched (page/block-capable) parse is also a valid legacy result.
-    // Populate the compact base key when it is missing so a later legacy
-    // request never repeats the conversion. A sidecar miss can coexist with
-    // a warm legacy key during rollout, so avoid rewriting that object.
+    // Populate the compact base key when it is missing (or aged out of the
+    // request's freshness window) so a later legacy request never repeats
+    // the conversion. A sidecar miss can coexist with a warm legacy key
+    // during rollout, so avoid rewriting a still-fresh object.
     // Strip the enriched payloads to keep the hot-path cache object small.
     if ((includePageMarkdown || includeBlocks) && ownVariant !== baseVariant) {
       const existingBase = await getPdfResultFromCache(
@@ -219,7 +315,11 @@ export async function maybeSaveResult(args: {
         "firepdf",
         baseVariant,
       );
-      if (!existingBase || !isValidCachedDocument(existingBase)) {
+      if (
+        !existingBase ||
+        !isValidCachedDocument(existingBase) ||
+        entryAgeMs(existingBase) > resolveCacheWindowMs(meta)
+      ) {
         const {
           pageMarkdown: _pageMarkdown,
           blocks: _blocks,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
@@ -209,6 +209,7 @@ export async function tryGetCached(
           requestedMode: mode,
           cacheVariant: variant ?? "base",
           cacheAgeMs: Math.round(ageMs),
+          cacheParserVersion: cached.parserVersion ?? null,
         });
         // Strip payloads the request didn't ask for so a richer sidecar
         // serves a poorer request without leaking extra capabilities.
@@ -217,6 +218,7 @@ export async function tryGetCached(
           pageMarkdown,
           blocks,
           createdAt: _createdAt,
+          parserVersion: _parserVersion,
           ...compactCached
         } = cached;
         return {
@@ -247,6 +249,9 @@ export async function maybeSaveResult(args: {
   result: PDFProcessorResult & { markdown: string };
   failedPages?: number[] | null;
   partialPages?: number[] | null;
+  /** fire-pdf parser quality version from the response that produced this
+   * result; stamped into the cache entry (older fire-pdf builds omit it). */
+  parserVersion?: number;
 }): Promise<void> {
   const {
     meta,
@@ -258,6 +263,7 @@ export async function maybeSaveResult(args: {
     result,
     failedPages,
     partialPages,
+    parserVersion,
   } = args;
   if (meta.internalOptions.zeroDataRetention) return;
   const { cacheable, ownVariant, baseVariant } = cacheKeyShape(
@@ -292,9 +298,13 @@ export async function maybeSaveResult(args: {
   }
 
   try {
+    const stampedResult = {
+      ...result,
+      ...(parserVersion !== undefined ? { parserVersion } : {}),
+    };
     const savedKey = await savePdfResultToCache(
       base64Content,
-      result,
+      stampedResult,
       "firepdf",
       ownVariant,
     );
@@ -324,7 +334,7 @@ export async function maybeSaveResult(args: {
           pageMarkdown: _pageMarkdown,
           blocks: _blocks,
           ...baseResult
-        } = result;
+        } = stampedResult;
         await savePdfResultToCache(
           base64Content,
           baseResult,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/metrics.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/metrics.ts
@@ -46,3 +46,21 @@ export type FallbackReason =
   | "terminal_cancelled"
   | "polling_timeout"
   | "result_503";
+
+export const pdfCacheLookupCounter = new Counter({
+  name: "firecrawl_pdf_cache_lookup_total",
+  help: "FirePDF result cache lookups by outcome",
+  labelNames: ["outcome"],
+});
+
+export const pdfCacheWriteCounter = new Counter({
+  name: "firecrawl_pdf_cache_write_total",
+  help: "FirePDF result cache write decisions by outcome",
+  labelNames: ["outcome"],
+});
+
+export const pdfCacheServedAgeDays = new Histogram({
+  name: "firecrawl_pdf_cache_served_age_days",
+  help: "Age in days of FirePDF cache entries served to requests",
+  buckets: [1, 3, 7, 14, 30, 60, 90, 180],
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -43,6 +43,7 @@ export const pollResponseSchema = z.object({
   pages_processed: z.number().optional(),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),
+  parser_version: z.number().optional(),
   error_class: z.string().optional(),
   error_message: z.string().optional(),
 });
@@ -125,6 +126,7 @@ export const resultResponseSchema = z.object({
   pages_processed: z.number().optional(),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),
+  parser_version: z.number().optional(),
 });
 
 export type PollResponse = z.infer<typeof pollResponseSchema>;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -140,6 +140,7 @@ export async function scrapePDFWithFirePDF(
     schema: z.object({
       markdown: z.string(),
       failed_pages: z.array(z.number()).nullable(),
+      partial_pages: z.array(z.number()).nullable().optional(),
       pages_processed: z.number().optional(),
       pages: firePdfPagesSchema,
       blocks: firePdfBlocksSchema,
@@ -186,6 +187,8 @@ export async function scrapePDFWithFirePDF(
       includePageMarkdown,
       includeBlocks,
       result: processorResult,
+      failedPages: resp.failed_pages,
+      partialPages: resp.partial_pages,
     });
   }
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/firePDF.ts
@@ -141,6 +141,7 @@ export async function scrapePDFWithFirePDF(
       markdown: z.string(),
       failed_pages: z.array(z.number()).nullable(),
       partial_pages: z.array(z.number()).nullable().optional(),
+      parser_version: z.number().optional(),
       pages_processed: z.number().optional(),
       pages: firePdfPagesSchema,
       blocks: firePdfBlocksSchema,
@@ -189,6 +190,7 @@ export async function scrapePDFWithFirePDF(
       result: processorResult,
       failedPages: resp.failed_pages,
       partialPages: resp.partial_pages,
+      parserVersion: resp.parser_version,
     });
   }
 


### PR DESCRIPTION
## Problem

The content-keyed PDF result cache had no freshness signal: an entry written once served forever, so parser improvements never reached repeat documents, `maxAge: 0` did not apply to this tier, and results with failed or partial pages were persisted and later served as complete.

## Change

- **Age stamping**: `createdAt` is stamped into cache entry bodies on save; reads on pre-existing entries fall back to the GCS object's `timeCreated`. Unresolvable age is treated as expired.
- **Parser-version stamping**: fire-pdf now surfaces a monotonic parser quality version in its results (firecrawl/fire-pdf#631); it is persisted as `parserVersion` in cache entries (stripped on serve, logged on hits). This sets up version lag as the primary staleness signal in a follow-up, with the time window as backstop. Entries from older fire-pdf builds carry no version and read as "old parser".
- **Freshness window on read**: an explicit `maxAge` wins (`maxAge: 0` is now a true bypass, matching the index tier's contract); `/v2/parse` uses `PARSE_PDF_CACHE_MAX_AGE_MS` (its hard-coded `maxAge: 0` targets the URL index, not this tier); everything else uses `PDF_CACHE_MAX_AGE_MS`. Both windows are env-tunable.
- **Degraded-result gate on write**: non-empty `failed_pages`/`partial_pages` (unioned across the async terminal poll and result fetch) or block pages with `status != "ok"` skip the cache write — the result is still served.
- **Metrics**: counters for lookup and write outcomes plus a served-age histogram.

The legacy RunPod cache tier is unchanged.

## Tests

111 pdf-engine unit tests pass (including new window, degraded-gate, and version round-trip suites); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)