### PR TITLE
fix(python-sdk): support only_clean_content option in ScrapeOptions (fixes #4393)

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -436,3 +436,21 @@ class TestPrepareScrapeOptions:
         assert result["minAge"] == 1000
         assert "min_age" not in result
         assert result["maxAge"] == 5000
+
+    def test_prepare_only_clean_content_maps_to_camel_case(self):
+        """only_clean_content must be sent as onlyCleanContent."""
+        options = ScrapeOptions(formats=["markdown"], only_clean_content=True)
+
+        result = prepare_scrape_options(options)
+
+        assert result["onlyCleanContent"] is True
+        assert "only_clean_content" not in result
+
+    def test_prepare_only_clean_content_false_maps_to_camel_case(self):
+        """only_clean_content=False must also be forwarded as onlyCleanContent: False."""
+        options = ScrapeOptions(formats=["markdown"], only_clean_content=False)
+
+        result = prepare_scrape_options(options)
+
+        assert result["onlyCleanContent"] is False
+        assert "only_clean_content" not in result

--- a/apps/python-sdk/firecrawl/v2/methods/crawl.py
+++ b/apps/python-sdk/firecrawl/v2/methods/crawl.py
@@ -540,7 +540,8 @@ def crawl_params_preview(client: HttpClient, request: CrawlParamsRequest) -> Cra
                         "onlyMainContent": "only_main_content",
                         "waitFor": "wait_for",
                         "skipTlsVerification": "skip_tls_verification",
-                        "removeBase64Images": "remove_base64_images"
+                        "removeBase64Images": "remove_base64_images",
+                        "onlyCleanContent": "only_clean_content"
                     }
                     
                     for scrape_camel, scrape_snake in scrape_field_mappings.items():

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -888,6 +888,7 @@ class ScrapeOptions(BaseModel):
     location: Optional["Location"] = None
     skip_tls_verification: Optional[bool] = None
     remove_base64_images: Optional[bool] = None
+    only_clean_content: Optional[bool] = None
     fast_mode: Optional[bool] = None
     use_mock: Optional[str] = None
     block_ads: Optional[bool] = None

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -561,6 +561,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
         "wait_for": "waitFor",
         "skip_tls_verification": "skipTlsVerification",
         "remove_base64_images": "removeBase64Images",
+        "only_clean_content": "onlyCleanContent",
         "fast_mode": "fastMode",
         "use_mock": "useMock",
         "block_ads": "blockAds",


### PR DESCRIPTION
Fixes #4393

### Description
The API v2/v1 supports `onlyCleanContent`, but the Python SDK `ScrapeOptions` model omitted the `only_clean_content` field, causing it to be silently ignored.

This PR adds:
1. `only_clean_content: Optional[bool] = None` to Python SDK `ScrapeOptions` in `types.py`.
2. Mapping `"only_clean_content": "onlyCleanContent"` in `prepare_scrape_options` in `validation.py`.
3. Reverse mapping in `crawl.py` `scrape_field_mappings`.
4. Unit regression tests in `test_validation.py` ensuring `only_clean_content=True` and `only_clean_content=False` map correctly to `onlyCleanContent` and do not leak the snake_case key.

### Verification
- 473/473 unit tests pass.