### PR TITLE
fix(python-sdk): forward idempotency_key in async batch start

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/test_async_batch_idempotency.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/test_async_batch_idempotency.py
@@ -1,0 +1,42 @@
+"""Async batch start should forward idempotency_key as header."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from firecrawl.v2.methods.aio.batch import start_batch_scrape
+
+
+@pytest.mark.asyncio
+async def test_async_batch_idempotency_key_forwarded():
+    client = MagicMock()
+    client._headers = MagicMock(return_value={"x-idempotency-key": "k123"})
+    mock_resp = MagicMock(status_code=200, json=lambda: {"success": True, "id": "job", "url": "u", "invalidURLs": []})
+    client.post = AsyncMock(return_value=mock_resp)
+
+    await start_batch_scrape(client, ["https://example.com"], idempotency_key="k123")
+
+    client._headers.assert_called_once_with("k123")
+    client.post.assert_awaited_once()
+    args, kwargs = client.post.call_args
+    # Verify headers were passed with the idempotency key
+    called_headers = kwargs.get("headers")
+    assert called_headers is not None
+    assert called_headers.get("x-idempotency-key") == "k123"
+
+
+@pytest.mark.asyncio
+async def test_async_batch_without_idempotency_no_header():
+    client = MagicMock()
+    mock_resp = MagicMock(status_code=200, json=lambda: {"success": True, "id": "job", "url": "u", "invalidURLs": []})
+    client.post = AsyncMock(return_value=mock_resp)
+
+    await start_batch_scrape(client, ["https://example.com"])
+
+    # _headers should not be called when no idempotency_key is provided
+    assert not hasattr(client, '_headers') or not client._headers.called or len(client._headers.call_args_list) == 0
+    # The post call should not have headers kwarg (or headers should not contain idempotency key)
+    client.post.assert_awaited_once()
+    args, kwargs = client.post.call_args
+    called_headers = kwargs.get("headers")
+    assert called_headers is None or "x-idempotency-key" not in called_headers

--- a/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/batch.py
@@ -60,8 +60,11 @@ def _prepare(urls: List[str], *, options: Optional[ScrapeOptions] = None, **kwar
 
 
 async def start_batch_scrape(client: AsyncHttpClient, urls: List[str], **kwargs) -> BatchScrapeResponse:
+    # Extract idempotency_key before _prepare (which does not handle it) and forward as header.
+    idempotency_key = kwargs.pop("idempotency_key", None)
     payload = _prepare(urls, **kwargs)
-    response = await client.post("/v2/batch/scrape", payload)
+    headers = client._headers(idempotency_key) if idempotency_key else None
+    response = await client.post("/v2/batch/scrape", payload, headers=headers)
     if response.status_code >= 400:
         handle_response_error(response, "start batch scrape")
     body = response.json()


### PR DESCRIPTION
## Why this change is needed

Sync `start_batch_scrape` forwards `idempotency_key` as `x-idempotency-key` header via `client._prepare_headers(idempotency_key)`, but async `start_batch_scrape` in `methods/aio/batch.py` accepted `**kwargs` and silently ignored `idempotency_key` — neither payload nor header. Retries could create duplicate batch jobs, breaking idempotent retry safety for large batches.

## What behavior changed

- `apps/python-sdk/firecrawl/v2/methods/aio/batch.py`: `start_batch_scrape` now pops `idempotency_key` before `_prepare()`, builds `headers = client._headers(idempotency_key) if idempotency_key else None`, and passes `headers` to `client.post()`, mirroring sync `methods/batch.py:88-89`.

## Exact tests / checks ran

```
py -m pytest apps/python-sdk/firecrawl/__tests__/unit/v2/test_async_batch_idempotency.py -v
# 2 passed
```

## Configuration, migration, security, or deployment impact

None. SDK-only, no env/migration/deploy impact. No secrets. Backwards-compatible — no header when key not provided; with key, prevents duplicates.

Fixes async/sync parity gap for idempotent batch starts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes async `start_batch_scrape` in the Python SDK so `idempotency_key` is forwarded as the `x-idempotency-key` header, matching the sync version. Previously the key was accepted via `**kwargs` but silently dropped, so retries could create duplicate batch jobs.

- Pops `idempotency_key` from kwargs before payload prep and passes it via `client._headers()` to the POST request.
- No header is sent when no key is provided, keeping the change backward compatible.
- Adds two async regression tests covering both paths; no migration or deployment impact.

<sup>Written for commit 0c780e7678845ed6fabcf4b04854512abe49a16e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

