### PR TITLE
fix(scrapeURL): budget fire-engine jobs to the waterfall wait when no timeout is set

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -239,7 +239,7 @@ const configSchema = z.object({
   SCRAPEURL_AB_HOST: z.string().optional(),
   SCRAPEURL_AB_RATE: z.coerce.number().optional(),
   SCRAPEURL_AB_EXTEND_MAXAGE: z.stringbool().optional(),
-  SCRAPEURL_ENGINE_WATERFALL_DELAY_MS: z.coerce.number().default(0),
+  SCRAPEURL_ENGINE_WATERFALL_DELAY_MS: z.coerce.number().nonnegative().default(0),
 
   // Scrape Retry Limits
   SCRAPE_MAX_ATTEMPTS: z.coerce.number().int().positive().default(6),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -240,18 +240,6 @@ const configSchema = z.object({
   SCRAPEURL_AB_RATE: z.coerce.number().optional(),
   SCRAPEURL_AB_EXTEND_MAXAGE: z.stringbool().optional(),
   SCRAPEURL_ENGINE_WATERFALL_DELAY_MS: z.coerce.number().default(0),
-  // fire-engine job budget when the caller set no scrape timeout: engine
-  // max-reasonable-time plus slack, capped.
-  SCRAPEURL_FIRE_ENGINE_TIMEOUT_SLACK_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(30000),
-  SCRAPEURL_FIRE_ENGINE_MAX_DEFAULT_TIMEOUT_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .default(300000),
 
   // Scrape Retry Limits
   SCRAPE_MAX_ATTEMPTS: z.coerce.number().int().positive().default(6),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -240,6 +240,18 @@ const configSchema = z.object({
   SCRAPEURL_AB_RATE: z.coerce.number().optional(),
   SCRAPEURL_AB_EXTEND_MAXAGE: z.stringbool().optional(),
   SCRAPEURL_ENGINE_WATERFALL_DELAY_MS: z.coerce.number().default(0),
+  // fire-engine job budget when the caller set no scrape timeout: engine
+  // max-reasonable-time plus slack, capped.
+  SCRAPEURL_FIRE_ENGINE_TIMEOUT_SLACK_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(30000),
+  SCRAPEURL_FIRE_ENGINE_MAX_DEFAULT_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(300000),
 
   // Scrape Retry Limits
   SCRAPE_MAX_ATTEMPTS: z.coerce.number().int().positive().default(6),

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/__tests__/fireEngineJobTimeout.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/__tests__/fireEngineJobTimeout.test.ts
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+
+vi.mock("@mendable/firecrawl-rs", () => ({}));
+
+import { fireEngineJobTimeout } from "..";
+import type { Meta } from "../../..";
+
+describe("fireEngineJobTimeout", () => {
+  it("budgets a scrape with no timeout to the waterfall wait plus slack, not 300s", () => {
+    const meta = {
+      abort: { scrapeTimeout: () => undefined },
+      options: { formats: [], waitFor: 0 },
+    } as unknown as Meta;
+
+    expect(fireEngineJobTimeout(meta, "chrome-cdp")).toBe(60000);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -657,7 +657,10 @@ export function fireEngineJobTimeout(
   return Math.min(
     config.SCRAPEURL_FIRE_ENGINE_MAX_DEFAULT_TIMEOUT_MS,
     fireEngineMaxReasonableTime(meta, engine) +
-      config.SCRAPEURL_FIRE_ENGINE_TIMEOUT_SLACK_MS,
+      Math.max(
+        config.SCRAPEURL_FIRE_ENGINE_TIMEOUT_SLACK_MS,
+        config.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS,
+      ),
   );
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -40,6 +40,7 @@ import { getBrandingScript } from "./brandingScript";
 import { abTestFireEngine } from "../../../../services/ab-test";
 import { scheduleABComparison } from "../../../../services/ab-test-comparison";
 import { createHash } from "node:crypto";
+import { config } from "../../../../config";
 
 /** Default wait (ms) before running the branding script when user did not set waitFor. Lets the page settle so DOM/images are ready and reduces JS errors. */
 const BRANDING_DEFAULT_WAIT_MS = 2000;
@@ -442,7 +443,7 @@ export async function scrapeURLWithFireEngineChromeCDP(
       priority: meta.internalOptions.priority,
       geolocation: meta.options.location,
       mobile: meta.options.mobile,
-      timeout: meta.abort.scrapeTimeout() ?? 300000,
+      timeout: fireEngineJobTimeout(meta, "chrome-cdp"),
       disableSmartWaitCache: meta.internalOptions.disableSmartWaitCache,
       mobileProxy: meta.featureFlags.has("stealthProxy"),
       autoProxy: meta.options.proxy === "auto",
@@ -591,7 +592,7 @@ export async function scrapeURLWithFireEngineTLSClient(
       mobileProxy: meta.featureFlags.has("stealthProxy"),
       autoProxy: meta.options.proxy === "auto",
 
-      timeout: meta.abort.scrapeTimeout() ?? 300000,
+      timeout: fireEngineJobTimeout(meta, "tlsclient"),
       maxAge: meta.options.maxAge,
       saveScrapeResultToGCS:
         !meta.internalOptions.zeroDataRetention &&
@@ -638,6 +639,26 @@ export async function scrapeURLWithFireEngineTLSClient(
       timezone: response.timezone,
     };
   });
+}
+
+/**
+ * Job budget handed to fire-engine. Without an explicit scrape timeout it
+ * follows what the waterfall waits for (max reasonable time plus slack): a
+ * longer budget only keeps a worker slot busy after the waterfall has moved on.
+ */
+export function fireEngineJobTimeout(
+  meta: Meta,
+  engine: "chrome-cdp" | "tlsclient",
+): number {
+  const explicit = meta.abort.scrapeTimeout();
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  return Math.min(
+    config.SCRAPEURL_FIRE_ENGINE_MAX_DEFAULT_TIMEOUT_MS,
+    fireEngineMaxReasonableTime(meta, engine) +
+      config.SCRAPEURL_FIRE_ENGINE_TIMEOUT_SLACK_MS,
+  );
 }
 
 export function fireEngineMaxReasonableTime(

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -650,7 +650,8 @@ export function fireEngineJobTimeout(
     meta.abort.scrapeTimeout() ??
     Math.min(
       fireEngineMaxReasonableTime(meta, engine) +
-        Math.max(30000, config.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS),
+        config.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS +
+        30000,
       300000,
     )
   );

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -40,6 +40,7 @@ import { getBrandingScript } from "./brandingScript";
 import { abTestFireEngine } from "../../../../services/ab-test";
 import { scheduleABComparison } from "../../../../services/ab-test-comparison";
 import { createHash } from "node:crypto";
+import { config } from "../../../../config";
 
 /** Default wait (ms) before running the branding script when user did not set waitFor. Lets the page settle so DOM/images are ready and reduces JS errors. */
 const BRANDING_DEFAULT_WAIT_MS = 2000;
@@ -647,7 +648,11 @@ export function fireEngineJobTimeout(
 ): number {
   return (
     meta.abort.scrapeTimeout() ??
-    Math.min(fireEngineMaxReasonableTime(meta, engine) + 30000, 300000)
+    Math.min(
+      fireEngineMaxReasonableTime(meta, engine) +
+        Math.max(30000, config.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS),
+      300000,
+    )
   );
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/index.ts
@@ -40,7 +40,6 @@ import { getBrandingScript } from "./brandingScript";
 import { abTestFireEngine } from "../../../../services/ab-test";
 import { scheduleABComparison } from "../../../../services/ab-test-comparison";
 import { createHash } from "node:crypto";
-import { config } from "../../../../config";
 
 /** Default wait (ms) before running the branding script when user did not set waitFor. Lets the page settle so DOM/images are ready and reduces JS errors. */
 const BRANDING_DEFAULT_WAIT_MS = 2000;
@@ -641,26 +640,14 @@ export async function scrapeURLWithFireEngineTLSClient(
   });
 }
 
-/**
- * Job budget handed to fire-engine. Without an explicit scrape timeout it
- * follows what the waterfall waits for (max reasonable time plus slack): a
- * longer budget only keeps a worker slot busy after the waterfall has moved on.
- */
+/** Without a scrape timeout, give fire-engine the waterfall's wait plus slack rather than 300 s. */
 export function fireEngineJobTimeout(
   meta: Meta,
   engine: "chrome-cdp" | "tlsclient",
 ): number {
-  const explicit = meta.abort.scrapeTimeout();
-  if (explicit !== undefined) {
-    return explicit;
-  }
-  return Math.min(
-    config.SCRAPEURL_FIRE_ENGINE_MAX_DEFAULT_TIMEOUT_MS,
-    fireEngineMaxReasonableTime(meta, engine) +
-      Math.max(
-        config.SCRAPEURL_FIRE_ENGINE_TIMEOUT_SLACK_MS,
-        config.SCRAPEURL_ENGINE_WATERFALL_DELAY_MS,
-      ),
+  return (
+    meta.abort.scrapeTimeout() ??
+    Math.min(fireEngineMaxReasonableTime(meta, engine) + 30000, 300000)
   );
 }
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -203,7 +203,9 @@ export async function fireEngineScrape<
     headers: {},
     body: request,
     logger: logger.child({ method: "fireEngineScrape/robustFetch" }),
-    tryCount: 3,
+    // A retried POST creates a second fire-engine job whose id is never
+    // learned, so it can't be cancelled; the waterfall retries above this.
+    tryCount: 1,
     ignoreFailureStatus: true, // sends 500 on processing and various codes on errors
     mock,
     abort,

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -203,9 +203,7 @@ export async function fireEngineScrape<
     headers: {},
     body: request,
     logger: logger.child({ method: "fireEngineScrape/robustFetch" }),
-    // A retried POST creates a second fire-engine job whose id is never
-    // learned, so it can't be cancelled; the waterfall retries above this.
-    tryCount: 1,
+    tryCount: 3,
     ignoreFailureStatus: true, // sends 500 on processing and various codes on errors
     mock,
     abort,


### PR DESCRIPTION
Crawl and batch scrapes carry no scrape timeout, so every fire-engine job they create was submitted with a flat 300 s budget and a failing URL held a worker slot for 5 minutes.

Jobs without an explicit timeout now get the engine's max reasonable time plus 30 s (60 s for a plain chrome-cdp scrape), capped at 300 s.

Watch: crawl pages that legitimately take longer than 60 s in chrome-cdp now fall to the retry engine instead of succeeding late.