### PR TITLE
Let the partner's gate decide whether a monitor run happens

### DIFF
--- a/apps/api/src/db/schema/public.ts
+++ b/apps/api/src/db/schema/public.ts
@@ -378,6 +378,7 @@ export const monitor_checks = pgTable("monitor_checks", {
   reserved_credits: integer("reserved_credits"),
   actual_credits: integer("actual_credits"),
   autumn_lock_id: text("autumn_lock_id"),
+  partner_run_token: text("partner_run_token"),
   billing_status: text("billing_status").notNull().default("not_applicable"),
   total_pages: integer("total_pages").notNull().default(0),
   same_count: integer("same_count").notNull().default(0),

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1333,6 +1333,84 @@ describe("firebill routing", () => {
     expect(mockCheck).not.toHaveBeenCalled();
   });
 
+  // The gate's whole premise is that it fails closed, and firebill cannot fail
+  // closed on its own behalf when firebill is the thing that is down. Without
+  // this the run proceeds unlocked and ungated: work done, nobody asked, and no
+  // run token to ever bill it under.
+  it("denies a gated run when firebill itself cannot answer", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+    const gated = {
+      teamId: "team-1",
+      value: 10,
+      lockId: "lock-1",
+      partnerJobToken: "job-token-abc",
+    };
+
+    mockFetch.mockResolvedValueOnce(lockResponse({ success: false }));
+    expect(await svc.lockCredits(gated)).toEqual({
+      status: "denied",
+      reason: "gate_unavailable",
+    });
+
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    expect(await svc.lockCredits(gated)).toEqual({
+      status: "denied",
+      reason: "gate_unavailable",
+    });
+
+    // An answer we cannot read is not an answer either.
+    mockFetch.mockResolvedValueOnce(lockResponse({ success: true }));
+    expect(await svc.lockCredits(gated)).toEqual({
+      status: "denied",
+      reason: "gate_unavailable",
+    });
+
+    expect(mockCheck).not.toHaveBeenCalled();
+  });
+
+  // The inverse, and it is what makes the change above affordable: an ordinary
+  // hold is still "proceed unlocked" when firebill blinks. Refusing those would
+  // turn a firebill blip into a customer-facing outage.
+  it("still skips rather than denies when no partner gate is involved", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    mockFetch.mockResolvedValueOnce(lockResponse({ success: false }));
+    expect(
+      await svc.lockCredits({ teamId: "team-1", value: 10, lockId: "lock-1" }),
+    ).toEqual({ status: "skipped" });
+  });
+
+  // Routing re-derives from a TTL-cached provisioning lookup and a rollout
+  // percentage, either of which can flip in the hour between a lock and its
+  // finalize. A run token is proof of the route the lock actually took, and
+  // going direct would silently drop the partner's only report of the run.
+  it("follows the run token to firebill even when routing says otherwise", async () => {
+    state.configRef = {
+      ...firebillConfig(),
+      FIREBILL_ORG_IDS: ["some-other-org"],
+    };
+    const svc = makeService();
+
+    await svc.finalizeCreditsLock({
+      lockId: "monitor_check-1",
+      action: "confirm",
+      overrideValue: 7,
+      teamId: "team-1",
+      externalRequestId: "run-42",
+    });
+
+    expect(mockFinalize).not.toHaveBeenCalled();
+    const finalizeCall = mockFetch.mock.calls.find(([url]) =>
+      String(url).endsWith("/v1/finalize"),
+    );
+    expect(finalizeCall).toBeDefined();
+    expect(JSON.parse(finalizeCall![1].body).external_request_id).toBe(
+      "run-42",
+    );
+  });
+
   it("hands the run token back on the finalize as the operation id", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1245,8 +1245,7 @@ describe("firebill routing", () => {
     );
   });
 
-  // Every lock in production today. The key must be absent, not null: present
-  // is what arms the gate, and firebill decides that on presence.
+  // Absent, not null: firebill arms the gate on presence.
   it("omits the token entirely for a monitor no partner created", async () => {
     state.configRef = firebillConfig();
     mockFetch.mockResolvedValue(
@@ -1270,9 +1269,8 @@ describe("firebill routing", () => {
     }
   });
 
-  // The caller acts on these differently: one skips an occurrence, one stops a
-  // schedule. Collapsing them would either strand a revoked job forever or
-  // cancel a monitor over a customer topping up late.
+  // Collapsing these would strand a revoked job or cancel a monitor over a
+  // customer topping up late.
   it("carries the partner's denial reason through, and only ones it knows", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();
@@ -1295,10 +1293,8 @@ describe("firebill routing", () => {
       ).toEqual({ status: "denied", reason });
     }
 
-    // An unknown reason is dropped rather than passed on: reading one we do
-    // not understand as `job_revoked` would pause a customer's monitor over a
-    // string. A plain denial is the safe reading, and is what Autumn's own
-    // denials already look like.
+    // Reading an unknown reason as `job_revoked` would pause a monitor over a
+    // string; a plain denial is the safe reading.
     mockFetch.mockResolvedValueOnce(
       lockResponse({ success: true, allowed: false, reason: "who-knows" }),
     );
@@ -1312,9 +1308,7 @@ describe("firebill routing", () => {
     ).toEqual({ status: "denied" });
   });
 
-  // Unreachable in practice — a partner-provisioned org always routes to
-  // firebill whatever the ramp says (#4403) — but a token that got here would
-  // silently skip the gate, which is the one failure the gate exists for.
+  // Unreachable (#4403), but a token here would silently skip the gate.
   it("refuses a hold when a job token reaches the direct-Autumn path", async () => {
     state.configRef = {
       ...firebillConfig(),
@@ -1333,10 +1327,7 @@ describe("firebill routing", () => {
     expect(mockCheck).not.toHaveBeenCalled();
   });
 
-  // The gate's whole premise is that it fails closed, and firebill cannot fail
-  // closed on its own behalf when firebill is the thing that is down. Without
-  // this the run proceeds unlocked and ungated: work done, nobody asked, and no
-  // run token to ever bill it under.
+  // firebill cannot fail closed on its own behalf when it is what is down.
   it("denies a gated run when firebill itself cannot answer", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();
@@ -1369,9 +1360,8 @@ describe("firebill routing", () => {
     expect(mockCheck).not.toHaveBeenCalled();
   });
 
-  // The inverse, and it is what makes the change above affordable: an ordinary
-  // hold is still "proceed unlocked" when firebill blinks. Refusing those would
-  // turn a firebill blip into a customer-facing outage.
+  // What makes the above affordable: refusing ordinary holds would turn a
+  // firebill blip into a customer-facing outage.
   it("still skips rather than denies when no partner gate is involved", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();
@@ -1382,10 +1372,8 @@ describe("firebill routing", () => {
     ).toEqual({ status: "skipped" });
   });
 
-  // Routing re-derives from a TTL-cached provisioning lookup and a rollout
-  // percentage, either of which can flip in the hour between a lock and its
-  // finalize. A run token is proof of the route the lock actually took, and
-  // going direct would silently drop the partner's only report of the run.
+  // Routing can flip in the hour between a lock and its finalize; going direct
+  // would drop the partner's only report of the run.
   it("follows the run token to firebill even when routing says otherwise", async () => {
     state.configRef = {
       ...firebillConfig(),

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1462,6 +1462,50 @@ describe("firebill routing", () => {
     );
   });
 
+  // firebill has no lock table and the Autumn finalize body carries no
+  // customer, so without this it cannot find the integration to report to.
+  it("sends the customer alongside the run token so the run can be reported", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    await svc.finalizeCreditsLock({
+      lockId: "monitor_check-1",
+      action: "confirm",
+      overrideValue: 7,
+      teamId: "team-1",
+      externalRequestId: "run-42",
+    });
+
+    const body = JSON.parse(
+      mockFetch.mock.calls
+        .filter(([url]) => String(url).endsWith("/v1/finalize"))
+        .pop()![1].body,
+    );
+    expect(body.customer_id).toBe("org-1");
+    expect(body.external_request_id).toBe("run-42");
+  });
+
+  // An ordinary settle reports to nobody, so it should not pay for the lookup
+  // or put a customer on the wire.
+  it("omits the customer when the settle is not gated", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    await svc.finalizeCreditsLock({
+      lockId: "monitor_check-1",
+      action: "confirm",
+      overrideValue: 7,
+      teamId: "team-1",
+    });
+
+    const body = JSON.parse(
+      mockFetch.mock.calls
+        .filter(([url]) => String(url).endsWith("/v1/finalize"))
+        .pop()![1].body,
+    );
+    expect(body).not.toHaveProperty("customer_id");
+  });
+
   it("omits the operation id when there is no partner to report to", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1485,6 +1485,31 @@ describe("firebill routing", () => {
     expect(body.external_request_id).toBe("run-42");
   });
 
+  // Sending it without the org would settle the lock and report nothing, and
+  // this finalize is the run's only chance to be reported.
+  it("refuses to send a gated finalize it cannot name the org for", async () => {
+    state.configRef = firebillConfig();
+    // No org row for this team, so resolving the customer throws.
+    state.supabaseStubData = { data: null, error: null };
+    const svc = makeService();
+
+    await expect(
+      svc.finalizeCreditsLock({
+        lockId: "monitor_check-1",
+        action: "confirm",
+        overrideValue: 7,
+        teamId: "team-99",
+        externalRequestId: "run-42",
+      }),
+    ).rejects.toThrow();
+
+    expect(
+      mockFetch.mock.calls.filter(([url]) =>
+        String(url).endsWith("/v1/finalize"),
+      ),
+    ).toHaveLength(0);
+  });
+
   // An ordinary settle reports to nobody, so it should not pay for the lookup
   // or put a customer on the wire.
   it("omits the customer when the settle is not gated", async () => {

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1271,6 +1271,49 @@ describe("firebill routing", () => {
 
   // Collapsing these would strand a revoked job or cancel a monitor over a
   // customer topping up late.
+  // A gated lock waits longer because it does more: firebill asks the partner
+  // before taking the hold. Giving up at 5s would abandon a call that still
+  // takes the hold - run skipped here, balance reserved there.
+  it("waits longer for a gated lock than an ordinary one", async () => {
+    state.configRef = firebillConfig();
+    mockFetch.mockResolvedValue(
+      lockResponse({ success: true, allowed: true, lock_id: "lock-1" }),
+    );
+    const svc = makeService();
+
+    // Capture the deadline each call asks for; two AbortSignals always differ
+    // as objects, so only the number proves anything.
+    const timeouts: number[] = [];
+    const realTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const spy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation((ms: number) => {
+        timeouts.push(ms);
+        return realTimeout(ms);
+      });
+
+    await svc.lockCredits({ teamId: "team-1", value: 1, lockId: "lock-1" });
+    const plain = mockFetch.mock.calls
+      .filter(([url]) => String(url).endsWith("/v1/lock"))
+      .pop();
+
+    await svc.lockCredits({
+      teamId: "team-1",
+      value: 1,
+      lockId: "lock-1",
+      partnerJobToken: "job-token-abc",
+    });
+    const gated = mockFetch.mock.calls
+      .filter(([url]) => String(url).endsWith("/v1/lock"))
+      .pop();
+
+    expect(timeouts.at(-1)).toBe(10000);
+    expect(timeouts.at(-2)).toBe(5000);
+    expect(gated![1].signal).toBeDefined();
+    expect(plain![1].signal).toBeDefined();
+    spy.mockRestore();
+  });
+
   it("carries the partner's denial reason through, and only ones it knows", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1209,6 +1209,169 @@ describe("firebill routing", () => {
     expect(mockCheck).not.toHaveBeenCalled();
   });
 
+  // -------------------------------------------------------------------------
+  // The partner's credit gate (firebill asks; we only carry the tokens)
+  // -------------------------------------------------------------------------
+
+  it("sends a partner job token so firebill can arm the gate, and brings the run token back", async () => {
+    state.configRef = firebillConfig();
+    mockFetch.mockResolvedValue(
+      lockResponse({
+        success: true,
+        allowed: true,
+        lock_id: "monitor_check-1",
+        operation_token: "run-42",
+      }),
+    );
+    const svc = makeService();
+
+    const result = await svc.lockCredits({
+      teamId: "team-1",
+      value: 10,
+      lockId: "monitor_check-1",
+      partnerJobToken: "job-token-abc",
+    });
+
+    expect(result).toEqual({
+      status: "locked",
+      lockId: "monitor_check-1",
+      operationToken: "run-42",
+    });
+    const lockCall = mockFetch.mock.calls.find(([url]) =>
+      String(url).endsWith("/v1/lock"),
+    );
+    expect(JSON.parse(lockCall![1].body).partner_job_token).toBe(
+      "job-token-abc",
+    );
+  });
+
+  // Every lock in production today. The key must be absent, not null: present
+  // is what arms the gate, and firebill decides that on presence.
+  it("omits the token entirely for a monitor no partner created", async () => {
+    state.configRef = firebillConfig();
+    mockFetch.mockResolvedValue(
+      lockResponse({ success: true, allowed: true, lock_id: "lock-1" }),
+    );
+    const svc = makeService();
+
+    for (const partnerJobToken of [undefined, null]) {
+      await svc.lockCredits({
+        teamId: "team-1",
+        value: 10,
+        lockId: "lock-1",
+        partnerJobToken,
+      });
+      const lockCall = mockFetch.mock.calls
+        .filter(([url]) => String(url).endsWith("/v1/lock"))
+        .pop();
+      expect(JSON.parse(lockCall![1].body)).not.toHaveProperty(
+        "partner_job_token",
+      );
+    }
+  });
+
+  // The caller acts on these differently: one skips an occurrence, one stops a
+  // schedule. Collapsing them would either strand a revoked job forever or
+  // cancel a monitor over a customer topping up late.
+  it("carries the partner's denial reason through, and only ones it knows", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    for (const reason of [
+      "out_of_credits",
+      "job_revoked",
+      "gate_unavailable",
+    ]) {
+      mockFetch.mockResolvedValueOnce(
+        lockResponse({ success: true, allowed: false, reason }),
+      );
+      expect(
+        await svc.lockCredits({
+          teamId: "team-1",
+          value: 10,
+          lockId: "lock-1",
+          partnerJobToken: "job-token-abc",
+        }),
+      ).toEqual({ status: "denied", reason });
+    }
+
+    // An unknown reason is dropped rather than passed on: reading one we do
+    // not understand as `job_revoked` would pause a customer's monitor over a
+    // string. A plain denial is the safe reading, and is what Autumn's own
+    // denials already look like.
+    mockFetch.mockResolvedValueOnce(
+      lockResponse({ success: true, allowed: false, reason: "who-knows" }),
+    );
+    expect(
+      await svc.lockCredits({
+        teamId: "team-1",
+        value: 10,
+        lockId: "lock-1",
+        partnerJobToken: "job-token-abc",
+      }),
+    ).toEqual({ status: "denied" });
+  });
+
+  // Unreachable in practice — a partner-provisioned org always routes to
+  // firebill whatever the ramp says (#4403) — but a token that got here would
+  // silently skip the gate, which is the one failure the gate exists for.
+  it("refuses a hold when a job token reaches the direct-Autumn path", async () => {
+    state.configRef = {
+      ...firebillConfig(),
+      FIREBILL_ORG_IDS: ["some-other-org"],
+    };
+    const svc = makeService();
+
+    expect(
+      await svc.lockCredits({
+        teamId: "team-1",
+        value: 10,
+        lockId: "lock-1",
+        partnerJobToken: "job-token-abc",
+      }),
+    ).toEqual({ status: "denied", reason: "gate_unavailable" });
+    expect(mockCheck).not.toHaveBeenCalled();
+  });
+
+  it("hands the run token back on the finalize as the operation id", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    await svc.finalizeCreditsLock({
+      lockId: "monitor_check-1",
+      action: "confirm",
+      overrideValue: 7,
+      teamId: "team-1",
+      externalRequestId: "run-42",
+    });
+
+    const finalizeCall = mockFetch.mock.calls.find(([url]) =>
+      String(url).endsWith("/v1/finalize"),
+    );
+    expect(JSON.parse(finalizeCall![1].body).external_request_id).toBe(
+      "run-42",
+    );
+  });
+
+  it("omits the operation id when there is no partner to report to", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    await svc.finalizeCreditsLock({
+      lockId: "monitor_check-1",
+      action: "confirm",
+      teamId: "team-1",
+      externalRequestId: null,
+    });
+
+    const finalizeCall = mockFetch.mock.calls.find(([url]) =>
+      String(url).endsWith("/v1/finalize"),
+    );
+    expect(JSON.parse(finalizeCall![1].body)).not.toHaveProperty(
+      "external_request_id",
+    );
+  });
+
   it("uses the direct Autumn lock path for orgs NOT on the allowlist", async () => {
     state.configRef = {
       ...firebillConfig(),

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1508,7 +1508,7 @@ describe("firebill routing", () => {
         teamId: "team-99",
         externalRequestId: "run-42",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.not.toThrow();
 
     const body = JSON.parse(
       mockFetch.mock.calls
@@ -1524,6 +1524,50 @@ describe("firebill routing", () => {
 
   // An ordinary settle reports to nobody, so it should not pay for the lookup
   // or put a customer on the wire.
+  // firebill answers `false` for a refusal, a timeout, or a non-OK, and none of
+  // them throw. A caller that cannot see that records a run as billed that
+  // nobody billed, with no retry — so the verdict has to come back.
+  it("reports whether the settle actually landed", async () => {
+    state.configRef = firebillConfig();
+    const svc = makeService();
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    );
+    await expect(
+      svc.finalizeCreditsLock({
+        lockId: "monitor_check-1",
+        action: "confirm",
+        overrideValue: 7,
+        teamId: "team-1",
+      }),
+    ).resolves.toBe(true);
+
+    // firebill took it but says it did not land.
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false }), { status: 200 }),
+    );
+    await expect(
+      svc.finalizeCreditsLock({
+        lockId: "monitor_check-2",
+        action: "confirm",
+        overrideValue: 7,
+        teamId: "team-1",
+      }),
+    ).resolves.toBe(false);
+
+    // Never answered at all.
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    await expect(
+      svc.finalizeCreditsLock({
+        lockId: "monitor_check-3",
+        action: "confirm",
+        overrideValue: 7,
+        teamId: "team-1",
+      }),
+    ).resolves.toBe(false);
+  });
+
   it("omits the customer when the settle is not gated", async () => {
     state.configRef = firebillConfig();
     const svc = makeService();

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1488,9 +1488,11 @@ describe("firebill routing", () => {
     expect(body.feature_id).toBe("CREDITS");
   });
 
-  // Sending it without the org would settle the lock and report nothing, and
-  // this finalize is the run's only chance to be reported.
-  it("refuses to send a gated finalize it cannot name the org for", async () => {
+  // There is no durable retry here: billMonitorCheck's caller catches, writes
+  // billing_status "failed", and nothing reads that back. Throwing would
+  // abandon the finalize, so the hold expires and the run goes unbilled as
+  // well as unreported — a worse loss than the missing label.
+  it("still finalizes when it cannot name the org, rather than abandoning the settle", async () => {
     state.configRef = firebillConfig();
     // No org row for this team, so resolving the customer throws.
     state.supabaseStubData = { data: null, error: null };
@@ -1504,13 +1506,17 @@ describe("firebill routing", () => {
         teamId: "team-99",
         externalRequestId: "run-42",
       }),
-    ).rejects.toThrow();
+    ).resolves.toBeUndefined();
 
-    expect(
-      mockFetch.mock.calls.filter(([url]) =>
-        String(url).endsWith("/v1/finalize"),
-      ),
-    ).toHaveLength(0);
+    const body = JSON.parse(
+      mockFetch.mock.calls
+        .filter(([url]) => String(url).endsWith("/v1/finalize"))
+        .pop()![1].body,
+    );
+    expect(body.lock_id).toBe("monitor_check-1");
+    // No org, so firebill cannot split or report — and counts the omission.
+    expect(body).not.toHaveProperty("customer_id");
+    expect(body).not.toHaveProperty("feature_id");
   });
 
   // An ordinary settle reports to nobody, so it should not pay for the lookup

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1474,6 +1474,7 @@ describe("firebill routing", () => {
       overrideValue: 7,
       teamId: "team-1",
       externalRequestId: "run-42",
+      heldValue: 12,
     });
 
     const body = JSON.parse(
@@ -1483,9 +1484,10 @@ describe("firebill routing", () => {
     );
     expect(body.customer_id).toBe("org-1");
     expect(body.external_request_id).toBe("run-42");
-    // Which balance the hold was against — without it firebill cannot split
-    // the settle and the ghost pays the whole run.
+    // The other two the split needs: which balance, and what was held —
+    // Autumn reports a balance net of that hold.
     expect(body.feature_id).toBe("CREDITS");
+    expect(body.held_value).toBe(12);
   });
 
   // There is no durable retry here: billMonitorCheck's caller catches, writes
@@ -1517,6 +1519,7 @@ describe("firebill routing", () => {
     // No org, so firebill cannot split or report — and counts the omission.
     expect(body).not.toHaveProperty("customer_id");
     expect(body).not.toHaveProperty("feature_id");
+    expect(body).not.toHaveProperty("held_value");
   });
 
   // An ordinary settle reports to nobody, so it should not pay for the lookup

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1483,6 +1483,9 @@ describe("firebill routing", () => {
     );
     expect(body.customer_id).toBe("org-1");
     expect(body.external_request_id).toBe("run-42");
+    // Which balance the hold was against — without it firebill cannot split
+    // the settle and the ghost pays the whole run.
+    expect(body.feature_id).toBe("CREDITS");
   });
 
   // Sending it without the org would settle the lock and report nothing, and
@@ -1529,6 +1532,7 @@ describe("firebill routing", () => {
         .pop()![1].body,
     );
     expect(body).not.toHaveProperty("customer_id");
+    expect(body).not.toHaveProperty("feature_id");
   });
 
   it("omits the operation id when there is no partner to report to", async () => {

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -10,6 +10,7 @@ import {
   firebillLock,
   firebillTrack,
   firebillCheck,
+  firebillConfigured,
   shouldRouteToFirebill,
 } from "./firebill";
 import { billingRouteTotal } from "./metrics";
@@ -553,6 +554,22 @@ export class AutumnService {
     }
     const resolvedLockId = lockId ?? `billing_${randomUUID()}`;
 
+    // firebill could not answer. For an ordinary hold that is "proceed
+    // unlocked" — losing a reservation is recoverable and refusing one would
+    // turn a firebill blip into a customer outage.
+    //
+    // For a gated run it is the opposite, and the asymmetry is the whole point
+    // of the gate: no answer means no run token, so the work could never be
+    // billed to the partner and doing it would mean doing it for free. firebill
+    // fails closed when it cannot reach the partner; it cannot fail closed on
+    // its own behalf when it is the thing that is down, so that has to happen
+    // here. Only token-bearing locks are affected — every other caller of this
+    // method keeps today's behaviour exactly.
+    const unreachable = (): LockCreditsResult =>
+      partnerJobToken
+        ? { status: "denied", reason: "gate_unavailable" }
+        : { status: "skipped" };
+
     try {
       const customerId = await this.ensureTrackingContext(teamId);
 
@@ -560,7 +577,8 @@ export class AutumnService {
       // their holds through firebill. The hold still lives in Autumn (firebill
       // keeps no lock state), but only firebill pins the retry/timeout budget
       // around the call. An unavailable answer maps to "skipped" — proceed
-      // unlocked — exactly like a direct-Autumn check failure below.
+      // unlocked — exactly like a direct-Autumn check failure below, EXCEPT
+      // when a partner gate is involved; see `unreachable` below.
       if (
         shouldRouteToFirebill(customerId, {
           gatewayProvisioned: await this.isGatewayProvisioned(teamId),
@@ -594,7 +612,7 @@ export class AutumnService {
             ...(result.reason ? { reason: result.reason } : {}),
           };
         }
-        return { status: "skipped" };
+        return unreachable();
       }
 
       // Direct Autumn cannot ask a partner anything. Unreachable in practice —
@@ -650,7 +668,9 @@ export class AutumnService {
           error,
         },
       );
-      return { status: "skipped" };
+      // Same asymmetry: a gated run that threw before it could ask anyone is
+      // still a run nobody authorized.
+      return unreachable();
     }
   }
 
@@ -662,6 +682,15 @@ export class AutumnService {
    * durably and retries delivery — a dropped direct finalize means the hold
    * just expires, leaving a confirm's work unbilled. Either route lands on the
    * same Autumn lock, so routing is a durability choice, not a correctness one.
+   *
+   * **Except when a run token is in hand.** Then it is a correctness choice:
+   * only firebill can report the operation to the partner, so a finalize that
+   * goes direct silently drops the report. And the routing predicate is not
+   * stable across the hour between a lock and its finalize — it re-derives from
+   * a TTL-cached provisioning lookup and a rollout percentage, either of which
+   * can flip in between. A run token only exists because firebill minted it on
+   * the lock, so its presence is proof of the route the lock actually took, and
+   * it wins over asking again.
    */
   async finalizeCreditsLock({
     lockId,
@@ -671,7 +700,8 @@ export class AutumnService {
     teamId,
     externalRequestId,
   }: FinalizeCreditsLockParams): Promise<void> {
-    if (teamId && (await this.isRoutedThroughFirebill(teamId))) {
+    const gated = Boolean(externalRequestId) && firebillConfigured();
+    if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
       await firebillFinalize({
         lockId,
         action,

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -554,17 +554,11 @@ export class AutumnService {
     }
     const resolvedLockId = lockId ?? `billing_${randomUUID()}`;
 
-    // firebill could not answer. For an ordinary hold that is "proceed
-    // unlocked" — losing a reservation is recoverable and refusing one would
-    // turn a firebill blip into a customer outage.
-    //
-    // For a gated run it is the opposite, and the asymmetry is the whole point
-    // of the gate: no answer means no run token, so the work could never be
-    // billed to the partner and doing it would mean doing it for free. firebill
-    // fails closed when it cannot reach the partner; it cannot fail closed on
-    // its own behalf when it is the thing that is down, so that has to happen
-    // here. Only token-bearing locks are affected — every other caller of this
-    // method keeps today's behaviour exactly.
+    // An ordinary hold proceeds unlocked; refusing would turn a firebill blip
+    // into a customer outage. A gated run is the opposite: no answer means no
+    // run token, so the work could never be billed. firebill fails closed when
+    // it cannot reach the partner, but it cannot do so when it is the thing
+    // that is down.
     const unreachable = (): LockCreditsResult =>
       partnerJobToken
         ? { status: "denied", reason: "gate_unavailable" }
@@ -577,8 +571,8 @@ export class AutumnService {
       // their holds through firebill. The hold still lives in Autumn (firebill
       // keeps no lock state), but only firebill pins the retry/timeout budget
       // around the call. An unavailable answer maps to "skipped" — proceed
-      // unlocked — exactly like a direct-Autumn check failure below, EXCEPT
-      // when a partner gate is involved; see `unreachable` below.
+      // unlocked — like a direct-Autumn check failure below, except when a
+      // partner gate is involved; see `unreachable` above.
       if (
         shouldRouteToFirebill(customerId, {
           gatewayProvisioned: await this.isGatewayProvisioned(teamId),
@@ -615,10 +609,8 @@ export class AutumnService {
         return unreachable();
       }
 
-      // Direct Autumn cannot ask a partner anything. Unreachable in practice —
-      // a partner-provisioned org always routes to firebill, whatever the ramp
-      // says (#4403) — but a token that got here would silently skip the gate,
-      // which is the one failure this whole path exists to prevent.
+      // Unreachable — a partner-provisioned org always routes to firebill
+      // (#4403) — but a token here would silently skip the gate.
       if (partnerJobToken) {
         logger.error(
           "A partner job token reached the direct-Autumn lock path, where no partner can be asked; refusing the hold",
@@ -668,8 +660,7 @@ export class AutumnService {
           error,
         },
       );
-      // Same asymmetry: a gated run that threw before it could ask anyone is
-      // still a run nobody authorized.
+      // A gated run that threw before asking anyone is still unauthorized.
       return unreachable();
     }
   }
@@ -683,14 +674,10 @@ export class AutumnService {
    * just expires, leaving a confirm's work unbilled. Either route lands on the
    * same Autumn lock, so routing is a durability choice, not a correctness one.
    *
-   * **Except when a run token is in hand.** Then it is a correctness choice:
-   * only firebill can report the operation to the partner, so a finalize that
-   * goes direct silently drops the report. And the routing predicate is not
-   * stable across the hour between a lock and its finalize — it re-derives from
-   * a TTL-cached provisioning lookup and a rollout percentage, either of which
-   * can flip in between. A run token only exists because firebill minted it on
-   * the lock, so its presence is proof of the route the lock actually took, and
-   * it wins over asking again.
+   * **Except with a run token in hand**, where it is a correctness choice: only
+   * firebill reports the operation to the partner, and the routing predicate is
+   * not stable across the hour between a lock and its finalize. The token is
+   * proof of the route the lock took, so it wins over asking again.
    */
   async finalizeCreditsLock({
     lockId,

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -688,7 +688,7 @@ export class AutumnService {
     externalRequestId,
     featureId = CREDITS_FEATURE_ID,
     heldValue,
-  }: FinalizeCreditsLockParams): Promise<void> {
+  }: FinalizeCreditsLockParams): Promise<boolean> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
     if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
       // Only resolved for a gated settle: firebill needs the org to split the
@@ -712,7 +712,10 @@ export class AutumnService {
               return null;
             })
           : null;
-      await firebillFinalize({
+      // Surfaced, not discarded. firebill answers `false` for a refusal, a
+      // timeout, or a non-OK — none of which throw — so a caller that ignores
+      // this records a run as billed that nobody billed.
+      return await firebillFinalize({
         lockId,
         action,
         overrideValue,
@@ -722,10 +725,11 @@ export class AutumnService {
         featureId: customerId ? featureId : null,
         heldValue: customerId ? heldValue : null,
       });
-      return;
     }
 
-    if (!autumnClient) return;
+    // No client means no hold was ever taken, so nothing can have gone
+    // unsettled.
+    if (!autumnClient) return true;
 
     try {
       await autumnClient.balances.finalize({
@@ -739,6 +743,7 @@ export class AutumnService {
         action,
         overrideValue,
       });
+      return true;
     } catch (error) {
       logger.error(
         "Autumn finalizeCreditsLock failed — billing API may be unavailable",
@@ -749,6 +754,7 @@ export class AutumnService {
           error,
         },
       );
+      return false;
     }
   }
 

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -691,10 +691,14 @@ export class AutumnService {
     if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
       // Only resolved for a gated settle: firebill needs the org to find the
       // integration to report to, and an ordinary finalize reports to nobody.
-      // Cached, but not worth a lookup on every settle that cannot use it.
+      //
+      // Deliberately not caught. A gated finalize sent without the org settles
+      // the lock and reports nothing — silently, and this is the run's only
+      // chance to be reported. Better to fail here and be retried than to
+      // succeed at the half that moves money and drop the half that records it.
       const customerId =
         externalRequestId && teamId
-          ? await this.ensureTrackingContext(teamId).catch(() => null)
+          ? await this.ensureTrackingContext(teamId)
           : null;
       await firebillFinalize({
         lockId,

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -546,6 +546,7 @@ export class AutumnService {
     expiresAt,
     properties,
     featureId = CREDITS_FEATURE_ID,
+    partnerJobToken,
   }: LockCreditsParams): Promise<LockCreditsResult> {
     if (!autumnClient || this.isPreviewTeam(teamId)) {
       return { status: "skipped" };
@@ -576,14 +577,36 @@ export class AutumnService {
           // monitor runner's convention, when the caller sets none.
           expiresAt: expiresAt ?? Date.now() + 60 * 60 * 1000,
           properties,
+          partnerJobToken,
         });
         if (result.status === "locked") {
-          return { status: "locked", lockId: result.lockId };
+          return {
+            status: "locked",
+            lockId: result.lockId,
+            ...(result.operationToken
+              ? { operationToken: result.operationToken }
+              : {}),
+          };
         }
         if (result.status === "denied") {
-          return { status: "denied" };
+          return {
+            status: "denied",
+            ...(result.reason ? { reason: result.reason } : {}),
+          };
         }
         return { status: "skipped" };
+      }
+
+      // Direct Autumn cannot ask a partner anything. Unreachable in practice —
+      // a partner-provisioned org always routes to firebill, whatever the ramp
+      // says (#4403) — but a token that got here would silently skip the gate,
+      // which is the one failure this whole path exists to prevent.
+      if (partnerJobToken) {
+        logger.error(
+          "A partner job token reached the direct-Autumn lock path, where no partner can be asked; refusing the hold",
+          { teamId, lockId: resolvedLockId },
+        );
+        return { status: "denied", reason: "gate_unavailable" };
       }
 
       const { allowed } = await autumnClient.check({
@@ -646,9 +669,16 @@ export class AutumnService {
     overrideValue,
     properties,
     teamId,
+    externalRequestId,
   }: FinalizeCreditsLockParams): Promise<void> {
     if (teamId && (await this.isRoutedThroughFirebill(teamId))) {
-      await firebillFinalize({ lockId, action, overrideValue, properties });
+      await firebillFinalize({
+        lockId,
+        action,
+        overrideValue,
+        properties,
+        externalRequestId,
+      });
       return;
     }
 

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -690,16 +690,26 @@ export class AutumnService {
   }: FinalizeCreditsLockParams): Promise<void> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
     if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
-      // Only resolved for a gated settle: firebill needs the org to find the
-      // integration to report to, and an ordinary finalize reports to nobody.
+      // Only resolved for a gated settle: firebill needs the org to split the
+      // settle and to find the integration to report to. An ordinary finalize
+      // does neither, so it does not pay for the lookup.
       //
-      // Deliberately not caught. A gated finalize sent without the org settles
-      // the lock and reports nothing — silently, and this is the run's only
-      // chance to be reported. Better to fail here and be retried than to
-      // succeed at the half that moves money and drop the half that records it.
+      // A failure degrades to omitting it rather than throwing. There is no
+      // durable retry on this path — `billMonitorCheck`'s only caller catches,
+      // writes `billing_status: "failed"`, and moves on, and nothing ever reads
+      // that back — so throwing would abandon the finalize entirely: the hold
+      // expires and the run goes unbilled at Autumn as well as unreported.
+      // Settling and losing the label is the lesser loss, and firebill counts
+      // the lost label as `partner_events_total{outcome="no_customer"}`.
       const customerId =
         externalRequestId && teamId
-          ? await this.ensureTrackingContext(teamId)
+          ? await this.ensureTrackingContext(teamId).catch(error => {
+              logger.error(
+                "Could not resolve the org for a gated settle; finalizing anyway, but this run cannot be reported to its partner",
+                { teamId, lockId, error },
+              );
+              return null;
+            })
           : null;
       await firebillFinalize({
         lockId,

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -686,6 +686,7 @@ export class AutumnService {
     properties,
     teamId,
     externalRequestId,
+    featureId = CREDITS_FEATURE_ID,
   }: FinalizeCreditsLockParams): Promise<void> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
     if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
@@ -707,6 +708,7 @@ export class AutumnService {
         properties,
         externalRequestId,
         customerId,
+        featureId: customerId ? featureId : null,
       });
       return;
     }

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -687,6 +687,7 @@ export class AutumnService {
     teamId,
     externalRequestId,
     featureId = CREDITS_FEATURE_ID,
+    heldValue,
   }: FinalizeCreditsLockParams): Promise<void> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
     if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
@@ -719,6 +720,7 @@ export class AutumnService {
         externalRequestId,
         customerId,
         featureId: customerId ? featureId : null,
+        heldValue: customerId ? heldValue : null,
       });
       return;
     }

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -689,12 +689,20 @@ export class AutumnService {
   }: FinalizeCreditsLockParams): Promise<void> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
     if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
+      // Only resolved for a gated settle: firebill needs the org to find the
+      // integration to report to, and an ordinary finalize reports to nobody.
+      // Cached, but not worth a lookup on every settle that cannot use it.
+      const customerId =
+        externalRequestId && teamId
+          ? await this.ensureTrackingContext(teamId).catch(() => null)
+          : null;
       await firebillFinalize({
         lockId,
         action,
         overrideValue,
         properties,
         externalRequestId,
+        customerId,
       });
       return;
     }

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -21,10 +21,8 @@ type FirebillLockResult =
   | { status: "unavailable" };
 
 /**
- * The `reason` values firebill puts on a denial its partner gate produced. An
- * unrecognised one is dropped rather than passed through: a caller reading an
- * unknown reason as `job_revoked` would stop a customer's schedule over a
- * string it does not understand.
+ * An unrecognised reason is dropped rather than passed through: reading one we
+ * do not understand as `job_revoked` would stop a customer's schedule.
  */
 const LOCK_DENIED_REASONS: readonly LockDeniedReason[] = [
   "out_of_credits",
@@ -67,11 +65,8 @@ function firebillOrgIds(): Set<string> {
 }
 
 /**
- * Whether firebill is reachable at all from this process. Separate from
- * {@link shouldRouteToFirebill} because one caller needs the question without
- * the rollout: a finalize carrying a run token has to follow the lock through
- * firebill whatever the ramp currently says, and the only thing that can stop
- * it is firebill not being configured here.
+ * Configured, without the rollout question — a finalize carrying a run token
+ * follows the lock through firebill whatever the ramp says.
  */
 export function firebillConfigured(): boolean {
   return Boolean(config.FIREBILL_URL && config.FIREBILL_SECRET);
@@ -457,9 +452,7 @@ export async function firebillLock({
         lock_id: lockId,
         expires_at: expiresAt,
         properties,
-        // Present is what arms firebill's partner gate: it asks the partner
-        // whether they will fund this occurrence before Autumn holds anything.
-        // Omitted → today's path exactly, no lookup and no outbound call.
+        // Present arms firebill's partner gate; omitted is today's path.
         ...(partnerJobToken ? { partner_job_token: partnerJobToken } : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
@@ -601,9 +594,7 @@ export async function firebillFinalize({
         // settle — e.g. the reconciler re-running a check it raced — dedupes
         // upstream instead of settling twice.
         idempotency_key: `fc:finalize:${action}:${lockId}`,
-        // The run token the lock handed back, brought home as the operation id
-        // this settle is reported under. One check, one run, one token, one
-        // charge.
+        // The run token, brought home as this settle's operation id.
         ...(externalRequestId
           ? { external_request_id: externalRequestId }
           : {}),

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -576,6 +576,7 @@ export async function firebillFinalize({
   properties,
   externalRequestId,
   customerId,
+  featureId,
 }: {
   lockId: string;
   action: "confirm" | "release";
@@ -583,6 +584,7 @@ export async function firebillFinalize({
   properties?: Record<string, unknown>;
   externalRequestId?: string | null;
   customerId?: string | null;
+  featureId?: string | null;
 }): Promise<boolean> {
   const url = firebillUrl("/v1/finalize");
   try {
@@ -612,6 +614,10 @@ export async function firebillFinalize({
         // and firebill keeps no lock table, so without this it cannot find the
         // integration to report the run to.
         ...(customerId ? { customer_id: customerId } : {}),
+        // With customer_id, this is what lets firebill split the settle across
+        // the ghost and its funder — it reads what the ghost has left of this
+        // feature. Without it the whole cost falls on the ghost.
+        ...(featureId ? { feature_id: featureId } : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -577,6 +577,7 @@ export async function firebillFinalize({
   externalRequestId,
   customerId,
   featureId,
+  heldValue,
 }: {
   lockId: string;
   action: "confirm" | "release";
@@ -585,6 +586,7 @@ export async function firebillFinalize({
   externalRequestId?: string | null;
   customerId?: string | null;
   featureId?: string | null;
+  heldValue?: number | null;
 }): Promise<boolean> {
   const url = firebillUrl("/v1/finalize");
   try {
@@ -618,6 +620,12 @@ export async function firebillFinalize({
         // the ghost and its funder — it reads what the ghost has left of this
         // feature. Without it the whole cost falls on the ghost.
         ...(featureId ? { feature_id: featureId } : {}),
+        // What the lock reserved. Autumn reports a balance net of outstanding
+        // holds, so firebill needs this to know what the ghost can actually
+        // pay for this run; without it the whole cost falls on the ghost.
+        ...(heldValue !== undefined && heldValue !== null
+          ? { held_value: heldValue }
+          : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -67,6 +67,17 @@ function firebillOrgIds(): Set<string> {
 }
 
 /**
+ * Whether firebill is reachable at all from this process. Separate from
+ * {@link shouldRouteToFirebill} because one caller needs the question without
+ * the rollout: a finalize carrying a run token has to follow the lock through
+ * firebill whatever the ramp currently says, and the only thing that can stop
+ * it is firebill not being configured here.
+ */
+export function firebillConfigured(): boolean {
+  return Boolean(config.FIREBILL_URL && config.FIREBILL_SECRET);
+}
+
+/**
  * Whether this org's usage goes through firebill rather than straight to Autumn.
  * Needs firebill configured, then any of: the allowlist, being
  * partner-provisioned, or the sticky percentage.
@@ -91,7 +102,7 @@ export function shouldRouteToFirebill(
   orgId: string,
   opts?: { gatewayProvisioned?: boolean },
 ): boolean {
-  if (!config.FIREBILL_URL || !config.FIREBILL_SECRET) return false;
+  if (!firebillConfigured()) return false;
   // Always-on set: test orgs stay routed even at 0 percent.
   if (firebillOrgIds().has(orgId)) return true;
   // A partner-provisioned org always routes: firebill is the only thing that
@@ -514,7 +525,8 @@ export async function firebillLock({
     }
 
     const operationToken =
-      typeof body.operation_token === "string" && body.operation_token.length > 0
+      typeof body.operation_token === "string" &&
+      body.operation_token.length > 0
         ? body.operation_token
         : undefined;
 

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -39,6 +39,12 @@ function lockDeniedReason(value: unknown): LockDeniedReason | undefined {
 // direct Autumn client.
 const FIREBILL_TIMEOUT_MS = 5000;
 
+// A gated lock legitimately does more: firebill asks the partner (2.5s ceiling)
+// before the Autumn hold (2s), on top of the funding lookup. Giving up at 5s
+// would abandon a call that is still going to take the hold - the run marked
+// skipped here, the balance reserved there.
+const FIREBILL_GATED_LOCK_TIMEOUT_MS = 10000;
+
 // Safe to retry because the idempotency key is stable across attempts: if the
 // first attempt did land (ambiguous confirm timeout), Autumn dedupes the second.
 // Small because a caller may be waiting, and a firebill refusing events usually
@@ -455,7 +461,9 @@ export async function firebillLock({
         // Present arms firebill's partner gate; omitted is today's path.
         ...(partnerJobToken ? { partner_job_token: partnerJobToken } : {}),
       }),
-      signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
+      signal: AbortSignal.timeout(
+        partnerJobToken ? FIREBILL_GATED_LOCK_TIMEOUT_MS : FIREBILL_TIMEOUT_MS,
+      ),
     });
 
     if (!response.ok) {

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -575,12 +575,14 @@ export async function firebillFinalize({
   overrideValue,
   properties,
   externalRequestId,
+  customerId,
 }: {
   lockId: string;
   action: "confirm" | "release";
   overrideValue?: number;
   properties?: Record<string, unknown>;
   externalRequestId?: string | null;
+  customerId?: string | null;
 }): Promise<boolean> {
   const url = firebillUrl("/v1/finalize");
   try {
@@ -606,6 +608,10 @@ export async function firebillFinalize({
         ...(externalRequestId
           ? { external_request_id: externalRequestId }
           : {}),
+        // Who the lock was for. The Autumn finalize body carries no customer
+        // and firebill keeps no lock table, so without this it cannot find the
+        // integration to report the run to.
+        ...(customerId ? { customer_id: customerId } : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "crypto";
 import { config } from "../../config";
 import { logger } from "../../lib/logger";
 import { sampled } from "../../lib/rollout";
-import type { TrackParams } from "./types";
+import type { LockDeniedReason, TrackParams } from "./types";
 import {
   firebillCheckTotal,
   firebillRetryTotal,
@@ -16,9 +16,25 @@ import {
  * Autumn at all and the caller decides how its endpoint fails.
  */
 type FirebillLockResult =
-  | { status: "locked"; lockId: string }
-  | { status: "denied" }
+  | { status: "locked"; lockId: string; operationToken?: string }
+  | { status: "denied"; reason?: LockDeniedReason }
   | { status: "unavailable" };
+
+/**
+ * The `reason` values firebill puts on a denial its partner gate produced. An
+ * unrecognised one is dropped rather than passed through: a caller reading an
+ * unknown reason as `job_revoked` would stop a customer's schedule over a
+ * string it does not understand.
+ */
+const LOCK_DENIED_REASONS: readonly LockDeniedReason[] = [
+  "out_of_credits",
+  "job_revoked",
+  "gate_unavailable",
+];
+
+function lockDeniedReason(value: unknown): LockDeniedReason | undefined {
+  return LOCK_DENIED_REASONS.find(reason => reason === value);
+}
 
 // firebill's own internal budget (durable write + forward attempt) is up to
 // ~3.5s worst case, so this is deliberately looser than the 2s timeout on the
@@ -400,6 +416,7 @@ export async function firebillLock({
   lockId,
   expiresAt,
   properties,
+  partnerJobToken,
 }: {
   customerId: string;
   entityId: string;
@@ -408,6 +425,7 @@ export async function firebillLock({
   lockId: string;
   expiresAt: number;
   properties?: Record<string, unknown>;
+  partnerJobToken?: string | null;
 }): Promise<FirebillLockResult> {
   const url = firebillUrl("/v1/lock");
   try {
@@ -428,6 +446,10 @@ export async function firebillLock({
         lock_id: lockId,
         expires_at: expiresAt,
         properties,
+        // Present is what arms firebill's partner gate: it asks the partner
+        // whether they will fund this occurrence before Autumn holds anything.
+        // Omitted → today's path exactly, no lookup and no outbound call.
+        ...(partnerJobToken ? { partner_job_token: partnerJobToken } : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });
@@ -448,6 +470,8 @@ export async function firebillLock({
       success?: boolean;
       allowed?: boolean;
       lock_id?: string;
+      reason?: unknown;
+      operation_token?: unknown;
     };
 
     if (body.success !== true) {
@@ -462,14 +486,16 @@ export async function firebillLock({
     }
 
     if (body.allowed === false) {
+      const reason = lockDeniedReason(body.reason);
       logger.info("firebill lock denied", {
         customerId,
         entityId,
         featureId,
         value,
         lockId,
+        reason,
       });
-      return { status: "denied" };
+      return { status: "denied", ...(reason ? { reason } : {}) };
     }
 
     // Only an explicit `allowed: false` is a denial. `success: true` with a
@@ -487,14 +513,24 @@ export async function firebillLock({
       return { status: "unavailable" };
     }
 
+    const operationToken =
+      typeof body.operation_token === "string" && body.operation_token.length > 0
+        ? body.operation_token
+        : undefined;
+
     logger.info("firebill lock succeeded", {
       customerId,
       entityId,
       featureId,
       value,
       lockId,
+      gated: operationToken !== undefined,
     });
-    return { status: "locked", lockId: body.lock_id ?? lockId };
+    return {
+      status: "locked",
+      lockId: body.lock_id ?? lockId,
+      ...(operationToken ? { operationToken } : {}),
+    };
   } catch (error) {
     logger.error("firebill lock failed — firebill may be unavailable", {
       customerId,
@@ -525,11 +561,13 @@ export async function firebillFinalize({
   action,
   overrideValue,
   properties,
+  externalRequestId,
 }: {
   lockId: string;
   action: "confirm" | "release";
   overrideValue?: number;
   properties?: Record<string, unknown>;
+  externalRequestId?: string | null;
 }): Promise<boolean> {
   const url = firebillUrl("/v1/finalize");
   try {
@@ -551,6 +589,12 @@ export async function firebillFinalize({
         // settle — e.g. the reconciler re-running a check it raced — dedupes
         // upstream instead of settling twice.
         idempotency_key: `fc:finalize:${action}:${lockId}`,
+        // The run token the lock handed back, brought home as the operation id
+        // this settle is reported under. One check, one run, one token, one
+        // charge.
+        ...(externalRequestId
+          ? { external_request_id: externalRequestId }
+          : {}),
       }),
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -52,26 +52,14 @@ export type LockCreditsParams = {
   expiresAt?: number;
   properties?: Record<string, unknown>;
   featureId?: string;
-  /**
-   * A gateway partner's opaque token for the recurring job this hold is one
-   * occurrence of. Present is what arms the partner's own credit gate inside
-   * firebill: it asks the partner whether they will fund this run *before*
-   * Autumn is asked to hold anything, and only then takes the hold.
-   *
-   * Honoured on the firebill route only — but a partner-provisioned org always
-   * routes there ({@link shouldRouteToFirebill}), so a token that matters is
-   * never on the direct-Autumn path.
-   */
+  /** Arms firebill's partner credit gate, which is asked before Autumn holds anything. */
   partnerJobToken?: string | null;
 };
 
 /**
- * Why a hold was refused, when a gateway partner's own gate is what refused it
- * rather than Autumn. Absent on an ordinary Autumn denial.
- *
- * `job_revoked` is the only one that never resolves on its own, and the only
- * one a caller may answer by stopping a schedule rather than waiting for the
- * next occurrence.
+ * Why a partner's gate refused, as opposed to Autumn. `job_revoked` is the only
+ * one that never resolves on its own, and so the only one a caller may answer
+ * by stopping a schedule.
  */
 export type LockDeniedReason =
   | "out_of_credits"
@@ -81,13 +69,10 @@ export type LockDeniedReason =
 /**
  * Outcome of an Autumn credit lock attempt.
  *
- * - `denied`: Autumn refused (`allowed: false`), or a gateway partner's gate
- *   did — see `reason`; either way the caller must NOT proceed.
- * - `skipped`: billing not in effect (no client, preview team, or API fallback);
- *   the caller should proceed without a lock.
- * - `locked`: reserved; `lockId` must be finalized later. `operationToken` is
- *   the partner's own id for this occurrence, when a partner gate authorized
- *   it: hand it back on the finalize and the run is reported under it.
+ * - `denied`: Autumn refused, or a partner's gate did — see `reason`.
+ * - `skipped`: billing not in effect; proceed without a lock.
+ * - `locked`: reserved; finalize with `lockId`. `operationToken` is the
+ *   partner's id for this occurrence — hand it back on the finalize.
  */
 export type LockCreditsResult =
   | { status: "locked"; lockId: string; operationToken?: string }
@@ -107,12 +92,7 @@ export type FinalizeCreditsLockParams = {
    * loses firebill's durable retry).
    */
   teamId?: string;
-  /**
-   * The partner's own id for the work being settled — for a gated run, the
-   * `operationToken` its lock handed back. firebill carries it as the
-   * operation id the charge is reported under. Ignored on the direct-Autumn
-   * route, which reports to no partner.
-   */
+  /** For a gated run, the `operationToken` its lock handed back. */
   externalRequestId?: string | null;
 };
 

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -94,6 +94,8 @@ export type FinalizeCreditsLockParams = {
   teamId?: string;
   /** For a gated run, the `operationToken` its lock handed back. */
   externalRequestId?: string | null;
+  /** Which balance the hold was against; lets firebill split the settle. */
+  featureId?: string;
 };
 
 export type TrackCreditsParams = {

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -96,6 +96,9 @@ export type FinalizeCreditsLockParams = {
   externalRequestId?: string | null;
   /** Which balance the hold was against; lets firebill split the settle. */
   featureId?: string;
+  /** What the lock reserved. Autumn nets outstanding holds out of a reported
+   * balance, so firebill adds this back to see what the ghost can really pay. */
+  heldValue?: number | null;
 };
 
 export type TrackCreditsParams = {

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -52,19 +52,46 @@ export type LockCreditsParams = {
   expiresAt?: number;
   properties?: Record<string, unknown>;
   featureId?: string;
+  /**
+   * A gateway partner's opaque token for the recurring job this hold is one
+   * occurrence of. Present is what arms the partner's own credit gate inside
+   * firebill: it asks the partner whether they will fund this run *before*
+   * Autumn is asked to hold anything, and only then takes the hold.
+   *
+   * Honoured on the firebill route only — but a partner-provisioned org always
+   * routes there ({@link shouldRouteToFirebill}), so a token that matters is
+   * never on the direct-Autumn path.
+   */
+  partnerJobToken?: string | null;
 };
+
+/**
+ * Why a hold was refused, when a gateway partner's own gate is what refused it
+ * rather than Autumn. Absent on an ordinary Autumn denial.
+ *
+ * `job_revoked` is the only one that never resolves on its own, and the only
+ * one a caller may answer by stopping a schedule rather than waiting for the
+ * next occurrence.
+ */
+export type LockDeniedReason =
+  | "out_of_credits"
+  | "job_revoked"
+  | "gate_unavailable";
 
 /**
  * Outcome of an Autumn credit lock attempt.
  *
- * - `denied`: Autumn refused (`allowed: false`); the caller must NOT proceed.
+ * - `denied`: Autumn refused (`allowed: false`), or a gateway partner's gate
+ *   did — see `reason`; either way the caller must NOT proceed.
  * - `skipped`: billing not in effect (no client, preview team, or API fallback);
  *   the caller should proceed without a lock.
- * - `locked`: reserved; `lockId` must be finalized later.
+ * - `locked`: reserved; `lockId` must be finalized later. `operationToken` is
+ *   the partner's own id for this occurrence, when a partner gate authorized
+ *   it: hand it back on the finalize and the run is reported under it.
  */
 export type LockCreditsResult =
-  | { status: "locked"; lockId: string }
-  | { status: "denied" }
+  | { status: "locked"; lockId: string; operationToken?: string }
+  | { status: "denied"; reason?: LockDeniedReason }
   | { status: "skipped" };
 
 export type FinalizeCreditsLockParams = {
@@ -80,6 +107,13 @@ export type FinalizeCreditsLockParams = {
    * loses firebill's durable retry).
    */
   teamId?: string;
+  /**
+   * The partner's own id for the work being settled — for a gated run, the
+   * `operationToken` its lock handed back. firebill carries it as the
+   * operation id the charge is reported under. Ignored on the direct-Autumn
+   * route, which reports to no partner.
+   */
+  externalRequestId?: string | null;
 };
 
 export type TrackCreditsParams = {

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -354,14 +354,18 @@ function summarize(pages: PageResult[]) {
   };
 }
 
+/// `false` means the settle did not land: the hold is still out there and this
+/// run is not billed. Only the caller can decide what to record for that, so it
+/// is returned rather than swallowed.
 async function billMonitorCheck(params: {
   monitor: MonitorRow;
   check: MonitorCheckRow;
   actualCredits: number;
   lockId: string | null;
-}): Promise<void> {
+}): Promise<boolean> {
+  let settled = true;
   if (params.lockId) {
-    await autumnService.finalizeCreditsLock({
+    settled = await autumnService.finalizeCreditsLock({
       lockId: params.lockId,
       action: "confirm",
       overrideValue: params.actualCredits,
@@ -379,7 +383,8 @@ async function billMonitorCheck(params: {
     });
   }
 
-  if (params.actualCredits <= 0 || !config.USE_DB_AUTHENTICATION) return;
+  if (params.actualCredits <= 0 || !config.USE_DB_AUTHENTICATION)
+    return settled;
 
   await getBillingQueue().add(
     "bill_team",
@@ -401,6 +406,8 @@ async function billMonitorCheck(params: {
       priority: 10,
     },
   );
+
+  return settled;
 }
 
 async function sendNotifications(params: {
@@ -1492,7 +1499,10 @@ export async function reconcileRunningMonitorChecks(
         status: errorCount > 0 ? "partial" : "completed",
         finished_at: new Date().toISOString(),
         actual_credits: actualCredits,
-        billing_status: check.autumn_lock_id ? "confirmed" : "not_applicable",
+        // Not `confirmed` yet — the settle has not been attempted. Claiming it
+        // here and then finding firebill refused leaves a run permanently
+        // recorded as billed that nobody billed, with no retry.
+        billing_status: check.autumn_lock_id ? "reserved" : "not_applicable",
         total_pages: totalPages,
         same_count: same,
         changed_count: changed,
@@ -1502,8 +1512,9 @@ export async function reconcileRunningMonitorChecks(
         target_results: targetResults,
       });
 
+      let settled = false;
       try {
-        await billMonitorCheck({
+        settled = await billMonitorCheck({
           monitor,
           check: finalized,
           actualCredits,
@@ -1515,10 +1526,27 @@ export async function reconcileRunningMonitorChecks(
           checkId: finalized.id,
           error,
         });
+      }
+
+      // A refusal and a throw are the same fact — the settle did not land — and
+      // both must be recorded as such. `firebillFinalize` answers `false`
+      // without throwing, so the catch alone never saw them.
+      if (check.autumn_lock_id) {
+        if (!settled) {
+          logger.error(
+            "Monitor check settle did not land; the hold is unsettled and this run is unbilled",
+            {
+              monitorId: monitor.id,
+              checkId: finalized.id,
+              lockId: check.autumn_lock_id,
+              actualCredits,
+            },
+          );
+        }
         finalized = await updateMonitorCheck(check.id, {
-          billing_status: "failed",
+          billing_status: settled ? "confirmed" : "failed",
         }).catch(updateError => {
-          logger.warn("Failed to record monitor check billing failure", {
+          logger.warn("Failed to record monitor check billing outcome", {
             monitorId: monitor.id,
             checkId: finalized.id,
             error: updateError,

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -386,6 +386,25 @@ async function billMonitorCheck(params: {
   if (params.actualCredits <= 0 || !config.USE_DB_AUTHENTICATION)
     return settled;
 
+  // The settle did not land, so Autumn has nothing and the hold expires by
+  // itself. Debiting the team's ledger anyway charges them for a run Autumn
+  // never billed, leaving the two ledgers disagreeing while the row already
+  // says `failed`. `autumnTrackInRequest` below would be a lie too: it tells
+  // the batch Autumn already has this, and it does not.
+  //
+  // So nothing is charged. Firecrawl absorbs the run — the direction this path
+  // errs everywhere else — and `billing_status: "failed"` plus the error beside
+  // it are how it is found.
+  if (!settled) {
+    logger.error("Not billing a monitor check whose settle did not land", {
+      monitorId: params.monitor.id,
+      checkId: params.check.id,
+      lockId: params.lockId,
+      actualCredits: params.actualCredits,
+    });
+    return false;
+  }
+
   await getBillingQueue().add(
     "bill_team",
     {

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -89,17 +89,10 @@ const MONITOR_CHECK_REVOKED_ERROR =
   "Monitor check skipped: the partner has revoked this job.";
 
 /**
- * Consecutive credit-skipped checks — this one included — before a `job_revoked`
- * denial stops the schedule.
- *
- * A 410 is permanent by contract, but pausing a customer's monitor is not a
- * thing to do on one response: a partner deploying a bad build would otherwise
- * take every monitor they fund down with it, and nothing here would start them
- * again. Three occurrences is cheap to wait for — the runs are skipped either
- * way, and the only cost of waiting is three rows.
- *
- * Never reached by a 402: the current denial must itself be `job_revoked`, so
- * a customer simply out of credits is skipped forever and never paused.
+ * Consecutive credit-skipped checks, this one included, before a `job_revoked`
+ * denial stops the schedule. A 410 is permanent, but pausing on one response
+ * would let a partner's bad build take down every monitor they fund. Never
+ * reached by a 402: the current denial must itself be `job_revoked`.
  */
 const MONITOR_GATE_REVOKED_STREAK = 3;
 const TERMINAL_CHECK_STATUSES = new Set([
@@ -378,8 +371,7 @@ async function billMonitorCheck(params: {
         jobId: params.check.id,
       },
       teamId: params.monitor.team_id,
-      // The confirm only. A release bills nothing, so there is no operation to
-      // report and nothing for the partner to hear about.
+      // Confirm only: a release bills nothing, so there is nothing to report.
       externalRequestId: params.check.partner_run_token,
     });
   }
@@ -966,16 +958,9 @@ export async function processMonitorCheckJob(
         endpoint: "monitor",
         jobId: check.id,
       },
-      // Arms the partner's own credit gate inside firebill for a monitor a
-      // gateway partner created. NULL for every other monitor, and NULL is
-      // simply today's lock.
-      //
-      // Not sent when this check already holds a run token. A redelivery of
-      // the same check is the same occurrence, and firebill keeps no lock
-      // table — so re-sending the token would ask the partner to authorize it
-      // a second time, and the second run token would orphan the first
-      // (credits they committed against an operation no cost event ever
-      // names). Autumn dedupes the hold itself via the lock id.
+      // Arms firebill's partner gate; NULL is today's lock. Withheld once this
+      // check holds a run token: a redelivery is the same occurrence, and
+      // asking twice would orphan the first token.
       partnerJobToken: check.partner_run_token
         ? null
         : monitor.partner_job_token,
@@ -993,9 +978,8 @@ export async function processMonitorCheckJob(
           : MONITOR_CHECK_NO_CREDITS_ERROR,
       });
 
-      // A revoked job never becomes unrevoked, so retrying it forever is a
-      // schedule doing nothing but writing skipped rows. Waited out rather
-      // than acted on immediately: see MONITOR_GATE_REVOKED_STREAK.
+      // A revoked job never becomes unrevoked; see MONITOR_GATE_REVOKED_STREAK
+      // for why it is waited out rather than acted on at once.
       const paused =
         revoked &&
         (await countRecentConsecutiveSkippedForCredits({
@@ -1014,8 +998,8 @@ export async function processMonitorCheckJob(
         });
       }
 
-      // A paused monitor must not be handed a next_run_at, and this reads the
-      // status off the object it is given rather than the row.
+      // Reads status off the object it is given, not the row — a paused
+      // monitor must not be handed a next_run_at.
       await updateMonitorScheduleAfterRun({
         monitor: paused ? { ...monitor, status: "paused" } : monitor,
         check,
@@ -1034,11 +1018,8 @@ export async function processMonitorCheckJob(
 
     check = await updateMonitorCheck(check.id, {
       autumn_lock_id: lockId,
-      // Beside the lock id, and for the same span: the finalize carries it
-      // back as the operation id this run is billed under. A token already on
-      // the row wins — the gate was not re-asked, so there is no newer one,
-      // and clobbering it with null would lose the operation the partner
-      // already authorized.
+      // A token already on the row wins: the gate was not re-asked, so there
+      // is no newer one, and null would lose the authorized operation.
       partner_run_token:
         check.partner_run_token ??
         (lock.status === "locked" ? (lock.operationToken ?? null) : null),

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -373,6 +373,9 @@ async function billMonitorCheck(params: {
       teamId: params.monitor.team_id,
       // Confirm only: a release bills nothing, so there is nothing to report.
       externalRequestId: params.check.partner_run_token,
+      // What the lock reserved. firebill adds it back to the ghost's reported
+      // balance, which Autumn returns net of this very hold.
+      heldValue: params.check.reserved_credits,
     });
   }
 

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -36,6 +36,7 @@ import { sendMonitoringSlackSummary } from "../notification/monitoring_slack";
 import {
   bulkUpsertMonitorPages,
   calculateMonitorCheckActualCredits,
+  countRecentConsecutiveSkippedForCredits,
   getMonitorCheck,
   getMonitorForUpdate,
   countMonitorCheckPages,
@@ -45,6 +46,7 @@ import {
   listMonitorCheckPages,
   listRunningMonitorChecks,
   markMonitorRunning,
+  pauseMonitor,
   updateMonitorCheck,
   updateMonitorCheckIfRunning,
   updateMonitorScheduleAfterRun,
@@ -83,6 +85,23 @@ const MONITOR_NOTIFY_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
 const MONITOR_CHECK_PAGE_SCAN_LIMIT = 100_000;
 const MONITOR_CHECK_NO_CREDITS_ERROR =
   "Monitor check skipped: insufficient credits.";
+const MONITOR_CHECK_REVOKED_ERROR =
+  "Monitor check skipped: the partner has revoked this job.";
+
+/**
+ * Consecutive credit-skipped checks — this one included — before a `job_revoked`
+ * denial stops the schedule.
+ *
+ * A 410 is permanent by contract, but pausing a customer's monitor is not a
+ * thing to do on one response: a partner deploying a bad build would otherwise
+ * take every monitor they fund down with it, and nothing here would start them
+ * again. Three occurrences is cheap to wait for — the runs are skipped either
+ * way, and the only cost of waiting is three rows.
+ *
+ * Never reached by a 402: the current denial must itself be `job_revoked`, so
+ * a customer simply out of credits is skipped forever and never paused.
+ */
+const MONITOR_GATE_REVOKED_STREAK = 3;
 const TERMINAL_CHECK_STATUSES = new Set([
   "completed",
   "partial",
@@ -359,6 +378,9 @@ async function billMonitorCheck(params: {
         jobId: params.check.id,
       },
       teamId: params.monitor.team_id,
+      // The confirm only. A release bills nothing, so there is no operation to
+      // report and nothing for the partner to hear about.
+      externalRequestId: params.check.partner_run_token,
     });
   }
 
@@ -944,23 +966,66 @@ export async function processMonitorCheckJob(
         endpoint: "monitor",
         jobId: check.id,
       },
+      // Arms the partner's own credit gate inside firebill for a monitor a
+      // gateway partner created. NULL for every other monitor, and NULL is
+      // simply today's lock.
+      //
+      // Not sent when this check already holds a run token. A redelivery of
+      // the same check is the same occurrence, and firebill keeps no lock
+      // table — so re-sending the token would ask the partner to authorize it
+      // a second time, and the second run token would orphan the first
+      // (credits they committed against an operation no cost event ever
+      // names). Autumn dedupes the hold itself via the lock id.
+      partnerJobToken: check.partner_run_token
+        ? null
+        : monitor.partner_job_token,
     });
 
     if (lock.status === "denied") {
+      const revoked = lock.reason === "job_revoked";
       check = await updateMonitorCheck(check.id, {
         status: "skipped_no_credits",
         finished_at: new Date().toISOString(),
         actual_credits: 0,
         billing_status: "not_applicable",
-        error: MONITOR_CHECK_NO_CREDITS_ERROR,
+        error: revoked
+          ? MONITOR_CHECK_REVOKED_ERROR
+          : MONITOR_CHECK_NO_CREDITS_ERROR,
       });
 
-      await updateMonitorScheduleAfterRun({ monitor, check });
+      // A revoked job never becomes unrevoked, so retrying it forever is a
+      // schedule doing nothing but writing skipped rows. Waited out rather
+      // than acted on immediately: see MONITOR_GATE_REVOKED_STREAK.
+      const paused =
+        revoked &&
+        (await countRecentConsecutiveSkippedForCredits({
+          teamId: monitor.team_id,
+          monitorId: monitor.id,
+          limit: MONITOR_GATE_REVOKED_STREAK,
+        })) >= MONITOR_GATE_REVOKED_STREAK;
 
-      logger.info("Skipped monitor check: insufficient credits", {
+      if (paused) {
+        await pauseMonitor(monitor.id);
+        logger.warn("Paused monitor: the partner has revoked this job", {
+          monitorId: monitor.id,
+          checkId: check.id,
+          teamId: monitor.team_id,
+          consecutiveSkips: MONITOR_GATE_REVOKED_STREAK,
+        });
+      }
+
+      // A paused monitor must not be handed a next_run_at, and this reads the
+      // status off the object it is given rather than the row.
+      await updateMonitorScheduleAfterRun({
+        monitor: paused ? { ...monitor, status: "paused" } : monitor,
+        check,
+      });
+
+      logger.info("Skipped monitor check: no credit authority allowed it", {
         monitorId: monitor.id,
         checkId: check.id,
         teamId: monitor.team_id,
+        reason: lock.reason,
       });
       return;
     }
@@ -969,6 +1034,14 @@ export async function processMonitorCheckJob(
 
     check = await updateMonitorCheck(check.id, {
       autumn_lock_id: lockId,
+      // Beside the lock id, and for the same span: the finalize carries it
+      // back as the operation id this run is billed under. A token already on
+      // the row wins — the gate was not re-asked, so there is no newer one,
+      // and clobbering it with null would lose the operation the partner
+      // already authorized.
+      partner_run_token:
+        check.partner_run_token ??
+        (lock.status === "locked" ? (lock.operationToken ?? null) : null),
       reserved_credits: lockId ? (check.estimated_credits ?? 1) : null,
       billing_status: lockId ? "reserved" : "not_applicable",
     });

--- a/apps/api/src/services/monitoring/store.gate.test.ts
+++ b/apps/api/src/services/monitoring/store.gate.test.ts
@@ -1,0 +1,90 @@
+const { rows, limits, updates, chain } = vi.hoisted(() => {
+  const rows: { status: string }[] = [];
+  const limits: number[] = [];
+  const updates: Record<string, unknown>[] = [];
+
+  const chain: Record<string, unknown> = {
+    from: () => chain,
+    where: () => chain,
+    orderBy: () => chain,
+    limit: (n: number) => {
+      limits.push(n);
+      return Promise.resolve(rows.slice(0, n));
+    },
+  };
+
+  return { rows, limits, updates, chain };
+});
+
+vi.mock("../../db/connection", () => ({
+  dbRr: { select: () => chain },
+  db: {
+    update: () => ({
+      set: (patch: Record<string, unknown>) => {
+        updates.push(patch);
+        return { where: async () => undefined };
+      },
+    }),
+  },
+}));
+vi.mock("../../db/rpc", () => ({ monitoringClaimDueMonitors: vi.fn() }));
+
+import { countRecentConsecutiveSkippedForCredits, pauseMonitor } from "./store";
+
+function seed(...statuses: string[]) {
+  rows.length = 0;
+  limits.length = 0;
+  rows.push(...statuses.map(status => ({ status })));
+}
+
+async function streak(limit = 3) {
+  return countRecentConsecutiveSkippedForCredits({
+    teamId: "11111111-1111-1111-1111-111111111111",
+    monitorId: "22222222-2222-2222-2222-222222222222",
+    limit,
+  });
+}
+
+describe("counting a monitor's credit-skip streak", () => {
+  const skipped = "skipped_no_credits";
+
+  it("counts the run ending at the newest check", async () => {
+    seed(skipped, skipped, skipped);
+    expect(await streak()).toBe(3);
+  });
+
+  // The streak is what makes a revoked job wait rather than pause on one bad
+  // response, so a single good run in between has to reset it — otherwise a
+  // partner that recovered would still lose the monitor on its next blip.
+  it("stops at the first check that ran", async () => {
+    seed(skipped, "completed", skipped);
+    expect(await streak()).toBe(1);
+  });
+
+  it("is zero when the newest check is not a skip", async () => {
+    seed("completed", skipped, skipped);
+    expect(await streak()).toBe(0);
+    seed();
+    expect(await streak()).toBe(0);
+  });
+
+  // Nothing above needs a number bigger than the threshold it compares
+  // against, so the query never reads more rows than that.
+  it("reads no more rows than the caller's limit", async () => {
+    seed(skipped, skipped, skipped, skipped, skipped);
+    expect(await streak(3)).toBe(3);
+    expect(limits).toEqual([3]);
+  });
+});
+
+describe("pausing a monitor", () => {
+  // paused, not deleted: nothing a partner says on their side should destroy a
+  // customer's configuration, and clearing next_run_at is what actually stops
+  // the runs from being claimed.
+  it("stops the schedule without destroying the monitor", async () => {
+    updates.length = 0;
+    await pauseMonitor("22222222-2222-2222-2222-222222222222");
+
+    expect(updates[0]).toMatchObject({ status: "paused", next_run_at: null });
+  });
+});

--- a/apps/api/src/services/monitoring/store.gate.test.ts
+++ b/apps/api/src/services/monitoring/store.gate.test.ts
@@ -53,9 +53,7 @@ describe("counting a monitor's credit-skip streak", () => {
     expect(await streak()).toBe(3);
   });
 
-  // The streak is what makes a revoked job wait rather than pause on one bad
-  // response, so a single good run in between has to reset it — otherwise a
-  // partner that recovered would still lose the monitor on its next blip.
+  // A partner that recovered must not lose the monitor on its next blip.
   it("stops at the first check that ran", async () => {
     seed(skipped, "completed", skipped);
     expect(await streak()).toBe(1);
@@ -68,8 +66,6 @@ describe("counting a monitor's credit-skip streak", () => {
     expect(await streak()).toBe(0);
   });
 
-  // Nothing above needs a number bigger than the threshold it compares
-  // against, so the query never reads more rows than that.
   it("reads no more rows than the caller's limit", async () => {
     seed(skipped, skipped, skipped, skipped, skipped);
     expect(await streak(3)).toBe(3);
@@ -78,9 +74,7 @@ describe("counting a monitor's credit-skip streak", () => {
 });
 
 describe("pausing a monitor", () => {
-  // paused, not deleted: nothing a partner says on their side should destroy a
-  // customer's configuration, and clearing next_run_at is what actually stops
-  // the runs from being claimed.
+  // Clearing next_run_at is what actually stops the runs being claimed.
   it("stops the schedule without destroying the monitor", async () => {
     updates.length = 0;
     await pauseMonitor("22222222-2222-2222-2222-222222222222");

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -802,6 +802,71 @@ export async function listMonitorChecks(params: {
   return data as MonitorCheckRow[];
 }
 
+/**
+ * How many of this monitor's most recent checks, ending at the newest, were
+ * skipped for want of credits — counting the leading run only, so one
+ * successful check in between resets it to zero.
+ *
+ * No column and no counter: a streak is derivable from the rows that already
+ * exist, and a stored counter would be a second source of truth to keep
+ * correct across retries and manual runs.
+ *
+ * Reads at most `limit` rows, because nothing above needs a number larger
+ * than the threshold it is comparing against.
+ */
+export async function countRecentConsecutiveSkippedForCredits(params: {
+  teamId: string;
+  monitorId: string;
+  limit: number;
+}): Promise<number> {
+  const rows = await run(
+    () =>
+      dbRr
+        .select({ status: schema.monitor_checks.status })
+        .from(schema.monitor_checks)
+        .where(
+          and(
+            eq(schema.monitor_checks.monitor_id, params.monitorId),
+            eq(schema.monitor_checks.team_id, params.teamId),
+          ),
+        )
+        .orderBy(desc(schema.monitor_checks.created_at))
+        .limit(params.limit),
+    "Failed to count skipped monitor checks",
+  );
+
+  let streak = 0;
+  for (const row of rows) {
+    if (row.status !== "skipped_no_credits") break;
+    streak += 1;
+  }
+  return streak;
+}
+
+/**
+ * Stop a monitor's schedule without destroying it.
+ *
+ * `paused`, not `deleted`: the customer's configuration, targets and history
+ * survive, and they (or we) can start it again by flipping one field. Nothing
+ * a partner says on their side should be able to delete a customer's monitor.
+ * `monitoring_claim_due_monitors` only ever claims `active` rows, so this is
+ * enough to stop the runs.
+ */
+export async function pauseMonitor(monitorId: string): Promise<void> {
+  await run(
+    () =>
+      db
+        .update(schema.monitors)
+        .set({
+          status: "paused",
+          next_run_at: null,
+          updated_at: new Date().toISOString(),
+        })
+        .where(eq(schema.monitors.id, monitorId)),
+    "Failed to pause monitor",
+  );
+}
+
 export async function updateMonitorCheck(
   checkId: string,
   patch: Partial<MonitorCheckRow>,

--- a/apps/api/src/services/monitoring/store.ts
+++ b/apps/api/src/services/monitoring/store.ts
@@ -803,16 +803,9 @@ export async function listMonitorChecks(params: {
 }
 
 /**
- * How many of this monitor's most recent checks, ending at the newest, were
- * skipped for want of credits — counting the leading run only, so one
- * successful check in between resets it to zero.
- *
- * No column and no counter: a streak is derivable from the rows that already
- * exist, and a stored counter would be a second source of truth to keep
- * correct across retries and manual runs.
- *
- * Reads at most `limit` rows, because nothing above needs a number larger
- * than the threshold it is comparing against.
+ * The leading run of credit-skipped checks ending at the newest, so one
+ * successful check resets it. Derived rather than counted: a stored counter
+ * would be a second source of truth to keep correct across retries.
  */
 export async function countRecentConsecutiveSkippedForCredits(params: {
   teamId: string;
@@ -844,13 +837,9 @@ export async function countRecentConsecutiveSkippedForCredits(params: {
 }
 
 /**
- * Stop a monitor's schedule without destroying it.
- *
- * `paused`, not `deleted`: the customer's configuration, targets and history
- * survive, and they (or we) can start it again by flipping one field. Nothing
- * a partner says on their side should be able to delete a customer's monitor.
- * `monitoring_claim_due_monitors` only ever claims `active` rows, so this is
- * enough to stop the runs.
+ * `paused`, not `deleted`: nothing a partner says should destroy a customer's
+ * configuration. `monitoring_claim_due_monitors` only claims `active` rows, so
+ * this is enough to stop the runs.
  */
 export async function pauseMonitor(monitorId: string): Promise<void> {
   await run(

--- a/apps/api/src/services/monitoring/types.ts
+++ b/apps/api/src/services/monitoring/types.ts
@@ -163,7 +163,8 @@ const monitorNotificationInner = z
     if (notification.slack?.enabled && !notification.slack.channelId) {
       ctx.addIssue({
         code: "custom",
-        message: "A Slack channel is required when Slack notifications are enabled",
+        message:
+          "A Slack channel is required when Slack notifications are enabled",
         path: ["slack", "channelId"],
       });
     }
@@ -353,12 +354,7 @@ export type MonitorCheckRow = {
   reserved_credits: number | null;
   actual_credits: number | null;
   autumn_lock_id: string | null;
-  /**
-   * The gateway partner's own id for this occurrence, minted when their credit
-   * gate authorized it. Carried back on the finalize as the operation id the
-   * run is billed under. Beside `autumn_lock_id` because it has the same
-   * lifetime: one check row, one hold, one settle.
-   */
+  /** The partner's id for this occurrence; carried back on the finalize. */
   partner_run_token: string | null;
   billing_status:
     | "not_applicable"

--- a/apps/api/src/services/monitoring/types.ts
+++ b/apps/api/src/services/monitoring/types.ts
@@ -353,6 +353,13 @@ export type MonitorCheckRow = {
   reserved_credits: number | null;
   actual_credits: number | null;
   autumn_lock_id: string | null;
+  /**
+   * The gateway partner's own id for this occurrence, minted when their credit
+   * gate authorized it. Carried back on the finalize as the operation id the
+   * run is billed under. Beside `autumn_lock_id` because it has the same
+   * lifetime: one check row, one hold, one settle.
+   */
+  partner_run_token: string | null;
   billing_status:
     | "not_applicable"
     | "reserved"


### PR DESCRIPTION
The switch. The previous PR keeps a partner's job token on the monitor;
firebill#17 turns that token into a call to the partner's own credit gate.
This is what connects them, and until it lands both are inert.

**Two authorities, not one.** Autumn answers "can this run be reserved" —
the hold this already takes. The partner answers "does *their* user still
have prepaid credits with *them*", a balance we cannot see. Both must say
yes, and the partner is asked first, so a refusal never leaves a hold
reserved until `expires_at` for a run that will not happen. firebill owns the
outbound call; the runner never learns who the partner is, and only carries
an opaque token down and another one back.

*Corrected: an earlier version of this description said Autumn answers "can
the ghost plus the partner pool pay" at lock time, and that #16 had taught it
to count the pool. Both were wrong. #15/#16 taught **`/v1/check`** to count
the pool; **`/v1/lock` only ever asked about the ghost** — which, for an
account designed to spend credits it does not have, refused exactly the runs
the pool exists to fund. firebill#20 found it in production (ghost `14350e95`,
zero balance, `allowed: false`, pool untouched) and firebill#21 fixed it by
moving the hold to the funder when the ghost cannot reserve it. The claim did
not merely misdescribe the system, it asserted the bug away — worth leaving
on the record, since anyone reading the original would have stopped looking.*

`lockCredits` forwards `monitor.partner_job_token`, which is NULL for every
monitor nobody proxied — and a NULL token is today's lock exactly: no
lookup, no outbound call, no added latency.

A `locked` answer can now carry `operationToken`, the partner's own id for
that occurrence. It is stored on the check row beside `autumn_lock_id`,
which is where it belongs because it has the same lifetime — one check row,
one hold, one settle — and comes home on the **confirm** as the operation id
the run is billed under. Not on a release: a release bills nothing, so there
is no operation to report.

Three denial reasons, because the caller acts on them differently, and an
unrecognised one is **dropped rather than passed through** — reading a
reason we do not understand as `job_revoked` would pause a customer's
monitor over a string.

`job_revoked` is the only permanent one, and the only one that stops a
schedule. It waits for three consecutive credit-skipped checks first. A 410
is permanent by contract, but pausing a monitor on a single response means a
partner deploying a bad build takes down every monitor they fund, with
nothing to start them again; three occurrences costs three skipped runs that
were being skipped anyway. A 402 can never reach it — the *current* denial
must itself be `job_revoked` — so a customer who is simply out of credits is
skipped indefinitely and never paused.

The streak needs no column and no counter: it is the leading run of
`skipped_no_credits` rows in `monitor_checks`, which already exist, and one
successful check resets it. A stored counter would be a second source of
truth to keep correct across retries and manual runs.

**Paused, not deleted.** Nothing a partner says on their side should destroy
a customer's targets, history or configuration. `monitoring_claim_due_monitors`
only claims `active` rows, so pausing is enough to stop the runs, and
starting again is one field. The schedule update is handed a monitor object
already marked paused, because it reads the status off the object rather
than the row — otherwise it would helpfully write the next `next_run_at`
onto the monitor we just stopped.

One case that should be unreachable is made loud rather than silent: a job
token arriving on the **direct-Autumn** lock path refuses the hold. A
partner-provisioned org always routes to firebill whatever the ramp says
(#4403), so this cannot happen today — but if it ever did, Autumn cannot ask
a partner anything, and the hold would be taken with the gate silently
skipped, which is the single failure this whole path exists to prevent.

11 new tests, all green: the token reaching `/v1/lock` and the run token
coming back, the key being *absent* rather than null when there is no
partner (presence is what arms the gate), each denial reason carried through
and an unknown one dropped, the direct-Autumn refusal, the operation id on
the finalize and its absence when there is nobody to report to, the streak
counting only the leading run and resetting on a successful check, and
pausing clearing `next_run_at` without deleting anything.

`tsc --noEmit` clean for every file touched. Two failures in
`src/services/monitoring` predate this branch and are unrelated — the tree's
`@mendable/firecrawl-rs` native module does not resolve locally, which stops
`runner.test.ts` loading at all, and `search/run.test.ts` has one failing
domain-scoping assertion. Both fail identically on the parent commit.
`firebill.ts` was already outside prettier's formatting before this change
and is left as found rather than reformatted inside a billing PR.

Ordering: **last**. It is the switch, and it needs the columns
(firecrawl-db#270), the stored job token, and firebill#17 to be live first.

---

**Stacked on #4427** — review that one first; this PR's diff is only the runner and the autumn client.

**This is the switch, and it should land last** — after firecrawl-db#270, #4427, firebill#17, and the firecrawl-infra alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a gateway partner's credit gate decide whether a monitor run happens. Autumn still answers whether the ghost and partner pool can pay, but firebill now asks the partner's own gate before Autumn holds anything, and a `job_revoked` denial can pause the schedule.

- The partner is asked first, so a refusal never leaves a hold reserved until `expires_at`; a NULL token keeps today's lock — no lookup, no outbound call, no added latency.
- A firebill non-answer now denies a gated run as `gate_unavailable`; an ordinary hold still skips and proceeds unlocked, and a gated lock waits 10s rather than 5s since firebill is still asking the partner.
- Denials carry one of three reasons (`out_of_credits`, `job_revoked`, `gate_unavailable`); unrecognised reasons are dropped rather than passed through.
- `job_revoked` pauses after three consecutive credit-skipped checks; a customer out of credits is skipped indefinitely but never paused.
- The streak is the leading `skipped_no_credits` rows — no stored counter — and one successful check resets it.
- A locked answer can carry the partner's operation token, stored on the check and returned on the confirm as the operation id, alongside the customer id, feature id, and what the lock reserved — the three firebill needs to find the integration, top the ghost back up from the hold, and split the settle; releases and ordinary settles report none of them.
- A gated finalize that cannot resolve the customer settles anyway, but without the customer — the error is logged and firebill counts the lost label as `no_customer`, since throwing would abandon the settle and lose the bill alongside the report.
- A run token forces the finalize through firebill even when routing says otherwise, so the partner's report of the run is never dropped.
- A redelivered check is not re-asked: the job token is withheld when the row already holds a run token, and an existing token wins over one a later lock returns.
- The finalize now answers whether the settle landed; a check is recorded `reserved` before settling and `confirmed` or `failed` after. An unsettled run is never recorded as billed and the team is never debited for it — Firecrawl absorbs the run, since a timeout is ambiguous and re-tracking could double charge.
- Pausing clears `next_run_at` so the claimer stops picking the monitor up; nothing is deleted, and one field flips it back.
- A job token reaching the direct-Autumn path refuses the hold, since no partner can be asked there.

**Rollout**
- Deploy only after the `monitor_checks.partner_run_token` column, the monitor job token, and the firebill gate endpoint are live.

<sup>Written for commit 1c5bc04f22718dc6a5eadef5b06bc1b2bfa21ba3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


