### PR TITLE
fix(js-sdk): don't auto-paginate crawl/batch status while job is running

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -30,6 +30,18 @@ describe("JS SDK v2 pagination", () => {
     expect(res.next).toBeNull();
   });
 
+  test("crawl: default autoPaginate does not block while status is non-terminal", async () => {
+    let calls = 0;
+    const http = makeHttp(() => {
+      calls += 1;
+      return { status: 200, data: { success: true, status: "scraping", completed: 1, total: 3, next: calls < 5 ? `https://api/n${calls}` : null, data: [{ markdown: `p${calls}` }] } };
+    });
+    const res = await getCrawlStatus(http, "job1");
+    expect(res.data.length).toBe(1);
+    expect(res.next).toBe("https://api/n1");
+    expect(calls).toBe(1);
+  });
+
   test("crawl: respects maxPages and maxResults", async () => {
     const first = { status: 200, data: { success: true, status: "completed", completed: 1, total: 10, next: "https://api/n1", data: [{ markdown: "a" }] } };
     const page = (n: number) => ({ status: 200, data: { success: true, next: n < 3 ? `https://api/n${n + 1}` : null, data: [{ markdown: `p${n}` }] } });
@@ -55,6 +67,18 @@ describe("JS SDK v2 pagination", () => {
     const res = await getBatchScrapeStatus(http, "jobB");
     expect(res.data.length).toBe(3);
     expect(res.next).toBeNull();
+  });
+
+  test("batch: default autoPaginate does not block while status is non-terminal", async () => {
+    let calls = 0;
+    const http = makeHttp(() => {
+      calls += 1;
+      return { status: 200, data: { success: true, status: "scraping", completed: 1, total: 3, next: calls < 5 ? `https://api/b${calls}` : null, data: [{ markdown: `p${calls}` }] } };
+    });
+    const res = await getBatchScrapeStatus(http, "jobB");
+    expect(res.data.length).toBe(1);
+    expect(res.next).toBe("https://api/b1");
+    expect(calls).toBe(1);
   });
 
   test("batch: autoPaginate=false returns next", async () => {

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -91,7 +91,8 @@ export async function getBatchScrapeStatus(
       throwForBadResponse(res, "get batch scrape status");
     const body = res.data;
     const initialDocs = (body.data || []) as Document[];
-    const auto = pagination?.autoPaginate ?? true;
+    const isTerminal = ["completed", "failed", "cancelled"].includes(body.status);
+    const auto = pagination?.autoPaginate ?? isTerminal;
     if (!auto || !body.next) {
       return {
         id: jobId,

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -75,7 +75,8 @@ export async function getCrawlStatus(
     const body = res.data;
     const initialDocs = (body.data || []) as Document[];
 
-    const auto = pagination?.autoPaginate ?? true;
+    const isTerminal = ["completed", "failed", "cancelled"].includes(body.status);
+    const auto = pagination?.autoPaginate ?? isTerminal;
     if (!auto || !body.next) {
       return {
         id: jobId,


### PR DESCRIPTION
## Summary

Fixes #4374.

`getCrawlStatus()` (and the identically-shaped `getBatchScrapeStatus()`) defaulted `autoPaginate` to `true` unconditionally. When called against a job that is still running, it follows the `next` cursor while the job keeps producing new pages, so a single status check turns into a call that blocks for the lifetime of the job.

`autoPaginate` now defaults to `true` only once the job's status is terminal (`completed` / `failed` / `cancelled`). While the job is still running, the first page is returned immediately along with the `next` cursor, exactly like passing `autoPaginate: false` explicitly. Once the job reaches a terminal status, the previous (blocking-until-done, i.e. never in practice) default behavior of aggregating all pages is unchanged.

This is the same class of bug in `getBatchScrapeStatus`, so it received the identical fix for consistency — both call sites share the exact same pagination logic.

## Root cause

`apps/js-sdk/firecrawl/src/v2/methods/crawl.ts:78` and the equivalent line in `batch.ts`:

```ts
const auto = pagination?.autoPaginate ?? true;
```

## Fix

```ts
const isTerminal = ["completed", "failed", "cancelled"].includes(body.status);
const auto = pagination?.autoPaginate ?? isTerminal;
```

## Test plan

Added two unit tests to `src/__tests__/unit/v2/pagination.test.ts` (one for crawl, one for batch) asserting that when `getCrawlStatus`/`getBatchScrapeStatus` is called with default options against a job whose status is non-terminal (`scraping`), only a single HTTP call is made and the returned `next` cursor is preserved rather than followed.

Verified the tests fail without the fix (checked out the pre-fix source, kept the new tests):

```
✕ crawl: default autoPaginate does not block while status is non-terminal
    expect(received).toBe(expected) // Object.is equality
    Expected: 1
    Received: 5
✕ batch: default autoPaginate does not block while status is non-terminal
    expect(received).toBe(expected) // Object.is equality
    Expected: 1
    Received: 5

Test Suites: 1 failed, 1 total
Tests:       2 failed, 9 passed, 11 total
```

And pass with the fix applied:

```
PASS src/__tests__/unit/v2/pagination.test.ts
  JS SDK v2 pagination
    ✓ crawl: autoPaginate=false returns next (3 ms)
    ✓ crawl: default autoPaginate aggregates and nulls next (1 ms)
    ✓ crawl: default autoPaginate does not block while status is non-terminal (1 ms)
    ✓ crawl: respects maxPages and maxResults
    ✓ batch: default autoPaginate aggregates and nulls next (1 ms)
    ✓ batch: default autoPaginate does not block while status is non-terminal
    ✓ batch: autoPaginate=false returns next
    ✓ monitor check: default autoPaginate aggregates pages and nulls next (1 ms)
    ✓ monitor check: autoPaginate=false returns next (1 ms)
    ✓ crawl: maxWaitTime stops pagination after first page (1 ms)
    ✓ batch: maxWaitTime stops pagination after first page

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
```

Also ran the full unit suite (`src/__tests__/unit/v2/*.test.ts`) before and after the change: 106/119 pass after (104/117 before, i.e. +2 for the new tests), with the same 13 pre-existing failures in unrelated files (`v1-aliases.test.ts`, `search-data-property.test.ts`, `scrape.unit.test.ts`, etc. — all `ReferenceError: jest is not defined` or an unrelated constructor-validation assertion) present identically on unmodified `main`.

Ran `tsc --noEmit`: same pre-existing type errors in `feedback.ts`, `monitor.ts`, and `validation.ts` present identically on unmodified `main`; nothing new introduced by this change.

## AI assistance disclosure

This change was authored by an autonomous coding agent (Claude).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `getCrawlStatus` and `getBatchScrapeStatus` from auto-paginating while a job is running so status checks return promptly. Previously they always auto-paginated, which could block for the job’s lifetime as new pages appeared.

- New default: `autoPaginate` is true only for terminal statuses (`completed`, `failed`, `cancelled`). Running jobs return the first page and the `next` cursor.
- Migration: If you relied on the previous blocking behavior for in-progress jobs, pass `pagination: { autoPaginate: true }`.
- Applied the same logic to both methods and added unit tests covering the non-terminal case.

<sup>Written for commit f3a57cdd8205e7031b81f0420c6d66a0876e4968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

