### PR TITLE
fix(go-sdk): clear consumed pagination cursors

### DIFF
--- a/apps/go-sdk/firecrawl.go
+++ b/apps/go-sdk/firecrawl.go
@@ -997,9 +997,8 @@ func (c *Client) paginateCrawl(ctx context.Context, job *CrawlJob) (*CrawlJob, e
 	if job.Data == nil {
 		job.Data = []Document{}
 	}
-	current := job
-	for current.Next != "" {
-		raw, err := c.http.getAbsolute(ctx, current.Next)
+	for job.Next != "" {
+		raw, err := c.http.getAbsolute(ctx, job.Next)
 		if err != nil {
 			return nil, err
 		}
@@ -1008,7 +1007,7 @@ func (c *Client) paginateCrawl(ctx context.Context, job *CrawlJob) (*CrawlJob, e
 			return nil, &FirecrawlError{Message: fmt.Sprintf("failed to decode pagination response: %v", err)}
 		}
 		job.Data = append(job.Data, nextPage.Data...)
-		current = &nextPage
+		job.Next = nextPage.Next
 	}
 	return job, nil
 }
@@ -1017,9 +1016,8 @@ func (c *Client) paginateBatchScrape(ctx context.Context, job *BatchScrapeJob) (
 	if job.Data == nil {
 		job.Data = []Document{}
 	}
-	current := job
-	for current.Next != "" {
-		raw, err := c.http.getAbsolute(ctx, current.Next)
+	for job.Next != "" {
+		raw, err := c.http.getAbsolute(ctx, job.Next)
 		if err != nil {
 			return nil, err
 		}
@@ -1028,7 +1026,7 @@ func (c *Client) paginateBatchScrape(ctx context.Context, job *BatchScrapeJob) (
 			return nil, &FirecrawlError{Message: fmt.Sprintf("failed to decode pagination response: %v", err)}
 		}
 		job.Data = append(job.Data, nextPage.Data...)
-		current = &nextPage
+		job.Next = nextPage.Next
 	}
 	return job, nil
 }

--- a/apps/go-sdk/pagination_test.go
+++ b/apps/go-sdk/pagination_test.go
@@ -1,0 +1,85 @@
+package firecrawl
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPaginateCrawlClearsConsumedNextCursor(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/crawl/page-2":
+			_ = json.NewEncoder(w).Encode(CrawlJob{
+				Data: []Document{{Markdown: "page 2"}},
+				Next: server.URL + "/crawl/page-3",
+			})
+		case "/crawl/page-3":
+			_ = json.NewEncoder(w).Encode(CrawlJob{Data: []Document{{Markdown: "page 3"}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{
+		http: newHTTPClient("", server.URL, server.Client(), 0, 0, nil),
+	}
+	job := &CrawlJob{
+		Data: []Document{{Markdown: "page 1"}},
+		Next: server.URL + "/crawl/page-2",
+	}
+
+	result, err := client.paginateCrawl(context.Background(), job)
+	if err != nil {
+		t.Fatalf("paginateCrawl returned an error: %v", err)
+	}
+	if len(result.Data) != 3 {
+		t.Fatalf("expected 3 documents, got %d", len(result.Data))
+	}
+	if result.Next != "" {
+		t.Fatalf("expected consumed next cursor to be cleared, got %q", result.Next)
+	}
+}
+
+func TestPaginateBatchScrapeClearsConsumedNextCursor(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/batch/page-2":
+			_ = json.NewEncoder(w).Encode(BatchScrapeJob{
+				Data: []Document{{Markdown: "page 2"}},
+				Next: server.URL + "/batch/page-3",
+			})
+		case "/batch/page-3":
+			_ = json.NewEncoder(w).Encode(BatchScrapeJob{Data: []Document{{Markdown: "page 3"}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{
+		http: newHTTPClient("", server.URL, server.Client(), 0, 0, nil),
+	}
+	job := &BatchScrapeJob{
+		Data: []Document{{Markdown: "page 1"}},
+		Next: server.URL + "/batch/page-2",
+	}
+
+	result, err := client.paginateBatchScrape(context.Background(), job)
+	if err != nil {
+		t.Fatalf("paginateBatchScrape returned an error: %v", err)
+	}
+	if len(result.Data) != 3 {
+		t.Fatalf("expected 3 documents, got %d", len(result.Data))
+	}
+	if result.Next != "" {
+		t.Fatalf("expected consumed next cursor to be cleared, got %q", result.Next)
+	}
+}


### PR DESCRIPTION
## Summary

- advance the returned crawl cursor as each pagination response is consumed
- clear `Next` after automatic pagination reaches the final page
- add multi-page regression coverage for both crawl and batch scrape jobs

## Why

The Go SDK aggregated all pages for `Crawl` and `BatchScrape`, but left the first page's `Next` cursor on the returned job. Callers could therefore incorrectly conclude that more results remained, and passing the result through pagination again could append duplicate pages.

## Test plan

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears consumed pagination cursors in the Go SDK for `Crawl` and `BatchScrape` auto-pagination. This prevents duplicate pages and removes the misleading “more results” signal.

- Old: auto-pagination aggregated all pages but returned the first page’s Next cursor.
- New: the Next cursor advances each page and is empty after the final page.
- Migration: if you re-paginate the job returned by auto-pagination, remove that second pass. The Next cursor will now be empty.
- Adds regression tests for multi-page crawl and batch scrape paths.

<sup>Written for commit 8428ffd68f3638f138ad2c4f9556f14692439698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

