### PR TITLE
pass autoProxy to fire-engine

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -421,6 +421,7 @@ export async function scrapeURLWithFireEngineChromeCDP(
       timeout: meta.abort.scrapeTimeout() ?? 300000,
       disableSmartWaitCache: meta.internalOptions.disableSmartWaitCache,
       mobileProxy: meta.featureFlags.has("stealthProxy"),
+      autoProxy: meta.options.proxy === "auto",
       maxAge: meta.options.maxAge,
       saveScrapeResultToGCS:
         !meta.internalOptions.zeroDataRetention &&
@@ -563,6 +564,7 @@ export async function scrapeURLWithFireEngineTLSClient(
       geolocation: meta.options.location,
       disableJsDom: meta.internalOptions.v0DisableJsDom,
       mobileProxy: meta.featureFlags.has("stealthProxy"),
+      autoProxy: meta.options.proxy === "auto",
 
       timeout: meta.abort.scrapeTimeout() ?? 300000,
       maxAge: meta.options.maxAge,

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -49,6 +49,7 @@ export type FireEngineScrapeRequestCommon = {
   geolocation?: { country?: string; languages?: string[] };
 
   mobileProxy?: boolean; // leave it undefined if user doesn't specify
+  autoProxy?: boolean;
 
   timeout?: number;
   maxAge?: number;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Passes `autoProxy` to Fire Engine so it can auto-select a proxy when the user sets `proxy="auto"`. Previously we never sent this signal, so Fire Engine could not distinguish “auto” from unset; other proxy modes remain unchanged.

- Adds optional `autoProxy?: boolean` to `FireEngineScrapeRequestCommon`.
- Sets `autoProxy` to `meta.options.proxy === "auto"` for both Chrome CDP and TLSClient paths.
- Scope: only affects jobs with `proxy="auto"`. Backward-compatible; no config or migration required.

<sup>Written for commit 2651e9e65b740de7ad9a9f03ff842e20fabb2322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

