### PR TITLE
fix(api): scale research rate limits with the Autumn multiplier

### DIFF
--- a/apps/api/src/services/__tests__/rate-limiter-research.test.ts
+++ b/apps/api/src/services/__tests__/rate-limiter-research.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for research rate-limit resolution.
+ *
+ * Research was historically absent from BASE_RATE_LIMITS, so the Autumn
+ * multiplier was fetched per request and then discarded. These tests pin the
+ * multiplier-scaling behaviour and the ceiling that bounds it.
+ *
+ * ioredis is mocked so importing the module under test never opens a socket;
+ * `points` is a public field on RateLimiterRedis, so the resolved limit is
+ * asserted directly off the returned limiter.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("ioredis", () => {
+  class RedisStub {
+    on() {
+      return this;
+    }
+    defineCommand() {}
+  }
+  return { default: RedisStub, Redis: RedisStub };
+});
+
+import { getAutumnRateLimiter, getRateLimiter } from "../rate-limiter";
+import { RateLimiterMode } from "../../types";
+
+const pointsFor = (mode: RateLimiterMode, multiplier?: number) =>
+  (getAutumnRateLimiter(mode, multiplier) as unknown as { points: number })
+    .points;
+
+describe("research rate limits", () => {
+  it("leaves the free tier (x1) at its historical flat limit", () => {
+    // Regression guard: adding research to BASE_RATE_LIMITS must not move the
+    // limit for teams on the default multiplier.
+    expect(pointsFor(RateLimiterMode.Research, 1)).toBe(100);
+    expect(pointsFor(RateLimiterMode.Research)).toBe(100);
+  });
+
+  it("scales with the Autumn multiplier instead of discarding it", () => {
+    expect(pointsFor(RateLimiterMode.Research, 10)).toBe(1_000);
+    expect(pointsFor(RateLimiterMode.Research, 50)).toBe(5_000);
+  });
+
+  it("caps the multiplier-scaled limit at the research ceiling", () => {
+    // Autumn fails open at x2500 (ERROR_FALLBACK_RATE_MULTIPLIER). Research is
+    // a direct proxy with no concurrency queue, so the ceiling is the only
+    // thing standing between an Autumn outage and an unbounded limit.
+    expect(pointsFor(RateLimiterMode.Research, 2500)).toBe(10_000);
+    expect(pointsFor(RateLimiterMode.Research, 1_000_000)).toBe(10_000);
+  });
+
+  it("treats a non-positive multiplier as x1 rather than zero", () => {
+    expect(pointsFor(RateLimiterMode.Research, 0)).toBe(100);
+    expect(pointsFor(RateLimiterMode.Research, -5)).toBe(100);
+  });
+
+  it("does not cap modes that have no ceiling configured", () => {
+    // Scrape is queue-backstopped, so it keeps scaling past 10k.
+    expect(pointsFor(RateLimiterMode.Scrape, 2500)).toBe(25_000);
+  });
+
+  it("keeps the preview-token path on the static fallback table", () => {
+    expect(
+      (
+        getRateLimiter(RateLimiterMode.Research) as unknown as {
+          points: number;
+        }
+      ).points,
+    ).toBe(100);
+  });
+});

--- a/apps/api/src/services/rate-limiter.ts
+++ b/apps/api/src/services/rate-limiter.ts
@@ -59,6 +59,30 @@ const BASE_RATE_LIMITS: Partial<Record<RateLimiterMode, number>> = {
   [RateLimiterMode.BrowserExecute]: 10,
   [RateLimiterMode.CrawlStatus]: 500,
   [RateLimiterMode.ExtractStatus]: 500,
+  // Research's historical flat limit becomes its x1 base, so free-tier teams
+  // (multiplier x1) see no change while paid tiers scale like every other
+  // mode. Bounded by MAX_RATE_LIMITS: unlike scrape/crawl, research requests
+  // are a direct upstream proxy with no per-team concurrency queue behind
+  // them, so this limiter is the only per-team backstop.
+  [RateLimiterMode.Research]: 100,
+};
+
+/**
+ * Optional ceilings on `base x multiplier`, per minute. Only needed for modes
+ * that bypass the concurrency queue, where nothing else bounds a team.
+ *
+ * `getRateLimitMultiplier` fails OPEN at x2500 when Autumn is unreachable
+ * (`ERROR_FALLBACK_RATE_MULTIPLIER`). That is safe for queued modes, whose
+ * comment notes the concurrency cap still applies, but research has no such
+ * cap -- without a ceiling an Autumn outage would lift every team to
+ * 250k/min simultaneously on an unmetered endpoint.
+ *
+ * Provisional value: sized for headroom over the historical flat limit rather
+ * than derived from measured upstream capacity. Revisit once research latency
+ * and sustainable concurrency are known.
+ */
+const MAX_RATE_LIMITS: Partial<Record<RateLimiterMode, number>> = {
+  [RateLimiterMode.Research]: 10_000,
 };
 
 /**
@@ -87,6 +111,8 @@ export function getAutumnRateLimiter(
   if (base !== undefined) {
     const safeMultiplier = multiplier > 0 ? multiplier : 1;
     rateLimit = base * safeMultiplier;
+    const ceiling = MAX_RATE_LIMITS[mode];
+    if (ceiling !== undefined) rateLimit = Math.min(rateLimit, ceiling);
   } else {
     rateLimit = fallbackRateLimits?.[mode] ?? 500;
   }


### PR DESCRIPTION
## Problem

`RateLimiterMode.Research` was missing from `BASE_RATE_LIMITS`, so `getAutumnRateLimiter` took the `base === undefined` path, fell through to the static `fallbackRateLimits` table, and **discarded the multiplier it had just been handed**.

`buildAuthenticatedRateLimiter` calls `autumnService.getRateLimitMultiplier(teamId, orgId)` on every authenticated request, research included — so the value was already being fetched, just thrown away. The result:

- Every team got a flat **100/min** on research, identical on every plan tier.
- Raising a customer's multiplier visibly moved their scrape/search/map/crawl limits and silently did nothing to research — which reads as "research is broken" rather than "research isn't wired to plans."

Every other multiplier-scaled mode (scrape, map, crawl, search, extract, browser, the two status modes) already had an entry.

## Change

**1. Research joins the multiplier path.** Its historical flat limit becomes the ×1 base:

```ts
[RateLimiterMode.Research]: 100,
```

Free-tier teams are on ×1, so their effective limit is unchanged at 100/min — this is a pure addition, not a customer-visible reduction. Paid tiers now scale off the multiplier they already have, with no per-account configuration.

**2. A ceiling, because research has no queue behind it.** `getRateLimitMultiplier` fails **open** at ×2500 when Autumn is unreachable (`ERROR_FALLBACK_RATE_MULTIPLIER`). The existing comment explains why that's acceptable — "the concurrency queue cap still applies" — and it is, for queued modes.

Research isn't one. It's a direct upstream proxy with no per-team concurrency queue, so this rate limiter is the only per-team backstop. Without a bound, an Autumn outage would lift *every* team to 250k/min simultaneously on an endpoint that costs 0 credits and permits keyless access.

So `MAX_RATE_LIMITS` clamps `base × multiplier` via `Math.min`. It applies only to modes listed in the map, so every other mode's scaling is untouched:

```ts
const MAX_RATE_LIMITS: Partial<Record<RateLimiterMode, number>> = {
  [RateLimiterMode.Research]: 10_000,
};
```

**The 10,000 is provisional and the comment says so.** It's ×100 headroom over the previous flat limit, not a figure derived from measured upstream capacity. It should be revisited once research latency and sustainable concurrency are known — see the sizing note below.

## Tests

First test coverage for this module — the existing `rate-limiter.test.ts` is entirely commented out. `ioredis` is mocked so importing the module opens no socket, and the resolved limit is asserted directly off the public `points` field on `RateLimiterRedis`.

Six cases: the ×1 regression guard (free tier must not move), multiplier scaling, the ceiling under both ×2500 and an absurd multiplier, non-positive multipliers falling back to ×1, an uncapped mode continuing to scale past the ceiling, and the preview-token path still resolving through the static fallback table.

```
✓ src/services/__tests__/rate-limiter-research.test.ts (6 tests)
```

Adjacent suites pass unchanged: `auth.test.ts` (13), `autumn.service.test.ts` (61).

`tsc --noEmit` reports 18 errors, none in the touched files — identical count on a clean checkout of `main`. They are a missing native module (`@mendable/firecrawl-rs`, not built locally) and an `overageBehavior` typing error in `autumn.service.ts`, both pre-existing.

## Sizing caveat for reviewers

This raises the ceiling on requests per minute but **not** the burst shape. `RateLimiterRedis` here is a fixed-window counter with no `execEvenly` and no `blockDuration`, so a team at ×100 can still put 10,000 requests into a single second, and a fixed (rather than sliding) window permits roughly double the nominal rate across a window boundary.

That's unchanged behaviour, not a regression, but it's the reason the ceiling exists and the reason the ceiling value shouldn't be raised much further without either measuring what the index sustains or adding pacing. Note `execEvenly` delays resolution rather than rejecting, so it trades 429s for latency — a real behaviour change for a consumer, not a free win.

## Not addressed here

The `researchBeta` team flag is declared in `v1/types.ts` and `v2/types.ts` and has a live admin toggle, but the API never reads it — flipping it does nothing. Left alone deliberately to keep this diff to the limits path; it wants either wiring up or removing along with its toggle.

Closes firecrawl/search#901


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scales Research rate limits with the Autumn multiplier and adds a 10,000/min ceiling. Previously Research ignored the multiplier and was always 100/min; now free tier remains 100/min (x1) and paid tiers scale, with a cap to protect an unqueued proxy during Autumn outages.

- Adds Research to `BASE_RATE_LIMITS` at 100 (x1). Uses the provided multiplier; non-positive multipliers fall back to x1.
- Introduces `MAX_RATE_LIMITS` and clamps Research to 10,000/min. The ceiling applies only to modes listed; other modes’ scaling is unchanged.
- Preview-token path (`getRateLimiter`) still resolves via the static fallback table.
- Tests added in `apps/api/src/services/__tests__/rate-limiter-research.test.ts`; `ioredis` is mocked. Cases cover scaling, ceiling, non-positive multipliers, uncapped modes, and the preview path.
- No config or migration needed; plan multipliers now affect Research immediately.

**Review notes**
- Ceiling value is provisional; revisit after measuring Research capacity.
- Burst/window semantics are unchanged (fixed window, no pacing).

<sup>Written for commit 495c692e869253356d922a1aaf1f51a50da7ec3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

