### PR TITLE
fix(api): honor forced ZDR in standalone search proxies

### DIFF
--- a/apps/api/src/__tests__/snips/v2/developer.test.ts
+++ b/apps/api/src/__tests__/snips/v2/developer.test.ts
@@ -163,6 +163,82 @@ describeIf(HAS_RESEARCH)("Developer Search API", () => {
     expect(requestLog?.integration).toBe("_research_test");
   }, 120000);
 
+  it("redacts stored payloads for a forced-ZDR team", async () => {
+    if (!config.USE_DB_AUTHENTICATION) return;
+
+    const identity = await idmux({
+      name: "developer/forced ZDR retention",
+      credits: 100,
+      flags: { searchZDR: "forced-zdr" },
+    });
+
+    const res = await researchRaw(
+      CANONICAL_PATH,
+      {
+        query: `private developer query ${Date.now()}`,
+        k: 1,
+      },
+      identity,
+    );
+    expect(res.statusCode).toBe(200);
+
+    const requestLog = await waitForSingleRow<{
+      id: string;
+      target_hint: string;
+      dr_clean_by: string | null;
+    }>(async () => {
+      const data = await db
+        .select({
+          id: schema.requests.id,
+          target_hint: schema.requests.target_hint,
+          dr_clean_by: schema.requests.dr_clean_by,
+        })
+        .from(schema.requests)
+        .where(
+          and(
+            eq(schema.requests.team_id, identity.teamId),
+            eq(schema.requests.kind, "code_search"),
+          ),
+        )
+        .orderBy(desc(schema.requests.created_at))
+        .limit(1);
+      return data[0] ?? null;
+    });
+
+    expect(requestLog).not.toBeNull();
+    expect(requestLog?.target_hint).toBe(
+      "<redacted due to zero data retention>",
+    );
+    expect(requestLog?.dr_clean_by).not.toBeNull();
+
+    const usageLog = await waitForSingleRow<{
+      target: string;
+      options: unknown;
+      response: unknown;
+      error: string | null;
+    }>(async () => {
+      if (!requestLog) return null;
+      const data = await db
+        .select({
+          target: schema.code_searches.target,
+          options: schema.code_searches.options,
+          response: schema.code_searches.response,
+          error: schema.code_searches.error,
+        })
+        .from(schema.code_searches)
+        .where(eq(schema.code_searches.request_id, requestLog.id))
+        .limit(1);
+      return data[0] ?? null;
+    });
+
+    expect(usageLog).toEqual({
+      target: "<redacted due to zero data retention>",
+      options: null,
+      response: null,
+      error: null,
+    });
+  }, 120000);
+
   it("writes a usage row with the billed credits", async () => {
     if (!config.USE_DB_AUTHENTICATION) return;
 

--- a/apps/api/src/controllers/v2/__tests__/research-proxy-zdr.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/research-proxy-zdr.test.ts
@@ -1,0 +1,145 @@
+import { vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  logRequest: vi.fn(),
+  logResearchEndpoint: vi.fn(),
+  fetchResearchUpstream: vi.fn(),
+}));
+
+vi.mock("../../../services/logging/log_job", () => ({
+  logRequest: mocks.logRequest,
+  logResearchEndpoint: mocks.logResearchEndpoint,
+}));
+
+vi.mock("../../../lib/research-upstream", () => ({
+  fetchResearchUpstream: mocks.fetchResearchUpstream,
+}));
+
+vi.mock("../../../services/billing/credit_billing", () => ({
+  billTeam: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../lib/keyless", () => ({
+  chargeKeylessCredits: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+import { createDeveloperRouter, createResearchRouter } from "../research-proxy";
+
+const TEAM_ID = "11111111-1111-1111-1111-111111111111";
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+function routeHandler(router: any, path: string) {
+  const layer = router.stack.find(
+    (candidate: any) =>
+      candidate.route?.path === path && candidate.route?.methods?.get,
+  );
+  return layer.route.stack[0].handle;
+}
+
+function makeReq(
+  query: Record<string, unknown>,
+  flags: Record<string, unknown>,
+) {
+  return {
+    method: "GET",
+    query,
+    params: {},
+    body: {},
+    headers: {},
+    auth: { team_id: TEAM_ID },
+    acuc: { api_key_id: 7, flags },
+  } as any;
+}
+
+function makeRes() {
+  const res: any = {
+    status: vi.fn(),
+    json: vi.fn(),
+    send: vi.fn(),
+    end: vi.fn(),
+    setHeader: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  res.send.mockReturnValue(res);
+  return res;
+}
+
+async function callRoute(
+  router: any,
+  path: string,
+  query: Record<string, unknown>,
+  flags: Record<string, unknown>,
+) {
+  routeHandler(router, path)(makeReq(query, flags), makeRes(), vi.fn());
+  await flush();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.logRequest.mockResolvedValue(undefined);
+  mocks.logResearchEndpoint.mockResolvedValue(undefined);
+  mocks.fetchResearchUpstream.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: async () =>
+      JSON.stringify({
+        success: true,
+        results: [{ id: "private-result", content: "private payload" }],
+      }),
+  });
+});
+
+describe.each([
+  {
+    name: "research paper search",
+    router: () => createResearchRouter(),
+    path: "/papers",
+    query: { query: "private research query" },
+  },
+  {
+    name: "developer search",
+    router: () => createDeveloperRouter(),
+    path: "/search",
+    query: { query: "private code query" },
+  },
+])("standalone ZDR persistence for $name", testCase => {
+  it.each([
+    { searchZDR: "forced-zdr" },
+    { searchZDR: "forced-anon" },
+    { forceZDR: true },
+  ])("marks forced team payloads for redaction and cleanup", async flags => {
+    await callRoute(testCase.router(), testCase.path, testCase.query, flags);
+
+    expect(mocks.logRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ zeroDataRetention: true }),
+    );
+    expect(mocks.logResearchEndpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ zeroDataRetention: true }),
+    );
+  });
+
+  it("keeps normal retention for a team that may opt into ZDR", async () => {
+    await callRoute(testCase.router(), testCase.path, testCase.query, {
+      searchZDR: "allowed",
+    });
+
+    expect(mocks.logRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ zeroDataRetention: false }),
+    );
+    expect(mocks.logResearchEndpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ zeroDataRetention: false }),
+    );
+  });
+});

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -284,6 +284,8 @@ function createResearchController(
 ): ResearchController {
   return async (req, res: Response) => {
     const authedReq = req as RequestWithAuth<any, any, any>;
+    const zeroDataRetention =
+      getSearchForcedKind(authedReq.acuc?.flags) !== null;
 
     const started = Date.now();
     const jobId = uuidv7();
@@ -321,7 +323,7 @@ function createResearchController(
       origin: requestOrigin(params, req),
       integration: params.integration ?? null,
       target_hint: targetHint,
-      zeroDataRetention: false,
+      zeroDataRetention,
       api_key_id: authedReq.acuc?.api_key_id ?? null,
     });
 
@@ -428,7 +430,7 @@ function createResearchController(
         credits_cost: statusCode >= 200 && statusCode < 300 ? credits : 0,
         is_successful: statusCode >= 200 && statusCode < 300,
         error,
-        zeroDataRetention: false,
+        zeroDataRetention,
       }).catch(logError => {
         logger.warn("Research endpoint log failed", { error: logError });
       });


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes standalone Research and Developer search proxies so forced-ZDR teams' payloads are now actually redacted and scheduled for cleanup, matching `/v2/search`. These proxies previously charged the ZDR rate but passed `zeroDataRetention: false`, leaving the target, options, response, and error in the persistence ledger.

- Resolves the effective forced-ZDR state from ACUC team flags via `getSearchForcedKind`, covering current and legacy flags.
- Passes the resolved state from `createResearchController` to `logRequest` and `logResearchEndpoint`.
- Adds unit tests covering forced ZDR, forced anonymous, legacy `forceZDR`, and optional ZDR modes for both Research and Developer controllers.
- Adds a Developer Index snip asserting `dr_clean_by` is set and all payload-bearing ledger fields are redacted.
- Suppresses the PostHog first-use analytics path in standalone proxies, matching their lack of GCS blobs and ClickHouse analytics writes.
- Normal and optional-ZDR teams keep existing retention.
- Leaves upstream search-service logging unchanged.

<sup>Written for commit 7e2a550c2c1e86c2c4a7fb61abd617162d5dd112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

