### PR TITLE
fix(api): allow configurable interact session ttl

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/scrape-browser.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/scrape-browser.test.ts
@@ -1,5 +1,5 @@
 import type { Response } from "express";
-import { vi } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { config } from "../../../config";
 import { supabaseGetScrapeById } from "../../../lib/supabase-jobs";
 import { scrapeInteractController } from "../scrape-browser";
@@ -29,8 +29,15 @@ vi.mock("../../../lib/browser-sessions", () => ({
 
 vi.mock("../../../lib/concurrency-limit", () => ({
   getConcurrencyLimitActiveJobsCount: vi.fn(),
+  getEffectiveConcurrencyLimit: vi.fn(() => Promise.resolve(10)),
   pushConcurrencyLimitActiveJob: vi.fn(() => Promise.resolve()),
   removeConcurrencyLimitActiveJob: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../services/worker/nuq-router", () => ({
+  getCombinedTeamActiveCount: vi.fn(() => Promise.resolve(0)),
+  mirrorExternalSlotAcquire: vi.fn(() => Promise.resolve()),
+  mirrorExternalSlotRelease: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../../lib/scrape-interact/browser-service-client", () => ({
@@ -38,6 +45,35 @@ vi.mock("../../../lib/scrape-interact/browser-service-client", () => ({
   BrowserServiceError: class BrowserServiceError extends Error {
     status = 500;
   },
+}));
+
+vi.mock("../../../lib/scrape-interact/scrape-replay", () => ({
+  buildReplayContextFromScrape: vi.fn(() => ({
+    context: {
+      targetUrl: "https://example.com",
+      waitForMs: 0,
+      actions: [],
+    },
+  })),
+  estimateReplayTimeoutSeconds: vi.fn(() => 30),
+  buildReplayScript: vi.fn(() => "// replay"),
+}));
+
+vi.mock("../../../lib/keyless", () => ({
+  KEYLESS_FREE_TIER_LIMIT_MESSAGE: "Keyless limit reached",
+  adjustKeylessCredits: vi.fn(() => Promise.resolve()),
+  keylessTeamUuid: vi.fn(() => null),
+  keylessLimitBody: vi.fn(() => ({ success: false, error: "Keyless limit" })),
+  logKeylessCreditUsage: vi.fn(() => Promise.resolve()),
+  reserveKeylessCredits: vi.fn(() => Promise.resolve({ ok: true })),
+}));
+
+vi.mock("../../../lib/agent-auth-discovery", () => ({
+  applyAgentAuthDiscoveryHeader: vi.fn(),
+}));
+
+vi.mock("../../../lib/zdr-helpers", () => ({
+  getScrapeZDR: vi.fn(() => null),
 }));
 
 vi.mock("../../../lib/scrape-interact/browser-agent", () => ({
@@ -99,6 +135,169 @@ describe("scrapeInteractController", () => {
       success: false,
       error:
         "Scrape interact requires stored scrape context and is not available when database authentication is disabled.",
+    });
+  });
+
+  describe("ttl/activityTtl passthrough", () => {
+    let browserServiceRequest: ReturnType<typeof vi.fn>;
+    let insertBrowserSession: ReturnType<typeof vi.fn>;
+    let getBrowserSessionFromScrape: ReturnType<typeof vi.fn>;
+    let checkCredits: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      config.USE_DB_AUTHENTICATION = true;
+      config.BROWSER_SERVICE_URL = "http://browser-service:3000";
+
+      browserServiceRequest = (
+        await import("../../../lib/scrape-interact/browser-service-client")
+      ).browserServiceRequest as unknown as ReturnType<typeof vi.fn>;
+      browserServiceRequest.mockResolvedValue({
+        sessionId: "browser-svc-123",
+        cdpUrl: "ws://cdp",
+        iframeUrl: "ws://view",
+        interactiveIframeUrl: "ws://interactive",
+        expiresAt: new Date().toISOString(),
+      });
+
+      insertBrowserSession = (
+        await import("../../../lib/browser-sessions")
+      ).insertBrowserSession as unknown as ReturnType<typeof vi.fn>;
+      insertBrowserSession.mockResolvedValue({
+        id: "session-123",
+        team_id: "team-123",
+        browser_id: "browser-svc-123",
+        status: "active",
+        ttl_total: 600,
+        ttl_without_activity: 300,
+      });
+
+      getBrowserSessionFromScrape = (
+        await import("../../../lib/browser-sessions")
+      ).getBrowserSessionFromScrape as unknown as ReturnType<typeof vi.fn>;
+      getBrowserSessionFromScrape.mockResolvedValue(null);
+
+      checkCredits = (
+        await import("../../../services/autumn/autumn.service")
+      ).autumnService.checkCredits as unknown as ReturnType<typeof vi.fn>;
+      checkCredits.mockResolvedValue({ allowed: true });
+
+      const scrape = {
+        id: "scrape-123",
+        team_id: "team-123",
+        url: "https://example.com",
+        options: {},
+      };
+      (supabaseGetScrapeById as ReturnType<typeof vi.fn>).mockResolvedValue(
+        scrape,
+      );
+    });
+
+    it("uses default ttl (600) and activityTtl (300) when not provided", async () => {
+      const req = {
+        params: { jobId: "scrape-123" },
+        body: { code: "console.log('hi')" },
+        auth: { team_id: "team-123" },
+        acuc: {},
+      } as RequestWithAuth<{ jobId: string }, any, any>;
+      const res = buildRes();
+
+      await scrapeInteractController(req, res);
+
+      // browserServiceRequest is called for /exec after session creation
+      expect(browserServiceRequest).toHaveBeenCalled();
+      // The first call is POST /browsers (session creation)
+      const createCall = browserServiceRequest.mock.calls.find(
+        (call: any[]) => call[0] === "POST" && call[1] === "/browsers",
+      );
+      expect(createCall).toBeDefined();
+      expect(createCall[2]).toMatchObject({
+        ttl: 600,
+        activityTtl: 300,
+      });
+    });
+
+    it("passes user-provided ttl and activityTtl to browser service", async () => {
+      const req = {
+        params: { jobId: "scrape-123" },
+        body: {
+          code: "console.log('hi')",
+          ttl: 120,
+          activityTtl: 60,
+        },
+        auth: { team_id: "team-123" },
+        acuc: {},
+      } as RequestWithAuth<{ jobId: string }, any, any>;
+      const res = buildRes();
+
+      await scrapeInteractController(req, res);
+
+      const createCall = browserServiceRequest.mock.calls.find(
+        (call: any[]) => call[0] === "POST" && call[1] === "/browsers",
+      );
+      expect(createCall).toBeDefined();
+      expect(createCall[2]).toMatchObject({
+        ttl: 120,
+        activityTtl: 60,
+      });
+    });
+
+    it("passes only ttl when only ttl is provided (activityTtl uses default)", async () => {
+      const req = {
+        params: { jobId: "scrape-123" },
+        body: {
+          code: "console.log('hi')",
+          ttl: 120,
+        },
+        auth: { team_id: "team-123" },
+        acuc: {},
+      } as RequestWithAuth<{ jobId: string }, any, any>;
+      const res = buildRes();
+
+      await scrapeInteractController(req, res);
+
+      const createCall = browserServiceRequest.mock.calls.find(
+        (call: any[]) => call[0] === "POST" && call[1] === "/browsers",
+      );
+      expect(createCall).toBeDefined();
+      expect(createCall[2]).toMatchObject({
+        ttl: 120,
+        activityTtl: 300, // default
+      });
+    });
+
+    it("rejects ttl below minimum (30)", async () => {
+      const req = {
+        params: { jobId: "scrape-123" },
+        body: {
+          code: "console.log('hi')",
+          ttl: 10,
+        },
+        auth: { team_id: "team-123" },
+        acuc: {},
+      } as RequestWithAuth<{ jobId: string }, any, any>;
+      const res = buildRes();
+
+      // Zod validation throws (Express error middleware converts to 400)
+      await expect(scrapeInteractController(req, res)).rejects.toThrow(
+        /expected number to be >=30/,
+      );
+    });
+
+    it("rejects activityTtl below minimum (10)", async () => {
+      const req = {
+        params: { jobId: "scrape-123" },
+        body: {
+          code: "console.log('hi')",
+          activityTtl: 5,
+        },
+        auth: { team_id: "team-123" },
+        acuc: {},
+      } as RequestWithAuth<{ jobId: string }, any, any>;
+      const res = buildRes();
+
+      await expect(scrapeInteractController(req, res)).rejects.toThrow(
+        /expected number to be >=10/,
+      );
     });
   });
 });

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -92,6 +92,8 @@ const browserExecuteRequestSchema = z
     origin: z.string().optional(),
     integration: integrationSchema.optional().transform(val => val || null),
     existingSessionId: z.string().optional(),
+    ttl: z.number().min(30).max(3600).optional(),
+    activityTtl: z.number().min(10).max(3600).optional(),
   })
   .refine(data => data.code || data.prompt, {
     message: "Either 'code' or 'prompt' must be provided.",
@@ -549,9 +551,10 @@ async function createSessionForScrape(
   | { status: number; body: { success: false; error: string }; error: true }
 > {
   const sessionId = uuidv7();
-  const { ttl, activityTtl, streamWebView } = browserCreateRequestSchema.parse(
-    {},
-  );
+  const { ttl, activityTtl, streamWebView } = browserCreateRequestSchema.parse({
+    ...(req.body?.ttl !== undefined && { ttl: req.body.ttl }),
+    ...(req.body?.activityTtl !== undefined && { activityTtl: req.body.activityTtl }),
+  });
   const integration = req.body?.integration ?? null;
 
   if (!config.BROWSER_SERVICE_URL) {


### PR DESCRIPTION
## Summary

Adds configurable `ttl` and `activityTtl` options to scrape-bound Interact sessions.

The Interact API now accepts these values and forwards them to the existing browser session creation flow instead of always using the defaults.

Fixes #4426

## Changes

- add optional `ttl` and `activityTtl` fields to the Interact request schema
- forward the provided values to `createSessionForScrape`
- preserve the existing default values when the options are omitted
- validate invalid TTL values
- add focused regression coverage

## Testing

Focused test:

`pnpm exec vitest run src/controllers/v2/__tests__/scrape-browser.test.ts`

Result:

- 1 test file passed
- 6 tests passed

### Test evidence

<img width="1536" height="864" alt="image" src="https://github.com/user-attachments/assets/7196dde8-ada7-44ca-946a-8a05f4904ba4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Interact session lifetimes configurable per request instead of always using the defaults, fixing the inability to tune session expiry for scrape-bound browser sessions.

Callers can now pass `ttl` (30–3600s) and `activityTtl` (10–3600s) in the request body; omitting either keeps the existing default of 600s total and 300s inactivity. Invalid values are rejected by schema validation. Fixes #4426.

<sup>Written for commit 1a5d2030659f96e3555ee7bed791cebc7a72a733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

