### PR TITLE
fix(js-sdk): forward ignoreRobotsTxt in v2 crawl payload

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/crawl.unit.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for v2 crawl payload serialisation.
+ *
+ * Regression tests for:
+ *   https://github.com/firecrawl/firecrawl/issues/3940
+ *   JS SDK v2 crawl() silently drops ignoreRobotsTxt option
+ */
+import { describe, expect, test, jest } from "@jest/globals";
+import { startCrawl } from "../../../v2/methods/crawl";
+
+describe("v2.crawl unit - prepareCrawlPayload", () => {
+  function makeHttp() {
+    return {
+      post: jest.fn().mockResolvedValue({
+        status: 200,
+        data: { success: true, id: "crawl-123", url: "https://api.firecrawl.dev/v2/crawl/crawl-123" },
+      }),
+    } as any;
+  }
+
+  test("forwards ignoreRobotsTxt: true to the API", async () => {
+    const http = makeHttp();
+    await startCrawl(http, { url: "https://example.com", ignoreRobotsTxt: true });
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({ ignoreRobotsTxt: true }),
+    );
+  });
+
+  test("forwards ignoreRobotsTxt: false to the API", async () => {
+    const http = makeHttp();
+    await startCrawl(http, { url: "https://example.com", ignoreRobotsTxt: false });
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({ ignoreRobotsTxt: false }),
+    );
+  });
+
+  test("omits ignoreRobotsTxt when not set", async () => {
+    const http = makeHttp();
+    await startCrawl(http, { url: "https://example.com" });
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("ignoreRobotsTxt");
+  });
+
+  test("forwards all standard options in a single call", async () => {
+    const http = makeHttp();
+    await startCrawl(http, {
+      url: "https://example.com",
+      ignoreRobotsTxt: true,
+      limit: 50,
+      allowExternalLinks: false,
+      allowSubdomains: true,
+      maxConcurrency: 5,
+      delay: 2,
+    });
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/crawl",
+      expect.objectContaining({
+        url: "https://example.com",
+        ignoreRobotsTxt: true,
+        limit: 50,
+        allowExternalLinks: false,
+        allowSubdomains: true,
+        maxConcurrency: 5,
+        delay: 2,
+      }),
+    );
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/crawl.ts
@@ -36,6 +36,7 @@ function prepareCrawlPayload(request: CrawlRequest): Record<string, unknown> {
   if (request.allowSubdomains != null) data.allowSubdomains = request.allowSubdomains;
   if (request.delay != null) data.delay = request.delay;
   if (request.maxConcurrency != null) data.maxConcurrency = request.maxConcurrency;
+  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
   if (request.regexOnFullURL != null) data.regexOnFullURL = request.regexOnFullURL;
   if (request.webhook != null) data.webhook = request.webhook;
   if (request.integration != null && request.integration.trim()) data.integration = request.integration.trim();


### PR DESCRIPTION
CrawlOptions.ignoreRobotsTxt was declared in types but never included in the request body built by prepareCrawlPayload(). Calling crawl() with ignoreRobotsTxt: true had no effect — the field was silently dropped and the API continued respecting robots.txt.

 ## What
  
  `CrawlOptions.ignoreRobotsTxt` was declared in the JS SDK v2 types but never forwarded to the API. Calling
  `crawl()` or `startCrawl()` with `ignoreRobotsTxt: true` had no effect — the field was silently dropped by
  `prepareCrawlPayload()` and the crawl continued respecting robots.txt regardless of what the caller passed.
  
  ## Root cause
  
  `prepareCrawlPayload()` in `src/v2/methods/crawl.ts` listed every `CrawlOptions` field except `ignoreRobotsTxt`.
  
  ## Fix
  
  Add the missing line:
  ```ts
  if (request.ignoreRobotsTxt != null) data.ignoreRobotsTxt = request.ignoreRobotsTxt;
```

## Tests
  4 new unit tests in crawl.unit.test.ts covering true, false, unset, and combined-options cases. All pass.


Fixes #3940


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards `CrawlOptions.ignoreRobotsTxt` in the v2 crawl payload so `crawl()` and `startCrawl()` now respect the flag instead of silently dropping it. This fixes #3940.

<sup>Written for commit 33ffed109d8c8d312ee738920abcc5a2223854a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

