### PR TITLE
fix(api): negative-cache failed spur lookups and normalize keyless ip

### DIFF
--- a/apps/api/src/__tests__/snips/v2/research.test.ts
+++ b/apps/api/src/__tests__/snips/v2/research.test.ts
@@ -66,11 +66,9 @@ function keylessHeaders(forwardedIp: string): Record<string, string> {
 // blocking KEYS scan on the shared rate-limit Redis, and stays deterministic
 // under concurrency: every parallel no-secret snip bumps the same client-IP
 // key, so the diff below still identifies exactly one bumped candidate.
-// The server keys counters on the RAW client-IP string: only keyless
-// *eligibility* strips the ::ffff: prefix (lib/keyless.ts normalizeKeylessIpv4
-// is not applied before consumeKeylessRequest/keylessTeamId), so an
-// IPv6-mapped connection legitimately produces keys like
-// `keyless_requests:::ffff:127.0.0.1`. Cover both spellings per candidate.
+// The server normalizes ::ffff:-mapped IPs to plain IPv4 before keying
+// (lib/keyless.ts normalizeKeylessIpv4, applied in auth), but keys written by
+// older builds may still carry the raw spelling, so cover both per candidate.
 function candidateKeylessIps(): string[] {
   const bare = new Set<string>(["127.0.0.1"]);
   for (const addrs of Object.values(os.networkInterfaces())) {

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -17,6 +17,7 @@ import {
   keylessExhaustionTelemetry,
   isKeylessIpEligible,
   keylessTeamId,
+  normalizeKeylessIpv4,
 } from "../lib/keyless";
 import { isKeylessIpSuspicious } from "../lib/spur";
 import { checkIpRestriction } from "../lib/ip-restriction";
@@ -458,6 +459,10 @@ async function handleKeylessAuth(
   // per-IP cap to mean anything, and malformed/forwarded values must not be
   // usable as arbitrary limiter buckets. Anything else falls through to 401.
   if (!isKeylessIpEligible(ip)) return unauthorized;
+
+  // Canonicalize `::ffff:`-mapped IPv4 so a client gets one Spur cache entry,
+  // one quota bucket, and one team id regardless of how the socket reported it.
+  ip = normalizeKeylessIpv4(ip);
 
   // Optional Spur Context check (only when SPUR_API_KEY is set): refuse keyless
   // for IPs fronting anonymizing/rotating infrastructure (VPN/proxy/TOR), the

--- a/apps/api/src/lib/__tests__/spur.test.ts
+++ b/apps/api/src/lib/__tests__/spur.test.ts
@@ -72,9 +72,34 @@ describe("Spur keyless IP reputation", () => {
 
   it("flags an IP fronting a live VPN/proxy tunnel", async () => {
     mockFetch(async () =>
-      okResponse({ ip: "1.2.3.4", tunnels: [{ type: "VPN" }] }),
+      okResponse({
+        ip: "1.2.3.4",
+        tunnels: [{ anonymous: true, type: "VPN" }],
+      }),
     );
     expect(await isKeylessIpSuspicious("1.2.3.4")).toBe(true);
+  });
+
+  it("allows a non-anonymous tunnel such as an enterprise VPN", async () => {
+    mockFetch(async () =>
+      okResponse({
+        ip: "1.2.3.14",
+        tunnels: [{ anonymous: false, operator: "ZSCALER", type: "VPN" }],
+      }),
+    );
+    expect(await isKeylessIpSuspicious("1.2.3.14")).toBe(false);
+  });
+
+  it("fails open on a malformed cached context instead of throwing", async () => {
+    store.set(
+      "spur_context:1.2.3.17",
+      JSON.stringify({ tunnels: 5, risks: "TUNNEL", client: { proxies: {} } }),
+    );
+    const fetchFn = mockFetch(async () =>
+      okResponse({ tunnels: [{ anonymous: true, type: "VPN" }] }),
+    );
+    expect(await isKeylessIpSuspicious("1.2.3.17")).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
   });
 
   it("allows a clean (datacenter-only) IP", async () => {
@@ -135,6 +160,13 @@ describe("Spur keyless IP reputation", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
+  it("stops looking up any IP once Spur reports the query balance is spent", async () => {
+    const fetchFn = mockFetch(async () => ({ ok: false, status: 429 }));
+    expect(await isKeylessIpSuspicious("1.2.3.15")).toBe(false);
+    expect(await isKeylessIpSuspicious("1.2.3.16")).toBe(false);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
   it("fails open when the Spur call throws, and retries once the negative cache expires", async () => {
     const fetchFn = mockFetch(async () => {
       throw new Error("network down");
@@ -148,7 +180,10 @@ describe("Spur keyless IP reputation", () => {
     // expiring. The lock was released, so a later call gets to fetch again.
     store.clear();
     fetchFn.mockImplementation(async () =>
-      okResponse({ ip: "1.2.3.8", tunnels: [{ type: "TOR" }] }),
+      okResponse({
+        ip: "1.2.3.8",
+        tunnels: [{ anonymous: true, type: "TOR" }],
+      }),
     );
     expect(await isKeylessIpSuspicious("1.2.3.8")).toBe(true);
     expect(fetchFn).toHaveBeenCalledTimes(2);

--- a/apps/api/src/lib/__tests__/spur.test.ts
+++ b/apps/api/src/lib/__tests__/spur.test.ts
@@ -160,13 +160,6 @@ describe("Spur keyless IP reputation", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
-  it("stops looking up any IP once Spur reports the query balance is spent", async () => {
-    const fetchFn = mockFetch(async () => ({ ok: false, status: 429 }));
-    expect(await isKeylessIpSuspicious("1.2.3.15")).toBe(false);
-    expect(await isKeylessIpSuspicious("1.2.3.16")).toBe(false);
-    expect(fetchFn).toHaveBeenCalledTimes(1);
-  });
-
   it("fails open when the Spur call throws, and retries once the negative cache expires", async () => {
     const fetchFn = mockFetch(async () => {
       throw new Error("network down");

--- a/apps/api/src/lib/__tests__/spur.test.ts
+++ b/apps/api/src/lib/__tests__/spur.test.ts
@@ -13,7 +13,12 @@ vi.mock("../logger", () => ({
 }));
 
 vi.mock("../../services/rate-limiter", () => ({
-  redisRateLimitClient: { get: vi.fn(), set: vi.fn(), eval: vi.fn() },
+  redisRateLimitClient: {
+    get: vi.fn(),
+    mget: vi.fn(),
+    set: vi.fn(),
+    eval: vi.fn(),
+  },
 }));
 
 // Minimal in-memory Redis backing the mock: enough SET semantics (NX guard,
@@ -22,6 +27,10 @@ function installFakeRedis(): Map<string, string> {
   const store = new Map<string, string>();
   (redisRateLimitClient.get as Mock).mockImplementation(async (k: string) =>
     store.has(k) ? store.get(k)! : null,
+  );
+  (redisRateLimitClient.mget as Mock).mockImplementation(
+    async (...keys: (string | string[])[]) =>
+      keys.flat().map(k => (store.has(k) ? store.get(k)! : null)),
   );
   (redisRateLimitClient.set as Mock).mockImplementation(
     async (k: string, v: string, ...args: unknown[]) => {
@@ -119,32 +128,25 @@ describe("Spur keyless IP reputation", () => {
     expect(results).toEqual([false, false, false, false, false]);
   });
 
-  it("fails open on a non-200 Spur response and negative-caches the failure", async () => {
+  it("fails open on a non-200 Spur response and does not retry within the negative-cache window", async () => {
     const fetchFn = mockFetch(async () => ({ ok: false, status: 429 }));
     expect(await isKeylessIpSuspicious("1.2.3.7")).toBe(false);
-    expect(store.get("spur_context:1.2.3.7")).toBe(
-      JSON.stringify({ __failed: true }),
-    );
-
-    // Within the negative-cache window: fail open from Redis, no upstream call.
     expect(await isKeylessIpSuspicious("1.2.3.7")).toBe(false);
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
-  it("fails open when the Spur call throws, negative-caches, and retries once the marker expires", async () => {
+  it("fails open when the Spur call throws, and retries once the negative cache expires", async () => {
     const fetchFn = mockFetch(async () => {
       throw new Error("network down");
     });
     expect(await isKeylessIpSuspicious("1.2.3.8")).toBe(false);
 
-    // The failure is remembered: a second call inside the negative-cache
-    // window never reaches Spur.
     expect(await isKeylessIpSuspicious("1.2.3.8")).toBe(false);
     expect(fetchFn).toHaveBeenCalledTimes(1);
 
-    // Simulate the negative TTL expiring (the fake redis ignores EX). The lock
-    // was released, so a later call gets to fetch again.
-    store.delete("spur_context:1.2.3.8");
+    // The fake redis ignores EX; clearing it stands in for the negative TTL
+    // expiring. The lock was released, so a later call gets to fetch again.
+    store.clear();
     fetchFn.mockImplementation(async () =>
       okResponse({ ip: "1.2.3.8", tunnels: [{ type: "TOR" }] }),
     );

--- a/apps/api/src/lib/__tests__/spur.test.ts
+++ b/apps/api/src/lib/__tests__/spur.test.ts
@@ -119,25 +119,50 @@ describe("Spur keyless IP reputation", () => {
     expect(results).toEqual([false, false, false, false, false]);
   });
 
-  it("fails open on a non-200 Spur response and caches nothing", async () => {
+  it("fails open on a non-200 Spur response and negative-caches the failure", async () => {
     const fetchFn = mockFetch(async () => ({ ok: false, status: 429 }));
     expect(await isKeylessIpSuspicious("1.2.3.7")).toBe(false);
+    expect(store.get("spur_context:1.2.3.7")).toBe(
+      JSON.stringify({ __failed: true }),
+    );
+
+    // Within the negative-cache window: fail open from Redis, no upstream call.
+    expect(await isKeylessIpSuspicious("1.2.3.7")).toBe(false);
     expect(fetchFn).toHaveBeenCalledTimes(1);
-    expect(store.has("spur_context:1.2.3.7")).toBe(false);
   });
 
-  it("fails open when the Spur call throws, and releases the lock so a later call retries", async () => {
+  it("fails open when the Spur call throws, negative-caches, and retries once the marker expires", async () => {
     const fetchFn = mockFetch(async () => {
       throw new Error("network down");
     });
     expect(await isKeylessIpSuspicious("1.2.3.8")).toBe(false);
 
-    // Lock must be freed: a subsequent call gets to fetch again.
+    // The failure is remembered: a second call inside the negative-cache
+    // window never reaches Spur.
+    expect(await isKeylessIpSuspicious("1.2.3.8")).toBe(false);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Simulate the negative TTL expiring (the fake redis ignores EX). The lock
+    // was released, so a later call gets to fetch again.
+    store.delete("spur_context:1.2.3.8");
     fetchFn.mockImplementation(async () =>
       okResponse({ ip: "1.2.3.8", tunnels: [{ type: "TOR" }] }),
     );
     expect(await isKeylessIpSuspicious("1.2.3.8")).toBe(true);
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("never looks up a non-IPv4 identity", async () => {
+    const fetchFn = mockFetch(async () =>
+      okResponse({ tunnels: [{ type: "VPN" }] }),
+    );
+    // Raw IPv6 and IPv4-mapped IPv6 both fail open without a Spur call: the
+    // call sites normalize `::ffff:` first, and raw IPv6 is too cheap to
+    // rotate for a per-IP cache to bound spend.
+    expect(await isKeylessIpSuspicious("2001:db8::1")).toBe(false);
+    expect(await isKeylessIpSuspicious("::ffff:1.2.3.4")).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(store.size).toBe(0);
   });
 
   it("a lock loser fails open within the bound when no result ever lands", async () => {

--- a/apps/api/src/lib/keyless.ts
+++ b/apps/api/src/lib/keyless.ts
@@ -43,7 +43,11 @@ const DAY_SECONDS = 86400;
 // logging. Rotation intentionally creates a new cohort namespace.
 export const KEYLESS_CONVERSION_COHORT_VERSION = "v1";
 
-function normalizeKeylessIpv4(ip: string): string {
+// Canonicalizes an IPv4-mapped IPv6 address (`::ffff:1.2.3.4`, what Node's
+// dual-stack sockets report) to plain IPv4. Every per-IP artifact (quota
+// buckets, team ids, Spur cache) must key off this form, or the same client
+// counts as two identities.
+export function normalizeKeylessIpv4(ip: string): string {
   const trimmed = ip.trim();
   const lower = trimmed.toLowerCase();
   return lower.startsWith("::ffff:") && isIPv4(trimmed.slice(7))
@@ -329,6 +333,8 @@ export async function checkKeylessEligibility(ip: string): Promise<{
   if (!ip || !isKeylessIpEligible(ip)) {
     return { eligible: false, reason: "ineligible_ip" };
   }
+  // Key the Spur cache and quota buckets below off the canonical IPv4 form.
+  ip = normalizeKeylessIpv4(ip);
   // Optional Spur Context check (only when SPUR_API_KEY is set): treat IPs on
   // anonymizing/rotating infrastructure as ineligible so the hosted MCP can
   // return a bounded recovery result instead of serving a request auth rejects.

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { isIPv4 } from "net";
 import { config } from "../config";
 import { logger } from "./logger";
 import { redisRateLimitClient } from "../services/rate-limiter";
@@ -11,15 +12,19 @@ import { redisRateLimitClient } from "../services/rate-limiter";
 // refuse keyless for them and steer the caller to sign up for an API key.
 //
 // Lookups are cached in Redis for 30 days so a given IP costs at most one Spur
-// API call per month. Concurrent misses for the same IP are collapsed with a
-// Redis single-flight lock so a burst from one IP triggers a single upstream
-// call — the loser callers briefly wait for that result instead of each hitting
-// Spur. The integration is entirely optional: with no key set the keyless tier
-// behaves exactly as before, and any Spur error (timeout, lock failure, outage)
-// fails open — the request is allowed — so Spur can never take down the free tier.
+// API call per month. Failed lookups (non-200, network error, timeout) are
+// negative-cached for a short TTL, so a failing or rate-limiting upstream is
+// re-hit at most once per IP per window instead of on every request.
+// Concurrent misses for the same IP are collapsed with a Redis single-flight
+// lock so a burst from one IP triggers a single upstream call; the loser
+// callers briefly wait for that result instead of each hitting Spur. The
+// integration is entirely optional: with no key set the keyless tier behaves
+// exactly as before, and any Spur error (timeout, lock failure, outage) fails
+// open, so Spur can never take down the free tier.
 
 const SPUR_API_BASE = "https://api.spur.us/v2/context";
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const NEGATIVE_CACHE_TTL_SECONDS = 10 * 60; // failed lookups: retry after 10 min
 const cacheKey = (ip: string) => `spur_context:${ip}`;
 
 // Everything below is bounded so a request can never get stuck on the upstream
@@ -56,10 +61,16 @@ function isSpurEnabled(): boolean {
   );
 }
 
-async function getCachedContext(ip: string): Promise<SpurContext | null> {
+// Returns "failed" when the entry is the negative-cache marker: a recent
+// lookup errored, so fail open without spending another Spur call.
+async function getCachedContext(
+  ip: string,
+): Promise<SpurContext | "failed" | null> {
   try {
     const raw = await redisRateLimitClient.get(cacheKey(ip));
-    return raw ? (JSON.parse(raw) as SpurContext) : null;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as SpurContext & { __failed?: boolean };
+    return parsed.__failed ? "failed" : parsed;
   } catch (error) {
     // Cache read failed (store down or corrupt value) — treat as a miss.
     logger.warn("Failed to read Spur context from cache", {
@@ -82,6 +93,24 @@ async function cacheContext(ip: string, ctx: SpurContext): Promise<void> {
   } catch (error) {
     // Best-effort: a failed cache write just means we look the IP up again.
     logger.warn("Failed to cache Spur context", {
+      canonicalLog: "spur/lookup",
+      ip,
+      error,
+    });
+  }
+}
+
+// Short TTL so a transient Spur outage recovers quickly.
+async function cacheFailure(ip: string): Promise<void> {
+  try {
+    await redisRateLimitClient.set(
+      cacheKey(ip),
+      JSON.stringify({ __failed: true }),
+      "EX",
+      NEGATIVE_CACHE_TTL_SECONDS,
+    );
+  } catch (error) {
+    logger.warn("Failed to negative-cache Spur lookup failure", {
       canonicalLog: "spur/lookup",
       ip,
       error,
@@ -176,24 +205,36 @@ async function waitForResult(ip: string): Promise<SpurContext | null> {
     // LOCK_WAIT_MS ceiling.
     await sleep(Math.min(POLL_INTERVAL_MS, deadline - Date.now()));
     const cached = await getCachedContext(ip);
+    // The winner's fetch failed: fail open now instead of burning the rest of
+    // the wait budget.
+    if (cached === "failed") return null;
     if (cached) return cached;
   }
   return null;
 }
 
 /**
- * Look up an IP's Spur context, preferring the 30-day Redis cache and only
- * caching successful (non-error) responses. Concurrent misses for the same IP
- * are collapsed via a Redis single-flight lock: one caller fetches, the rest
- * wait (bounded) for its result. Returns null when Spur is disabled or anything
- * goes wrong (lock error, timeout, upstream failure) — callers then fail open
- * (treat the IP as not suspicious). Every wait here is bounded, so a request can
- * never get stuck on the lock or on another request's in-flight lookup.
+ * Look up an IP's Spur context, preferring the 30-day Redis cache. Every lookup
+ * outcome is cached: successes for CACHE_TTL_SECONDS, failures (non-200,
+ * network error, timeout) as a short-TTL negative entry, so a given IP costs at
+ * most one upstream call per cache window no matter what Spur returns.
+ * Concurrent misses for the same IP are collapsed via a Redis single-flight
+ * lock: one caller fetches, the rest wait (bounded) for its result. Returns
+ * null when Spur is disabled or anything goes wrong (lock error, timeout,
+ * upstream failure); callers then fail open (treat the IP as not suspicious).
+ * Every wait here is bounded, so a request can never get stuck on the lock or
+ * on another request's in-flight lookup.
  */
 async function getSpurContext(ip: string): Promise<SpurContext | null> {
   if (!isSpurEnabled()) return null;
 
+  // Callers already gate on isKeylessIpEligible, but a call site passing raw
+  // IPv6 (rotatable per-request) would explode cache cardinality and Spur
+  // spend, so refuse non-IPv4 here too and fail open.
+  if (!isIPv4(ip)) return null;
+
   const cached = await getCachedContext(ip);
+  if (cached === "failed") return null;
   if (cached) return cached;
 
   try {
@@ -215,11 +256,22 @@ async function getSpurContext(ip: string): Promise<SpurContext | null> {
       // Another winner may have populated the cache between our miss and
       // winning the lock — re-check before spending a Spur call.
       const fresh = await getCachedContext(ip);
+      if (fresh === "failed") return null;
       if (fresh) return fresh;
 
-      const ctx = await fetchContext(ip);
-      // Only cache non-error responses.
-      if (ctx) await cacheContext(ip, ctx);
+      let ctx: SpurContext | null;
+      try {
+        ctx = await fetchContext(ip);
+      } catch (error) {
+        // Negative-cache before rethrowing so waiting losers unblock now.
+        await cacheFailure(ip);
+        throw error;
+      }
+      if (ctx) {
+        await cacheContext(ip, ctx);
+      } else {
+        await cacheFailure(ip);
+      }
       return ctx;
     } finally {
       await releaseLock(ip, token);

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -22,15 +22,16 @@ const LOCK_WAIT_MS = LOCK_TTL_MS;
 const LOCK_POLL_MS = 200;
 const CONTEXT_TTL_SEC = 30 * 24 * 60 * 60;
 const FAILED_TTL_SEC = 10 * 60;
+const EXHAUSTED_TTL_SEC = 60 * 60;
 
 const RELEASE_LOCK_SCRIPT =
   'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) end return 0';
 
 type SpurContext = {
   infrastructure?: string;
-  risks?: string[];
-  tunnels?: { anonymous?: boolean; operator?: string; type?: string }[];
-  client?: { behaviors?: string[]; proxies?: string[] };
+  risks: string[];
+  tunnels: { anonymous?: boolean; operator?: string; type?: string }[];
+  client: { proxies: string[] };
 };
 
 type CacheState =
@@ -41,6 +42,7 @@ type CacheState =
 const contextKey = (ip: string) => `spur_context:${ip}`;
 const failedKey = (ip: string) => `spur_context_failed:${ip}`;
 const lockKey = (ip: string) => `spur_lock:${ip}`;
+const EXHAUSTED_KEY = "spur_exhausted";
 
 const meta = (ip: string) => ({ canonicalLog: "spur/lookup", ip });
 
@@ -50,20 +52,40 @@ function summarize(ctx: SpurContext) {
   return {
     infrastructure: ctx.infrastructure,
     risks: ctx.risks,
-    tunnels: ctx.tunnels?.map(t => t.type),
-    proxies: ctx.client?.proxies,
+    tunnels: ctx.tunnels.map(t => t.type),
+    proxies: ctx.client.proxies,
   };
 }
 
-// DATACENTER infrastructure and GEO_MISMATCH are deliberately not signals:
-// legit users hit free tiers from cloud and CGNAT, and per-IP caps cover those.
+const strings = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter(x => typeof x === "string") : [];
+
+const objects = <T>(v: unknown): T[] =>
+  Array.isArray(v) ? v.filter(x => x && typeof x === "object") : [];
+
+// Both Redis and Spur feed this; the verdict code must never see an
+// unvalidated shape, since a throw here would fail the request closed.
+function toContext(raw: unknown): SpurContext | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+  const client = r.client as Record<string, unknown> | undefined;
+  return {
+    infrastructure:
+      typeof r.infrastructure === "string" ? r.infrastructure : undefined,
+    risks: strings(r.risks),
+    tunnels: objects(r.tunnels),
+    client: { proxies: strings(client?.proxies) },
+  };
+}
+
+// Only IP-rotation infrastructure counts. DATACENTER, GEO_MISMATCH and
+// non-anonymous tunnels (enterprise VPN, ZTNA) are legit developer traffic.
 function isSuspicious(ctx: SpurContext): boolean {
-  const risks = ctx.risks ?? [];
   return (
-    (ctx.tunnels?.length ?? 0) > 0 ||
-    (ctx.client?.proxies?.length ?? 0) > 0 ||
-    risks.includes("CALLBACK_PROXY") ||
-    risks.includes("TUNNEL")
+    ctx.tunnels.some(t => t.anonymous === true) ||
+    ctx.client.proxies.length > 0 ||
+    ctx.risks.includes("CALLBACK_PROXY") ||
+    ctx.risks.includes("TUNNEL")
   );
 }
 
@@ -85,10 +107,7 @@ function cachedVerdict(ip: string, cached: CacheState): boolean {
 function parseContext(raw: string | null): SpurContext | null {
   if (raw === null) return null;
   try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed
-      : null;
+    return toContext(JSON.parse(raw));
   } catch {
     return null;
   }
@@ -97,10 +116,12 @@ function parseContext(raw: string | null): SpurContext | null {
 async function readCache(ip: string): Promise<CacheState> {
   let raw: string | null;
   let failed: string | null;
+  let exhausted: string | null;
   try {
-    [raw, failed] = await redisRateLimitClient.mget(
+    [raw, failed, exhausted] = await redisRateLimitClient.mget(
       contextKey(ip),
       failedKey(ip),
+      EXHAUSTED_KEY,
     );
   } catch (error) {
     logger.warn("Spur cache read failed", { ...meta(ip), error });
@@ -108,7 +129,7 @@ async function readCache(ip: string): Promise<CacheState> {
   }
   const ctx = parseContext(raw);
   if (ctx) return { state: "hit", ctx };
-  if (failed !== null) return { state: "failed" };
+  if (failed !== null || exhausted !== null) return { state: "failed" };
   return { state: "miss" };
 }
 
@@ -150,9 +171,17 @@ async function fetchContext(
       ...meta(ip),
       status: res.status,
     });
+    // 429 means the account's query balance is spent, so every IP would fail.
+    if (res.status === 429) {
+      await writeCache(ip, EXHAUSTED_KEY, "1", EXHAUSTED_TTL_SEC);
+    }
     return null;
   }
-  const ctx = (await res.json()) as SpurContext;
+  const ctx = toContext(await res.json());
+  if (!ctx) {
+    logger.warn("Spur Context API returned a malformed body", meta(ip));
+    return null;
+  }
   logger.info("Spur Context API response", { ...meta(ip), ...summarize(ctx) });
   return ctx;
 }

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -22,7 +22,6 @@ const LOCK_WAIT_MS = LOCK_TTL_MS;
 const LOCK_POLL_MS = 200;
 const CONTEXT_TTL_SEC = 30 * 24 * 60 * 60;
 const FAILED_TTL_SEC = 10 * 60;
-const EXHAUSTED_TTL_SEC = 60 * 60;
 
 const RELEASE_LOCK_SCRIPT =
   'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) end return 0';
@@ -42,7 +41,6 @@ type CacheState =
 const contextKey = (ip: string) => `spur_context:${ip}`;
 const failedKey = (ip: string) => `spur_context_failed:${ip}`;
 const lockKey = (ip: string) => `spur_lock:${ip}`;
-const EXHAUSTED_KEY = "spur_exhausted";
 
 const meta = (ip: string) => ({ canonicalLog: "spur/lookup", ip });
 
@@ -116,12 +114,10 @@ function parseContext(raw: string | null): SpurContext | null {
 async function readCache(ip: string): Promise<CacheState> {
   let raw: string | null;
   let failed: string | null;
-  let exhausted: string | null;
   try {
-    [raw, failed, exhausted] = await redisRateLimitClient.mget(
+    [raw, failed] = await redisRateLimitClient.mget(
       contextKey(ip),
       failedKey(ip),
-      EXHAUSTED_KEY,
     );
   } catch (error) {
     logger.warn("Spur cache read failed", { ...meta(ip), error });
@@ -129,7 +125,7 @@ async function readCache(ip: string): Promise<CacheState> {
   }
   const ctx = parseContext(raw);
   if (ctx) return { state: "hit", ctx };
-  if (failed !== null || exhausted !== null) return { state: "failed" };
+  if (failed !== null) return { state: "failed" };
   return { state: "miss" };
 }
 
@@ -171,10 +167,6 @@ async function fetchContext(
       ...meta(ip),
       status: res.status,
     });
-    // 429 means the account's query balance is spent, so every IP would fail.
-    if (res.status === 429) {
-      await writeCache(ip, EXHAUSTED_KEY, "1", EXHAUSTED_TTL_SEC);
-    }
     return null;
   }
   const ctx = toContext(await res.json());

--- a/apps/api/src/lib/spur.ts
+++ b/apps/api/src/lib/spur.ts
@@ -1,124 +1,51 @@
+/**
+ * Spur Context API (https://docs.spur.us/context-api) check for the keyless
+ * free tier. When SPUR_API_KEY is set, the IPv4 behind a keyless request is
+ * looked up and IPs fronting anonymizing infrastructure (VPN/proxy/TOR
+ * tunnels, residential proxy networks) are refused keyless access.
+ *
+ * Spur bills per lookup, so an IP costs at most one upstream call per cache
+ * window regardless of outcome: results and failures are cached in Redis and
+ * concurrent callers for one IP coalesce behind a lock. Every error fails
+ * open (not suspicious) so Spur can never take down the free tier.
+ */
 import { randomUUID } from "crypto";
 import { isIPv4 } from "net";
 import { config } from "../config";
-import { logger } from "./logger";
 import { redisRateLimitClient } from "../services/rate-limiter";
+import { logger } from "./logger";
 
-// Optional Spur Context API integration for the keyless free tier. When
-// SPUR_API_KEY is set, the IP behind every keyless request is looked up against
-// Spur's IP-context database (https://docs.spur.us/context-api). IPs fronting
-// anonymizing/rotating infrastructure — VPN/proxy/TOR tunnels or residential
-// proxy networks — are the cheapest way to defeat the per-IP keyless caps, so we
-// refuse keyless for them and steer the caller to sign up for an API key.
-//
-// Lookups are cached in Redis for 30 days so a given IP costs at most one Spur
-// API call per month. Failed lookups (non-200, network error, timeout) are
-// negative-cached for a short TTL, so a failing or rate-limiting upstream is
-// re-hit at most once per IP per window instead of on every request.
-// Concurrent misses for the same IP are collapsed with a Redis single-flight
-// lock so a burst from one IP triggers a single upstream call; the loser
-// callers briefly wait for that result instead of each hitting Spur. The
-// integration is entirely optional: with no key set the keyless tier behaves
-// exactly as before, and any Spur error (timeout, lock failure, outage) fails
-// open, so Spur can never take down the free tier.
-
-const SPUR_API_BASE = "https://api.spur.us/v2/context";
-const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
-const NEGATIVE_CACHE_TTL_SECONDS = 10 * 60; // failed lookups: retry after 10 min
-const cacheKey = (ip: string) => `spur_context:${ip}`;
-
-// Everything below is bounded so a request can never get stuck on the upstream
-// call, on holding the lock, or on waiting for another request's result.
-//
-// - FETCH_TIMEOUT_MS aborts the Spur HTTP call.
-// - LOCK_TTL_MS is the single-flight lock's auto-expiry; it sits ~1s above the
-//   fetch timeout (headroom for the surrounding Redis round-trips) so the winner
-//   isn't preempted mid-fetch, and it caps how long a dead winner can block
-//   others (Redis expires the lock even if the process crashes before releasing).
-// - LOCK_WAIT_MS caps how long a loser waits for the winner's result before
-//   failing open; POLL_INTERVAL_MS is how often it re-checks the result cache.
 const FETCH_TIMEOUT_MS = 5000;
+// Headroom over the fetch timeout for the Redis round-trips around it.
 const LOCK_TTL_MS = FETCH_TIMEOUT_MS + 1000;
 const LOCK_WAIT_MS = LOCK_TTL_MS;
-const POLL_INTERVAL_MS = 200;
-const lockKey = (ip: string) => `spur_lock:${ip}`;
+const LOCK_POLL_MS = 200;
+const CONTEXT_TTL_SEC = 30 * 24 * 60 * 60;
+const FAILED_TTL_SEC = 10 * 60;
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const RELEASE_LOCK_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) end return 0';
 
-// Subset of the Spur IP Context Object we read. See the API docs for the full
-// shape; everything here is optional because Spur omits empty fields.
 type SpurContext = {
-  ip?: string;
   infrastructure?: string;
   risks?: string[];
   tunnels?: { anonymous?: boolean; operator?: string; type?: string }[];
   client?: { behaviors?: string[]; proxies?: string[] };
 };
 
-function isSpurEnabled(): boolean {
-  return (
-    typeof config.SPUR_API_KEY === "string" && config.SPUR_API_KEY.length > 0
-  );
-}
+type CacheState =
+  | { state: "hit"; ctx: SpurContext }
+  | { state: "failed" }
+  | { state: "miss" };
 
-// Returns "failed" when the entry is the negative-cache marker: a recent
-// lookup errored, so fail open without spending another Spur call.
-async function getCachedContext(
-  ip: string,
-): Promise<SpurContext | "failed" | null> {
-  try {
-    const raw = await redisRateLimitClient.get(cacheKey(ip));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as SpurContext & { __failed?: boolean };
-    return parsed.__failed ? "failed" : parsed;
-  } catch (error) {
-    // Cache read failed (store down or corrupt value) — treat as a miss.
-    logger.warn("Failed to read Spur context from cache", {
-      canonicalLog: "spur/lookup",
-      ip,
-      error,
-    });
-    return null;
-  }
-}
+const contextKey = (ip: string) => `spur_context:${ip}`;
+const failedKey = (ip: string) => `spur_context_failed:${ip}`;
+const lockKey = (ip: string) => `spur_lock:${ip}`;
 
-async function cacheContext(ip: string, ctx: SpurContext): Promise<void> {
-  try {
-    await redisRateLimitClient.set(
-      cacheKey(ip),
-      JSON.stringify(ctx),
-      "EX",
-      CACHE_TTL_SECONDS,
-    );
-  } catch (error) {
-    // Best-effort: a failed cache write just means we look the IP up again.
-    logger.warn("Failed to cache Spur context", {
-      canonicalLog: "spur/lookup",
-      ip,
-      error,
-    });
-  }
-}
+const meta = (ip: string) => ({ canonicalLog: "spur/lookup", ip });
 
-// Short TTL so a transient Spur outage recovers quickly.
-async function cacheFailure(ip: string): Promise<void> {
-  try {
-    await redisRateLimitClient.set(
-      cacheKey(ip),
-      JSON.stringify({ __failed: true }),
-      "EX",
-      NEGATIVE_CACHE_TTL_SECONDS,
-    );
-  } catch (error) {
-    logger.warn("Failed to negative-cache Spur lookup failure", {
-      canonicalLog: "spur/lookup",
-      ip,
-      error,
-    });
-  }
-}
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-// Compact summary of a context for logs — never dump the full object.
 function summarize(ctx: SpurContext) {
   return {
     infrastructure: ctx.infrastructure,
@@ -128,213 +55,180 @@ function summarize(ctx: SpurContext) {
   };
 }
 
-async function fetchContext(ip: string): Promise<SpurContext | null> {
-  // Cache miss → hit the real Spur API. Logged so we can track real spend.
-  // The request is bounded by FETCH_TIMEOUT_MS; an abort throws and the caller
-  // fails open.
-  logger.info("Spur Context API request (cache miss)", {
-    canonicalLog: "spur/lookup",
-    ip,
-  });
-  const response = await fetch(`${SPUR_API_BASE}/${encodeURIComponent(ip)}`, {
-    method: "GET",
-    headers: { Token: config.SPUR_API_KEY! },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!response.ok) {
-    logger.warn("Spur Context API request failed", {
-      canonicalLog: "spur/lookup",
-      ip,
-      status: response.status,
-    });
-    return null;
-  }
-  const ctx = (await response.json()) as SpurContext;
-  logger.info("Spur Context API response", {
-    canonicalLog: "spur/lookup",
-    ip,
+// DATACENTER infrastructure and GEO_MISMATCH are deliberately not signals:
+// legit users hit free tiers from cloud and CGNAT, and per-IP caps cover those.
+function isSuspicious(ctx: SpurContext): boolean {
+  const risks = ctx.risks ?? [];
+  return (
+    (ctx.tunnels?.length ?? 0) > 0 ||
+    (ctx.client?.proxies?.length ?? 0) > 0 ||
+    risks.includes("CALLBACK_PROXY") ||
+    risks.includes("TUNNEL")
+  );
+}
+
+function verdict(ip: string, ctx: SpurContext | null): boolean {
+  if (!ctx || !isSuspicious(ctx)) return false;
+  logger.info("Keyless IP flagged suspicious by Spur", {
+    ...meta(ip),
+    suspicious: true,
     ...summarize(ctx),
   });
-  return ctx;
+  return true;
 }
 
-// Single-flight lock: the winner (returns a token) is the only caller that hits
-// Spur for this IP; everyone else waits for its cached result. `null` means we
-// lost the race. Redis errors propagate so the caller fails open rather than
-// waiting on a lock we never held.
-async function acquireLock(ip: string): Promise<string | null> {
-  const token = randomUUID();
-  const result = await redisRateLimitClient.set(
-    lockKey(ip),
-    token,
-    "PX",
-    LOCK_TTL_MS,
-    "NX",
-  );
-  return result === "OK" ? token : null;
+// Verdict for a cache entry that is not a miss: a failure marker fails open.
+function cachedVerdict(ip: string, cached: CacheState): boolean {
+  return verdict(ip, cached.state === "hit" ? cached.ctx : null);
 }
 
-// Atomic compare-and-delete so we only ever clear our own lock — a plain
-// get-then-del could delete a successor's lock if our lease expired in between.
-// Best-effort: failures are swallowed since the PX TTL frees the lock regardless.
-const RELEASE_LOCK_SCRIPT = `
-if redis.call("get", KEYS[1]) == ARGV[1] then
-  return redis.call("del", KEYS[1])
-end
-return 0`;
+function parseContext(raw: string | null): SpurContext | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
 
-async function releaseLock(ip: string, token: string): Promise<void> {
+async function readCache(ip: string): Promise<CacheState> {
+  let raw: string | null;
+  let failed: string | null;
+  try {
+    [raw, failed] = await redisRateLimitClient.mget(
+      contextKey(ip),
+      failedKey(ip),
+    );
+  } catch (error) {
+    logger.warn("Spur cache read failed", { ...meta(ip), error });
+    return { state: "miss" };
+  }
+  const ctx = parseContext(raw);
+  if (ctx) return { state: "hit", ctx };
+  if (failed !== null) return { state: "failed" };
+  return { state: "miss" };
+}
+
+async function writeCache(
+  ip: string,
+  key: string,
+  value: string,
+  ttlSec: number,
+) {
+  try {
+    await redisRateLimitClient.set(key, value, "EX", ttlSec);
+  } catch (error) {
+    logger.warn("Spur cache write failed", { ...meta(ip), key, error });
+  }
+}
+
+async function releaseLock(ip: string, token: string) {
   try {
     await redisRateLimitClient.eval(RELEASE_LOCK_SCRIPT, 1, lockKey(ip), token);
   } catch (error) {
-    logger.warn("Failed to release Spur single-flight lock", {
-      canonicalLog: "spur/lookup",
-      ip,
-      error,
-    });
+    logger.warn("Spur lock release failed", { ...meta(ip), error });
   }
 }
 
-// Loser path: poll for the winner's cached result every POLL_INTERVAL_MS,
-// bounded by LOCK_WAIT_MS. If the result never lands (winner failed or is still
-// running at the deadline), give up and fail open.
-async function waitForResult(ip: string): Promise<SpurContext | null> {
-  const deadline = Date.now() + LOCK_WAIT_MS;
-  while (Date.now() < deadline) {
-    // Clamp the last sleep to the remaining budget so we never overshoot the
-    // LOCK_WAIT_MS ceiling.
-    await sleep(Math.min(POLL_INTERVAL_MS, deadline - Date.now()));
-    const cached = await getCachedContext(ip);
-    // The winner's fetch failed: fail open now instead of burning the rest of
-    // the wait budget.
-    if (cached === "failed") return null;
-    if (cached) return cached;
-  }
-  return null;
-}
-
-/**
- * Look up an IP's Spur context, preferring the 30-day Redis cache. Every lookup
- * outcome is cached: successes for CACHE_TTL_SECONDS, failures (non-200,
- * network error, timeout) as a short-TTL negative entry, so a given IP costs at
- * most one upstream call per cache window no matter what Spur returns.
- * Concurrent misses for the same IP are collapsed via a Redis single-flight
- * lock: one caller fetches, the rest wait (bounded) for its result. Returns
- * null when Spur is disabled or anything goes wrong (lock error, timeout,
- * upstream failure); callers then fail open (treat the IP as not suspicious).
- * Every wait here is bounded, so a request can never get stuck on the lock or
- * on another request's in-flight lookup.
- */
-async function getSpurContext(ip: string): Promise<SpurContext | null> {
-  if (!isSpurEnabled()) return null;
-
-  // Callers already gate on isKeylessIpEligible, but a call site passing raw
-  // IPv6 (rotatable per-request) would explode cache cardinality and Spur
-  // spend, so refuse non-IPv4 here too and fail open.
-  if (!isIPv4(ip)) return null;
-
-  const cached = await getCachedContext(ip);
-  if (cached === "failed") return null;
-  if (cached) return cached;
-
-  try {
-    const token = await acquireLock(ip);
-    if (!token) {
-      // Lost the race → a lookup for this IP is already in flight. Wait for its
-      // result instead of making our own call. Logged so we can measure how many
-      // Spur calls the single-flight coalescing saves (savedApiCall === true).
-      const result = await waitForResult(ip);
-      logger.info("Spur lookup coalesced by single-flight", {
-        canonicalLog: "spur/lookup",
-        ip,
-        savedApiCall: result !== null,
-      });
-      return result;
-    }
-
-    try {
-      // Another winner may have populated the cache between our miss and
-      // winning the lock — re-check before spending a Spur call.
-      const fresh = await getCachedContext(ip);
-      if (fresh === "failed") return null;
-      if (fresh) return fresh;
-
-      let ctx: SpurContext | null;
-      try {
-        ctx = await fetchContext(ip);
-      } catch (error) {
-        // Negative-cache before rethrowing so waiting losers unblock now.
-        await cacheFailure(ip);
-        throw error;
-      }
-      if (ctx) {
-        await cacheContext(ip, ctx);
-      } else {
-        await cacheFailure(ip);
-      }
-      return ctx;
-    } finally {
-      await releaseLock(ip, token);
-    }
-  } catch (error) {
-    // Lock error, fetch timeout/abort, or any upstream failure → fail open.
-    // AbortSignal.timeout rejects with a TimeoutError; flag it so the timeout
-    // rate is countable separately from other failures.
-    const timedOut = error instanceof Error && error.name === "TimeoutError";
-    logger.warn("Spur context lookup failed; failing open", {
-      canonicalLog: "spur/lookup",
-      ip,
-      timedOut,
-      error,
+async function fetchContext(
+  ip: string,
+  apiKey: string,
+): Promise<SpurContext | null> {
+  logger.info("Spur Context API request (cache miss)", meta(ip));
+  const res = await fetch(
+    `https://api.spur.us/v2/context/${encodeURIComponent(ip)}`,
+    {
+      headers: { Token: apiKey },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    },
+  );
+  if (!res.ok) {
+    logger.warn("Spur Context API request failed", {
+      ...meta(ip),
+      status: res.status,
     });
     return null;
   }
+  const ctx = (await res.json()) as SpurContext;
+  logger.info("Spur Context API response", { ...meta(ip), ...summarize(ctx) });
+  return ctx;
 }
 
-// Risk flags that, on their own, mark an IP as fronting proxy/tunnel
-// infrastructure. Plain DATACENTER or GEO_MISMATCH signals are intentionally
-// NOT treated as suspicious — many legitimate clients hit a free tier from
-// cloud/CGNAT, and the per-IP caps already cover those.
-const SUSPICIOUS_RISKS = new Set(["CALLBACK_PROXY", "TUNNEL"]);
+async function lookup(ip: string, apiKey: string): Promise<boolean> {
+  let ctx: SpurContext | null;
+  try {
+    ctx = await fetchContext(ip, apiKey);
+  } catch (error) {
+    logger.warn("Spur context lookup failed; failing open", {
+      ...meta(ip),
+      timedOut: error instanceof Error && error.name === "TimeoutError",
+      error,
+    });
+    ctx = null;
+  }
+  if (ctx) {
+    await writeCache(ip, contextKey(ip), JSON.stringify(ctx), CONTEXT_TTL_SEC);
+  } else {
+    await writeCache(ip, failedKey(ip), "1", FAILED_TTL_SEC);
+  }
+  return verdict(ip, ctx);
+}
 
-function isSuspiciousContext(ctx: SpurContext): boolean {
-  // A live VPN/proxy/TOR tunnel — the canonical IP-rotation vector.
-  if (Array.isArray(ctx.tunnels) && ctx.tunnels.length > 0) return true;
-  // Residential / rotating proxy networks observed exiting this IP.
-  if (Array.isArray(ctx.client?.proxies) && ctx.client.proxies.length > 0) {
-    return true;
+async function waitForResult(ip: string): Promise<boolean> {
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  while (Date.now() < deadline) {
+    await sleep(Math.min(LOCK_POLL_MS, deadline - Date.now()));
+    const cached = await readCache(ip);
+    if (cached.state === "miss") continue;
+    logger.info("Spur lookup coalesced by single-flight", {
+      ...meta(ip),
+      savedApiCall: true,
+    });
+    return cachedVerdict(ip, cached);
   }
-  // Explicit proxy/tunnel risk flags.
-  if (
-    Array.isArray(ctx.risks) &&
-    ctx.risks.some(r => SUSPICIOUS_RISKS.has(r))
-  ) {
-    return true;
-  }
+  logger.info("Spur lookup coalesced by single-flight", {
+    ...meta(ip),
+    savedApiCall: false,
+  });
   return false;
 }
 
-/**
- * Whether the keyless tier should refuse this IP because Spur flags it as
- * anonymizing/rotating infrastructure. No-op (false) when Spur is disabled, and
- * fails open (false) on any lookup error so a Spur outage never breaks keyless.
- */
 export async function isKeylessIpSuspicious(ip: string): Promise<boolean> {
-  if (!isSpurEnabled()) return false;
+  const apiKey = config.SPUR_API_KEY;
+  if (!apiKey || !isIPv4(ip)) return false;
 
-  const ctx = await getSpurContext(ip);
-  if (!ctx) return false;
+  const cached = await readCache(ip);
+  if (cached.state !== "miss") return cachedVerdict(ip, cached);
 
-  const suspicious = isSuspiciousContext(ctx);
-  if (suspicious) {
-    logger.info("Keyless IP flagged suspicious by Spur", {
-      canonicalLog: "spur/lookup",
-      ip,
-      suspicious: true,
-      tunnels: ctx.tunnels?.map(t => t.type),
-      proxies: ctx.client?.proxies,
-      risks: ctx.risks,
+  const token = randomUUID();
+  let locked: boolean;
+  try {
+    locked =
+      (await redisRateLimitClient.set(
+        lockKey(ip),
+        token,
+        "PX",
+        LOCK_TTL_MS,
+        "NX",
+      )) === "OK";
+  } catch (error) {
+    logger.warn("Spur context lookup failed; failing open", {
+      ...meta(ip),
+      timedOut: false,
+      error,
     });
+    return false;
   }
-  return suspicious;
+  if (!locked) return waitForResult(ip);
+
+  try {
+    const refreshed = await readCache(ip);
+    if (refreshed.state !== "miss") return cachedVerdict(ip, refreshed);
+    return await lookup(ip, apiKey);
+  } finally {
+    await releaseLock(ip, token);
+  }
 }


### PR DESCRIPTION
Failed Spur lookups (non-200, network error, timeout) were never cached, so every keyless request from that IP made another Spur call; the single-flight lock only collapses concurrent ones. Failures are now negative-cached for 10 minutes, and waiting losers fail open as soon as the marker lands.

Keyless eligibility accepted `::ffff:1.2.3.4` but the raw string keyed the Spur cache, quota buckets and team id, so a dual-stack client counted as two identities. The IP is now normalized after the eligibility gate, and `getSpurContext` refuses non-IPv4 outright.

Watch: any Spur outage now recovers within 10 minutes per IP rather than instantly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Negative-caches failed Spur lookups, normalizes IPv4-mapped `::ffff:` addresses to plain IPv4, and flags only anonymous tunnels as suspicious. Previously, failures weren’t cached and `::ffff:1.2.3.4` keyed separate buckets; now failures cache for 10 minutes per IP and dual‑stack clients map to one identity.

- Caching: successful lookups cache 30 days in `spur_context:{ip}`; failures/non-200s set `spur_context_failed:{ip}` with a 10‑minute TTL. Single‑flight lock (NX + PX) bounds concurrent calls; losers read these keys and fail open. No global backoff on HTTP 429.
- IP normalization: export/apply `normalizeKeylessIpv4` in `auth` and `keyless` so quota buckets, `keylessTeamId`, and the Spur cache use one identity. Non‑IPv4 is ignored by Spur checks (fails open). Legacy Redis keys with `::ffff:` remain readable.
- Verdict policy: suspicious only if a tunnel is `anonymous: true`, client proxies exist, or risks include `CALLBACK_PROXY`/`TUNNEL`. Enterprise/ZTNA VPNs are allowed.
- Robustness: tolerate malformed cached contexts; Redis mock gains `mget`. No migration; old keys expire naturally.

<sup>Written for commit b3bd98d1c031723773e4cf488e9d9e8a22c05f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

