### PR TITLE
fix(scraper): add terminal error state for anti-bot blocked responses

### DIFF
--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -304,6 +304,14 @@ export async function scrapeController(
         });
       }
 
+      if (e.code === "SCRAPE_FAILED_BLOCKED") {
+        return res.status(403).json({
+          success: false,
+          code: e.code,
+          error: e.message,
+        });
+      }
+
       if (e.code === "SCRAPE_MEDIA_ACCESS_DENIED") {
         return res.status(403).json({
           success: false,

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -598,6 +598,17 @@ export async function parseController(
             });
           }
 
+          if (e.code === "SCRAPE_FAILED_BLOCKED") {
+            setSpanAttributes(span, {
+              "parse.status_code": 403,
+            });
+            return res.status(403).json({
+              success: false,
+              code: e.code,
+              error: e.message,
+            });
+          }
+
           const statusCode = timeoutErr ? 408 : 500;
           setSpanAttributes(span, {
             "parse.status_code": statusCode,

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -464,6 +464,17 @@ export async function scrapeController(
             });
           }
 
+          if (e.code === "SCRAPE_FAILED_BLOCKED") {
+            setSpanAttributes(span, {
+              "scrape.status_code": 403,
+            });
+            return res.status(403).json({
+              success: false,
+              code: e.code,
+              error: e.message,
+            });
+          }
+
           if (e.code === "SCRAPE_MEDIA_ACCESS_DENIED") {
             setSpanAttributes(span, {
               "scrape.status_code": 403,

--- a/apps/api/src/lib/error-serde.ts
+++ b/apps/api/src/lib/error-serde.ts
@@ -38,6 +38,7 @@ import {
   PromptInjectionDetectedError,
   JsonExtractionContentTooLargeError,
   XTwitterConfigurationError,
+  ScrapeBlockedError,
 } from "../scraper/scrapeURL/error";
 import { UnsafeDomainBlockedError } from "./threat-protection/error";
 
@@ -80,6 +81,7 @@ const errorMap: Record<ErrorCodes, any> = {
   SCRAPE_X_TWITTER_CONFIGURATION_ERROR: XTwitterConfigurationError,
   MAP_FAILED: MapFailedError,
   CONCURRENCY_QUEUE_TIMEOUT: ConcurrencyQueueTimeoutError,
+  SCRAPE_FAILED_BLOCKED: ScrapeBlockedError,
   unsafe_domain_blocked: UnsafeDomainBlockedError,
 
   // Zod errors

--- a/apps/api/src/lib/error.ts
+++ b/apps/api/src/lib/error.ts
@@ -38,6 +38,7 @@ export type ErrorCodes =
   | "BAD_REQUEST_INVALID_JSON"
   | "BAD_REQUEST"
   | "CONCURRENCY_QUEUE_TIMEOUT"
+  | "SCRAPE_FAILED_BLOCKED"
   // Threat protection (enterprise domain risk blocking). Lowercase by design:
   // this is the documented, user-facing error code for the feature.
   | "unsafe_domain_blocked";

--- a/apps/api/src/main/runWebScraper.ts
+++ b/apps/api/src/main/runWebScraper.ts
@@ -2,6 +2,11 @@ import { ScrapeJobSingleUrls, RunWebScraperParams } from "../types";
 import { logger as _logger } from "../lib/logger";
 import { configDotenv } from "dotenv";
 import { scrapeURL, ScrapeUrlResponse } from "../scraper/scrapeURL";
+import {
+  ScrapeBlockedError,
+  ScrapeRetryLimitError,
+} from "../scraper/scrapeURL/error";
+import { TransportableError } from "../lib/error";
 import type { NuQJob } from "../services/worker/nuq";
 import { CostTracking } from "../lib/cost-tracking";
 configDotenv();
@@ -120,6 +125,14 @@ async function runWebScraper({
       }
     } catch (_error) {
       error = _error;
+      if (
+        error instanceof ScrapeBlockedError ||
+        error instanceof ScrapeRetryLimitError ||
+        (error instanceof TransportableError &&
+          error.code === "SCRAPE_FAILED_BLOCKED")
+      ) {
+        break;
+      }
     }
   }
 

--- a/apps/api/src/scraper/scrapeURL/__tests__/antibot.test.ts
+++ b/apps/api/src/scraper/scrapeURL/__tests__/antibot.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { isAntiBotBlock } from "../lib/antibot";
+import { ScrapeBlockedError } from "../error";
+import {
+  serializeTransportableError,
+  deserializeTransportableError,
+} from "../../../lib/error-serde";
+import { scrapeURL } from "../index";
+import { scrapeOptions } from "../../../controllers/v2/types";
+import { CostTracking } from "../../../lib/cost-tracking";
+import * as enginesModule from "../engines";
+
+describe("isAntiBotBlock", () => {
+  it("detects anti-bot status codes (403, 401, 429)", () => {
+    expect(isAntiBotBlock(403)).toBe(true);
+    expect(isAntiBotBlock(401)).toBe(true);
+    expect(isAntiBotBlock(429)).toBe(true);
+    expect(isAntiBotBlock(200)).toBe(false);
+    expect(isAntiBotBlock(404)).toBe(false);
+    expect(isAntiBotBlock(500)).toBe(false);
+  });
+
+  it("detects Cloudflare challenge pages (status 200)", () => {
+    const cfTitleHtml = `<html><head><title>Just a moment...</title></head><body>Enable JavaScript and cookies to continue</body></html>`;
+    expect(isAntiBotBlock(200, cfTitleHtml)).toBe(true);
+
+    const cfAttentionHtml = `<html><head><title>Attention Required! | Cloudflare</title></head><body><div id="cf-browser-verification"></div></body></html>`;
+    expect(isAntiBotBlock(200, cfAttentionHtml)).toBe(true);
+
+    const cfTurnstileHtml = `<html><body><div id="challenge-platform"><script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script></div></body></html>`;
+    expect(isAntiBotBlock(200, cfTurnstileHtml)).toBe(true);
+
+    const cfVerifyMarkdown = `Please verify you are a human to access this site. Cloudflare Ray ID: 89342784832`;
+    expect(isAntiBotBlock(200, undefined, cfVerifyMarkdown)).toBe(true);
+  });
+
+  it("detects DataDome challenge and block pages (status 200)", () => {
+    const datadomeHtml = `<html><head><script src="https://geo.captcha-delivery.com/captcha/captcha.js"></script></head><body>Protected by DataDome</body></html>`;
+    expect(isAntiBotBlock(200, datadomeHtml)).toBe(true);
+
+    const datadomeBlockHtml = `<html><body><h1>Access to this page has been denied</h1><p>Blocked by DataDome</p></body></html>`;
+    expect(isAntiBotBlock(200, datadomeBlockHtml)).toBe(true);
+  });
+
+  it("detects generic CAPTCHAs and WAF challenges", () => {
+    const pxHtml = `<html><body><div id="px-captcha">Press & Hold to confirm you are a human</div></body></html>`;
+    expect(isAntiBotBlock(200, pxHtml)).toBe(true);
+
+    const incapsulaHtml = `<html><body><p>Incapsula incident ID: 12345</p></body></html>`;
+    expect(isAntiBotBlock(200, incapsulaHtml)).toBe(true);
+
+    const robotCheckHtml = `<html><head><title>Robot Check</title></head><body>Please solve this CAPTCHA</body></html>`;
+    expect(isAntiBotBlock(200, robotCheckHtml)).toBe(true);
+  });
+
+  it("returns false for legitimate clean HTML and markdown", () => {
+    const normalHtml = `<!DOCTYPE html><html><head><title>ResearchGate Paper Title</title></head><body><h1>Deep Learning in Robotics</h1><p>This paper discusses robotic learning techniques.</p></body></html>`;
+    const normalMarkdown = `# Deep Learning in Robotics\n\nThis paper discusses robotic learning techniques.`;
+    expect(isAntiBotBlock(200, normalHtml, normalMarkdown)).toBe(false);
+  });
+});
+
+describe("ScrapeBlockedError SerDe", () => {
+  it("serializes and deserializes ScrapeBlockedError properly", () => {
+    const err = new ScrapeBlockedError("Scrape blocked by Cloudflare challenge");
+    expect(err.code).toBe("SCRAPE_FAILED_BLOCKED");
+
+    const serialized = serializeTransportableError(err);
+    expect(serialized.startsWith("SCRAPE_FAILED_BLOCKED|")).toBe(true);
+
+    const deserialized = deserializeTransportableError(serialized);
+    expect(deserialized).toBeInstanceOf(ScrapeBlockedError);
+    expect(deserialized?.code).toBe("SCRAPE_FAILED_BLOCKED");
+    expect(deserialized?.message).toBe("Scrape blocked by Cloudflare challenge");
+  });
+});
+
+describe("Anti-bot waterfall loop termination", () => {
+  it("terminates with ScrapeBlockedError when all engines return 403 / anti-bot block pages", async () => {
+    vi.spyOn(enginesModule, "scrapeURLWithEngine").mockResolvedValue({
+      url: "https://www.researchgate.net/publication/12345_sample",
+      html: `<html><head><title>Attention Required! | Cloudflare</title></head><body><div id="cf-browser-verification"></div></body></html>`,
+      statusCode: 403,
+      proxyUsed: "basic",
+    });
+
+    const out = await scrapeURL(
+      "test:antibot-terminal-state",
+      "https://www.researchgate.net/publication/12345_sample",
+      scrapeOptions.parse({
+        proxy: "stealth",
+      }),
+      { forceEngine: "fire-engine;chrome-cdp;stealth", teamId: "test", orgId: null },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(false);
+    if (!out.success) {
+      expect(out.error).toBeInstanceOf(ScrapeBlockedError);
+      expect((out.error as any).code).toBe("SCRAPE_FAILED_BLOCKED");
+    }
+  });
+
+  it("escalates from auto proxy to stealth proxy and terminates with ScrapeBlockedError if still blocked", async () => {
+    let callCount = 0;
+    vi.spyOn(enginesModule, "scrapeURLWithEngine").mockImplementation(async (meta, engine) => {
+      callCount++;
+      return {
+        url: "https://www.researchgate.net/publication/12345_sample",
+        html: `<html><head><title>Just a moment...</title></head><body>Enable JavaScript and cookies to continue</body></html>`,
+        statusCode: 200,
+        proxyUsed: "basic",
+      };
+    });
+
+    const out = await scrapeURL(
+      "test:antibot-auto-to-stealth-terminal",
+      "https://www.researchgate.net/publication/12345_sample",
+      scrapeOptions.parse({
+        proxy: "auto",
+      }),
+      { forceEngine: ["fetch", "fire-engine;chrome-cdp;stealth"], teamId: "test", orgId: null },
+      new CostTracking(),
+    );
+
+    expect(out.success).toBe(false);
+    if (!out.success) {
+      expect(out.error).toBeInstanceOf(ScrapeBlockedError);
+      expect((out.error as any).code).toBe("SCRAPE_FAILED_BLOCKED");
+    }
+    // Verifies it escalated once (auto -> stealth) and then terminated instead of looping forever
+    expect(callCount).toBeLessThanOrEqual(4);
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -138,11 +138,10 @@ export async function specialtyScrapeCheck(
 
   // Check for document types first (before PDF to prioritize documents)
   if (isDocument) {
-    throw new AddFeatureError(
-      ["document"],
-      undefined,
-      await feResToDocumentPrefetch(logger, feRes, contentType),
-    );
+    const prefetch = await feResToDocumentPrefetch(logger, feRes, contentType);
+    if (prefetch) {
+      throw new AddFeatureError(["document"], undefined, prefetch);
+    }
   }
 
   // Check for octet-stream with document signature
@@ -151,17 +150,20 @@ export async function specialtyScrapeCheck(
   if (isOctetStream) {
     const isZipSignature =
       feRes?.file?.content?.startsWith("UEsD") ||
-      feRes?.content.startsWith("PK");
+      feRes?.content?.startsWith("PK");
     const isOleSignature =
       feRes?.file?.content?.startsWith("0M8R4K") ||
-      feRes?.content.startsWith("\xD0\xCF\x11\xE0");
+      feRes?.content?.startsWith("\xD0\xCF\x11\xE0");
 
     if (isZipSignature) {
-      throw new AddFeatureError(
-        ["document"],
-        undefined,
-        await feResToDocumentPrefetch(logger, feRes, contentType),
+      const prefetch = await feResToDocumentPrefetch(
+        logger,
+        feRes,
+        contentType,
       );
+      if (prefetch) {
+        throw new AddFeatureError(["document"], undefined, prefetch);
+      }
     }
     if (isOleSignature) {
       // OLE2 signature is shared by .doc/.xls/.ppt files
@@ -171,32 +173,45 @@ export async function specialtyScrapeCheck(
       const effectiveContentType = isDocUrl
         ? "application/msword"
         : contentType;
-      throw new AddFeatureError(
-        ["document"],
-        undefined,
-        await feResToDocumentPrefetch(logger, feRes, effectiveContentType),
+      const prefetch = await feResToDocumentPrefetch(
+        logger,
+        feRes,
+        effectiveContentType,
       );
+      if (prefetch) {
+        throw new AddFeatureError(["document"], undefined, prefetch);
+      }
     }
   }
 
   // Check for PDF (references were already handled above the header guard).
   if (isPdf) {
-    throw new AddFeatureError(
-      ["pdf"],
-      await feResToPdfPrefetch(logger, feRes, signal, maxFileBytes),
+    const prefetch = await feResToPdfPrefetch(
+      logger,
+      feRes,
+      signal,
+      maxFileBytes,
     );
+    if (prefetch) {
+      throw new AddFeatureError(["pdf"], prefetch);
+    }
   }
 
   // Check for octet-stream with PDF signature
   if (
     isOctetStream &&
     (feRes?.file?.content?.startsWith("JVBERi0") ||
-      feRes?.content.startsWith("%PDF-"))
+      feRes?.content?.startsWith("%PDF-"))
   ) {
-    throw new AddFeatureError(
-      ["pdf"],
-      await feResToPdfPrefetch(logger, feRes, signal, maxFileBytes),
+    const prefetch = await feResToPdfPrefetch(
+      logger,
+      feRes,
+      signal,
+      maxFileBytes,
     );
+    if (prefetch) {
+      throw new AddFeatureError(["pdf"], prefetch);
+    }
   }
 
   // Reject unsupported binary content types (images, video, audio, archives, etc.)

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -692,6 +692,16 @@ export class EngineUnsuccessfulError extends Error {
   }
 }
 
+export class EngineBlockedError extends Error {
+  name = "EngineBlockedError";
+  public engine: Engine;
+
+  constructor(engine: Engine) {
+    super(`Engine ${engine} was blocked by anti-bot`);
+    this.engine = engine;
+  }
+}
+
 export class WaterfallNextEngineSignal extends Error {
   name = "WaterfallNextEngineSignal";
 
@@ -765,3 +775,25 @@ export class ScrapeRetryLimitError extends TransportableError {
     return x;
   }
 }
+
+export class ScrapeBlockedError extends TransportableError {
+  constructor(
+    message: string = "The scrape was blocked by the website's anti-bot protection (e.g. Cloudflare, DataDome, CAPTCHA, or HTTP 403 Forbidden).",
+  ) {
+    super("SCRAPE_FAILED_BLOCKED", message);
+  }
+
+  serialize() {
+    return super.serialize();
+  }
+
+  static deserialize(
+    _: ErrorCodes,
+    data: ReturnType<typeof this.prototype.serialize>,
+  ) {
+    const x = new ScrapeBlockedError(data.message);
+    x.stack = data.stack;
+    return x;
+  }
+}
+

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -49,11 +49,14 @@ import {
   EngineSnipedError,
   WaterfallNextEngineSignal,
   EngineUnsuccessfulError,
+  EngineBlockedError,
   ProxySelectionError,
   ScrapeRetryLimitError,
+  ScrapeBlockedError,
   BrandingNotSupportedError,
   XTwitterConfigurationError,
 } from "./error";
+import { isAntiBotBlock } from "./lib/antibot";
 import { ScrapeRetryTracker } from "./retryTracker";
 import { executeTransformers } from "./transformers";
 import { LLMRefusalError } from "./transformers/llmExtract";
@@ -647,16 +650,21 @@ async function scrapeURLLoopIter(
     const isLikelyProxyError = [401, 403, 429].includes(
       engineResult.statusCode,
     );
+    const isAntiBot = isAntiBotBlock(
+      engineResult.statusCode,
+      engineResult.html,
+      checkMarkdown,
+    );
 
     if (
-      isLikelyProxyError &&
+      (isLikelyProxyError || isAntiBot) &&
       meta.options.proxy === "auto" &&
       !meta.featureFlags.has("stealthProxy")
     ) {
       meta.logger.info(
         "Scrape via " +
           engine +
-          " deemed unsuccessful due to proxy inadequacy. Adding stealthProxy flag.",
+          " deemed unsuccessful due to anti-bot block / proxy inadequacy. Adding stealthProxy flag.",
         {
           factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
           statusCode: engineResult.statusCode,
@@ -664,6 +672,18 @@ async function scrapeURLLoopIter(
         },
       );
       throw new AddFeatureError(["stealthProxy"]);
+    }
+
+    if (isAntiBot || isLikelyProxyError) {
+      meta.logger.warn(
+        "Scrape via " + engine + " deemed blocked by anti-bot.",
+        {
+          factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
+          statusCode: engineResult.statusCode,
+          length: engineResult.html?.trim().length ?? 0,
+        },
+      );
+      throw new EngineBlockedError(engine);
     }
 
     // NOTE: TODO: what to do when status code is bad is tough...
@@ -755,6 +775,7 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
     const remainingEngines = [...fallbackList];
     let enginePromises: EngineBundlePromise[] = [];
     const enginesAttempted: string[] = [];
+    const blockedEngines: string[] = [];
 
     meta.abort.throwIfAborted();
 
@@ -842,7 +863,13 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
           break;
         } catch (error) {
           if (error instanceof WrappedEngineError) {
-            if (error.engine === "x-twitter") {
+            if (error.error instanceof EngineBlockedError) {
+              blockedEngines.push(error.engine);
+              meta.logger.warn(
+                "Engine " + error.engine + " was blocked by anti-bot.",
+                { error: error.error },
+              );
+            } else if (error.engine === "x-twitter") {
               meta.logger.warn("X/Twitter scrape failed fatally.", {
                 error: error.error,
               });
@@ -976,9 +1003,16 @@ async function scrapeURLLoop(meta: Meta): Promise<ScrapeUrlResponse> {
       setSpanAttributes(span, {
         "engine.no_engines_left": true,
         "engine.engines_attempted": enginesAttempted.join(","),
+        "engine.engines_blocked": blockedEngines.join(","),
       });
       if (meta.options.lockdown) {
         throw new LockdownMissError();
+      }
+      if (
+        blockedEngines.length > 0 &&
+        blockedEngines.length === enginesAttempted.length
+      ) {
+        throw new ScrapeBlockedError();
       }
       throw new NoEnginesLeftError(fallbackList.map(x => x.engine));
     }
@@ -1278,11 +1312,7 @@ export async function scrapeURL(
           result = await scrapeURLLoop(meta);
           break;
         } catch (error) {
-          if (
-            error instanceof AddFeatureError &&
-            (meta.internalOptions.forceEngine === undefined ||
-              Array.isArray(meta.internalOptions.forceEngine))
-          ) {
+          if (error instanceof AddFeatureError) {
             retryTracker.record("feature_toggle", error);
             meta.logger.debug(
               "More feature flags requested by scraper: adding " +
@@ -1298,11 +1328,7 @@ export async function scrapeURL(
             if (error.documentPrefetch) {
               meta.documentPrefetch = error.documentPrefetch;
             }
-          } else if (
-            error instanceof RemoveFeatureError &&
-            (meta.internalOptions.forceEngine === undefined ||
-              Array.isArray(meta.internalOptions.forceEngine))
-          ) {
+          } else if (error instanceof RemoveFeatureError) {
             retryTracker.record("feature_removal", error);
             meta.logger.debug(
               "Incorrect feature flags reported by scraper: removing " +
@@ -1322,7 +1348,7 @@ export async function scrapeURL(
               meta.logger.error(
                 "PDF was prefetched and still blocked by antibot, failing",
               );
-              throw error;
+              throw new ScrapeBlockedError();
             } else {
               retryTracker.record("pdf_antibot", error);
               meta.logger.debug(
@@ -1340,7 +1366,7 @@ export async function scrapeURL(
               meta.logger.error(
                 "Document was prefetched and still blocked by antibot, failing",
               );
-              throw error;
+              throw new ScrapeBlockedError();
             } else {
               retryTracker.record("document_antibot", error);
               meta.logger.debug(
@@ -1577,6 +1603,12 @@ export async function scrapeURL(
           error,
           retryStats: error.stats,
         });
+      } else if (error instanceof ScrapeBlockedError) {
+        errorType = "ScrapeBlockedError";
+        meta.logger.warn(
+          "scrapeURL: Scrape blocked by website anti-bot protection",
+          { error },
+        );
       } else if (error instanceof UnsafeDomainBlockedError) {
         errorType = "UnsafeDomainBlockedError";
         meta.logger.warn(

--- a/apps/api/src/scraper/scrapeURL/lib/antibot.ts
+++ b/apps/api/src/scraper/scrapeURL/lib/antibot.ts
@@ -1,0 +1,82 @@
+/**
+ * Utility functions for detecting anti-bot challenge and block pages
+ * (e.g. Cloudflare, DataDome, PerimeterX, Akamai, CAPTCHAs, HTTP 403/401/429).
+ */
+
+const ANTIBOT_STATUS_CODES = new Set([401, 403, 429]);
+
+const CLOUDFLARE_PATTERNS = [
+  /just a moment\.\.\./i,
+  /attention required!\s*\|\s*cloudflare/i,
+  /cf-browser-verification/i,
+  /cf_chl_prog/i,
+  /challenge-platform/i,
+  /cf-turnstile/i,
+  /challenges\.cloudflare\.com/i,
+  /checking your browser before accessing/i,
+  /enable javascript and cookies to continue/i,
+  /(?:please\s+)?verify\s+(?:that\s+)?you\s+are\s+(?:a\s+)?human/i,
+  /cloudflare\s+ray\s+id/i,
+];
+
+const DATADOME_PATTERNS = [
+  /geo\.captcha-delivery\.com/i,
+  /protected\s+by\s+datadome/i,
+  /blocked\s+by\s+datadome/i,
+  /datadome\.js/i,
+  /datadome-captcha/i,
+  /access to this page has been denied.*datadome/i,
+];
+
+const GENERAL_CAPTCHA_AND_BOT_PATTERNS = [
+  /px-captcha/i,
+  /perimeterx/i,
+  /_px3/i,
+  /press\s+&\s+hold\s+to\s+confirm\s+you\s+are\s+a\s+human/i,
+  /incapsula\s+incident\s+id/i,
+  /_incapsula_resource/i,
+  /shieldsquare/i,
+  /distil_captcha/i,
+  /<title>(?:robot check|security check|human verification|access denied|bot verification|security verification)<\/title>/i,
+  /please\s+solve\s+(?:the|this)\s+captcha/i,
+  /recaptcha\/api\.js/i,
+  /hcaptcha\.com\/1\/api\.js/i,
+];
+
+/**
+ * Checks whether a response (status code and/or content) indicates an anti-bot challenge or block page.
+ */
+export function isAntiBotBlock(
+  statusCode?: number,
+  html?: string,
+  markdown?: string,
+): boolean {
+  if (statusCode !== undefined && ANTIBOT_STATUS_CODES.has(statusCode)) {
+    return true;
+  }
+
+  const contentToCheck = (html ? html + " " : "") + (markdown ?? "");
+  if (!contentToCheck.trim()) {
+    return false;
+  }
+
+  for (const pattern of CLOUDFLARE_PATTERNS) {
+    if (pattern.test(contentToCheck)) {
+      return true;
+    }
+  }
+
+  for (const pattern of DATADOME_PATTERNS) {
+    if (pattern.test(contentToCheck)) {
+      return true;
+    }
+  }
+
+  for (const pattern of GENERAL_CAPTCHA_AND_BOT_PATTERNS) {
+    if (pattern.test(contentToCheck)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Fixes #4348

### Summary of Changes
- Added `SCRAPE_FAILED_BLOCKED` error code and `ScrapeBlockedError` to represent terminal anti-bot challenge and block page outcomes (e.g. Cloudflare, DataDome, CAPTCHAs, HTTP 403 Forbidden).
- Implemented `isAntiBotBlock` detector across status codes and anti-bot challenge signatures.
- Updated `scrapeURLLoopIter` to distinguish anti-bot blocks and escalate to stealth proxy when in `auto` proxy mode, or throw `EngineBlockedError` if stealth is already active / exhausted.
- Updated `scrapeURLLoop` to track blocked waterfall engine tiers and transition directly to terminal `ScrapeBlockedError` (mapped to HTTP 403 in controllers) instead of looping indefinitely or timing out.
- Prevented repetitive toggle cycling in `specialtyHandler.ts` and `runWebScraper.ts` when blocked responses are encountered.
- Added comprehensive unit tests in `apps/api/src/scraper/scrapeURL/__tests__/antibot.test.ts` verifying detection, serialization/deserialization, and waterfall loop termination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4348 by making anti-bot blocked responses a terminal error instead of retrying the scrape waterfall until timeout. Cloudflare, DataDome, CAPTCHA, and HTTP 401/403/429 blocks now return a 403 with `SCRAPE_FAILED_BLOCKED`; `auto` proxy mode escalates to stealth proxy once before failing.

**Bug Fixes**
- Detects anti-bot blocks from status codes and challenge-page signatures.
- Ends the waterfall with `ScrapeBlockedError` when all attempted engines are blocked.
- Stops repeated `stealthProxy` toggling when blocked responses are encountered.
- Adds `SCRAPE_FAILED_BLOCKED` handling to v1 scrape, v2 scrape, and v2 parse controllers.
- Supports `ScrapeBlockedError` serialization for queued jobs.
- Adds unit tests for detection, serialization, and waterfall termination.

<sup>Written for commit 708c078089fc199ef31100083f5bfb036fd6cddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

