### PR TITLE
feat(pdf): by-reference deadline decoupling + content-level job adoption

### DIFF
--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -11,7 +11,10 @@ import {
 } from "./types";
 import { v7 as uuidv7 } from "uuid";
 import { hasFormatOfType } from "../../lib/format-utils";
-import { TransportableError } from "../../lib/error";
+import {
+  getTimeoutProcessingDetails,
+  TransportableError,
+} from "../../lib/error";
 import { NuQJob } from "../../services/worker/nuq";
 import { checkPermissions } from "../../lib/permissions";
 import {
@@ -474,10 +477,20 @@ export async function scrapeController(
           setSpanAttributes(span, {
             "scrape.status_code": statusCode,
           });
+          // Large-PDF timeouts where the fire-pdf job keeps processing
+          // server-side carry structured retry guidance: surface it as
+          // `details` plus a standard Retry-After header so clients (and
+          // retry libraries) know a timed retry returns the finished
+          // result instead of restarting the work.
+          const processing = getTimeoutProcessingDetails(e);
+          if (processing) {
+            res.setHeader("Retry-After", String(processing.retryAfterSeconds));
+          }
           return res.status(statusCode).json({
             success: false,
             code: e.code,
             error: e.message,
+            ...(processing && { details: processing }),
           });
         } else {
           const id = uuidv7();

--- a/apps/api/src/lib/__tests__/timeoutProcessing.test.ts
+++ b/apps/api/src/lib/__tests__/timeoutProcessing.test.ts
@@ -1,0 +1,128 @@
+import {
+  composeTimeoutProcessing,
+  getTimeoutProcessingDetails,
+  ScrapeJobTimeoutError,
+  TransportableError,
+} from "../error";
+import {
+  deserializeTransportableError,
+  serializeTransportableError,
+} from "../error-serde";
+
+const T0 = 1_756_200_000_000;
+
+describe("composeTimeoutProcessing", () => {
+  it("estimates from pages minus elapsed, rounded up to whole minutes", () => {
+    // 700 pages × 500ms + 60s base = 410s total; 2min elapsed → 290s
+    // remaining → rounds up to 5 minutes.
+    const { message, details } = composeTimeoutProcessing({
+      pagesEstimate: 700,
+      submittedAtMs: T0,
+      jobDeadlineAtMs: T0 + 11 * 60_000,
+      lastStatus: "running",
+      nowMs: T0 + 2 * 60_000,
+    });
+    expect(details).toEqual({
+      state: "processing_continues",
+      documentPages: 700,
+      jobStatus: "running",
+      estimatedRemainingSeconds: 300,
+      retryAfterSeconds: 300,
+    });
+    expect(message).toContain("700-page PDF is still being processed");
+    expect(message).toContain("~5 minutes");
+  });
+
+  it("queued and published statuses read as queued, place is kept", () => {
+    for (const lastStatus of ["queued", "published"] as const) {
+      const { message, details } = composeTimeoutProcessing({
+        pagesEstimate: 120,
+        submittedAtMs: T0,
+        lastStatus,
+        nowMs: T0,
+      });
+      expect(details.jobStatus).toBe("queued");
+      expect(message).toContain("queued for processing");
+      expect(message).toContain("will not lose its place");
+    }
+  });
+
+  it("estimate floors at one minute and caps Retry-After at 10 minutes", () => {
+    // Nearly done: elapsed exceeds the estimate → 1 minute floor.
+    const nearlyDone = composeTimeoutProcessing({
+      pagesEstimate: 100,
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0 + 30 * 60_000,
+    });
+    expect(nearlyDone.details.estimatedRemainingSeconds).toBe(60);
+    expect(nearlyDone.details.retryAfterSeconds).toBe(60);
+
+    // Monster document: estimate is huge but Retry-After stays sane.
+    const monster = composeTimeoutProcessing({
+      pagesEstimate: 6_000,
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0,
+    });
+    expect(monster.details.estimatedRemainingSeconds).toBe(3_060);
+    expect(monster.details.retryAfterSeconds).toBe(600);
+  });
+
+  it("flags documents that may exceed the job's processing window", () => {
+    // 6000 pages ≈ 51min of work against a 30-minute job deadline.
+    const { message, details } = composeTimeoutProcessing({
+      pagesEstimate: 6_000,
+      submittedAtMs: T0,
+      jobDeadlineAtMs: T0 + 30 * 60_000,
+      lastStatus: "running",
+      nowMs: T0,
+    });
+    expect(details.mayExceedProcessingWindow).toBe(true);
+    expect(message).toContain(
+      "may exceed the maximum server-side processing window",
+    );
+    expect(message).toContain("contact support");
+  });
+
+  it("handles an unknown page count with a flat conservative estimate", () => {
+    const { message, details } = composeTimeoutProcessing({
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0,
+    });
+    expect(details.documentPages).toBeUndefined();
+    expect(details.estimatedRemainingSeconds).toBe(300);
+    expect(message).toContain("this PDF");
+  });
+});
+
+describe("SCRAPE_TIMEOUT processing details transport", () => {
+  it("survives the worker→controller serde round trip", () => {
+    const { message, details } = composeTimeoutProcessing({
+      pagesEstimate: 700,
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0 + 60_000,
+    });
+    const original = new ScrapeJobTimeoutError(message, details);
+    const revived = deserializeTransportableError(
+      serializeTransportableError(original),
+    );
+    expect(revived).toBeInstanceOf(ScrapeJobTimeoutError);
+    expect(revived.message).toBe(message);
+    expect(getTimeoutProcessingDetails(revived)).toEqual(details);
+  });
+
+  it("getTimeoutProcessingDetails ignores plain timeouts and other errors", () => {
+    expect(
+      getTimeoutProcessingDetails(new ScrapeJobTimeoutError()),
+    ).toBeUndefined();
+    expect(
+      getTimeoutProcessingDetails(
+        new TransportableError("UNKNOWN_ERROR", "nope"),
+      ),
+    ).toBeUndefined();
+    expect(getTimeoutProcessingDetails(new Error("nope"))).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/error.ts
+++ b/apps/api/src/lib/error.ts
@@ -65,22 +65,121 @@ export class TransportableError extends Error {
   }
 }
 
+/**
+ * Attached to a SCRAPE_TIMEOUT when a large-PDF (by-reference FirePDF)
+ * job keeps processing server-side after the request's own window
+ * expired — by design, the job is not cancelled (see fire-pdf/async.ts).
+ * Surfaced to the caller as the error response's `details` plus a
+ * `Retry-After` header, so a retry of the same URL is a deliberate,
+ * timed action instead of a blind loop.
+ */
+type ScrapeTimeoutProcessingDetails = {
+  state: "processing_continues";
+  documentPages?: number;
+  jobStatus: "queued" | "running";
+  estimatedRemainingSeconds: number;
+  retryAfterSeconds: number;
+  /** Set when the document may not finish within the server-side
+   * processing ceiling even across retries. */
+  mayExceedProcessingWindow?: boolean;
+};
+
+/** Matches BY_REFERENCE_DEADLINE_PER_PAGE_MS (fire-pdf/utils.ts) — the
+ * conservative worst-case processing rate the job deadline is built
+ * from. Kept as a default parameter here so lib/error stays free of
+ * scraper imports. */
+const PROCESSING_ESTIMATE_PER_PAGE_MS = 500;
+/** Fixed overhead the estimate grants beyond pure page work: queue
+ * pickup, render bootstrap, result assembly. */
+const PROCESSING_ESTIMATE_BASE_MS = 60_000;
+
+/**
+ * Compose the customer-facing "we're still working on it" message and
+ * structured details for a timed-out large-PDF scrape. Estimates are
+ * deliberately conservative and coarse (whole minutes, floored at one):
+ * an estimate that is early twice reads as magic, one that is late once
+ * reads as broken.
+ */
+export function composeTimeoutProcessing(args: {
+  pagesEstimate?: number;
+  submittedAtMs: number;
+  jobDeadlineAtMs?: number;
+  lastStatus: "queued" | "published" | "running";
+  nowMs: number;
+  perPageMs?: number;
+}): { message: string; details: ScrapeTimeoutProcessingDetails } {
+  const perPageMs = args.perPageMs ?? PROCESSING_ESTIMATE_PER_PAGE_MS;
+  const pages = args.pagesEstimate;
+  const totalMs =
+    pages !== undefined && pages > 0
+      ? pages * perPageMs + PROCESSING_ESTIMATE_BASE_MS
+      : 5 * 60_000;
+  const elapsedMs = Math.max(0, args.nowMs - args.submittedAtMs);
+  const remainingMs = Math.max(60_000, totalMs - elapsedMs);
+  const remainingMinutes = Math.ceil(remainingMs / 60_000);
+  const estimatedRemainingSeconds = remainingMinutes * 60;
+  const retryAfterSeconds = Math.min(600, estimatedRemainingSeconds);
+  const jobStatus: "queued" | "running" =
+    args.lastStatus === "running" ? "running" : "queued";
+  const mayExceedProcessingWindow =
+    args.jobDeadlineAtMs !== undefined &&
+    args.nowMs + remainingMs > args.jobDeadlineAtMs;
+
+  const docLabel =
+    pages !== undefined && pages > 0 ? `this ${pages}-page PDF` : "this PDF";
+  const inMinutes = `~${remainingMinutes} minute${remainingMinutes === 1 ? "" : "s"}`;
+
+  const message = mayExceedProcessingWindow
+    ? `Request timed out. Note: ${docLabel} is very large and may exceed the maximum server-side processing window. Retry the same URL in ${inMinutes} to pick up the result if it completes; if retries keep timing out, pass a larger \`timeout\` or contact support to raise your document processing ceiling.`
+    : jobStatus === "running"
+      ? `Request timed out, but ${docLabel} is still being processed on our side. Retrying the same URL in ${inMinutes} returns the completed result without re-processing. To avoid the retry entirely, pass a \`timeout\` that covers the estimate.`
+      : `Request timed out. Note: ${docLabel} is queued for processing on our side and will not lose its place. Retrying the same URL in ${inMinutes} returns the completed result without re-processing.`;
+
+  return {
+    message,
+    details: {
+      state: "processing_continues",
+      ...(pages !== undefined && pages > 0 && { documentPages: pages }),
+      jobStatus,
+      estimatedRemainingSeconds,
+      retryAfterSeconds,
+      ...(mayExceedProcessingWindow && { mayExceedProcessingWindow: true }),
+    },
+  };
+}
+
+/** Safe accessor for the processing details on a (possibly deserialized)
+ * SCRAPE_TIMEOUT error. */
+export function getTimeoutProcessingDetails(
+  e: unknown,
+): ScrapeTimeoutProcessingDetails | undefined {
+  if (e instanceof TransportableError && e.code === "SCRAPE_TIMEOUT") {
+    const p = (e as ScrapeJobTimeoutError).processing;
+    if (p && p.state === "processing_continues") return p;
+  }
+  return undefined;
+}
+
 export class ScrapeJobTimeoutError extends TransportableError {
   constructor(
     message: string = "The scrape operation timed out before completing. This happens when a page takes too long to load, render, or process. Possible causes: (1) The website is slow or unresponsive, (2) The page has heavy JavaScript that takes time to execute, (3) The page is very large or has many resources to load, (4) Network latency is high. To fix this, try increasing the timeout parameter in your scrape request, or if using actions, ensure your selectors are correct and the page is ready before actions are executed.",
+    public processing?: ScrapeTimeoutProcessingDetails,
   ) {
     super("SCRAPE_TIMEOUT", message);
   }
 
   serialize() {
-    return super.serialize();
+    return {
+      ...super.serialize(),
+      processing: this.processing,
+    };
   }
 
   static deserialize(
     _code: ErrorCodes,
     data: ReturnType<typeof this.prototype.serialize>,
   ) {
-    const x = new ScrapeJobTimeoutError(data.message);
+    const x = new ScrapeJobTimeoutError(data.message, data.processing);
     x.stack = data.stack;
     return x;
   }

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -1185,8 +1185,9 @@ describe("scrapePDFWithFirePDFAsync", () => {
         },
       ]);
 
+      const meta = makeMeta();
       const result = await scrapePDFWithFirePDFAsync(
-        makeMeta(),
+        meta,
         BY_REF,
         undefined,
         6543,
@@ -1195,6 +1196,9 @@ describe("scrapePDFWithFirePDFAsync", () => {
       );
 
       expect(result.markdown).toBe("# big doc");
+      // Completed within this scrape — no "processing continues" state
+      // may leak into a later timeout.
+      expect(meta.largePdfProcessing).toBeUndefined();
       // The by-reference LOOKUP happens at the call site before the input
       // object is uploaded (a hit must skip the transfer, which has already
       // happened by the time this function runs) — so no lookup here, only
@@ -1353,8 +1357,9 @@ describe("scrapePDFWithFirePDFAsync", () => {
         },
       ]);
 
+      const meta = makeMeta();
       const error = await scrapePDFWithFirePDFAsync(
-        makeMeta(),
+        meta,
         { ...BY_REF },
         undefined,
         500,
@@ -1368,6 +1373,16 @@ describe("scrapePDFWithFirePDFAsync", () => {
       expect(error).toBeInstanceOf(FirePdfAsyncFailure);
       expect(error.reason).toBe("network_error");
       expect(calls.map(call => call.method)).toEqual(["POST", "GET"]);
+      // The live job's state survives for timeout-error enrichment
+      // ("processing continues, retry in ~N minutes").
+      expect(meta.largePdfProcessing).toMatchObject({
+        jobScrapeId: "scrape-id-test",
+        pagesEstimate: 500,
+        lastStatus: "queued",
+      });
+      expect(meta.largePdfProcessing.jobDeadlineAtMs).toBeGreaterThan(
+        meta.largePdfProcessing.submittedAtMs,
+      );
     });
   });
 
@@ -1443,8 +1458,9 @@ describe("scrapePDFWithFirePDFAsync", () => {
         },
       ]);
 
+      const meta = makeMeta();
       const error = await scrapePDFWithFirePDFAsync(
-        makeMeta(),
+        meta,
         ADOPTED,
         undefined,
         500,
@@ -1456,6 +1472,8 @@ describe("scrapePDFWithFirePDFAsync", () => {
       expect(error.reason).toBe("terminal_expired");
       // Never DELETE a job this caller does not own.
       expect(calls.map(call => call.method)).toEqual(["GET"]);
+      // The job is dead — no "processing continues" state may survive.
+      expect(meta.largePdfProcessing).toBeUndefined();
     });
 
     it("throws for adopted input under ZDR", async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -11,6 +11,7 @@ import {
   FirePdfAsyncFailure,
   scrapePDFWithFirePDFAsync,
 } from "../fire-pdf/async";
+import { lookupAdoptableFirePdfJob } from "../fire-pdf/lookup";
 import {
   getPdfResultFromCache,
   savePdfResultToCache,
@@ -1291,5 +1292,249 @@ describe("scrapePDFWithFirePDFAsync", () => {
         ).rejects.toThrow(/pages estimate/);
       }
     });
+
+    it("advertises a page-scaled deadline decoupled from the caller window", async () => {
+      let submittedBody: any;
+      const fetchImpl: any = async (url: string, init: any) => {
+        if (/\/jobs$/.test(url) && (init?.method ?? "GET") === "POST") {
+          submittedBody = JSON.parse(init.body as string);
+          return jsonResp({
+            status: 200,
+            body: { scrape_id: "x", status: "done", pages_processed: 1000 },
+          });
+        }
+        return jsonResp({
+          status: 200,
+          body: { markdown: "ok", pages_processed: 1000 },
+        });
+      };
+      // Caller has only 60s left, but the JOB gets what the document
+      // needs: 5min base + 1000 pages × 500ms ≈ 13.3min. The job then
+      // outlives this caller by design — cancel-on-abandon is skipped for
+      // by-reference — so the completion feeds the raw-sha cache and the
+      // adoption lookup for the customer's retry.
+      const meta = makeMeta();
+      meta.abort.scrapeTimeout = vi.fn(() => 60_000);
+
+      await scrapePDFWithFirePDFAsync(
+        meta,
+        { ...BY_REF },
+        undefined,
+        1000,
+        undefined,
+        {
+          fetchImpl,
+          fallbackImpl: vi.fn(),
+          sleepImpl: noopSleep,
+        },
+      );
+
+      const delta = new Date(submittedBody.deadline_at).getTime() - Date.now();
+      expect(delta).toBeGreaterThan(12 * 60 * 1_000);
+      expect(delta).toBeLessThanOrEqual(14 * 60 * 1_000);
+    });
+
+    it("does NOT cancel a by-reference job when polling is abandoned", async () => {
+      const { fetchImpl, calls } = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs$/,
+          matchMethod: "POST",
+          response: {
+            status: 202,
+            body: { scrape_id: "scrape-id-test", status: "queued", lane: "xl" },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test$/,
+          matchMethod: "GET",
+          response: () => {
+            throw new Error("poll transport failed");
+          },
+        },
+      ]);
+
+      const error = await scrapePDFWithFirePDFAsync(
+        makeMeta(),
+        { ...BY_REF },
+        undefined,
+        500,
+        undefined,
+        { fetchImpl, fallbackImpl: vi.fn(), sleepImpl: noopSleep },
+      ).catch(error => error);
+
+      // Same abandonment as the inline cancel test above — but the
+      // by-reference job is left to finish server-side: its completion
+      // still has value through the raw-sha cache and adoption.
+      expect(error).toBeInstanceOf(FirePdfAsyncFailure);
+      expect(error.reason).toBe("network_error");
+      expect(calls.map(call => call.method)).toEqual(["POST", "GET"]);
+    });
+  });
+
+  describe("adopted job input (content-level retry convergence)", () => {
+    const ADOPTED = {
+      adoptScrapeId: "adopted-123",
+      sha256: "cd".repeat(32),
+    };
+
+    it("polls the adopted scrape_id without submitting anything", async () => {
+      vi.mocked(getPdfResultFromCache).mockClear();
+      vi.mocked(savePdfResultToCache).mockClear();
+      const { fetchImpl, calls } = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs\/adopted-123$/,
+          matchMethod: "GET",
+          response: {
+            status: 200,
+            body: {
+              scrape_id: "adopted-123",
+              status: "done",
+              pages_processed: 500,
+            },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/adopted-123\/result$/,
+          matchMethod: "GET",
+          response: {
+            status: 200,
+            body: {
+              schema_version: 1,
+              markdown: "# adopted doc",
+              pages_processed: 500,
+              failed_pages: null,
+              partial_pages: null,
+            },
+          },
+        },
+      ]);
+
+      const result = await scrapePDFWithFirePDFAsync(
+        makeMeta(),
+        ADOPTED,
+        undefined,
+        500,
+        undefined,
+        { fetchImpl, fallbackImpl: vi.fn(), sleepImpl: noopSleep },
+      );
+
+      expect(result.markdown).toBe("# adopted doc");
+      // No POST /jobs — the whole point is not duplicating the job.
+      expect(calls.map(call => call.method)).toEqual(["GET", "GET"]);
+      // The adopted result populates the same raw-sha cache a fresh
+      // by-reference run would, so the attempt after next is a cache hit.
+      expect(vi.mocked(savePdfResultToCache)).toHaveBeenCalledWith(
+        { key: `raw-${ADOPTED.sha256}` },
+        expect.anything(),
+        "firepdf",
+        undefined,
+      );
+    });
+
+    it("surfaces an adopted job's terminal failure without cancelling it", async () => {
+      const { fetchImpl, calls } = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs\/adopted-123$/,
+          matchMethod: "GET",
+          response: {
+            status: 410,
+            body: { scrape_id: "adopted-123", status: "expired" },
+          },
+        },
+      ]);
+
+      const error = await scrapePDFWithFirePDFAsync(
+        makeMeta(),
+        ADOPTED,
+        undefined,
+        500,
+        undefined,
+        { fetchImpl, fallbackImpl: vi.fn(), sleepImpl: noopSleep },
+      ).catch(error => error);
+
+      expect(error).toBeInstanceOf(FirePdfAsyncFailure);
+      expect(error.reason).toBe("terminal_expired");
+      // Never DELETE a job this caller does not own.
+      expect(calls.map(call => call.method)).toEqual(["GET"]);
+    });
+
+    it("throws for adopted input under ZDR", async () => {
+      await expect(
+        scrapePDFWithFirePDFAsync(
+          makeMeta({
+            internalOptions: {
+              zeroDataRetention: true,
+              teamId: "team-x",
+              teamConcurrency: 12,
+              crawlId: undefined,
+            },
+          }),
+          ADOPTED,
+          undefined,
+          500,
+          undefined,
+          { fetchImpl: vi.fn(), fallbackImpl: vi.fn(), sleepImpl: noopSleep },
+        ),
+      ).rejects.toThrow(/zero data retention/);
+    });
+  });
+});
+
+describe("lookupAdoptableFirePdfJob", () => {
+  const SHA = "ef".repeat(32);
+
+  it("returns an adoption handle on a 200 hit", async () => {
+    const { fetchImpl, calls } = makeFetchFromSequence([
+      {
+        matchUrl: /\/jobs\/lookup$/,
+        matchMethod: "POST",
+        response: {
+          status: 200,
+          body: { scrape_id: "found-1", status: "running" },
+        },
+      },
+    ]);
+    const found = await lookupAdoptableFirePdfJob(
+      makeMeta(),
+      SHA,
+      { mode: "auto", pages_estimate: 100 },
+      fetchImpl,
+    );
+    expect(found).toEqual({ adoptScrapeId: "found-1", sha256: SHA });
+    const body = calls[0].body as Record<string, unknown>;
+    expect(body.input_sha256).toBe(SHA);
+    expect(body.options).toEqual({ mode: "auto", pages_estimate: 100 });
+  });
+
+  it("returns null on 404, non-200, malformed bodies, and transport failure", async () => {
+    for (const response of [
+      { status: 404, body: { error: "not_found" } },
+      { status: 503, body: { error: "lookup_failed" } },
+      { status: 200, body: { nope: true } },
+    ]) {
+      const { fetchImpl } = makeFetchFromSequence([
+        { matchUrl: /\/jobs\/lookup$/, matchMethod: "POST", response },
+      ]);
+      expect(
+        await lookupAdoptableFirePdfJob(makeMeta(), SHA, {}, fetchImpl),
+      ).toBeNull();
+    }
+    const throwing: any = async () => {
+      throw new Error("connect ECONNREFUSED");
+    };
+    expect(
+      await lookupAdoptableFirePdfJob(makeMeta(), SHA, {}, throwing),
+    ).toBeNull();
+  });
+
+  it("propagates a scrape abort instead of swallowing it", async () => {
+    const meta = makeMeta();
+    const abortError = new Error("scrape aborted");
+    meta.abort.throwIfAborted = vi.fn(() => {
+      throw abortError;
+    });
+    await expect(
+      lookupAdoptableFirePdfJob(meta, SHA, {}, vi.fn()),
+    ).rejects.toBe(abortError);
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -82,6 +82,7 @@ function makeMeta(overrides: Record<string, unknown> = {}) {
     options: {
       parsers: [{ type: "pdf", __firePdfAsync: true }],
     },
+    largePdfProcessing: {},
     ...overrides,
   } as any;
 }
@@ -1187,7 +1188,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
 
       const meta = makeMeta();
       const result = await scrapePDFWithFirePDFAsync(
-        meta,
+        { ...meta, logger: meta.logger },
         BY_REF,
         undefined,
         6543,
@@ -1198,7 +1199,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
       expect(result.markdown).toBe("# big doc");
       // Completed within this scrape — no "processing continues" state
       // may leak into a later timeout.
-      expect(meta.largePdfProcessing).toBeUndefined();
+      expect(meta.largePdfProcessing.current).toBeUndefined();
       // The by-reference LOOKUP happens at the call site before the input
       // object is uploaded (a hit must skip the transfer, which has already
       // happened by the time this function runs) — so no lookup here, only
@@ -1358,8 +1359,12 @@ describe("scrapePDFWithFirePDFAsync", () => {
       ]);
 
       const meta = makeMeta();
+      // Call through a spread copy, exactly like the real callers (engine
+      // dispatch and the by-reference flow's child logger): the shared
+      // container is what makes the write visible on the original meta
+      // that the outer timeout handler inspects.
       const error = await scrapePDFWithFirePDFAsync(
-        meta,
+        { ...meta, logger: meta.logger },
         { ...BY_REF },
         undefined,
         500,
@@ -1375,13 +1380,13 @@ describe("scrapePDFWithFirePDFAsync", () => {
       expect(calls.map(call => call.method)).toEqual(["POST", "GET"]);
       // The live job's state survives for timeout-error enrichment
       // ("processing continues, retry in ~N minutes").
-      expect(meta.largePdfProcessing).toMatchObject({
+      expect(meta.largePdfProcessing.current).toMatchObject({
         jobScrapeId: "scrape-id-test",
         pagesEstimate: 500,
         lastStatus: "queued",
       });
-      expect(meta.largePdfProcessing.jobDeadlineAtMs).toBeGreaterThan(
-        meta.largePdfProcessing.submittedAtMs,
+      expect(meta.largePdfProcessing.current.jobDeadlineAtMs).toBeGreaterThan(
+        meta.largePdfProcessing.current.submittedAtMs,
       );
     });
   });
@@ -1473,7 +1478,7 @@ describe("scrapePDFWithFirePDFAsync", () => {
       // Never DELETE a job this caller does not own.
       expect(calls.map(call => call.method)).toEqual(["GET"]);
       // The job is dead — no "processing continues" state may survive.
-      expect(meta.largePdfProcessing).toBeUndefined();
+      expect(meta.largePdfProcessing.current).toBeUndefined();
     });
 
     it("throws for adopted input under ZDR", async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsyncRouting.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsyncRouting.test.ts
@@ -5,6 +5,7 @@ import {
   FIRE_PDF_ASYNC_MIN_REMAINING_MS,
 } from "../fire-pdf/routing";
 import {
+  computeByReferenceDeadlineMs,
   computeDeadlineMs,
   firePdfHeaders,
   nextPollDelay,
@@ -149,6 +150,24 @@ describe("FirePDF async transport helpers", () => {
 
   it("does not inflate a caller deadline", () => {
     expect(computeDeadlineMs(4_000)).toBe(4_000);
+  });
+
+  it("page-scales the by-reference job deadline independently of the caller", () => {
+    // 5min base + pages × 500ms, floored at the caller window, capped at
+    // MAX_DEADLINE_MS. The caller's own polling stops at its window; the
+    // decoupled job deadline is what lets the job finish server-side.
+    const FIVE_MIN = 5 * 60 * 1_000;
+    // Small doc, tiny caller window → base dominates.
+    expect(computeByReferenceDeadlineMs(60_000, 100)).toBe(FIVE_MIN + 50_000);
+    // Big doc → page term dominates, capped at 30 min.
+    expect(computeByReferenceDeadlineMs(60_000, 6_543)).toBe(30 * 60 * 1_000);
+    // A caller with a LONGER explicit window than the page-scaled need
+    // keeps its window (never advertise less than the caller has).
+    expect(computeByReferenceDeadlineMs(20 * 60 * 1_000, 100)).toBe(
+      20 * 60 * 1_000,
+    );
+    // No pages estimate → base + caller floor semantics still hold.
+    expect(computeByReferenceDeadlineMs(undefined, undefined)).toBe(FIVE_MIN);
   });
 
   it("adds the shared FirePDF bearer credential when configured", () => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -11,10 +11,12 @@ import { firePdfAsyncTotalDurationSeconds } from "./metrics";
 import { pollUntilTerminal } from "./poll";
 import { fetchResult } from "./result";
 import type { FirePdfByReferenceInput } from "./by-reference";
+import type { FirePdfAdoptedJobInput } from "./lookup";
 import { FIRE_PDF_ASYNC_MIN_REMAINING_MS } from "./routing";
 import { POLL_FLOOR_MS, POLL_TIMEOUT_BUFFER_MS } from "./schema";
 import { submitJob, SubmitJobMayHaveBeenAcceptedError } from "./submit";
 import {
+  computeByReferenceDeadlineMs,
   computeDeadlineMs,
   defaultSleep,
   failAsync,
@@ -33,11 +35,13 @@ type FirePdfAsyncDeps = {
 
 export async function scrapePDFWithFirePDFAsync(
   meta: Meta,
-  /** Inline base64 (string, the historical shape) or a pre-uploaded GCS
-   * reference for large files. By-reference has no sync fallback — the
-   * bytes don't fit fire-pdf's inline paths — so infra fallbacks below
-   * only apply to the string form. */
-  input: string | FirePdfByReferenceInput,
+  /** Inline base64 (string, the historical shape), a pre-uploaded GCS
+   * reference for large files, or an existing job to adopt (found by
+   * content lookup — no upload, no submit, just poll + fetch). Neither
+   * non-string form has a sync fallback — the bytes don't fit fire-pdf's
+   * inline paths — so infra fallbacks below only apply to the string
+   * form. */
+  input: string | FirePdfByReferenceInput | FirePdfAdoptedJobInput,
   maxPages?: number,
   pagesProcessed?: number,
   mode?: PDFMode,
@@ -52,13 +56,21 @@ export async function scrapePDFWithFirePDFAsync(
   const now = deps.nowImpl ?? Date.now;
   const random = deps.randomImpl ?? Math.random;
   const base64Content = typeof input === "string" ? input : undefined;
+  const adopted =
+    typeof input !== "string" && "adoptScrapeId" in input ? input : undefined;
+  const byReference =
+    typeof input !== "string" && "gcsUri" in input ? input : undefined;
+  // Which fire-pdf job this attempt watches: our own scrape_id, or the
+  // adopted job's. Poll, result-fetch, and cancel must all agree.
+  const jobScrapeId = adopted ? adopted.adoptScrapeId : meta.id;
 
   // Async persists inputs and queue state, so ZDR is excluded until that
   // lifecycle has an explicit delete-on-completion contract.
   if (meta.internalOptions.zeroDataRetention) {
     if (base64Content === undefined) {
-      // By-reference already persisted the input object; the routing layer
-      // must never send ZDR traffic here.
+      // By-reference already persisted the input object, and adoption
+      // reads another submitter's persisted job; the routing layer must
+      // never send ZDR traffic here.
       throw new Error(
         "fire-pdf by-reference submit is not available under zero data retention",
       );
@@ -136,13 +148,25 @@ export async function scrapePDFWithFirePDFAsync(
 
   const overallStartedAt = now();
   const submitTime = now();
-  // Note for large by-reference documents: the no-budget fallback inside
-  // computeDeadlineMs is 5 minutes because scrapeURLLoop kills no-timeout
-  // scrapes at 5 minutes anyway. Callers wanting the full multi-minute
-  // window for big documents must pass an explicit `timeout`.
-  const deadlineFromNow = computeDeadlineMs(remainingMs);
+  // The caller's window governs how long THIS attempt polls: scrapeURLLoop
+  // kills no-timeout scrapes at 5 minutes regardless of what the job is
+  // allowed, so polling past it only burns a dead scrape's cycles.
+  const callerWindowMs = computeDeadlineMs(remainingMs);
+  // The JOB deadline is decoupled from the caller for by-reference
+  // submits: page-scaled, never below the caller window, capped at
+  // 30 min. An inline job's deadline stays the caller window exactly —
+  // when its caller dies, the job is cancelled and the work discarded, so
+  // advertising more time would be a lie. A by-reference job instead
+  // outlives its caller on purpose (cancel is skipped below): it finishes
+  // server-side, lands in the raw-sha cache and the content-adoption
+  // lookup, and the customer's retry — with a fresh scrape_id — converges
+  // instead of restarting a multi-minute document from zero. Callers
+  // wanting first-attempt success must still pass an explicit `timeout`.
+  const deadlineFromNow = byReference
+    ? computeByReferenceDeadlineMs(remainingMs, pagesProcessed)
+    : callerWindowMs;
   const deadlineAt = new Date(submitTime + deadlineFromNow).toISOString();
-  const pollingDeadline = submitTime + deadlineFromNow + POLL_TIMEOUT_BUFFER_MS;
+  const pollingDeadline = submitTime + callerWindowMs + POLL_TIMEOUT_BUFFER_MS;
 
   // Account context for FirePDF's per-team admission observation,
   // snapshotted from the request ACUC into internalOptions at
@@ -154,46 +178,71 @@ export async function scrapePDFWithFirePDFAsync(
       ? rawConcurrency
       : undefined;
 
-  // ── Step 1: POST /jobs ────────────────────────────────────────────────
+  // ── Step 1: POST /jobs (skipped when adopting an existing job) ────────
   let submissionAccepted = false;
   let terminalReached = false;
   let polled: Awaited<ReturnType<typeof pollUntilTerminal>>;
   let fetched: Awaited<ReturnType<typeof fetchResult>>;
+  // What goes on the wire for step 1 — null means nothing does: an
+  // adopted job was submitted by an earlier attempt and is only watched.
+  const wireInput = byReference
+    ? ({
+        kind: "byReference",
+        gcsUri: byReference.gcsUri,
+        sha256: byReference.sha256,
+      } as const)
+    : base64Content !== undefined
+      ? ({ kind: "inline", base64Content } as const)
+      : null;
+  // Ownership policy, in one place: only an abandoned INLINE job is
+  // cancelled. An adopted job is not ours to kill — its owner or other
+  // retries may still be watching. A by-reference job is left running BY
+  // DESIGN: its input is durably content-addressed, so the completion
+  // this caller never sees still lands in the raw-sha cache and the
+  // adoption lookup, converting the customer's retry loop into a cache
+  // hit. The cost is bounded — the job's own deadline (≤30 min) — and
+  // strictly smaller than the redo loop it replaces.
+  const cancelOnAbandon = wireInput?.kind === "inline";
+
   try {
-    const submit = await submitJob({
-      meta,
-      baseUrl,
-      input:
-        typeof input === "string"
-          ? { kind: "inline", base64Content: input }
-          : {
-              kind: "byReference",
-              gcsUri: input.gcsUri,
-              sha256: input.sha256,
-            },
-      maxPages,
-      pagesProcessed,
-      mode,
-      includePageMarkdown,
-      includeBlocks,
-      pageMarkers,
-      deadlineAt,
-      teamConcurrency,
-      fetchImpl,
-    });
-    submissionAccepted = true;
-    terminalReached = submit.alreadyDone;
+    let alreadyDone = false;
+    let initialDelay: number = POLL_FLOOR_MS;
+    if (wireInput === null) {
+      meta.logger.info("FirePDF async adopting existing job", {
+        scrapeId: meta.id,
+        adoptedScrapeId: jobScrapeId,
+      });
+    } else {
+      const submit = await submitJob({
+        meta,
+        baseUrl,
+        input: wireInput,
+        maxPages,
+        pagesProcessed,
+        mode,
+        includePageMarkdown,
+        includeBlocks,
+        pageMarkers,
+        deadlineAt,
+        teamConcurrency,
+        fetchImpl,
+      });
+      submissionAccepted = true;
+      alreadyDone = submit.alreadyDone;
+      initialDelay = submit.retryAfterMs ?? POLL_FLOOR_MS;
+    }
+    terminalReached = alreadyDone;
 
     // ── Step 2: poll until terminal (skip on idempotent-replay done) ──────
-    polled = submit.alreadyDone
+    polled = alreadyDone
       ? {
-          poll: { scrape_id: meta.id, status: "done" as const },
+          poll: { scrape_id: jobScrapeId, status: "done" as const },
           pollCount: 0,
         }
       : await pollUntilTerminal({
           baseUrl,
-          scrapeId: meta.id,
-          initialDelay: submit.retryAfterMs ?? POLL_FLOOR_MS,
+          scrapeId: jobScrapeId,
+          initialDelay,
           pollingDeadline,
           meta,
           fetchImpl,
@@ -206,7 +255,7 @@ export async function scrapePDFWithFirePDFAsync(
     // ── Step 3: GET /jobs/:id/result ────────────────────────────────────
     fetched = await fetchResult({
       baseUrl,
-      scrapeId: meta.id,
+      scrapeId: jobScrapeId,
       meta,
       fetchImpl,
       sleep,
@@ -220,6 +269,7 @@ export async function scrapePDFWithFirePDFAsync(
         error.reason === "terminal_expired" ||
         error.reason === "terminal_cancelled");
     if (
+      cancelOnAbandon &&
       (submissionAccepted || submitMayHaveBeenAccepted) &&
       !terminalReached &&
       !jobAlreadyTerminal

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -214,13 +214,17 @@ export async function scrapePDFWithFirePDFAsync(
       });
       // Adopted jobs are live by definition (done ones return on the
       // first poll); the true start time is unknown, so the estimate
-      // conservatively counts from now.
-      meta.largePdfProcessing = {
-        jobScrapeId,
-        pagesEstimate: pagesProcessed,
-        submittedAtMs: submitTime,
-        lastStatus: "running",
-      };
+      // conservatively counts from now. Written into the shared
+      // container so it survives the spread copies between here and the
+      // outer timeout handler.
+      if (meta.largePdfProcessing) {
+        meta.largePdfProcessing.current = {
+          jobScrapeId,
+          pagesEstimate: pagesProcessed,
+          submittedAtMs: submitTime,
+          lastStatus: "running",
+        };
+      }
     } else {
       const submit = await submitJob({
         meta,
@@ -239,11 +243,13 @@ export async function scrapePDFWithFirePDFAsync(
       submissionAccepted = true;
       alreadyDone = submit.alreadyDone;
       initialDelay = submit.retryAfterMs ?? POLL_FLOOR_MS;
-      if (byReference && !alreadyDone) {
+      if (byReference && !alreadyDone && meta.largePdfProcessing) {
         // The job now exists server-side and (per the cancel policy
         // above) will keep running if this scrape is abandoned — record
-        // enough state for the timeout error to say so.
-        meta.largePdfProcessing = {
+        // enough state for the timeout error to say so. Written into the
+        // shared container so it survives the spread copies between here
+        // and the outer timeout handler.
+        meta.largePdfProcessing.current = {
           jobScrapeId,
           pagesEstimate: pagesProcessed,
           submittedAtMs: submitTime,
@@ -271,8 +277,8 @@ export async function scrapePDFWithFirePDFAsync(
           now,
           random,
           onNonTerminalStatus: status => {
-            if (meta.largePdfProcessing) {
-              meta.largePdfProcessing.lastStatus = status;
+            if (meta.largePdfProcessing?.current) {
+              meta.largePdfProcessing.current.lastStatus = status;
             }
           },
         });
@@ -294,9 +300,9 @@ export async function scrapePDFWithFirePDFAsync(
       (error.reason === "terminal_failed" ||
         error.reason === "terminal_expired" ||
         error.reason === "terminal_cancelled");
-    if (jobAlreadyTerminal || terminalReached) {
+    if ((jobAlreadyTerminal || terminalReached) && meta.largePdfProcessing) {
       // The job is dead — a "processing continues" message would lie.
-      meta.largePdfProcessing = undefined;
+      meta.largePdfProcessing.current = undefined;
     }
     if (
       cancelOnAbandon &&
@@ -307,6 +313,13 @@ export async function scrapePDFWithFirePDFAsync(
       await cancelJob({ baseUrl, scrapeId: meta.id, meta, fetchImpl });
     }
     throw submitMayHaveBeenAccepted ? error.originalError : error;
+  }
+
+  // The job reached a terminal state and its result was fetched — nothing
+  // "continues", regardless of how the validations below turn out (their
+  // failAsync throws must not leave stale processing state behind).
+  if (meta.largePdfProcessing) {
+    meta.largePdfProcessing.current = undefined;
   }
 
   // ── Assemble + cache save ─────────────────────────────────────────────
@@ -332,9 +345,6 @@ export async function scrapePDFWithFirePDFAsync(
       note: "FirePDF result did not acknowledge requested page markers",
     });
   }
-  // Job completed within this scrape's lifetime — nothing continues.
-  meta.largePdfProcessing = undefined;
-
   const durationMs = now() - overallStartedAt;
   firePdfAsyncTotalDurationSeconds.observe(durationMs / 1000);
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -212,6 +212,15 @@ export async function scrapePDFWithFirePDFAsync(
         scrapeId: meta.id,
         adoptedScrapeId: jobScrapeId,
       });
+      // Adopted jobs are live by definition (done ones return on the
+      // first poll); the true start time is unknown, so the estimate
+      // conservatively counts from now.
+      meta.largePdfProcessing = {
+        jobScrapeId,
+        pagesEstimate: pagesProcessed,
+        submittedAtMs: submitTime,
+        lastStatus: "running",
+      };
     } else {
       const submit = await submitJob({
         meta,
@@ -230,6 +239,18 @@ export async function scrapePDFWithFirePDFAsync(
       submissionAccepted = true;
       alreadyDone = submit.alreadyDone;
       initialDelay = submit.retryAfterMs ?? POLL_FLOOR_MS;
+      if (byReference && !alreadyDone) {
+        // The job now exists server-side and (per the cancel policy
+        // above) will keep running if this scrape is abandoned — record
+        // enough state for the timeout error to say so.
+        meta.largePdfProcessing = {
+          jobScrapeId,
+          pagesEstimate: pagesProcessed,
+          submittedAtMs: submitTime,
+          jobDeadlineAtMs: submitTime + deadlineFromNow,
+          lastStatus: "queued",
+        };
+      }
     }
     terminalReached = alreadyDone;
 
@@ -249,6 +270,11 @@ export async function scrapePDFWithFirePDFAsync(
           sleep,
           now,
           random,
+          onNonTerminalStatus: status => {
+            if (meta.largePdfProcessing) {
+              meta.largePdfProcessing.lastStatus = status;
+            }
+          },
         });
     terminalReached = true;
 
@@ -268,6 +294,10 @@ export async function scrapePDFWithFirePDFAsync(
       (error.reason === "terminal_failed" ||
         error.reason === "terminal_expired" ||
         error.reason === "terminal_cancelled");
+    if (jobAlreadyTerminal || terminalReached) {
+      // The job is dead — a "processing continues" message would lie.
+      meta.largePdfProcessing = undefined;
+    }
     if (
       cancelOnAbandon &&
       (submissionAccepted || submitMayHaveBeenAccepted) &&
@@ -302,6 +332,9 @@ export async function scrapePDFWithFirePDFAsync(
       note: "FirePDF result did not acknowledge requested page markers",
     });
   }
+  // Job completed within this scrape's lifetime — nothing continues.
+  meta.largePdfProcessing = undefined;
+
   const durationMs = now() - overallStartedAt;
   firePdfAsyncTotalDurationSeconds.observe(durationMs / 1000);
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference-flow.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference-flow.ts
@@ -70,7 +70,11 @@ export async function runFirePdfByReferenceAttempt(
   // key, it is the content-adoption identity (fire-pdf's
   // POST /jobs/lookup) and it verifies a fire-engine handoff
   // before the server-side copy. Uncacheable requests (maxPages)
-  // skip only the cache LOOKUP — they still adopt. A failed
+  // skip only the cache LOOKUP — they still adopt; gating the hash
+  // on cacheability (the pre-adoption rule) would permanently lock
+  // those requests out of adoption. The cost is one extra streamed
+  // disk read — seconds even at 256MB — against the upload and
+  // multi-minute processing run an adoption hit skips. A failed
   // pre-hash falls through to the upload path (which hashes
   // in-pipeline), never errors the scrape.
   const handoff = meta.pdfPrefetch?.gcsReference;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference-flow.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference-flow.ts
@@ -81,6 +81,11 @@ export async function runFirePdfByReferenceAttempt(
     includeBlocks,
     pageMarkers,
   );
+  // asSignal() after an abort returns a signal whose listeners never
+  // fire — check the manager directly (outside the swallowing catch
+  // below) so an already-cancelled scrape doesn't stream-read the whole
+  // file first.
+  meta.abort.throwIfAborted();
   let localSha256: string | undefined;
   try {
     localSha256 = await sha256OfFile(tempFilePath, meta.abort.asSignal());

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference-flow.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference-flow.ts
@@ -1,0 +1,272 @@
+import type { Meta } from "../../..";
+import type { PDFMode } from "../../../../../controllers/v2/types";
+import type { PDFProcessorResult } from "../types";
+import { scrapePDFWithFirePDFAsync } from "./async";
+import {
+  rewritePdfInputForFirePdf,
+  sha256OfFile,
+  uploadPdfInputForFirePdf,
+} from "./by-reference";
+import { cacheKeyShape, tryGetCached } from "./cache";
+import { lookupAdoptableFirePdfJob } from "./lookup";
+import { buildFirePdfJobOptions, FirePdfAsyncFailure } from "./utils";
+
+type FirePdfByReferenceAttemptArgs = {
+  meta: Meta;
+  tempFilePath: string;
+  fileSizeBytes: number;
+  /** Detected page count; the caller guarantees it is positive (fire-pdf
+   * rejects by-reference submits without one). */
+  pagesEstimate: number;
+  mode: PDFMode | undefined;
+  maxPages: number | undefined;
+  includePageMarkdown: boolean;
+  includeBlocks: boolean;
+  pageMarkers: boolean;
+};
+
+/**
+ * The full by-reference attempt for one large PDF, in cost order — each
+ * step only runs when the previous one didn't already produce a result:
+ *
+ *   1. raw-sha cache lookup  (one streamed disk read)
+ *   2. content adoption      (poll a live/done job for the same
+ *                             bytes+options — no upload, no reprocessing)
+ *   3. handoff rewrite or streaming upload, then a fresh async submit
+ *
+ * Returns the processor result, or null when the input could not even be
+ * placed in the fire-pdf bucket (rewrite AND upload failed) — the caller
+ * falls through to the legacy chain, preserving pre-by-reference
+ * behavior. Anything after a successful placement throws on failure
+ * instead: there is no inline retry at this size, and the legacy chain
+ * would silently degrade a large document to text-only extraction.
+ *
+ * Kept out of the engine router on purpose: this is transport/lifecycle
+ * recovery, not routing.
+ */
+export async function runFirePdfByReferenceAttempt(
+  args: FirePdfByReferenceAttemptArgs,
+): Promise<PDFProcessorResult | null> {
+  const {
+    meta,
+    tempFilePath,
+    fileSizeBytes,
+    pagesEstimate,
+    mode,
+    maxPages,
+    includePageMarkdown,
+    includeBlocks,
+    pageMarkers,
+  } = args;
+
+  // Cache BEFORE upload: the raw-byte sha is the by-reference cache
+  // identity, and it must be checked before the 30-256MB transfer —
+  // a repeat scrape of the same document should cost one streamed
+  // disk read, not a full re-upload. scrapePDFWithFirePDFAsync
+  // deliberately skips the by-reference lookup for the same reason
+  // (it runs post-upload) and only saves.
+  //
+  // The pre-hash is unconditional on this path: besides the cache
+  // key, it is the content-adoption identity (fire-pdf's
+  // POST /jobs/lookup) and it verifies a fire-engine handoff
+  // before the server-side copy. Uncacheable requests (maxPages)
+  // skip only the cache LOOKUP — they still adopt. A failed
+  // pre-hash falls through to the upload path (which hashes
+  // in-pipeline), never errors the scrape.
+  const handoff = meta.pdfPrefetch?.gcsReference;
+  const { cacheable: byRefCacheable } = cacheKeyShape(
+    mode,
+    maxPages,
+    includePageMarkdown,
+    includeBlocks,
+    pageMarkers,
+  );
+  let localSha256: string | undefined;
+  try {
+    localSha256 = await sha256OfFile(tempFilePath, meta.abort.asSignal());
+  } catch (error) {
+    meta.logger.warn(
+      "Pre-upload hash of large PDF failed; continuing without cache lookup",
+      {
+        method: "scrapePDF/firePdfByReference",
+        error,
+        scrape_id: meta.id,
+      },
+    );
+  }
+  const cachedByRef =
+    byRefCacheable && localSha256
+      ? await tryGetCached(
+          meta,
+          { key: `raw-${localSha256}` },
+          mode,
+          maxPages,
+          pagesEstimate,
+          includePageMarkdown,
+          includeBlocks,
+          pageMarkers,
+        )
+      : null;
+  // A scrape cancelled during the hash/lookup must not return a
+  // success out of the cache.
+  meta.abort.throwIfAborted();
+  if (cachedByRef) {
+    return cachedByRef;
+  }
+
+  // Content adoption, still BEFORE upload: retries carry fresh
+  // scrape_ids, so fire-pdf's scrape_id idempotency can't join
+  // them to a job an earlier attempt started (and, by design,
+  // never cancelled — see the async module's cancel policy). If a
+  // job for these exact bytes+options is live or done, poll IT:
+  // no upload, no duplicate processing. On success the result is
+  // saved under the raw-sha cache key, so the attempt after next
+  // is a pure cache hit. If the adopted job dies (expired/failed)
+  // or fire-pdf errors, fall through to a fresh upload+submit —
+  // except when the failure says this caller's own budget is
+  // gone, where a fresh submit could not succeed either.
+  if (localSha256) {
+    const adoptable = await lookupAdoptableFirePdfJob(
+      meta,
+      localSha256,
+      buildFirePdfJobOptions({
+        maxPages,
+        pagesProcessed: pagesEstimate,
+        mode,
+        includePageMarkdown,
+        includeBlocks,
+        pageMarkers,
+      }),
+    );
+    meta.abort.throwIfAborted();
+    if (adoptable) {
+      try {
+        return await scrapePDFWithFirePDFAsync(
+          {
+            ...meta,
+            logger: meta.logger.child({
+              method: "scrapePDF/firePDFAsyncAdopted",
+            }),
+          },
+          adoptable,
+          maxPages,
+          pagesEstimate,
+          mode,
+          undefined,
+          includePageMarkdown,
+          includeBlocks,
+          pageMarkers,
+        );
+      } catch (error) {
+        // An aborted scrape must not fall through to a fresh
+        // upload+submit (covers every abort shape without
+        // matching error classes).
+        meta.abort.throwIfAborted();
+        if (
+          error instanceof FirePdfAsyncFailure &&
+          (error.reason === "polling_timeout" ||
+            error.reason === "deadline_too_close")
+        ) {
+          throw error;
+        }
+        meta.logger.warn(
+          "Adopted FirePDF job did not deliver; submitting fresh",
+          {
+            method: "scrapePDF/firePDFAsyncAdopted",
+            event: "fire_pdf_adoption_fallthrough",
+            error,
+            adopted_scrape_id: adoptable.adoptScrapeId,
+            scrape_id: meta.id,
+          },
+        );
+      }
+    }
+  }
+
+  // When fire-engine already handed the file off via GCS, a server-side
+  // rewrite moves it into the fire-pdf input bucket without the bytes
+  // transiting this process; otherwise (or if the rewrite fails)
+  // stream-upload the local temp file. The handoff hash becomes
+  // fire-pdf's idempotency identity, so it must match the raw-byte sha
+  // already computed for the cache check above (no second disk read
+  // needed); any mismatch falls back to the hashing upload.
+  const handoffShaMatches =
+    localSha256 !== undefined &&
+    handoff?.sha256 !== undefined &&
+    handoff.sha256.toLowerCase() === localSha256;
+  if (
+    localSha256 !== undefined &&
+    handoff?.sha256 !== undefined &&
+    !handoffShaMatches
+  ) {
+    meta.logger.warn(
+      "fire-engine handoff sha256 does not match local bytes; using streaming upload",
+      {
+        method: "scrapePDF/firePdfByReference",
+        event: "fire_pdf_handoff_sha_mismatch",
+        scrape_id: meta.id,
+      },
+    );
+  }
+  const rewriteEligible =
+    handoffShaMatches &&
+    handoff !== undefined &&
+    handoff.sizeBytes === fileSizeBytes;
+  const uploaded =
+    (rewriteEligible && handoff
+      ? await rewritePdfInputForFirePdf(meta, {
+          uri: handoff.uri,
+          // rewriteEligible implies handoffShaMatches implies defined
+          sha256: localSha256!,
+          sizeBytes: fileSizeBytes,
+          generation: handoff.generation,
+        })
+      : null) ??
+    // A distinct key when a rewrite was attempted: a timed-out
+    // copy may still complete and must never overwrite this
+    // upload.
+    (await uploadPdfInputForFirePdf(meta, tempFilePath, fileSizeBytes, {
+      keyVariant: rewriteEligible ? "s" : undefined,
+      precomputedSha256: localSha256,
+    }));
+  if (!uploaded) {
+    // Upload failure: the caller falls through to the legacy chain — its
+    // oversized-skip warning still fires, preserving the
+    // pre-by-reference behavior.
+    return null;
+  }
+
+  try {
+    return await scrapePDFWithFirePDFAsync(
+      {
+        ...meta,
+        logger: meta.logger.child({
+          method: "scrapePDF/firePDFAsyncByReference",
+        }),
+      },
+      uploaded,
+      maxPages,
+      pagesEstimate,
+      mode,
+      undefined,
+      includePageMarkdown,
+      includeBlocks,
+      pageMarkers,
+    );
+  } catch (error) {
+    // No inline retry exists at this size, and the legacy chain
+    // below would silently degrade a large document to text-only
+    // extraction. Surface the failure instead.
+    meta.logger.error(
+      "FirePDF by-reference scrape failed (no fallback at this size)",
+      {
+        method: "scrapePDF/firePDFAsyncByReference",
+        error,
+        file_size_bytes: fileSizeBytes,
+        scrape_id: meta.id,
+        team_id: meta.internalOptions.teamId,
+      },
+    );
+    throw error;
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/lookup.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/lookup.ts
@@ -1,0 +1,116 @@
+/**
+ * FirePDF content-level job lookup (POST /jobs/lookup) — the adoption
+ * half of the async job protocol. Lives alongside submit/poll/result
+ * rather than the GCS transport helpers: adoption is about which JOB an
+ * attempt watches, not how bytes travel.
+ */
+import type { Meta } from "../../..";
+import { config } from "../../../../../config";
+import { fetch as undiciFetch } from "undici";
+import { firePdfHeaders } from "./utils";
+
+/** Handle for adopting an existing fire-pdf job instead of submitting a
+ * new one. Produced by {@link lookupAdoptableFirePdfJob}: the job was
+ * created by an earlier attempt (ours or another pod's) for the same
+ * document bytes and options, so the async flow polls it rather than
+ * re-uploading and re-processing. `sha256` keeps the raw-byte cache
+ * identity so the adopted result still lands in the content cache. */
+export type FirePdfAdoptedJobInput = {
+  adoptScrapeId: string;
+  sha256: string;
+};
+
+/** The lookup is one indexed Postgres read behind fire-pdf's API; this
+ * bound keeps a hung fire-pdf from eating the scrape budget on what is a
+ * pure optimization. */
+const LOOKUP_TIMEOUT_MS = 10_000;
+
+/**
+ * Ask fire-pdf whether a job already exists for these exact document
+ * bytes and options (POST /jobs/lookup). Retries arrive with fresh
+ * scrape_ids, so fire-pdf's scrape_id-keyed idempotency cannot join
+ * them to the original job — this content-level lookup can. A hit means
+ * the caller skips the 30-256MB upload AND the duplicate processing run,
+ * and just polls the returned scrape_id.
+ *
+ * Scoped to the submitting team: the body's team_id mirrors what the
+ * submit sends (absent when the account context has none), and fire-pdf
+ * only matches jobs with the same value — a request can never adopt
+ * another tenant's job.
+ *
+ * Best-effort by design: any failure (endpoint missing on an older
+ * fire-pdf, timeout, malformed body) returns null and the caller submits
+ * fresh — adoption can only ever remove work, never add failure modes.
+ * Scrape aborts are the one exception and propagate.
+ */
+export async function lookupAdoptableFirePdfJob(
+  meta: Meta,
+  sha256: string,
+  options: Record<string, unknown>,
+  fetchImpl: typeof undiciFetch = undiciFetch,
+): Promise<FirePdfAdoptedJobInput | null> {
+  const baseUrl = config.FIRE_PDF_BASE_URL;
+  if (!baseUrl) return null;
+  try {
+    // A first asSignal() call AFTER cancellation returns a signal whose
+    // abort listeners were attached post-abort and never fire — check the
+    // manager directly first.
+    meta.abort.throwIfAborted();
+    const signal = AbortSignal.any([
+      AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+      meta.abort.asSignal(),
+    ]);
+    const resp = await fetchImpl(`${baseUrl}/jobs/lookup`, {
+      method: "POST",
+      headers: firePdfHeaders(true),
+      body: JSON.stringify({
+        input_sha256: sha256,
+        // Same conditional shape as the submit body — the lookup must
+        // mirror it exactly for `IS NOT DISTINCT FROM` to match.
+        ...(meta.internalOptions.teamId && {
+          team_id: meta.internalOptions.teamId,
+        }),
+        options,
+      }),
+      signal,
+    });
+    if (resp.status === 404) return null;
+    if (resp.status !== 200) {
+      meta.logger.warn(
+        "FirePDF adoption lookup returned non-200; submitting fresh",
+        {
+          method: "scrapePDF/firePdfByReference",
+          event: "fire_pdf_adoption_lookup_miss",
+          status: resp.status,
+          scrape_id: meta.id,
+        },
+      );
+      return null;
+    }
+    const json = (await resp.json()) as {
+      scrape_id?: unknown;
+      status?: unknown;
+    };
+    if (typeof json.scrape_id !== "string" || json.scrape_id.length === 0) {
+      return null;
+    }
+    meta.logger.info("FirePDF adoption lookup hit", {
+      method: "scrapePDF/firePdfByReference",
+      event: "fire_pdf_adoption_lookup_hit",
+      scrape_id: meta.id,
+      adopted_scrape_id: json.scrape_id,
+      adopted_status: json.status,
+    });
+    return { adoptScrapeId: json.scrape_id, sha256 };
+  } catch (error) {
+    // An aborted scrape must not proceed to a fresh upload+submit.
+    meta.abort.throwIfAborted();
+    meta.logger.warn("FirePDF adoption lookup failed; submitting fresh", {
+      method: "scrapePDF/firePdfByReference",
+      event: "fire_pdf_adoption_lookup_failed",
+      error,
+      scrape_id: meta.id,
+    });
+    return null;
+  }
+}

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/lookup.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/lookup.ts
@@ -74,17 +74,21 @@ export async function lookupAdoptableFirePdfJob(
       }),
       signal,
     });
-    if (resp.status === 404) return null;
     if (resp.status !== 200) {
-      meta.logger.warn(
-        "FirePDF adoption lookup returned non-200; submitting fresh",
-        {
-          method: "scrapePDF/firePdfByReference",
-          event: "fire_pdf_adoption_lookup_miss",
-          status: resp.status,
-          scrape_id: meta.id,
-        },
-      );
+      // Drain the unused body so undici can return the pooled connection
+      // immediately instead of holding it until GC.
+      await resp.body?.cancel().catch(() => {});
+      if (resp.status !== 404) {
+        meta.logger.warn(
+          "FirePDF adoption lookup returned non-200; submitting fresh",
+          {
+            method: "scrapePDF/firePdfByReference",
+            event: "fire_pdf_adoption_lookup_miss",
+            status: resp.status,
+            scrape_id: meta.id,
+          },
+        );
+      }
       return null;
     }
     const json = (await resp.json()) as {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/poll.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/poll.ts
@@ -23,6 +23,10 @@ type PollDeps = {
   sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
   now: () => number;
   random?: () => number;
+  /** Observes each non-terminal status seen while polling — lets the
+   * caller keep a live "where is this job" snapshot (used to enrich
+   * timeout errors for by-reference jobs that outlive the scrape). */
+  onNonTerminalStatus?: (status: "queued" | "published" | "running") => void;
 };
 
 type PollOk = { poll: PollResponse; pollCount: number };
@@ -133,6 +137,14 @@ export async function pollUntilTerminal(deps: PollDeps): Promise<PollOk> {
         });
       }
       return { poll: parsed.data, pollCount };
+    }
+
+    if (
+      parsed.data.status === "queued" ||
+      parsed.data.status === "published" ||
+      parsed.data.status === "running"
+    ) {
+      deps.onNonTerminalStatus?.(parsed.data.status);
     }
 
     lastDelay = nextPollDelay(lastDelay, parsed.data.retry_after_ms, random);

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
@@ -4,7 +4,7 @@ import { fetch as undiciFetch } from "undici";
 import { AbortManagerThrownError } from "../../../lib/abortManager";
 import { firePdfAsyncSubmittedTotal } from "./metrics";
 import { submitResponseSchema } from "./schema";
-import { failAsync, firePdfHeaders } from "./utils";
+import { buildFirePdfJobOptions, failAsync, firePdfHeaders } from "./utils";
 
 type SubmitOutcome = {
   lane: string | undefined;
@@ -110,19 +110,16 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
     ...(teamConcurrency !== undefined && {
       team_concurrency: teamConcurrency,
     }),
-    options: {
-      ...(pagesProcessed !== undefined && { pages_estimate: pagesProcessed }),
-      ...(maxPages !== undefined && { max_pages: maxPages }),
-      ...(mode !== undefined && { mode }),
-      ...(includePageMarkdown && { include_page_markdown: true }),
-      ...(includeBlocks && { include_blocks: true }),
-      // Intentionally camelCase, unlike its siblings: the fire-pdf async
-      // /jobs options schema named this key `pageMarkers` (fire-pdf
-      // api/src/http/schemas/jobs.ts) while the sync /ocr path uses
-      // `page_markers`. Sending snake_case here would be rejected as an
-      // unknown option.
-      ...(pageMarkers && { pageMarkers: true }),
-    },
+    // Shared with the POST /jobs/lookup adoption client — the two must
+    // build identical options or adoption never matches this job.
+    options: buildFirePdfJobOptions({
+      maxPages,
+      pagesProcessed,
+      mode,
+      includePageMarkdown,
+      includeBlocks,
+      pageMarkers,
+    }),
   };
 
   let status: number;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/utils.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/utils.ts
@@ -1,4 +1,5 @@
 import type { Meta } from "../../..";
+import type { PDFMode } from "../../../../../controllers/v2/types";
 import { config } from "../../../../../config";
 import { MAX_DEADLINE_MS, POLL_FLOOR_MS, POLL_CAP_MS } from "./schema";
 import { firePdfAsyncFallbackTotal, type FallbackReason } from "./metrics";
@@ -50,6 +51,70 @@ export function computeDeadlineMs(scrapeTimeoutMs: number | undefined): number {
   const fallback = 5 * 60 * 1_000;
   const candidate = scrapeTimeoutMs ?? fallback;
   return Math.min(MAX_DEADLINE_MS, candidate);
+}
+
+/** Rough worst-case processing rate for the page-scaled by-reference
+ * deadline. Prod xl-lane runs land well under this (a 6,543-page document
+ * processed in ~29 minutes ≈ 270ms/page including queue wait); the slack
+ * absorbs queue depth without pushing every big document to the 30-min
+ * ceiling. */
+const BY_REFERENCE_DEADLINE_PER_PAGE_MS = 500;
+const BY_REFERENCE_DEADLINE_BASE_MS = 5 * 60 * 1_000;
+
+/**
+ * Job deadline for by-reference submits, DECOUPLED from the caller's
+ * remaining budget: what the document needs (page-scaled), never less
+ * than the caller's own window, capped at fire-pdf's 30-min maximum.
+ *
+ * Inline submits advertise exactly the caller window (computeDeadlineMs)
+ * because an abandoned inline job is cancelled and its work discarded.
+ * A by-reference job that outlives its caller is NOT discarded: the
+ * async caller skips cancel-on-abandon, the job finishes server-side,
+ * and the result lands in the raw-sha cache and the content-adoption
+ * lookup — so the customer's retry converges instead of restarting a
+ * multi-minute document from zero on every attempt.
+ */
+export function computeByReferenceDeadlineMs(
+  scrapeTimeoutMs: number | undefined,
+  pagesEstimate: number | undefined,
+): number {
+  const callerWindow = computeDeadlineMs(scrapeTimeoutMs);
+  const pages =
+    pagesEstimate !== undefined && pagesEstimate > 0 ? pagesEstimate : 0;
+  const pageScaled =
+    BY_REFERENCE_DEADLINE_BASE_MS + pages * BY_REFERENCE_DEADLINE_PER_PAGE_MS;
+  return Math.min(MAX_DEADLINE_MS, Math.max(callerWindow, pageScaled));
+}
+
+/**
+ * The `options` object for fire-pdf async wire calls. One builder for
+ * both POST /jobs and POST /jobs/lookup: adoption matches on fire-pdf's
+ * idempotency options, so a lookup that built its options differently
+ * from the submit would silently never match.
+ */
+export function buildFirePdfJobOptions(args: {
+  maxPages: number | undefined;
+  pagesProcessed: number | undefined;
+  mode: PDFMode | undefined;
+  includePageMarkdown: boolean;
+  includeBlocks: boolean;
+  pageMarkers: boolean;
+}): Record<string, unknown> {
+  return {
+    ...(args.pagesProcessed !== undefined && {
+      pages_estimate: args.pagesProcessed,
+    }),
+    ...(args.maxPages !== undefined && { max_pages: args.maxPages }),
+    ...(args.mode !== undefined && { mode: args.mode }),
+    ...(args.includePageMarkdown && { include_page_markdown: true }),
+    ...(args.includeBlocks && { include_blocks: true }),
+    // Intentionally camelCase, unlike its siblings: the fire-pdf async
+    // /jobs options schema named this key `pageMarkers` (fire-pdf
+    // api/src/http/schemas/jobs.ts) while the sync /ocr path uses
+    // `page_markers`. Sending snake_case here would be rejected as an
+    // unknown option.
+    ...(args.pageMarkers && { pageMarkers: true }),
+  };
 }
 
 export function firePdfHeaders(includeJson = false): Record<string, string> {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -47,11 +47,8 @@ import {
   byReferenceReachableForRequest,
   largePdfLimitBytes,
   mineruDiverted,
-  rewritePdfInputForFirePdf,
-  sha256OfFile,
-  uploadPdfInputForFirePdf,
 } from "./fire-pdf/by-reference";
-import { cacheKeyShape, tryGetCached } from "./fire-pdf/cache";
+import { runFirePdfByReferenceAttempt } from "./fire-pdf/by-reference-flow";
 import { decideFirePdfAsyncRoute } from "./fire-pdf/routing";
 import { scrapePDFWithParsePDF } from "./pdfParse";
 import { toPublicBlocks } from "./blocks";
@@ -475,164 +472,30 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
             },
           );
         } else {
-          // Cache BEFORE upload: the raw-byte sha is the by-reference cache
-          // identity, and it must be checked before the 30-256MB transfer —
-          // a repeat scrape of the same document should cost one streamed
-          // disk read, not a full re-upload. scrapePDFWithFirePDFAsync
-          // deliberately skips the by-reference lookup for the same reason
-          // (it runs post-upload) and only saves.
-          //
-          // The local hash also verifies a fire-engine handoff before the
-          // server-side copy, so it is computed whenever a handoff carries
-          // a sha — even for uncacheable requests (maxPages), which skip
-          // only the cache LOOKUP. Requests with neither use skip the
-          // pre-hash entirely; the upload hashes in-pipeline. A failed
-          // pre-hash falls through to the upload path (legacy fallback
-          // semantics), never errors the scrape.
-          const handoff = meta.pdfPrefetch?.gcsReference;
-          const { cacheable: byRefCacheable } = cacheKeyShape(
+          // The whole attempt — raw-sha cache, content adoption, handoff
+          // rewrite / streaming upload, fresh async submit — lives in
+          // by-reference-flow.ts; this router only gates and reconciles.
+          // A null return means the input never made it into the fire-pdf
+          // bucket: fall through to the legacy chain, whose oversized-skip
+          // warning below still fires (pre-by-reference behavior).
+          const byRefResult = await runFirePdfByReferenceAttempt({
+            meta,
+            tempFilePath,
+            fileSizeBytes,
+            pagesEstimate: effectivePageCount,
             mode,
             maxPages,
             includePageMarkdown,
             includeBlocks,
             pageMarkers,
-          );
-          let localSha256: string | undefined;
-          if (byRefCacheable || handoff?.sha256 !== undefined) {
-            try {
-              localSha256 = await sha256OfFile(
-                tempFilePath,
-                meta.abort.asSignal(),
-              );
-            } catch (error) {
-              meta.logger.warn(
-                "Pre-upload hash of large PDF failed; continuing without cache lookup",
-                {
-                  method: "scrapePDF/firePdfByReference",
-                  error,
-                  scrape_id: meta.id,
-                },
-              );
-            }
-          }
-          const cachedByRef =
-            byRefCacheable && localSha256
-              ? await tryGetCached(
-                  meta,
-                  { key: `raw-${localSha256}` },
-                  mode,
-                  maxPages,
-                  effectivePageCount,
-                  includePageMarkdown,
-                  includeBlocks,
-                  pageMarkers,
-                )
-              : null;
-          // A scrape cancelled during the hash/lookup must not return a
-          // success out of the cache.
-          meta.abort.throwIfAborted();
-          if (cachedByRef) {
-            result = cachedByRef;
+          });
+          if (byRefResult) {
+            result = byRefResult;
             effectivePageCount = reconcilePageCountWithFirePdf(
               effectivePageCount,
               result,
             );
           }
-          // On a miss: when fire-engine already handed the file off via
-          // GCS, a server-side rewrite moves it into the fire-pdf input
-          // bucket without the bytes transiting this process; otherwise
-          // (or if the rewrite fails) stream-upload the local temp file.
-          // The handoff hash becomes fire-pdf's idempotency identity, so it
-          // must match the raw-byte sha already computed for the cache
-          // check above (no second disk read needed); any mismatch falls
-          // back to the hashing upload.
-          const handoffShaMatches =
-            localSha256 !== undefined &&
-            handoff?.sha256 !== undefined &&
-            handoff.sha256.toLowerCase() === localSha256;
-          if (
-            localSha256 !== undefined &&
-            handoff?.sha256 !== undefined &&
-            !handoffShaMatches
-          ) {
-            meta.logger.warn(
-              "fire-engine handoff sha256 does not match local bytes; using streaming upload",
-              {
-                method: "scrapePDF/firePdfByReference",
-                event: "fire_pdf_handoff_sha_mismatch",
-                scrape_id: meta.id,
-              },
-            );
-          }
-          const rewriteEligible =
-            !result &&
-            handoffShaMatches &&
-            handoff!.sizeBytes === fileSizeBytes;
-          const uploaded = result
-            ? null
-            : ((rewriteEligible && handoff
-                ? await rewritePdfInputForFirePdf(meta, {
-                    uri: handoff.uri,
-                    // rewriteEligible implies handoffShaMatches implies defined
-                    sha256: localSha256!,
-                    sizeBytes: fileSizeBytes,
-                    generation: handoff.generation,
-                  })
-                : null) ??
-              // A distinct key when a rewrite was attempted: a timed-out
-              // copy may still complete and must never overwrite this
-              // upload.
-              (await uploadPdfInputForFirePdf(
-                meta,
-                tempFilePath,
-                fileSizeBytes,
-                {
-                  keyVariant: rewriteEligible ? "s" : undefined,
-                  precomputedSha256: localSha256,
-                },
-              )));
-          if (uploaded) {
-            try {
-              result = await scrapePDFWithFirePDFAsync(
-                {
-                  ...meta,
-                  logger: meta.logger.child({
-                    method: "scrapePDF/firePDFAsyncByReference",
-                  }),
-                },
-                uploaded,
-                maxPages,
-                effectivePageCount,
-                mode,
-                undefined,
-                includePageMarkdown,
-                includeBlocks,
-                pageMarkers,
-              );
-              effectivePageCount = reconcilePageCountWithFirePdf(
-                effectivePageCount,
-                result,
-              );
-            } catch (error) {
-              // No inline retry exists at this size, and the legacy chain
-              // below would silently degrade a large document to text-only
-              // extraction. Surface the failure instead.
-              meta.logger.error(
-                "FirePDF by-reference scrape failed (no fallback at this size)",
-                {
-                  method: "scrapePDF/firePDFAsyncByReference",
-                  error,
-                  file_size_bytes: fileSizeBytes,
-                  scrape_id: meta.id,
-                  team_id: meta.internalOptions.teamId,
-                },
-              );
-              throw error;
-            }
-          }
-          // Upload failure: fall through to the legacy chain — the
-          // oversized-skip warning below still fires, preserving the
-          // pre-by-reference behavior.
         }
       }
     }

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -76,6 +76,7 @@ import {
 } from "./lib/abortManager";
 import {
   ScrapeJobTimeoutError,
+  composeTimeoutProcessing,
   CrawlDenialError,
   ActionsNotSupportedError,
 } from "../../lib/error";
@@ -167,6 +168,20 @@ export type Meta = {
       }
     | null
     | undefined; // undefined: no prefetch yet, null: prefetch came back empty
+  /** Live state of a by-reference FirePDF job (large PDFs) this scrape
+   * submitted or adopted. Such jobs outlive an abandoned scrape BY
+   * DESIGN (see fire-pdf/async.ts's cancel policy), so a SCRAPE_TIMEOUT
+   * uses this to tell the caller processing continues and when a retry
+   * of the same URL will pick up the finished result. Set by
+   * fire-pdf/async.ts; cleared when the job reaches a terminal state
+   * within this scrape's lifetime. */
+  largePdfProcessing?: {
+    jobScrapeId: string;
+    pagesEstimate?: number;
+    submittedAtMs: number;
+    jobDeadlineAtMs?: number;
+    lastStatus: "queued" | "published" | "running";
+  };
   documentPrefetch:
     | {
         filePath: string;
@@ -1415,6 +1430,27 @@ export async function scrapeURL(
       // if (Object.values(meta.results).length > 0 && Object.values(meta.results).every(x => x.state === "error" && x.error instanceof FEPageLoadFailed)) {
       //   throw new FEPageLoadFailed();
       // } else
+      // A timed-out large-PDF scrape leaves its fire-pdf job running by
+      // design (fire-pdf/async.ts cancel policy); upgrade the timeout
+      // error IN PLACE so the caller learns processing continues and
+      // when a retry of the same URL picks the result up. Covers both
+      // the engine race's own timer and the abort manager's inner
+      // timeout, which exits through the early rethrow below.
+      const timeoutCandidate =
+        error instanceof AbortManagerThrownError ? error.inner : error;
+      if (
+        meta.largePdfProcessing &&
+        timeoutCandidate instanceof ScrapeJobTimeoutError &&
+        timeoutCandidate.processing === undefined
+      ) {
+        const composed = composeTimeoutProcessing({
+          ...meta.largePdfProcessing,
+          nowMs: Date.now(),
+        });
+        timeoutCandidate.processing = composed.details;
+        timeoutCandidate.message = composed.message;
+      }
+
       meta.logger.debug("scrapeURL metrics", {
         module: "scrapeURL/metrics",
         timeTaken: Date.now() - startTime,

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -172,15 +172,22 @@ export type Meta = {
    * submitted or adopted. Such jobs outlive an abandoned scrape BY
    * DESIGN (see fire-pdf/async.ts's cancel policy), so a SCRAPE_TIMEOUT
    * uses this to tell the caller processing continues and when a retry
-   * of the same URL will pick up the finished result. Set by
-   * fire-pdf/async.ts; cleared when the job reaches a terminal state
-   * within this scrape's lifetime. */
+   * of the same URL will pick up the finished result.
+   *
+   * Shaped as a mutable container (like `threatDecisions`) on purpose:
+   * engine dispatch and the pdf engine hand out SPREAD COPIES of meta,
+   * and only the shared inner object makes writes from those copies
+   * visible to the outer timeout handler here. Set by fire-pdf/async.ts;
+   * `current` is cleared when the job reaches a terminal state within
+   * this scrape's lifetime. */
   largePdfProcessing?: {
-    jobScrapeId: string;
-    pagesEstimate?: number;
-    submittedAtMs: number;
-    jobDeadlineAtMs?: number;
-    lastStatus: "queued" | "published" | "running";
+    current?: {
+      jobScrapeId: string;
+      pagesEstimate?: number;
+      submittedAtMs: number;
+      jobDeadlineAtMs?: number;
+      lastStatus: "queued" | "published" | "running";
+    };
   };
   documentPrefetch:
     | {
@@ -472,6 +479,7 @@ async function buildMetaObject(
     fetchPrefetch,
     costTracking,
     threatDecisions: [],
+    largePdfProcessing: {},
   };
 }
 
@@ -1439,12 +1447,12 @@ export async function scrapeURL(
       const timeoutCandidate =
         error instanceof AbortManagerThrownError ? error.inner : error;
       if (
-        meta.largePdfProcessing &&
+        meta.largePdfProcessing?.current &&
         timeoutCandidate instanceof ScrapeJobTimeoutError &&
         timeoutCandidate.processing === undefined
       ) {
         const composed = composeTimeoutProcessing({
-          ...meta.largePdfProcessing,
+          ...meta.largePdfProcessing.current,
           nowMs: Date.now(),
         });
         timeoutCandidate.processing = composed.details;


### PR DESCRIPTION
## What

Makes large-PDF (by-reference) scrapes **converge across retries** instead of restarting from zero each attempt. Three coordinated changes, all scoped to the by-reference path — inline submits keep today's exact behavior.

## The failure loop this fixes

A large document takes longer than the caller's scrape window (no explicit `timeout` ⇒ scrapeURLLoop's 5-minute wall). Today: submit → caller dies → we cancel the fire-pdf job → the work is discarded → the customer's retry carries a fresh scrape_id, so fire-pdf's scrape_id-keyed idempotency can't join it to anything → full re-upload + full re-process → same death. Observed in prod as the same document re-submitted repeatedly, completing never, burning GPU every time.

## The three changes

1. **Deadline decoupling** (`computeByReferenceDeadlineMs`): the *job* gets a page-scaled budget (5 min base + 500 ms/page, floored at the caller's window, capped at fire-pdf's 30-min max). The *caller's polling* still stops at its own window — the request fails exactly as it does today; the job keeps running server-side.
2. **No cancel-on-abandon for by-reference jobs** (single `cancelOnAbandon` policy in `async.ts`): the completion the caller never sees still lands in the raw-sha content cache. Cost is bounded by the job's own deadline and is strictly smaller than the redo loop it replaces. Inline jobs still cancel; adopted jobs are never ours to cancel.
3. **Content adoption** (`fire-pdf/lookup.ts` + fire-pdf's new `POST /jobs/lookup`, companion PR): before uploading, ask fire-pdf for an existing job with the same bytes + idempotency options + team. A hit skips the 30–256 MB upload AND the duplicate processing — the attempt just polls the existing job. On success the result is saved under the raw-sha cache key, so the attempt after next is a pure cache hit.

Net effect: one processing run per unique document; the customer's existing retry behavior converges to a cached result with no client changes. (Passing an explicit `timeout` remains the way to get first-attempt success.)

## Customer-facing messaging

A timed-out large-PDF request no longer returns a bare timeout. The scrape tracks the live job (`meta.largePdfProcessing`: pages, last polled status, submit time, job deadline — updated every poll, cleared on any terminal outcome), and the timeout error is upgraded in place:

```
HTTP 408
Retry-After: 300
{
  "success": false,
  "code": "SCRAPE_TIMEOUT",
  "error": "Request timed out, but this 700-page PDF is still being processed on our side. Retrying the same URL in ~5 minutes returns the completed result without re-processing. ...",
  "details": {
    "state": "processing_continues",
    "documentPages": 700,
    "jobStatus": "running",
    "estimatedRemainingSeconds": 300,
    "retryAfterSeconds": 300
  }
}
```

Estimates are conservative (500ms/page + 60s base, whole minutes, floored at 1 min; `Retry-After` capped at 10 min). Three variants: running, queued ("will not lose its place"), and an honest `mayExceedProcessingWindow` for documents bigger than the server-side ceiling. The details ride `ScrapeJobTimeoutError`'s serde, so worker-processed (crawl/batch) jobs carry the enriched message in their stored errors too; the structured `details` + `Retry-After` surface on v2 `/scrape`. This also sets up SDK auto-resume (sleep on `Retry-After`, re-issue, return the finished result) as a follow-up.

## Structure

- `fire-pdf/by-reference-flow.ts`: the whole by-reference attempt (hash → cache → adopt → rewrite/upload → submit) extracted out of the engine router; the router only gates and reconciles.
- `fire-pdf/lookup.ts`: the adoption client + `FirePdfAdoptedJobInput`, protocol-side (submit/poll/result peers); `by-reference.ts` stays pure GCS transport.
- `buildFirePdfJobOptions` shared between submit and lookup so the two can never drift (adoption would silently never match).

## Safety

- **Team-scoped**: the lookup mirrors the submit's `team_id`; fire-pdf matches it — no cross-tenant adoption, including for uncacheable (maxPages) requests.
- **Best-effort**: lookup timeout (10 s), non-200, malformed body, or an older fire-pdf without the endpoint ⇒ null ⇒ fresh submit (today's behavior). Aborts propagate.
- **Adopted-job failure** (expired/failed) falls through to a fresh upload+submit within the same attempt — except when the caller's own budget is exhausted (`polling_timeout` / `deadline_too_close`), where a fresh submit couldn't succeed either.
- ZDR is excluded from by-reference entirely (unchanged).

## Verification

- 8 new unit tests: deadline decoupling + clamp math, by-ref no-cancel (vs. the existing inline cancel test), adopted happy path (no POST, raw-sha cache save), adopted terminal failure (no DELETE), adopted ZDR guard, lookup client contract (hit/miss/failure/abort).
- `tsc` clean, all 134 pdf-engine tests green, knip clean.
- Local cubic drained across four rounds (team scoping, flow extraction, lookup module placement, single ownership policy).

## Rollout

Deploy the fire-pdf side (endpoint + index migration) first for full effect; this PR alone is still safe — the lookup 404s and everything degrades to current behavior. **Do not merge yet** — being reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
