### PR TITLE
fix(api): report which field failed validation instead of "Bad Request"

### DIFF
--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -114,6 +114,83 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
     expect(create.body.success).toBe(false);
   });
 
+  // Issue #4054: every zod code other than a top-level unrecognized key or a
+  // leading custom refinement used to collapse to the bare string "Bad Request",
+  // so a third-party client had nothing to act on. These pin the message, not
+  // just the status.
+  it("names the offending target field rather than returning a bare Bad Request", async () => {
+    const create = await monitorCreateRaw(
+      {
+        name: "wrong target shape",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        targets: [
+          {
+            type: "scrape",
+            // `url` where the scrape target wants `urls`
+            url: createTestIdUrl(),
+          },
+        ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      identity,
+    );
+
+    expect(create.statusCode).toBe(400);
+    expect(create.body.success).toBe(false);
+    expect(create.body.error).not.toBe("Bad Request");
+    expect(create.body.error).toContain("targets.0.urls");
+    // The crawl branch only failed on its discriminator; surfacing it would send
+    // the caller after a field they never meant to set.
+    expect(create.body.error).not.toContain('expected "crawl"');
+  });
+
+  it("names the offending field for a top-level type mismatch", async () => {
+    const create = await monitorCreateRaw(
+      {
+        name: "wrong retention type",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        targets: [
+          {
+            type: "scrape",
+            urls: [createTestIdUrl()],
+          },
+        ],
+        retentionDays: "30",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      identity,
+    );
+
+    expect(create.statusCode).toBe(400);
+    expect(create.body.success).toBe(false);
+    expect(create.body.error).not.toBe("Bad Request");
+    expect(create.body.error).toContain("retentionDays");
+  });
+
+  it("names the offending field inside a search target", async () => {
+    const create = await monitorCreateRaw(
+      {
+        name: "bad search window",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        goal: "track launches",
+        targets: [
+          {
+            type: "search",
+            queries: ["firecrawl"],
+            searchWindow: "3d",
+          },
+        ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      identity,
+    );
+
+    expect(create.statusCode).toBe(400);
+    expect(create.body.success).toBe(false);
+    expect(create.body.error).not.toBe("Bad Request");
+    expect(create.body.error).toContain("searchWindow");
+  });
+
   it("rejects cron schedules under 15 minutes", async () => {
     const response = await monitorCreateRaw(
       {

--- a/apps/api/src/__tests__/snips/v2/parsers.test.ts
+++ b/apps/api/src/__tests__/snips/v2/parsers.test.ts
@@ -292,7 +292,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers.0");
       },
       scrapeTimeout,
     );
@@ -310,7 +311,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers");
       },
       scrapeTimeout,
     );
@@ -328,7 +330,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers");
       },
       scrapeTimeout,
     );
@@ -346,7 +349,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers.0.maxPages");
       },
       scrapeTimeout,
     );
@@ -364,7 +368,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers.0.maxPages");
       },
       scrapeTimeout,
     );
@@ -382,7 +387,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers.0.mode");
       },
       scrapeTimeout,
     );
@@ -400,7 +406,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers.0.pages");
       },
       scrapeTimeout,
     );
@@ -418,7 +425,8 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE)("Parsers parameter tests", () => {
 
         expect(raw.statusCode).toBe(400);
         expect(raw.body.success).toBe(false);
-        expect(raw.body.error).toBe("Bad Request");
+        expect(raw.body.error).not.toBe("Bad Request");
+        expect(raw.body.error).toContain("parsers.0");
       },
       scrapeTimeout,
     );

--- a/apps/api/src/__tests__/snips/v2/system-prompt-rejection.test.ts
+++ b/apps/api/src/__tests__/snips/v2/system-prompt-rejection.test.ts
@@ -42,7 +42,8 @@ describeIf(TEST_PRODUCTION || (HAS_AI && ALLOW_TEST_SUITE_WEBSITE))(
 
         expect(response.statusCode).toBe(400);
         expect(response.body.success).toBe(false);
-        expect(response.body.error).toBe("Bad Request");
+        expect(response.body.error).not.toBe("Bad Request");
+        expect(response.body.error).toContain("systemPrompt");
       },
       scrapeTimeout,
     );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./controllers/v1/types";
 import { ZodError } from "zod";
 import { QueueFullError } from "./lib/queue-full-error";
+import { formatZodIssues } from "./lib/zod-error-message";
 import { v7 as uuidv7 } from "uuid";
 import { cacheableLookup } from "./scraper/scrapeURL/lib/cacheableLookup";
 import { v2Router } from "./routes/v2";
@@ -240,11 +241,15 @@ app.use(
       const strictMessage =
         "Unrecognized key in body -- please review the v2 API documentation for request body changes";
 
+      // Anything that isn't a top-level unrecognized key or a leading custom
+      // refinement used to collapse to the bare string "Bad Request", leaving
+      // clients with nothing actionable -- the real issues only ever reached
+      // `details`. See issue #4054.
       const customErrorMessage = hasUnrecognizedKeys
         ? strictMessage
         : issues.length > 0 && issues[0].code === "custom"
           ? issues[0].message
-          : "Bad Request";
+          : (formatZodIssues(issues) ?? "Bad Request");
 
       res.status(400).json({
         success: false,

--- a/apps/api/src/lib/zod-error-message.test.ts
+++ b/apps/api/src/lib/zod-error-message.test.ts
@@ -68,6 +68,26 @@ describe("formatZodIssues", () => {
     expect(message).not.toContain("targets.0.urls");
   });
 
+  it("prefers the branch that got furthest into the structure", () => {
+    // No literal discriminator here, so both branches are "informative" and the
+    // discriminator rule cannot break the tie. The array branch fails at its own
+    // root (it never matched the shape); the object branch matched and is
+    // complaining about a real field, which is what the caller needs to see.
+    const schema = z.object({
+      field: z.union([
+        z.array(z.string()),
+        z.strictObject({ mode: z.enum(["a", "b"]), depth: z.number() }),
+      ]),
+    });
+
+    const message = formatZodIssues(
+      issuesFor(schema, { field: { mode: "zzz", depth: 1 } }),
+    );
+
+    expect(message).toContain("field.mode");
+    expect(message).not.toContain("expected array");
+  });
+
   it("caps the message and reports how many issues were elided", () => {
     const schema = z.object({
       a: z.string(),

--- a/apps/api/src/lib/zod-error-message.test.ts
+++ b/apps/api/src/lib/zod-error-message.test.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { formatZodIssues } from "./zod-error-message";
+
+function issuesFor(schema: z.ZodType, value: unknown) {
+  const result = schema.safeParse(value);
+  if (result.success) throw new Error("expected the parse to fail");
+  return result.error.issues;
+}
+
+describe("formatZodIssues", () => {
+  it("names the offending field for a plain type mismatch", () => {
+    const schema = z.object({ retentionDays: z.number().int() });
+    expect(formatZodIssues(issuesFor(schema, { retentionDays: "30" }))).toBe(
+      "retentionDays: Invalid input: expected number, received string",
+    );
+  });
+
+  it("descends into union branches and prefixes the union's path", () => {
+    const schema = z.object({
+      targets: z.array(
+        z.union([
+          z.strictObject({
+            type: z.literal("scrape"),
+            urls: z.array(z.string()).min(1),
+          }),
+          z.strictObject({ type: z.literal("crawl"), url: z.string() }),
+        ]),
+      ),
+    });
+
+    // The shape issue #4054 most likely hit: `url` where `urls` belongs.
+    const message = formatZodIssues(
+      issuesFor(schema, { targets: [{ type: "scrape", url: "https://a.com" }] }),
+    );
+
+    expect(message).toContain("targets.0.urls");
+    // The crawl branch only failed on its discriminator -- reporting it would
+    // send the caller after the wrong field.
+    expect(message).not.toContain('expected "crawl"');
+  });
+
+  it("does not mistake a failed enum for a branch discriminator", () => {
+    const schema = z.object({
+      targets: z.array(
+        z.union([
+          z.strictObject({
+            type: z.literal("scrape"),
+            urls: z.array(z.string()).min(1),
+          }),
+          z.strictObject({
+            type: z.literal("search"),
+            queries: z.array(z.string()).min(1),
+            window: z.enum(["1h", "24h", "7d"]),
+          }),
+        ]),
+      ),
+    });
+
+    const message = formatZodIssues(
+      issuesFor(schema, {
+        targets: [{ type: "search", queries: ["ai"], window: "3d" }],
+      }),
+    );
+
+    // `window` permits several values, so it is an ordinary field the caller got
+    // wrong -- not a discriminator disqualifying the search branch.
+    expect(message).toContain("targets.0.window");
+    expect(message).not.toContain("targets.0.urls");
+  });
+
+  it("caps the message and reports how many issues were elided", () => {
+    const schema = z.object({
+      a: z.string(),
+      b: z.string(),
+      c: z.string(),
+      d: z.string(),
+    });
+    const message = formatZodIssues(issuesFor(schema, {}));
+    expect(message).toContain("a:");
+    expect(message).toContain("b:");
+    expect(message).toContain("and 2 more validation errors");
+    expect(message).not.toContain("c:");
+  });
+
+  it("returns null when there is nothing worth showing", () => {
+    expect(formatZodIssues([])).toBeNull();
+  });
+});

--- a/apps/api/src/lib/zod-error-message.ts
+++ b/apps/api/src/lib/zod-error-message.ts
@@ -31,6 +31,30 @@ function isNonMatchingBranch(issues: readonly $ZodIssue[]): boolean {
 }
 
 /**
+ * How far into the structure a branch got before failing. A branch that failed
+ * at its own root (`expected array, received object`) never matched the input's
+ * shape; one that failed at `["mode"]` did match and is complaining about a real
+ * field. Prefer the deeper branch, so object-shaped input with a bad nested
+ * field reports that field rather than a sibling branch's shape mismatch.
+ */
+function branchDepth(issues: readonly $ZodIssue[]): number {
+  return issues.reduce((max, issue) => Math.max(max, issue.path.length), 0);
+}
+
+function pickBranch(branches: $ZodIssue[][]): $ZodIssue[] {
+  let best = branches[0];
+  let bestDepth = branchDepth(best);
+  for (const branch of branches.slice(1)) {
+    const depth = branchDepth(branch);
+    if (depth > bestDepth) {
+      best = branch;
+      bestDepth = depth;
+    }
+  }
+  return best;
+}
+
+/**
  * Flatten zod issues into `{ path, message }` pairs, descending into
  * `invalid_union` branches. Branch paths are relative to the union node, so the
  * union's own path is prefixed back on as we recurse.
@@ -51,7 +75,7 @@ function flattenIssues(
       );
       const chosen = informative.length > 0 ? informative : branches;
       if (chosen.length > 0) {
-        flattened.push(...flattenIssues(chosen[0], path));
+        flattened.push(...flattenIssues(pickBranch(chosen), path));
         continue;
       }
     }

--- a/apps/api/src/lib/zod-error-message.ts
+++ b/apps/api/src/lib/zod-error-message.ts
@@ -1,0 +1,93 @@
+import type { $ZodIssue } from "zod/v4/core";
+
+const MAX_ISSUES_IN_MESSAGE = 2;
+const MAX_MESSAGE_LENGTH = 512;
+
+function renderPath(path: PropertyKey[]): string {
+  return path.map(segment => String(segment)).join(".");
+}
+
+/**
+ * A branch that rejected the payload's literal discriminator (`type`, `format`,
+ * ...) is a branch the caller never meant to hit -- reporting "expected \"crawl\""
+ * for a payload that clearly said `"type": "scrape"` sends people after the wrong
+ * field. Such a branch is non-matching no matter what else it complains about, so
+ * test for the discriminator failure alone rather than requiring it be the only
+ * issue: a mismatched branch also reports every field it is missing.
+ */
+function isNonMatchingBranch(issues: readonly $ZodIssue[]): boolean {
+  return issues.some(
+    issue =>
+      issue.code === "invalid_value" &&
+      // A literal permits exactly one value; an enum (searchWindow, status, ...)
+      // permits several and is an ordinary field the caller got wrong, not a
+      // discriminator saying "wrong branch".
+      issue.values.length === 1 &&
+      // Depth 1 is a discriminator property (`{ type: "scrape" }`); depth 0 is a
+      // bare-literal branch (`z.literal("pdf")` beside an object form) that the
+      // payload plainly is not. Deeper than that is an ordinary nested field.
+      issue.path.length <= 1,
+  );
+}
+
+/**
+ * Flatten zod issues into `{ path, message }` pairs, descending into
+ * `invalid_union` branches. Branch paths are relative to the union node, so the
+ * union's own path is prefixed back on as we recurse.
+ */
+function flattenIssues(
+  issues: readonly $ZodIssue[],
+  basePath: PropertyKey[] = [],
+): { path: string; message: string }[] {
+  const flattened: { path: string; message: string }[] = [];
+
+  for (const issue of issues) {
+    const path = [...basePath, ...issue.path];
+
+    if (issue.code === "invalid_union") {
+      const branches = (issue.errors ?? []) as $ZodIssue[][];
+      const informative = branches.filter(
+        branch => branch.length > 0 && !isNonMatchingBranch(branch),
+      );
+      const chosen = informative.length > 0 ? informative : branches;
+      if (chosen.length > 0) {
+        flattened.push(...flattenIssues(chosen[0], path));
+        continue;
+      }
+    }
+
+    flattened.push({ path: renderPath(path), message: issue.message });
+  }
+
+  return flattened;
+}
+
+/**
+ * Build the user-facing `error` string for a zod validation failure.
+ *
+ * Every issue code other than `unrecognized_keys` and a leading `custom` used to
+ * collapse to the literal string "Bad Request", which is all a client sees --
+ * the real issues only ever reached the `details` array. See issue #4054, where
+ * a create-monitor call failed with nothing but "Bad Request" to go on.
+ *
+ * Returns null when no issue yields anything worth showing, so the caller keeps
+ * its own fallback.
+ */
+export function formatZodIssues(issues: readonly $ZodIssue[]): string | null {
+  const flattened = flattenIssues(issues).filter(x => x.message);
+  if (flattened.length === 0) return null;
+
+  const shown = flattened
+    .slice(0, MAX_ISSUES_IN_MESSAGE)
+    .map(({ path, message }) => (path ? `${path}: ${message}` : message))
+    .join("; ");
+  const remaining = flattened.length - MAX_ISSUES_IN_MESSAGE;
+  const message =
+    remaining > 0
+      ? `${shown} (and ${remaining} more validation ${remaining === 1 ? "error" : "errors"})`
+      : shown;
+
+  return message.length > MAX_MESSAGE_LENGTH
+    ? message.slice(0, MAX_MESSAGE_LENGTH - 1) + "…"
+    : message;
+}


### PR DESCRIPTION
## What

Zod validation failures returned the bare string `"Bad Request"` as the `error`
field for every issue code except a top-level `unrecognized_keys` or a leading
`custom` refinement. The real issues only ever reached `details`, which most
clients never surface. This replaces that fallback with a message that names the
offending field path.

Refs #4054, where a create-monitor call failed with nothing but "Bad Request".

| case | before | after |
|---|---|---|
| monitor target uses `url` not `urls` | `Bad Request` | `targets.0.urls: expected array, received undefined` |
| `retentionDays: "30"` | `Bad Request` | `retentionDays: expected number, received string` |
| `parsers: [{type:"pdf", maxPages:10001}]` | `Bad Request` | `parsers.0.maxPages: Too big: expected number to be <=10000` |

`status`, `code`, and `details` are unchanged. Only the `error` string changes.

## Union branch selection

`targets` is a union of three strict objects, so any malformed target produces a
single top-level `invalid_union` issue with the per-branch failures nested in
`errors: ZodIssue[][]` — which is also why the existing `unrecognized_keys`
check never fires for a bad target.

Naive flattening reports every branch, so a caller who sent `type: "scrape"` is
told the API `expected "crawl"`. The rule used here: discard a branch that fails
on an `invalid_value` with **exactly one** permitted value at depth <= 1. One
permitted value means a literal discriminator (`{ type: "scrape" }`) or a
bare-literal branch (`z.literal("pdf")` beside an object form); an enum such as
`searchWindow` permits several and is an ordinary field the caller got wrong, so
its branch is kept. If every branch is disqualified, the first is reported.

## Contract change beyond v2 (please review this part specifically)

`index.ts:226` is the single app-level `ZodError` handler, and `v0Router`,
`v1Router`, `v2Router`, `labsRouter`, `exchangeRouter` and `adminRouter` all
mount on the same app. **This changes v0 and v1 error messages too, not just v2
monitors.** Controllers that catch `ZodError` locally (`v0/scrape.ts`,
`v0/crawl.ts`, `v1/search.ts`, `v2/search.ts`, ...) are unaffected; everything
that lets the error propagate is not.

The nine tests updated below all live in `snips/v2/`, and the only `v1`
assertion on this string is commented out (`snips/v1/crawl.test.ts:390`). So the
v1 message contract moves here with no test coverage either way. That is a
deliberate call, not an oversight — flagging it for an owner decision rather
than burying it in the diff.

## Tests updated

Nine assertions pinned the literal string `"Bad Request"` — eight in
`snips/v2/parsers.test.ts`, one in `snips/v2/system-prompt-rejection.test.ts`.
They pinned a placeholder rather than a contract, which is why this shipped:
they passed while clients got nothing actionable. Each now asserts the real
field path.

Added: 3 E2E cases in `snips/v2/monitor.test.ts` (wrong target shape, top-level
type mismatch, bad `searchWindow`) and 5 unit cases for the formatter.

## Relationship to #4382

#4382 adds the missing `integration` field to the monitor schema and is the
likely *functional* fix for #4054. This PR is the reason the next such failure
will be legible instead of arriving as a bare "Bad Request". They are
independent and can merge in either order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns field-specific Zod validation messages in the `error` string instead of the generic "Bad Request", so clients get actionable 400s. Previously most Zod failures returned `"Bad Request"`; now `error` includes the offending path (for example, `targets.0.urls: expected array, received undefined`) and prefers the deepest union branch to surface the real field.

- Add `formatZodIssues` to flatten issues, recurse into `invalid_union`, discard branches that only fail a literal discriminator at depth ≤ 1, then pick the branch that got furthest into the structure (max path depth).
- Cap output to 2 issues and 512 chars, appending `(and N more validation errors)` when truncated.
- Use it in the app-level `ZodError` handler; affects v0, v1, v2, `labs`, `exchange`, and `admin` routes that let the error propagate. Controllers that catch `ZodError` locally are unchanged.
- Contract: only `error` changes; `status`, `code`, and `details` are unchanged.
- Tests: update 9 assertions that pinned `"Bad Request"`; add 3 E2E monitor cases and 5 unit tests for the formatter.
- Rollout: no schema changes. If any client code relies on the literal `"Bad Request"`, update it. Related to #4054; independent of #4382.

<sup>Written for commit 3ccbb1ec3407463b1afd784d9971b4b093531913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

