### PR TITLE
fix(python-sdk): add only_clean_content to v2 ScrapeOptions

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -436,3 +436,12 @@ class TestPrepareScrapeOptions:
         assert result["minAge"] == 1000
         assert "min_age" not in result
         assert result["maxAge"] == 5000
+
+    def test_prepare_only_clean_content_maps_to_camel_case(self):
+        """only_clean_content must be sent as onlyCleanContent; the server drops the snake_case key."""
+        options = ScrapeOptions(only_clean_content=True)
+
+        result = prepare_scrape_options(options)
+
+        assert result["onlyCleanContent"] is True
+        assert "only_clean_content" not in result

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -888,6 +888,7 @@ class ScrapeOptions(BaseModel):
     location: Optional["Location"] = None
     skip_tls_verification: Optional[bool] = None
     remove_base64_images: Optional[bool] = None
+    only_clean_content: Optional[bool] = None
     fast_mode: Optional[bool] = None
     use_mock: Optional[str] = None
     block_ads: Optional[bool] = None

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -561,6 +561,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
         "wait_for": "waitFor",
         "skip_tls_verification": "skipTlsVerification",
         "remove_base64_images": "removeBase64Images",
+        "only_clean_content": "onlyCleanContent",
         "fast_mode": "fastMode",
         "use_mock": "useMock",
         "block_ads": "blockAds",


### PR DESCRIPTION
## Summary

Fixes #4393.

The `onlyCleanContent` scrape option exists in the API's zod schema (`apps/api/src/controllers/v2/types.ts:759`, and v1's `types.ts:479`) and is implemented in the engine (`performCleanContent()` in `apps/api/src/scraper/scrapeURL/transformers/llmExtract.ts`, gated in `transformers/index.ts:126`), but it was missing from the Python v2 SDK's `ScrapeOptions` model.

Because `ScrapeOptions` is a Pydantic model with the default `extra="ignore"`, passing `only_clean_content=True` was silently swallowed — no error, no effect, and the key never reached the wire. This is the same failure class as the earlier `min_age` fix (#4015).

## Fix

- `apps/python-sdk/firecrawl/v2/types.py`: add `only_clean_content: Optional[bool] = None` to `ScrapeOptions`, next to its sibling `remove_base64_images`.
- `apps/python-sdk/firecrawl/v2/utils/validation.py`: add `"only_clean_content": "onlyCleanContent"` to the `field_mappings` dict in `prepare_scrape_options`, so the snake_case field is converted to the camelCase key the API expects.

Scope note: the issue also flags this option as missing from the other 8 SDKs (js/go/rust/ruby/php/java/elixir/dot-net). This PR only fixes the Python v2 SDK, matching the verified/minimal fix described in the issue; the other SDKs would need separate follow-up PRs.

## Test plan

Added a regression test mirroring the existing `test_prepare_min_age_maps_to_camel_case` pattern:

```python
def test_prepare_only_clean_content_maps_to_camel_case(self):
    """only_clean_content must be sent as onlyCleanContent; the server drops the snake_case key."""
    options = ScrapeOptions(only_clean_content=True)

    result = prepare_scrape_options(options)

    assert result["onlyCleanContent"] is True
    assert "only_clean_content" not in result
```

Verified the test fails without the fix (checked out `types.py`/`validation.py` at `HEAD~1` and reran):

```
firecrawl/__tests__/unit/v2/utils/test_validation.py::TestPrepareScrapeOptions::test_prepare_only_clean_content_maps_to_camel_case FAILED
E       KeyError: 'onlyCleanContent'
```

With the fix applied, the new test and the full unit suite pass:

```
$ python3 -m pytest firecrawl/__tests__/unit -q
472 passed in 2.44s
```

- [x] Added a failing-without-fix regression test
- [x] Full Python SDK unit suite passes (472/472)
- [x] Minimal diff: 2 source lines + 1 new test

## AI assistance disclosure

This change was prepared with AI assistance (Claude Code), including investigation, implementation, and test verification. All changes were reviewed before submission.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds only_clean_content to the Python v2 ScrapeOptions and sends it as onlyCleanContent to the API. Previously, only_clean_content was ignored by the SDK (extra="ignore"), so the server never received the option.

- Adds only_clean_content: Optional[bool] to ScrapeOptions and maps it to onlyCleanContent in prepare_scrape_options.
- Adds a regression test to ensure the snake_case field is converted and the snake_case key is not sent.
- Scope: Python v2 SDK only; other SDKs remain unchanged.

<sup>Written for commit 52c1100ed381d3fd5375ae8b0f66776e67a92e1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

