### PR TITLE
fix(api/agent/list): fix bad clickhouse date parsing

### DIFF
--- a/apps/api/src/controllers/v2/agent-list.ts
+++ b/apps/api/src/controllers/v2/agent-list.ts
@@ -102,7 +102,7 @@ export async function agentListController(
           before: (parsedBefore !== undefined
             ? new Date(parsedBefore).toISOString()
             : new Date().toISOString()
-          ).slice(-1), // slice Z off the end of the ISO string because clickhouse hates it
+          ).slice(0, -1), // slice Z off the end of the ISO string because clickhouse hates it
         },
         format: "JSONEachRow",
       });

--- a/apps/api/src/controllers/v2/agent-list.ts
+++ b/apps/api/src/controllers/v2/agent-list.ts
@@ -99,10 +99,10 @@ export async function agentListController(
           // Fetch one extra row so we can tell whether another page exists
           // instead of emitting a next cursor whenever the page is full.
           limit: limit + 1,
-          before:
-            parsedBefore !== undefined
-              ? new Date(parsedBefore).toISOString()
-              : new Date().toISOString(),
+          before: (parsedBefore !== undefined
+            ? new Date(parsedBefore).toISOString()
+            : new Date().toISOString()
+          ).slice(-1), // slice Z off the end of the ISO string because clickhouse hates it
         },
         format: "JSONEachRow",
       });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the agent list API sending ISO timestamps with a trailing `Z` to ClickHouse, which caused bad date parsing. The `before` cursor now strips the `Z` before querying.

<sup>Written for commit e404bb6ccb3d4276496b5d64fbc5575048e1cee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

