### PR TITLE
fix(crawler): remove redundant sitemap fetch retry in catch block

### DIFF
--- a/apps/api/src/scraper/WebScraper/crawler.ts
+++ b/apps/api/src/scraper/WebScraper/crawler.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from "axios";
 import { config } from "../../config";
 import { load } from "cheerio"; // rustified
 import { URL } from "url";
@@ -1047,26 +1046,6 @@ export class WebCrawler {
             sitemapUrl: baseUrlSitemap,
             error,
           });
-          if (error instanceof AxiosError && error.response?.status === 404) {
-            // ignore 404
-          } else {
-            sitemapCount += await getLinksFromSitemap(
-              {
-                sitemapUrl: baseUrlSitemap,
-                urlsHandler,
-                mode: "fire-engine",
-                maxAge,
-                zeroDataRetention: this.zeroDataRetention,
-                location: this.location,
-                headers: this.headers,
-              },
-              this.logger,
-              this.jobId,
-              this.sitemapsHit,
-              abort,
-              mock,
-            );
-          }
         }
       }
     }


### PR DESCRIPTION
Fixes #4297

### Description
In `apps/api/src/scraper/WebScraper/crawler.ts`, `tryFetchSitemapLinks` had a catch block for the `baseUrlSitemap` fallback fetch that attempted to call `getLinksFromSitemap` a second time when encountering non-404 non-timeout errors. This was redundant, lacked backoff, increased server load, and risked unhandled errors inside the catch block.

This PR removes the redundant retry call and unused `AxiosError` import, matching the graceful error handling pattern used across the rest of `tryFetchSitemapLinks`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant sitemap fetch retry in `tryFetchSitemapLinks` so non-404 errors no longer trigger a second `getLinksFromSitemap` call from inside the catch block. The retry had no backoff, added server load, and risked unhandled errors; it now falls through gracefully, matching the rest of the function.

- Removes the unused `AxiosError` import.

Fixes #4297.

<sup>Written for commit 761222a32a65650b8e5536690567488912053d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

