### PR TITLE
fix(api/agent/list): fix date parsing again

### DIFF
--- a/apps/api/src/controllers/v2/agent-list.ts
+++ b/apps/api/src/controllers/v2/agent-list.ts
@@ -102,7 +102,7 @@ export async function agentListController(
           before: (parsedBefore !== undefined
             ? new Date(parsedBefore).toISOString()
             : new Date().toISOString()
-          ).slice(0, -1), // slice Z off the end of the ISO string because clickhouse hates it
+          ).split(".")[0], // slice .nnnZ off the end of the ISO string because clickhouse hates it
         },
         format: "JSONEachRow",
       });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes date formatting for ClickHouse queries in the agent list endpoint so timestamps no longer include fractional seconds, which ClickHouse misparses. The previous fix stripped only the trailing `Z`, leaving milliseconds; now it strips everything after the decimal point, producing a clean `YYYY-MM-DDTHH:MM:SS` string.

<sup>Written for commit f9ab906d680a7ef2d2799acf6fc33c6cc0ecd100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

