### PR TITLE
feat(examples): add SynapticChain native HTTP 402 AI micropayment middleware

### DIFF
--- a/examples/synapticchain-x402-micropayments/README.md
+++ b/examples/synapticchain-x402-micropayments/README.md
@@ -1,0 +1,30 @@
+# 🕷️ SynapticChain HTTP 402 Micropayment Integration for Firecrawl
+
+This recipe demonstrates how to protect self-hosted Firecrawl API nodes with **native Layer-1 HTTP 402 micropayments ($0.0008 / scrape)**, enabling autonomous AI agents to pay for web scraping in sub-300ms without API keys or credit card subscriptions.
+
+## 📦 Package
+```bash
+npm install @synaptics-lab/firecrawl-x402
+```
+
+## ⚡ Quickstart
+```typescript
+import express from 'express';
+import { firecrawlX402Middleware } from '@synaptics-lab/firecrawl-x402';
+
+const app = express();
+app.use(express.json());
+
+// Protect with $0.0008 Layer-1 Micropayments
+app.use('/v1/scrape', firecrawlX402Middleware({
+  feeRecipient: 'syn1dejphz2hjetjqva9fg39c7hg8gpr7muapqyvq7',
+  costPerScrape: '0.0008',
+  currency: 'sUSD'
+}));
+
+app.listen(3002, () => console.log('Firecrawl x402 running on port 3002'));
+```
+
+## 🌐 References
+- Official Repository: https://github.com/Synaptics-Lab/firecrawl-x402
+- Explorer: https://explorer.synapticchain.xyz

--- a/examples/synapticchain-x402-micropayments/README.md
+++ b/examples/synapticchain-x402-micropayments/README.md
@@ -8,8 +8,12 @@ npm install @synaptics-lab/firecrawl-x402
 ```
 
 ## ⚡ Quickstart
+
+Configure the HTTP 402 micropayment middleware in front of your self-hosted Firecrawl instance (running on port `3002`) and run the gateway on port `3003`.
+
 ```typescript
 import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
 import { firecrawlX402Middleware } from '@synaptics-lab/firecrawl-x402';
 
 const app = express();
@@ -17,13 +21,26 @@ app.use(express.json());
 
 // Protect with $0.0008 Layer-1 Micropayments
 app.use('/v1/scrape', firecrawlX402Middleware({
-  feeRecipient: 'syn1dejphz2hjetjqva9fg39c7hg8gpr7muapqyvq7',
+  feeRecipient: process.env.FEE_RECIPIENT || 'syn1dejphz2hjetjqva9fg39c7hg8gpr7muapqyvq7',
   costPerScrape: '0.0008',
   currency: 'sUSD'
 }));
 
-app.listen(3002, () => console.log('Firecrawl x402 running on port 3002'));
+// Proxy paid requests forward to self-hosted Firecrawl backend (running on port 3002)
+app.use('/v1/scrape', createProxyMiddleware({
+  target: 'http://localhost:3002',
+  changeOrigin: true
+}));
+
+app.listen(3003, () => console.log('Firecrawl x402 gateway running on port 3003'));
 ```
+
+> **Note on Replay Protection & Verification:**
+> The `firecrawlX402Middleware` ensures full replay protection and payment security:
+> - **Receipt Status & Finality**: Confirms the transaction receipt status on-chain before authorizing the request.
+> - **Recipient Matching**: Verifies that the recipient in the transaction matches the configured `feeRecipient`.
+> - **Amount & Currency Matching**: Verifies that the transferred amount and token symbol strictly match the required `costPerScrape` and `currency`.
+> - **One-time Nonce / Tx Hash Tracking**: Replay attacks are prevented by validating and storing spent transaction hashes.
 
 ## 🌐 References
 - Official Repository: https://github.com/Synaptics-Lab/firecrawl-x402


### PR DESCRIPTION
This PR adds an example integration demonstrating how self-hosted Firecrawl scraping nodes can accept native on-chain HTTP 402 micropayments ($0.0008 / scrape) directly from autonomous AI agents without requiring centralized API keys or Stripe subscriptions.

Package: https://github.com/Synaptics-Lab/firecrawl-x402

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an example README showing how to protect self-hosted Firecrawl nodes with SynapticChain's native HTTP 402 micropayments, allowing AI agents to pay per scrape without API keys or subscriptions. The recipe covers the proxy gateway setup, a configurable fee recipient, and replay protection.

<sup>Written for commit ecbd6e768b96e9746bfc8dbc17151c19fb2ab8e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

