### PR TITLE
docs: fix typos in scrapeURL README

### DIFF
--- a/apps/api/src/scraper/scrapeURL/README.md
+++ b/apps/api/src/scraper/scrapeURL/README.md
@@ -18,8 +18,8 @@ flowchart TD;
  - The job of `WebScraperDataProvider.validateInitialUrl` has been delegated to the zod layer above `scrapeUrl`.
  - `WebScraperDataProvider.mode` has no equivalent, only `scrape_url` is supported.
  - You may no longer specify multiple URLs.
- - Built on `v1` definitons, instead of `v0`.
+ - Built on `v1` definitions, instead of `v0`.
  - PDFs are now converted straight to markdown using LlamaParse, instead of converting to just plaintext.
  - DOCXs are now converted straight to HTML (and then later to markdown) using mammoth, instead of converting to just plaintext.
- - Using new JSON Schema OpenAI API -- schema fails with LLM Extract will be basically non-existant.
+ - Using new JSON Schema OpenAI API -- schema fails with LLM Extract will be basically non-existent.
         


### PR DESCRIPTION
## Summary
- Fix two misspellings in `apps/api/src/scraper/scrapeURL/README.md`:
  - `definitons` → `definitions`
  - `non-existant` → `non-existent`

## Why this helps
- The README documents the `scrapeURL` scraper's differences from `WebScraperDataProvider`; both words are misspelled in the "Differences" list, which is the first thing a developer reads when working on this component.

## Test Plan
- [x] `git diff --check` clean
- [x] Diff is 2 lines (docs-only change)
- [x] Verified no remaining occurrences of `definitons` / `non-existant` in the file

Intentionally tiny, documentation-only change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two typos (`definitons` → `definitions`, `non-existant` → `non-existent`) in the `scrapeURL` README so the documentation reads correctly. Docs-only change, no behavior or code impact.

<sup>Written for commit d004b867ac127787732fb8c8f865fa1becdd33fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

