### PR TITLE
chore(api): bump anydoc to 0.2.2

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-anydoc = "0.2.1"
+anydoc = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"

--- a/apps/api/src/__tests__/snips/v2/document-converter.test.ts
+++ b/apps/api/src/__tests__/snips/v2/document-converter.test.ts
@@ -38,7 +38,7 @@ describe("Document Converter tests", () => {
   });
 
   describe("XLSX document conversion", () => {
-    const expectedMarkdown = `## Sheet1\n\n| sample file | test |\n| --- | --- |\n|  |  |\n| Name | Price |\n| iPhone | 1000 |\n| iPad | 800 |\n| Macbook | 1200 |\n\n## Sheet2\n\n|  |  |\n| --- | --- |\n| other tab |  |\n|  |  |\n| Name | Price |\n| ChatGPT | 20 |\n| Claude | 17 |\n| Perplexity | 20 |\n`;
+    const expectedMarkdown = `## Sheet1\n\n| sample file | test |\n| --- | --- |\n|  |  |\n| Name | Price |\n| iPhone | 1000 |\n| iPad | 800 |\n| Macbook | 1200 |\n\n## Sheet2\n\n|  |  |\n| --- | --- |\n| other tab |  |\n|  |  |\n| Name | Price |\n| ChatGPT | $20.00 |\n| Claude | $17.00 |\n| Perplexity | $20.00 |\n`;
 
     it("should convert XLSX document and return expected markdown", () => {
       const filePath = path.join(samplesDir, "sample.xlsx");


### PR DESCRIPTION
Updates the `anydoc` dependency in `apps/api/native` from 0.2.1 to 0.2.2, which stops escaping every `$` in text (prices came out as `\$20.00`). The xlsx converter test now expects the currency-formatted prices anydoc's own spreadsheet reader has produced since 0.2.0. Verified locally with `cargo check`.