### PR TITLE
fix(api): treat empty OPENAI_API_KEY/BASE_URL as unset (#4083)

### DIFF
--- a/apps/api/src/__tests__/config.test.ts
+++ b/apps/api/src/__tests__/config.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+// config.ts runs `validatedConfigSchema.parse(process.env)` at import time, so
+// each case sets the env then imports the module fresh via vi.resetModules().
+// Modeled on the env-reload pattern in snips/v2/audio-routing.test.ts.
+describe("config emptyStringAsUndefined (OPENAI_API_KEY / OPENAI_BASE_URL)", () => {
+  const originalOpenAiKey = process.env.OPENAI_API_KEY;
+  const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
+
+  async function loadConfig() {
+    vi.resetModules();
+    const mod = await import("../config.js");
+    return mod.config;
+  }
+
+  afterAll(() => {
+    if (originalOpenAiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    }
+    if (originalOpenAiBaseUrl === undefined) {
+      delete process.env.OPENAI_BASE_URL;
+    } else {
+      process.env.OPENAI_BASE_URL = originalOpenAiBaseUrl;
+    }
+  });
+
+  it("treats an empty string as undefined (docker-compose ${VAR} passthrough)", async () => {
+    process.env.OPENAI_API_KEY = "";
+    process.env.OPENAI_BASE_URL = "";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBeUndefined();
+    expect(config.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("treats whitespace-only strings as undefined", async () => {
+    process.env.OPENAI_API_KEY = "   ";
+    process.env.OPENAI_BASE_URL = "\t\n ";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBeUndefined();
+    expect(config.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("passes real values through unchanged", async () => {
+    process.env.OPENAI_API_KEY = "sk-real-key";
+    process.env.OPENAI_BASE_URL = "https://api.openai.com/v1";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBe("sk-real-key");
+    expect(config.OPENAI_BASE_URL).toBe("https://api.openai.com/v1");
+  });
+
+  it("leaves unset vars undefined", async () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBeUndefined();
+    expect(config.OPENAI_BASE_URL).toBeUndefined();
+  });
+});

--- a/apps/api/src/__tests__/snips/v2/config.test.ts
+++ b/apps/api/src/__tests__/snips/v2/config.test.ts
@@ -6,6 +6,8 @@ import { afterAll, describe, expect, it, vi } from "vitest";
 describe("config empty/whitespace OpenAI env vars (#4083)", () => {
   const originalOpenAiKey = process.env.OPENAI_API_KEY;
   const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
+  const originalFirebrainUrl = process.env.FIREBRAIN_TRACKS_URL;
+  const originalFirebrainApiKey = process.env.FIREBRAIN_TRACKS_API_KEY;
 
   async function loadConfig() {
     vi.resetModules();
@@ -23,6 +25,16 @@ describe("config empty/whitespace OpenAI env vars (#4083)", () => {
       delete process.env.OPENAI_BASE_URL;
     } else {
       process.env.OPENAI_BASE_URL = originalOpenAiBaseUrl;
+    }
+    if (originalFirebrainUrl === undefined) {
+      delete process.env.FIREBRAIN_TRACKS_URL;
+    } else {
+      process.env.FIREBRAIN_TRACKS_URL = originalFirebrainUrl;
+    }
+    if (originalFirebrainApiKey === undefined) {
+      delete process.env.FIREBRAIN_TRACKS_API_KEY;
+    } else {
+      process.env.FIREBRAIN_TRACKS_API_KEY = originalFirebrainApiKey;
     }
   });
 
@@ -74,12 +86,12 @@ describe("config empty/whitespace OpenAI env vars (#4083)", () => {
     expect(process.env.OPENAI_BASE_URL).toBe("https://api.openai.com/v1");
   });
 
-  it("keeps whitespace-padded real values untrimmed", async () => {
+  it("trims whitespace-padded real values", async () => {
     process.env.OPENAI_API_KEY = "  sk-key  ";
     process.env.OPENAI_BASE_URL = " https://api.openai.com/v1\n";
     const config = await loadConfig();
-    expect(config.OPENAI_API_KEY).toBe("  sk-key  ");
-    expect(config.OPENAI_BASE_URL).toBe(" https://api.openai.com/v1\n");
+    expect(config.OPENAI_API_KEY).toBe("sk-key");
+    expect(config.OPENAI_BASE_URL).toBe("https://api.openai.com/v1");
   });
 
   it("preserves FIREBRAIN_TRACKS whitespace semantics after helper consolidation", async () => {

--- a/apps/api/src/__tests__/snips/v2/config.test.ts
+++ b/apps/api/src/__tests__/snips/v2/config.test.ts
@@ -3,13 +3,13 @@ import { afterAll, describe, expect, it, vi } from "vitest";
 // config.ts runs `validatedConfigSchema.parse(process.env)` at import time, so
 // each case sets the env then imports the module fresh via vi.resetModules().
 // Modeled on the env-reload pattern in snips/v2/audio-routing.test.ts.
-describe("config emptyStringAsUndefined (OPENAI_API_KEY / OPENAI_BASE_URL)", () => {
+describe("config empty/whitespace OpenAI env vars (#4083)", () => {
   const originalOpenAiKey = process.env.OPENAI_API_KEY;
   const originalOpenAiBaseUrl = process.env.OPENAI_BASE_URL;
 
   async function loadConfig() {
     vi.resetModules();
-    const mod = await import("../config.js");
+    const mod = await import("../../../config.js");
     return mod.config;
   }
 
@@ -56,5 +56,43 @@ describe("config emptyStringAsUndefined (OPENAI_API_KEY / OPENAI_BASE_URL)", () 
     const config = await loadConfig();
     expect(config.OPENAI_API_KEY).toBeUndefined();
     expect(config.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("deletes empty-string keys from process.env so the AI SDK env fallback cannot resurrect them", async () => {
+    process.env.OPENAI_API_KEY = "";
+    process.env.OPENAI_BASE_URL = "";
+    await loadConfig();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("does not delete process.env when values are real", async () => {
+    process.env.OPENAI_API_KEY = "sk-real-key";
+    process.env.OPENAI_BASE_URL = "https://api.openai.com/v1";
+    await loadConfig();
+    expect(process.env.OPENAI_API_KEY).toBe("sk-real-key");
+    expect(process.env.OPENAI_BASE_URL).toBe("https://api.openai.com/v1");
+  });
+
+  it("keeps whitespace-padded real values untrimmed", async () => {
+    process.env.OPENAI_API_KEY = "  sk-key  ";
+    process.env.OPENAI_BASE_URL = " https://api.openai.com/v1\n";
+    const config = await loadConfig();
+    expect(config.OPENAI_API_KEY).toBe("  sk-key  ");
+    expect(config.OPENAI_BASE_URL).toBe(" https://api.openai.com/v1\n");
+  });
+
+  it("preserves FIREBRAIN_TRACKS whitespace semantics after helper consolidation", async () => {
+    process.env.FIREBRAIN_TRACKS_URL = "   ";
+    process.env.FIREBRAIN_TRACKS_API_KEY = "   ";
+    const config = await loadConfig();
+    expect(config.FIREBRAIN_TRACKS_URL).toBeUndefined();
+    expect(config.FIREBRAIN_TRACKS_API_KEY).toBeUndefined();
+
+    process.env.FIREBRAIN_TRACKS_URL = "https://tracks.example.com";
+    process.env.FIREBRAIN_TRACKS_API_KEY = "sk-firebrain";
+    const config2 = await loadConfig();
+    expect(config2.FIREBRAIN_TRACKS_URL).toBe("https://tracks.example.com");
+    expect(config2.FIREBRAIN_TRACKS_API_KEY).toBe("sk-firebrain");
   });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -11,6 +11,16 @@ const delimitedList = (separator = ",") => {
 };
 
 const emptyStringAsUndefined = <T extends z.ZodTypeAny>(schema: T) =>
+  z.preprocess(value => (value === "" ? undefined : value), schema.optional());
+
+// Like emptyStringAsUndefined but also coerces whitespace-only strings (e.g.
+// docker-compose `${VAR}` passthrough can produce "  "). Only used for fields
+// where a whitespace-only value is never meaningful and silent-disable is the
+// correct semantics — do NOT use for credential/URL fields that must fail
+// closed at boot (FIREBILL_*, KEYLESS_*, MCP_DELEGATED_*, ...).
+const emptyOrWhitespaceStringAsUndefined = <T extends z.ZodTypeAny>(
+  schema: T,
+) =>
   z.preprocess(
     value =>
       typeof value === "string" && value.trim() === "" ? undefined : value,
@@ -77,8 +87,10 @@ const configSchema = z.object({
   FIRECRAWL_DASHBOARD_URL: z.url().default("https://www.firecrawl.dev"),
   SUPPORT_AGENT_URL: z.string().url().optional(),
   SUPPORT_AGENT_VERCEL_BYPASS_SECRET: z.string().optional(),
-  FIREBRAIN_TRACKS_URL: emptyStringAsUndefined(z.string().url()),
-  FIREBRAIN_TRACKS_API_KEY: emptyStringAsUndefined(z.string().trim()),
+  FIREBRAIN_TRACKS_URL: emptyOrWhitespaceStringAsUndefined(z.string().url()),
+  FIREBRAIN_TRACKS_API_KEY: emptyOrWhitespaceStringAsUndefined(
+    z.string().trim(),
+  ),
   RESEARCH_PROXY_URL: z.string().url().optional(),
   RESEARCH_KEYLESS_DISABLED: researchKeylessDisabled,
   LABS_SEARCH_URL: z.string().url().optional(),
@@ -154,11 +166,12 @@ const configSchema = z.object({
     z.string().trim().min(1),
   ),
   // Empty strings from docker-compose ${VAR} passthrough must become
-  // undefined: an empty value would otherwise be forwarded to createOpenAI as
-  // a literal apiKey/baseURL and falsely signal provider availability,
-  // producing opaque "Failed to parse URL" failures (see #4083).
-  OPENAI_API_KEY: emptyStringAsUndefined(z.string()),
-  OPENAI_BASE_URL: emptyStringAsUndefined(z.string()),
+  // undefined. Note this alone is not enough: @ai-sdk/openai re-reads
+  // process.env at request time when the createOpenAI option is undefined
+  // (loadApiKey / loadOptionalSetting), so config.ts also deletes these keys
+  // from process.env below after parsing (see #4083).
+  OPENAI_API_KEY: emptyOrWhitespaceStringAsUndefined(z.string()),
+  OPENAI_BASE_URL: emptyOrWhitespaceStringAsUndefined(z.string()),
   OPENROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
@@ -572,3 +585,19 @@ const validatedConfigSchema = configSchema.superRefine((value, context) => {
 });
 
 export const config = validatedConfigSchema.parse(process.env);
+
+// @ai-sdk/openai resolves apiKey/baseURL lazily per request and falls back to
+// process.env when the createOpenAI option is undefined. Docker Compose passes
+// unset .env vars through as empty strings, so unless we remove them here the
+// SDK would resurrect "" and produce `Failed to parse URL from /responses` —
+// a silent json-format failure that still bills credits (see #4083).
+for (const key of ["OPENAI_API_KEY", "OPENAI_BASE_URL"] as const) {
+  if (config[key] === undefined && process.env[key] !== undefined) {
+    delete process.env[key];
+    // console.warn (not the winston logger): config.ts is imported before the
+    // logger exists, and logger.ts imports config — a cycle.
+    console.warn(
+      `[config] ${key} is set but empty/whitespace-only; the OpenAI provider will be unavailable (see #4083)`,
+    );
+  }
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -170,8 +170,8 @@ const configSchema = z.object({
   // process.env at request time when the createOpenAI option is undefined
   // (loadApiKey / loadOptionalSetting), so config.ts also deletes these keys
   // from process.env below after parsing (see #4083).
-  OPENAI_API_KEY: emptyOrWhitespaceStringAsUndefined(z.string()),
-  OPENAI_BASE_URL: emptyOrWhitespaceStringAsUndefined(z.string()),
+  OPENAI_API_KEY: emptyOrWhitespaceStringAsUndefined(z.string().trim()),
+  OPENAI_BASE_URL: emptyOrWhitespaceStringAsUndefined(z.string().trim()),
   OPENROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),
@@ -597,7 +597,9 @@ for (const key of ["OPENAI_API_KEY", "OPENAI_BASE_URL"] as const) {
     // console.warn (not the winston logger): config.ts is imported before the
     // logger exists, and logger.ts imports config — a cycle.
     console.warn(
-      `[config] ${key} is set but empty/whitespace-only; the OpenAI provider will be unavailable (see #4083)`,
+      key === "OPENAI_API_KEY"
+        ? "[config] OPENAI_API_KEY is set but empty/whitespace-only; the OpenAI provider will be unavailable (see #4083)"
+        : "[config] OPENAI_BASE_URL is set but empty/whitespace-only; defaulting to https://api.openai.com/v1 (see #4083)",
     );
   }
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -11,7 +11,11 @@ const delimitedList = (separator = ",") => {
 };
 
 const emptyStringAsUndefined = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess(value => (value === "" ? undefined : value), schema.optional());
+  z.preprocess(
+    value =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    schema.optional(),
+  );
 
 const emptyStringAsDefault = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess(value => (value === "" ? undefined : value), schema);
@@ -155,8 +159,10 @@ const configSchema = z.object({
   S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY: emptyStringAsUndefined(
     z.string().trim().min(1),
   ),
-  OPENAI_API_KEY: z.string().optional(),
-  OPENAI_BASE_URL: z.string().optional(),
+  // Empty strings from docker-compose ${VAR} passthrough must become undefined
+  // so loadApiKey / createOpenAI fall back correctly (see #4083).
+  OPENAI_API_KEY: emptyStringAsUndefined(z.string()),
+  OPENAI_BASE_URL: emptyStringAsUndefined(z.string()),
   OPENROUTER_API_KEY: z.string().optional(),
   XAI_API_KEY: z.string().optional(),
   LLAMAPARSE_API_KEY: z.string().optional(),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -77,14 +77,8 @@ const configSchema = z.object({
   FIRECRAWL_DASHBOARD_URL: z.url().default("https://www.firecrawl.dev"),
   SUPPORT_AGENT_URL: z.string().url().optional(),
   SUPPORT_AGENT_VERCEL_BYPASS_SECRET: z.string().optional(),
-  FIREBRAIN_TRACKS_URL: z.preprocess(
-    v => (typeof v === "string" && v.trim() === "" ? undefined : v),
-    z.string().url().optional(),
-  ),
-  FIREBRAIN_TRACKS_API_KEY: z.preprocess(
-    v => (typeof v === "string" && v.trim() === "" ? undefined : v),
-    z.string().trim().optional(),
-  ),
+  FIREBRAIN_TRACKS_URL: emptyStringAsUndefined(z.string().url()),
+  FIREBRAIN_TRACKS_API_KEY: emptyStringAsUndefined(z.string().trim()),
   RESEARCH_PROXY_URL: z.string().url().optional(),
   RESEARCH_KEYLESS_DISABLED: researchKeylessDisabled,
   LABS_SEARCH_URL: z.string().url().optional(),
@@ -159,8 +153,10 @@ const configSchema = z.object({
   S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY: emptyStringAsUndefined(
     z.string().trim().min(1),
   ),
-  // Empty strings from docker-compose ${VAR} passthrough must become undefined
-  // so loadApiKey / createOpenAI fall back correctly (see #4083).
+  // Empty strings from docker-compose ${VAR} passthrough must become
+  // undefined: an empty value would otherwise be forwarded to createOpenAI as
+  // a literal apiKey/baseURL and falsely signal provider availability,
+  // producing opaque "Failed to parse URL" failures (see #4083).
   OPENAI_API_KEY: emptyStringAsUndefined(z.string()),
   OPENAI_BASE_URL: emptyStringAsUndefined(z.string()),
   OPENROUTER_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary

Self-hosted deployments that pass `OPENAI_API_KEY` / `OPENAI_BASE_URL` through docker-compose `${VAR}` passthrough receive empty strings when the variables are unset in `.env`. The config schema accepted `""`, so `createOpenAI` received a literal empty `apiKey`/`baseURL`, and `formats: ["json"]` requests failed with `Failed to parse URL from /responses` — returning `success: true` with no `json` field while still billing credits.

Fixes #4083.

## What changed

- `emptyStringAsUndefined` keeps its exact-`""` semantics. A new `emptyOrWhitespaceStringAsUndefined` helper also coerces whitespace-only strings, and is used only where a whitespace-only value is never meaningful: `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and the `FIREBRAIN_TRACKS_*` pair (which already had inline trim behavior).
- Credential and URL fields that must fail closed at boot (`FIREBILL_URL`, `FIREBILL_SECRET`, `KEYLESS_CONVERSION_HMAC_SECRET`, `MCP_DELEGATED_CREDENTIAL_SECRET`, etc.) are untouched — a whitespace-only `FIREBILL_URL` still fails validation at startup instead of silently disabling billing routing.
- Config-layer coercion alone was not enough: `@ai-sdk/openai` re-reads `process.env` at request time via `loadApiKey` / `loadOptionalSetting` when the `createOpenAI` option is `undefined`. So `config.ts` now deletes `OPENAI_API_KEY` / `OPENAI_BASE_URL` from `process.env` after parsing when they were coerced to `undefined`, and warns at boot. The SDK then raises the intended missing-key error and falls back to the default base URL.
- The regression test moved into `src/__tests__/snips/v2/` so CI's `pnpm harness pnpm test:snips` lane executes it, and now also asserts `process.env` deletion, FIREBRAIN behavior, and whitespace-padded passthrough.

## Verification

- `vitest run src/__tests__/snips/v2/config.test.ts` — 8/8 pass (empty, whitespace-only, real, unset, `process.env` deletion, FIREBRAIN, padded passthrough).
- Empirically verified against the installed `@ai-sdk/openai` 3.0.71: before, env `""` produced request URL `"/responses"` (the `ERR_INVALID_URL` failure); after, the resolved URL uses the default `https://api.openai.com/v1` base.
- `vitest run src/search/highlights.test.ts src/lib/threat-protection/config.test.ts` — pass (45 tests total).
- `tsc --noEmit` — no errors in changed files (remaining repo-wide errors are pre-existing `@mendable/firecrawl-rs` native-module resolution, built by CI).

## Impact

- No migration, no deployment changes, no SDK/API surface changes.
- Operators with a set-but-empty OpenAI key now see a boot warning instead of silent per-request failures that still bill credits.
- Behavior for all other `emptyStringAsUndefined` users is unchanged (exact-`""` semantics preserved).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-hosted deployments where docker-compose `${VAR}` passthrough exposes empty `OPENAI_API_KEY` and `OPENAI_BASE_URL` strings. Empty and whitespace-only values are now treated as unset, so `@ai-sdk/openai` raises the intended missing-key error and falls back to the default base URL instead of failing per-request and still billing credits.

**Bug Fixes**

- Added `emptyOrWhitespaceStringAsUndefined` for `OPENAI_*` and `FIREBRAIN_TRACKS_*` vars; real values are trimmed so padded keys and URLs reach the SDK normalized.
- Deletes coerced-to-undefined OpenAI keys from `process.env` after config parse, since the SDK re-reads env at request time. Boot warnings differentiate: an empty key makes the OpenAI provider unavailable, while an empty base URL falls back to the default.
- Other fail-closed fields (`FIREBILL_*`, `KEYLESS_*`, `MCP_DELEGATED_*`) keep exact-`""` semantics, so whitespace-only values still fail validation at startup.
- Regression tests moved to `src/__tests__/snips/v2/` so CI's snips lane runs them; coverage includes empty, whitespace-only, real, unset, trimming, and `process.env` deletion cases.

<sup>Written for commit 0fdb5906bc1dd54dceb51b3cce19c71243d03fa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

