### PR TITLE
Add embedded PDF scraping support (Fixes #839)

### DIFF
--- a/apps/api/src/lib/document-formats.ts
+++ b/apps/api/src/lib/document-formats.ts
@@ -63,3 +63,13 @@ export function documentExtensionFromUrlPath(urlPath: string): string | null {
   }
   return null;
 }
+
+export function isPdfUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const path = u.pathname.toLowerCase();
+    return path.endsWith(".pdf") || path.includes(".pdf?") || path.includes(".pdf#");
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/embeddedPdf.test.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/__tests__/embeddedPdf.test.ts
@@ -1,0 +1,206 @@
+import { embeddedPdfPostprocessor, extractEmbeddedPdfUrl } from "../embeddedPdf";
+import { isPdfUrl } from "../../../../lib/document-formats";
+
+describe("isPdfUrl", () => {
+  it("returns true for direct PDF URLs", () => {
+    expect(isPdfUrl("https://example.com/document.pdf")).toBe(true);
+    expect(isPdfUrl("https://example.com/path/to/document.pdf")).toBe(true);
+  });
+
+  it("returns true for PDF URLs with query parameters", () => {
+    expect(isPdfUrl("https://example.com/document.pdf?download=1")).toBe(true);
+    expect(isPdfUrl("https://example.com/document.pdf?token=abc")).toBe(true);
+  });
+
+  it("returns true for PDF URLs with fragments", () => {
+    expect(isPdfUrl("https://example.com/document.pdf#page=1")).toBe(true);
+    expect(isPdfUrl("https://example.com/document.pdf#page=5")).toBe(true);
+  });
+
+  it("returns false for non-PDF URLs", () => {
+    expect(isPdfUrl("https://example.com/document.html")).toBe(false);
+    expect(isPdfUrl("https://example.com/document.docx")).toBe(false);
+    expect(isPdfUrl("https://example.com/document")).toBe(false);
+    expect(isPdfUrl("https://example.com/")).toBe(false);
+  });
+
+  it("returns false for invalid URLs", () => {
+    expect(isPdfUrl("not-a-url")).toBe(false);
+    expect(isPdfUrl("")).toBe(false);
+  });
+});
+
+describe("extractEmbeddedPdfUrl", () => {
+  const baseUrl = "https://example.com/page";
+
+  it("extracts PDF from iframe src", () => {
+    const html = '<iframe src="document.pdf"></iframe>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://example.com/document.pdf");
+  });
+
+  it("extracts PDF from object data", () => {
+    const html = '<object data="document.pdf"></object>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://example.com/document.pdf");
+  });
+
+  it("extracts PDF from embed src", () => {
+    const html = '<embed src="document.pdf"></embed>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://example.com/document.pdf");
+  });
+
+  it("extracts PDF from iframe with full URL", () => {
+    const html = '<iframe src="https://other.com/doc.pdf"></iframe>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://other.com/doc.pdf");
+  });
+
+  it("extracts PDF from object with relative path", () => {
+    const html = '<object data="/docs/report.pdf"></object>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://example.com/docs/report.pdf");
+  });
+
+  it("returns null for HTML without embedded PDFs", () => {
+    const html = '<div>No PDF here</div>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for iframe with non-PDF src", () => {
+    const html = '<iframe src="page.html"></iframe>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBeNull();
+  });
+
+  it("handles malformed HTML gracefully", () => {
+    const html = '<iframe src="doc.pdf">unclosed';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://example.com/doc.pdf");
+  });
+
+  it("prefers first embedded PDF found", () => {
+    const html = '<iframe src="first.pdf"></iframe><object data="second.pdf"></object>';
+    const result = extractEmbeddedPdfUrl(html, baseUrl);
+    expect(result).toBe("https://example.com/first.pdf");
+  });
+});
+
+describe("embeddedPdfPostprocessor.shouldRun", () => {
+  const baseMeta = {
+    options: { lockdown: false },
+    featureFlags: new Set(),
+  } as any;
+
+  it("returns false when already processed", () => {
+    expect(
+      embeddedPdfPostprocessor.shouldRun(
+        baseMeta,
+        new URL("https://example.com"),
+        ["embedded-pdf"],
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for lockdown", () => {
+    expect(
+      embeddedPdfPostprocessor.shouldRun(
+        { ...baseMeta, options: { lockdown: true } },
+        new URL("https://example.com"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for PDF feature flag", () => {
+    expect(
+      embeddedPdfPostprocessor.shouldRun(
+        { ...baseMeta, featureFlags: new Set(["pdf"]) },
+        new URL("https://example.com"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for normal HTML pages", () => {
+    expect(
+      embeddedPdfPostprocessor.shouldRun(
+        baseMeta,
+        new URL("https://example.com/page"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("embeddedPdfPostprocessor.run", () => {
+  const baseMeta = {
+    options: { lockdown: false },
+    featureFlags: new Set(),
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      child: () => ({ info: vi.fn(), warn: vi.fn() }),
+    },
+    url: "https://example.com/page",
+  } as any;
+
+  const baseEngineResult = {
+    url: "https://example.com/page",
+    html: '<iframe src="document.pdf"></iframe>',
+    markdown: "original page",
+  } as any;
+
+  it("returns original result when no embedded PDF found", async () => {
+    const meta = { ...baseMeta, logger: { info: vi.fn(), warn: vi.fn(), child: () => ({ info: vi.fn(), warn: vi.fn() }) } };
+    const engineResult = { ...baseEngineResult, html: "<div>No PDF</div>" };
+
+    const result = await embeddedPdfPostprocessor.run(meta, engineResult);
+    expect(result).toBe(engineResult);
+  });
+
+  it("returns original result when no HTML", async () => {
+    const meta = { ...baseMeta, logger: { info: vi.fn(), warn: vi.fn(), child: () => ({ info: vi.fn(), warn: vi.fn() }) } };
+    const engineResult = { ...baseEngineResult, html: null };
+
+    const result = await embeddedPdfPostprocessor.run(meta, engineResult);
+    expect(result).toBe(engineResult);
+  });
+
+  it("returns original result for lockdown", async () => {
+    const meta = { ...baseMeta, options: { lockdown: true }, logger: { info: vi.fn(), warn: vi.fn(), child: () => ({ info: vi.fn(), warn: vi.fn() }) } };
+
+    const result = await embeddedPdfPostprocessor.run(meta, baseEngineResult);
+    expect(result).toBe(baseEngineResult);
+  });
+
+  it("attempts to scrape embedded PDF when found", async () => {
+    // This test verifies the postprocessor correctly identifies embedded PDFs
+    // and attempts to scrape them. The actual PDF engine call is tested separately.
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      child: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        child: () => ({ info: vi.fn(), warn: vi.fn() }),
+      }),
+    };
+    const meta = {
+      ...baseMeta,
+      logger,
+      url: "https://example.com/page",
+      options: { lockdown: false },
+      featureFlags: new Set(),
+    };
+
+    const engineResult = { ...baseEngineResult };
+
+    // The postprocessor will try to call the PDF engine, which will fail
+    // in this test environment. We just verify it doesn't crash and logs appropriately.
+    const result = await embeddedPdfPostprocessor.run({ ...meta, logger }, engineResult);
+
+    // Should return original result when PDF engine fails
+    expect(result).toEqual(engineResult);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/postprocessors/embeddedPdf.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/embeddedPdf.ts
@@ -1,0 +1,113 @@
+import type { Meta } from "..";
+import type { Postprocessor } from ".";
+import type { EngineScrapeResult } from "../engines";
+import { scrapeURLWithEngine } from "../engines";
+import { isPdfUrl } from "../../../lib/document-formats";
+
+const EMBEDDED_PDF_SELECTORS = [
+  'iframe[src$=".pdf"]',
+  'object[data$=".pdf"]',
+  'embed[src$=".pdf"]',
+  'iframe[src*=".pdf"]',
+  'object[data*=".pdf"]',
+  'embed[src*=".pdf"]',
+];
+
+export function extractEmbeddedPdfUrl(html: string, baseUrl: string): string | null {
+  const lowerHtml = html.toLowerCase();
+
+  for (const selector of EMBEDDED_PDF_SELECTORS) {
+    const attr = selector.includes("iframe") ? "src" : selector.includes("object") ? "data" : "src";
+    const tag = selector.split("[")[0];
+
+    const regex = new RegExp(
+      `<${tag}[^>]*${attr}\\s*=\\s*["']([^"']*\\.pdf[^"']*)["']`,
+      "i",
+    );
+
+    const match = html.match(regex);
+    if (match?.[1]) {
+      try {
+        return new URL(match[1], baseUrl).href;
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return null;
+}
+
+export const embeddedPdfPostprocessor: Postprocessor = {
+  name: "embedded-pdf",
+  shouldRun: (meta: Meta, url: URL, postProcessorsUsed?: string[]) => {
+    if (postProcessorsUsed?.includes("embedded-pdf")) {
+      return false;
+    }
+
+    if (meta.options.lockdown) {
+      return false;
+    }
+
+    const isPdfRequest = meta.featureFlags.has("pdf");
+    if (isPdfRequest) {
+      return false;
+    }
+
+    if (meta.options.lockdown) {
+      return false;
+    }
+
+    return true;
+  },
+  run: async (meta: Meta, engineResult: EngineScrapeResult) => {
+    if (meta.options.lockdown) {
+      return engineResult;
+    }
+
+    if (!engineResult.html || typeof engineResult.html !== "string") {
+      return engineResult;
+    }
+
+    const baseUrl = engineResult.url;
+    const embeddedPdfUrl = extractEmbeddedPdfUrl(engineResult.html, baseUrl);
+
+    if (!embeddedPdfUrl || !isPdfUrl(embeddedPdfUrl)) {
+      return engineResult;
+    }
+
+    meta.logger.info("Found embedded PDF, scraping it", {
+      embeddedPdfUrl,
+      baseUrl,
+    });
+
+    try {
+      const pdfMeta = {
+        ...meta,
+        logger: meta.logger.child({ method: "embeddedPdfPostprocessor" }),
+        url: embeddedPdfUrl,
+        rewrittenUrl: embeddedPdfUrl,
+      };
+
+      const pdfResult = await scrapeURLWithEngine(pdfMeta, "pdf");
+
+      return {
+        ...engineResult,
+        markdown: pdfResult.markdown ?? engineResult.markdown,
+        html: pdfResult.html ?? engineResult.html,
+        pdfMetadata: pdfResult.pdfMetadata,
+        contentType: "application/pdf",
+        postprocessorsUsed: [
+          ...(engineResult.postprocessorsUsed ?? []),
+          "embedded-pdf",
+        ],
+      };
+    } catch (error) {
+      meta.logger.warn("Failed to scrape embedded PDF, returning original result", {
+        embeddedPdfUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return engineResult;
+    }
+  },
+};

--- a/apps/api/src/scraper/scrapeURL/postprocessors/index.ts
+++ b/apps/api/src/scraper/scrapeURL/postprocessors/index.ts
@@ -1,6 +1,7 @@
 import { Meta } from "..";
 import { EngineScrapeResult } from "../engines";
 import { youtubePostprocessor } from "./youtube";
+import { embeddedPdfPostprocessor } from "./embeddedPdf";
 
 export interface Postprocessor {
   name: string;
@@ -11,4 +12,4 @@ export interface Postprocessor {
   ) => Promise<EngineScrapeResult>;
 }
 
-export const postprocessors: Postprocessor[] = [youtubePostprocessor];
+export const postprocessors: Postprocessor[] = [youtubePostprocessor, embeddedPdfPostprocessor];


### PR DESCRIPTION
## Summary

This PR adds support for scraping embedded PDFs in web pages, addressing issue #839.

When a web page contains an embedded PDF (via `<iframe>`, `<object>`, or `<embed>` tags pointing to a PDF), Firecrawl now detects it, extracts the PDF URL, and uses the PDF engine to scrape the embedded PDF content.

## Changes

### Core Implementation
- **New postprocessor** (`embeddedPdf.ts`): Detects embedded PDFs in HTML using CSS selectors for `<iframe>`, `<object>`, and `<embed>` tags with PDF sources
- **URL extraction**: Resolves relative PDF URLs against the base page URL
- **PDF engine integration**: Uses existing PDF engine to scrape the embedded PDF content
- **Graceful fallback**: Returns original HTML result if PDF scraping fails

### New Utilities
- **`isPdfUrl()`** in `lib/document-formats.ts`: Validates if a URL points to a PDF
- **`extractEmbeddedPdfUrl()`**: Extracts first embedded PDF URL from HTML

### Tests
- `isPdfUrl`: Direct URLs, query params, fragments, non-PDF URLs, invalid URLs
- `extractEmbeddedPdfUrl`: iframe/object/embed tags, full/relative URLs, malformed HTML, multiple PDFs
- `embeddedPdfPostprocessor.shouldRun`: Lockdown, PDF flag, already processed
- `embeddedPdfPostprocessor.run`: No PDF, no HTML, lockdown, graceful degradation

## Example

```html
<!-- Before: returns HTML with iframe -->
<iframe src="document.pdf"></iframe>

<!-- After: returns extracted PDF content -->
{
  markdown: "PDF document content...",
  html: "PDF HTML content...",
  pdfMetadata: { numPages: 5, totalPages: 5, title: "Document" },
  contentType: "application/pdf"
}
```

## Backward Compatibility
- Only runs when `pdf` feature flag is not set
- Skips in lockdown mode
- Gracefully returns original result if PDF scraping fails
- Only processes first embedded PDF found

## Verification
- All new tests pass
- Existing postprocessor tests still pass
- Graceful degradation tested: returns original result on PDF engine failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrapes embedded PDFs found in HTML pages. Previously we returned the original HTML with an iframe/object/embed; now we resolve the first embedded PDF and use the PDF engine to return its markdown/html and metadata, setting contentType to application/pdf.

- Adds an `embedded-pdf` postprocessor that detects PDF URLs in iframe/object/embed attributes and resolves relative URLs; registers it in the postprocessor list.
- Uses the existing PDF engine; on failure or no match, returns the original result. Skips in lockdown and when the `pdf` feature flag is set.
- Introduces `isPdfUrl()` and `extractEmbeddedPdfUrl()` utilities with comprehensive tests.
- Processes only the first embedded PDF and tags results via postprocessorsUsed.

<sup>Written for commit 7dc406d62226d15a7edbfbb856dbdb5ecec2e295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

