### PR TITLE
fix(python-sdk): add threat_protection to ExtractRequest

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/test_extract_threat_protection.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/test_extract_threat_protection.py
@@ -1,0 +1,19 @@
+from firecrawl.v2.types import ExtractRequest
+from firecrawl.v2.types import ThreatProtectionOptions
+
+
+def test_extract_request_serializes_threat_protection():
+    req = ExtractRequest(
+        urls=["https://example.com"],
+        prompt="extract",
+        threat_protection=ThreatProtectionOptions(mode="normal"),
+    )
+    data = req.model_dump(by_alias=True, exclude_none=True)
+    assert "threatProtection" in data
+    assert data["threatProtection"]["mode"] == "normal"
+
+
+def test_extract_request_without_threat_protection_excludes():
+    req = ExtractRequest(urls=["https://example.com"], prompt="extract")
+    data = req.model_dump(by_alias=True, exclude_none=True)
+    assert "threatProtection" not in data

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1426,6 +1426,11 @@ class ExtractRequest(BaseModel):
     ignore_invalid_urls: Optional[bool] = None
     integration: Optional[str] = None
     agent: Optional[AgentOptions] = None
+    threat_protection: Optional[ThreatProtectionOptions] = Field(
+        default=None, alias="threatProtection"
+    )
+
+    model_config = {"populate_by_name": True}
 
 
 class ExtractResponse(BaseModel):


### PR DESCRIPTION
## Why this change is needed

`ExtractRequest` lacked `threat_protection` (`threatProtection`) despite `methods/extract.py` accepting it and the API/JS SDK (`types.ts`) supporting it. Users constructing `ExtractRequest` directly had the field silently dropped due to missing model field.

## What behavior changed

- `apps/python-sdk/firecrawl/v2/types.py`: Added `threat_protection: Optional[ThreatProtectionOptions] = Field(alias="threatProtection")` with `model_config = {"populate_by_name": True}` to `ExtractRequest`.

## Exact tests / checks ran

```
py -m pytest apps/python-sdk/firecrawl/__tests__/unit/v2/test_extract_threat_protection.py -v
# 2 passed
```

## Configuration, migration, security, or deployment impact

None. SDK-only, no env/migration/deploy impact. No secrets. Backwards-compatible.

Fixes type parity gap vs JS SDK


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ExtractRequest` in the Python SDK so `threat_protection` (`threatProtection`) is no longer silently dropped when constructing the request directly, matching the API and JS SDK.

- Adds `threat_protection: Optional[ThreatProtectionOptions]` with alias `threatProtection` and `populate_by_name` config.
- Adds two unit tests covering serialization with and without the field.

<sup>Written for commit cb90f2bad81994ed8746dc339f33bdd588faa0a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

