### PR TITLE
docs(test-suite): fix broken CONTRIBUTING.md relative link

### DIFF
--- a/apps/test-suite/README.md
+++ b/apps/test-suite/README.md
@@ -56,4 +56,4 @@ If you encounter any failures or unexpected results, please check the following:
 
 ## Contributing
 
-Contributions to the test suite are welcome. Please refer to the project's main [CONTRIBUTING.md](../CONTRIBUTING.md) file for guidelines on how to contribute.
+Contributions to the test suite are welcome. Please refer to the project's main [CONTRIBUTING.md](../../CONTRIBUTING.md) file for guidelines on how to contribute.


### PR DESCRIPTION
### Problem

`apps/test-suite/README.md` links to the project's main contributing guide with a single-dot-dot relative path:

```markdown
Please refer to the project's main [CONTRIBUTING.md](../CONTRIBUTING.md) file for guidelines...
```

From `apps/test-suite/`, `../CONTRIBUTING.md` resolves to `apps/CONTRIBUTING.md`, which does not exist. The only `CONTRIBUTING.md` in the repo lives at the root, so the link 404s on GitHub (and anywhere the README is rendered relative to its own path).

### Fix

Point the link one more level up so it reaches the root file:

```markdown
[CONTRIBUTING.md](../../CONTRIBUTING.md)
```

The surrounding sentence already says "the project's **main** CONTRIBUTING.md", so the intended target is unambiguously the root file.

### How to verify

From the repo root:

```bash
# broken target (what the current link points at) -> absent
test -f apps/CONTRIBUTING.md || echo "apps/CONTRIBUTING.md: MISSING"
# fixed target -> present
test -f CONTRIBUTING.md && echo "CONTRIBUTING.md (root): OK"
```

Or open `apps/test-suite/README.md` on GitHub and click the link before/after: `../CONTRIBUTING.md` 404s, `../../CONTRIBUTING.md` lands on the root guide.

Docs-only, one line changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken relative link in `apps/test-suite/README.md` so it points to the root `CONTRIBUTING.md` instead of the non-existent `apps/CONTRIBUTING.md`.

<sup>Written for commit 77167dddbc5094bd358776cb8b9fe126c88e3172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

