### PR TITLE
perf(api): bound search gateway overhead

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
@@ -305,6 +305,38 @@ describe("developer category code_searches ledger", () => {
     expect(body.creditsUsed).toBe(2);
   });
 
+  it("returns before the request ledger insert completes", async () => {
+    let finishLogRequest!: () => void;
+    mockLogRequest.mockReturnValue(
+      new Promise<void>(resolve => {
+        finishLogRequest = resolve;
+      }),
+    );
+    const req = makeReq({
+      query: "vector database client",
+      categories: ["developer"],
+    });
+    const res = makeRes();
+
+    const controllerPromise = searchController(req, res);
+    await flushAsync();
+    const returnedBeforeInsert = res.status.mock.calls.some(
+      ([status]) => status === 200,
+    );
+    const loggedChildrenBeforeInsert =
+      mockLogSearch.mock.calls.length +
+      mockLogResearchEndpoint.mock.calls.length;
+
+    finishLogRequest();
+    await controllerPromise;
+    await flushAsync();
+
+    expect(returnedBeforeInsert).toBe(true);
+    expect(loggedChildrenBeforeInsert).toBe(0);
+    expect(mockLogSearch).toHaveBeenCalledTimes(1);
+    expect(mockLogResearchEndpoint).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the developer category for a team with no flags", async () => {
     mockExecuteSearch.mockResolvedValue(
       executeResult({ response: { web: [] } }),

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -297,66 +297,68 @@ export async function searchController(
     const endTime = new Date().getTime();
     const timeTakenInSeconds = (endTime - middlewareStartTime) / 1000;
 
-    // Ensure the parent `requests` row is committed before the child
-    // `searches` insert, to avoid a request_id FK violation. The insert has
-    // been in flight since the top of the controller, so this is ~free in
-    // practice; robustInsert never rejects, so this await cannot throw.
     const logStart = Date.now();
-    await logRequestPromise;
-    const waited = Date.now() - logStart;
-    if (waited >= 5)
-      logger.warn("Had to wait for log request promise to complete", {
-        timeMs: waited,
-      });
+    void Promise.resolve(logRequestPromise)
+      .then(() => {
+        const waited = Date.now() - logStart;
+        if (waited >= 5) {
+          logger.warn("Request ledger insert completed after the response", {
+            timeMs: waited,
+          });
+        }
 
-    logSearch(
-      {
-        id: jobId,
-        request_id: agentRequestId ?? jobId,
-        query: req.body.query,
-        is_successful: true,
-        error: undefined,
-        results: result.response as any,
-        num_results: result.totalResultsCount,
-        time_taken: timeTakenInSeconds,
-        team_id: req.auth.team_id,
-        options: req.body,
-        // Don't record preview tokens as billed in the ledger — only record
-        // credits when billing is actually applied.
-        credits_cost: !isSearchPreview && shouldBill ? result.searchCredits : 0,
-        zeroDataRetention,
-      },
-      false,
-    );
-
-    if (wantsDeveloperCategory(req.body.categories as CategoryOption[])) {
-      logResearchEndpoint({
-        table: "code_searches",
-        id: uuidv7(),
-        request_id: agentRequestId ?? jobId,
-        team_id: req.auth.team_id,
-        target: req.body.query,
-        options: {
-          origin: requestOrigin({ origin: rawOrigin }, req),
-          integration: req.body.integration ?? null,
-          api_version: "v2",
-          categories: req.body.categories,
-          via: "search_category",
-        },
-        response: null,
-        num_results: result.developerResultsCount,
-        time_taken: timeTakenInSeconds,
-        // Ensure preview-mode searches don't get a non-zero credits_cost
-        // in the research ledger when preview tokens are used.
-        credits_cost: !isSearchPreview && shouldBill ? result.searchCredits : 0,
-        is_successful: true,
-        zeroDataRetention,
-      }).catch(ledgerError => {
-        logger.warn("Failed to log developer category usage", {
-          error: ledgerError,
+        void logSearch(
+          {
+            id: jobId,
+            request_id: agentRequestId ?? jobId,
+            query: req.body.query,
+            is_successful: true,
+            error: undefined,
+            results: result.response as any,
+            num_results: result.totalResultsCount,
+            time_taken: timeTakenInSeconds,
+            team_id: req.auth.team_id,
+            options: req.body,
+            credits_cost:
+              !isSearchPreview && shouldBill ? result.searchCredits : 0,
+            zeroDataRetention,
+          },
+          false,
+        ).catch(logError => {
+          logger.warn("Failed to log search", { error: logError });
         });
+
+        if (wantsDeveloperCategory(req.body.categories as CategoryOption[])) {
+          void logResearchEndpoint({
+            table: "code_searches",
+            id: uuidv7(),
+            request_id: agentRequestId ?? jobId,
+            team_id: req.auth.team_id,
+            target: req.body.query,
+            options: {
+              origin: requestOrigin({ origin: rawOrigin }, req),
+              integration: req.body.integration ?? null,
+              api_version: "v2",
+              categories: req.body.categories,
+              via: "search_category",
+            },
+            response: null,
+            num_results: result.developerResultsCount,
+            time_taken: timeTakenInSeconds,
+            credits_cost:
+              !isSearchPreview && shouldBill ? result.searchCredits : 0,
+            is_successful: true,
+            zeroDataRetention,
+          }).catch(ledgerError => {
+            logger.warn("Failed to log developer category usage", {
+              error: ledgerError,
+            });
+          });
+        }
+      })
+      .catch(logError => {
+        logger.warn("Failed to order search logs", { error: logError });
       });
-    }
 
     const totalRequestTime = new Date().getTime() - middlewareStartTime;
     const controllerTime = new Date().getTime() - controllerStartTime;

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -924,6 +924,24 @@ describe("firebill routing", () => {
     expect(mockCheck).not.toHaveBeenCalled();
   });
 
+  it("limits the fail-open check to the interactive request budget", async () => {
+    state.configRef = firebillConfig();
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    const svc = makeService();
+
+    try {
+      await svc.checkCredits({
+        teamId: "team-1",
+        value: 100,
+        properties: {},
+      });
+
+      expect(timeout).toHaveBeenCalledWith(200);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
+
   it("checks directly in Autumn for orgs NOT on the allowlist", async () => {
     state.configRef = {
       ...firebillConfig(),

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -38,6 +38,7 @@ function lockDeniedReason(value: unknown): LockDeniedReason | undefined {
 // ~3.5s worst case, so this is deliberately looser than the 2s timeout on the
 // direct Autumn client.
 const FIREBILL_TIMEOUT_MS = 5000;
+const FIREBILL_CHECK_TIMEOUT_MS = 200;
 
 // A gated lock legitimately does more: firebill asks the partner (2.5s ceiling)
 // before the Autumn hold (2s), on top of the funding lookup. Giving up at 5s
@@ -354,7 +355,7 @@ export async function firebillCheck({
         value,
         properties,
       }),
-      signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
+      signal: AbortSignal.timeout(FIREBILL_CHECK_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces latency for cached searches by capping the fail-open Firebill check at 200 ms and moving the search ledger chain off the response path, so the controller now replies before the parent `requests` insert settles.

**Notes**
- The 200 ms budget applies to all routed teams using `checkCreditsMiddleware`; direct Autumn checks keep the existing 5 s timeout.
- The shorter check can admit work during a slow Firebill response, but billing and credit accounting are unchanged.
- The ledgers stay best-effort: a process termination right after the response can now lose the parent row along with the child rows, and child writes still start only after the parent insert settles.
- Search payload, credit calculation, billing, analytics, GCS persistence, and ZDR redaction are unchanged.

<sup>Written for commit 9d2690859205172e08e4bf85d76cd21a27112945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

