### PR TITLE
feat(exchange): proxy more routes

### DIFF
--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -11,6 +11,7 @@ const RETRIEVE_TIMEOUT_MS = 50_000;
 const ANALYTICS_TIMEOUT_MS = 20_000;
 const APPLICATIONS_TIMEOUT_MS = 15_000;
 const CLAIMS_TIMEOUT_MS = 20_000;
+const SUPPLY_TIMEOUT_MS = 30_000;
 
 const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
 const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
@@ -166,6 +167,12 @@ exchangeRouter.post(
   wrap(exchangeProxy(APPLICATIONS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );
 
+exchangeRouter.post(
+  "/applications/:id/withdraw",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(APPLICATIONS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
 exchangeRouter.get(
   "/claims",
   authMiddleware(RateLimiterMode.Labs),
@@ -188,4 +195,40 @@ exchangeRouter.post(
   "/claims/:id/verify",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(CLAIMS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
+  "/publisher/supply/key",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/publisher/supply/key",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.put(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.delete(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -156,6 +156,12 @@ exchangeRouter.get(
 );
 
 exchangeRouter.get(
+  "/publisher/supply/key",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
   "/publisher{/*path}",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
@@ -195,12 +201,6 @@ exchangeRouter.post(
   "/claims/:id/verify",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(CLAIMS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
-);
-
-exchangeRouter.get(
-  "/publisher/supply/key",
-  authMiddleware(RateLimiterMode.Labs),
-  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );
 
 exchangeRouter.post(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Proxies additional exchange routes for withdrawing applications and managing supply keys, so these endpoints now reach the upstream service.

- Adds `POST /applications/:id/withdraw`, `GET`/`POST /publisher/supply/key`, and `GET`/`POST`/`PUT`/`DELETE /supply/*` proxy routes.
- Uses a new 30-second timeout for supply routes; withdraw uses the existing applications timeout.

<sup>Written for commit 1e1cb44d8789670e2362e441e1b37e242baae228. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

