### PR TITLE
feat(pdf): prefer fire-pdf's live remaining estimates in timeout messaging

### DIFF
--- a/apps/api/src/lib/__tests__/timeoutProcessing.test.ts
+++ b/apps/api/src/lib/__tests__/timeoutProcessing.test.ts
@@ -107,8 +107,7 @@ describe("composeTimeoutProcessing — server estimate preference", () => {
       submittedAtMs: T0,
       lastStatus: "running",
       nowMs: T0 + 2 * 60_000,
-      serverEstimateMs: 9.5 * 60_000,
-      serverEstimateAtMs: T0 + 30_000,
+      serverEstimate: { remainingMs: 9.5 * 60_000, observedAtMs: T0 + 30_000 },
     });
     expect(details.estimatedRemainingSeconds).toBe(8 * 60);
     expect(message).toContain("~8 minutes");
@@ -120,8 +119,7 @@ describe("composeTimeoutProcessing — server estimate preference", () => {
       submittedAtMs: T0,
       lastStatus: "running",
       nowMs: T0 + 20 * 60_000,
-      serverEstimateMs: 60_000,
-      serverEstimateAtMs: T0,
+      serverEstimate: { remainingMs: 60_000, observedAtMs: T0 },
     });
     expect(details.estimatedRemainingSeconds).toBe(60);
   });

--- a/apps/api/src/lib/__tests__/timeoutProcessing.test.ts
+++ b/apps/api/src/lib/__tests__/timeoutProcessing.test.ts
@@ -97,6 +97,47 @@ describe("composeTimeoutProcessing", () => {
   });
 });
 
+describe("composeTimeoutProcessing — server estimate preference", () => {
+  it("prefers fire-pdf's live estimate, aged since observation", () => {
+    // Server said 9.5 minutes remaining, observed 90s ago → 8 minutes
+    // after aging and minute-ceiling; the static formula (700 pages)
+    // would have said 5 minutes here.
+    const { message, details } = composeTimeoutProcessing({
+      pagesEstimate: 700,
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0 + 2 * 60_000,
+      serverEstimateMs: 9.5 * 60_000,
+      serverEstimateAtMs: T0 + 30_000,
+    });
+    expect(details.estimatedRemainingSeconds).toBe(8 * 60);
+    expect(message).toContain("~8 minutes");
+  });
+
+  it("an aged-out server estimate floors at one minute", () => {
+    const { details } = composeTimeoutProcessing({
+      pagesEstimate: 700,
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0 + 20 * 60_000,
+      serverEstimateMs: 60_000,
+      serverEstimateAtMs: T0,
+    });
+    expect(details.estimatedRemainingSeconds).toBe(60);
+  });
+
+  it("falls back to static math when no server estimate was observed", () => {
+    const withServer = composeTimeoutProcessing({
+      pagesEstimate: 700,
+      submittedAtMs: T0,
+      lastStatus: "running",
+      nowMs: T0 + 2 * 60_000,
+    });
+    // 700×500ms + 60s − 2min elapsed → 5 minutes (static path).
+    expect(withServer.details.estimatedRemainingSeconds).toBe(300);
+  });
+});
+
 describe("SCRAPE_TIMEOUT processing details transport", () => {
   it("survives the worker→controller serde round trip", () => {
     const { message, details } = composeTimeoutProcessing({

--- a/apps/api/src/lib/error.ts
+++ b/apps/api/src/lib/error.ts
@@ -113,8 +113,7 @@ export function composeTimeoutProcessing(args: {
    * when it was observed. Preferred over the static per-page math: the
    * server sees measured lane throughput and real queue depth, which
    * the static formula cannot. */
-  serverEstimateMs?: number;
-  serverEstimateAtMs?: number;
+  serverEstimate?: { remainingMs: number; observedAtMs: number };
 }): { message: string; details: ScrapeTimeoutProcessingDetails } {
   const perPageMs = args.perPageMs ?? PROCESSING_ESTIMATE_PER_PAGE_MS;
   const pages = args.pagesEstimate;
@@ -127,9 +126,9 @@ export function composeTimeoutProcessing(args: {
   // observed it; the static formula is the fallback for older fire-pdf
   // builds and lanes without measured throughput.
   const serverRemainingMs =
-    args.serverEstimateMs !== undefined && args.serverEstimateAtMs !== undefined
-      ? args.serverEstimateMs -
-        Math.max(0, args.nowMs - args.serverEstimateAtMs)
+    args.serverEstimate !== undefined
+      ? args.serverEstimate.remainingMs -
+        Math.max(0, args.nowMs - args.serverEstimate.observedAtMs)
       : undefined;
   const remainingMs =
     serverRemainingMs !== undefined

--- a/apps/api/src/lib/error.ts
+++ b/apps/api/src/lib/error.ts
@@ -109,6 +109,12 @@ export function composeTimeoutProcessing(args: {
   lastStatus: "queued" | "published" | "running";
   nowMs: number;
   perPageMs?: number;
+  /** fire-pdf's live estimate from the last poll that carried one, and
+   * when it was observed. Preferred over the static per-page math: the
+   * server sees measured lane throughput and real queue depth, which
+   * the static formula cannot. */
+  serverEstimateMs?: number;
+  serverEstimateAtMs?: number;
 }): { message: string; details: ScrapeTimeoutProcessingDetails } {
   const perPageMs = args.perPageMs ?? PROCESSING_ESTIMATE_PER_PAGE_MS;
   const pages = args.pagesEstimate;
@@ -117,7 +123,18 @@ export function composeTimeoutProcessing(args: {
       ? pages * perPageMs + PROCESSING_ESTIMATE_BASE_MS
       : 5 * 60_000;
   const elapsedMs = Math.max(0, args.nowMs - args.submittedAtMs);
-  const remainingMs = Math.max(60_000, totalMs - elapsedMs);
+  // Live server estimate wins when available, aged by the time since we
+  // observed it; the static formula is the fallback for older fire-pdf
+  // builds and lanes without measured throughput.
+  const serverRemainingMs =
+    args.serverEstimateMs !== undefined && args.serverEstimateAtMs !== undefined
+      ? args.serverEstimateMs -
+        Math.max(0, args.nowMs - args.serverEstimateAtMs)
+      : undefined;
+  const remainingMs =
+    serverRemainingMs !== undefined
+      ? Math.max(60_000, serverRemainingMs)
+      : Math.max(60_000, totalMs - elapsedMs);
   const remainingMinutes = Math.ceil(remainingMs / 60_000);
   const estimatedRemainingSeconds = remainingMinutes * 60;
   const retryAfterSeconds = Math.min(600, estimatedRemainingSeconds);

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -1298,6 +1298,82 @@ describe("scrapePDFWithFirePDFAsync", () => {
       }
     });
 
+    it("records fire-pdf's live estimate from 202 polls for timeout enrichment", async () => {
+      const { fetchImpl } = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs$/,
+          matchMethod: "POST",
+          response: {
+            status: 202,
+            body: { scrape_id: "scrape-id-test", status: "queued", lane: "xl" },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test$/,
+          matchMethod: "GET",
+          response: {
+            status: 202,
+            body: {
+              scrape_id: "scrape-id-test",
+              status: "running",
+              estimated_remaining_ms: 240_000,
+            },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test$/,
+          matchMethod: "GET",
+          response: {
+            status: 200,
+            body: {
+              scrape_id: "scrape-id-test",
+              status: "done",
+              pages_processed: 500,
+            },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test\/result$/,
+          matchMethod: "GET",
+          response: {
+            status: 200,
+            body: {
+              schema_version: 1,
+              markdown: "# ok",
+              pages_processed: 500,
+              failed_pages: null,
+              partial_pages: null,
+            },
+          },
+        },
+      ]);
+
+      const meta = makeMeta();
+      let observed: unknown;
+      const sleepSpy = async () => {
+        // Snapshot mid-flight state after the first 202 recorded it —
+        // completion clears the container, so assert before that.
+        observed = { ...(meta.largePdfProcessing.current ?? {}) };
+      };
+      await scrapePDFWithFirePDFAsync(
+        { ...meta, logger: meta.logger },
+        { ...BY_REF },
+        undefined,
+        500,
+        undefined,
+        { fetchImpl, fallbackImpl: vi.fn(), sleepImpl: sleepSpy },
+      );
+
+      // The last snapshot before completion carries the server estimate.
+      expect(observed).toMatchObject({
+        lastStatus: "running",
+        serverEstimateMs: 240_000,
+      });
+      expect(
+        (observed as { serverEstimateAtMs?: number }).serverEstimateAtMs,
+      ).toBeGreaterThan(0);
+    });
+
     it("advertises a page-scaled deadline decoupled from the caller window", async () => {
       let submittedBody: any;
       const fetchImpl: any = async (url: string, init: any) => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -1367,10 +1367,11 @@ describe("scrapePDFWithFirePDFAsync", () => {
       // The last snapshot before completion carries the server estimate.
       expect(observed).toMatchObject({
         lastStatus: "running",
-        serverEstimateMs: 240_000,
+        serverEstimate: { remainingMs: 240_000 },
       });
       expect(
-        (observed as { serverEstimateAtMs?: number }).serverEstimateAtMs,
+        (observed as { serverEstimate?: { observedAtMs: number } })
+          .serverEstimate?.observedAtMs,
       ).toBeGreaterThan(0);
     });
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -276,9 +276,13 @@ export async function scrapePDFWithFirePDFAsync(
           sleep,
           now,
           random,
-          onNonTerminalStatus: status => {
-            if (meta.largePdfProcessing?.current) {
-              meta.largePdfProcessing.current.lastStatus = status;
+          onNonTerminalStatus: (status, estimatedRemainingMs) => {
+            const current = meta.largePdfProcessing?.current;
+            if (!current) return;
+            current.lastStatus = status;
+            if (estimatedRemainingMs !== undefined) {
+              current.serverEstimateMs = estimatedRemainingMs;
+              current.serverEstimateAtMs = now();
             }
           },
         });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -281,8 +281,10 @@ export async function scrapePDFWithFirePDFAsync(
             if (!current) return;
             current.lastStatus = status;
             if (estimatedRemainingMs !== undefined) {
-              current.serverEstimateMs = estimatedRemainingMs;
-              current.serverEstimateAtMs = now();
+              current.serverEstimate = {
+                remainingMs: estimatedRemainingMs,
+                observedAtMs: now(),
+              };
             }
           },
         });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/poll.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/poll.ts
@@ -25,8 +25,12 @@ type PollDeps = {
   random?: () => number;
   /** Observes each non-terminal status seen while polling — lets the
    * caller keep a live "where is this job" snapshot (used to enrich
-   * timeout errors for by-reference jobs that outlive the scrape). */
-  onNonTerminalStatus?: (status: "queued" | "published" | "running") => void;
+   * timeout errors for by-reference jobs that outlive the scrape).
+   * `estimatedRemainingMs` is fire-pdf's live estimate when present. */
+  onNonTerminalStatus?: (
+    status: "queued" | "published" | "running",
+    estimatedRemainingMs?: number,
+  ) => void;
 };
 
 type PollOk = { poll: PollResponse; pollCount: number };
@@ -144,7 +148,10 @@ export async function pollUntilTerminal(deps: PollDeps): Promise<PollOk> {
       parsed.data.status === "published" ||
       parsed.data.status === "running"
     ) {
-      deps.onNonTerminalStatus?.(parsed.data.status);
+      deps.onNonTerminalStatus?.(
+        parsed.data.status,
+        parsed.data.estimated_remaining_ms,
+      );
     }
 
     lastDelay = nextPollDelay(lastDelay, parsed.data.retry_after_ms, random);

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -41,6 +41,11 @@ export const pollResponseSchema = z.object({
   ]),
   retry_after_ms: z.number().optional(),
   pages_processed: z.number().optional(),
+  // Live remaining-time estimate computed server-side from lane
+  // throughput + backlog (fire-pdf phase 2). Optional and additive;
+  // absent on older fire-pdf builds or when the lane has no measured
+  // throughput.
+  estimated_remaining_ms: z.number().optional(),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),
   error_class: z.string().optional(),

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -44,8 +44,15 @@ export const pollResponseSchema = z.object({
   // Live remaining-time estimate computed server-side from lane
   // throughput + backlog (fire-pdf phase 2). Optional and additive;
   // absent on older fire-pdf builds or when the lane has no measured
-  // throughput.
-  estimated_remaining_ms: z.number().optional(),
+  // throughput. `.catch(undefined)` so a malformed value (negative,
+  // NaN, Infinity) degrades to "no estimate" instead of failing the
+  // whole poll response.
+  estimated_remaining_ms: z
+    .number()
+    .finite()
+    .nonnegative()
+    .optional()
+    .catch(undefined),
   failed_pages: z.array(z.number()).nullable().optional(),
   partial_pages: z.array(z.number()).nullable().optional(),
   error_class: z.string().optional(),

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -187,6 +187,11 @@ export type Meta = {
       submittedAtMs: number;
       jobDeadlineAtMs?: number;
       lastStatus: "queued" | "published" | "running";
+      /** fire-pdf's live remaining estimate from the last poll that
+       * carried one, and when we observed it — preferred over the
+       * static per-page math when composing the timeout message. */
+      serverEstimateMs?: number;
+      serverEstimateAtMs?: number;
     };
   };
   documentPrefetch:

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -188,10 +188,10 @@ export type Meta = {
       jobDeadlineAtMs?: number;
       lastStatus: "queued" | "published" | "running";
       /** fire-pdf's live remaining estimate from the last poll that
-       * carried one, and when we observed it — preferred over the
-       * static per-page math when composing the timeout message. */
-      serverEstimateMs?: number;
-      serverEstimateAtMs?: number;
+       * carried one, with its observation time — one atomic datum,
+       * preferred over the static per-page math when composing the
+       * timeout message. */
+      serverEstimate?: { remainingMs: number; observedAtMs: number };
     };
   };
   documentPrefetch:


### PR DESCRIPTION
## What

Phase 2 (consumer side) of the large-PDF timeout messaging: when fire-pdf's 202 poll responses carry a live `estimated_remaining_ms` (companion fire-pdf PR — computed from measured lane throughput and real queue position), the timeout message prefers it over the static per-page formula.

## How

- `pollResponseSchema` accepts `estimated_remaining_ms` as `finite().nonnegative().optional().catch(undefined)` — a malformed value degrades to "no estimate" instead of failing the poll.
- The poll observer records the latest estimate as one atomic `{remainingMs, observedAtMs}` snapshot on the shared processing-state container.
- `composeTimeoutProcessing` prefers the server estimate, aged by time since observation and floored at one minute; the static 500ms/page formula remains the fallback for older fire-pdf builds and lanes without fresh throughput measurements.

## Why it matters

The static formula can't see queue depth: during a surge, "retry in ~5 minutes" could be wildly optimistic; on an idle fleet, it overshoots ~2×. The server number reflects both.

## Verification

- New tests: server-estimate preference + aging, aged-out floor at 1 min, static fallback when absent, and the poll→meta plumbing snapshotted mid-flight.
- tsc/knip clean; all 145 tests in touched files + full pdf-engine suite green; local cubic clean (round 2, after taking round 1's hardening + atomic-snapshot findings).

## Rollout

Independent of the fire-pdf side: absent field ⇒ static fallback (today's behavior). Safe in either deploy order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses fire-pdf's live remaining-time estimate in large-PDF timeout messages instead of the static per-page formula, so the estimate reflects measured lane throughput and real queue depth.

- Poll responses may now carry `estimated_remaining_ms`; malformed values degrade to no estimate instead of failing the poll.
- The latest estimate is stored with its observation time as one atomic snapshot on the shared processing state.
- Timeout messaging ages the estimate since observation and floors it at one minute.
- The static 500ms-per-page formula remains the fallback for older fire-pdf builds and lanes without measured throughput.
- Rollout is safe in either deploy order: an absent field preserves today's static behavior.

<sup>Written for commit b4dd0775257d9c2181a4042d3b13d506a3521af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

