### PR TITLE
fix(pdf): enforce the per-team cap inside both by-reference placement functions

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/fireEngineHandoff.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/fireEngineHandoff.test.ts
@@ -71,10 +71,11 @@ vi.mock("../../../../../lib/gcs-jobs", async () => {
 import {
   largePdfLimitBytes,
   rewritePdfInputForFirePdf,
+  uploadPdfInputForFirePdf,
 } from "../fire-pdf/by-reference";
 import { downloadFireEngineGcsFile } from "../../utils/downloadGcsFile";
 import { config } from "../../../../../config";
-import { stat, readFile as readFileAsync } from "node:fs/promises";
+import { stat, readFile as readFileAsync, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -293,5 +294,95 @@ describe("fire-engine GCS handoff (positive paths, mocked storage)", () => {
     expect(gcsFake.copies[0].destKey).toMatch(
       /^inputs\/[0-9a-f]{8}-scrape-id-handoff\.pdf$/,
     );
+  });
+});
+
+describe("per-team cap enforcement at the placement functions", () => {
+  const ORIGINAL_BUCKET = config.FIRE_ENGINE_PDF_GCS_BUCKET;
+  const ORIGINAL_IDS = config.PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS;
+  beforeAll(() => {
+    (config as any).FIRE_ENGINE_PDF_GCS_BUCKET = "fire-engine-scrape-storage";
+  });
+  afterAll(() => {
+    (config as any).FIRE_ENGINE_PDF_GCS_BUCKET = ORIGINAL_BUCKET;
+  });
+  beforeEach(() => {
+    gcsFake.reset();
+    (config as any).PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS = "team-privileged";
+  });
+  afterEach(() => {
+    (config as any).PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS = ORIGINAL_IDS;
+  });
+
+  const HANDOFF = {
+    uri: "gs://fire-engine-scrape-storage/pdf-handoff/x.pdf",
+    sha256: "ab".repeat(32),
+    generation: "123456789012345678",
+  };
+
+  function metaForTeam(teamId: string) {
+    const meta = makeMeta();
+    meta.internalOptions.teamId = teamId;
+    return meta;
+  }
+
+  it("rewrite refuses a handoff above the default cap for an unlisted team", async () => {
+    await expect(
+      rewritePdfInputForFirePdf(metaForTeam("team-x"), {
+        ...HANDOFF,
+        sizeBytes: 60 * 1024 * 1024,
+      }),
+    ).resolves.toBeNull();
+    expect(gcsFake.copies).toEqual([]);
+  });
+
+  it("rewrite allows the same size for a privileged team", async () => {
+    const res = await rewritePdfInputForFirePdf(
+      metaForTeam("team-privileged"),
+      {
+        ...HANDOFF,
+        sizeBytes: 60 * 1024 * 1024,
+      },
+    );
+    expect(res).toMatchObject({ sizeBytes: 60 * 1024 * 1024 });
+    expect(gcsFake.copies).toHaveLength(1);
+  });
+
+  it("rewrite refuses above the privileged cap even for a privileged team", async () => {
+    await expect(
+      rewritePdfInputForFirePdf(metaForTeam("team-privileged"), {
+        ...HANDOFF,
+        sizeBytes: 205 * 1024 * 1024,
+      }),
+    ).resolves.toBeNull();
+    expect(gcsFake.copies).toEqual([]);
+  });
+
+  it("upload refuses an over-cap file before reading a byte", async () => {
+    // The path deliberately does not exist: an over-cap upload must be
+    // refused by the size guard alone, before any disk or network I/O.
+    await expect(
+      uploadPdfInputForFirePdf(
+        metaForTeam("team-x"),
+        path.join(tmpdir(), "does-not-exist.pdf"),
+        60 * 1024 * 1024,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("upload accepts a within-cap size for a privileged team", async () => {
+    const filePath = path.join(
+      tmpdir(),
+      `upload-test-${crypto.randomUUID()}.pdf`,
+    );
+    await writeFile(filePath, Buffer.alloc(1024, 7));
+    const res = await uploadPdfInputForFirePdf(
+      metaForTeam("team-privileged"),
+      filePath,
+      // Declared size sits over the default tier but under the privileged
+      // one — the guard must use the team's own cap.
+      60 * 1024 * 1024,
+    );
+    expect(res).toMatchObject({ sizeBytes: 60 * 1024 * 1024 });
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/fireEngineHandoff.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/fireEngineHandoff.test.ts
@@ -75,7 +75,12 @@ import {
 } from "../fire-pdf/by-reference";
 import { downloadFireEngineGcsFile } from "../../utils/downloadGcsFile";
 import { config } from "../../../../../config";
-import { stat, readFile as readFileAsync, writeFile } from "node:fs/promises";
+import {
+  stat,
+  readFile as readFileAsync,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -300,6 +305,12 @@ describe("fire-engine GCS handoff (positive paths, mocked storage)", () => {
 describe("per-team cap enforcement at the placement functions", () => {
   const ORIGINAL_BUCKET = config.FIRE_ENGINE_PDF_GCS_BUCKET;
   const ORIGINAL_IDS = config.PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS;
+  const ORIGINAL_DEFAULT = config.PDF_BY_REFERENCE_MAX_BYTES_DEFAULT;
+  const ORIGINAL_PRIVILEGED = config.PDF_BY_REFERENCE_MAX_BYTES_PRIVILEGED;
+  // Explicit caps, so the size assertions below can never drift from the
+  // schema defaults or be skewed by env overrides.
+  const DEFAULT_CAP = 50 * 1024 * 1024;
+  const PRIVILEGED_CAP = 200 * 1024 * 1024;
   beforeAll(() => {
     (config as any).FIRE_ENGINE_PDF_GCS_BUCKET = "fire-engine-scrape-storage";
   });
@@ -309,9 +320,13 @@ describe("per-team cap enforcement at the placement functions", () => {
   beforeEach(() => {
     gcsFake.reset();
     (config as any).PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS = "team-privileged";
+    (config as any).PDF_BY_REFERENCE_MAX_BYTES_DEFAULT = DEFAULT_CAP;
+    (config as any).PDF_BY_REFERENCE_MAX_BYTES_PRIVILEGED = PRIVILEGED_CAP;
   });
   afterEach(() => {
     (config as any).PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS = ORIGINAL_IDS;
+    (config as any).PDF_BY_REFERENCE_MAX_BYTES_DEFAULT = ORIGINAL_DEFAULT;
+    (config as any).PDF_BY_REFERENCE_MAX_BYTES_PRIVILEGED = ORIGINAL_PRIVILEGED;
   });
 
   const HANDOFF = {
@@ -326,11 +341,15 @@ describe("per-team cap enforcement at the placement functions", () => {
     return meta;
   }
 
+  // Over the default tier, under the privileged one — the size that tells
+  // the two caps apart.
+  const OVER_DEFAULT_BYTES = DEFAULT_CAP + 1024 * 1024;
+
   it("rewrite refuses a handoff above the default cap for an unlisted team", async () => {
     await expect(
       rewritePdfInputForFirePdf(metaForTeam("team-x"), {
         ...HANDOFF,
-        sizeBytes: 60 * 1024 * 1024,
+        sizeBytes: OVER_DEFAULT_BYTES,
       }),
     ).resolves.toBeNull();
     expect(gcsFake.copies).toEqual([]);
@@ -341,10 +360,10 @@ describe("per-team cap enforcement at the placement functions", () => {
       metaForTeam("team-privileged"),
       {
         ...HANDOFF,
-        sizeBytes: 60 * 1024 * 1024,
+        sizeBytes: OVER_DEFAULT_BYTES,
       },
     );
-    expect(res).toMatchObject({ sizeBytes: 60 * 1024 * 1024 });
+    expect(res).toMatchObject({ sizeBytes: OVER_DEFAULT_BYTES });
     expect(gcsFake.copies).toHaveLength(1);
   });
 
@@ -352,7 +371,7 @@ describe("per-team cap enforcement at the placement functions", () => {
     await expect(
       rewritePdfInputForFirePdf(metaForTeam("team-privileged"), {
         ...HANDOFF,
-        sizeBytes: 205 * 1024 * 1024,
+        sizeBytes: PRIVILEGED_CAP + 1024 * 1024,
       }),
     ).resolves.toBeNull();
     expect(gcsFake.copies).toEqual([]);
@@ -365,7 +384,7 @@ describe("per-team cap enforcement at the placement functions", () => {
       uploadPdfInputForFirePdf(
         metaForTeam("team-x"),
         path.join(tmpdir(), "does-not-exist.pdf"),
-        60 * 1024 * 1024,
+        OVER_DEFAULT_BYTES,
       ),
     ).resolves.toBeNull();
   });
@@ -376,13 +395,17 @@ describe("per-team cap enforcement at the placement functions", () => {
       `upload-test-${crypto.randomUUID()}.pdf`,
     );
     await writeFile(filePath, Buffer.alloc(1024, 7));
-    const res = await uploadPdfInputForFirePdf(
-      metaForTeam("team-privileged"),
-      filePath,
-      // Declared size sits over the default tier but under the privileged
-      // one — the guard must use the team's own cap.
-      60 * 1024 * 1024,
-    );
-    expect(res).toMatchObject({ sizeBytes: 60 * 1024 * 1024 });
+    try {
+      const res = await uploadPdfInputForFirePdf(
+        metaForTeam("team-privileged"),
+        filePath,
+        // Declared size sits over the default tier but under the privileged
+        // one — the guard must use the team's own cap.
+        OVER_DEFAULT_BYTES,
+      );
+      expect(res).toMatchObject({ sizeBytes: OVER_DEFAULT_BYTES });
+    } finally {
+      await unlink(filePath);
+    }
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/by-reference.ts
@@ -71,6 +71,24 @@ export async function rewritePdfInputForFirePdf(
     // bucket named by response data.
     return null;
   }
+  const limitBytes = largePdfLimitBytes(meta);
+  if (source.sizeBytes > limitBytes) {
+    // The routing gate already rejects oversized files, but this placement
+    // is the last step before bytes land in the fire-pdf bucket — it must
+    // enforce the team cap itself rather than trust every caller.
+    meta.logger.warn(
+      "fire-engine PDF handoff exceeds this team's large-PDF limit; refusing rewrite",
+      {
+        method: "scrapePDF/firePdfByReference",
+        event: "fire_pdf_by_reference_rewrite_over_cap",
+        scrape_id: meta.id,
+        team_id: meta.internalOptions.teamId,
+        size_bytes: source.sizeBytes,
+        limit_bytes: limitBytes,
+      },
+    );
+    return null;
+  }
   const destBucket = config.FIRE_PDF_GCS_INPUT_BUCKET;
   const destKey = firePdfInputObjectKey(meta.id);
   const startedAt = Date.now();
@@ -151,7 +169,10 @@ export async function rewritePdfInputForFirePdf(
  * architectural ceiling. Every acquisition path enforces this one number —
  * the direct-download admission, the fire-engine handoff download, the
  * by-reference routing gate, and (as pdfMaxSize) fire-engine's own capture
- * ceiling, so no path can admit bytes another would reject.
+ * ceiling, so no path can admit bytes another would reject. Both placement
+ * functions (the handoff rewrite and the streaming upload) enforce it once
+ * more themselves: nothing lands in the fire-pdf bucket above the team cap
+ * even if a caller skips the gates.
  */
 export function largePdfLimitBytes(meta: Meta): number {
   const teamId = meta.internalOptions.teamId;
@@ -269,6 +290,24 @@ export async function uploadPdfInputForFirePdf(
     keyVariant?: string;
   },
 ): Promise<FirePdfByReferenceInput | null> {
+  const limitBytes = largePdfLimitBytes(meta);
+  if (sizeBytes > limitBytes) {
+    // Same placement-level enforcement as the rewrite: the router's gate
+    // already rejects oversized files, but nothing may reach the fire-pdf
+    // bucket above the team cap regardless of which caller asked.
+    meta.logger.warn(
+      "Large PDF exceeds this team's large-PDF limit; refusing upload",
+      {
+        method: "scrapePDF/firePdfByReference",
+        event: "fire_pdf_by_reference_upload_over_cap",
+        scrape_id: meta.id,
+        team_id: meta.internalOptions.teamId,
+        size_bytes: sizeBytes,
+        limit_bytes: limitBytes,
+      },
+    );
+    return null;
+  }
   const bucketName = config.FIRE_PDF_GCS_INPUT_BUCKET;
   const objectKey = firePdfInputObjectKey(meta.id, opts?.keyVariant);
   const startedAt = Date.now();


### PR DESCRIPTION
## What

Enforces the per-team large-PDF byte limit (`largePdfLimitBytes`) inside both by-reference placement functions — `rewritePdfInputForFirePdf` (the fire-engine handoff server-side copy) and `uploadPdfInputForFirePdf` (the streaming upload). Both now refuse an over-cap input and return null, so an oversized file follows the existing pre-by-reference oversized path (legacy chain, oversized-skip warning) instead of landing in the fire-pdf bucket. Refusals log `fire_pdf_by_reference_rewrite_over_cap` / `fire_pdf_by_reference_upload_over_cap` with the size and the team's limit.

## Why

Prod showed default-tier teams uploading well past the 50MB default cap (max observed 205.1MB, team `cad3f439…`, 02:31–04:47Z on 2026-08-26). Tracing the acquisition paths:

- The over-cap uploads all date from the window when prod ran #4409 alone, whose download admission and routing gate used the flat 256MB architectural ceiling — per-team tiering did not exist yet. They stop at 04:47Z, right as #4411 (which introduced `largePdfLimitBytes` and wired it into the direct-download admission, the handoff download, the routing gate, and fire-engine's `pdfMaxSize` grant) rolled out. Since then, prod logs show non-privileged uploads bounded at 50MiB and only the privileged team above it — the tiering works.
- At HEAD, one gap remained versus the documented design ("every acquisition path enforces this one number"): the two placement functions themselves never check the cap and trust their callers to have applied the router's gates. They are the last step before bytes land in the fire-pdf bucket, so they now enforce the cap themselves.
- Verified (no change needed): the fire-engine capture grant already sends the per-team value (`pdfMaxSize: largePdfLimitBytes(meta)`), the handoff download caps via GCS metadata with a generation-pinned read, and `downloadFile` enforces the admission cap via content-length plus a streaming limiter.

## Tests

Extended `fireEngineHandoff.test.ts`: rewrite refuses over-default-cap for an unlisted team, allows the same size for a privileged team, refuses above the privileged cap even for a privileged team; upload refuses over-cap before any I/O and accepts an over-default / under-privileged size for a privileged team. `vitest run src/scraper/scrapeURL/engines/pdf/__tests__` (140 passed) and `tsc --noEmit` are clean.

## Note

Existing >50MB objects already processed for default-tier teams during the 02:31–04:47Z window are done and billed — this is forward-looking enforcement only, no retroactive action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the per-team large-PDF byte limit (`largePdfLimitBytes`) in both by-reference placement functions — `rewritePdfInputForFirePdf` and `uploadPdfInputForFirePdf`. Previously these trusted their callers to have applied the cap; now each refuses an over-cap input by returning `null` and logging a warning, so oversized files take the existing pre-by-reference oversized path instead of reaching the fire-pdf bucket.

**Why it matters**
- Prod showed default-tier teams uploading past the 50MB default cap (up to 205.1MB) in the window before per-team tiering existed.
- Already-processed over-cap objects are done and billed; enforcement is forward-looking only, with no retroactive action.

**Tests**
- Extended `fireEngineHandoff.test.ts` covering over-cap refusal for default teams, acceptance for privileged teams, and refusal above the privileged cap.
- Cap configs are pinned explicitly in the test block, and the upload-accept test cleans up its temp file.

<sup>Written for commit 98a353b89e3e73a46a36829428272523239d4038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

