### PR TITLE
fix(api): survive malformed percent escapes in DuckDuckGo uddg URLs

### DIFF
--- a/apps/api/src/search/v2/ddgsearch.test.ts
+++ b/apps/api/src/search/v2/ddgsearch.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanUrl } from "./ddgsearch";
+
+// silence logger.warn during tests
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("cleanUrl", () => {
+  it("decodes a valid uddg value with percent escapes", () => {
+    const href =
+      "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpath%3Fq%3Dhello%20world";
+    expect(cleanUrl(href)).toBe("https://example.com/path?q=hello world");
+  });
+
+  it("returns href unchanged when uddg is absent", () => {
+    const href = "https://example.com/some/page";
+    expect(cleanUrl(href)).toBe(href);
+  });
+
+  it("returns href unchanged when uddg is present but empty", () => {
+    const href = "https://duckduckgo.com/l/?uddg=&other=1";
+    expect(cleanUrl(href)).toBe(href);
+  });
+
+  it("returns href unchanged when uddg has a malformed percent escape (regression for #4375)", () => {
+    // %ZZ is not a valid percent escape — decodeURIComponent throws URIError.
+    const href =
+      "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%ZZbad&ia=web";
+    expect(() => cleanUrl(href)).not.toThrow();
+    expect(cleanUrl(href)).toBe(href);
+  });
+});

--- a/apps/api/src/search/v2/ddgsearch.test.ts
+++ b/apps/api/src/search/v2/ddgsearch.test.ts
@@ -35,4 +35,11 @@ describe("cleanUrl", () => {
     expect(() => cleanUrl(href)).not.toThrow();
     expect(cleanUrl(href)).toBe(href);
   });
+
+  it("returns href unchanged when the DDG redirect URL itself is unparseable", () => {
+    // `new URL` throws TypeError for an invalid absolute URL.
+    const href = "http://[bad?uddg=https%3A%2F%2Fexample.com";
+    expect(() => cleanUrl(href)).not.toThrow();
+    expect(cleanUrl(href)).toBe(href);
+  });
 });

--- a/apps/api/src/search/v2/ddgsearch.ts
+++ b/apps/api/src/search/v2/ddgsearch.ts
@@ -30,11 +30,23 @@ interface SearchOptions {
   timeout?: number;
 }
 
-function cleanUrl(href: string): string {
+export function cleanUrl(href: string): string {
   if (href.includes("uddg=")) {
     const url = new URL(href, "https://duckduckgo.com");
     const uddg = url.searchParams.get("uddg");
-    return uddg ? decodeURIComponent(uddg) : href;
+    if (!uddg) return href;
+    try {
+      return decodeURIComponent(uddg);
+    } catch (err) {
+      logger.warn(
+        "DuckDuckGo: malformed percent escape in uddg, skipping decode",
+        {
+          href,
+          error: (err as Error).message,
+        },
+      );
+      return href;
+    }
   }
   return href;
 }

--- a/apps/api/src/search/v2/ddgsearch.ts
+++ b/apps/api/src/search/v2/ddgsearch.ts
@@ -31,24 +31,24 @@ interface SearchOptions {
 }
 
 export function cleanUrl(href: string): string {
-  if (href.includes("uddg=")) {
-    const url = new URL(href, "https://duckduckgo.com");
-    const uddg = url.searchParams.get("uddg");
-    if (!uddg) return href;
-    try {
+  try {
+    if (href.includes("uddg=")) {
+      const url = new URL(href, "https://duckduckgo.com");
+      const uddg = url.searchParams.get("uddg");
+      if (!uddg) return href;
       return decodeURIComponent(uddg);
-    } catch (err) {
-      logger.warn(
-        "DuckDuckGo: malformed percent escape in uddg, skipping decode",
-        {
-          href,
-          error: (err as Error).message,
-        },
-      );
-      return href;
     }
+    return href;
+  } catch (err) {
+    logger.warn(
+      "DuckDuckGo: unparseable or malformed result URL, returning href",
+      {
+        href,
+        error: (err as Error).message,
+      },
+    );
+    return href;
   }
-  return href;
 }
 
 function extractResults(


### PR DESCRIPTION
Fixes #4375

## Problem

On self-hosted instances without SearXNG, `/v2/search` can return `200` with `success: true` and `web: []` even when DuckDuckGo extraction crashed. One malformed percent escape in a result's `uddg=` redirect URL makes `decodeURIComponent` throw `URIError` inside `cleanUrl`, which aborts extraction for the entire page.

## Root cause

`apps/api/src/search/v2/ddgsearch.ts` called `decodeURIComponent(uddg)` without guarding against malformed escapes. The throw bubbled out of `extractResults` → `ddgSearch`, was caught at the outer handler, and surfaced as an empty result set instead of an error.

## Fix

- Export `cleanUrl` for unit testing.
- Wrap `decodeURIComponent(uddg)` in try/catch; on `URIError`, log a warning and return the raw `href` so other results on the page still extract.

## Verification

From `apps/api`:

```bash
./node_modules/.bin/vitest run src/search/v2/ddgsearch.test.ts
```

Result: 4 passed (valid decode, no uddg, empty uddg, malformed `%ZZ` regression for #4375).

**Upstream preflight:** `firecrawl/firecrawl` main @ `35811c4b4`

## Risks

Low — localized to DuckDuckGo URL cleanup. Malformed URLs keep the redirect href instead of crashing the whole search.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `/v2/search` from dropping all results when a DuckDuckGo `uddg` redirect is malformed. Previously one bad percent escape or an invalid redirect URL threw and returned `success: true` with `web: []`; now we keep the original href and continue.

- Wraps the entire `cleanUrl` in try/catch to handle both `URIError` and `TypeError`.
- Logs a warning and falls back to the original href on any error.
- Exports `cleanUrl` and adds tests for valid, missing, empty, malformed `uddg`, and invalid DuckDuckGo redirect URLs.
- Valid URLs remain unchanged.

<sup>Written for commit f9ebd657f7e0df999d111928d5ef9d1282d1125a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

