### PR TITLE
chore(api): bump anydoc to 0.2.1

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-anydoc = "0.2.0"
+anydoc = "0.2.1"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"


### PR DESCRIPTION
Updates the `anydoc` dependency in `apps/api/native` from 0.2.0 to 0.2.1, which converts equations (Word, PowerPoint, OpenDocument, EPUB, RTF) to LaTeX math instead of dropping them. Verified locally with `cargo check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `anydoc` in `apps/api/native` from 0.2.0 to 0.2.1 to preserve equations by converting them to LaTeX math. Previously equations in Word, PowerPoint, OpenDocument, EPUB, and RTF were dropped; now they appear as LaTeX in extracted content, which can affect rendering and snapshots.

- Review and rollout
  - No API or config changes.
  - If consumers render or sanitize content, ensure LaTeX math is supported or escaped.
  - Update tests or snapshots that assumed equations were omitted.

<sup>Written for commit 76c5cf27757ea5e0c71313d7b25a8cde06d5e476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

