### PR TITLE
fix(api): missing serde error

### DIFF
--- a/apps/api/src/lib/error-serde.ts
+++ b/apps/api/src/lib/error-serde.ts
@@ -1,5 +1,6 @@
 import {
   ActionsNotSupportedError,
+  ConcurrencyQueueTimeoutError,
   CrawlDenialError,
   ErrorCodes,
   MapFailedError,
@@ -78,6 +79,7 @@ const errorMap: Record<ErrorCodes, any> = {
   SCRAPE_JSON_CONTENT_TOO_LARGE: JsonExtractionContentTooLargeError,
   SCRAPE_X_TWITTER_CONFIGURATION_ERROR: XTwitterConfigurationError,
   MAP_FAILED: MapFailedError,
+  CONCURRENCY_QUEUE_TIMEOUT: ConcurrencyQueueTimeoutError,
   unsafe_domain_blocked: UnsafeDomainBlockedError,
 
   // Zod errors


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing serialization for `CONCURRENCY_QUEUE_TIMEOUT` errors so they now return the correct `ConcurrencyQueueTimeoutError` payload instead of falling through unhandled.

<sup>Written for commit 0d6a87614f910fc957ba40fbcc81f5eb8d1c96e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

