### PR TITLE
Exchange/applications proxy

### DIFF
--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -31,12 +31,6 @@ function upstreamBase(): string | null {
   return config.FIRE_EXCHANGE_URL.replace(/\/+$/, "");
 }
 
-/**
- * `requiresRetrieveFlag` is opt-out for a reason: consuming the Exchange is what that flag grants,
- * and every route here consumes it except the one where somebody offers something of their own. An
- * applicant is not yet a customer, so gating their application on a consumption entitlement would
- * refuse exactly the people the route exists for.
- */
 function exchangeProxy(
   timeout: number,
   options: { requiresRetrieveFlag?: boolean } = {},

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -9,6 +9,7 @@ import { authMiddleware, wrap } from "./shared";
 const DISCOVER_TIMEOUT_MS = 10_000;
 const RETRIEVE_TIMEOUT_MS = 50_000;
 const ANALYTICS_TIMEOUT_MS = 20_000;
+const APPLICATIONS_TIMEOUT_MS = 15_000;
 
 const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
 const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
@@ -30,7 +31,17 @@ function upstreamBase(): string | null {
   return config.FIRE_EXCHANGE_URL.replace(/\/+$/, "");
 }
 
-function exchangeProxy(timeout: number) {
+/**
+ * `requiresRetrieveFlag` is opt-out for a reason: consuming the Exchange is what that flag grants,
+ * and every route here consumes it except the one where somebody offers something of their own. An
+ * applicant is not yet a customer, so gating their application on a consumption entitlement would
+ * refuse exactly the people the route exists for.
+ */
+function exchangeProxy(
+  timeout: number,
+  options: { requiresRetrieveFlag?: boolean } = {},
+) {
+  const requiresRetrieveFlag = options.requiresRetrieveFlag !== false;
   const dispatcher = dispatcherFor(timeout);
 
   return async function controller(req: Request, res: Response) {
@@ -47,7 +58,7 @@ function exchangeProxy(timeout: number) {
       return exchangeError(res, 503, "This endpoint is not available.");
     }
 
-    if (!authedReq.acuc?.flags?.exchangeRetrieve) {
+    if (requiresRetrieveFlag && !authedReq.acuc?.flags?.exchangeRetrieve) {
       return exchangeError(
         res,
         403,
@@ -122,4 +133,10 @@ exchangeRouter.get(
   "/analytics{/*path}",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS)),
+);
+
+exchangeRouter.post(
+  "/applications",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(APPLICATIONS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a proxy for `/exchange/applications` so applicants can become providers without the `exchangeRetrieve` flag. Previously, every exchange route required that flag, which grants consuming the Exchange. The new route is for applicants who aren't yet customers, so requiring the flag would block them. The flag is now optional per route, defaulting to required, and only this route opts out.

<sup>Written for commit 50f16f3fededb2a1c9211fa01de8c5df484af4bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

