### PR TITLE
fix(python-sdk): preserve base_url path prefix when joining endpoints in v2 client

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_base_url.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_base_url.py
@@ -1,0 +1,33 @@
+import pytest
+from firecrawl.v2.utils.http_client import HttpClient
+from firecrawl.v2.utils.http_client_async import AsyncHttpClient
+
+
+class TestHttpClientBuildUrl:
+    """Unit tests for _build_url in HttpClient and endpoint resolution in AsyncHttpClient."""
+
+    def test_build_url_standard(self):
+        client = HttpClient(api_url="https://api.firecrawl.dev", api_key="fc-test")
+        assert client._build_url("/v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+        assert client._build_url("v2/scrape") == "https://api.firecrawl.dev/v2/scrape"
+
+    def test_build_url_with_path_prefix(self):
+        # When Firecrawl is deployed behind reverse proxy under a path prefix
+        client = HttpClient(api_url="http://firecrawl.example.com/firecrawl", api_key="fc-test")
+        assert client._build_url("/v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+        assert client._build_url("v2/search") == "http://firecrawl.example.com/firecrawl/v2/search"
+
+    def test_build_url_with_path_prefix_trailing_slash(self):
+        client = HttpClient(api_url="http://firecrawl.example.com/firecrawl/", api_key="fc-test")
+        assert client._build_url("/v2/scrape") == "http://firecrawl.example.com/firecrawl/v2/scrape"
+        assert client._build_url("v2/scrape") == "http://firecrawl.example.com/firecrawl/v2/scrape"
+
+    def test_build_url_with_query(self):
+        client = HttpClient(api_url="http://firecrawl.example.com/custom/path", api_key="fc-test")
+        assert client._build_url("/v2/crawl/status?page=2") == "http://firecrawl.example.com/custom/path/v2/crawl/status?page=2"
+
+    def test_async_http_client_resolve_endpoint(self):
+        client = AsyncHttpClient(api_url="http://firecrawl.example.com/firecrawl", api_key="fc-test")
+        assert client._resolve_endpoint("/v2/search") == "v2/search"
+        assert client._resolve_endpoint("v2/search") == "v2/search"
+        assert client._resolve_endpoint("https://external.com/api") == "https://external.com/api"

--- a/apps/python-sdk/firecrawl/v2/utils/http_client.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client.py
@@ -41,13 +41,15 @@ class HttpClient:
             return urlunparse((base.scheme or "https", base.netloc, path, "", ep.query, ""))
 
         # Relative (including leading slash or not)
-        base_str = self.api_url if self.api_url.endswith("/") else f"{self.api_url}/"
         # Guard protocol-relative like //host/path slipping through as “relative”
         if endpoint.startswith("//"):
             ep2 = urlparse(f"https:{endpoint}")
             path = ep2.path or "/"
             return urlunparse((base.scheme or "https", base.netloc, path, "", ep2.query, ""))
-        return urljoin(base_str, endpoint)
+        base_path = base.path.rstrip("/")
+        ep_path = ep.path.lstrip("/")
+        combined_path = f"{base_path}/{ep_path}" if base_path else f"/{ep_path}"
+        return urlunparse((base.scheme or "https", base.netloc, combined_path, "", ep.query, ""))
     
     def _prepare_headers(
         self,

--- a/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
+++ b/apps/python-sdk/firecrawl/v2/utils/http_client_async.py
@@ -26,11 +26,17 @@ class AsyncHttpClient:
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
+        norm_url = api_url if api_url.endswith("/") else f"{api_url}/"
         self._client = httpx.AsyncClient(
-            base_url=api_url,
+            base_url=norm_url,
             headers=headers,
             limits=httpx.Limits(max_keepalive_connections=0),
         )
+
+    def _resolve_endpoint(self, endpoint: str) -> str:
+        if endpoint.startswith("http://") or endpoint.startswith("https://") or endpoint.startswith("//"):
+            return endpoint
+        return endpoint.lstrip("/")
 
     async def close(self) -> None:
         await self._client.aclose()
@@ -66,7 +72,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.post(
-                    endpoint,
+                    self._resolve_endpoint(endpoint),
                     json=payload,
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,
@@ -107,7 +113,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.post(
-                    endpoint,
+                    self._resolve_endpoint(endpoint),
                     data=data,
                     files=files,
                     headers={**self._headers(), **(headers or {})},
@@ -147,7 +153,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.get(
-                    endpoint,
+                    self._resolve_endpoint(endpoint),
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,
                 )
@@ -185,7 +191,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.delete(
-                    endpoint,
+                    self._resolve_endpoint(endpoint),
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,
                 )
@@ -227,7 +233,7 @@ class AsyncHttpClient:
         for attempt in range(num_attempts):
             try:
                 response = await self._client.patch(
-                    endpoint,
+                    self._resolve_endpoint(endpoint),
                     json=payload,
                     headers={**self._headers(), **(headers or {})},
                     timeout=timeout,


### PR DESCRIPTION
## Problem
When Firecrawl is deployed behind a reverse proxy under a path prefix (e.g. `api_url="http://firecrawl.example.com/firecrawl"`), `urllib.parse.urljoin` in `HttpClient._build_url` and httpx leading-slash endpoint resolution in `AsyncHttpClient` replaced the base path prefix with root-level relative paths (e.g. `http://firecrawl.example.com/v2/search` instead of `http://firecrawl.example.com/firecrawl/v2/search`), causing 404 errors on reverse-proxied self-hosted deployments.

## Solution
- Preserved base path prefix in `HttpClient._build_url` by concatenating sanitized base and relative endpoint path segments.
- Normalized `base_url` and added `_resolve_endpoint` helper to `AsyncHttpClient` to preserve path prefixes across all async methods (`post`, `get`, `delete`, `patch`, `post_multipart`).
- Added unit tests in `apps/python-sdk/firecrawl/__tests__/unit/v2/utils/test_http_client_base_url.py` covering standard URLs, reverse-proxied URLs with path prefixes, trailing slashes, and query params.

Fixes #4339

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Python SDK v2 client so it preserves a base_url path prefix when joining endpoints, preventing 404s on reverse-proxied Firecrawl deployments.

**Bug Fixes**
- `HttpClient._build_url` now joins the base path and endpoint manually instead of using `urljoin`.
- `AsyncHttpClient` normalizes `base_url` and strips leading slashes from endpoints so httpx doesn't drop the prefix.
- Added unit tests for standard URLs, path prefixes, trailing slashes, and query params.

Fixes #4339.

<sup>Written for commit 636ab4277d42427d8a5b129f6e990df49553a288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

