### PR TITLE
fix(api): run native document conversion off the Node.js event loop

### DIFF
--- a/apps/api/native/src/document.rs
+++ b/apps/api/native/src/document.rs
@@ -5,15 +5,31 @@ use napi_derive::napi;
 /// csv, ...) to GitHub-Flavored Markdown using anydoc. The format is detected
 /// from the file content; `extension_hint` (with or without a leading dot) is
 /// only consulted for signature-less formats like CSV.
+///
+/// Runs on tokio's blocking thread pool: conversion is CPU-bound and can take
+/// seconds on large documents, which would otherwise freeze the Node.js event
+/// loop (and every in-flight request on the process) for the duration.
 #[napi]
-pub fn convert_document_to_markdown(data: &[u8], extension_hint: Option<String>) -> Result<String> {
-  let format = anydoc::Format::from_bytes(data).or_else(|| {
-    extension_hint
-      .as_deref()
-      .map(|ext| ext.trim_start_matches('.'))
-      .and_then(anydoc::Format::from_extension)
-  });
+pub async fn convert_document_to_markdown(
+  data: Uint8Array,
+  extension_hint: Option<String>,
+) -> Result<String> {
+  tokio::task::spawn_blocking(move || {
+    let format = anydoc::Format::from_bytes(&data).or_else(|| {
+      extension_hint
+        .as_deref()
+        .map(|ext| ext.trim_start_matches('.'))
+        .and_then(anydoc::Format::from_extension)
+    });
 
-  anydoc::to_markdown_bytes(data, format)
-    .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))
+    anydoc::to_markdown_bytes(&data, format)
+      .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))
+  })
+  .await
+  .map_err(|e| {
+    Error::new(
+      Status::GenericFailure,
+      format!("Document conversion task failed to complete: {e}"),
+    )
+  })?
 }

--- a/apps/api/src/__tests__/snips/v2/document-converter.test.ts
+++ b/apps/api/src/__tests__/snips/v2/document-converter.test.ts
@@ -29,7 +29,9 @@ describe("Document Converter tests", () => {
         const fileBuffer = fs.readFileSync(filePath);
 
         // No extension hint: the format must be detected from the bytes
-        const markdown = convertDocumentToMarkdown(new Uint8Array(fileBuffer));
+        const markdown = await convertDocumentToMarkdown(
+          new Uint8Array(fileBuffer),
+        );
 
         expect(markdown).toBe(expectedMarkdownBase(name));
       },
@@ -40,19 +42,24 @@ describe("Document Converter tests", () => {
   describe("XLSX document conversion", () => {
     const expectedMarkdown = `## Sheet1\n\n| sample file | test |\n| --- | --- |\n|  |  |\n| Name | Price |\n| iPhone | 1000 |\n| iPad | 800 |\n| Macbook | 1200 |\n\n## Sheet2\n\n|  |  |\n| --- | --- |\n| other tab |  |\n|  |  |\n| Name | Price |\n| ChatGPT | $20.00 |\n| Claude | $17.00 |\n| Perplexity | $20.00 |\n`;
 
-    it("should convert XLSX document and return expected markdown", () => {
+    it("should convert XLSX document and return expected markdown", async () => {
       const filePath = path.join(samplesDir, "sample.xlsx");
       const fileBuffer = fs.readFileSync(filePath);
-      const markdown = convertDocumentToMarkdown(new Uint8Array(fileBuffer));
+      const markdown = await convertDocumentToMarkdown(
+        new Uint8Array(fileBuffer),
+      );
       expect(markdown).toBe(expectedMarkdown);
     });
   });
 
   describe("CSV document conversion", () => {
-    it("should convert CSV to a markdown table using the extension hint", () => {
+    it("should convert CSV to a markdown table using the extension hint", async () => {
       // CSV has no magic bytes, so the extension hint selects the parser
       const csv = Buffer.from("Name,Price\niPhone,1000\niPad,800\n");
-      const markdown = convertDocumentToMarkdown(new Uint8Array(csv), ".csv");
+      const markdown = await convertDocumentToMarkdown(
+        new Uint8Array(csv),
+        ".csv",
+      );
       expect(markdown).toBe(
         "| Name | Price |\n| --- | --- |\n| iPhone | 1000 |\n| iPad | 800 |\n",
       );
@@ -60,10 +67,10 @@ describe("Document Converter tests", () => {
   });
 
   describe("unrecognized content", () => {
-    it("should throw on content that is not a supported document", () => {
-      expect(() =>
+    it("should throw on content that is not a supported document", async () => {
+      await expect(
         convertDocumentToMarkdown(new Uint8Array([1, 2, 3, 4, 5])),
-      ).toThrow();
+      ).rejects.toThrow();
     });
   });
 });

--- a/apps/api/src/scraper/scrapeURL/engines/document/__tests__/nativeBinding.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/document/__tests__/nativeBinding.test.ts
@@ -1,0 +1,63 @@
+import { convertDocumentToMarkdown } from "@mendable/firecrawl-rs";
+
+/**
+ * Tests for the native (Rust) document binding's interaction with the Node
+ * event loop. Regression: convertDocumentToMarkdown used to be a synchronous
+ * napi call — a large DOCX/RTF/XLSX conversion would freeze the event loop of
+ * whichever pod executed the scrape (including API app pods running sync
+ * scrapes in-process), failing liveness probes and timing out every unrelated
+ * in-flight request on the process. It must run off the main thread (tokio
+ * spawn_blocking), same as processPdf/detectPdf.
+ */
+
+/** Minimal RTF writer — no fixtures checked into the repo. */
+function makeRtf(paragraphs: number): Buffer {
+  const parts = ["{\\rtf1\\ansi\\deff0 {\\fonttbl {\\f0 Times New Roman;}}"];
+  for (let i = 0; i < paragraphs; i++) {
+    parts.push(
+      `\\pard {\\b Heading ${i}} \\par The quick brown fox jumps over the lazy dog. {\\i Pack my box} with five dozen liquor jugs. Paragraph ${i}. \\par`,
+    );
+  }
+  parts.push("}");
+  return Buffer.from(parts.join("\n"), "latin1");
+}
+
+describe("native document binding", () => {
+  it("converts a document to markdown", async () => {
+    const markdown = await convertDocumentToMarkdown(
+      new Uint8Array(makeRtf(1)),
+    );
+    expect(markdown).toContain("quick brown fox");
+    expect(markdown).toContain("**Heading 0**");
+  });
+
+  it("does not block the event loop during large conversions", async () => {
+    // Big enough that conversion takes ~1s of CPU: with the old synchronous
+    // binding the event loop would be frozen for that entire time.
+    const heavyRtf = makeRtf(100000);
+
+    let maxLag = 0;
+    let last = Date.now();
+    const interval = setInterval(() => {
+      const now = Date.now();
+      maxLag = Math.max(maxLag, now - last - 50);
+      last = now;
+    }, 50);
+
+    try {
+      const markdown = await convertDocumentToMarkdown(
+        new Uint8Array(heavyRtf),
+      );
+      expect(markdown).toContain("Paragraph 99999");
+    } finally {
+      // Let any overdue interval tick fire before clearing: the await
+      // continuation is a microtask and would otherwise beat the timer,
+      // hiding the lag a synchronous binding would have caused.
+      await new Promise(resolve => setTimeout(resolve, 100));
+      clearInterval(interval);
+    }
+
+    // Synchronous binding: lag ~= full conversion time (~1s+ for this file).
+    expect(maxLag).toBeLessThan(250);
+  }, 30000);
+});


### PR DESCRIPTION
## Problem

`convert_document_to_markdown` in `apps/api/native/src/document.rs` was a synchronous `#[napi]` fn, so the `await` at its call site in the document engine was a no-op. Every DOCX/ODT/RTF/XLSX/PPTX/EPUB conversion ran directly on the Node.js event loop of whichever pod executed the scrape — including API app pods that run sync scrapes in-process — freezing every unrelated in-flight request for the duration of the conversion.

This is the same bug class fixed for PDFs in e33e1f6c1 (`processPdf`/`detectPdf`).

## Fix

- Convert `convert_document_to_markdown` to `pub async fn` that offloads the CPU-bound conversion to tokio's blocking thread pool via `tokio::task::spawn_blocking`, mirroring the pattern in `apps/api/native/src/pdf.rs`. The binding now takes an owned `Uint8Array` and returns `Promise<string>`.
- The engine call site already `await`ed, so it needed no change; the direct calls in the document-converter snips test are now awaited.

## Tests

- New regression test `apps/api/src/scraper/scrapeURL/engines/document/__tests__/nativeBinding.test.ts`, modeled on the PDF one: generates a ~20MB RTF (no fixtures) whose conversion takes ~1s of CPU and asserts max event-loop lag stays under 250ms. With the old synchronous binding, lag ≈ the full conversion time; with this fix it measures ~2ms.
- Existing document-converter snips tests pass against the async binding (happy paths for DOCX/ODT/RTF/XLSX/CSV and the failure path for unrecognized bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes native document conversion (DOCX/ODT/RTF/XLSX/PPTX/EPUB) run off the Node.js event loop so large conversions no longer freeze unrelated in-flight requests.

**Bug Fixes**
- The old binding was synchronous, so the `await` at the engine call site was a no-op and the full conversion blocked the event loop.
- Conversion now offloads to tokio's blocking thread pool via `spawn_blocking`, matching the PDF `processPdf`/`detectPdf` fix.
- The binding takes an owned `Uint8Array` and returns `Promise<string>`; the engine call site already awaited and needed no change.
- Adds a regression test that generates a ~20MB RTF and asserts event-loop lag stays under 250ms.

<sup>Written for commit ce2be957b94d1e6acdc3ee32f261188db6970021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

