### PR TITLE
feat(api): add PDF file size telemetry

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -11,7 +11,7 @@ import {
   RemoveFeatureError,
   EngineUnsuccessfulError,
 } from "../../error";
-import { open, readFile, unlink } from "node:fs/promises";
+import { open, readFile, stat, unlink } from "node:fs/promises";
 import type { Response } from "undici";
 import { AbortManagerThrownError } from "../../lib/abortManager";
 import {
@@ -59,6 +59,16 @@ function getIneligibleReason(
   return null;
 }
 
+function logPdfDownload(meta: Meta, fileSizeBytes: number) {
+  meta.logger.info("PDF download complete", {
+    method: "scrapePDF",
+    event: "pdf_download_complete",
+    file_size_bytes: fileSizeBytes,
+    scrape_id: meta.id,
+    team_id: meta.internalOptions.teamId,
+  });
+}
+
 export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
   const shouldParse = shouldParsePDF(meta.options.parsers);
   const maxPages = getPDFMaxPages(meta.options.parsers);
@@ -87,9 +97,9 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
 
   if (!shouldParse) {
     if (meta.pdfPrefetch !== undefined && meta.pdfPrefetch !== null) {
-      const content = (await readFile(meta.pdfPrefetch.filePath)).toString(
-        "base64",
-      );
+      const pdfBuffer = await readFile(meta.pdfPrefetch.filePath);
+      logPdfDownload(meta, pdfBuffer.length);
+      const content = pdfBuffer.toString("base64");
       return {
         url: meta.pdfPrefetch.url ?? meta.rewrittenUrl ?? meta.url,
         statusCode: meta.pdfPrefetch.status,
@@ -124,6 +134,8 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
           throw new PDFPrefetchFailed();
         }
       }
+
+      logPdfDownload(meta, file.buffer.length);
 
       const content = file.buffer.toString("base64");
       return {
@@ -180,6 +192,8 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
         throw new PDFPrefetchFailed();
       }
     }
+
+    logPdfDownload(meta, (await stat(tempFilePath)).size);
 
     let result: PDFProcessorResult | null = null;
     let effectivePageCount: number = 0;

--- a/apps/api/src/scraper/scrapeURL/engines/utils/__tests__/downloadFile.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/__tests__/downloadFile.test.ts
@@ -1,0 +1,67 @@
+import { ReadableStream } from "node:stream/web";
+import {
+  checkContentLength,
+  createSizeLimiter,
+  DownloadSizeLimitError,
+} from "../downloadFile";
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return chunks;
+    chunks.push(value);
+  }
+}
+
+describe("download size limits", () => {
+  it("records the declared size when Content-Length exceeds the limit", () => {
+    const response = {
+      headers: new Headers({ "content-length": "104857600" }),
+    };
+
+    expect(() => checkContentLength(response, 52428800)).toThrowError(
+      expect.objectContaining({
+        max_size_bytes: 52428800,
+        size_source: "content_length",
+        declared_size_bytes: 104857600,
+      }),
+    );
+  });
+
+  it("records bytes received when a stream exceeds the limit", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(4));
+        controller.enqueue(new Uint8Array(4));
+        controller.close();
+      },
+    });
+
+    await expect(
+      readStream(source.pipeThrough(createSizeLimiter(5))),
+    ).rejects.toMatchObject({
+      max_size_bytes: 5,
+      size_source: "stream",
+      observed_size_bytes: 8,
+    } satisfies Partial<DownloadSizeLimitError>);
+  });
+
+  it("allows a stream whose size equals the limit", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2));
+        controller.enqueue(new Uint8Array(3));
+        controller.close();
+      },
+    });
+
+    const chunks = await readStream(source.pipeThrough(createSizeLimiter(5)));
+
+    expect(chunks.reduce((total, chunk) => total + chunk.byteLength, 0)).toBe(
+      5,
+    );
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/utils/downloadFile.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/downloadFile.ts
@@ -58,13 +58,44 @@ const mapUndiciError = (url: string, skipTlsVerification: boolean, e: any) => {
   }
 };
 
-function createSizeLimiter(maxSize: number) {
+export class DownloadSizeLimitError extends UnsupportedFileError {
+  public readonly max_size_bytes: number;
+  public readonly size_source: "content_length" | "stream";
+  public readonly declared_size_bytes?: number;
+  public readonly observed_size_bytes?: number;
+
+  constructor({
+    maxSizeBytes,
+    sizeSource,
+    declaredSizeBytes,
+    observedSizeBytes,
+  }: {
+    maxSizeBytes: number;
+    sizeSource: "content_length" | "stream";
+    declaredSizeBytes?: number;
+    observedSizeBytes?: number;
+  }) {
+    super("File exceeds size limit");
+    this.max_size_bytes = maxSizeBytes;
+    this.size_source = sizeSource;
+    this.declared_size_bytes = declaredSizeBytes;
+    this.observed_size_bytes = observedSizeBytes;
+  }
+}
+
+export function createSizeLimiter(maxSize: number) {
   let bytesRead = 0;
   return new NodeTransformStream<Uint8Array, Uint8Array>({
     transform(chunk, controller) {
       bytesRead += chunk.byteLength;
       if (bytesRead > maxSize) {
-        controller.error(new UnsupportedFileError("File exceeds size limit"));
+        controller.error(
+          new DownloadSizeLimitError({
+            maxSizeBytes: maxSize,
+            sizeSource: "stream",
+            observedSizeBytes: bytesRead,
+          }),
+        );
         return;
       }
       controller.enqueue(chunk);
@@ -72,12 +103,19 @@ function createSizeLimiter(maxSize: number) {
   });
 }
 
-function checkContentLength(response: undici.Response, maxSize: number) {
+export function checkContentLength(
+  response: { headers: { get(name: string): string | null } },
+  maxSize: number,
+) {
   const header = response.headers.get("content-length");
   if (header === null) return;
   const declared = Number(header);
   if (Number.isFinite(declared) && declared > maxSize) {
-    throw new UnsupportedFileError("File exceeds size limit");
+    throw new DownloadSizeLimitError({
+      maxSizeBytes: maxSize,
+      sizeSource: "content_length",
+      declaredSizeBytes: declared,
+    });
   }
 }
 
@@ -114,7 +152,11 @@ export async function fetchFileToBuffer(
       bytesRead += value.byteLength;
       if (bytesRead > maxSize) {
         await reader.cancel().catch(() => {});
-        throw new UnsupportedFileError("File exceeds size limit");
+        throw new DownloadSizeLimitError({
+          maxSizeBytes: maxSize,
+          sizeSource: "stream",
+          observedSizeBytes: bytesRead,
+        });
       }
       chunks.push(value);
     }


### PR DESCRIPTION
## Summary

Adds structured byte-size telemetry for completed PDF downloads and file-size limit errors. Declared sizes are recorded from Content-Length, while streaming overages record the bytes received when the configured limit is crossed.