### PR TITLE
fix(api/monitor): accept integration field in create/update body

### DIFF
--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -137,9 +137,10 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
   });
 
   it("still rejects an empty patch body once integration is declared", async () => {
-    // `integration` carries a .transform() on the create path, which fires even
-    // when the key is absent. Left unoverridden on the update schema it would
-    // materialize `integration: null` on every PATCH and defeat the
+    // Guards the reason `integration` is declared without the
+    // .transform(val => val || null) the sibling v2 schemas carry: that
+    // transform fires even on an absent key, so inherited through .partial() it
+    // would materialize `integration: null` on every PATCH and defeat this
     // "Update body cannot be empty" guard.
     const create = await monitorCreateRaw(
       {

--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -93,6 +93,77 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
     await monitorDeleteRaw(id, identity);
   });
 
+  it("accepts an integration field in the create body", async () => {
+    const create = await monitorCreateRaw(
+      {
+        name: "integration monitor",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        targets: [
+          {
+            type: "scrape",
+            urls: [createTestIdUrl()],
+          },
+        ],
+        integration: "dify",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      identity,
+    );
+
+    expect(create.statusCode).toBe(200);
+    expect(create.body.success).toBe(true);
+    await monitorDeleteRaw(create.body.data.id, identity);
+  });
+
+  it("rejects an unknown integration value", async () => {
+    const create = await monitorCreateRaw(
+      {
+        name: "bad integration monitor",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        targets: [
+          {
+            type: "scrape",
+            urls: [createTestIdUrl()],
+          },
+        ],
+        integration: "not-a-real-integration",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      identity,
+    );
+
+    expect(create.statusCode).toBe(400);
+    expect(create.body.success).toBe(false);
+  });
+
+  it("still rejects an empty patch body once integration is declared", async () => {
+    // `integration` carries a .transform() on the create path, which fires even
+    // when the key is absent. Left unoverridden on the update schema it would
+    // materialize `integration: null` on every PATCH and defeat the
+    // "Update body cannot be empty" guard.
+    const create = await monitorCreateRaw(
+      {
+        name: "empty patch monitor",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        targets: [
+          {
+            type: "scrape",
+            urls: [createTestIdUrl()],
+          },
+        ],
+      },
+      identity,
+    );
+    expect(create.statusCode).toBe(200);
+    const id = create.body.data.id;
+
+    const patch = await monitorPatchRaw(id, {}, identity);
+    expect(patch.statusCode).toBe(400);
+    expect(patch.body.success).toBe(false);
+
+    await monitorDeleteRaw(id, identity);
+  });
+
   it("still rejects unknown keys in the create body", async () => {
     const create = await monitorCreateRaw(
       {

--- a/apps/api/src/services/monitoring/types.ts
+++ b/apps/api/src/services/monitoring/types.ts
@@ -4,6 +4,7 @@ import {
   URL as urlSchema,
   type ScrapeOptions,
 } from "../../controllers/v2/types";
+import { integrationSchema } from "../../utils/integration";
 import { createWebhookSchema } from "../webhook/schema";
 import { parseMonitorScheduleText } from "./cron";
 
@@ -197,6 +198,10 @@ const createMonitorBaseSchema = z.strictObject({
   goal: z.string().max(2000).nullish(),
   judgeEnabled: z.boolean().optional(),
   origin: z.string().optional().prefault("api"),
+  // Declared for the same reason as `origin` above (see 4d2f303e): clients
+  // tag requests with `integration`, every other v2 request schema accepts
+  // it, and this schema is strict -- so omitting it 400s the whole request.
+  integration: integrationSchema.optional().transform(val => val || null),
 });
 
 function requireGoalForSearchTargets(
@@ -261,6 +266,9 @@ export const updateMonitorSchema = createMonitorBaseSchema
     retentionDays: z.number().int().positive().max(365).optional(),
     // Drop the create-path .prefault("api") so an empty PATCH stays empty (the guard below fires).
     origin: z.string().optional(),
+    // Same reason: the create-path .transform() fires even when the key is absent,
+    // which would materialize `integration: null` on every PATCH and defeat the guard.
+    integration: integrationSchema.optional(),
   })
   .superRefine(rejectGoalClearedWithSearchTargets)
   .refine(x => Object.keys(x).length > 0, "Update body cannot be empty");

--- a/apps/api/src/services/monitoring/types.ts
+++ b/apps/api/src/services/monitoring/types.ts
@@ -201,7 +201,11 @@ const createMonitorBaseSchema = z.strictObject({
   // Declared for the same reason as `origin` above (see 4d2f303e): clients
   // tag requests with `integration`, every other v2 request schema accepts
   // it, and this schema is strict -- so omitting it 400s the whole request.
-  integration: integrationSchema.optional().transform(val => val || null),
+  // No .transform(val => val || null) as the sibling v2 schemas carry: they
+  // read the value, this one discards it, and the transform fires even on an
+  // absent key -- which through .partial() would materialize `integration: null`
+  // on every PATCH and defeat the "Update body cannot be empty" guard below.
+  integration: integrationSchema.optional(),
 });
 
 function requireGoalForSearchTargets(
@@ -266,9 +270,6 @@ export const updateMonitorSchema = createMonitorBaseSchema
     retentionDays: z.number().int().positive().max(365).optional(),
     // Drop the create-path .prefault("api") so an empty PATCH stays empty (the guard below fires).
     origin: z.string().optional(),
-    // Same reason: the create-path .transform() fires even when the key is absent,
-    // which would materialize `integration: null` on every PATCH and defeat the guard.
-    integration: integrationSchema.optional(),
   })
   .superRefine(rejectGoalClearedWithSearchTargets)
   .refine(x => Object.keys(x).length > 0, "Update body cannot be empty");


### PR DESCRIPTION
Refs #4054

## Problem

`/v2/monitor` rejects requests that carry an `integration` field, while every
other v2 endpoint accepts it.

`createMonitorSchema` is a `z.strictObject`, and unlike ~14 other v2 request
schemas it does not declare `integration`
(`apps/api/src/controllers/v2/types.ts:1019` and friends). `IntegrationEnum`'s
first member is `DIFY = "dify"` (`apps/api/src/utils/integration.ts:4`), so a
client that tags its requests the way the rest of the API expects gets a 400
from this one endpoint.

This is the same omission `4d2f303e` fixed for `origin`, one field later. That
commit's message describes the identical failure mode:

> Every other v2 endpoint declares `origin: ...` on its request schema, but the
> monitor schema used `z.strictObject` without it. SDKs auto-inject `origin`
> into POST bodies ... which caused `/v2/monitor` to reject with
> `Unrecognized key: "origin"`.

It is a strong candidate for the cause of #4054, where Dify's Create Monitor
returns 400 while List Monitor Checks works on the same credentials. I have not
been able to confirm the exact body Dify sends, so this is stated as the likely
cause rather than a proven one — but the field belongs on the schema either way,
for consistency with the rest of v2.

## Change

- `createMonitorBaseSchema`: add
  `integration: integrationSchema.optional().transform(val => val || null)`,
  matching the sibling v2 schemas.
- `updateMonitorSchema`: override it as `integrationSchema.optional()`.

The override is the non-obvious part. The create-path `.transform()` fires even
when the key is **absent**, so inherited through `.partial()` it materializes
`integration: null` on every PATCH and defeats the
`"Update body cannot be empty"` guard. That is the same trap already documented
in this file for `origin` and `notification`. Verified both ways:

| case | without override | with override |
|---|---|---|
| `PATCH {}` | **parses OK** (guard defeated) | rejected, "Update body cannot be empty" |
| `PATCH {status:"paused"}` | keys `["integration","status"]` | keys `["status"]` |

Like `origin`, the value is accepted and not persisted — the monitor store does
not read it.

## Tests

Three E2E cases in `snips/v2/monitor.test.ts`: create accepts `integration`,
create rejects an unknown integration value, and an empty PATCH is still
rejected (the regression guard for the trap above).

## Verification

`tsc --noEmit` clean on both changed files; `knip` exits 0. The schema behaviour
above was exercised directly against the real `createMonitorSchema` /
`updateMonitorSchema`. The three E2E cases need a live server and have not been
run locally — leaving those to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts an `integration` field on `/v2/monitor` create and update, aligning with other v2 endpoints and preventing 400s when clients include it. Previously the endpoint rejected bodies with `integration`; now both paths accept the field but do not persist it.

- Schema: add `integration: integrationSchema.optional()` to `createMonitorBaseSchema` with no transform, so PATCH does not materialize the key and the "empty update body" guard still works.
- Behavior: unknown `integration` value returns 400; known values are accepted and ignored; unknown keys remain rejected; empty `PATCH {}` is still rejected.
- Tests: E2E cases for create with `integration`, invalid `integration`, and empty PATCH rejection.
- Migration: none. Clients may include `integration` in monitor create/update as with other v2 endpoints.

<sup>Written for commit e00d727cf9c3267b25cea56ae8b6eedb58bcccac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

