### PR TITLE
fix(python-sdk): preserve api_url path prefix in _build_url (fixes #4339)

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client.py
@@ -1,0 +1,36 @@
+from firecrawl.v2.utils.http_client import HttpClient
+
+
+class TestHttpClientBuildUrl:
+    def test_build_url_standard_api_url(self):
+        client = HttpClient(api_key="test-key", api_url="https://api.firecrawl.dev")
+        assert client._build_url("/v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+        assert client._build_url("v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+
+    def test_build_url_standard_api_url_trailing_slash(self):
+        client = HttpClient(api_key="test-key", api_url="https://api.firecrawl.dev/")
+        assert client._build_url("/v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+        assert client._build_url("v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+
+    def test_build_url_with_path_prefix(self):
+        """Preserve reverse proxy path prefix when joining endpoints (fixes #4339)."""
+        client = HttpClient(api_key="test-key", api_url="http://firecrawl.example.com/firecrawl")
+        assert client._build_url("/v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+        assert client._build_url("v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+
+    def test_build_url_with_path_prefix_trailing_slash(self):
+        client = HttpClient(api_key="test-key", api_url="http://firecrawl.example.com/firecrawl/")
+        assert client._build_url("/v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+        assert client._build_url("v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+
+    def test_build_url_with_nested_path_and_query(self):
+        client = HttpClient(api_key="test-key", api_url="http://localhost:8080/nested/prefix")
+        assert client._build_url("/v2/crawl/status?job_id=123") == "http://localhost:8080/nested/prefix/v2/crawl/status?job_id=123"
+
+    def test_build_url_absolute_endpoint_same_host(self):
+        client = HttpClient(api_key="test-key", api_url="https://api.firecrawl.dev")
+        assert client._build_url("https://api.firecrawl.dev/v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+
+    def test_build_url_absolute_endpoint_different_host_normalizes_to_base(self):
+        client = HttpClient(api_key="test-key", api_url="https://api.firecrawl.dev")
+        assert client._build_url("https://attacker.com/v2/scrape") == "https://api.firecrawl.dev/v2/scrape"

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -33,24 +33,21 @@ class HttpClient:
 
         # Absolute or protocol-relative (has netloc)
         if ep.netloc:
-            # Different host: keep path/query but force base host/scheme (no token leakage)
+            # Different host: keep path/params/query but force base host/scheme (no token leakage)
             path = ep.path or "/"
-            if (ep.hostname or "") != (base.hostname or ""):
-                return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
-            # Same host: normalize scheme to base
-            return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
+            return urlunparse((base.scheme or "https", base.netloc, path, ep.params, ep.query, ""))
 
         # Relative (including leading slash or not)
         # Guard protocol-relative like //host/path slipping through as “relative”
         if endpoint.startswith("//"):
             ep2 = urlparse(f"https:{endpoint}")
             path = ep2.path or "/"
-            return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
+            return urlunparse((base.scheme or "https", base.netloc, path, ep2.params, ep2.query, ""))
 
         base_path = base.path.rstrip("/")
         ep_path = ep.path.lstrip("/")
         combined_path = f"{base_path}/{ep_path}" if base_path else f"/{ep_path}"
-        return urlunparse((base.scheme or "https", base.netloc, combined_path, "", ep.query, ""))
+        return urlunparse((base.scheme or "https", base.netloc, combined_path, ep.params, ep.query, ""))
     
     def _prepare_headers(
         self,

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -41,13 +41,16 @@ class HttpClient:
             return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
 
         # Relative (including leading slash or not)
-        base_str = self.api_url if self.api_url.endswith("/") else f"{self.api_url}/"
         # Guard protocol-relative like //host/path slipping through as “relative”
         if endpoint.startswith("//"):
             ep2 = urlparse(f"https:{endpoint}")
             path = ep2.path or "/"
             return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
-        return urljoin(base_str, endpoint)
+
+        base_path = base.path.rstrip("/")
+        ep_path = ep.path.lstrip("/")
+        combined_path = f"{base_path}/{ep_path}" if base_path else f"/{ep_path}"
+        return urlunparse((base.scheme or "https", base.netloc, combined_path, "", ep.query, ""))
     
     def _prepare_headers(
         self,


### PR DESCRIPTION
Fixes #4339

### Description
When self-hosted Firecrawl is deployed behind a reverse proxy with a path prefix (e.g. `api_url = "http://firecrawl.example.com/firecrawl"`), `_build_url` previously used `urljoin(base_str, endpoint)` with endpoints like `"/v2/search"`. In Python's `urllib.parse.urljoin`, leading slashes in relative endpoint paths replace the base URL's entire path component, dropping `/firecrawl` and sending requests to `http://firecrawl.example.com/v2/search`.

This PR fixes `_build_url` in `HttpClient` to:
- Preserve the base URL's path prefix when resolving relative endpoints.
- Support both leading-slash and non-leading-slash endpoints uniformly.
- Preserve query parameters and security checks (host normalization).
- Adds dedicated unit tests in `test_http_client.py` covering standard URLs, trailing slash variants, path prefixes, nested prefixes, query params, and domain normalization.

### Verification
- 478/478 unit tests pass.