### PR TITLE
fix(python-sdk): preserve api_url path prefix in v2 HttpClient._build_url

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_build_url.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_build_url.py
@@ -1,0 +1,31 @@
+from firecrawl.v2.utils.http_client import HttpClient
+
+
+class TestBuildUrlPathPrefix:
+    """A self-hosted Firecrawl behind a reverse proxy path prefix (e.g. nginx serving it
+    at "/firecrawl") must keep that prefix on every request, since every v2 method passes
+    a leading-slash endpoint (e.g. "/v2/search")."""
+
+    def test_preserves_base_path_prefix(self):
+        client = HttpClient(api_key=None, api_url="http://firecrawl.example.com/firecrawl")
+        assert client._build_url("/v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+
+    def test_preserves_base_path_prefix_with_trailing_slash(self):
+        client = HttpClient(api_key=None, api_url="http://firecrawl.example.com/firecrawl/")
+        assert client._build_url("/v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+
+    def test_root_base_url_unaffected(self):
+        client = HttpClient(api_key=None, api_url="https://api.firecrawl.dev")
+        assert client._build_url("/v2/search") == "https://api.firecrawl.dev/v2/search"
+
+    def test_endpoint_with_query_string_is_preserved(self):
+        client = HttpClient(api_key=None, api_url="http://firecrawl.example.com/firecrawl")
+        assert (
+            client._build_url("/v2/crawl/123?limit=10")
+            == "http://firecrawl.example.com/firecrawl/v2/crawl/123?limit=10"
+        )
+
+    def test_absolute_endpoint_on_a_different_host_forces_base_host(self):
+        client = HttpClient(api_key=None, api_url="http://firecrawl.example.com/firecrawl")
+        result = client._build_url("http://other-host.com/v2/search")
+        assert result == "http://firecrawl.example.com/v2/search"

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -47,7 +47,11 @@ class HttpClient:
             ep2 = urlparse(f"https:{endpoint}")
             path = ep2.path or "/"
             return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
-        return urljoin(base_str, endpoint)
+        # A leading-slash endpoint (every v2 method passes one, e.g. "/v2/search") would make
+        # urljoin() replace the base URL's entire path per RFC 3986, dropping any prefix a
+        # self-hosted deployment serves Firecrawl under (e.g. behind nginx at "/firecrawl").
+        # Strip the leading slash so it joins as a relative reference onto base_str instead.
+        return urljoin(base_str, endpoint.lstrip("/"))
     
     def _prepare_headers(
         self,


### PR DESCRIPTION
## Summary

`HttpClient._build_url` in the Python v2 SDK dropped the path prefix of a self-hosted `api_url` when building request URLs. Every v2 method passes a leading-slash endpoint (e.g. `/v2/search`), and per RFC 3986, `urljoin()` treats a leading-slash reference as replacing the base URL's entire path. So a deployment reachable through a reverse-proxy prefix (e.g. nginx serving Firecrawl at `http://host/firecrawl`) had that prefix silently dropped, producing 404s from the proxy.

Fixes #4339

## Root cause and fix

`_build_url`'s final fallback path called `urljoin(base_str, endpoint)` with the endpoint as-is. Stripping the leading slash before joining (`endpoint.lstrip("/")`) makes it a relative reference instead, so it composes onto `base_str`'s existing path rather than replacing it. This only touches the fallback branch; the existing absolute-URL and protocol-relative branches above it are untouched.

## Testing

Added `firecrawl/__tests__/unit/v2/utils/test_http_client_build_url.py` covering:
- a prefixed base URL with and without a trailing slash
- a root base URL (regression guard, unaffected by the fix)
- an endpoint carrying a query string
- an absolute endpoint on a different host (existing behavior, unaffected)

Ran the full unit suite (`firecrawl/__tests__/unit`): 495 passed, 2 pre-existing failures unrelated to this change (`test_pagination.py`'s `endswith("firecrawl/v2/...")` path assertions fail on Windows regardless of this diff, since paths use backslashes there; confirmed by running the same two tests against `main` unmodified).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Python v2 SDK's `HttpClient._build_url` so self-hosted deployments with a path prefix in `api_url` (e.g. nginx serving Firecrawl at `/firecrawl`) no longer drop that prefix from request URLs, which caused 404s. Fixes #4339.

- `urljoin()` replaced the base path when the endpoint began with `/`; stripping the leading slash turns it into a relative reference that composes onto the base path.
- Adds unit tests covering prefixed and root base URLs, query strings, and absolute endpoints on other hosts.

<sup>Written for commit 1252a6d73fdc9ab92250ef591634deaa42afa869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

