### PR TITLE
feat(api,sdk): allow configurable ttl and activityTtl for interact API

### DIFF
--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -92,6 +92,8 @@ const browserExecuteRequestSchema = z
     origin: z.string().optional(),
     integration: integrationSchema.optional().transform(val => val || null),
     existingSessionId: z.string().optional(),
+    ttl: z.number().min(30).max(3600).optional(),
+    activityTtl: z.number().min(10).max(3600).optional(),
   })
   .refine(data => data.code || data.prompt, {
     message: "Either 'code' or 'prompt' must be provided.",
@@ -549,9 +551,10 @@ async function createSessionForScrape(
   | { status: number; body: { success: false; error: string }; error: true }
 > {
   const sessionId = uuidv7();
-  const { ttl, activityTtl, streamWebView } = browserCreateRequestSchema.parse(
-    {},
-  );
+  const { ttl, activityTtl, streamWebView } = browserCreateRequestSchema.parse({
+    ttl: req.body?.ttl,
+    activityTtl: req.body?.activityTtl,
+  });
   const integration = req.body?.integration ?? null;
 
   if (!config.BROWSER_SERVICE_URL) {

--- a/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts
@@ -171,6 +171,8 @@ export async function interact(
   body.language = args.language ?? "node";
   if (args.timeout != null) body.timeout = args.timeout;
   if (args.origin) body.origin = args.origin;
+  if (args.ttl != null) body.ttl = args.ttl;
+  if (args.activityTtl != null) body.activityTtl = args.activityTtl;
 
   try {
     const res = await http.post<ScrapeExecuteResponse>(

--- a/apps/js-sdk/firecrawl/src/v2/types.ts
+++ b/apps/js-sdk/firecrawl/src/v2/types.ts
@@ -1661,6 +1661,8 @@ export interface ScrapeExecuteRequest {
   language?: "python" | "node" | "bash";
   timeout?: number;
   origin?: string;
+  ttl?: number;
+  activityTtl?: number;
 }
 
 export type ScrapeExecuteResponse = BrowserExecuteResponse;

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_aio_scrape_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/aio/test_aio_scrape_request_preparation.py
@@ -95,6 +95,7 @@ class TestAsyncScrapeRequestPreparation:
                 200,
                 {
                     "success": True,
+                    "sessionId": "session-123",
                     "stdout": "ok",
                     "exitCode": 0,
                 },
@@ -107,6 +108,8 @@ class TestAsyncScrapeRequestPreparation:
             "console.log('ok')",
             timeout=30,
             origin="_unit-test",
+            ttl=1200,
+            activity_ttl=600,
         )
 
         assert client.last_post[0] == "/v2/scrape/job-123/interact"
@@ -115,8 +118,11 @@ class TestAsyncScrapeRequestPreparation:
             "language": "node",
             "timeout": 30,
             "origin": "_unit-test",
+            "ttl": 1200,
+            "activityTtl": 600,
         }
         assert response.success is True
+        assert response.session_id == "session-123"
         assert response.exit_code == 0
 
     @pytest.mark.asyncio
@@ -126,6 +132,7 @@ class TestAsyncScrapeRequestPreparation:
                 200,
                 {
                     "success": True,
+                    "sessionId": "session-456",
                     "output": "Clicked the button",
                     "cdpUrl": "wss://browser.example.com/cdp",
                     "liveViewUrl": "https://live.example.com/view",
@@ -140,14 +147,17 @@ class TestAsyncScrapeRequestPreparation:
             client,
             "job-456",
             prompt="Click the login button",
+            ttl=900,
         )
 
         assert client.last_post[0] == "/v2/scrape/job-456/interact"
         assert client.last_post[1] == {
             "language": "node",
             "prompt": "Click the login button",
+            "ttl": 900,
         }
         assert response.success is True
+        assert response.session_id == "session-456"
         assert response.output == "Clicked the button"
         assert response.cdp_url == "wss://browser.example.com/cdp"
         assert response.live_view_url == "https://live.example.com/view"

--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_scrape_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_scrape_request_preparation.py
@@ -148,6 +148,7 @@ class TestScrapeRequestPreparation:
                 200,
                 {
                     "success": True,
+                    "sessionId": "session-123",
                     "stdout": "ok",
                     "exitCode": 0,
                 },
@@ -160,6 +161,8 @@ class TestScrapeRequestPreparation:
             "console.log('ok')",
             timeout=45,
             origin="_unit-test",
+            ttl=1200,
+            activity_ttl=600,
         )
 
         assert client.last_post[0] == "/v2/scrape/job-123/interact"
@@ -168,8 +171,11 @@ class TestScrapeRequestPreparation:
             "language": "node",
             "timeout": 45,
             "origin": "_unit-test",
+            "ttl": 1200,
+            "activityTtl": 600,
         }
         assert response.success is True
+        assert response.session_id == "session-123"
         assert response.exit_code == 0
 
     def test_interact_with_prompt(self):
@@ -178,6 +184,7 @@ class TestScrapeRequestPreparation:
                 200,
                 {
                     "success": True,
+                    "sessionId": "session-456",
                     "output": "Clicked the button",
                     "cdpUrl": "wss://browser.example.com/cdp",
                     "liveViewUrl": "https://live.example.com/view",
@@ -192,14 +199,17 @@ class TestScrapeRequestPreparation:
             client,
             "job-456",
             prompt="Click the login button",
+            ttl=900,
         )
 
         assert client.last_post[0] == "/v2/scrape/job-456/interact"
         assert client.last_post[1] == {
             "language": "node",
             "prompt": "Click the login button",
+            "ttl": 900,
         }
         assert response.success is True
+        assert response.session_id == "session-456"
         assert response.output == "Clicked the button"
         assert response.cdp_url == "wss://browser.example.com/cdp"
         assert response.live_view_url == "https://live.example.com/view"

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -267,6 +267,8 @@ class FirecrawlClient:
         language: Literal["python", "node", "bash"] = "node",
         timeout: Optional[int] = None,
         origin: Optional[str] = None,
+        ttl: Optional[int] = None,
+        activity_ttl: Optional[int] = None,
     ):
         """
         Interact with the browser session associated with a scrape job.
@@ -280,6 +282,8 @@ class FirecrawlClient:
             language: Programming language ("python", "node", or "bash")
             timeout: Execution timeout in seconds (1-300)
             origin: Optional request origin tag
+            ttl: Total time-to-live in seconds (30-3600, default 600)
+            activity_ttl: Inactivity TTL in seconds (10-3600, default 300)
 
         Returns:
             BrowserExecuteResponse with execution result
@@ -292,6 +296,8 @@ class FirecrawlClient:
             language=language,
             timeout=timeout,
             origin=origin,
+            ttl=ttl,
+            activity_ttl=activity_ttl,
         )
 
     def stop_interaction(self, job_id: str):
@@ -319,6 +325,8 @@ class FirecrawlClient:
         language: Literal["python", "node", "bash"] = "node",
         timeout: Optional[int] = None,
         origin: Optional[str] = None,
+        ttl: Optional[int] = None,
+        activity_ttl: Optional[int] = None,
     ):
         """Deprecated alias for interact()."""
         return self.interact(
@@ -328,6 +336,8 @@ class FirecrawlClient:
             language=language,
             timeout=timeout,
             origin=origin,
+            ttl=ttl,
+            activity_ttl=activity_ttl,
         )
 
     def delete_scrape_browser(self, job_id: str):

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -153,6 +153,8 @@ class AsyncFirecrawlClient:
         language: Literal["python", "node", "bash"] = "node",
         timeout: Optional[int] = None,
         origin: Optional[str] = None,
+        ttl: Optional[int] = None,
+        activity_ttl: Optional[int] = None,
     ):
         return await async_scrape.interact(
             self.async_http_client,
@@ -162,6 +164,8 @@ class AsyncFirecrawlClient:
             language=language,
             timeout=timeout,
             origin=origin,
+            ttl=ttl,
+            activity_ttl=activity_ttl,
         )
 
     async def stop_interaction(self, job_id: str):
@@ -183,6 +187,8 @@ class AsyncFirecrawlClient:
         language: Literal["python", "node", "bash"] = "node",
         timeout: Optional[int] = None,
         origin: Optional[str] = None,
+        ttl: Optional[int] = None,
+        activity_ttl: Optional[int] = None,
     ):
         """Deprecated alias for interact()."""
         return await self.interact(
@@ -192,6 +198,8 @@ class AsyncFirecrawlClient:
             language=language,
             timeout=timeout,
             origin=origin,
+            ttl=ttl,
+            activity_ttl=activity_ttl,
         )
 
     async def delete_scrape_browser(self, job_id: str):

--- a/apps/python-sdk/firecrawl/v2/methods/aio/scrape.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/scrape.py
@@ -64,6 +64,8 @@ async def interact(
     language: Literal["python", "node", "bash"] = "node",
     timeout: Optional[int] = None,
     origin: Optional[str] = None,
+    ttl: Optional[int] = None,
+    activity_ttl: Optional[int] = None,
 ) -> BrowserExecuteResponse:
     if not job_id or not job_id.strip():
         raise ValueError("Job ID cannot be empty")
@@ -83,6 +85,10 @@ async def interact(
         payload["timeout"] = timeout
     if origin is not None:
         payload["origin"] = origin
+    if ttl is not None:
+        payload["ttl"] = ttl
+    if activity_ttl is not None:
+        payload["activityTtl"] = activity_ttl
 
     response = await client.post(f"/v2/scrape/{job_id}/interact", payload)
     if response.status_code >= 400:
@@ -93,6 +99,8 @@ async def interact(
         raise Exception(body.get("error", "Unknown error occurred"))
 
     normalized = dict(body)
+    if "sessionId" in normalized and "session_id" not in normalized:
+        normalized["session_id"] = normalized["sessionId"]
     if "exitCode" in normalized and "exit_code" not in normalized:
         normalized["exit_code"] = normalized["exitCode"]
     if "cdpUrl" in normalized and "cdp_url" not in normalized:
@@ -142,6 +150,8 @@ async def scrape_execute(
     language: Literal["python", "node", "bash"] = "node",
     timeout: Optional[int] = None,
     origin: Optional[str] = None,
+    ttl: Optional[int] = None,
+    activity_ttl: Optional[int] = None,
 ) -> BrowserExecuteResponse:
     """Deprecated alias for interact()."""
     return await interact(
@@ -152,6 +162,8 @@ async def scrape_execute(
         language=language,
         timeout=timeout,
         origin=origin,
+        ttl=ttl,
+        activity_ttl=activity_ttl,
     )
 
 

--- a/apps/python-sdk/firecrawl/v2/methods/scrape.py
+++ b/apps/python-sdk/firecrawl/v2/methods/scrape.py
@@ -97,6 +97,8 @@ def interact(
     language: Literal["python", "node", "bash"] = "node",
     timeout: Optional[int] = None,
     origin: Optional[str] = None,
+    ttl: Optional[int] = None,
+    activity_ttl: Optional[int] = None,
 ) -> BrowserExecuteResponse:
     """
     Interact with the scrape-bound browser session for a scrape job.
@@ -113,6 +115,8 @@ def interact(
         language: Programming language ("python", "node", or "bash")
         timeout: Execution timeout in seconds (1-300)
         origin: Optional request origin tag
+        ttl: Total time-to-live in seconds (30-3600, default 600)
+        activity_ttl: Inactivity TTL in seconds (10-3600, default 300)
 
     Returns:
         BrowserExecuteResponse with execution output
@@ -135,6 +139,10 @@ def interact(
         body["timeout"] = timeout
     if origin is not None:
         body["origin"] = origin
+    if ttl is not None:
+        body["ttl"] = ttl
+    if activity_ttl is not None:
+        body["activityTtl"] = activity_ttl
 
     response = client.post(f"/v2/scrape/{job_id}/interact", body)
     if not response.ok:
@@ -145,6 +153,8 @@ def interact(
         raise Exception(payload.get("error", "Unknown error occurred"))
 
     normalized = dict(payload)
+    if "sessionId" in normalized and "session_id" not in normalized:
+        normalized["session_id"] = normalized["sessionId"]
     if "exitCode" in normalized and "exit_code" not in normalized:
         normalized["exit_code"] = normalized["exitCode"]
     if "cdpUrl" in normalized and "cdp_url" not in normalized:
@@ -204,6 +214,8 @@ def scrape_execute(
     language: Literal["python", "node", "bash"] = "node",
     timeout: Optional[int] = None,
     origin: Optional[str] = None,
+    ttl: Optional[int] = None,
+    activity_ttl: Optional[int] = None,
 ) -> BrowserExecuteResponse:
     """Deprecated alias for interact()."""
     return interact(
@@ -214,6 +226,8 @@ def scrape_execute(
         language=language,
         timeout=timeout,
         origin=origin,
+        ttl=ttl,
+        activity_ttl=activity_ttl,
     )
 
 

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1678,6 +1678,7 @@ class BrowserExecuteResponse(BaseModel):
     """Response from executing code in a browser session."""
 
     success: bool
+    session_id: Optional[str] = None
     cdp_url: Optional[str] = None
     live_view_url: Optional[str] = None
     interactive_live_view_url: Optional[str] = None


### PR DESCRIPTION
Closes #4426

### Summary of Changes
- **API (`apps/api`)**: Added `ttl` (min 30, max 3600) and `activityTtl` (min 10, max 3600) to `browserExecuteRequestSchema` in `scrape-browser.ts` and passed them through when creating the browser session in `createSessionForScrape`.
- **Python SDK (`apps/python-sdk`)**:
  - Added `ttl` and `activity_ttl` parameters to `interact()` and `scrape_execute()` in sync and async clients/methods.
  - Added `session_id` to `BrowserExecuteResponse` and normalized `sessionId` from response payloads.
  - Added unit tests for sync and async request preparation and response normalization.
- **JavaScript SDK (`apps/js-sdk`)**: Added `ttl` and `activityTtl` to `ScrapeExecuteRequest` and `interact()` payload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes browser session lifetimes configurable in the interact API instead of always using the defaults, and exposes the session ID in Python SDK responses. Closes #4426.

- `ttl` (30–3600s) and `activityTtl` (10–3600s) are now accepted by the API, the JS SDK, and the Python SDK on `interact()` and `scrape_execute()`.
- The Python SDK response now maps `sessionId` from the API payload to a new `session_id` field.

<sup>Written for commit 0b9cefdc9d4c5fc5c8d078fb12a024db01213525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

