### PR TITLE
ci: use trusted publishing for JS SDK

### DIFF
--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -11,10 +11,14 @@ on:
 env:
   TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     name: Publish
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install pnpm
@@ -24,21 +28,17 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: './apps/js-sdk/firecrawl/pnpm-lock.yaml'
-      - name: Authenticate
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish
         run: |
           pnpm install
           pnpm run build
-          pnpm publish --access public --no-git-checks
+          npm publish --access public
           sed -i 's/"name": "@mendable\/firecrawl-js"/"name": "@mendable\/firecrawl"/g' package.json
-          pnpm publish --access public --no-git-checks
+          npm publish --access public
           sed -i 's/"name": "@mendable\/firecrawl"/"name": "firecrawl"/g' package.json
           sed -i '/"firecrawl":/d' package.json
-          pnpm publish --access public --no-git-checks
+          npm publish --access public
         working-directory: ./apps/js-sdk/firecrawl

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           pnpm install
           pnpm run build
-          npm publish --access public
+          pnpm publish --access public --no-git-checks
           sed -i 's/"name": "@mendable\/firecrawl-js"/"name": "@mendable\/firecrawl"/g' package.json
-          npm publish --access public
+          pnpm publish --access public --no-git-checks
           sed -i 's/"name": "@mendable\/firecrawl"/"name": "firecrawl"/g' package.json
           sed -i '/"firecrawl":/d' package.json
-          npm publish --access public
+          pnpm publish --access public --no-git-checks
         working-directory: ./apps/js-sdk/firecrawl


### PR DESCRIPTION
## Summary

- grant the JS SDK publish workflow GitHub OIDC permissions and move it to a GitHub-hosted runner
- use Node 24 so pnpm's delegated npm publish runs with a trusted-publishing-compatible runtime and npm CLI
- remove the long-lived `NPM_TOKEN` authentication step while preserving the existing pnpm publication flow for all three SDK package names

## npm coordination

Before the next JS SDK version bump, configure a GitHub Actions trusted publisher for each package:

- `@mendable/firecrawl-js`
- `@mendable/firecrawl`
- `firecrawl`

Use repository `firecrawl/firecrawl`, workflow `publish-js-sdk.yml`, no environment, and allow `npm publish`.

Merging this PR does not itself publish: the workflow's push trigger only watches `apps/js-sdk/firecrawl/package.json`.

## Validation

- `actionlint .github/workflows/publish-js-sdk.yml`
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm publish --dry-run --access public --no-git-checks`
- npm pack dry-runs for all three published package names
