### PR TITLE
feat(python-sdk): configurable origin attribution for Arcade and other integrators

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_origin.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_origin.py
@@ -1,0 +1,28 @@
+"""Unit tests for configurable request origin attribution."""
+
+from firecrawl.v2.utils.http_client import HttpClient
+from firecrawl.v2.utils.http_client_async import AsyncHttpClient
+from firecrawl.v2.utils.get_version import get_version
+
+
+def test_http_client_default_origin():
+    client = HttpClient(api_key="fc-test", api_url="https://api.firecrawl.dev")
+    assert client.origin == f"python-sdk@{get_version()}"
+
+
+def test_http_client_custom_origin():
+    client = HttpClient(
+        api_key="fc-test",
+        api_url="https://api.firecrawl.dev",
+        origin="arcade-mcp",
+    )
+    assert client.origin == "arcade-mcp"
+
+
+def test_async_http_client_custom_origin():
+    client = AsyncHttpClient(
+        api_key="fc-test",
+        api_url="https://api.firecrawl.dev",
+        origin="arcade-mcp",
+    )
+    assert client.origin == "arcade-mcp"

--- a/apps/python-sdk/firecrawl/client.py
+++ b/apps/python-sdk/firecrawl/client.py
@@ -241,6 +241,7 @@ class Firecrawl:
         timeout: float = None,
         max_retries: int = 3,
         backoff_factor: float = 0.5,
+        origin: str = None,
     ):
         """Initialize the unified client.
 
@@ -250,6 +251,8 @@ class Firecrawl:
             timeout: Default request timeout in seconds for all HTTP requests
             max_retries: Maximum number of retries for failed requests (default: 3)
             backoff_factor: Exponential backoff factor for retries (default: 0.5)
+            origin: Attribution string stamped into API request payloads
+                (defaults to ``python-sdk@<version>``)
         """
         self.api_key = api_key
         self.api_url = api_url
@@ -262,6 +265,7 @@ class Firecrawl:
             timeout=timeout,
             max_retries=max_retries,
             backoff_factor=backoff_factor,
+            origin=origin,
         ) if V2FirecrawlClient else None
         
         # Create version-specific proxies
@@ -289,6 +293,7 @@ class Firecrawl:
 
         self.crawl = self._v2_client.crawl
         self.start_crawl = self._v2_client.start_crawl
+        self.wait_crawl = self._v2_client.wait_crawl
         self.crawl_params_preview = self._v2_client.crawl_params_preview
         self.get_crawl_status = self._v2_client.get_crawl_status
         self.get_crawl_status_page = self._v2_client.get_crawl_status_page
@@ -386,6 +391,7 @@ class AsyncFirecrawl:
         timeout: float = None,
         max_retries: int = 3,
         backoff_factor: float = 0.5,
+        origin: str = None,
     ):
         self.api_key = api_key
         self.api_url = api_url
@@ -398,6 +404,7 @@ class AsyncFirecrawl:
             timeout=timeout,
             max_retries=max_retries,
             backoff_factor=backoff_factor,
+            origin=origin,
         ) if AsyncFirecrawlClient else None
         
         # Create version-specific proxies
@@ -426,6 +433,7 @@ class AsyncFirecrawl:
         self.get_monitor_check = self._v2_client.get_monitor_check
 
         self.start_crawl = self._v2_client.start_crawl
+        self.wait_crawl = self._v2_client.wait_crawl
         self.get_crawl_status = self._v2_client.get_crawl_status
         self.get_crawl_status_page = self._v2_client.get_crawl_status_page
         self.cancel_crawl = self._v2_client.cancel_crawl

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -111,7 +111,8 @@ class FirecrawlClient:
         api_url: str = "https://api.firecrawl.dev",
         timeout: Optional[float] = None,
         max_retries: int = 3,
-        backoff_factor: float = 0.5
+        backoff_factor: float = 0.5,
+        origin: Optional[str] = None,
     ):
         """
         Initialize the Firecrawl client.
@@ -122,6 +123,8 @@ class FirecrawlClient:
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries for failed requests
             backoff_factor: Exponential backoff factor for retries (e.g. 0.5 means wait 0.5s, then 1s, then 2s between retries)
+            origin: Attribution string stamped into API request payloads
+                (defaults to ``python-sdk@<version>``)
         """
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
@@ -145,6 +148,7 @@ class FirecrawlClient:
             timeout=timeout,
             max_retries=max_retries,
             backoff_factor=backoff_factor,
+            origin=origin,
         )
     
     def scrape(

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -90,6 +90,7 @@ class AsyncFirecrawlClient:
         timeout: Optional[float] = None,
         max_retries: int = 3,
         backoff_factor: float = 0.5,
+        origin: Optional[str] = None,
     ):
         if api_key is None:
             api_key = os.getenv("FIRECRAWL_API_KEY")
@@ -101,6 +102,7 @@ class AsyncFirecrawlClient:
             timeout=timeout,
             max_retries=max_retries,
             backoff_factor=backoff_factor,
+            origin=origin,
         )
         self.async_http_client = AsyncHttpClient(
             api_key,
@@ -108,6 +110,7 @@ class AsyncFirecrawlClient:
             timeout=timeout,
             max_retries=max_retries,
             backoff_factor=backoff_factor,
+            origin=origin,
         )
 
     # Scrape

--- a/apps/python-sdk/firecrawl/v2/methods/aio/agent.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/agent.py
@@ -103,7 +103,7 @@ async def start_agent(
         audit_metadata=audit_metadata,
     )
     resp = await client.post("/v2/agent", body)
-    if not resp.ok:
+    if resp.status_code >= 400:
         handle_response_error(resp, "agent")
     payload = _normalize_agent_response_payload(resp.json())
     return AgentResponse(**payload)
@@ -111,7 +111,7 @@ async def start_agent(
 
 async def get_agent_status(client: AsyncHttpClient, job_id: str) -> AgentResponse:
     resp = await client.get(f"/v2/agent/{job_id}")
-    if not resp.ok:
+    if resp.status_code >= 400:
         handle_response_error(resp, "agent-status")
     payload = _normalize_agent_response_payload(resp.json())
     return AgentResponse(**payload)
@@ -188,7 +188,7 @@ async def get_agent_trace(
     if live_view:
         endpoint += "?liveView=true"
     resp = await client.get(endpoint)
-    if not resp.ok:
+    if resp.status_code >= 400:
         handle_response_error(resp, "agent-trace")
     return AgentTraceResponse(**resp.json())
 
@@ -206,7 +206,7 @@ async def get_agent_snapshot(
         snapshot_id: Snapshot ID from an artifact.updated trace event
     """
     resp = await client.get(f"/v2/agent/{job_id}/snapshots/{snapshot_id}")
-    if not resp.ok:
+    if resp.status_code >= 400:
         handle_response_error(resp, "agent-snapshot")
     return AgentSnapshotResponse(**resp.json())
 
@@ -226,6 +226,6 @@ async def cancel_agent(client: AsyncHttpClient, job_id: str) -> bool:
         Exception: If the cancellation fails
     """
     resp = await client.delete(f"/v2/agent/{job_id}")
-    if not resp.ok:
+    if resp.status_code >= 400:
         handle_response_error(resp, "cancel agent")
     return resp.json().get("success", False)

--- a/apps/python-sdk/firecrawl/v2/methods/aio/research.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/research.py
@@ -44,7 +44,11 @@ from ..research_docs import (
 
 
 BASE = "/v2/search/research"
-ORIGIN = f"python-sdk@{get_version()}"
+_DEFAULT_ORIGIN = f"python-sdk@{get_version()}"
+
+
+def _origin(client: AsyncHttpClient) -> str:
+    return getattr(client, "origin", None) or _DEFAULT_ORIGIN
 
 
 def _query(params: Dict[str, Any]) -> str:
@@ -89,7 +93,7 @@ async def search_papers(
                 "categories": categories,
                 "from": from_date,
                 "to": to_date,
-                "origin": ORIGIN,
+                "origin": _origin(client),
             }
         ),
     )
@@ -99,7 +103,7 @@ async def search_papers(
 async def inspect_paper(client: AsyncHttpClient, paper_id: str) -> Dict[str, Any]:
     return await _get(
         client,
-        f"{BASE}/papers/{quote(paper_id, safe='')}" + _query({"origin": ORIGIN}),
+        f"{BASE}/papers/{quote(paper_id, safe='')}" + _query({"origin": _origin(client)}),
     )
 
 
@@ -114,7 +118,7 @@ async def read_paper(
     return await _get(
         client,
         f"{BASE}/papers/{quote(paper_id, safe='')}"
-        + _query({"query": query, "k": k, "origin": ORIGIN}),
+        + _query({"query": query, "k": k, "origin": _origin(client)}),
     )
 
 
@@ -139,7 +143,7 @@ async def related_papers(
                 "k": k,
                 "rerank": None if rerank is None else str(rerank).lower(),
                 "anchor": anchor,
-                "origin": ORIGIN,
+                "origin": _origin(client),
             }
         ),
     )
@@ -154,5 +158,5 @@ async def search_github(
 ) -> Dict[str, Any]:
     return await _get(
         client,
-        BASE + "/github" + _query({"query": query, "k": k, "origin": ORIGIN}),
+        BASE + "/github" + _query({"query": query, "k": k, "origin": _origin(client)}),
     )

--- a/apps/python-sdk/firecrawl/v2/methods/research.py
+++ b/apps/python-sdk/firecrawl/v2/methods/research.py
@@ -43,7 +43,11 @@ from .research_docs import (
 
 
 BASE = "/v2/search/research"
-ORIGIN = f"python-sdk@{get_version()}"
+_DEFAULT_ORIGIN = f"python-sdk@{get_version()}"
+
+
+def _origin(client: HttpClient) -> str:
+    return getattr(client, "origin", None) or _DEFAULT_ORIGIN
 
 
 def _query(params: Dict[str, Any]) -> str:
@@ -88,7 +92,7 @@ def search_papers(
                 "categories": categories,
                 "from": from_date,
                 "to": to_date,
-                "origin": ORIGIN,
+                "origin": _origin(client),
             }
         ),
     )
@@ -98,7 +102,7 @@ def search_papers(
 def inspect_paper(client: HttpClient, paper_id: str) -> Dict[str, Any]:
     return _get(
         client,
-        f"{BASE}/papers/{quote(paper_id, safe='')}" + _query({"origin": ORIGIN}),
+        f"{BASE}/papers/{quote(paper_id, safe='')}" + _query({"origin": _origin(client)}),
     )
 
 
@@ -113,7 +117,7 @@ def read_paper(
     return _get(
         client,
         f"{BASE}/papers/{quote(paper_id, safe='')}"
-        + _query({"query": query, "k": k, "origin": ORIGIN}),
+        + _query({"query": query, "k": k, "origin": _origin(client)}),
     )
 
 
@@ -138,7 +142,7 @@ def related_papers(
                 "k": k,
                 "rerank": None if rerank is None else str(rerank).lower(),
                 "anchor": anchor,
-                "origin": ORIGIN,
+                "origin": _origin(client),
             }
         ),
     )
@@ -153,5 +157,5 @@ def search_github(
 ) -> Dict[str, Any]:
     return _get(
         client,
-        BASE + "/github" + _query({"query": query, "k": k, "origin": ORIGIN}),
+        BASE + "/github" + _query({"query": query, "k": k, "origin": _origin(client)}),
     )

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -20,12 +20,15 @@ class HttpClient:
         timeout: Optional[float] = None,
         max_retries: int = 3,
         backoff_factor: float = 0.5,
+        origin: Optional[str] = None,
     ):
         self.api_key = api_key
         self.api_url = api_url
         self.timeout = timeout
         self.max_retries = max_retries
         self.backoff_factor = backoff_factor
+        # Attribution string stamped into request payloads / research query params.
+        self.origin = origin or f"python-sdk@{version}"
 
     def _build_url(self, endpoint: str) -> str:
         base = urlparse(self.api_url)
@@ -88,7 +91,7 @@ class HttpClient:
             backoff_factor = self.backoff_factor
 
         payload = dict(data)
-        payload['origin'] = f'python-sdk@{version}'
+        payload['origin'] = self.origin
 
         url = self._build_url(endpoint)
 
@@ -285,7 +288,7 @@ class HttpClient:
             backoff_factor = self.backoff_factor
 
         payload = dict(data)
-        payload['origin'] = f'python-sdk@{version}'
+        payload['origin'] = self.origin
         url = self._build_url(endpoint)
 
         last_exception = None

--- a/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
@@ -14,12 +14,15 @@ class AsyncHttpClient:
         timeout: Optional[float] = None,
         max_retries: int = 3,
         backoff_factor: float = 0.5,
+        origin: Optional[str] = None,
     ):
         self.api_key = api_key
         self.api_url = api_url
         self.timeout = timeout
         self.max_retries = max_retries
         self.backoff_factor = backoff_factor
+        # Attribution string stamped into request payloads / research query params.
+        self.origin = origin or f"python-sdk@{version}"
 
         headers = {}
 
@@ -58,7 +61,7 @@ class AsyncHttpClient:
             backoff_factor = self.backoff_factor
 
         payload = dict(data)
-        payload["origin"] = f"python-sdk@{version}"
+        payload["origin"] = self.origin
 
         last_exception = None
         num_attempts = max(1, retries)
@@ -219,7 +222,7 @@ class AsyncHttpClient:
             backoff_factor = self.backoff_factor
 
         payload = dict(data)
-        payload["origin"] = f"python-sdk@{version}"
+        payload["origin"] = self.origin
 
         last_exception = None
         num_attempts = max(1, retries)


### PR DESCRIPTION
## Summary
- Add optional `origin=` on `Firecrawl` / `AsyncFirecrawl` and v2 HTTP clients so integrators can stamp attribution (e.g. `arcade-mcp`) instead of the hardcoded `python-sdk@version`
- Thread origin through research GET helpers via `client.origin`
- Expose `wait_crawl` on the top-level async client (parity with sync)
- Fix async agent methods to use `status_code >= 400` instead of `resp.ok` (httpx has no `.ok`)

## Test plan
- [x] `pytest apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_origin.py`
- [ ] Confirm scrape/search payloads include custom `origin` when constructed with `origin="arcade-mcp"`
- [ ] Confirm research GETs include `origin` query param from the client

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable request origin attribution to the Python SDK so integrators like Arcade can stamp their own identifier (e.g. `arcade-mcp`) instead of the hardcoded `python-sdk@<version>`. Defaults to `python-sdk@<version>` when no `origin=` is provided, so existing callers are unaffected.

**New Features**
- Adds an optional `origin=` argument to `Firecrawl`, `AsyncFirecrawl`, and the v2 HTTP clients.
- Threads the configured origin through research GET helpers so all request types carry it.
- Exposes `wait_crawl` on `AsyncFirecrawl`, matching the sync client.

**Bug Fixes**
- Fixes async agent methods to use `status_code >= 400` since httpx responses have no `.ok` attribute.

<sup>Written for commit e5705545c62a4e9c01714a0927ab316ea1242d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

