### PR TITLE
fix(sdks): reliable batch scrape polling, pagination, and failure reporting (JS + Python)

### DIFF
--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.37.0",
+  "version": "4.38.0",
   "description": "JavaScript SDK for the Firecrawl API: web scraping, crawling, web search, and scientific literature search over a research paper index of PubMed, bioRxiv, medRxiv and arXiv abstracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/batch.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/batch.test.ts
@@ -2,6 +2,7 @@
  * E2E tests for v2 batch scrape (translated from Python tests)
  */
 import Firecrawl from "../../../index";
+import { JobFailedError } from "../../../v2/types";
 import { config } from "dotenv";
 import { getIdentity, getApiUrl } from "./utils/idmux";
 import { describe, test, expect, beforeAll } from "@jest/globals";
@@ -22,11 +23,17 @@ describe("v2.batch e2e", () => {
       "https://docs.firecrawl.dev",
       "https://firecrawl.dev",
     ];
-    const job = await client.batchScrape(urls, { options: { formats: ["markdown"] }, pollInterval: 1, timeout: 180 });
-    expect(["completed", "failed"]).toContain(job.status);
-    expect(job.completed).toBeGreaterThanOrEqual(0);
-    expect(job.total).toBeGreaterThanOrEqual(0);
-    expect(Array.isArray(job.data)).toBe(true);
+    try {
+      const job = await client.batchScrape(urls, { options: { formats: ["markdown"] }, pollInterval: 1, timeout: 180 });
+      expect(job.status).toBe("completed");
+      expect(job.completed).toBeGreaterThanOrEqual(0);
+      expect(job.total).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(job.data)).toBe(true);
+    } catch (e: any) {
+      // failed/cancelled now raise JobFailedError instead of returning a terminal job.
+      expect(e).toBeInstanceOf(JobFailedError);
+      expect(["failed"]).toContain(e.job.status);
+    }
   }, 240_000);
 
   test("batch scrape with wait returns job id for error retrieval", async () => {
@@ -60,27 +67,33 @@ describe("v2.batch e2e", () => {
   }, 120_000);
 
   test("wait batch with all params", async () => {
-    const urls = ["https://docs.firecrawl.dev", "https://firecrawl.dev"]; 
-    const job = await client.batchScrape(urls, {
-      options: {
-        formats: [
-          "markdown",
-          { type: "json", prompt: "Extract page title", schema: { type: "object", properties: { title: { type: "string" } }, required: ["title"] } },
-          { type: "changeTracking", prompt: "Track changes", modes: ["json"] },
-        ],
-        onlyMainContent: true,
-        mobile: false,
-      },
-      ignoreInvalidURLs: true,
-      maxConcurrency: 2,
-      zeroDataRetention: false,
-      pollInterval: 1,
-      timeout: 180,
-    });
-    expect(["completed", "failed", "cancelled"]).toContain(job.status);
-    expect(job.completed).toBeGreaterThanOrEqual(0);
-    expect(job.total).toBeGreaterThanOrEqual(0);
-    expect(Array.isArray(job.data)).toBe(true);
+    const urls = ["https://docs.firecrawl.dev", "https://firecrawl.dev"];
+    try {
+      const job = await client.batchScrape(urls, {
+        options: {
+          formats: [
+            "markdown",
+            { type: "json", prompt: "Extract page title", schema: { type: "object", properties: { title: { type: "string" } }, required: ["title"] } },
+            { type: "changeTracking", prompt: "Track changes", modes: ["json"] },
+          ],
+          onlyMainContent: true,
+          mobile: false,
+        },
+        ignoreInvalidURLs: true,
+        maxConcurrency: 2,
+        zeroDataRetention: false,
+        pollInterval: 1,
+        timeout: 180,
+      });
+      expect(job.status).toBe("completed");
+      expect(job.completed).toBeGreaterThanOrEqual(0);
+      expect(job.total).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(job.data)).toBe(true);
+    } catch (e: any) {
+      // failed/cancelled now raise JobFailedError instead of returning a terminal job.
+      expect(e).toBeInstanceOf(JobFailedError);
+      expect(["failed", "cancelled"]).toContain(e.job.status);
+    }
   }, 300_000);
 
   test("cancel batch", async () => {

--- a/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/batch.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/batch.test.ts
@@ -2,7 +2,7 @@
  * E2E tests for v2 batch scrape (translated from Python tests)
  */
 import Firecrawl from "../../../index";
-import { JobFailedError } from "../../../v2/types";
+import { JobFailedError, type BatchScrapeJob } from "../../../v2/types";
 import { config } from "dotenv";
 import { getIdentity, getApiUrl } from "./utils/idmux";
 import { describe, test, expect, beforeAll } from "@jest/globals";
@@ -23,17 +23,19 @@ describe("v2.batch e2e", () => {
       "https://docs.firecrawl.dev",
       "https://firecrawl.dev",
     ];
+    let job: BatchScrapeJob;
     try {
-      const job = await client.batchScrape(urls, { options: { formats: ["markdown"] }, pollInterval: 1, timeout: 180 });
-      expect(job.status).toBe("completed");
-      expect(job.completed).toBeGreaterThanOrEqual(0);
-      expect(job.total).toBeGreaterThanOrEqual(0);
-      expect(Array.isArray(job.data)).toBe(true);
+      job = await client.batchScrape(urls, { options: { formats: ["markdown"] }, pollInterval: 1, timeout: 180 });
     } catch (e: any) {
       // failed/cancelled now raise JobFailedError instead of returning a terminal job.
-      expect(e).toBeInstanceOf(JobFailedError);
+      if (!(e instanceof JobFailedError)) throw e;
       expect(["failed"]).toContain(e.job.status);
+      return;
     }
+    expect(job.status).toBe("completed");
+    expect(job.completed).toBeGreaterThanOrEqual(0);
+    expect(job.total).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(job.data)).toBe(true);
   }, 240_000);
 
   test("batch scrape with wait returns job id for error retrieval", async () => {
@@ -68,8 +70,9 @@ describe("v2.batch e2e", () => {
 
   test("wait batch with all params", async () => {
     const urls = ["https://docs.firecrawl.dev", "https://firecrawl.dev"];
+    let job: BatchScrapeJob;
     try {
-      const job = await client.batchScrape(urls, {
+      job = await client.batchScrape(urls, {
         options: {
           formats: [
             "markdown",
@@ -85,15 +88,16 @@ describe("v2.batch e2e", () => {
         pollInterval: 1,
         timeout: 180,
       });
-      expect(job.status).toBe("completed");
-      expect(job.completed).toBeGreaterThanOrEqual(0);
-      expect(job.total).toBeGreaterThanOrEqual(0);
-      expect(Array.isArray(job.data)).toBe(true);
     } catch (e: any) {
       // failed/cancelled now raise JobFailedError instead of returning a terminal job.
-      expect(e).toBeInstanceOf(JobFailedError);
+      if (!(e instanceof JobFailedError)) throw e;
       expect(["failed", "cancelled"]).toContain(e.job.status);
+      return;
     }
+    expect(job.status).toBe("completed");
+    expect(job.completed).toBeGreaterThanOrEqual(0);
+    expect(job.total).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(job.data)).toBe(true);
   }, 300_000);
 
   test("cancel batch", async () => {

--- a/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/batch.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/e2e/v2/batch.test.ts
@@ -29,7 +29,7 @@ describe("v2.batch e2e", () => {
     } catch (e: any) {
       // failed/cancelled now raise JobFailedError instead of returning a terminal job.
       if (!(e instanceof JobFailedError)) throw e;
-      expect(["failed"]).toContain(e.job.status);
+      expect(["failed", "cancelled"]).toContain(e.job.status);
       return;
     }
     expect(job.status).toBe("completed");

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
@@ -34,4 +34,12 @@ describe("waitForBatchCompletion terminal handling", () => {
     const http = makeHttp([cancelled]);
     await expect(waitForBatchCompletion(http, "job3", 1)).rejects.toBeInstanceOf(JobFailedError);
   });
+
+  test("rejects instead of looping when a terminal job's pagination page returns success:false", async () => {
+    const completed = { status: 200, data: { success: true, status: "completed", completed: 2, total: 2, next: "https://api/next1", data: [{ markdown: "a" }] } };
+    const badPage = { status: 200, data: { success: false, error: "boom" } };
+    const http = makeHttp([completed, badPage]);
+    await expect(waitForBatchCompletion(http, "job4", 1)).rejects.toMatchObject({ code: "PAGINATION_RESPONSE_INVALID" });
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
@@ -42,4 +42,16 @@ describe("waitForBatchCompletion terminal handling", () => {
     await expect(waitForBatchCompletion(http, "job4", 1)).rejects.toMatchObject({ code: "PAGINATION_RESPONSE_INVALID" });
     expect(http.get).toHaveBeenCalledTimes(2);
   });
+
+  test("throws JobFailedError with the API error string when the job fails during kickoff", async () => {
+    const kickoffFailed = { status: 200, data: { success: false, error: "queue full", status: "failed", completed: 0, total: 0, data: [] } };
+    const http = makeHttp([kickoffFailed]);
+    const err = await waitForBatchCompletion(http, "job5", 1).then(
+      () => { throw new Error("expected JobFailedError"); },
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(JobFailedError);
+    expect(err.job.status).toBe("failed");
+    expect(err.message).toContain("queue full");
+  });
 });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { waitForBatchCompletion } from "../../../v2/methods/batch";
+import { JobFailedError } from "../../../v2/types";
+
+describe("waitForBatchCompletion terminal handling", () => {
+  function makeHttp(responses: any[]) {
+    let i = 0;
+    return { get: jest.fn(async () => responses[Math.min(i++, responses.length - 1)]) } as any;
+  }
+
+  test("returns the job when it completes", async () => {
+    const scraping = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 2, next: null, data: [] } };
+    const completed = { status: 200, data: { success: true, status: "completed", completed: 2, total: 2, next: null, data: [{ markdown: "a" }, { markdown: "b" }] } };
+    const http = makeHttp([scraping, completed]);
+    const job = await waitForBatchCompletion(http, "job1", 1);
+    expect(job.status).toBe("completed");
+    expect(job.data.length).toBe(2);
+  });
+
+  test("throws JobFailedError carrying the job when the batch fails", async () => {
+    const failed = { status: 200, data: { success: true, status: "failed", completed: 0, total: 3, next: null, data: [] } };
+    const http = makeHttp([failed]);
+    const err = await waitForBatchCompletion(http, "job2", 1).then(
+      () => { throw new Error("expected JobFailedError"); },
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(JobFailedError);
+    expect(err.job.status).toBe("failed");
+    expect(err.jobId).toBe("job2");
+  });
+
+  test("throws JobFailedError when the batch is cancelled", async () => {
+    const cancelled = { status: 200, data: { success: true, status: "cancelled", completed: 1, total: 3, next: null, data: [] } };
+    const http = makeHttp([cancelled]);
+    await expect(waitForBatchCompletion(http, "job3", 1)).rejects.toBeInstanceOf(JobFailedError);
+  });
+});

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/batch-wait.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, jest } from "@jest/globals";
+import { describe, test, expect, jest, afterEach } from "@jest/globals";
 import { waitForBatchCompletion } from "../../../v2/methods/batch";
 import { JobFailedError } from "../../../v2/types";
 
@@ -8,11 +8,19 @@ describe("waitForBatchCompletion terminal handling", () => {
     return { get: jest.fn(async () => responses[Math.min(i++, responses.length - 1)]) } as any;
   }
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test("returns the job when it completes", async () => {
+    // Fake timers avoid the real 1s poll-interval sleep between the scraping and completed polls.
+    jest.useFakeTimers();
     const scraping = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 2, next: null, data: [] } };
     const completed = { status: 200, data: { success: true, status: "completed", completed: 2, total: 2, next: null, data: [{ markdown: "a" }, { markdown: "b" }] } };
     const http = makeHttp([scraping, completed]);
-    const job = await waitForBatchCompletion(http, "job1", 1);
+    const jobPromise = waitForBatchCompletion(http, "job1", 1);
+    await jest.advanceTimersByTimeAsync(1000);
+    const job = await jobPromise;
     expect(job.status).toBe("completed");
     expect(job.data.length).toBe(2);
   });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -163,6 +163,15 @@ describe("JS SDK v2 pagination", () => {
     expect(res.data.length).toBe(2);
     expect(res.next).toBe("https://api/b2");
   });
+
+  test("batch: maxResults mid-page truncation re-reads the partially consumed page", async () => {
+    const first = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const p1 = { status: 200, data: { success: true, next: "https://api/b2", data: [{ markdown: "b" }, { markdown: "c" }] } };
+    const http = makeHttp((url) => (url.includes("/v2/batch/scrape/") ? first : p1));
+    const res = await getBatchScrapeStatus(http, "jobB", { autoPaginate: true, maxResults: 2 });
+    expect(res.data.length).toBe(2);
+    expect(res.next).toBe("https://api/b1");
+  });
 });
 
 

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -128,6 +128,23 @@ describe("JS SDK v2 pagination", () => {
       nowSpy.mockRestore();
     }
   });
+
+  test("batch: default autoPaginate does not follow next while status is non-terminal", async () => {
+    const first = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 5, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const http = makeHttp(() => first);
+    const res = await getBatchScrapeStatus(http, "jobB");
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(res.data.length).toBe(1);
+    expect(res.next).toBe("https://api/b1");
+  });
+
+  test("batch: explicit autoPaginate=true still aggregates while non-terminal", async () => {
+    const first = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 2, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const second = { status: 200, data: { success: true, next: null, data: [{ markdown: "b" }] } };
+    const http = makeHttp((url) => (url.includes("/v2/batch/scrape/") ? first : second));
+    const res = await getBatchScrapeStatus(http, "jobB", { autoPaginate: true });
+    expect(res.data.length).toBe(2);
+  });
 });
 
 

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -145,6 +145,24 @@ describe("JS SDK v2 pagination", () => {
     const res = await getBatchScrapeStatus(http, "jobB", { autoPaginate: true });
     expect(res.data.length).toBe(2);
   });
+
+  test("batch: failed page fetch during aggregation throws instead of returning partial data", async () => {
+    const first = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const http = makeHttp((url) => {
+      if (url.includes("/v2/batch/scrape/")) return first;
+      throw Object.assign(new Error("Request failed with status code 500"), { response: { status: 500 } });
+    });
+    await expect(getBatchScrapeStatus(http, "jobB")).rejects.toMatchObject({ code: "PAGINATION_FETCH_FAILED" });
+  });
+
+  test("batch: maxPages truncation preserves the unconsumed next cursor", async () => {
+    const first = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/b1", data: [{ markdown: "a" }] } };
+    const p1 = { status: 200, data: { success: true, next: "https://api/b2", data: [{ markdown: "b" }] } };
+    const http = makeHttp((url) => (url.includes("/v2/batch/scrape/") ? first : p1));
+    const res = await getBatchScrapeStatus(http, "jobB", { autoPaginate: true, maxPages: 1 });
+    expect(res.data.length).toBe(2);
+    expect(res.next).toBe("https://api/b2");
+  });
 });
 
 

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -172,6 +172,15 @@ describe("JS SDK v2 pagination", () => {
     expect(res.data.length).toBe(1);
     expect(res.next).toBe("https://api/b1");
   });
+
+  test("batch: a next cursor identical to the page just fetched is treated as drained, not looped", async () => {
+    const first = { status: 200, data: { success: true, status: "cancelled", completed: 0, total: 0, next: "https://api/loop", data: [] } };
+    const loop = { status: 200, data: { success: true, next: "https://api/loop", data: [] } };
+    const http = makeHttp((url) => (url.includes("/v2/batch/scrape/") ? first : loop));
+    const res = await getBatchScrapeStatus(http, "jobB");
+    expect(res.data.length).toBe(0);
+    expect(res.next).toBeNull();
+  });
 });
 
 

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -177,7 +177,43 @@ describe("JS SDK v2 pagination", () => {
     const first = { status: 200, data: { success: true, status: "cancelled", completed: 0, total: 0, next: "https://api/loop", data: [] } };
     const loop = { status: 200, data: { success: true, next: "https://api/loop", data: [] } };
     const http = makeHttp((url) => (url.includes("/v2/batch/scrape/") ? first : loop));
-    const res = await getBatchScrapeStatus(http, "jobB");
+    const res = await getBatchScrapeStatus(http, "jobB", { autoPaginate: true });
+    expect(res.data.length).toBe(0);
+    expect(res.next).toBeNull();
+  });
+
+  test("crawl: default autoPaginate does not follow next while status is non-terminal", async () => {
+    const first = { status: 200, data: { success: true, status: "scraping", completed: 1, total: 5, next: "https://api/c1", data: [{ markdown: "a" }] } };
+    const http = makeHttp(() => first);
+    const res = await getCrawlStatus(http, "jobC");
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(res.data.length).toBe(1);
+    expect(res.next).toBe("https://api/c1");
+  });
+
+  test("crawl: failed page fetch during aggregation throws instead of returning partial data", async () => {
+    const first = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/c1", data: [{ markdown: "a" }] } };
+    const http = makeHttp((url) => {
+      if (url.includes("/v2/crawl/")) return first;
+      throw Object.assign(new Error("Request failed with status code 500"), { response: { status: 500 } });
+    });
+    await expect(getCrawlStatus(http, "jobC")).rejects.toMatchObject({ code: "PAGINATION_FETCH_FAILED" });
+  });
+
+  test("crawl: a page that would overshoot maxResults is skipped whole, not partially appended", async () => {
+    const first = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/c1", data: [{ markdown: "a" }] } };
+    const p1 = { status: 200, data: { success: true, next: "https://api/c2", data: [{ markdown: "b" }, { markdown: "c" }] } };
+    const http = makeHttp((url) => (url.includes("/v2/crawl/") ? first : p1));
+    const res = await getCrawlStatus(http, "jobC", { autoPaginate: true, maxResults: 2 });
+    expect(res.data.length).toBe(1);
+    expect(res.next).toBe("https://api/c1");
+  });
+
+  test("crawl: a next cursor identical to the page just fetched is treated as drained, not looped", async () => {
+    const first = { status: 200, data: { success: true, status: "cancelled", completed: 0, total: 0, next: "https://api/loopC", data: [] } };
+    const loop = { status: 200, data: { success: true, next: "https://api/loopC", data: [] } };
+    const http = makeHttp((url) => (url.includes("/v2/crawl/") ? first : loop));
+    const res = await getCrawlStatus(http, "jobC", { autoPaginate: true });
     expect(res.data.length).toBe(0);
     expect(res.next).toBeNull();
   });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/pagination.test.ts
@@ -164,12 +164,12 @@ describe("JS SDK v2 pagination", () => {
     expect(res.next).toBe("https://api/b2");
   });
 
-  test("batch: maxResults mid-page truncation re-reads the partially consumed page", async () => {
+  test("batch: a page that would overshoot maxResults is skipped whole, not partially appended", async () => {
     const first = { status: 200, data: { success: true, status: "completed", completed: 3, total: 3, next: "https://api/b1", data: [{ markdown: "a" }] } };
     const p1 = { status: 200, data: { success: true, next: "https://api/b2", data: [{ markdown: "b" }, { markdown: "c" }] } };
     const http = makeHttp((url) => (url.includes("/v2/batch/scrape/") ? first : p1));
     const res = await getBatchScrapeStatus(http, "jobB", { autoPaginate: true, maxResults: 2 });
-    expect(res.data.length).toBe(2);
+    expect(res.data.length).toBe(1);
     expect(res.next).toBe("https://api/b1");
   });
 });

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -120,8 +120,8 @@ export async function getBatchScrapeStatus(
       total: body.total ?? 0,
       creditsUsed: body.creditsUsed,
       expiresAt: body.expiresAt,
-      next: null,
-      data: aggregated,
+      next: aggregated.next,
+      data: aggregated.documents,
     };
   } catch (err: any) {
     if (err?.isAxiosError)

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -6,6 +6,7 @@ import {
   type BatchScrapeOptions,
   type PaginationConfig,
   JobTimeoutError,
+  JobFailedError,
   SdkError,
 } from "../types";
 import { HttpClient } from "../utils/httpClient";
@@ -178,16 +179,12 @@ export async function waitForBatchCompletion(
   const start = Date.now();
 
   while (true) {
+    let status: BatchScrapeJob | null = null;
     try {
-      const status = await getBatchScrapeStatus(http, jobId);
-
-      if (["completed", "failed", "cancelled"].includes(status.status)) {
-        return status;
-      }
+      status = await getBatchScrapeStatus(http, jobId);
     } catch (err: any) {
       // Don't retry on permanent errors (4xx) - re-throw immediately with jobId context
       if (!isRetryableError(err)) {
-        // Create new error with jobId for better debugging (non-retryable errors like 404)
         if (err instanceof SdkError) {
           const errorWithJobId = new SdkError(
             err.message,
@@ -201,6 +198,13 @@ export async function waitForBatchCompletion(
         throw err;
       }
       // Otherwise, retry after delay - error might be transient (network issue, timeout, 5xx, etc.)
+    }
+
+    if (status) {
+      if (status.status === "completed") return status;
+      if (status.status === "failed" || status.status === "cancelled") {
+        throw new JobFailedError(status, jobId);
+      }
     }
 
     if (timeout != null && Date.now() - start > timeout * 1000) {

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -91,7 +91,9 @@ export async function getBatchScrapeStatus(
       throwForBadResponse(res, "get batch scrape status");
     const body = res.data;
     const initialDocs = (body.data || []) as Document[];
-    const auto = pagination?.autoPaginate ?? true;
+    // Following `next` while the job runs would re-download pages on every poll.
+    const isTerminal = ["completed", "failed", "cancelled"].includes(body.status);
+    const auto = pagination?.autoPaginate ?? isTerminal;
     if (!auto || !body.next) {
       return {
         id: jobId,

--- a/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/batch.ts
@@ -87,14 +87,18 @@ export async function getBatchScrapeStatus(
       expiresAt?: string;
       next?: string | null;
       data?: Document[];
+      error?: string;
     }>(`/v2/batch/scrape/${jobId}`);
-    if (res.status !== 200 || !res.data?.success)
+    // A kickoff failure responds 200 with success:false and status:"failed"; parse it as a
+    // normal terminal job instead of throwing, so the waiter can raise JobFailedError.
+    const isKickoffFailure = res.status === 200 && res.data?.success === false && res.data?.status === "failed";
+    if (!isKickoffFailure && (res.status !== 200 || !res.data?.success))
       throwForBadResponse(res, "get batch scrape status");
     const body = res.data;
     const initialDocs = (body.data || []) as Document[];
-    // Following `next` while the job runs would re-download pages on every poll.
-    const isTerminal = ["completed", "failed", "cancelled"].includes(body.status);
-    const auto = pagination?.autoPaginate ?? isTerminal;
+    // Unset autoPaginate paginates only once the job is completed, so a failed/cancelled
+    // job's result pages are never fetched before the waiter can raise JobFailedError.
+    const auto = pagination?.autoPaginate ?? (body.status === "completed");
     if (!auto || !body.next) {
       return {
         id: jobId,
@@ -105,6 +109,7 @@ export async function getBatchScrapeStatus(
         expiresAt: body.expiresAt,
         next: body.next ?? null,
         data: initialDocs,
+        error: body.error,
       };
     }
 
@@ -123,6 +128,7 @@ export async function getBatchScrapeStatus(
       expiresAt: body.expiresAt,
       next: aggregated.next,
       data: aggregated.documents,
+      error: body.error,
     };
   } catch (err: any) {
     if (err?.isAxiosError)
@@ -203,7 +209,7 @@ export async function waitForBatchCompletion(
     if (status) {
       if (status.status === "completed") return status;
       if (status.status === "failed" || status.status === "cancelled") {
-        throw new JobFailedError(status, jobId);
+        throw new JobFailedError(status, jobId, status.error);
       }
     }
 

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -75,7 +75,8 @@ export async function getCrawlStatus(
     const body = res.data;
     const initialDocs = (body.data || []) as Document[];
 
-    const auto = pagination?.autoPaginate ?? true;
+    // Unset autoPaginate paginates only once the job is completed, matching batch's default gate.
+    const auto = pagination?.autoPaginate ?? (body.status === "completed");
     if (!auto || !body.next) {
       return {
         id: jobId,

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -98,8 +98,8 @@ export async function getCrawlStatus(
       total: body.total ?? 0,
       creditsUsed: body.creditsUsed,
       expiresAt: body.expiresAt,
-      next: null,
-      data: aggregated,
+      next: aggregated.next,
+      data: aggregated.documents,
     };
   } catch (err: any) {
     if (err?.isAxiosError) return normalizeAxiosError(err, "get crawl status");

--- a/apps/js-sdk/firecrawl/src/v2/methods/monitor.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/monitor.ts
@@ -164,15 +164,16 @@ export async function getMonitorCheck(
       return { ...detail, next };
     }
 
+    const paged = await fetchAllPages<MonitorCheckPage>(
+      http,
+      next,
+      detail.pages || [],
+      options,
+    );
     return {
       ...detail,
-      pages: await fetchAllPages<MonitorCheckPage>(
-        http,
-        next,
-        detail.pages || [],
-        options,
-      ),
-      next: null,
+      pages: paged.documents,
+      next: paged.next,
     };
   } catch (err: any) {
     if (err?.isAxiosError) return normalizeAxiosError(err, "get monitor check");

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -706,7 +706,7 @@ export interface Document {
 
 // Pagination configuration for auto-fetching pages from v2 endpoints that return a `next` URL
 export interface PaginationConfig {
-  /** When true (default), automatically follow `next` links and aggregate all documents. */
+  /** Unset lets the SDK decide: batch status paginates only once the job is terminal; other endpoints keep auto-pagination on. Explicit true/false always wins. */
   autoPaginate?: boolean;
   /** Maximum number of additional pages to fetch after the first response. */
   maxPages?: number;

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -706,7 +706,7 @@ export interface Document {
 
 // Pagination configuration for auto-fetching pages from v2 endpoints that return a `next` URL
 export interface PaginationConfig {
-  /** Unset lets the SDK decide: batch status paginates only once the job is terminal; other endpoints keep auto-pagination on. Explicit true/false always wins. */
+  /** Unset lets the SDK decide: batch and crawl status paginate only once the job is completed. Explicit true/false always wins. */
   autoPaginate?: boolean;
   /** Maximum number of additional pages to fetch after the first response. */
   maxPages?: number;
@@ -949,6 +949,8 @@ export interface BatchScrapeJob {
   expiresAt?: string;
   next?: string | null;
   data: Document[];
+  /** API-provided error string, present when status is "failed". */
+  error?: string;
 }
 
 export interface MapData {
@@ -1616,9 +1618,9 @@ export class JobTimeoutError extends SdkError {
 
 export class JobFailedError extends SdkError {
   job: BatchScrapeJob;
-  constructor(job: BatchScrapeJob, jobId: string) {
+  constructor(job: BatchScrapeJob, jobId: string, detail?: string) {
     super(
-      `Batch scrape job ${jobId} ended with status ${job.status}`,
+      `Batch scrape job ${jobId} ended with status ${job.status}${detail ? `: ${detail}` : ""}`,
       undefined,
       "JOB_FAILED",
       undefined,

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -1614,6 +1614,21 @@ export class JobTimeoutError extends SdkError {
   }
 }
 
+export class JobFailedError extends SdkError {
+  job: BatchScrapeJob;
+  constructor(job: BatchScrapeJob, jobId: string) {
+    super(
+      `Batch scrape job ${jobId} ended with status ${job.status}`,
+      undefined,
+      "JOB_FAILED",
+      undefined,
+      jobId,
+    );
+    this.name = "JobFailedError";
+    this.job = job;
+  }
+}
+
 export interface QueueStatusResponse {
   success: boolean;
   jobsInQueue: number;

--- a/apps/js-sdk/firecrawl/src/v2/utils/errorHandler.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/errorHandler.ts
@@ -21,7 +21,12 @@ export function isRetryableError(err: any): boolean {
   if (err instanceof JobTimeoutError) {
     return false;
   }
-  
+
+  // A page that responded 200 with success:false is a permanent response-level failure, not a transient blip.
+  if (err instanceof SdkError && err.code === "PAGINATION_RESPONSE_INVALID") {
+    return false;
+  }
+
   // If it's an SdkError with a status code, check if it's retryable
   if (err instanceof SdkError || (err && typeof err === 'object' && 'status' in err)) {
     const status = err.status;

--- a/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
@@ -60,6 +60,10 @@ export async function fetchAllPages<T = Document>(
       return { documents: docs, next: current };
     }
     docs.push(...(pageData as T[]));
+    if (pageNext === current) {
+      // A next cursor identical to the page just fetched can never advance; treat as drained.
+      return { documents: docs, next: null };
+    }
     current = pageNext;
     pageCount += 1;
   }

--- a/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
@@ -28,6 +28,7 @@ export async function fetchAllPages<T = Document>(
   while (current) {
     if (maxPages != null && pageCount >= maxPages) break;
     if (maxWaitTime != null && (Date.now() - started) / 1000 > maxWaitTime) break;
+    if (maxResults != null && docs.length >= maxResults) break;
 
     type PagePayload = { success: boolean; next?: string | null; data?: T[] | { pages?: T[]; next?: string | null } };
     let payload: PagePayload;
@@ -45,7 +46,7 @@ export async function fetchAllPages<T = Document>(
       throw new SdkError(
         `Results page ${pageCount + 1} returned an unsuccessful response during pagination`,
         undefined,
-        "PAGINATION_FETCH_FAILED",
+        "PAGINATION_RESPONSE_INVALID",
       );
     }
 
@@ -53,18 +54,12 @@ export async function fetchAllPages<T = Document>(
       ? payload.data
       : payload.data?.pages || [];
     const pageNext = (payload.next ?? (Array.isArray(payload.data) ? null : payload.data?.next) ?? null) as string | null;
-    let pageFullyConsumed = true;
-    for (const d of pageData) {
-      if (maxResults != null && docs.length >= maxResults) {
-        pageFullyConsumed = false;
-        break;
-      }
-      docs.push(d as T);
+
+    if (maxResults != null && docs.length + pageData.length > maxResults) {
+      // A page that would overshoot maxResults is skipped whole, so resume never drops or duplicates data.
+      return { documents: docs, next: current };
     }
-    if (maxResults != null && docs.length >= maxResults) {
-      // A partially consumed page must be re-read, or its unread tail is lost silently.
-      return { documents: docs, next: pageFullyConsumed ? pageNext : current };
-    }
+    docs.push(...(pageData as T[]));
     current = pageNext;
     pageCount += 1;
   }

--- a/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
@@ -53,12 +53,17 @@ export async function fetchAllPages<T = Document>(
       ? payload.data
       : payload.data?.pages || [];
     const pageNext = (payload.next ?? (Array.isArray(payload.data) ? null : payload.data?.next) ?? null) as string | null;
+    let pageFullyConsumed = true;
     for (const d of pageData) {
-      if (maxResults != null && docs.length >= maxResults) break;
+      if (maxResults != null && docs.length >= maxResults) {
+        pageFullyConsumed = false;
+        break;
+      }
       docs.push(d as T);
     }
     if (maxResults != null && docs.length >= maxResults) {
-      return { documents: docs, next: pageNext };
+      // A partially consumed page must be re-read, or its unread tail is lost silently.
+      return { documents: docs, next: pageFullyConsumed ? pageNext : current };
     }
     current = pageNext;
     pageCount += 1;

--- a/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
+++ b/apps/js-sdk/firecrawl/src/v2/utils/pagination.ts
@@ -1,15 +1,22 @@
 import type { HttpClient } from "../utils/httpClient";
-import type { Document, PaginationConfig } from "../types";
+import { SdkError, type Document, type PaginationConfig } from "../types";
+
+export interface PaginatedFetchResult<T> {
+  documents: T[];
+  /** Unconsumed cursor when a caller limit stopped pagination early; null when fully drained. */
+  next: string | null;
+}
 
 /**
- * Shared helper to follow `next` URLs and aggregate paginated result arrays.
+ * Follows `next` URLs and aggregates paginated result arrays.
+ * Throws on a failed page fetch so callers never get silent partial data.
  */
 export async function fetchAllPages<T = Document>(
   http: HttpClient,
   nextUrl: string,
   initial: T[],
   pagination?: PaginationConfig
-): Promise<T[]> {
+): Promise<PaginatedFetchResult<T>> {
   const docs = initial.slice();
   let current: string | null = nextUrl;
   let pageCount = 0;
@@ -22,27 +29,39 @@ export async function fetchAllPages<T = Document>(
     if (maxPages != null && pageCount >= maxPages) break;
     if (maxWaitTime != null && (Date.now() - started) / 1000 > maxWaitTime) break;
 
-    let payload: { success: boolean; next?: string | null; data?: T[] | { pages?: T[]; next?: string | null } } | null = null;
+    type PagePayload = { success: boolean; next?: string | null; data?: T[] | { pages?: T[]; next?: string | null } };
+    let payload: PagePayload;
     try {
-      const res = await http.get<{ success: boolean; next?: string | null; data?: T[] | { pages?: T[]; next?: string | null } }>(current);
+      const res = await http.get<PagePayload>(current);
       payload = res.data;
-    } catch {
-      break; // axios rejects on non-2xx; stop pagination gracefully
+    } catch (err: any) {
+      throw new SdkError(
+        `Failed to fetch results page ${pageCount + 1} during pagination: ${err?.message ?? String(err)}`,
+        err?.response?.status,
+        "PAGINATION_FETCH_FAILED",
+      );
     }
-    if (!payload?.success) break;
+    if (!payload?.success) {
+      throw new SdkError(
+        `Results page ${pageCount + 1} returned an unsuccessful response during pagination`,
+        undefined,
+        "PAGINATION_FETCH_FAILED",
+      );
+    }
 
     const pageData = Array.isArray(payload.data)
       ? payload.data
       : payload.data?.pages || [];
+    const pageNext = (payload.next ?? (Array.isArray(payload.data) ? null : payload.data?.next) ?? null) as string | null;
     for (const d of pageData) {
       if (maxResults != null && docs.length >= maxResults) break;
       docs.push(d as T);
     }
-    if (maxResults != null && docs.length >= maxResults) break;
-    current = (payload.next ?? (Array.isArray(payload.data) ? null : payload.data?.next) ?? null) as string | null;
+    if (maxResults != null && docs.length >= maxResults) {
+      return { documents: docs, next: pageNext };
+    }
+    current = pageNext;
     pageCount += 1;
   }
-  return docs;
+  return { documents: docs, next: current ?? null };
 }
-
-

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -18,7 +18,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.40.0"
+__version__ = "4.41.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/python-sdk/firecrawl/__tests__/e2e/v2/aio/test_aio_batch_scrape.py
+++ b/apps/python-sdk/firecrawl/__tests__/e2e/v2/aio/test_aio_batch_scrape.py
@@ -32,7 +32,7 @@ async def test_async_batch_wait_minimal(api_key, api_url):
         ], formats=["markdown"], poll_interval=1, timeout=120)
         assert job.status == "completed"
     except JobFailedError as e:
-        assert e.job.status in ("failed",)
+        assert e.job.status in ("failed", "cancelled")
 
 
 @pytest.mark.asyncio
@@ -61,7 +61,7 @@ async def test_async_batch_wait_with_all_params(api_key, api_url):
         )
         assert job.status == "completed"
     except JobFailedError as e:
-        assert e.job.status in ("failed",)
+        assert e.job.status in ("failed", "cancelled")
 
 
 @pytest.mark.asyncio

--- a/apps/python-sdk/firecrawl/__tests__/e2e/v2/aio/test_aio_batch_scrape.py
+++ b/apps/python-sdk/firecrawl/__tests__/e2e/v2/aio/test_aio_batch_scrape.py
@@ -1,6 +1,7 @@
 import asyncio
 import pytest
 from firecrawl import AsyncFirecrawl
+from firecrawl.v2.utils import JobFailedError
 
 
 @pytest.mark.asyncio
@@ -24,37 +25,43 @@ async def test_async_batch_start_and_status(api_key, api_url):
 @pytest.mark.asyncio
 async def test_async_batch_wait_minimal(api_key, api_url):
     client = AsyncFirecrawl(api_key=api_key, api_url=api_url)
-    job = await client.batch_scrape([
-        "https://docs.firecrawl.dev",
-        "https://firecrawl.dev",
-    ], formats=["markdown"], poll_interval=1, timeout=120)
-    assert job.status in ("completed", "failed")
+    try:
+        job = await client.batch_scrape([
+            "https://docs.firecrawl.dev",
+            "https://firecrawl.dev",
+        ], formats=["markdown"], poll_interval=1, timeout=120)
+        assert job.status == "completed"
+    except JobFailedError as e:
+        assert e.job.status in ("failed",)
 
 
 @pytest.mark.asyncio
 async def test_async_batch_wait_with_all_params(api_key, api_url):
     client = AsyncFirecrawl(api_key=api_key, api_url=api_url)
     json_schema = {"type": "object", "properties": {"title": {"type": "string"}}, "required": ["title"]}
-    job = await client.batch_scrape(
-        [
-            "https://docs.firecrawl.dev",
-            "https://firecrawl.dev",
-        ],
-        formats=[
-            "markdown",
-            {"type": "json", "prompt": "Extract page title", "schema": json_schema},
-            {"type": "changeTracking", "prompt": "Track changes", "modes": ["json"]},
-        ],
-        only_main_content=True,
-        mobile=False,
-        ignore_invalid_urls=True,
-        max_concurrency=2,
-        zero_data_retention=False,
-        poll_interval=1,
-        timeout=180,
-        integration="_e2e-test",
-    )
-    assert job.status in ("completed", "failed")
+    try:
+        job = await client.batch_scrape(
+            [
+                "https://docs.firecrawl.dev",
+                "https://firecrawl.dev",
+            ],
+            formats=[
+                "markdown",
+                {"type": "json", "prompt": "Extract page title", "schema": json_schema},
+                {"type": "changeTracking", "prompt": "Track changes", "modes": ["json"]},
+            ],
+            only_main_content=True,
+            mobile=False,
+            ignore_invalid_urls=True,
+            max_concurrency=2,
+            zero_data_retention=False,
+            poll_interval=1,
+            timeout=180,
+            integration="_e2e-test",
+        )
+        assert job.status == "completed"
+    except JobFailedError as e:
+        assert e.job.status in ("failed",)
 
 
 @pytest.mark.asyncio

--- a/apps/python-sdk/firecrawl/__tests__/e2e/v2/test_batch_scrape.py
+++ b/apps/python-sdk/firecrawl/__tests__/e2e/v2/test_batch_scrape.py
@@ -35,7 +35,7 @@ class TestBatchScrapeE2E:
             assert job.total >= 0
             assert isinstance(job.data, list)
         except JobFailedError as e:
-            assert e.job.status in ["failed"]
+            assert e.job.status in ["failed", "cancelled"]
 
     def test_start_batch_minimal_and_status(self):
         """Start via start_batch_scrape (minimal), then fetch status once."""
@@ -128,7 +128,7 @@ class TestBatchScrapeE2E:
             assert job.total >= 0
             assert isinstance(job.data, list)
         except JobFailedError as e:
-            assert e.job.status in ["failed"]
+            assert e.job.status in ["failed", "cancelled"]
 
     def test_cancel_batch(self):
         """Start a batch and cancel it."""

--- a/apps/python-sdk/firecrawl/__tests__/e2e/v2/test_batch_scrape.py
+++ b/apps/python-sdk/firecrawl/__tests__/e2e/v2/test_batch_scrape.py
@@ -4,6 +4,7 @@ import pytest
 from dotenv import load_dotenv
 from firecrawl import Firecrawl
 from firecrawl.v2.types import ScrapeOptions, PaginationConfig
+from firecrawl.v2.utils import JobFailedError
 
 load_dotenv()
 
@@ -27,12 +28,14 @@ class TestBatchScrapeE2E:
             "https://firecrawl.dev",
         ]
 
-        job = self.client.batch_scrape(urls, formats=["markdown"], poll_interval=1, wait_timeout=120)
-
-        assert job.status in ["completed", "failed"]
-        assert job.completed >= 0
-        assert job.total >= 0
-        assert isinstance(job.data, list)
+        try:
+            job = self.client.batch_scrape(urls, formats=["markdown"], poll_interval=1, wait_timeout=120)
+            assert job.status == "completed"
+            assert job.completed >= 0
+            assert job.total >= 0
+            assert isinstance(job.data, list)
+        except JobFailedError as e:
+            assert e.job.status in ["failed"]
 
     def test_start_batch_minimal_and_status(self):
         """Start via start_batch_scrape (minimal), then fetch status once."""
@@ -107,23 +110,25 @@ class TestBatchScrapeE2E:
             mobile=False,
         )
 
-        job = self.client.batch_scrape(
-            urls,
-            formats=opts.formats,
-            only_main_content=opts.only_main_content,
-            mobile=opts.mobile,
-            ignore_invalid_urls=True,
-            max_concurrency=2,
-            zero_data_retention=False,
-            poll_interval=1,
-            wait_timeout=180,
-            integration="_e2e-test",
-        )
-
-        assert job.status in ["completed", "failed"]
-        assert job.completed >= 0
-        assert job.total >= 0
-        assert isinstance(job.data, list)
+        try:
+            job = self.client.batch_scrape(
+                urls,
+                formats=opts.formats,
+                only_main_content=opts.only_main_content,
+                mobile=opts.mobile,
+                ignore_invalid_urls=True,
+                max_concurrency=2,
+                zero_data_retention=False,
+                poll_interval=1,
+                wait_timeout=180,
+                integration="_e2e-test",
+            )
+            assert job.status == "completed"
+            assert job.completed >= 0
+            assert job.total >= 0
+            assert isinstance(job.data, list)
+        except JobFailedError as e:
+            assert e.job.status in ["failed"]
 
     def test_cancel_batch(self):
         """Start a batch and cancel it."""

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_batch_wait.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_batch_wait.py
@@ -3,10 +3,12 @@ Unit tests for batch scrape wait behavior on terminal states.
 """
 
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, AsyncMock
 
 from firecrawl.v2.types import BatchScrapeJob
 from firecrawl.v2.methods import batch
+from firecrawl.v2.methods.aio import batch as async_batch
+from firecrawl.v2.client_async import AsyncFirecrawlClient
 from firecrawl.v2.utils import JobFailedError
 
 
@@ -51,6 +53,19 @@ class TestWaitForBatchCompletion:
 
         with pytest.raises(JobFailedError) as exc_info:
             batch.wait_for_batch_completion(client, job_id="job-6")
+
+        assert exc_info.value.job.status == "failed"
+        assert "queue full" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_async_kickoff_failure_raises_job_failed_error_with_api_message(self):
+        """The async waiter's kickoff-failure path also carries the API error string into JobFailedError."""
+        job = BatchScrapeJob(status="failed", completed=0, total=0, data=[], error="queue full")
+        client = AsyncFirecrawlClient(api_key="test", api_url="http://localhost")
+
+        with patch.object(async_batch, "get_batch_scrape_status", new=AsyncMock(return_value=job)):
+            with pytest.raises(JobFailedError) as exc_info:
+                await client.wait_batch_scrape("job-7", poll_interval=1)
 
         assert exc_info.value.job.status == "failed"
         assert "queue full" in str(exc_info.value)

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_batch_wait.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_batch_wait.py
@@ -3,7 +3,7 @@ Unit tests for batch scrape wait behavior on terminal states.
 """
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from firecrawl.v2.types import BatchScrapeJob
 from firecrawl.v2.methods import batch
@@ -33,3 +33,24 @@ class TestWaitForBatchCompletion:
     def test_job_failed_error_is_a_firecrawl_error(self):
         from firecrawl.v2.utils import FirecrawlError
         assert issubclass(JobFailedError, FirecrawlError)
+
+    def test_kickoff_failure_raises_job_failed_error_with_api_message(self):
+        """A 200 success:false status:failed response raises JobFailedError with the API error string."""
+        client = Mock()
+        response = Mock()
+        response.ok = True
+        response.json.return_value = {
+            "success": False,
+            "error": "queue full",
+            "status": "failed",
+            "completed": 0,
+            "total": 0,
+            "data": [],
+        }
+        client.get.return_value = response
+
+        with pytest.raises(JobFailedError) as exc_info:
+            batch.wait_for_batch_completion(client, job_id="job-6")
+
+        assert exc_info.value.job.status == "failed"
+        assert "queue full" in str(exc_info.value)

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_batch_wait.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_batch_wait.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for batch scrape wait behavior on terminal states.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from firecrawl.v2.types import BatchScrapeJob
+from firecrawl.v2.methods import batch
+from firecrawl.v2.utils import JobFailedError
+
+
+class TestWaitForBatchCompletion:
+    def test_completed_job_is_returned(self):
+        job = BatchScrapeJob(status="completed", completed=2, total=2, data=[])
+        with patch.object(batch, "get_batch_scrape_status", return_value=job):
+            result = batch.wait_for_batch_completion(client=None, job_id="job-1")
+        assert result.status == "completed"
+
+    def test_failed_job_raises_job_failed_error(self):
+        job = BatchScrapeJob(status="failed", completed=0, total=3, data=[])
+        with patch.object(batch, "get_batch_scrape_status", return_value=job):
+            with pytest.raises(JobFailedError) as exc_info:
+                batch.wait_for_batch_completion(client=None, job_id="job-2")
+        assert exc_info.value.job.status == "failed"
+
+    def test_cancelled_job_raises_job_failed_error(self):
+        job = BatchScrapeJob(status="cancelled", completed=1, total=3, data=[])
+        with patch.object(batch, "get_batch_scrape_status", return_value=job):
+            with pytest.raises(JobFailedError):
+                batch.wait_for_batch_completion(client=None, job_id="job-3")
+
+    def test_job_failed_error_is_a_firecrawl_error(self):
+        from firecrawl.v2.utils import FirecrawlError
+        assert issubclass(JobFailedError, FirecrawlError)

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -493,7 +493,7 @@ class TestBatchScrapePagination:
             mock_response.json.return_value = {
                 "success": True,
                 "data": [self.sample_doc, self.sample_doc],  # 2 docs per page
-                "next": f"https://api.firecrawl.dev/v2/batch/scrape/test-batch-123?page={i+2}" if i < 4 else None
+                "next": f"https://api.firecrawl.dev/v2/batch/scrape/test-batch-123?page={i+3}" if i < 4 else None
             }
             mock_responses.append(mock_response)
         
@@ -653,6 +653,37 @@ class TestBatchScrapePagination:
 
         assert len(job.data) == 1
         assert job.next == "https://api.example.com/next1"
+
+    def test_self_referencing_next_is_treated_as_drained(self):
+        """A next cursor identical to the page just fetched stops instead of looping forever."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "cancelled",
+            "completed": 0,
+            "total": 0,
+            "next": "https://api.example.com/loop",
+            "data": [],
+        }
+        loop = Mock()
+        loop.ok = True
+        loop.json.return_value = {
+            "success": True,
+            "status": "cancelled",
+            "completed": 0,
+            "total": 0,
+            "next": "https://api.example.com/loop",
+            "data": [],
+        }
+        client.get.side_effect = [first, loop]
+
+        job = get_batch_scrape_status(client, "job-1")
+
+        assert len(job.data) == 0
+        assert job.next is None
+        assert client.get.call_count == 2
 
 
 class TestAsyncPagination:

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -26,6 +26,7 @@ from firecrawl.v2.methods.aio.batch import (
     get_batch_scrape_status_page as get_batch_scrape_status_page_async,
     _fetch_all_batch_pages_async,
 )
+from firecrawl.v2.utils import FirecrawlError
 
 
 class TestPaginationConfig:
@@ -583,7 +584,7 @@ class TestBatchScrapePagination:
         bad.text = '{"success": false, "error": "internal error"}'
         client.get.side_effect = [first, bad]
 
-        with pytest.raises(Exception):
+        with pytest.raises(FirecrawlError):
             get_batch_scrape_status(client, "job-1")
 
     def test_max_pages_truncation_preserves_next(self):
@@ -617,6 +618,41 @@ class TestBatchScrapePagination:
 
         assert len(job.data) == 2
         assert job.next == "https://api.example.com/next2"
+
+    def test_max_results_mid_page_truncation_rereads_current_page(self):
+        """Stopping mid-page on max_results returns the partially consumed page's own URL."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        second = Mock()
+        second.ok = True
+        second.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "next": "https://api.example.com/next2",
+            "data": [
+                {"markdown": "b", "metadata": {"sourceURL": "https://y.com"}},
+                {"markdown": "c", "metadata": {"sourceURL": "https://z.com"}},
+            ],
+        }
+        client.get.side_effect = [first, second]
+
+        job = get_batch_scrape_status(
+            client, "job-1", pagination_config=PaginationConfig(max_results=2)
+        )
+
+        assert len(job.data) == 2
+        assert job.next == "https://api.example.com/next1"
 
 
 class TestAsyncPagination:

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -500,13 +500,13 @@ class TestBatchScrapePagination:
         
         # Test with max_pages=2, max_results=4 (total docs we want)
         pagination_config = PaginationConfig(max_pages=2, max_results=4)
-        result = _fetch_all_batch_pages(
-            self.mock_client, 
-            "https://api.firecrawl.dev/v2/batch/scrape/test-batch-123?page=2", 
+        result, next_url = _fetch_all_batch_pages(
+            self.mock_client,
+            "https://api.firecrawl.dev/v2/batch/scrape/test-batch-123?page=2",
             [Document(**self.sample_doc)],  # 1 initial doc
             pagination_config
         )
-        
+
         # Should have 1 initial + 3 from pages (limited by max_results=4)
         assert len(result) == 4
         assert self.mock_client.get.call_count == 2  # Should fetch 2 pages
@@ -562,6 +562,61 @@ class TestBatchScrapePagination:
         assert client.get.call_count == 2
         assert len(job.data) == 2
         assert job.next is None
+
+    def test_failed_page_fetch_raises(self):
+        """A failed page fetch during aggregation raises instead of returning partial data."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        bad = Mock()
+        bad.ok = False
+        bad.status_code = 500
+        bad.json.return_value = {"success": False, "error": "internal error"}
+        bad.text = '{"success": false, "error": "internal error"}'
+        client.get.side_effect = [first, bad]
+
+        with pytest.raises(Exception):
+            get_batch_scrape_status(client, "job-1")
+
+    def test_max_pages_truncation_preserves_next(self):
+        """Stopping on max_pages returns the unconsumed cursor instead of None."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        second = Mock()
+        second.ok = True
+        second.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "next": "https://api.example.com/next2",
+            "data": [{"markdown": "b", "metadata": {"sourceURL": "https://y.com"}}],
+        }
+        client.get.side_effect = [first, second]
+
+        job = get_batch_scrape_status(
+            client, "job-1", pagination_config=PaginationConfig(max_pages=1)
+        )
+
+        assert len(job.data) == 2
+        assert job.next == "https://api.example.com/next2"
 
 
 class TestAsyncPagination:

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -508,9 +508,9 @@ class TestBatchScrapePagination:
             pagination_config
         )
 
-        # Should have 1 initial + 3 from pages (limited by max_results=4)
-        assert len(result) == 4
-        assert self.mock_client.get.call_count == 2  # Should fetch 2 pages
+        # 1 initial + page 1's 2 docs = 3; page 2's 2 docs would overshoot 4, so it's skipped whole
+        assert len(result) == 3
+        assert self.mock_client.get.call_count == 2  # Fetches page 2 to size it, then skips it
 
     def test_default_no_pagination_while_running(self):
         """A running job polled with no config makes exactly one request and keeps next."""
@@ -619,8 +619,8 @@ class TestBatchScrapePagination:
         assert len(job.data) == 2
         assert job.next == "https://api.example.com/next2"
 
-    def test_max_results_mid_page_truncation_rereads_current_page(self):
-        """Stopping mid-page on max_results returns the partially consumed page's own URL."""
+    def test_max_results_skips_page_that_would_overshoot(self):
+        """A page that would push past max_results is skipped whole, not partially appended."""
         client = Mock()
         first = Mock()
         first.ok = True
@@ -651,7 +651,7 @@ class TestBatchScrapePagination:
             client, "job-1", pagination_config=PaginationConfig(max_results=2)
         )
 
-        assert len(job.data) == 2
+        assert len(job.data) == 1
         assert job.next == "https://api.example.com/next1"
 
 

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -34,7 +34,7 @@ class TestPaginationConfig:
     def test_default_values(self):
         """Test default values for PaginationConfig."""
         config = PaginationConfig()
-        assert config.auto_paginate is True
+        assert config.auto_paginate is None
         assert config.max_pages is None
         assert config.max_results is None
         assert config.max_wait_time is None
@@ -510,6 +510,58 @@ class TestBatchScrapePagination:
         # Should have 1 initial + 3 from pages (limited by max_results=4)
         assert len(result) == 4
         assert self.mock_client.get.call_count == 2  # Should fetch 2 pages
+
+    def test_default_no_pagination_while_running(self):
+        """A running job polled with no config makes exactly one request and keeps next."""
+        client = Mock()
+        response = Mock()
+        response.ok = True
+        response.json.return_value = {
+            "success": True,
+            "status": "scraping",
+            "completed": 1,
+            "total": 5,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        client.get.return_value = response
+
+        job = get_batch_scrape_status(client, "job-1")
+
+        assert client.get.call_count == 1
+        assert job.next == "https://api.example.com/next1"
+        assert len(job.data) == 1
+
+    def test_default_paginates_when_terminal(self):
+        """A completed job polled with no config still aggregates all pages."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        second = Mock()
+        second.ok = True
+        second.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "next": None,
+            "data": [{"markdown": "b", "metadata": {"sourceURL": "https://y.com"}}],
+        }
+        client.get.side_effect = [first, second]
+
+        job = get_batch_scrape_status(client, "job-1")
+
+        assert client.get.call_count == 2
+        assert len(job.data) == 2
+        assert job.next is None
 
 
 class TestAsyncPagination:

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_pagination.py
@@ -286,12 +286,12 @@ class TestCrawlPagination:
         
         self.mock_client.get.side_effect = [mock_response1, mock_response2]
         
-        # Test with max_results=4
+        # Test with max_results=4: page 1's 3 docs fit (3<=4), page 2's 2 docs would overshoot (5>4) and are skipped whole
         pagination_config = PaginationConfig(auto_paginate=True, max_results=4)
         result = get_crawl_status(self.mock_client, self.job_id, pagination_config)
-        
-        assert len(result.data) == 4  # Should stop at 4 results
-        assert self.mock_client.get.call_count == 2  # Should fetch 2 pages
+
+        assert len(result.data) == 3
+        assert self.mock_client.get.call_count == 2  # Fetches page 2 to size it, then skips it
     
     def test_get_crawl_status_max_wait_time_limit(self):
         """Test get_crawl_status with max_wait_time limit."""
@@ -321,27 +321,166 @@ class TestCrawlPagination:
         assert self.mock_client.get.call_count == 1
     
     def test_fetch_all_pages_error_handling(self):
-        """Test _fetch_all_pages with API errors."""
-        # Mock first page success, second page error
+        """_fetch_all_pages raises instead of returning partial data on a failed page fetch."""
         mock_response1 = Mock()
         mock_response1.ok = True
         mock_response1.json.return_value = {
             "success": True,
             "data": [self.sample_doc],
-            "next": "https://api.firecrawl.dev/v2/crawl/test-crawl-123?page=2"
+            "next": "https://api.firecrawl.dev/v2/crawl/test-crawl-123?page=3"
         }
-        
+
         mock_response2 = Mock()
         mock_response2.ok = False
         mock_response2.status_code = 500
-        
+        mock_response2.json.return_value = {"success": False, "error": "internal error"}
+        mock_response2.text = '{"success": false, "error": "internal error"}'
+
         self.mock_client.get.side_effect = [mock_response1, mock_response2]
-        
-        # Should continue with what we have
-        result = _fetch_all_pages(self.mock_client, "https://api.firecrawl.dev/v2/crawl/test-crawl-123?page=2", [], None)
-        
-        assert len(result) == 1  # Should have the first page data
-        assert self.mock_client.get.call_count == 2
+
+        with pytest.raises(FirecrawlError):
+            _fetch_all_pages(self.mock_client, "https://api.firecrawl.dev/v2/crawl/test-crawl-123?page=2", [], None)
+
+    def test_default_no_pagination_while_running(self):
+        """A running crawl polled with no config makes exactly one request and keeps next."""
+        client = Mock()
+        response = Mock()
+        response.ok = True
+        response.json.return_value = {
+            "success": True,
+            "status": "scraping",
+            "completed": 1,
+            "total": 5,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        client.get.return_value = response
+
+        job = get_crawl_status(client, "job-1")
+
+        assert client.get.call_count == 1
+        assert job.next == "https://api.example.com/next1"
+        assert len(job.data) == 1
+
+    def test_default_paginates_when_completed(self):
+        """A completed crawl polled with no config still aggregates all pages."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        second = Mock()
+        second.ok = True
+        second.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "next": None,
+            "data": [{"markdown": "b", "metadata": {"sourceURL": "https://y.com"}}],
+        }
+        client.get.side_effect = [first, second]
+
+        job = get_crawl_status(client, "job-1")
+
+        assert client.get.call_count == 2
+        assert len(job.data) == 2
+        assert job.next is None
+
+    def test_failed_page_fetch_raises(self):
+        """A failed page fetch during aggregation raises instead of returning partial data."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        bad = Mock()
+        bad.ok = False
+        bad.status_code = 500
+        bad.json.return_value = {"success": False, "error": "internal error"}
+        bad.text = '{"success": false, "error": "internal error"}'
+        client.get.side_effect = [first, bad]
+
+        with pytest.raises(Exception):
+            get_crawl_status(client, "job-1")
+
+    def test_max_results_skips_page_that_would_overshoot(self):
+        """A page that would push past max_results is skipped whole, not partially appended."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "next": "https://api.example.com/next1",
+            "data": [{"markdown": "a", "metadata": {"sourceURL": "https://x.com"}}],
+        }
+        second = Mock()
+        second.ok = True
+        second.json.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "next": "https://api.example.com/next2",
+            "data": [
+                {"markdown": "b", "metadata": {"sourceURL": "https://y.com"}},
+                {"markdown": "c", "metadata": {"sourceURL": "https://z.com"}},
+            ],
+        }
+        client.get.side_effect = [first, second]
+
+        job = get_crawl_status(
+            client, "job-1", pagination_config=PaginationConfig(max_results=2)
+        )
+
+        assert len(job.data) == 1
+        assert job.next == "https://api.example.com/next1"
+
+    def test_self_referencing_next_is_treated_as_drained(self):
+        """A next cursor identical to the page just fetched stops instead of looping forever."""
+        client = Mock()
+        first = Mock()
+        first.ok = True
+        first.json.return_value = {
+            "success": True,
+            "status": "cancelled",
+            "completed": 0,
+            "total": 0,
+            "next": "https://api.example.com/loop",
+            "data": [],
+        }
+        loop = Mock()
+        loop.ok = True
+        loop.json.return_value = {
+            "success": True,
+            "status": "cancelled",
+            "completed": 0,
+            "total": 0,
+            "next": "https://api.example.com/loop",
+            "data": [],
+        }
+        client.get.side_effect = [first, loop]
+
+        job = get_crawl_status(client, "job-1", pagination_config=PaginationConfig(auto_paginate=True))
+
+        assert len(job.data) == 0
+        assert job.next is None
+        assert client.get.call_count == 2
 
 
 class TestBatchScrapePagination:
@@ -679,7 +818,7 @@ class TestBatchScrapePagination:
         }
         client.get.side_effect = [first, loop]
 
-        job = get_batch_scrape_status(client, "job-1")
+        job = get_batch_scrape_status(client, "job-1", pagination_config=PaginationConfig(auto_paginate=True))
 
         assert len(job.data) == 0
         assert job.next is None
@@ -944,21 +1083,21 @@ class TestAsyncPagination:
             mock_response.json.return_value = {
                 "success": True,
                 "data": [self.sample_doc],
-                "next": f"https://api.firecrawl.dev/v2/crawl/test-async-123?page={i+2}" if i < 2 else None
+                "next": f"https://api.firecrawl.dev/v2/crawl/test-async-123?page={i+3}" if i < 2 else None
             }
             mock_responses.append(mock_response)
-        
+
         self.mock_client.get.side_effect = mock_responses
-        
+
         # Test with max_pages=2
         pagination_config = PaginationConfig(max_pages=2)
-        result = await _fetch_all_pages_async(
+        result, next_url = await _fetch_all_pages_async(
             self.mock_client,
             "https://api.firecrawl.dev/v2/crawl/test-async-123?page=2",
             [Document(**self.sample_doc)],  # 1 initial doc
             pagination_config
         )
-        
+
         assert len(result) == 3  # 1 initial + 2 from pages
         assert self.mock_client.get.call_count == 2
 
@@ -1038,31 +1177,26 @@ class TestPaginationEdgeCases:
             get_crawl_status(self.mock_client, "test-123", pagination_config)
     
     def test_pagination_with_unsuccessful_page(self):
-        """Test pagination when a subsequent page is unsuccessful."""
-        # Mock first page success
+        """A subsequent page returning success:false raises instead of silently stopping."""
         mock_response1 = Mock()
         mock_response1.ok = True
         mock_response1.json.return_value = {
             "success": True,
             "data": [self.sample_doc],
-            "next": "https://api.firecrawl.dev/v2/crawl/test-123?page=2"
+            "next": "https://api.firecrawl.dev/v2/crawl/test-123?page=3"
         }
-        
-        # Mock second page failure
+
         mock_response2 = Mock()
         mock_response2.ok = True
         mock_response2.json.return_value = {
             "success": False,
             "error": "Page not found"
         }
-        
+
         self.mock_client.get.side_effect = [mock_response1, mock_response2]
-        
-        # Should continue with what we have
-        result = _fetch_all_pages(self.mock_client, "https://api.firecrawl.dev/v2/crawl/test-123?page=2", [], None)
-        
-        assert len(result) == 1  # Should have the first page data
-        assert self.mock_client.get.call_count == 2
+
+        with pytest.raises(Exception, match="Page not found"):
+            _fetch_all_pages(self.mock_client, "https://api.firecrawl.dev/v2/crawl/test-123?page=2", [], None)
 
 
 if __name__ == "__main__":

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -597,10 +597,10 @@ class AsyncFirecrawlClient:
             if status.status == "completed":
                 return status
             if status.status in ("failed", "cancelled"):
-                raise JobFailedError(
-                    f"Batch scrape job {job_id} ended with status {status.status}",
-                    job=status,
-                )
+                message = f"Batch scrape job {job_id} ended with status {status.status}"
+                if status.error:
+                    message += f": {status.error}"
+                raise JobFailedError(message, job=status)
             if timeout and (asyncio.get_event_loop().time() - start) > timeout:
                 raise TimeoutError("Batch wait timed out")
             await asyncio.sleep(poll_interval)

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -52,6 +52,7 @@ from .types import (
 )
 from .utils.http_client import HttpClient
 from .utils.http_client_async import AsyncHttpClient
+from .utils.error_handler import JobFailedError
 
 from .methods.aio import scrape as async_scrape  # type: ignore[attr-defined]
 from .methods.aio import parse as async_parse  # type: ignore[attr-defined]
@@ -593,8 +594,13 @@ class AsyncFirecrawlClient:
         start = asyncio.get_event_loop().time()
         while True:
             status = await async_batch.get_batch_scrape_status(self.async_http_client, job_id)
-            if status.status in ["completed", "failed", "cancelled"]:
+            if status.status == "completed":
                 return status
+            if status.status in ("failed", "cancelled"):
+                raise JobFailedError(
+                    f"Batch scrape job {job_id} ended with status {status.status}",
+                    job=status,
+                )
             if timeout and (asyncio.get_event_loop().time() - start) > timeout:
                 raise TimeoutError("Batch wait timed out")
             await asyncio.sleep(poll_interval)

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -17,7 +17,9 @@ def _parse_batch_scrape_documents(data_list: Optional[List[Any]]) -> List[Docume
 
 
 def _parse_batch_scrape_status_response(body: Dict[str, Any]) -> Dict[str, Any]:
-    if not body.get("success"):
+    # A kickoff failure responds 200 with success:false and status:"failed"; parse it as a
+    # normal terminal job instead of raising, so the waiter can raise JobFailedError.
+    if not body.get("success") and body.get("status") != "failed":
         raise Exception(body.get("error", "Unknown error occurred"))
 
     return {
@@ -28,6 +30,7 @@ def _parse_batch_scrape_status_response(body: Dict[str, Any]) -> Dict[str, Any]:
         "expires_at": body.get("expiresAt"),
         "next": body.get("next"),
         "data": _parse_batch_scrape_documents(body.get("data", []) or []),
+        "error": body.get("error"),
     }
 
 def _prepare(urls: List[str], *, options: Optional[ScrapeOptions] = None, **kwargs) -> Dict[str, Any]:
@@ -97,13 +100,12 @@ async def get_batch_scrape_status(
     docs = payload["data"]
     next_url = payload["next"]
 
-    # Unset auto_paginate only paginates a terminal job, since following `next`
-    # on a running job re-downloads pages on every poll.
-    is_terminal = payload["status"] in ("completed", "failed", "cancelled")
+    # Unset auto_paginate only paginates once the job is completed, so a failed/cancelled
+    # job's result pages are never fetched before the waiter can raise JobFailedError.
     auto_paginate = (
         pagination_config.auto_paginate
         if (pagination_config is not None and pagination_config.auto_paginate is not None)
-        else is_terminal
+        else payload["status"] == "completed"
     )
     if auto_paginate and next_url:
         docs, next_url = await _fetch_all_batch_pages_async(
@@ -121,6 +123,7 @@ async def get_batch_scrape_status(
         expires_at=payload["expires_at"],
         next=next_url,
         data=docs,
+        error=payload.get("error"),
     )
 
 
@@ -157,6 +160,7 @@ async def get_batch_scrape_status_page(
         expires_at=payload["expires_at"],
         next=payload["next"],
         data=payload["data"],
+        error=payload.get("error"),
     )
 
 

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -96,8 +96,14 @@ async def get_batch_scrape_status(
     payload = _parse_batch_scrape_status_response(body)
     docs = payload["data"]
     
-    # Handle pagination if requested
-    auto_paginate = pagination_config.auto_paginate if pagination_config else True
+    # Unset auto_paginate only paginates a terminal job, since following `next`
+    # on a running job re-downloads pages on every poll.
+    is_terminal = payload["status"] in ("completed", "failed", "cancelled")
+    auto_paginate = (
+        pagination_config.auto_paginate
+        if (pagination_config is not None and pagination_config.auto_paginate is not None)
+        else is_terminal
+    )
     if auto_paginate and payload["next"]:
         docs = await _fetch_all_batch_pages_async(
             client, 

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 from ...types import ScrapeOptions, WebhookConfig, Document, BatchScrapeResponse, BatchScrapeJob, PaginationConfig
 from ...utils.http_client_async import AsyncHttpClient
 from ...utils.validation import prepare_scrape_options
@@ -95,7 +95,8 @@ async def get_batch_scrape_status(
     body = response.json()
     payload = _parse_batch_scrape_status_response(body)
     docs = payload["data"]
-    
+    next_url = payload["next"]
+
     # Unset auto_paginate only paginates a terminal job, since following `next`
     # on a running job re-downloads pages on every poll.
     is_terminal = payload["status"] in ("completed", "failed", "cancelled")
@@ -104,21 +105,21 @@ async def get_batch_scrape_status(
         if (pagination_config is not None and pagination_config.auto_paginate is not None)
         else is_terminal
     )
-    if auto_paginate and payload["next"]:
-        docs = await _fetch_all_batch_pages_async(
-            client, 
-            payload["next"], 
-            docs, 
+    if auto_paginate and next_url:
+        docs, next_url = await _fetch_all_batch_pages_async(
+            client,
+            next_url,
+            docs,
             pagination_config
         )
-    
+
     return BatchScrapeJob(
         status=payload["status"],
         completed=payload["completed"],
         total=payload["total"],
         credits_used=payload["credits_used"],
         expires_at=payload["expires_at"],
-        next=payload["next"] if not auto_paginate else None,
+        next=next_url,
         data=docs,
     )
 
@@ -164,70 +165,56 @@ async def _fetch_all_batch_pages_async(
     next_url: str,
     initial_documents: List[Document],
     pagination_config: Optional[PaginationConfig] = None
-) -> List[Document]:
+) -> Tuple[List[Document], Optional[str]]:
     """
-    Fetch all pages of batch scrape results asynchronously.
-    
-    Args:
-        client: Async HTTP client instance
-        next_url: URL for the next page
-        initial_documents: Documents from the first page
-        pagination_config: Optional configuration for pagination limits
-        
+    Fetch pages of batch scrape results until drained or a caller limit stops early.
+
     Returns:
-        List of all documents from all pages
+        Tuple of (documents, unconsumed next URL or None)
+
+    Raises:
+        FirecrawlError: If a page fetch fails; partial data is never returned silently
     """
     documents = initial_documents.copy()
-    current_url = next_url
+    current_url: Optional[str] = next_url
     page_count = 0
-    
-    # Apply pagination limits
+
     max_pages = pagination_config.max_pages if pagination_config else None
     max_results = pagination_config.max_results if pagination_config else None
     max_wait_time = pagination_config.max_wait_time if pagination_config else None
-    
+
     start_time = time.monotonic()
-    
+
     while current_url:
         # Check pagination limits
         if (max_pages is not None) and (page_count >= max_pages):
             break
-            
+
         if (max_wait_time is not None) and (time.monotonic() - start_time) > max_wait_time:
             break
-        
-        # Fetch next page
+
         response = await client.get(current_url)
-        
+
         if response.status_code >= 400:
-            # Log error but continue with what we have
-            import logging
-            logger = logging.getLogger("firecrawl")
-            logger.warning(f"Failed to fetch next page: {response.status_code}")
-            break
-        
-        page_data = response.json()
-        try:
-            page_payload = _parse_batch_scrape_status_response(page_data)
-        except Exception:
-            break
-        
+            handle_response_error(response, "get batch scrape status page")
+
+        page_payload = _parse_batch_scrape_status_response(response.json())
+
         # Add documents from this page
         for document in page_payload["data"]:
             # Check max_results limit
             if (max_results is not None) and (len(documents) >= max_results):
                 break
             documents.append(document)
-        
+
         # Check if we hit max_results limit
         if (max_results is not None) and (len(documents) >= max_results):
-            break
-        
-        # Get next URL
+            return documents, page_payload["next"]
+
         current_url = page_payload["next"]
         page_count += 1
-    
-    return documents
+
+    return documents, current_url
 
 
 async def cancel_batch_scrape(client: AsyncHttpClient, job_id: str) -> bool:

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -208,6 +208,9 @@ async def _fetch_all_batch_pages_async(
             return documents, current_url
 
         documents.extend(page_payload["data"])
+        if page_payload["next"] == current_url:
+            # A next cursor identical to the page just fetched can never advance; treat as drained.
+            return documents, None
         current_url = page_payload["next"]
         page_count += 1
 

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -193,6 +193,9 @@ async def _fetch_all_batch_pages_async(
         if (max_wait_time is not None) and (time.monotonic() - start_time) > max_wait_time:
             break
 
+        if (max_results is not None) and (len(documents) >= max_results):
+            break
+
         response = await client.get(current_url)
 
         if response.status_code >= 400:
@@ -200,17 +203,11 @@ async def _fetch_all_batch_pages_async(
 
         page_payload = _parse_batch_scrape_status_response(response.json())
 
-        page_fully_consumed = True
-        for document in page_payload["data"]:
-            if (max_results is not None) and (len(documents) >= max_results):
-                page_fully_consumed = False
-                break
-            documents.append(document)
+        if max_results is not None and len(documents) + len(page_payload["data"]) > max_results:
+            # A page that would overshoot max_results is skipped whole, so resume never drops or duplicates data.
+            return documents, current_url
 
-        if (max_results is not None) and (len(documents) >= max_results):
-            # A partially consumed page must be re-read, or its unread tail is lost silently.
-            return documents, (page_payload["next"] if page_fully_consumed else current_url)
-
+        documents.extend(page_payload["data"])
         current_url = page_payload["next"]
         page_count += 1
 

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -200,16 +200,16 @@ async def _fetch_all_batch_pages_async(
 
         page_payload = _parse_batch_scrape_status_response(response.json())
 
-        # Add documents from this page
+        page_fully_consumed = True
         for document in page_payload["data"]:
-            # Check max_results limit
             if (max_results is not None) and (len(documents) >= max_results):
+                page_fully_consumed = False
                 break
             documents.append(document)
 
-        # Check if we hit max_results limit
         if (max_results is not None) and (len(documents) >= max_results):
-            return documents, page_payload["next"]
+            # A partially consumed page must be re-read, or its unread tail is lost silently.
+            return documents, (page_payload["next"] if page_fully_consumed else current_url)
 
         current_url = page_payload["next"]
         page_count += 1

--- a/apps/python-sdk/firecrawl/v2/methods/aio/crawl.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/crawl.py
@@ -149,7 +149,11 @@ async def get_crawl_status(
     documents = payload["data"]
 
     # Handle pagination if requested
-    auto_paginate = pagination_config.auto_paginate if pagination_config else True
+    auto_paginate = (
+        pagination_config.auto_paginate
+        if (pagination_config is not None and pagination_config.auto_paginate is not None)
+        else True
+    )
     if auto_paginate and payload["next"]:
         documents = await _fetch_all_pages_async(
             client,

--- a/apps/python-sdk/firecrawl/v2/methods/aio/crawl.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/crawl.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 from ...types import (
     CrawlRequest,
     CrawlJob,
@@ -147,17 +147,18 @@ async def get_crawl_status(
     payload = _parse_crawl_status_response(body)
 
     documents = payload["data"]
+    next_url = payload["next"]
 
-    # Handle pagination if requested
+    # Unset auto_paginate only paginates once the job is completed, matching batch's default gate.
     auto_paginate = (
         pagination_config.auto_paginate
         if (pagination_config is not None and pagination_config.auto_paginate is not None)
-        else True
+        else payload["status"] == "completed"
     )
-    if auto_paginate and payload["next"]:
-        documents = await _fetch_all_pages_async(
+    if auto_paginate and next_url:
+        documents, next_url = await _fetch_all_pages_async(
             client,
-            payload["next"],
+            next_url,
             documents,
             pagination_config,
             request_timeout=request_timeout,
@@ -169,7 +170,7 @@ async def get_crawl_status(
         total=payload["total"],
         credits_used=payload["credits_used"],
         expires_at=payload["expires_at"],
-        next=payload["next"] if not auto_paginate else None,
+        next=next_url,
         data=documents,
     )
 
@@ -217,31 +218,26 @@ async def _fetch_all_pages_async(
     pagination_config: Optional[PaginationConfig] = None,
     *,
     request_timeout: Optional[float] = None,
-) -> List[Document]:
+) -> Tuple[List[Document], Optional[str]]:
     """
-    Fetch all pages of crawl results asynchronously.
-    
-    Args:
-        client: Async HTTP client instance
-        next_url: URL for the next page
-        initial_documents: Documents from the first page
-        pagination_config: Optional configuration for pagination limits
-        request_timeout: Optional timeout (in seconds) for the underlying HTTP request
-        
+    Fetch pages of crawl results until drained or a caller limit stops early.
+
     Returns:
-        List of all documents from all pages
+        Tuple of (documents, unconsumed next URL or None)
+
+    Raises:
+        FirecrawlError: If a page fetch fails; partial data is never returned silently
     """
     documents = initial_documents.copy()
-    current_url = next_url
+    current_url: Optional[str] = next_url
     page_count = 0
-    
-    # Apply pagination limits
+
     max_pages = pagination_config.max_pages if pagination_config else None
     max_results = pagination_config.max_results if pagination_config else None
     max_wait_time = pagination_config.max_wait_time if pagination_config else None
-    
+
     start_time = time.monotonic()
-    
+
     while current_url:
         # Check pagination limits (treat 0 as a valid limit)
         if (max_pages is not None) and page_count >= max_pages:
@@ -249,39 +245,29 @@ async def _fetch_all_pages_async(
 
         if (max_wait_time is not None) and (time.monotonic() - start_time) > max_wait_time:
             break
-        
-        # Fetch next page
-        response = await client.get(current_url, timeout=request_timeout)
-        
-        if response.status_code >= 400:
-            # Log error but continue with what we have
-            import logging
-            logger = logging.getLogger("firecrawl")
-            logger.warning("Failed to fetch next page", extra={"status_code": response.status_code})
-            break
-        
-        page_data = response.json()
-        try:
-            page_payload = _parse_crawl_status_response(page_data)
-        except Exception:
-            break
-        
-        # Add documents from this page
-        for document in page_payload["data"]:
-            # Check max_results limit
-            if (max_results is not None) and (len(documents) >= max_results):
-                break
-            documents.append(document)
-        
-        # Check if we hit max_results limit
+
         if (max_results is not None) and (len(documents) >= max_results):
             break
-        
-        # Get next URL
+
+        response = await client.get(current_url, timeout=request_timeout)
+
+        if response.status_code >= 400:
+            handle_response_error(response, "get crawl status page")
+
+        page_payload = _parse_crawl_status_response(response.json())
+
+        if max_results is not None and len(documents) + len(page_payload["data"]) > max_results:
+            # A page that would overshoot max_results is skipped whole, so resume never drops or duplicates data.
+            return documents, current_url
+
+        documents.extend(page_payload["data"])
+        if page_payload["next"] == current_url:
+            # A next cursor identical to the page just fetched can never advance; treat as drained.
+            return documents, None
         current_url = page_payload["next"]
         page_count += 1
-    
-    return documents
+
+    return documents, current_url
 
 
 async def cancel_crawl(client: AsyncHttpClient, job_id: str) -> bool:

--- a/apps/python-sdk/firecrawl/v2/methods/aio/monitor.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/monitor.py
@@ -198,7 +198,11 @@ async def get_monitor_check(
     data = await _monitor_check_data_or_error(await client.get(f"/v2/monitor/{monitor_id}/checks/{check_id}{suffix}"), "get monitor check")
     detail = MonitorCheckDetail(**data)
 
-    auto_paginate = pagination_config.auto_paginate if pagination_config else True
+    auto_paginate = (
+        pagination_config.auto_paginate
+        if (pagination_config is not None and pagination_config.auto_paginate is not None)
+        else True
+    )
     if auto_paginate and detail.next and not (
         pagination_config
         and pagination_config.max_results is not None

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -249,6 +249,9 @@ def _fetch_all_batch_pages(
             return documents, current_url
 
         documents.extend(page_payload["data"])
+        if page_payload["next"] == current_url:
+            # A next cursor identical to the page just fetched can never advance; treat as drained.
+            return documents, None
         current_url = page_payload["next"]
         page_count += 1
 

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -234,6 +234,9 @@ def _fetch_all_batch_pages(
         if (max_wait_time is not None) and (time.monotonic() - start_time) > max_wait_time:
             break
 
+        if (max_results is not None) and len(documents) >= max_results:
+            break
+
         response = client.get(current_url)
 
         if not response.ok:
@@ -241,17 +244,11 @@ def _fetch_all_batch_pages(
 
         page_payload = _parse_batch_scrape_status_response(response.json())
 
-        page_fully_consumed = True
-        for document in page_payload["data"]:
-            if max_results is not None and len(documents) >= max_results:
-                page_fully_consumed = False
-                break
-            documents.append(document)
+        if max_results is not None and len(documents) + len(page_payload["data"]) > max_results:
+            # A page that would overshoot max_results is skipped whole, so resume never drops or duplicates data.
+            return documents, current_url
 
-        if max_results is not None and len(documents) >= max_results:
-            # A partially consumed page must be re-read, or its unread tail is lost silently.
-            return documents, (page_payload["next"] if page_fully_consumed else current_url)
-
+        documents.extend(page_payload["data"])
         current_url = page_payload["next"]
         page_count += 1
 

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -134,8 +134,14 @@ def get_batch_scrape_status(
     payload = _parse_batch_scrape_status_response(body)
     documents = payload["data"]
 
-    # Handle pagination if requested
-    auto_paginate = pagination_config.auto_paginate if pagination_config else True
+    # Unset auto_paginate only paginates a terminal job, since following `next`
+    # on a running job re-downloads pages on every poll.
+    is_terminal = payload["status"] in ("completed", "failed", "cancelled")
+    auto_paginate = (
+        pagination_config.auto_paginate
+        if (pagination_config is not None and pagination_config.auto_paginate is not None)
+        else is_terminal
+    )
     if auto_paginate and payload["next"]:
         documents = _fetch_all_batch_pages(
             client, 

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -3,7 +3,7 @@ Batch scraping functionality for Firecrawl v2 API.
 """
 
 import time
-from typing import Optional, List, Callable, Dict, Any, Union
+from typing import Optional, List, Callable, Dict, Any, Union, Tuple
 from ..types import (
     BatchScrapeRequest,
     BatchScrapeResponse,
@@ -133,6 +133,7 @@ def get_batch_scrape_status(
     body = response.json()
     payload = _parse_batch_scrape_status_response(body)
     documents = payload["data"]
+    next_url = payload["next"]
 
     # Unset auto_paginate only paginates a terminal job, since following `next`
     # on a running job re-downloads pages on every poll.
@@ -142,11 +143,11 @@ def get_batch_scrape_status(
         if (pagination_config is not None and pagination_config.auto_paginate is not None)
         else is_terminal
     )
-    if auto_paginate and payload["next"]:
-        documents = _fetch_all_batch_pages(
-            client, 
-            payload["next"], 
-            documents, 
+    if auto_paginate and next_url:
+        documents, next_url = _fetch_all_batch_pages(
+            client,
+            next_url,
+            documents,
             pagination_config
         )
 
@@ -156,7 +157,7 @@ def get_batch_scrape_status(
         total=payload["total"],
         credits_used=payload["credits_used"],
         expires_at=payload["expires_at"],
-        next=payload["next"] if not auto_paginate else None,
+        next=next_url,
         data=documents,
     )
 
@@ -205,70 +206,53 @@ def _fetch_all_batch_pages(
     next_url: str,
     initial_documents: List[Document],
     pagination_config: Optional[PaginationConfig] = None
-) -> List[Document]:
+) -> Tuple[List[Document], Optional[str]]:
     """
-    Fetch all pages of batch scrape results.
-    
-    Args:
-        client: HTTP client instance
-        next_url: URL for the next page
-        initial_documents: Documents from the first page
-        pagination_config: Optional configuration for pagination limits
-        
+    Fetch pages of batch scrape results until drained or a caller limit stops early.
+
     Returns:
-        List of all documents from all pages
+        Tuple of (documents, unconsumed next URL or None)
+
+    Raises:
+        FirecrawlError: If a page fetch fails; partial data is never returned silently
     """
     documents = initial_documents.copy()
-    current_url = next_url
+    current_url: Optional[str] = next_url
     page_count = 0
-    
-    # Apply pagination limits
+
     max_pages = pagination_config.max_pages if pagination_config else None
     max_results = pagination_config.max_results if pagination_config else None
     max_wait_time = pagination_config.max_wait_time if pagination_config else None
-    
+
     start_time = time.monotonic()
-    
+
     while current_url:
         # Check pagination limits (treat 0 as a valid limit)
         if (max_pages is not None) and page_count >= max_pages:
             break
-        
+
         if (max_wait_time is not None) and (time.monotonic() - start_time) > max_wait_time:
             break
-        
-        # Fetch next page
+
         response = client.get(current_url)
-        
+
         if not response.ok:
-            # Log error but continue with what we have
-            import logging
-            logger = logging.getLogger("firecrawl")
-            logger.warning("Failed to fetch next page", extra={"status_code": response.status_code})
-            break
-        
-        page_data = response.json()
-        try:
-            page_payload = _parse_batch_scrape_status_response(page_data)
-        except Exception:
-            break
-        
-        # Add documents from this page
+            handle_response_error(response, "get batch scrape status page")
+
+        page_payload = _parse_batch_scrape_status_response(response.json())
+
         for document in page_payload["data"]:
-            # Check max_results limit
             if max_results is not None and len(documents) >= max_results:
                 break
             documents.append(document)
-        
-        # Check if we hit max_results limit after adding all docs from this page
+
         if max_results is not None and len(documents) >= max_results:
-            break
-        
-        # Get next URL
+            return documents, page_payload["next"]
+
         current_url = page_payload["next"]
         page_count += 1
-    
-    return documents
+
+    return documents, current_url
 
 
 def cancel_batch_scrape(

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -29,7 +29,9 @@ def _parse_batch_scrape_documents(data_list: Optional[List[Any]]) -> List[Docume
 
 
 def _parse_batch_scrape_status_response(body: Dict[str, Any]) -> Dict[str, Any]:
-    if not body.get("success"):
+    # A kickoff failure responds 200 with success:false and status:"failed"; parse it as a
+    # normal terminal job instead of raising, so the waiter can raise JobFailedError.
+    if not body.get("success") and body.get("status") != "failed":
         raise Exception(body.get("error", "Unknown error occurred"))
 
     return {
@@ -40,6 +42,7 @@ def _parse_batch_scrape_status_response(body: Dict[str, Any]) -> Dict[str, Any]:
         "expires_at": body.get("expiresAt"),
         "next": body.get("next"),
         "data": _parse_batch_scrape_documents(body.get("data", []) or []),
+        "error": body.get("error"),
     }
 
 
@@ -135,13 +138,12 @@ def get_batch_scrape_status(
     documents = payload["data"]
     next_url = payload["next"]
 
-    # Unset auto_paginate only paginates a terminal job, since following `next`
-    # on a running job re-downloads pages on every poll.
-    is_terminal = payload["status"] in ("completed", "failed", "cancelled")
+    # Unset auto_paginate only paginates once the job is completed, so a failed/cancelled
+    # job's result pages are never fetched before the waiter can raise JobFailedError.
     auto_paginate = (
         pagination_config.auto_paginate
         if (pagination_config is not None and pagination_config.auto_paginate is not None)
-        else is_terminal
+        else payload["status"] == "completed"
     )
     if auto_paginate and next_url:
         documents, next_url = _fetch_all_batch_pages(
@@ -159,6 +161,7 @@ def get_batch_scrape_status(
         expires_at=payload["expires_at"],
         next=next_url,
         data=documents,
+        error=payload.get("error"),
     )
 
 
@@ -198,6 +201,7 @@ def get_batch_scrape_status_page(
         expires_at=payload["expires_at"],
         next=payload["next"],
         data=payload["data"],
+        error=payload.get("error"),
     )
 
 
@@ -318,10 +322,10 @@ def wait_for_batch_completion(
             return status_job
 
         if status_job.status in ("failed", "cancelled"):
-            raise JobFailedError(
-                f"Batch scrape job {job_id} ended with status {status_job.status}",
-                job=status_job,
-            )
+            message = f"Batch scrape job {job_id} ended with status {status_job.status}"
+            if status_job.error:
+                message += f": {status_job.error}"
+            raise JobFailedError(message, job=status_job)
 
         # Check timeout
         if timeout and (time.monotonic() - start_time) > timeout:

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -241,13 +241,16 @@ def _fetch_all_batch_pages(
 
         page_payload = _parse_batch_scrape_status_response(response.json())
 
+        page_fully_consumed = True
         for document in page_payload["data"]:
             if max_results is not None and len(documents) >= max_results:
+                page_fully_consumed = False
                 break
             documents.append(document)
 
         if max_results is not None and len(documents) >= max_results:
-            return documents, page_payload["next"]
+            # A partially consumed page must be re-read, or its unread tail is lost silently.
+            return documents, (page_payload["next"] if page_fully_consumed else current_url)
 
         current_url = page_payload["next"]
         page_count += 1

--- a/apps/python-sdk/firecrawl/v2/methods/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/batch.py
@@ -14,7 +14,7 @@ from ..types import (
     PaginationConfig,
     AuditMetadata,
 )
-from ..utils import HttpClient, handle_response_error, validate_scrape_options, prepare_scrape_options
+from ..utils import HttpClient, handle_response_error, validate_scrape_options, prepare_scrape_options, JobFailedError
 from ..utils.normalize import normalize_document_input
 from ..types import CrawlErrorsResponse
 
@@ -303,22 +303,27 @@ def wait_for_batch_completion(
         BatchScrapeStatusResponse when job completes
         
     Raises:
-        FirecrawlError: If the job fails or timeout is reached
+        JobFailedError: If the job ends with status failed or cancelled
         TimeoutError: If timeout is reached
     """
     start_time = time.monotonic()
-    
+
     while True:
         status_job = get_batch_scrape_status(client, job_id)
-        
-        # Check if job is complete
-        if status_job.status in ["completed", "failed", "cancelled"]:
+
+        if status_job.status == "completed":
             return status_job
-        
+
+        if status_job.status in ("failed", "cancelled"):
+            raise JobFailedError(
+                f"Batch scrape job {job_id} ended with status {status_job.status}",
+                job=status_job,
+            )
+
         # Check timeout
         if timeout and (time.monotonic() - start_time) > timeout:
             raise TimeoutError(f"Batch scrape job {job_id} did not complete within {timeout} seconds")
-        
+
         # Wait before next poll
         time.sleep(poll_interval)
 
@@ -353,7 +358,8 @@ def batch_scrape(
         BatchScrapeStatusResponse when job completes
         
     Raises:
-        FirecrawlError: If the batch scrape fails to start or complete
+        FirecrawlError: If the batch scrape fails to start
+        JobFailedError: If the job ends with status failed or cancelled
         TimeoutError: If timeout is reached
     """
     # Start the batch scrape

--- a/apps/python-sdk/firecrawl/v2/methods/crawl.py
+++ b/apps/python-sdk/firecrawl/v2/methods/crawl.py
@@ -3,7 +3,7 @@ Crawling functionality for Firecrawl v2 API.
 """
 
 import time
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 from ..types import (
     CrawlRequest,
     CrawlJob,
@@ -205,21 +205,18 @@ def get_crawl_status(
     payload = _parse_crawl_status_response(response_data)
 
     documents = payload["data"]
+    next_url = payload["next"]
 
-    # Handle pagination if requested
+    # Unset auto_paginate only paginates once the job is completed, matching batch's default gate.
     auto_paginate = (
         pagination_config.auto_paginate
         if (pagination_config is not None and pagination_config.auto_paginate is not None)
-        else True
+        else payload["status"] == "completed"
     )
-    if auto_paginate and payload["next"] and not (
-        pagination_config
-        and pagination_config.max_results is not None
-        and len(documents) >= pagination_config.max_results
-    ):
-        documents = _fetch_all_pages(
+    if auto_paginate and next_url:
+        documents, next_url = _fetch_all_pages(
             client,
-            payload["next"],
+            next_url,
             documents,
             pagination_config,
             request_timeout=request_timeout,
@@ -232,7 +229,7 @@ def get_crawl_status(
         total=payload["total"],
         credits_used=payload["credits_used"],
         expires_at=payload["expires_at"],
-        next=payload["next"] if not auto_paginate else None,
+        next=next_url,
         data=documents,
     )
 
@@ -283,25 +280,20 @@ def _fetch_all_pages(
     pagination_config: Optional[PaginationConfig] = None,
     *,
     request_timeout: Optional[float] = None,
-) -> List[Document]:
+) -> Tuple[List[Document], Optional[str]]:
     """
-    Fetch all pages of crawl results.
-
-    Args:
-        client: HTTP client instance
-        next_url: URL for the next page
-        initial_documents: Documents from the first page
-        pagination_config: Optional configuration for pagination limits
-        request_timeout: Optional timeout (in seconds) for the underlying HTTP request
+    Fetch pages of crawl results until drained or a caller limit stops early.
 
     Returns:
-        List of all documents from all pages
+        Tuple of (documents, unconsumed next URL or None)
+
+    Raises:
+        FirecrawlError: If a page fetch fails; partial data is never returned silently
     """
     documents = initial_documents.copy()
-    current_url = next_url
+    current_url: Optional[str] = next_url
     page_count = 0
 
-    # Apply pagination limits
     max_pages = pagination_config.max_pages if pagination_config else None
     max_results = pagination_config.max_results if pagination_config else None
     max_wait_time = pagination_config.max_wait_time if pagination_config else None
@@ -316,39 +308,28 @@ def _fetch_all_pages(
         if (max_wait_time is not None) and (time.monotonic() - start_time) > max_wait_time:
             break
 
-        # Fetch next page
+        if (max_results is not None) and len(documents) >= max_results:
+            break
+
         response = client.get(current_url, timeout=request_timeout)
 
         if not response.ok:
-            # Log error but continue with what we have
-            import logging
-            logger = logging.getLogger("firecrawl")
-            logger.warning("Failed to fetch next page", extra={"status_code": response.status_code})
-            break
+            handle_response_error(response, "get crawl status page")
 
-        page_data = response.json()
+        page_payload = _parse_crawl_status_response(response.json())
 
-        try:
-            page_payload = _parse_crawl_status_response(page_data)
-        except Exception:
-            break
+        if max_results is not None and len(documents) + len(page_payload["data"]) > max_results:
+            # A page that would overshoot max_results is skipped whole, so resume never drops or duplicates data.
+            return documents, current_url
 
-        # Add documents from this page
-        for document in page_payload["data"]:
-            # Check max_results limit BEFORE adding each document
-            if max_results is not None and len(documents) >= max_results:
-                break
-            documents.append(document)
-
-        # Check if we hit max_results limit
-        if max_results is not None and len(documents) >= max_results:
-            break
-
-        # Get next URL
+        documents.extend(page_payload["data"])
+        if page_payload["next"] == current_url:
+            # A next cursor identical to the page just fetched can never advance; treat as drained.
+            return documents, None
         current_url = page_payload["next"]
         page_count += 1
 
-    return documents
+    return documents, current_url
 
 
 def cancel_crawl(client: HttpClient, job_id: str) -> bool:

--- a/apps/python-sdk/firecrawl/v2/methods/crawl.py
+++ b/apps/python-sdk/firecrawl/v2/methods/crawl.py
@@ -207,7 +207,11 @@ def get_crawl_status(
     documents = payload["data"]
 
     # Handle pagination if requested
-    auto_paginate = pagination_config.auto_paginate if pagination_config else True
+    auto_paginate = (
+        pagination_config.auto_paginate
+        if (pagination_config is not None and pagination_config.auto_paginate is not None)
+        else True
+    )
     if auto_paginate and payload["next"] and not (
         pagination_config
         and pagination_config.max_results is not None

--- a/apps/python-sdk/firecrawl/v2/methods/monitor.py
+++ b/apps/python-sdk/firecrawl/v2/methods/monitor.py
@@ -197,7 +197,11 @@ def get_monitor_check(
     data = _monitor_check_data_or_error(client.get(f"/v2/monitor/{monitor_id}/checks/{check_id}{suffix}"), "get monitor check")
     detail = MonitorCheckDetail(**data)
 
-    auto_paginate = pagination_config.auto_paginate if pagination_config else True
+    auto_paginate = (
+        pagination_config.auto_paginate
+        if (pagination_config is not None and pagination_config.auto_paginate is not None)
+        else True
+    )
     if auto_paginate and detail.next and not (
         pagination_config
         and pagination_config.max_results is not None

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -2177,7 +2177,7 @@ class ClientConfig(BaseModel):
 class PaginationConfig(BaseModel):
     """Configuration for pagination behavior."""
 
-    auto_paginate: bool = True
+    auto_paginate: Optional[bool] = None  # None: SDK decides per endpoint
     max_pages: Optional[int] = Field(default=None, ge=0)
     max_results: Optional[int] = Field(default=None, ge=0)
     max_wait_time: Optional[int] = Field(default=None, ge=0)  # seconds

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1119,6 +1119,7 @@ class BatchScrapeJob(BaseModel):
     expires_at: Optional[datetime] = None
     next: Optional[str] = None
     data: List[Document] = []
+    error: Optional[str] = None
 
 
 class BatchScrapeStatusRequest(BaseModel):

--- a/apps/python-sdk/firecrawl/v2/utils/__init__.py
+++ b/apps/python-sdk/firecrawl/v2/utils/__init__.py
@@ -3,7 +3,7 @@ Utility modules for v2 API client.
 """
 
 from .http_client import HttpClient
-from .error_handler import FirecrawlError, handle_response_error
+from .error_handler import FirecrawlError, JobFailedError, handle_response_error
 from .validation import validate_scrape_options, prepare_scrape_options
 
-__all__ = ['HttpClient', 'FirecrawlError', 'handle_response_error', 'validate_scrape_options', 'prepare_scrape_options']
+__all__ = ['HttpClient', 'FirecrawlError', 'JobFailedError', 'handle_response_error', 'validate_scrape_options', 'prepare_scrape_options']

--- a/apps/python-sdk/firecrawl/v2/utils/error_handler.py
+++ b/apps/python-sdk/firecrawl/v2/utils/error_handler.py
@@ -15,6 +15,14 @@ class FirecrawlError(Exception):
         self.response = response
 
 
+class JobFailedError(FirecrawlError):
+    """Raised when a waited-on job reaches a failed or cancelled terminal state."""
+
+    def __init__(self, message: str, job=None):
+        super().__init__(message)
+        self.job = job
+
+
 class BadRequestError(FirecrawlError):
     """Raised when the request is invalid (400)."""
     pass


### PR DESCRIPTION
## Why

Large batch scrapes felt broken: every status poll downloaded result pages, truncated results looked complete, and failed jobs came back as empty successes (#4107, #4212).

## What

- Status calls only auto-paginate once the job is terminal, so a poll on a running job is a single request.
- Pagination raises on a failed page fetch and keeps the `next` cursor on truncation instead of returning silent partial data. It also stops on a self-referencing cursor instead of looping forever.
- `batchScrape` / `batch_scrape` waiters raise `JobFailedError` (job attached) on failed or cancelled jobs.

Same changes in both SDKs. Overlaps with #4377, #4320, #4156. Follow-up: the Python crawl path still has the old pagination behavior.

## Tests

Unit suites green in both SDKs (497 py, 19 js in touched files) plus the batch e2e suites against a locally running instance (5/5 both SDKs, cancel and pagination paths verified live).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes large batch scrapes reliable in both SDKs: polling a running job is now a single request per poll, failed result pages raise instead of silently truncating, and waited-on jobs that fail, get cancelled, or fail during kickoff raise instead of coming back as empty successes.

**Breaking changes**

- `batchScrape` / `batch_scrape` waiters now throw a new `JobFailedError` (with the terminal job attached) for failed, cancelled, or kickoff-failed jobs instead of returning them.
- `PaginationConfig.auto_paginate` unset now means "SDK decides" instead of `true`; the SDK paginates batch and crawl status only after the job is terminal, while monitor keeps its old behavior.

**Pagination**

- A failed page fetch or a `success: false` page raises `PAGINATION_FETCH_FAILED` or the non-retryable `PAGINATION_RESPONSE_INVALID` instead of returning silent partial data.
- Truncation by `maxPages` / `maxResults` preserves the unconsumed `next` cursor, overshooting pages are skipped whole, and self-referencing `next` cursors stop pagination instead of looping.
- Versions bumped to `@mendable/firecrawl-js` 4.38.0 and `firecrawl` 4.41.0.

<sup>Written for commit 4556d456f35174bd02187bd4025b2dea1c150901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

