### PR TITLE
fix(api): extend fire-privacy timeout

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -451,7 +451,9 @@ const configSchema = z.object({
 
   // PII Redaction (fire-privacy)
   FIRE_PRIVACY_URL: z.string().optional(),
-  FIRE_PRIVACY_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
+  // fire-privacy's model request budget is 30s; allow 2s for network and
+  // response handling so the caller does not abort a request still in flight.
+  FIRE_PRIVACY_TIMEOUT_MS: z.coerce.number().int().positive().default(32000),
 
   NUQ_PREFETCH_WORKER_HEARTBEAT_URL: z.string().optional(),
 

--- a/apps/api/src/lib/fire-privacy-client.test.ts
+++ b/apps/api/src/lib/fire-privacy-client.test.ts
@@ -55,6 +55,10 @@ function withBody(body: unknown, status = 200): Handler {
 }
 
 describe("redactText", () => {
+  it("uses a caller timeout longer than fire-privacy's model budget", () => {
+    expect(config.FIRE_PRIVACY_TIMEOUT_MS).toBe(32_000);
+  });
+
   it("returns status=ok with redacted_text and spans on 200", async () => {
     handler = withBody({
       redacted_text: "Hi, my name is <PERSON>.",

--- a/apps/api/src/lib/fire-privacy-client.ts
+++ b/apps/api/src/lib/fire-privacy-client.ts
@@ -79,9 +79,9 @@ const DEFAULTS = {
 // PDF pages, ~10 chunks, ~60s wall at c=3 with the model on. Anything
 // larger pushes past the typical scrape budget and starves the fleet.
 const MAX_REDACT_BYTES = 250_000;
-// Chunks fan out at this concurrency to fire-privacy. The fleet has 6
-// pods at saturation; c=3 keeps a single call under 50% of capacity so
-// other tenants aren't starved.
+// Chunks fan out at this concurrency to fire-privacy. The fleet has a
+// four-pod baseline; c=3 leaves capacity for other calls while bounding
+// the pressure a single scrape can place on the service.
 const CHUNK_CONCURRENCY = 3;
 
 // Maps a span's `kind` (as returned by either OPF or Presidio) onto the


### PR DESCRIPTION
## Summary

Extends the fire-privacy caller timeout from 5 seconds to 32 seconds so it exceeds the model service request budget and does not abort redactions that are still in flight. Updates the fleet-capacity comment and asserts the new default.