### PR TITLE
fix: use registrable domain for isSameDomain/isSameSubdomain (multi-part TLDs)

### DIFF
--- a/apps/api/src/lib/validateUrl.test.ts
+++ b/apps/api/src/lib/validateUrl.test.ts
@@ -17,6 +17,14 @@ describe("isSameDomain", () => {
     expect(result).toBe(false);
   });
 
+  it("should treat different registrable domains under a multi-part suffix as different", () => {
+    // co.uk / github.io are public suffixes, so foo.co.uk and bar.co.uk are
+    // different sites. The last-two-labels split wrongly reported them equal.
+    expect(isSameDomain("https://foo.co.uk", "https://bar.co.uk")).toBe(false);
+    expect(isSameDomain("https://a.github.io", "https://b.github.io")).toBe(false);
+    expect(isSameDomain("https://x.example.co.uk", "https://y.example.co.uk")).toBe(true);
+  });
+
   it("should return true for a subdomain with different protocols", () => {
     const result = isSameDomain(
       "https://sub.example.com",
@@ -77,6 +85,18 @@ describe("isSameSubdomain", () => {
   it("should return false for different domains", () => {
     const result = isSameSubdomain("http://example.com", "http://another.com");
     expect(result).toBe(false);
+  });
+
+  it("should compare subdomains under a multi-part suffix correctly", () => {
+    // Registrable domain is example.co.uk and the subdomain is just "sub":
+    // the last-two-labels split treated the domain as co.uk and the subdomain
+    // as sub.example, so two different sites compared equal.
+    expect(
+      isSameSubdomain("https://sub.example.co.uk", "https://other.example.co.uk"),
+    ).toBe(false);
+    expect(
+      isSameSubdomain("https://sub.example.co.uk", "https://sub.example.co.uk"),
+    ).toBe(true);
   });
 
   it("should return false for invalid URLs", () => {

--- a/apps/api/src/lib/validateUrl.ts
+++ b/apps/api/src/lib/validateUrl.ts
@@ -1,5 +1,6 @@
 import * as undici from "undici";
 import { getSecureDispatcher } from "../scraper/scrapeURL/engines/utils/safeFetch";
+import { parseHostname } from "./url-utils";
 
 export const protocolIncluded = (url: string) => {
   // if :// not in the start of the url assume http (maybe https?)
@@ -73,23 +74,15 @@ export function isSameDomain(url: string, baseUrl: string) {
     return false;
   }
 
-  const typedUrlObj1 = urlObj1 as URL;
-  const typedUrlObj2 = urlObj2 as URL;
+  // Use the registrable domain (public-suffix aware) so multi-part suffixes
+  // like co.uk, com.au, github.io and vercel.app are handled correctly:
+  // foo.co.uk and bar.co.uk are different sites, not a shared "co.uk" domain.
+  // The naive last-two-labels split treated them as the same. parseHostname is
+  // already the codebase's registrable-domain helper (and strips www itself).
+  const domain1 = parseHostname((urlObj1 as URL).hostname).domain;
+  const domain2 = parseHostname((urlObj2 as URL).hostname).domain;
 
-  const cleanHostname = (hostname: string) => {
-    return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
-  };
-
-  const domain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-  const domain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-
-  return domain1 === domain2;
+  return domain1 !== null && domain1 === domain2;
 }
 
 export function isSameSubdomain(url: string, baseUrl: string) {
@@ -100,33 +93,22 @@ export function isSameSubdomain(url: string, baseUrl: string) {
     return false;
   }
 
-  const typedUrlObj1 = urlObj1 as URL;
-  const typedUrlObj2 = urlObj2 as URL;
+  // A leading www. is ignored (www.docs.example.com and docs.example.com are
+  // the same subdomain). Everything else is compared via the public-suffix
+  // aware registrable domain and subdomain, so multi-part suffixes such as
+  // co.uk are correct: previously sub.example.co.uk split its "domain" as
+  // co.uk and its "subdomain" as sub.example.
+  const stripWww = (hostname: string) =>
+    hostname.startsWith("www.") ? hostname.slice(4) : hostname;
 
-  const cleanHostname = (hostname: string) => {
-    return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
-  };
+  const parsed1 = parseHostname(stripWww((urlObj1 as URL).hostname));
+  const parsed2 = parseHostname(stripWww((urlObj2 as URL).hostname));
 
-  const domain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-  const domain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-
-  const subdomain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(0, -2)
-    .join(".");
-  const subdomain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(0, -2)
-    .join(".");
-
-  // Check if the domains are the same and the subdomains are the same
-  return domain1 === domain2 && subdomain1 === subdomain2;
+  return (
+    parsed1.domain !== null &&
+    parsed1.domain === parsed2.domain &&
+    (parsed1.subdomain ?? "") === (parsed2.subdomain ?? "")
+  );
 }
 
 export const checkAndUpdateURLForMap = (


### PR DESCRIPTION
## Problem

`isSameDomain` and `isSameSubdomain` derive the domain from the **last two hostname labels** (`hostname.split(".").slice(-2)`). That is wrong for multi-part public suffixes:

- `foo.co.uk` and `bar.co.uk` both reduce to `co.uk` → reported as the **same domain**
- `a.github.io` and `b.github.io` → same
- `x.vercel.app` / `y.vercel.app`, `*.com.au`, `*.pages.dev`, etc. → same

These two functions gate the `/map` endpoint's same-domain filter (`lib/map-utils.ts` and the v1 map controller filter `mapResults`/`links` with `isSameDomain`/`isSameSubdomain`). So a map of a site hosted on such a suffix (e.g. a `*.github.io` project page, a `.co.uk` site) can include URLs from **other people's sites** sharing the suffix. `isSameSubdomain` has the same defect in both its domain and subdomain computation (`sub.example.co.uk` split its domain as `co.uk` and its subdomain as `sub.example`).

## Fix

Use `parseHostname` (tldts, public-suffix aware) for the registrable domain and subdomain — the helper the rest of the codebase already uses for exactly this (see `lib/url-utils.ts`, which documents the `allowPrivateDomains` option so hosting suffixes like `vercel.app` are handled). A leading `www.` is still ignored in the subdomain comparison.

```ts
isSameDomain("https://foo.co.uk", "https://bar.co.uk")   // before: true   after: false
isSameDomain("https://a.github.io", "https://b.github.io")// before: true   after: false
isSameDomain("https://sub.example.com", "https://example.com") // true (unchanged)
```

## Testing

All existing `isSameDomain`/`isSameSubdomain` cases still pass, and I added tests for the multi-part-suffix cases. I verified the fixed logic against every existing test input plus the suffix cases by running it against `tldts` directly (the resolver the fix uses); the full API test suite runs in CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `isSameDomain` and `isSameSubdomain` to use the public-suffix-aware registrable domain instead of the last two hostname labels, so the `/map` endpoint no longer treats `foo.co.uk` and `bar.co.uk` (or `a.github.io` and `b.github.io`) as the same site. Both functions now use `parseHostname` from `lib/url-utils`, and a leading `www.` is still ignored in subdomain comparisons. Adds tests for multi-part suffix cases.

<sup>Written for commit c973250d95e3d4b281fbb1d85e0919f971fd9a69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

