### PR TITLE
docs: fix Node.js SDK initialization and import examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ search_result = app.search("firecrawl", limit=5)
 
 **Node.js**
 ```javascript
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
+const app = new FirecrawlApp({ apiKey: "fc-YOUR_API_KEY" });
 
 app.search("firecrawl", { limit: 5 })
 ```
@@ -161,9 +161,9 @@ result = app.scrape('firecrawl.dev')
 
 **Node.js**
 ```javascript
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+const app = new FirecrawlApp({ apiKey: "fc-YOUR_API_KEY" });
 
 app.scrape('firecrawl.dev')
 ```
@@ -219,9 +219,9 @@ app.interact(scrape_id, prompt="Click the first result")
 
 **Node.js**
 ```javascript
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
+const app = new FirecrawlApp({ apiKey: "fc-YOUR_API_KEY" });
 
 const result = await app.scrape("https://amazon.com");
 
@@ -568,12 +568,12 @@ print(results)
 
 Install the SDK:
 ```bash
-npm install firecrawl
+npm install @mendable/firecrawl-js
 ```
 ```javascript
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+const app = new FirecrawlApp({ apiKey: 'fc-YOUR_API_KEY' });
 
 // Scrape a single URL
 const doc = await app.scrape('https://firecrawl.dev', { formats: ['markdown'] });

--- a/apps/js-sdk/example.js
+++ b/apps/js-sdk/example.js
@@ -33,10 +33,10 @@ run().catch((e) => {
 
 // old stuff:
 
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 import { z } from 'zod';
 
-const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
+const app = new FirecrawlApp({apiKey: "fc-YOUR_API_KEY"});
 
 const main = async () => {
 

--- a/apps/js-sdk/example.ts
+++ b/apps/js-sdk/example.ts
@@ -1,7 +1,7 @@
 // Placeholder v2 example (TypeScript)
 // Minimal usage of new FirecrawlClient. Replace with your API key before running.
 
-// import { Firecrawl } from 'firecrawl';
+// import FirecrawlApp from '@mendable/firecrawl-js';
 import Firecrawl from './firecrawl/src/index';
 
 const run = async () => {
@@ -36,9 +36,9 @@ run().catch((e) => {
 
 // old stuff:
 
-import { Firecrawl, CrawlStatusResponse, ErrorResponse } from 'firecrawl';
+import FirecrawlApp, { CrawlStatusResponse, ErrorResponse } from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
+const app = new FirecrawlApp({apiKey: "fc-YOUR_API_KEY"});
 
 const main = async () => {
 

--- a/apps/js-sdk/example_v1.js
+++ b/apps/js-sdk/example_v1.js
@@ -1,10 +1,10 @@
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
 // Placeholder v1 example (JavaScript)
 // Mirrors the older SDK usage. Replace with your API key before running.
 
 async function main() {
-  const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY || 'fc-YOUR_API_KEY' });
+  const app = new FirecrawlApp({ apiKey: process.env.FIRECRAWL_API_KEY || 'fc-YOUR_API_KEY' });
 
   const scrape = await app.v1.scrapeUrl('firecrawl.dev');
   if (scrape && scrape.success) console.log(scrape.markdown);

--- a/apps/js-sdk/example_v1.ts
+++ b/apps/js-sdk/example_v1.ts
@@ -1,7 +1,7 @@
 // Placeholder v1 example (TypeScript)
 // Mirrors the older SDK usage. Replace with your API key before running.
 
-// import { Firecrawl } from 'firecrawl';
+// import FirecrawlApp from '@mendable/firecrawl-js';
 import Firecrawl from './firecrawl/src/index'
 
 async function main() {

--- a/apps/js-sdk/firecrawl/README.md
+++ b/apps/js-sdk/firecrawl/README.md
@@ -7,7 +7,7 @@ The Firecrawl Node SDK is a library that lets you easily search, scrape, and int
 To install the Firecrawl Node SDK, you can use npm:
 
 ```bash
-npm install firecrawl
+npm install @mendable/firecrawl-js
 ```
 
 ## Usage
@@ -18,9 +18,9 @@ npm install firecrawl
 Here's an example of how to use the SDK with error handling:
 
 ```js
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+const app = new FirecrawlApp({ apiKey: 'fc-YOUR_API_KEY' });
 
 // Scrape a website
 const scrapeResponse = await app.scrape('https://firecrawl.dev', {
@@ -138,10 +138,10 @@ const status = await app.getCrawlStatus(id);
 Use `extract` with a prompt and schema. Zod schemas are supported directly.
 
 ```js
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 import { z } from 'zod';
 
-const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+const app = new FirecrawlApp({ apiKey: 'fc-YOUR_API_KEY' });
 
 const schema = z.object({
   title: z.string(),
@@ -358,9 +358,9 @@ await watch.start();
 The feature‑frozen v1 is still available under `app.v1` with the original method names.
 
 ```js
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({ apiKey: 'fc-YOUR_API_KEY' });
+const app = new FirecrawlApp({ apiKey: 'fc-YOUR_API_KEY' });
 
 // v1 methods (feature‑frozen)
 const scrapeV1 = await app.v1.scrapeUrl('https://firecrawl.dev', { formats: ['markdown', 'html'] });

--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/prototype-discoverability.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/prototype-discoverability.test.ts
@@ -1,7 +1,14 @@
-import { Firecrawl, FirecrawlClient } from "../../../index";
+import FirecrawlAppDefault, { Firecrawl, FirecrawlApp, FirecrawlClient } from "../../../index";
 
 describe("V2 prototype discoverability", () => {
   const app = new Firecrawl({ apiKey: "fc-test", apiUrl: "http://localhost:9" });
+
+  it("exports FirecrawlApp alias and default", () => {
+    expect(FirecrawlApp).toBe(Firecrawl);
+    expect(FirecrawlAppDefault).toBe(Firecrawl);
+    const appFromAlias = new FirecrawlApp({ apiKey: "fc-test", apiUrl: "http://localhost:9" });
+    expect(appFromAlias).toBeInstanceOf(Firecrawl);
+  });
 
   it("exposes V2 methods on immediate Firecrawl prototype", () => {
     const names = Object.getOwnPropertyNames(Object.getPrototypeOf(app));

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -2,7 +2,7 @@
  * Firecrawl JS/TS SDK — unified entrypoint.
  * - v2 by default on the top‑level client
  * - v1 available under `.v1` (feature‑frozen)
- * - Exports: `Firecrawl` (default), `FirecrawlClient` (v2), `FirecrawlAppV1` (v1), and v2 types
+ * - Exports: `Firecrawl` (default), `FirecrawlApp` (alias), `FirecrawlClient` (v2), `FirecrawlAppV1` (v1), and v2 types
  */
 
 /** Direct v2 client. */
@@ -58,5 +58,6 @@ export class Firecrawl extends V2 {
   }
 })();
 
+export { Firecrawl as FirecrawlApp };
 export default Firecrawl;
 

--- a/examples/attributes-extraction-js-sdk.js
+++ b/examples/attributes-extraction-js-sdk.js
@@ -2,9 +2,9 @@
  * Example: Using Firecrawl JS SDK v2 to extract attributes from HTML elements
  */
 
-import { Firecrawl } from 'firecrawl';
+import FirecrawlApp from '@mendable/firecrawl-js';
 
-const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+const app = new FirecrawlApp({ apiKey: process.env.FIRECRAWL_API_KEY });
 
 async function main() {
   console.log('🎯 Extracting attributes from Hacker News...');

--- a/examples/scrape_and_analyze_airbnb_data_e2b/scraping.ts
+++ b/examples/scrape_and_analyze_airbnb_data_e2b/scraping.ts
@@ -1,6 +1,6 @@
 //@ts-ignore
 import * as fs from 'fs'
-import { Firecrawl } from 'firecrawl'
+import FirecrawlApp from '@mendable/firecrawl-js'
 import 'dotenv/config'
 import { config } from 'dotenv'
 import { z } from 'zod'
@@ -9,8 +9,8 @@ config()
 
 export async function scrapeAirbnb() {
   try {
-    // Initialize the Firecrawl with your API key
-    const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY })
+    // Initialize FirecrawlApp with your API key
+    const app = new FirecrawlApp({ apiKey: process.env.FIRECRAWL_API_KEY })
 
     // Define the URL to crawl
     const listingsUrl =


### PR DESCRIPTION
### Summary of Changes
- Updated outdated import syntax across `apps/js-sdk/firecrawl/README.md` and `examples/` to use the official scoped package `@mendable/firecrawl-js`.
- Added `export { Firecrawl as FirecrawlApp }` alias in `apps/js-sdk/firecrawl/src/index.ts` to ensure backward compatibility for legacy tutorials and scripts.
- Added unit tests for prototype discoverability and alias export verification.

### Testing
- Ran SDK unit tests (`npm test` in `apps/js-sdk/firecrawl`) — all passed cleanly.