### PR TITLE
fix(ci): restore Blacksmith image builds

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -69,10 +69,10 @@ jobs:
         include:
           - platform: linux/amd64
             platform_suffix: linux-amd64
-            runner: ubuntu-24.04
+            runner: blacksmith-4vcpu-ubuntu-2404
           - platform: linux/arm64
             platform_suffix: linux-arm64
-            runner: ubuntu-24.04-arm
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
     defaults:
       run:
         working-directory: './apps/api'
@@ -80,8 +80,8 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@main
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
       - name: 'Login to GitHub Container Registry'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -91,7 +91,7 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: 'Build and Push Image'
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: ./apps/api
           push: true
@@ -125,7 +125,7 @@ jobs:
           '
 
   publish:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs:
       - version
       - build


### PR DESCRIPTION
## Summary

Restores the production API image build workflow to Blacksmith runners and Blacksmith Docker build actions, reversing the GitHub-hosted fallback introduced in #4306.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the production API image build workflow to Blacksmith runners and Blacksmith Docker build actions, reversing the GitHub-hosted fallback from #4306.

The workflow now uses the Blacksmith builder setup and build-push actions instead of the standard Docker actions, and all three jobs return to Blacksmith runners.

<sup>Written for commit 4546c368080dadf4f8389334781d37bd7d3cde1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

