### PR TITLE
feat(api): always route pdf/document downloads through fire-engine when available

### DIFF
--- a/apps/api/src/lib/robots-txt.ts
+++ b/apps/api/src/lib/robots-txt.ts
@@ -1,17 +1,13 @@
 import robotsParser, { Robot } from "robots-parser";
-import { config } from "../config";
 import { Logger } from "winston";
 import { ScrapeOptions, scrapeOptions } from "../controllers/v2/types";
 import { scrapeURL } from "../scraper/scrapeURL";
 import { Engine } from "../scraper/scrapeURL/engines";
+import { useFireEngine } from "../scraper/scrapeURL/engines/fire-engine/available";
 import { CostTracking } from "./cost-tracking";
 import { useIndex } from "../services";
 
 const ROBOTS_MAX_AGE = 1 * 24 * 60 * 60 * 1000;
-
-const useFireEngine =
-  config.FIRE_ENGINE_BETA_URL !== "" &&
-  config.FIRE_ENGINE_BETA_URL !== undefined;
 
 interface RobotsTxtChecker {
   robotsTxtUrl: string;

--- a/apps/api/src/scraper/WebScraper/sitemap.ts
+++ b/apps/api/src/scraper/WebScraper/sitemap.ts
@@ -1,5 +1,4 @@
 import { parseStringPromise } from "xml2js";
-import { config } from "../../config";
 import { WebCrawler, SITEMAP_LIMIT } from "./crawler";
 import { scrapeURL } from "../scrapeURL";
 import { scrapeOptions } from "../../controllers/v2/types";
@@ -8,6 +7,7 @@ import { CostTracking } from "../../lib/cost-tracking";
 import { ScrapeJobTimeoutError } from "../../lib/error";
 import type { ScrapeOptions } from "../../controllers/v2/types";
 import { Engine } from "../scrapeURL/engines";
+import { useFireEngine } from "../scrapeURL/engines/fire-engine/available";
 import {
   ParsedSitemap,
   parseSitemapXml,
@@ -18,10 +18,6 @@ import { gunzip } from "node:zlib";
 import { promisify } from "node:util";
 import { fetchFileToBuffer } from "../scrapeURL/engines/utils/downloadFile";
 import { useIndex } from "../../services";
-
-const useFireEngine =
-  config.FIRE_ENGINE_BETA_URL !== "" &&
-  config.FIRE_ENGINE_BETA_URL !== undefined;
 
 const gunzipAsync = promisify(gunzip);
 

--- a/apps/api/src/scraper/crawler/sitemap.ts
+++ b/apps/api/src/scraper/crawler/sitemap.ts
@@ -1,9 +1,9 @@
 import type { Logger } from "winston";
-import { config } from "../../config";
 import { scrapeOptions, ScrapeOptions } from "../../controllers/v2/types";
 import { logger as _logger } from "../../lib/logger";
 import { Engine } from "../scrapeURL/engines";
 import { scrapeURL } from "../scrapeURL";
+import { useFireEngine } from "../scrapeURL/engines/fire-engine/available";
 import { CostTracking } from "../../lib/cost-tracking";
 import {
   processSitemap,
@@ -14,10 +14,6 @@ import { gunzip } from "node:zlib";
 import { promisify } from "node:util";
 import { SitemapError } from "../../lib/error";
 import { useIndex } from "../../services";
-
-const useFireEngine =
-  config.FIRE_ENGINE_BETA_URL !== "" &&
-  config.FIRE_ENGINE_BETA_URL !== undefined;
 
 type SitemapScrapeOptions = {
   url: string;

--- a/apps/api/src/scraper/scrapeURL/engines/document/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/document/index.ts
@@ -18,8 +18,30 @@ import {
   documentExtensionFromUrlPath,
 } from "../../../../lib/document-formats";
 import { readFile, unlink } from "node:fs/promises";
+import { useFireEngine } from "../fire-engine/available";
 
 export async function scrapeDocument(meta: Meta): Promise<EngineScrapeResult> {
+  // With fire-engine available this engine never downloads files itself:
+  // buildFallbackList routes file URLs through the browser engines and the
+  // file arrives here via documentPrefetch. Reaching the direct download
+  // means either an explicit forceEngine pin (the escape hatch, kept
+  // working) or a browser handoff that came back empty
+  // (documentPrefetch === null) — signal antibot so the retry loop can give
+  // the browser another round trip. In self-hosted deployments (no
+  // fire-engine) the direct download stays the primary path. Ordinary
+  // pages (no "document" flag) keep declining via EngineUnsuccessfulError
+  // so the waterfall just moves on.
+  if (
+    useFireEngine &&
+    meta.internalOptions.forceEngine === undefined &&
+    meta.documentPrefetch == null
+  ) {
+    if (!meta.featureFlags.has("document")) {
+      throw new EngineUnsuccessfulError("document");
+    }
+    throw new DocumentAntibotError();
+  }
+
   let response: Response;
   let buffer: Buffer;
   let proxyUsed: "basic" | "stealth" = "basic";

--- a/apps/api/src/scraper/scrapeURL/engines/document/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/document/index.ts
@@ -36,7 +36,10 @@ export async function scrapeDocument(meta: Meta): Promise<EngineScrapeResult> {
     meta.internalOptions.forceEngine === undefined &&
     meta.documentPrefetch == null
   ) {
-    if (!meta.featureFlags.has("document")) {
+    // A cross-type handoff (a .docx URL serving a PDF) lands in
+    // pdfPrefetch: the file is in hand, just not for this engine — decline
+    // so the waterfall reaches the engine that can parse it.
+    if (meta.pdfPrefetch != null || !meta.featureFlags.has("document")) {
       throw new EngineUnsuccessfulError("document");
     }
     throw new DocumentAntibotError();

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/available.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/available.ts
@@ -1,0 +1,19 @@
+import { config } from "../../../../config";
+
+/**
+ * Whether the fire-engine scraping service is configured for this
+ * deployment. When true, file downloads (PDFs, documents) are always
+ * routed through the browser engines — fire-engine fetches the file and
+ * hands it to the file engines as a prefetch — and the file engines'
+ * own direct undici downloads stay reachable only in self-hosted
+ * deployments (where this is false) or under an explicit forceEngine pin.
+ *
+ * Evaluated from config at module load, exactly like the historical
+ * inline check in engines/index.ts. Kept in its own module so the file
+ * engines can read it without importing engines/index.ts (which would
+ * create a circular import: engines/index imports the file engines to
+ * build its handler table).
+ */
+export const useFireEngine =
+  config.FIRE_ENGINE_BETA_URL !== "" &&
+  config.FIRE_ENGINE_BETA_URL !== undefined;

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/available.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/available.ts
@@ -1,19 +1,5 @@
 import { config } from "../../../../config";
 
-/**
- * Whether the fire-engine scraping service is configured for this
- * deployment. When true, file downloads (PDFs, documents) are always
- * routed through the browser engines — fire-engine fetches the file and
- * hands it to the file engines as a prefetch — and the file engines'
- * own direct undici downloads stay reachable only in self-hosted
- * deployments (where this is false) or under an explicit forceEngine pin.
- *
- * Evaluated from config at module load, exactly like the historical
- * inline check in engines/index.ts. Kept in its own module so the file
- * engines can read it without importing engines/index.ts (which would
- * create a circular import: engines/index imports the file engines to
- * build its handler table).
- */
 export const useFireEngine =
   config.FIRE_ENGINE_BETA_URL !== "" &&
   config.FIRE_ENGINE_BETA_URL !== undefined;

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -26,6 +26,7 @@ import {
   isXTwitterUrl,
 } from "./x-twitter";
 import { queryEngpickerVerdict, useIndex } from "../../../services";
+import { useFireEngine } from "./fire-engine/available";
 import { hasFormatOfType } from "../../../lib/format-utils";
 import {
   getPDFBlocks,
@@ -62,9 +63,6 @@ export type Engine =
   | "wikipedia"
   | "x-twitter";
 
-const useFireEngine =
-  config.FIRE_ENGINE_BETA_URL !== "" &&
-  config.FIRE_ENGINE_BETA_URL !== undefined;
 const usePlaywright =
   config.PLAYWRIGHT_MICROSERVICE_URL !== "" &&
   config.PLAYWRIGHT_MICROSERVICE_URL !== undefined;
@@ -738,6 +736,101 @@ export async function buildFallbackList(meta: Meta): Promise<
     if (indexDocumentsIndex !== -1) {
       _engines.splice(indexDocumentsIndex, 1);
     }
+  }
+
+  // File-fetch routing: when fire-engine is available, PDF and document
+  // downloads always go through the browser engines, which fetch the file
+  // through fire-engine's proxy infrastructure and hand it back to this
+  // waterfall via AddFeatureError (specialtyScrapeCheck) — the same route
+  // the PDFAntibotError/PDFFetchProxyError and document-equivalent
+  // recoveries have always taken, just taken immediately instead of after
+  // a wasted direct download. The file engines (pdf, document) then run
+  // as pure parsers on the prefetched file, and their own direct undici
+  // downloads stay reachable only in self-hosted deployments (no
+  // fire-engine) or under an explicit forceEngine pin.
+  //
+  // This is a bespoke list rather than a flag tweak because the pdf and
+  // document flags (priority 100) exist precisely to keep every
+  // non-file-capable engine out of the waterfall via the supportScore
+  // threshold — the browser engines declare pdf/document: false, so they
+  // can never qualify while the flag is set. Clearing the flag instead
+  // would let fastMode/atsv requests admit tlsclient, which cannot hand
+  // off files at all (the file download handler is chrome-cdp only) and
+  // would burn prefetch round trips on null handoffs.
+  const fileFetchFlag: FeatureFlag | null = meta.featureFlags.has("document")
+    ? "document"
+    : meta.featureFlags.has("pdf")
+      ? "pdf"
+      : null;
+
+  // A handoff of either file type ends the fetch leg: a .pdf URL can
+  // legitimately serve a docx (and vice versa), so either prefetch being
+  // set means the file is already in hand and the normal waterfall below
+  // routes it to the right parser.
+  if (
+    useFireEngine &&
+    fileFetchFlag !== null &&
+    meta.pdfPrefetch === undefined &&
+    meta.documentPrefetch === undefined &&
+    // Lockdown and agentIndexOnly pin forceEngine above, so their
+    // index-only semantics win; every other explicit pin is the escape
+    // hatch that keeps the file engines' direct downloads working.
+    meta.internalOptions.forceEngine === undefined
+  ) {
+    // Branding needs a rendered HTML page; preserve the historical
+    // clean error (this early return would otherwise skip the check at
+    // the bottom of this function).
+    if (meta.featureFlags.has("branding")) {
+      throw new BrandingNotSupportedError(
+        fileFetchFlag === "pdf"
+          ? "Branding extraction is only supported for HTML web pages. PDFs are not supported."
+          : "Branding extraction is only supported for HTML web pages. Documents (docx, xlsx, etc.) are not supported.",
+      );
+    }
+
+    const browserEngines: Engine[] = meta.featureFlags.has("stealthProxy")
+      ? // Explicit stealth: only the stealth variants can honor it. The
+        // auto path escalates here on its own via AddFeatureError(["stealthProxy"]).
+        [
+          "fire-engine;chrome-cdp;stealth",
+          "fire-engine(retry);chrome-cdp;stealth",
+        ]
+      : [
+          "fire-engine;chrome-cdp",
+          "fire-engine(retry);chrome-cdp",
+          "fire-engine;chrome-cdp;stealth",
+          "fire-engine(retry);chrome-cdp;stealth",
+        ];
+
+    const selectedEngines = [
+      // Cache first: an index;documents hit serves the file without any
+      // fetch at all. (Plain "index" is the same lookup, but the pdf
+      // flag has always threshold-filtered it out for file URLs.)
+      ...(shouldUseIndex(meta) ? (["index;documents"] as Engine[]) : []),
+      ...browserEngines,
+    ].map(engine => {
+      const supportedFlags = new Set([
+        ...Object.entries(engineOptions[engine].features)
+          .filter(
+            ([k, v]) => meta.featureFlags.has(k as FeatureFlag) && v === true,
+          )
+          .map(([k, _]) => k),
+      ]);
+      const unsupportedFeatures = new Set([...meta.featureFlags]);
+      for (const flag of meta.featureFlags) {
+        if (supportedFlags.has(flag)) {
+          unsupportedFeatures.delete(flag);
+        }
+      }
+      return { engine, unsupportedFeatures };
+    });
+
+    meta.logger.info("Selected engines", {
+      selectedEngines,
+      fileFetchRoute: fileFetchFlag,
+    });
+
+    return selectedEngines;
   }
 
   // When fire-engine is available, drop tlsclient and fetch from the general

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -46,6 +46,7 @@ import {
 } from "../../../../lib/native-logging";
 import { withSpan, setSpanAttributes } from "../../../../lib/otel-tracer";
 import { scrapePDFWithRunPodMU } from "./runpodMU";
+import { useFireEngine } from "../fire-engine/available";
 import { reconcilePageCountWithFirePdf, scrapePDFWithFirePDF } from "./firePDF";
 import { scrapePDFWithFirePDFAsync } from "./fire-pdf/async";
 import {
@@ -107,6 +108,27 @@ function fetchPdfFileGuardingProxyFailure<T>(
 }
 
 export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
+  // With fire-engine available this engine never downloads files itself:
+  // buildFallbackList routes file URLs through the browser engines and the
+  // file arrives here via pdfPrefetch. Reaching the direct download means
+  // either an explicit forceEngine pin (the escape hatch, kept working) or
+  // a browser handoff that came back empty (pdfPrefetch === null) —
+  // signal antibot so the retry loop can give the browser another round
+  // trip, exactly like a handoff whose bytes failed the PDF sniff. In
+  // self-hosted deployments (no fire-engine) the direct download stays the
+  // primary path. Ordinary pages (no "pdf" flag) keep declining via
+  // EngineUnsuccessfulError so the waterfall just moves on.
+  if (
+    useFireEngine &&
+    meta.internalOptions.forceEngine === undefined &&
+    meta.pdfPrefetch == null
+  ) {
+    if (!meta.featureFlags.has("pdf")) {
+      throw new EngineUnsuccessfulError("pdf");
+    }
+    throw new PDFAntibotError();
+  }
+
   const shouldParse = shouldParsePDF(meta.options.parsers);
   const maxPages = getPDFMaxPages(meta.options.parsers);
   const mode: PDFMode = getPDFMode(meta.options.parsers);
@@ -911,7 +933,10 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
       },
 
       contentType: "application/pdf",
-      proxyUsed: "basic",
+      // Report the proxy that actually delivered the file: a browser
+      // handoff may have come through the stealth proxy, while the direct
+      // download always uses the basic route.
+      proxyUsed: meta.pdfPrefetch?.proxyUsed ?? "basic",
     };
   } finally {
     // Always clean up temp file after we're done with it

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/index.ts
@@ -123,7 +123,10 @@ export async function scrapePDF(meta: Meta): Promise<EngineScrapeResult> {
     meta.internalOptions.forceEngine === undefined &&
     meta.pdfPrefetch == null
   ) {
-    if (!meta.featureFlags.has("pdf")) {
+    // A cross-type handoff (a .pdf URL serving a docx) lands in
+    // documentPrefetch: the file is in hand, just not for this engine —
+    // decline so the waterfall reaches the engine that can parse it.
+    if (meta.documentPrefetch != null || !meta.featureFlags.has("pdf")) {
       throw new EngineUnsuccessfulError("pdf");
     }
     throw new PDFAntibotError();

--- a/apps/api/src/search/fireEngine.ts
+++ b/apps/api/src/search/fireEngine.ts
@@ -3,10 +3,7 @@ import { SearchResult } from "../../src/lib/entities";
 import * as Sentry from "@sentry/node";
 import { logger } from "../lib/logger";
 import { executeWithRetry, attemptRequest } from "../lib/retry-utils";
-
-const useFireEngine =
-  config.FIRE_ENGINE_BETA_URL !== "" &&
-  config.FIRE_ENGINE_BETA_URL !== undefined;
+import { useFireEngine } from "../scraper/scrapeURL/engines/fire-engine/available";
 
 function hasResults(results: unknown): results is SearchResult[] {
   return Array.isArray(results) && results.length > 0;

--- a/apps/api/src/search/v2/fireEngine-v2.ts
+++ b/apps/api/src/search/v2/fireEngine-v2.ts
@@ -7,10 +7,7 @@ import {
 import * as Sentry from "@sentry/node";
 import { logger } from "../../lib/logger";
 import { executeWithRetry, attemptRequest } from "../../lib/retry-utils";
-
-const useFireEngine =
-  config.FIRE_ENGINE_BETA_URL !== "" &&
-  config.FIRE_ENGINE_BETA_URL !== undefined;
+import { useFireEngine } from "../../scraper/scrapeURL/engines/fire-engine/available";
 
 function normalizeSearchTypes(
   type?: SearchResultType | SearchResultType[],


### PR DESCRIPTION
## What

When fire-engine is configured, PDF and document downloads always go through the browser engines (chrome-cdp via fire-engine, which hands the file back to the waterfall as a prefetch via the existing `specialtyScrapeCheck`/`AddFeatureError` machinery) — the same route the `PDFAntibotError`/`PDFFetchProxyError` (and document-equivalent) recoveries have always taken, just taken **immediately** instead of after a wasted direct download that had to fail first. The file engines become pure parsers. Their direct undici downloads now run only in **self-hosted deployments** (no fire-engine) or under an explicit **`forceEngine` pin**.

## Why

The pdf/document engines each fetch files with a plain direct download first, and the browser route only kicked in reactively after an antibot hit or a proxy failure. That split path means files are fetched through different proxy/antibot infrastructure depending on how the first attempt fails. With fire-engine enabled there is no reason for a simple fetch at all — and per the same rationale as the existing fetch/tlsclient waterfall drop ("we'd rather fail the scrape outright"), a fire-engine outage now fails file scrapes rather than silently degrading to a plain HTTP client.

## How

- **`buildFallbackList`** (`engines/index.ts`): new explicit file-fetch routing branch — when fire-engine is on, the pdf/document flag is set, no file is prefetched yet, and no `forceEngine` pin exists, return `[index;documents (cache first), fire-engine;chrome-cdp, fire-engine(retry);chrome-cdp, + stealth variants]`, stealth-only when a stealth proxy is requested. This is a bespoke list, not a flag tweak: the priority-100 `pdf`/`document` flags exist precisely to threshold-filter non-file engines out of the waterfall (browsers declare `pdf/document: false`, so they can never qualify while the flag is set), and clearing the flag instead would let fastMode/atsv requests admit tlsclient — which cannot hand off files at all (the file download handler is chrome-cdp only) and would burn prefetch round trips on null handoffs. Once a handoff lands, the normal waterfall takes over and the file engine parses the prefetched file. Preserved: index-cache hits still serve with zero fetching, the branding-on-PDF clean error, `proxy: "auto"` stealth escalation via the feature-flag loop, lockdown/agentIndexOnly index-only semantics (they pin `forceEngine` upstream of the branch).
- **`scrapePDF` / `scrapeDocument`**: guard the direct download behind `!useFireEngine` (pins exempt). A null browser handoff ("ran, delivered no file") throws the antibot error so the retry loop gives the browser another round trip, exactly like a handoff whose bytes failed the PDF sniff; ordinary pages (no file flag) keep declining via `EngineUnsuccessfulError` so the waterfall tail moves on without a wasted download.
- **pdf parse path**: report `proxyUsed` from the prefetch — stealth handoffs were mislabeled `"basic"`.
- **`engines/fire-engine/available.ts`**: shared `useFireEngine` const in its own module so the file engines can read it without a circular import against `engines/index.ts` (which imports them for its handler table).

## Notes

- No behavior change in self-hosted: no fire-engine ⇒ the historical waterfall (`[index;documents, pdf/document]` with the direct download) is untouched.
- `forceEngine` pins (used by `/v2/parse` uploads, `FORCED_ENGINE_DOMAINS`, and tests) keep the direct download working as the escape hatch.
- Self-hosted CI matrix is unaffected (no `FIRE_ENGINE_BETA_URL` there); the production CI's existing f-e-dependent PDF snips (`scrape.test.ts` "PDF (f-e dependent)", parsers, parse, scrape-cache) now exercise the browser-first route as regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When `fire-engine` is configured, PDF and document downloads always go through the browser engines instead of trying a direct download first. Files arrive at the `pdf`/`document` engines as prefetches; their direct undici downloads only run in self-hosted deployments or under an explicit `forceEngine` pin.

**Behavior**
- With `fire-engine` on, a file scrape never attempts a direct fetch; a null browser handoff throws an antibot error so the retry loop gives the browser another round trip.
- A cross-type handoff (a `.pdf` URL serving a docx, or vice versa) declines via `EngineUnsuccessfulError` so the waterfall reaches the engine that can parse it.
- The bespoke fallback list keeps `index;documents` cache hits, then the `chrome-cdp` variants (stealth-only when stealth is requested); clearing the `pdf`/`document` flag isn't viable because it would admit `tlsclient`, which can't hand off files.
- `proxyUsed` for PDF parses now comes from the prefetch, so stealth handoffs are no longer labeled `basic`.
- The shared `useFireEngine` const lives in `engines/fire-engine/available.ts`; the robots-txt, sitemap, and search fire-engine modules now import it instead of keeping local copies.
- Behavior in self-hosted deployments is unchanged; `forceEngine` pins keep the direct download as an escape hatch.

<sup>Written for commit 5475c0950adad3c3475d9d95b8635e2b76c991d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

