### PR TITLE
chore(sdks): bump versions for the agent list endpoint

### DIFF
--- a/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
+++ b/apps/dot-net-sdk/Firecrawl/Firecrawl.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>firecrawl-sdk</PackageId>
-    <Version>1.13.0</Version>
+    <Version>1.14.0</Version>
     <Authors>Firecrawl</Authors>
     <Company>Firecrawl</Company>
     <Description>.NET SDK for the Firecrawl API - web scraping, crawling, and data extraction</Description>

--- a/apps/dot-net-sdk/Firecrawl/FirecrawlClient.cs
+++ b/apps/dot-net-sdk/Firecrawl/FirecrawlClient.cs
@@ -740,7 +740,7 @@ public class FirecrawlClient
     // INTERNAL UTILITIES
     // ================================================================
 
-    private const string SdkOrigin = "dotnet-sdk@1.13.0";
+    private const string SdkOrigin = "dotnet-sdk@1.14.0";
 
     private static Dictionary<string, object> BuildBody(object? options)
     {

--- a/apps/elixir-sdk/mix.exs
+++ b/apps/elixir-sdk/mix.exs
@@ -1,7 +1,7 @@
 defmodule Firecrawl.MixProject do
   use Mix.Project
 
-  @version "1.10.0"
+  @version "1.11.0"
   @source_url "https://github.com/firecrawl/firecrawl/tree/main/apps/elixir-sdk"
 
   def project do

--- a/apps/go-sdk/version.go
+++ b/apps/go-sdk/version.go
@@ -9,4 +9,4 @@ package firecrawl
 // Bump this when preparing a new release. The publish-go-sdk GitHub workflow
 // reads this value and creates the corresponding monorepo-prefixed tag on
 // merge to main.
-const Version = "1.13.0"
+const Version = "1.14.0"

--- a/apps/java-sdk/build.gradle.kts
+++ b/apps/java-sdk/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.firecrawl"
-version = "1.16.0"
+version = "1.17.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java
+++ b/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ForkJoinPool;
 public class FirecrawlClient {
 
     private static final String DEFAULT_API_URL = "https://api.firecrawl.dev";
-    private static final String SDK_ORIGIN = "java-sdk@1.16.0";
+    private static final String SDK_ORIGIN = "java-sdk@1.17.0";
     private static final long DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
     private static final int DEFAULT_MAX_RETRIES = 3;
     private static final double DEFAULT_BACKOFF_FACTOR = 0.5;

--- a/apps/js-sdk/firecrawl/package.json
+++ b/apps/js-sdk/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/firecrawl-js",
-  "version": "4.37.0",
+  "version": "4.38.0",
   "description": "JavaScript SDK for the Firecrawl API: web scraping, crawling, web search, and scientific literature search over a research paper index of PubMed, bioRxiv, medRxiv and arXiv abstracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/apps/php-sdk/CHANGELOG.md
+++ b/apps/php-sdk/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Firecrawl PHP SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-08-31
+
+### Added
+- `listAgents()` returning a page of the team's agent runs (most recent
+  first) with an optional `$before` cursor. The method does not
+  auto-paginate; pass the `before` value from the response's `next` URL to
+  fetch the next page.
+
 ## [1.14.0] - 2026-08-26
 
 ### Added

--- a/apps/php-sdk/src/Version.php
+++ b/apps/php-sdk/src/Version.php
@@ -6,5 +6,5 @@ namespace Firecrawl;
 
 final class Version
 {
-    public const SDK_VERSION = '1.14.0';
+    public const SDK_VERSION = '1.15.0';
 }

--- a/apps/python-sdk/firecrawl/__init__.py
+++ b/apps/python-sdk/firecrawl/__init__.py
@@ -18,7 +18,7 @@ from .v1 import (
     V1ChangeTrackingOptions,
 )
 
-__version__ = "4.40.0"
+__version__ = "4.41.0"
 
 # Define the logger for the Firecrawl project
 logger: logging.Logger = logging.getLogger("firecrawl")

--- a/apps/ruby-sdk/lib/firecrawl/version.rb
+++ b/apps/ruby-sdk/lib/firecrawl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Firecrawl
-  VERSION = "1.15.0"
+  VERSION = "1.16.0"
 end

--- a/apps/rust-sdk/CHANGELOG.md
+++ b/apps/rust-sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## CHANGELOG
 
+## [2.18.0] - 2026-08-31
+
+### Added
+
+- Added `Client::list_agents` returning a page of the team's agent runs
+  (most recent first) with an optional `before` cursor. The method does not
+  auto-paginate; pass the `before` value from the response's `next` URL to
+  fetch the next page.
+
 ## [2.17.0] - 2026-08-26
 
 ### Added

--- a/apps/rust-sdk/Cargo.lock
+++ b/apps/rust-sdk/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecrawl"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "mockito",
  "reqwest",

--- a/apps/rust-sdk/Cargo.toml
+++ b/apps/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecrawl"
-version = "2.17.0"
+version = "2.18.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://www.firecrawl.dev/"


### PR DESCRIPTION
Follow-up to #4467 (merged) — bumps each package version so the publish workflows release the new `listAgents` / `list_agents` method:

- js-sdk **4.38.0**
- python-sdk **4.41.0**
- go-sdk **1.14.0**
- rust-sdk **2.18.0**
- java-sdk **1.17.0**
- dot-net-sdk **1.14.0**
- php-sdk **1.15.0**
- ruby-sdk **1.16.0**
- elixir-sdk **1.11.0**

All minor bumps (new backwards-compatible feature). Also updates the version-coupled origin constants (`java-sdk@`, `dotnet-sdk@`) and the rust/php changelogs. The publish workflows' version-increment guards will pick these up on merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps all SDK versions to release the new `listAgents` / `list_agents` method from #4467.

- Each SDK gets a minor bump: js 4.38.0, python 4.41.0, go 1.14.0, rust 2.18.0, java 1.17.0, dot-net 1.14.0, php 1.15.0, ruby 1.16.0, elixir 1.11.0.
- Updates the version-coupled origin constants in the Java and .NET SDKs and the Rust and PHP changelogs.
- The publish workflows' version-increment guards will release on merge.

<sup>Written for commit eba18a59a83b294708de5c8c6d407dcbc5300dfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

