### PR TITLE
fix(api/v2/search): lack of logging if awaiting logRequestPromise took time

### DIFF
--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -301,7 +301,13 @@ export async function searchController(
     // `searches` insert, to avoid a request_id FK violation. The insert has
     // been in flight since the top of the controller, so this is ~free in
     // practice; robustInsert never rejects, so this await cannot throw.
+    const logStart = Date.now();
     await logRequestPromise;
+    const waited = Date.now() - logStart;
+    if (waited > 0)
+      logger.warn("Had to wait for log request promise to complete", {
+        timeMs: waited,
+      });
 
     logSearch(
       {

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -304,7 +304,7 @@ export async function searchController(
     const logStart = Date.now();
     await logRequestPromise;
     const waited = Date.now() - logStart;
-    if (waited > 0)
+    if (waited > 50)
       logger.warn("Had to wait for log request promise to complete", {
         timeMs: waited,
       });

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -304,7 +304,7 @@ export async function searchController(
     const logStart = Date.now();
     await logRequestPromise;
     const waited = Date.now() - logStart;
-    if (waited > 50)
+    if (waited >= 5)
       logger.warn("Had to wait for log request promise to complete", {
         timeMs: waited,
       });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
In the v2 search controller, adds a warning log when waiting for the log request promise takes at least 5ms, so slow waits are no longer silent.

<sup>Written for commit f524f176459841818643fdef3f06655281483cdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

