### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/publish-java-sdk.yml
+++ b/.github/workflows/publish-java-sdk.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set up JDK 11
         if: ${{ env.VERSION_INCREMENTED == 'true' }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '11'

--- a/.github/workflows/test-java-sdk.yml
+++ b/.github/workflows/test-java-sdk.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "11"


### PR DESCRIPTION
## Summary

Upgrade both Java SDK workflows from actions/setup-java v4 to v6.0.0.

## Validation

Reviewed the workflow-only diff and verified no setup-java reference older than v6 remains in active workflow YAML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `actions/setup-java@v6` in the Java SDK test and publish workflows to stay on a supported major and receive fixes. Previously we used v4; now we use v6 with Temurin JDK 11 unchanged, so CI behavior should remain the same.

- Changes are limited to `.github/workflows/publish-java-sdk.yml` and `.github/workflows/test-java-sdk.yml`.
- No migration actions required; `distribution: temurin` and `java-version: 11` remain the same.

<sup>Written for commit 23299a9ba23890f42f13a74534bad2e5bc791b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

