### PR TITLE
Feat/pass request id to fire engine search

### DIFF
--- a/apps/api/src/lib/retry-utils.ts
+++ b/apps/api/src/lib/retry-utils.ts
@@ -11,6 +11,7 @@ export async function attemptRequest<T>(
   url: string,
   data: string,
   abort?: AbortSignal,
+  headers?: Record<string, string>,
 ): Promise<T | null> {
   try {
     const response = await fetch(url, {
@@ -18,6 +19,7 @@ export async function attemptRequest<T>(
       headers: {
         "Content-Type": "application/json",
         "X-Disable-Cache": "true",
+        ...headers,
       },
       body: data,
       signal: abort,

--- a/apps/api/src/lib/retry-utils.ts
+++ b/apps/api/src/lib/retry-utils.ts
@@ -11,7 +11,7 @@ export async function attemptRequest<T>(
   url: string,
   data: string,
   abort?: AbortSignal,
-  headers?: Record<string, string>,
+  requestId?: string,
 ): Promise<T | null> {
   try {
     const response = await fetch(url, {
@@ -19,7 +19,7 @@ export async function attemptRequest<T>(
       headers: {
         "Content-Type": "application/json",
         "X-Disable-Cache": "true",
-        ...headers,
+        ...(requestId ? { "X-Request-ID": requestId } : {}),
       },
       body: data,
       signal: abort,

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -129,6 +129,8 @@ export async function executeSearch(
     : ((await search({
         query: searchQuery,
         logger,
+        requestId: context.jobId,
+  
         advanced: false,
         num_results: num_results_buffer,
         tbs: options.tbs,

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -129,8 +129,7 @@ export async function executeSearch(
     : ((await search({
         query: searchQuery,
         logger,
-        requestId: context.jobId,
-  
+        requestId: context.requestId,
         advanced: false,
         num_results: num_results_buffer,
         tbs: options.tbs,

--- a/apps/api/src/search/v2/fireEngine-v2.ts
+++ b/apps/api/src/search/v2/fireEngine-v2.ts
@@ -40,6 +40,7 @@ function normalizeSearchTypes(
 export async function fire_engine_search_v2(
   q: string,
   options: {
+    requestId?: string;
     tbs?: string;
     filter?: string;
     lang?: string;
@@ -78,7 +79,10 @@ export async function fire_engine_search_v2(
   const data = JSON.stringify(payload);
 
   const result = await executeWithRetry<SearchV2Response>(
-    () => attemptRequest<SearchV2Response>(url, data, abort),
+    () =>
+      attemptRequest<SearchV2Response>(url, data, abort, {
+        ...(options.requestId ? { "X-Request-ID": options.requestId } : {}),
+      }),
     (response): response is SearchV2Response => response !== null,
     abort,
   );

--- a/apps/api/src/search/v2/fireEngine-v2.ts
+++ b/apps/api/src/search/v2/fireEngine-v2.ts
@@ -79,10 +79,7 @@ export async function fire_engine_search_v2(
   const data = JSON.stringify(payload);
 
   const result = await executeWithRetry<SearchV2Response>(
-    () =>
-      attemptRequest<SearchV2Response>(url, data, abort, {
-        ...(options.requestId ? { "X-Request-ID": options.requestId } : {}),
-      }),
+    () => attemptRequest<SearchV2Response>(url, data, abort, options.requestId),
     (response): response is SearchV2Response => response !== null,
     abort,
   );

--- a/apps/api/src/search/v2/index.ts
+++ b/apps/api/src/search/v2/index.ts
@@ -8,6 +8,7 @@ import { Logger } from "winston";
 export async function search({
   query,
   logger,
+  requestId,
   advanced = false,
   num_results = 5,
   tbs = undefined,
@@ -24,6 +25,7 @@ export async function search({
 }: {
   query: string;
   logger: Logger;
+  requestId?: string;
   advanced?: boolean;
   num_results?: number;
   tbs?: string;
@@ -42,6 +44,7 @@ export async function search({
     if (config.FIRE_ENGINE_BETA_URL) {
       logger.info("Using fire engine search");
       const results = await fire_engine_search_v2(query, {
+        requestId,
         numResults: num_results,
         tbs,
         filter,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Passes the request ID through the search pipeline to Fire Engine v2 to improve tracing and log correlation without changing search results.

- New Features
  - Adds an optional requestId to search and fire_engine_search_v2.
  - executeSearch supplies context.requestId and search forwards it to Fire Engine v2.
  - attemptRequest includes the X-Request-ID header when requestId is present.

<sup>Written for commit c255673ec24b68452009ef71b40ffe764471c394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

