### PR TITLE
fix(api): sanitize NUL bytes from returnvalue before Postgres INSERT

### DIFF
--- a/apps/api/src/__tests__/nuq-postgres.test.ts
+++ b/apps/api/src/__tests__/nuq-postgres.test.ts
@@ -74,4 +74,42 @@ describeIf("NuQ Postgres queue", () => {
       }),
     ).resolves.toBeNull();
   });
+
+  // Regression test for https://github.com/firecrawl/firecrawl/issues/4113
+  // Postgres rejects JSON containing U+0000 (NUL bytes) with error 22P05.
+  // The worker must sanitise the returnvalue before the UPDATE so scraped
+  // content with embedded NUL bytes never crash-loops the api container.
+  test("jobFinish with NUL bytes in returnvalue does not throw (22P05)", async () => {
+    const jobId = randomUUID();
+    ids.push(jobId);
+
+    const job = await scrapeQueue.addJob(jobId, scrapeData());
+    expect(job).toMatchObject({ id: jobId, status: "waiting" });
+
+    // Lock the job so jobFinish's UPDATE matches
+    const locked = await scrapeQueue.getJob(jobId);
+    expect(locked).not.toBeNull();
+
+    // Build a returnvalue whose JSON contains a NUL byte — the exact shape
+    // that certain PDF parsers (e.g. pdf-parse on Google Sheets exports)
+    // produce, which triggered the Postgres 22P05 error.
+    const nulReturnvalue = {
+      markdown: "\u0000Hello from a broken PDF\u0000",
+      metadata: { title: "broken\u0000pdf" },
+    };
+
+    // jobFinish must complete without throwing, even with NUL bytes present.
+    await expect(
+      scrapeQueue.jobFinish(jobId, locked!.lock!, nulReturnvalue),
+    ).resolves.not.toThrow();
+
+    // The row must be marked completed and the stored value must be NUL-free.
+    const row = await cleanupPool.query(
+      "SELECT status, returnvalue FROM nuq.queue_scrape WHERE id = $1",
+      [jobId],
+    );
+    expect(row.rows[0].status).toBe("completed");
+    const stored = JSON.stringify(row.rows[0].returnvalue);
+    expect(stored).not.toContain("\u0000");
+  });
 });

--- a/apps/api/src/services/worker/nuq.ts
+++ b/apps/api/src/services/worker/nuq.ts
@@ -1375,11 +1375,24 @@ class NuQ<JobData = any, JobReturnValue = any> {
         "nuq.job_id": id,
       });
 
+      // Postgres rejects JSON containing U+0000 (NUL bytes) with error code
+      // 22P05 ("untranslatable character"). Strip them from the serialised
+      // payload before the INSERT so scraped content with embedded NUL bytes
+      // (e.g. certain PDFs) does not crash the worker process.
+      // JSON.stringify encodes NUL as the literal 6-char sequence \u0000, so
+      // we strip that escape sequence from the serialised string before parsing
+      // back — this is safer than walking the object tree because it handles
+      // arbitrarily nested structures without recursion limits.
+      const sanitizedReturnvalue =
+        returnvalue != null
+          ? JSON.parse(JSON.stringify(returnvalue).replace(/\\u0000/g, ""))
+          : returnvalue;
+
       const start = Date.now();
       try {
         const result = await nuqPool.query(
           `UPDATE ${this.queueName} SET status = 'completed'::nuq.job_status, lock = null, locked_at = null, finished_at = now(), returnvalue = $3 WHERE id = $1 AND lock = $2 RETURNING id, listen_channel_id;`,
-          [id, lock, returnvalue],
+          [id, lock, sanitizedReturnvalue],
         );
 
         const success = result.rowCount !== 0;


### PR DESCRIPTION
Scraped content containing U+0000 (NUL bytes) — e.g. certain PDFs exported from Google Sheets — causes jobFinish() to crash with Postgres error 22P05. The exception propagates unhandled, the nuq-worker exits, and the harness tears down the entire api container.

Strip the literal \u0000 escape sequence from the JSON-serialised returnvalue before the UPDATE so NUL bytes in scraped content never reach Postgres.

## What
  
  When scraped content contains U+0000 (NUL bytes) — e.g. certain PDFs exported from Google Sheets — `nuq-worker`'s
  `jobFinish()` crashes with Postgres error `22P05: \u0000 cannot be converted to text`. The exception is unhandled,
  the worker exits code 1, and the harness tears down the entire api container in a crash-loop.
  
  ## Root cause
  
  `jobFinish()` passes `returnvalue` directly to `nuqPool.query()`. The `pg` driver serialises it via
  `JSON.stringify`, which encodes NUL chars as the literal `\u0000` escape sequence. Postgres text encoding rejects
  this.
  
  ## Fix
  
  Sanitise before the INSERT:
  ```ts
  const sanitizedReturnvalue =
    returnvalue != null
      ? JSON.parse(JSON.stringify(returnvalue).replace(/\\u0000/g, ""))
      : returnvalue;
  ```

  Tests
  
  Regression test added to nuq-postgres.test.ts: creates a job, finishes it with a NUL-byte returnvalue, asserts no
  throw, and verifies the stored row contains no NUL bytes.
  
  Fixes #4113


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
"Strips NUL bytes (`\u0000`) from job return values before writing to Postgres, so scraped content with embedded NUL characters no longer crashes `jobFinish()` with Postgres error 22P05 and brings down the api container.

**Bug Fixes**
- Removes the `\u0000` escape sequence from the JSON-serialized returnvalue before the UPDATE, so stored rows never contain NUL bytes.
- Adds a regression test that finishes a job with a NUL-byte returnvalue and verifies it completes and stores clean data.
- Fixes #4113.

<sup>Written for commit 97df8c530268ccc228357ffc590e59ff246ab020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

