### PR TITLE
Exchange/applications proxy

### DIFF
--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -11,6 +11,7 @@ const RETRIEVE_TIMEOUT_MS = 50_000;
 const ANALYTICS_TIMEOUT_MS = 20_000;
 const APPLICATIONS_TIMEOUT_MS = 15_000;
 const CLAIMS_TIMEOUT_MS = 20_000;
+const SUPPLY_TIMEOUT_MS = 30_000;
 
 const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
 const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
@@ -166,6 +167,12 @@ exchangeRouter.post(
   wrap(exchangeProxy(APPLICATIONS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );
 
+exchangeRouter.post(
+  "/applications/:id/withdraw",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(APPLICATIONS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
 exchangeRouter.get(
   "/claims",
   authMiddleware(RateLimiterMode.Labs),
@@ -188,4 +195,40 @@ exchangeRouter.post(
   "/claims/:id/verify",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(CLAIMS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
+  "/publisher/supply/key",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/publisher/supply/key",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.put(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.delete(
+  "/supply{/*path}",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -232,3 +232,9 @@ exchangeRouter.delete(
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );
+
+exchangeRouter.post(
+  "/records/fetch",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(RETRIEVE_TIMEOUT_MS)),
+);

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -156,6 +156,12 @@ exchangeRouter.get(
 );
 
 exchangeRouter.get(
+  "/publisher/supply/key",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
   "/publisher{/*path}",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
@@ -195,12 +201,6 @@ exchangeRouter.post(
   "/claims/:id/verify",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(CLAIMS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
-);
-
-exchangeRouter.get(
-  "/publisher/supply/key",
-  authMiddleware(RateLimiterMode.Labs),
-  wrap(exchangeProxy(SUPPLY_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );
 
 exchangeRouter.post(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds exchange proxy routes for publisher supply, supply management, application withdrawal, and records fetch.

All new routes use the Labs rate limiter. Supply routes use a new 30s timeout; records fetch reuses the existing retrieve timeout.

<sup>Written for commit 90ff187ce4ca186f2a944368952be4cbcb4e99df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

