### PR TITLE
fix(api): enforce crawl limit atomically in lockURL

### DIFF
--- a/apps/api/src/lib/crawl-redis.test.ts
+++ b/apps/api/src/lib/crawl-redis.test.ts
@@ -1,4 +1,42 @@
-import { generateURLPermutations } from "./crawl-redis";
+import { randomUUID } from "node:crypto";
+import { redisEvictConnection } from "../services/redis";
+
+vi.mock("../scraper/WebScraper/crawler", () => ({ WebCrawler: class {} }));
+
+import {
+  generateURLPermutations,
+  lockURL,
+  type StoredCrawl,
+} from "./crawl-redis";
+
+describe("lockURL", () => {
+  it("does not exceed the crawl limit when URLs are locked concurrently", async () => {
+    const id = `lock-url-limit-${randomUUID()}`;
+    const visitedKey = `crawl:${id}:visited`;
+    const visitedUniqueKey = `crawl:${id}:visited_unique`;
+    const sc = {
+      crawlerOptions: { limit: 1, deduplicateSimilarURLs: false },
+      scrapeOptions: {},
+      internalOptions: {},
+      team_id: "test-team",
+      createdAt: Date.now(),
+    } as StoredCrawl;
+
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 20 }, (_, index) =>
+          lockURL(id, sc, `https://example.com/page-${index}`),
+        ),
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      expect(await redisEvictConnection.scard(visitedKey)).toBe(1);
+      expect(await redisEvictConnection.scard(visitedUniqueKey)).toBe(1);
+    } finally {
+      await redisEvictConnection.del(visitedKey, visitedUniqueKey);
+    }
+  });
+});
 
 describe("generateURLPermutations", () => {
   it("generates permutations correctly", () => {

--- a/apps/api/src/lib/crawl-redis.ts
+++ b/apps/api/src/lib/crawl-redis.ts
@@ -485,6 +485,22 @@ export function generateURLPermutations(url: string | URL): URL[] {
   return [...new Set(permutations.map(x => x.href))].map(x => new URL(x));
 }
 
+const LOCK_URL_WITH_LIMIT_SCRIPT = `
+if redis.call("SCARD", KEYS[2]) >= tonumber(ARGV[3]) then
+  return 0
+end
+
+local added = redis.call("SADD", KEYS[1], ARGV[1])
+redis.call("EXPIRE", KEYS[1], ARGV[4])
+if added == 0 then
+  return -1
+end
+
+redis.call("SADD", KEYS[2], ARGV[2])
+redis.call("EXPIRE", KEYS[2], ARGV[4])
+return 1
+`;
+
 export async function lockURL(
   id: string,
   sc: StoredCrawl,
@@ -499,26 +515,38 @@ export async function lockURL(
       operation: "lock_url",
     });
 
+    const visitedKey = "crawl:" + id + ":visited";
+    const visitedUniqueKey = "crawl:" + id + ":visited_unique";
+    const visitedUrl = !sc.crawlerOptions?.deduplicateSimilarURLs
+      ? normalizedUrl
+      : generateURLPermutations(normalizedUrl)[0].href;
+
     if (typeof sc.crawlerOptions?.limit === "number") {
-      if (
-        (await redisEvictConnection.scard("crawl:" + id + ":visited_unique")) >=
-        sc.crawlerOptions.limit
-      ) {
+      const result = Number(
+        await redisEvictConnection.eval(
+          LOCK_URL_WITH_LIMIT_SCRIPT,
+          2,
+          visitedKey,
+          visitedUniqueKey,
+          visitedUrl,
+          normalizedUrl,
+          sc.crawlerOptions.limit,
+          24 * 60 * 60,
+        ),
+      );
+
+      if (result === 0) {
         setSpanAttributes(span, { "crawl.limit_reached": true });
-        return false;
       }
+
+      const res = result === 1;
+      setSpanAttributes(span, { "crawl.url_locked": res });
+      return res;
     }
 
     const pipeline = redisEvictConnection.pipeline();
-
-    if (!sc.crawlerOptions?.deduplicateSimilarURLs) {
-      pipeline.sadd("crawl:" + id + ":visited", normalizedUrl);
-    } else {
-      const permutation = generateURLPermutations(normalizedUrl)[0].href;
-      pipeline.sadd("crawl:" + id + ":visited", permutation);
-    }
-
-    pipeline.expire("crawl:" + id + ":visited", 24 * 60 * 60);
+    pipeline.sadd(visitedKey, visitedUrl);
+    pipeline.expire(visitedKey, 24 * 60 * 60);
 
     const results = await pipeline.exec();
     const saddResult = results?.[0]?.[1] as number;
@@ -526,8 +554,8 @@ export async function lockURL(
 
     if (res) {
       const uniquePipeline = redisEvictConnection.pipeline();
-      uniquePipeline.sadd("crawl:" + id + ":visited_unique", normalizedUrl);
-      uniquePipeline.expire("crawl:" + id + ":visited_unique", 24 * 60 * 60);
+      uniquePipeline.sadd(visitedUniqueKey, normalizedUrl);
+      uniquePipeline.expire(visitedUniqueKey, 24 * 60 * 60);
       await uniquePipeline.exec();
     }
 


### PR DESCRIPTION
Supersedes #4299 with a fresh branch based on current `main` (`47f283f89144d9a1b48d5fd0f1ce3e661b10d2ac`).

Fixes #4298.

## Problem

`lockURL()` checked `visited_unique` with `SCARD` before separate writes. Concurrent workers could all observe a count below the crawl limit and then lock distinct URLs, exceeding `crawlerOptions.limit`.

## Fix

For finite limits, execute the count check and both set updates in one Redis Lua script. Redis runs the script atomically, so only calls within the remaining limit can add a new URL.

The unlimited path keeps the existing pipeline behavior. Deduplication and 24-hour TTL behavior are preserved.

## Regression coverage

Added a real-Redis concurrency test that starts 20 distinct `lockURL` calls with `limit: 1` and verifies:

- exactly one call succeeds;
- `visited` cardinality is 1;
- `visited_unique` cardinality is 1.

Local verification:

- targeted Vitest concurrency test: passed;
- Prettier check for both changed files: passed;
- `git diff --check`: passed.

The existing unrelated `generateURLPermutations` expectation still fails on unmodified `main` (expected 16, actual 12); this patch does not change that code.

## Scope

Only these files are changed:

- `apps/api/src/lib/crawl-redis.ts`
- `apps/api/src/lib/crawl-redis.test.ts`

Prepared with AI assistance; the diff and targeted test results were reviewed before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `lockURL()` enforcing the crawl limit non-atomically, so concurrent workers could lock distinct URLs and exceed `crawlerOptions.limit`. The count check and set updates now run in a single Redis Lua script for finite limits; the unlimited path keeps the existing pipeline behavior, and deduplication plus the 24-hour TTL are unchanged.

**Bug Fixes**
- Added a real-Redis concurrency test that starts 20 `lockURL` calls with `limit: 1` and verifies exactly one succeeds and both set cardinalities stay at 1.
- Returns `0` when the limit is reached, `1` on a successful lock, and `-1` for duplicate URLs within the script.

<sup>Written for commit cd2f6c59b60f551ce10684ae1fff2b110b29b5e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

