### PR TITLE
Raise the privileged large-PDF cap to the 256MB architectural ceiling

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -387,7 +387,7 @@ const configSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(200 * 1024 * 1024),
+    .default(256 * 1024 * 1024),
   // Comma-separated team ids granted the privileged cap.
   PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS: z.string().optional(),
 

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/fireEngineHandoff.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/fireEngineHandoff.test.ts
@@ -202,10 +202,10 @@ describe("largePdfLimitBytes (team tiers)", () => {
     expect(largePdfLimitBytes(metaForTeam(undefined))).toBe(50 * 1024 * 1024);
   });
 
-  it("returns the privileged cap (200MB) for allowlisted teams", () => {
+  it("returns the privileged cap (256MB) for allowlisted teams", () => {
     (config as any).PDF_BY_REFERENCE_PRIVILEGED_TEAM_IDS = "team-a, team-b";
-    expect(largePdfLimitBytes(metaForTeam("team-a"))).toBe(200 * 1024 * 1024);
-    expect(largePdfLimitBytes(metaForTeam("team-b"))).toBe(200 * 1024 * 1024);
+    expect(largePdfLimitBytes(metaForTeam("team-a"))).toBe(256 * 1024 * 1024);
+    expect(largePdfLimitBytes(metaForTeam("team-b"))).toBe(256 * 1024 * 1024);
   });
 
   it("clamps configured caps to the 256MB architectural ceiling", () => {


### PR DESCRIPTION
## What

Raises the default of `PDF_BY_REFERENCE_MAX_BYTES_PRIVILEGED` from 200MB to 256MB, matching the `FIRE_PDF_BY_REFERENCE_MAX_FILE_SIZE` architectural ceiling. Updates the test that pinned the old default.

## Why

Every other layer is already sized for 256MB — `largePdfLimitBytes` clamps to the 256MB ceiling on every acquisition path, and the downstream PDF service accepts 256MB GCS inputs. The 200MB privileged default was the one remaining gap, rejecting documents in the 200–256MB range that the rest of the pipeline handles fine.

No behavior change for non-allowlisted teams (default cap stays 50MB).

## Verification

- `vitest run …/fireEngineHandoff.test.ts` — 16/16 pass
- `tsc --noEmit` — clean
- Local cubic review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the privileged large-PDF cap from 200MB to 256MB, matching the architectural ceiling the rest of the pipeline already uses. The old cap rejected documents in the 200–256MB range that downstream layers handle; now allowlisted teams can process them. No change for non-allowlisted teams (default remains 50MB). Updates the test that pinned the old value.

<sup>Written for commit bf646f15cd7e6505174df3445304d80849eb1508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

