### PR TITLE
fix(python-sdk): forward onlyCleanContent in scrape options payload

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py
@@ -436,3 +436,21 @@ class TestPrepareScrapeOptions:
         assert result["minAge"] == 1000
         assert "min_age" not in result
         assert result["maxAge"] == 5000
+
+    def test_prepare_only_clean_content_maps_to_camel_case(self):
+        """only_clean_content must be sent as onlyCleanContent; the server drops the snake_case key."""
+        options = ScrapeOptions(only_clean_content=True)
+
+        result = prepare_scrape_options(options)
+
+        assert result["onlyCleanContent"] is True
+        assert "only_clean_content" not in result
+
+    def test_prepare_only_clean_content_false_is_preserved(self):
+        """Explicit only_clean_content=False must still be forwarded (not dropped as falsy)."""
+        options = ScrapeOptions(only_clean_content=False)
+
+        result = prepare_scrape_options(options)
+
+        assert result["onlyCleanContent"] is False
+        assert "only_clean_content" not in result

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -894,6 +894,7 @@ class ScrapeOptions(BaseModel):
     location: Optional["Location"] = None
     skip_tls_verification: Optional[bool] = None
     remove_base64_images: Optional[bool] = None
+    only_clean_content: Optional[bool] = None
     fast_mode: Optional[bool] = None
     use_mock: Optional[str] = None
     block_ads: Optional[bool] = None

--- a/apps/python-sdk/firecrawl/v2/utils/validation.py
+++ b/apps/python-sdk/firecrawl/v2/utils/validation.py
@@ -563,6 +563,7 @@ def prepare_scrape_options(options: Optional[ScrapeOptions]) -> Optional[Dict[st
         "wait_for": "waitFor",
         "skip_tls_verification": "skipTlsVerification",
         "remove_base64_images": "removeBase64Images",
+        "only_clean_content": "onlyCleanContent",
         "fast_mode": "fastMode",
         "use_mock": "useMock",
         "block_ads": "blockAds",


### PR DESCRIPTION
## Why this change is needed

The `onlyCleanContent` API option exists in the API zod schemas and is fully implemented in the engine (`performCleanContent()` in `llmExtract.ts`), but was missing from the Python SDK's `ScrapeOptions` model and `field_mappings`. Passing the option was **silently swallowed** — no error, no warning, no effect.

This is the same class of bug as `min_age` (dropped from Python SDK payload) and `ignoreRobotsTxt` (dropped from JS SDK payload #3940/#4016).

## What behavior changed

- **`apps/python-sdk/firecrawl/v2/types.py`**: Added `only_clean_content: Optional[bool] = None` to `ScrapeOptions` (between `remove_base64_images` and `fast_mode`, matching API field order)
- **`apps/python-sdk/firecrawl/v2/utils/validation.py`**: Added `"only_clean_content": "onlyCleanContent"` to the `field_mappings` dict in `prepare_scrape_options()`
- **`apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py`**: Added 2 regression tests:
  - `test_prepare_only_clean_content_maps_to_camel_case` — verifies `True` flows to the wire as `onlyCleanContent`
  - `test_prepare_only_clean_content_false_is_preserved` — verifies explicit `False` is not dropped

## Exact tests / checks ran

```
py -m pytest apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_validation.py -v
# 29 passed in 3.88s (27 existing + 2 new)
```

No harness needed — SDK-only unit tests. `py -m pytest apps/python-sdk/firecrawl/__tests__/unit/v2/utils/ -v` also passes (111 in full utils suite).

## Configuration, migration, security, or deployment impact

None. SDK-only change, no environment, migration, or deployment impact. No credentials or secrets in commits. Backwards-compatible — new optional field defaults to `None` (not sent) when not set.

## Screenshots / request-response evidence

Before: `prepare_scrape_options(ScrapeOptions(only_clean_content=True))` returned `{}` (swallowed)
After: returns `{"onlyCleanContent": True}` — verified by unit tests above.

Fixes #4393
