### PR TITLE
feat(api): Exchange content and provider search and retrieval

### DIFF
--- a/apps/api/docs/exchange.md
+++ b/apps/api/docs/exchange.md
@@ -1,0 +1,67 @@
+# Exchange search and retrieval
+
+Both sources require the team's existing `exchangeRetrieve` permission.
+
+## Search
+
+`POST /v2/search` accepts source names or source objects:
+
+```json
+{
+  "query": "government funding opportunities",
+  "sources": ["web", "exchange", "exchange-provider"]
+}
+```
+
+- `data.exchange` contains indexed content previews, including the canonical
+  `address`, title, description, and retrieval price in `credits`.
+  A source `url` can be null for uploaded documents.
+- `data["exchange-provider"]` contains provider capabilities that can answer
+  the query.
+- Exchange discovery does not fetch the full record or run provider capabilities.
+  Existing web search and threat-scan charges still apply.
+- An unavailable Exchange source is omitted. An available source with no matches
+  returns an empty array.
+
+This PR changes the pre-release `exchange` source from capability discovery to
+content discovery. Clients seeking capabilities must use `exchange-provider`.
+
+## Call a provider
+
+`POST /v2/scrape`:
+
+```json
+{
+  "exchange": {
+    "provider": "financial-datasets",
+    "capability": "prices/latest",
+    "options": { "ticker": "NVDA" }
+  }
+}
+```
+
+Existing arrays of 1–10 provider calls remain supported. Results remain in
+`data.exchange`, an array, with the total in `data.creditsCost`.
+
+## Fetch indexed content
+
+Use the exact `address` returned by content discovery:
+
+```json
+{
+  "exchange": {
+    "url": "firecrawl://exchange/website/pages/record-id",
+    "maxCredits": 3
+  }
+}
+```
+
+`maxCredits` is required and is the maximum accepted charge. If the actual price
+exceeds it, the request returns 409 without delivering content or charging the
+team. A null discovery price is unknown, not free; set a budget explicitly.
+
+Record fetches accept one canonical address per request. They cannot be mixed
+into provider batches. A successful response uses the same `data.exchange`
+array envelope, with the retrieved record under the entry's `data`.
+Billing authorization and queueing must succeed before content is returned;
+the billing queue confirms the access event after the debit.

--- a/apps/api/src/controllers/v2/scrape-exchange.test.ts
+++ b/apps/api/src/controllers/v2/scrape-exchange.test.ts
@@ -136,6 +136,17 @@ describe("scrape({ exchange })", () => {
     });
   });
 
+  it("answers 502 rather than 500 for a failure the proxy did not classify", async () => {
+    forward.mockRejectedValueOnce(new Error("something unexpected"));
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-7");
+    expect(out.status).toBe(502);
+    expect(out.body).toEqual({
+      success: false,
+      error: "The request could not be completed.",
+    });
+  });
+
   it("maps proxy failures to the proxy's statuses", async () => {
     forward.mockRejectedValueOnce(new ExchangeProxyError("timeout"));
     const { r, out } = res();

--- a/apps/api/src/controllers/v2/scrape-exchange.test.ts
+++ b/apps/api/src/controllers/v2/scrape-exchange.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { config } from "../../config";
+import { ExchangeProxyError } from "../../lib/exchange-proxy";
+import { exchangeScrapeController } from "./scrape-exchange";
+
+vi.mock("../../lib/exchange-proxy", async importOriginal => ({
+  ...(await importOriginal<typeof import("../../lib/exchange-proxy")>()),
+  forwardToExchange: vi.fn(),
+}));
+vi.mock("../../services/logging/log_job", () => ({
+  logRequest: vi.fn(async () => {}),
+}));
+vi.mock("../../lib/external-request-id", () => ({
+  externalRequestId: () => "ext",
+}));
+
+import { forwardToExchange } from "../../lib/exchange-proxy";
+const forward = vi.mocked(forwardToExchange);
+
+const CALL = {
+  provider: "financial-datasets",
+  capability: "prices/latest",
+  options: { ticker: "NVDA" },
+};
+
+function req(
+  body: unknown,
+  flags: Record<string, unknown> = { exchangeRetrieve: true },
+) {
+  return {
+    body,
+    auth: { team_id: "team_a" },
+    acuc: { api_key_id: 7, flags },
+    headers: {},
+  } as any;
+}
+function res() {
+  const out: { status?: number; body?: any } = {};
+  const r: any = {
+    status: (s: number) => {
+      out.status = s;
+      return r;
+    },
+    json: (b: unknown) => {
+      out.body = b;
+      return r;
+    },
+  };
+  return { r, out };
+}
+
+describe("scrape({ exchange })", () => {
+  beforeEach(() => {
+    forward.mockReset();
+    config.FIRE_EXCHANGE_URL = "https://exchange.example";
+  });
+
+  it("forwards every call as one batch under the team, and relays results with the cost", async () => {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: "application/json",
+      requestId: null,
+      body: {
+        success: true,
+        creditsCost: 1,
+        results: [{ ...CALL, creditsCost: 1, data: { price: 1 } }],
+      },
+    });
+    const { r, out } = res();
+
+    await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-1");
+
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: "team_a",
+        method: "POST",
+        path: "/v1/retrieve",
+        body: { requests: [CALL] },
+        requestId: "job-1",
+      }),
+    );
+    expect(out.status).toBe(200);
+    expect(out.body).toEqual({
+      success: true,
+      scrape_id: "job-1",
+      data: {
+        exchange: [{ ...CALL, creditsCost: 1, data: { price: 1 } }],
+        creditsCost: 1,
+      },
+    });
+  });
+
+  it("refuses a team without the flag, before forwarding, the way /exchange/retrieve does", async () => {
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: [CALL] }, {}), r, "job-2");
+    expect(out.status).toBe(403);
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it("is unavailable without an Exchange URL", async () => {
+    config.FIRE_EXCHANGE_URL = "";
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-3");
+    expect(out.status).toBe(503);
+  });
+
+  it("rejects an empty list, more than ten, and page-scrape fields, with a field-level message", async () => {
+    for (const body of [
+      { exchange: [] },
+      { exchange: Array.from({ length: 11 }, () => CALL) },
+      { exchange: [CALL], url: "https://x.example" },
+      { exchange: [{ provider: "p" }] },
+    ]) {
+      const { r, out } = res();
+      await exchangeScrapeController(req(body), r, "job-4");
+      expect(out.status).toBe(400);
+      expect(out.body.error).toMatch(/^Bad Request: /);
+    }
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it("relays the Exchange's own error and status", async () => {
+    forward.mockResolvedValueOnce({
+      status: 400,
+      contentType: null,
+      requestId: null,
+      body: { code: "missing_option", error: "ticker is required" },
+    });
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-5");
+    expect(out.status).toBe(400);
+    expect(out.body).toEqual({
+      success: false,
+      code: "missing_option",
+      error: "ticker is required",
+    });
+  });
+
+  it("maps proxy failures to the proxy's statuses", async () => {
+    forward.mockRejectedValueOnce(new ExchangeProxyError("timeout"));
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-6");
+    expect(out.status).toBe(504);
+  });
+});

--- a/apps/api/src/controllers/v2/scrape-exchange.test.ts
+++ b/apps/api/src/controllers/v2/scrape-exchange.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "../../config";
 import { ExchangeProxyError } from "../../lib/exchange-proxy";
+import { billExchangeRecord } from "../../lib/exchange-record-billing";
 import { exchangeScrapeController } from "./scrape-exchange";
 
 vi.mock("../../lib/exchange-proxy", async importOriginal => ({
   ...(await importOriginal<typeof import("../../lib/exchange-proxy")>()),
   forwardToExchange: vi.fn(),
+}));
+vi.mock("../../lib/exchange-record-billing", () => ({
+  billExchangeRecord: vi.fn(),
 }));
 vi.mock("../../services/logging/log_job", () => ({
   logRequest: vi.fn(async () => {}),
@@ -55,40 +59,43 @@ describe("scrape({ exchange })", () => {
     config.FIRE_EXCHANGE_URL = "https://exchange.example";
   });
 
-  it("forwards every call as one batch under the team, and relays results with the cost", async () => {
-    forward.mockResolvedValueOnce({
-      status: 200,
-      contentType: "application/json",
-      requestId: null,
-      body: {
+  it.each([CALL, [CALL]])(
+    "normalizes the supported request shape %j and relays results with the cost",
+    async exchange => {
+      forward.mockResolvedValueOnce({
+        status: 200,
+        contentType: "application/json",
+        requestId: null,
+        body: {
+          success: true,
+          creditsCost: 1,
+          results: [{ ...CALL, creditsCost: 1, data: { price: 1 } }],
+        },
+      });
+      const { r, out } = res();
+
+      await exchangeScrapeController(req({ exchange }), r, "job-1");
+
+      expect(forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamId: "team_a",
+          method: "POST",
+          path: "/v1/retrieve",
+          body: { requests: [CALL] },
+          requestId: "job-1",
+        }),
+      );
+      expect(out.status).toBe(200);
+      expect(out.body).toEqual({
         success: true,
-        creditsCost: 1,
-        results: [{ ...CALL, creditsCost: 1, data: { price: 1 } }],
-      },
-    });
-    const { r, out } = res();
-
-    await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-1");
-
-    expect(forward).toHaveBeenCalledWith(
-      expect.objectContaining({
-        teamId: "team_a",
-        method: "POST",
-        path: "/v1/retrieve",
-        body: { requests: [CALL] },
-        requestId: "job-1",
-      }),
-    );
-    expect(out.status).toBe(200);
-    expect(out.body).toEqual({
-      success: true,
-      scrape_id: "job-1",
-      data: {
-        exchange: [{ ...CALL, creditsCost: 1, data: { price: 1 } }],
-        creditsCost: 1,
-      },
-    });
-  });
+        scrape_id: "job-1",
+        data: {
+          exchange: [{ ...CALL, creditsCost: 1, data: { price: 1 } }],
+          creditsCost: 1,
+        },
+      });
+    },
+  );
 
   it("refuses a team without the flag, before forwarding, the way /exchange/retrieve does", async () => {
     const { r, out } = res();
@@ -107,6 +114,12 @@ describe("scrape({ exchange })", () => {
   it("rejects an empty list, more than ten, and page-scrape fields, with a field-level message", async () => {
     for (const body of [
       { exchange: [] },
+      { exchange: null },
+      { exchange: "invalid" },
+      { exchange: {} },
+      { exchange: { provider: "p" } },
+      { exchange: { ...CALL, options: [] } },
+      { exchange: CALL, url: "https://x.example" },
       { exchange: Array.from({ length: 11 }, () => CALL) },
       { exchange: [CALL], url: "https://x.example" },
       { exchange: [{ provider: "p" }] },
@@ -152,5 +165,80 @@ describe("scrape({ exchange })", () => {
     const { r, out } = res();
     await exchangeScrapeController(req({ exchange: [CALL] }), r, "job-6");
     expect(out.status).toBe(504);
+  });
+});
+
+describe("Exchange record retrieval", () => {
+  const record = {
+    url: "firecrawl://exchange/website/pages/123",
+    maxCredits: 3,
+  };
+  const data = {
+    id: "123",
+    url: record.url,
+    title: "Page",
+    source: { provider: "website", recordId: "123", recordType: "pages" },
+    metadata: {},
+    markdown: "Content",
+  };
+  beforeEach(() => {
+    vi.mocked(billExchangeRecord).mockReset();
+    forward.mockReset();
+    config.FIRE_EXCHANGE_URL = "https://exchange.example";
+  });
+  function answer() {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: "application/json",
+      requestId: null,
+      body: {
+        success: true,
+        accessEventId: "10000000-0000-4000-8000-000000000001",
+        creditsCost: 2,
+        data,
+      },
+    });
+  }
+  it("fetches the canonical record and bills before returning content", async () => {
+    answer();
+    vi.mocked(billExchangeRecord).mockResolvedValueOnce({ success: true });
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: record }), r, "record-job");
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/v1/records/fetch",
+        body: { url: record.url },
+        teamId: "team_a",
+      }),
+    );
+    expect(billExchangeRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ creditsCost: 2 }),
+      { teamId: "team_a", apiKeyId: 7, maxCredits: 3 },
+    );
+    expect(out.status).toBe(200);
+    expect(out.body.data.exchange[0].data).toEqual(data);
+  });
+  it("does not expose the record when billing is denied", async () => {
+    answer();
+    vi.mocked(billExchangeRecord).mockResolvedValueOnce({
+      success: false,
+      status: 402,
+      error: "Insufficient credits",
+    });
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange: record }), r, "record-job");
+    expect(out.status).toBe(402);
+    expect(out.body).not.toHaveProperty("data");
+  });
+  it.each([
+    { url: record.url },
+    { ...record, maxCredits: -1 },
+    { ...record, url: "https://example.com" },
+    [record],
+  ])("rejects invalid record request %j", async exchange => {
+    const { r, out } = res();
+    await exchangeScrapeController(req({ exchange }), r, "record-job");
+    expect(out.status).toBe(400);
+    expect(forward).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/controllers/v2/scrape-exchange.ts
+++ b/apps/api/src/controllers/v2/scrape-exchange.ts
@@ -1,0 +1,137 @@
+import { Response } from "express";
+import { z } from "zod";
+import { config } from "../../config";
+import { logger as _logger } from "../../lib/logger";
+import {
+  EXCHANGE_RETRIEVE_TIMEOUT_MS,
+  ExchangeProxyError,
+  exchangeProxyFailureResponse,
+  forwardToExchange,
+} from "../../lib/exchange-proxy";
+import { logRequest } from "../../services/logging/log_job";
+import { externalRequestId } from "../../lib/external-request-id";
+import {
+  exchangeScrapeRequestSchema,
+  type ExchangeScrapeResult,
+  type RequestWithAuth,
+  type ScrapeResponse,
+} from "./types";
+
+const retrieveBatchSchema = z
+  .object({
+    success: z.literal(true),
+    creditsCost: z.number().int().nonnegative(),
+    results: z.array(z.record(z.string(), z.unknown())),
+  })
+  .passthrough();
+
+export async function exchangeScrapeController(
+  req: RequestWithAuth<{}, ScrapeResponse, unknown>,
+  res: Response<ScrapeResponse>,
+  jobId: string,
+) {
+  const logger = _logger.child({
+    method: "exchangeScrapeController",
+    jobId,
+    teamId: req.auth.team_id,
+  });
+
+  const parsed = exchangeScrapeRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      error: `Bad Request: ${parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,
+    });
+  }
+  const body = parsed.data;
+
+  if (!req.acuc?.flags?.exchangeRetrieve) {
+    return res.status(403).json({
+      success: false,
+      error: "This endpoint is not enabled for this team.",
+    });
+  }
+  if (!config.FIRE_EXCHANGE_URL) {
+    return res.status(503).json({
+      success: false,
+      error: "This endpoint is not available.",
+    });
+  }
+
+  void logRequest({
+    id: jobId,
+    kind: "scrape",
+    api_version: "v2",
+    external_request_id: externalRequestId(req),
+    team_id: req.auth.team_id,
+    origin: body.origin ?? "api",
+    integration: body.integration,
+    target_hint: `exchange:${body.exchange.map(e => `${e.provider}/${e.capability}`).join(",")}`,
+    zeroDataRetention: false,
+    api_key_id: req.acuc?.api_key_id ?? null,
+  }).catch(err =>
+    logger.warn("Background request log failed", { error: err, jobId }),
+  );
+
+  const timeoutMs = Math.min(
+    body.timeout ?? EXCHANGE_RETRIEVE_TIMEOUT_MS,
+    EXCHANGE_RETRIEVE_TIMEOUT_MS,
+  );
+
+  try {
+    const upstream = await forwardToExchange({
+      teamId: req.auth.team_id,
+      method: "POST",
+      path: "/v1/retrieve",
+      body: { requests: body.exchange },
+      timeoutMs,
+      requestId: jobId,
+    });
+
+    if (upstream.status < 200 || upstream.status >= 300) {
+      const detail =
+        typeof upstream.body === "object" && upstream.body !== null
+          ? (upstream.body as { error?: unknown; code?: unknown })
+          : {};
+      return res.status(upstream.status).json({
+        success: false,
+        error:
+          typeof detail.error === "string"
+            ? detail.error
+            : "The Exchange could not complete the request.",
+        ...(typeof detail.code === "string"
+          ? { code: detail.code as any }
+          : {}),
+      });
+    }
+
+    const answer = retrieveBatchSchema.safeParse(upstream.body);
+    if (!answer.success) {
+      logger.error("Exchange retrieve answered in an unknown shape", {
+        status: upstream.status,
+      });
+      return res.status(502).json({
+        success: false,
+        error: "The request could not be completed.",
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      scrape_id: jobId,
+      data: {
+        exchange: answer.data.results as ExchangeScrapeResult[],
+        creditsCost: answer.data.creditsCost,
+      },
+    });
+  } catch (error: unknown) {
+    if (error instanceof ExchangeProxyError) {
+      logger.error("Exchange scrape proxy failed", { kind: error.kind });
+      const failure = exchangeProxyFailureResponse(error.kind);
+      return res
+        .status(failure.status)
+        .json({ success: false, error: failure.error });
+    }
+    throw error;
+  }
+}

--- a/apps/api/src/controllers/v2/scrape-exchange.ts
+++ b/apps/api/src/controllers/v2/scrape-exchange.ts
@@ -132,6 +132,10 @@ export async function exchangeScrapeController(
         .status(failure.status)
         .json({ success: false, error: failure.error });
     }
-    throw error;
+    logger.error("Exchange scrape failed", { error });
+    const failure = exchangeProxyFailureResponse("unreachable");
+    return res
+      .status(failure.status)
+      .json({ success: false, error: failure.error });
   }
 }

--- a/apps/api/src/controllers/v2/scrape-exchange.ts
+++ b/apps/api/src/controllers/v2/scrape-exchange.ts
@@ -1,3 +1,4 @@
+import { billExchangeRecord } from "../../lib/exchange-record-billing";
 import { Response } from "express";
 import { z } from "zod";
 import { config } from "../../config";
@@ -44,6 +45,10 @@ export async function exchangeScrapeController(
     });
   }
   const body = parsed.data;
+  const record =
+    body.exchange.length === 1 && "url" in body.exchange[0]
+      ? body.exchange[0]
+      : null;
 
   if (!req.acuc?.flags?.exchangeRetrieve) {
     return res.status(403).json({
@@ -66,7 +71,7 @@ export async function exchangeScrapeController(
     team_id: req.auth.team_id,
     origin: body.origin ?? "api",
     integration: body.integration,
-    target_hint: `exchange:${body.exchange.map(e => `${e.provider}/${e.capability}`).join(",")}`,
+    target_hint: `exchange:${body.exchange.map(e => ("url" in e ? e.url : `${e.provider}/${e.capability}`)).join(",")}`,
     zeroDataRetention: false,
     api_key_id: req.acuc?.api_key_id ?? null,
   }).catch(err =>
@@ -82,8 +87,8 @@ export async function exchangeScrapeController(
     const upstream = await forwardToExchange({
       teamId: req.auth.team_id,
       method: "POST",
-      path: "/v1/retrieve",
-      body: { requests: body.exchange },
+      path: record ? "/v1/records/fetch" : "/v1/retrieve",
+      body: record ? { url: record.url } : { requests: body.exchange },
       timeoutMs,
       requestId: jobId,
     });
@@ -105,6 +110,61 @@ export async function exchangeScrapeController(
       });
     }
 
+    if (record) {
+      const answer = z
+        .object({
+          success: z.literal(true),
+          accessEventId: z.string().uuid(),
+          creditsCost: z.number().int().nonnegative().safe(),
+          data: z
+            .object({
+              id: z.string(),
+              url: z.string(),
+              title: z.string(),
+              source: z.object({
+                provider: z.string(),
+                recordId: z.string(),
+                recordType: z.string(),
+              }),
+              metadata: z.record(z.string(), z.unknown()),
+              markdown: z.string().optional(),
+              json: z.record(z.string(), z.unknown()).optional(),
+            })
+            .passthrough(),
+        })
+        .safeParse(upstream.body);
+      if (!answer.success)
+        return res
+          .status(502)
+          .json({
+            success: false,
+            error: "Exchange returned an invalid record.",
+          });
+      const billed = await billExchangeRecord(answer.data, {
+        teamId: req.auth.team_id,
+        apiKeyId: req.acuc?.api_key_id ?? null,
+        maxCredits: record.maxCredits,
+      });
+      if (!billed.success)
+        return res
+          .status(billed.status)
+          .json({ success: false, error: billed.error });
+      return res.status(200).json({
+        success: true,
+        scrape_id: jobId,
+        data: {
+          exchange: [
+            {
+              provider: answer.data.data.source.provider,
+              capability: "records/fetch",
+              creditsCost: answer.data.creditsCost,
+              data: answer.data.data,
+            },
+          ],
+          creditsCost: answer.data.creditsCost,
+        },
+      });
+    }
     const answer = retrieveBatchSchema.safeParse(upstream.body);
     if (!answer.success) {
       logger.error("Exchange retrieve answered in an unknown shape", {

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -44,6 +44,7 @@ import { applyAgentAuthDiscoveryHeader } from "../../lib/agent-auth-discovery";
 import { resolveThreatProtection } from "../../lib/threat-protection/request";
 import { getEffectiveConcurrencyLimit } from "../../lib/concurrency-limit";
 import { isAgentInteropSecretValid } from "../../lib/agent-interop";
+import { exchangeScrapeController } from "./scrape-exchange";
 
 const AGENT_INTEROP_CONCURRENCY_BOOST = 3;
 
@@ -61,6 +62,10 @@ export async function scrapeController(
 
       const jobId = uuidv7();
       const preNormalizedBody = { ...req.body };
+
+      if (Array.isArray((req.body as { exchange?: unknown }).exchange)) {
+        return exchangeScrapeController(req, res, jobId);
+      }
 
       // Set initial span attributes
       setSpanAttributes(span, {

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -63,10 +63,6 @@ export async function scrapeController(
       const jobId = uuidv7();
       const preNormalizedBody = { ...req.body };
 
-      if (Array.isArray((req.body as { exchange?: unknown }).exchange)) {
-        return exchangeScrapeController(req, res, jobId);
-      }
-
       // Set initial span attributes
       setSpanAttributes(span, {
         "scrape.job_id": jobId,
@@ -75,6 +71,12 @@ export async function scrapeController(
         "scrape.api_key_id": req.acuc?.api_key_id,
         "scrape.middleware_time_ms": controllerStartTime - middlewareStartTime,
       });
+
+      if (
+        Array.isArray((req.body as { exchange?: unknown } | null)?.exchange)
+      ) {
+        return exchangeScrapeController(req, res, jobId);
+      }
 
       // Validation span
       await withSpan("api.scrape.validate", async validateSpan => {

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -72,9 +72,7 @@ export async function scrapeController(
         "scrape.middleware_time_ms": controllerStartTime - middlewareStartTime,
       });
 
-      if (
-        Array.isArray((req.body as { exchange?: unknown } | null)?.exchange)
-      ) {
+      if ((req.body as { exchange?: unknown } | null)?.exchange !== undefined) {
         return exchangeScrapeController(req, res, jobId);
       }
 

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -164,6 +164,22 @@ export async function searchController(
       }
     }
 
+    const wantsExchange = (req.body.sources as Array<{ type: string }>).some(
+      source => source.type === "exchange",
+    );
+    if (wantsExchange && !req.acuc?.flags?.exchangeRetrieve) {
+      return res.status(403).json({
+        success: false,
+        error: "The exchange source is not enabled for this team.",
+      });
+    }
+    if (wantsExchange && !config.FIRE_EXCHANGE_URL) {
+      return res.status(503).json({
+        success: false,
+        error: "The exchange source is not available.",
+      });
+    }
+
     const isZDR = req.body.enterprise?.includes("zdr");
     const isAnon = req.body.enterprise?.includes("anon");
     const isZDROrAnon = isZDR || isAnon;

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -165,7 +165,8 @@ export async function searchController(
     }
 
     const wantsExchange = (req.body.sources as Array<{ type: string }>).some(
-      source => source.type === "exchange",
+      source =>
+        source.type === "exchange" || source.type === "exchange-provider",
     );
     if (wantsExchange && !req.acuc?.flags?.exchangeRetrieve) {
       return res.status(403).json({

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1470,7 +1470,48 @@ export type ScrapeResponse =
       warning?: string;
       data: Document;
       scrape_id?: string;
+    }
+  | ExchangeScrapeResponse;
+
+export const exchangeScrapeRequestSchema = z.strictObject({
+  exchange: z
+    .array(
+      z.strictObject({
+        provider: z.string().min(1),
+        capability: z.string().min(1),
+        options: z.record(z.string(), z.unknown()).optional(),
+      }),
+    )
+    .min(1)
+    .max(10),
+  origin: z.string().optional().prefault("api"),
+  integration: integrationSchema.optional().transform(val => val || null),
+  timeout: z.int().positive().finite().optional(),
+});
+
+export type ExchangeScrapeResult =
+  | {
+      provider: string;
+      capability: string;
+      creditsCost: number;
+      data: unknown;
+      [key: string]: unknown;
+    }
+  | {
+      provider?: string;
+      capability?: string;
+      error: { code: string; message: string; status?: number };
+      [key: string]: unknown;
     };
+
+export type ExchangeScrapeResponse = {
+  success: true;
+  scrape_id: string;
+  data: {
+    exchange: ExchangeScrapeResult[];
+    creditsCost: number;
+  };
+};
 
 export interface URLTrace {
   url: string;
@@ -2060,6 +2101,10 @@ const newsSearchSourceOptions = z.strictObject({
   type: z.literal("news"),
 });
 
+const exchangeSearchSourceOptions = z.strictObject({
+  type: z.literal("exchange"),
+});
+
 // Category source type definitions
 const githubCategoryOptions = z.strictObject({
   type: z.literal("github"),
@@ -2141,13 +2186,14 @@ export const searchRequestSchema = z
     sources: z
       .union([
         // Array of strings (simple format)
-        z.array(z.enum(["web", "images", "news"])),
+        z.array(z.enum(["web", "images", "news", "exchange"])),
         // Array of objects (advanced format)
         z.array(
           z.union([
             webSearchSourceOptions,
             imagesSearchSourceOptions,
             newsSearchSourceOptions,
+            exchangeSearchSourceOptions,
           ]),
         ),
       ])
@@ -2281,6 +2327,8 @@ export const searchRequestSchema = z
                 country,
                 location: x.location,
               };
+            case "exchange":
+              return { type: "exchange" as const };
             default:
               return { type: s as any };
           }

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1473,17 +1473,25 @@ export type ScrapeResponse =
     }
   | ExchangeScrapeResponse;
 
+const exchangeScrapeCallSchema = z.strictObject({
+  provider: z.string().min(1),
+  capability: z.string().min(1),
+  options: z.record(z.string(), z.unknown()).optional(),
+});
+
+const exchangeRecordCallSchema = z.strictObject({
+  url: z.string().regex(/^firecrawl:\/\/exchange\/[^/?#]+\/[^/?#]+\/[^/?#]+$/),
+  maxCredits: z.number().int().nonnegative().safe(),
+});
+
 export const exchangeScrapeRequestSchema = z.strictObject({
   exchange: z
-    .array(
-      z.strictObject({
-        provider: z.string().min(1),
-        capability: z.string().min(1),
-        options: z.record(z.string(), z.unknown()).optional(),
-      }),
-    )
-    .min(1)
-    .max(10),
+    .union([
+      exchangeRecordCallSchema,
+      exchangeScrapeCallSchema,
+      z.array(exchangeScrapeCallSchema).min(1).max(10),
+    ])
+    .transform(value => (Array.isArray(value) ? value : [value])),
   origin: z.string().optional().prefault("api"),
   integration: integrationSchema.optional().transform(val => val || null),
   timeout: z.int().positive().finite().optional(),
@@ -2102,7 +2110,7 @@ const newsSearchSourceOptions = z.strictObject({
 });
 
 const exchangeSearchSourceOptions = z.strictObject({
-  type: z.literal("exchange"),
+  type: z.enum(["exchange", "exchange-provider"]),
 });
 
 // Category source type definitions
@@ -2186,7 +2194,9 @@ export const searchRequestSchema = z
     sources: z
       .union([
         // Array of strings (simple format)
-        z.array(z.enum(["web", "images", "news", "exchange"])),
+        z.array(
+          z.enum(["web", "images", "news", "exchange", "exchange-provider"]),
+        ),
         // Array of objects (advanced format)
         z.array(
           z.union([
@@ -2328,7 +2338,8 @@ export const searchRequestSchema = z
                 location: x.location,
               };
             case "exchange":
-              return { type: "exchange" as const };
+            case "exchange-provider":
+              return { type: s };
             default:
               return { type: s as any };
           }

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -161,12 +161,22 @@ export interface WebSearchResult {
   highlights?: string;
 }
 
-export type SearchResultType = "web" | "images" | "news";
+export type SearchResultType = "web" | "images" | "news" | "exchange";
+
+export interface ExchangeSearchResult {
+  provider: string;
+  capability: string;
+  concept: string;
+  cohorts: string[];
+  creditsCost: number;
+  similarity: number;
+}
 
 export interface SearchV2Response {
   web?: WebSearchResult[];
   images?: ImageSearchResult[];
   news?: NewsSearchResult[];
+  exchange?: ExchangeSearchResult[];
 }
 
 export interface ScrapeActionContent {

--- a/apps/api/src/lib/entities.ts
+++ b/apps/api/src/lib/entities.ts
@@ -161,7 +161,12 @@ export interface WebSearchResult {
   highlights?: string;
 }
 
-export type SearchResultType = "web" | "images" | "news" | "exchange";
+export type SearchResultType =
+  | "web"
+  | "images"
+  | "news"
+  | "exchange"
+  | "exchange-provider";
 
 export interface ExchangeSearchResult {
   provider: string;
@@ -172,11 +177,25 @@ export interface ExchangeSearchResult {
   similarity: number;
 }
 
+export interface ExchangeContentResult {
+  address: string;
+  url: string | null;
+  title: string;
+  description: string;
+  domain: string | null;
+  kind: "document" | "page";
+  provider: string;
+  providerName: string;
+  credits: number | null;
+  relevance: number;
+}
+
 export interface SearchV2Response {
   web?: WebSearchResult[];
   images?: ImageSearchResult[];
   news?: NewsSearchResult[];
-  exchange?: ExchangeSearchResult[];
+  exchange?: ExchangeContentResult[];
+  "exchange-provider"?: ExchangeSearchResult[];
 }
 
 export interface ScrapeActionContent {

--- a/apps/api/src/lib/exchange-proxy.test.ts
+++ b/apps/api/src/lib/exchange-proxy.test.ts
@@ -1,0 +1,125 @@
+import { fetch } from "undici";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { config } from "../config";
+import { ExchangeProxyError, forwardToExchange } from "./exchange-proxy";
+
+vi.mock("undici", () => ({
+  fetch: vi.fn(),
+  Agent: class {
+    constructor(_opts: unknown) {}
+  },
+}));
+
+const fetchMock = vi.mocked(fetch);
+
+function upstream(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  return {
+    status,
+    headers: new Headers({ "content-type": "application/json", ...headers }),
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as any;
+}
+
+describe("forwardToExchange", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    config.FIRE_EXCHANGE_URL = "https://exchange.example/";
+  });
+
+  it("sets the team from the authenticated caller and never from the request", async () => {
+    fetchMock.mockResolvedValueOnce(
+      upstream(200, { ok: true }, { "x-request-id": "rid-1" }),
+    );
+
+    const result = await forwardToExchange({
+      teamId: "team_a",
+      method: "POST",
+      path: "/v1/retrieve",
+      body: { requests: [] },
+      timeoutMs: 1_000,
+      requestId: "rid-1",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]! as [string, any];
+    expect(url).toBe("https://exchange.example/v1/retrieve");
+    expect(init.headers).toMatchObject({
+      "x-exchange-team-id": "team_a",
+      "x-request-id": "rid-1",
+      "content-type": "application/json",
+    });
+    expect(init.body).toBe(JSON.stringify({ requests: [] }));
+    expect(result).toMatchObject({
+      status: 200,
+      body: { ok: true },
+      requestId: "rid-1",
+    });
+  });
+
+  it("sends no body on GET", async () => {
+    fetchMock.mockResolvedValueOnce(upstream(200, { capabilities: [] }));
+    await forwardToExchange({
+      teamId: "t",
+      method: "GET",
+      path: "/v1/discover?q=x",
+      timeoutMs: 1_000,
+    });
+    expect((fetchMock.mock.calls[0]![1] as any).body).toBeUndefined();
+  });
+
+  it("is unconfigured without an Exchange URL, before any call", async () => {
+    config.FIRE_EXCHANGE_URL = "";
+    await expect(
+      forwardToExchange({
+        teamId: "t",
+        method: "GET",
+        path: "/v1/discover",
+        timeoutMs: 1,
+      }),
+    ).rejects.toMatchObject({ kind: "unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("names a timeout as a timeout and anything else as unreachable", async () => {
+    fetchMock.mockRejectedValueOnce(
+      new DOMException("aborted", "TimeoutError"),
+    );
+    await expect(
+      forwardToExchange({
+        teamId: "t",
+        method: "GET",
+        path: "/v1/discover",
+        timeoutMs: 1,
+      }),
+    ).rejects.toMatchObject({ kind: "timeout" });
+
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const error = await forwardToExchange({
+      teamId: "t",
+      method: "GET",
+      path: "/v1/discover",
+      timeoutMs: 1,
+    }).catch(e => e);
+    expect(error).toBeInstanceOf(ExchangeProxyError);
+    expect(error.kind).toBe("unreachable");
+  });
+
+  it("relays a non-JSON body as text rather than failing", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 502,
+      headers: new Headers({ "content-type": "text/plain" }),
+      text: async () => "bad gateway",
+    } as any);
+    const result = await forwardToExchange({
+      teamId: "t",
+      method: "GET",
+      path: "/v1/x",
+      timeoutMs: 1,
+    });
+    expect(result).toMatchObject({ status: 502, body: "bad gateway" });
+  });
+});

--- a/apps/api/src/lib/exchange-proxy.test.ts
+++ b/apps/api/src/lib/exchange-proxy.test.ts
@@ -108,6 +108,76 @@ describe("forwardToExchange", () => {
     expect(error.kind).toBe("unreachable");
   });
 
+  it("forwards the method verbatim, including PUT and DELETE", async () => {
+    for (const method of ["PUT", "DELETE", "GET", "POST"]) {
+      fetchMock.mockResolvedValueOnce(upstream(200, { ok: true }));
+      await forwardToExchange({
+        teamId: "t",
+        method,
+        path: "/v1/supply/x",
+        timeoutMs: 1,
+        body: { a: 1 },
+      });
+      const init = fetchMock.mock.calls.at(-1)![1] as any;
+      expect(init.method).toBe(method);
+      expect(init.body === undefined).toBe(method === "GET");
+    }
+  });
+
+  it("treats undici's own timeout codes as timeouts", async () => {
+    for (const code of [
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_HEADERS_TIMEOUT",
+      "UND_ERR_BODY_TIMEOUT",
+    ]) {
+      fetchMock.mockRejectedValueOnce(Object.assign(new Error(code), { code }));
+      await expect(
+        forwardToExchange({
+          teamId: "t",
+          method: "GET",
+          path: "/v1/x",
+          timeoutMs: 1,
+        }),
+      ).rejects.toMatchObject({ kind: "timeout" });
+    }
+  });
+
+  it("maps a failure while reading the body the same way as one before it", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      headers: new Headers(),
+      text: async () => {
+        throw Object.assign(new Error("body"), {
+          code: "UND_ERR_BODY_TIMEOUT",
+        });
+      },
+    } as any);
+    await expect(
+      forwardToExchange({
+        teamId: "t",
+        method: "GET",
+        path: "/v1/x",
+        timeoutMs: 1,
+      }),
+    ).rejects.toMatchObject({ kind: "timeout" });
+
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      headers: new Headers(),
+      text: async () => {
+        throw new Error("socket hang up");
+      },
+    } as any);
+    await expect(
+      forwardToExchange({
+        teamId: "t",
+        method: "GET",
+        path: "/v1/x",
+        timeoutMs: 1,
+      }),
+    ).rejects.toMatchObject({ kind: "unreachable" });
+  });
+
   it("relays a non-JSON body as text rather than failing", async () => {
     fetchMock.mockResolvedValueOnce({
       status: 502,

--- a/apps/api/src/lib/exchange-proxy.ts
+++ b/apps/api/src/lib/exchange-proxy.ts
@@ -1,0 +1,108 @@
+import { Agent, fetch } from "undici";
+import { config } from "../config";
+
+type ExchangeUpstream = {
+  status: number;
+  body: unknown;
+  contentType: string | null;
+  requestId: string | null;
+};
+
+type ExchangeProxyFailure = "unconfigured" | "timeout" | "unreachable";
+
+export class ExchangeProxyError extends Error {
+  constructor(
+    readonly kind: ExchangeProxyFailure,
+    readonly cause?: unknown,
+  ) {
+    super(`exchange proxy: ${kind}`);
+    this.name = "ExchangeProxyError";
+  }
+}
+
+export function exchangeProxyFailureResponse(kind: ExchangeProxyFailure): {
+  status: number;
+  error: string;
+} {
+  switch (kind) {
+    case "unconfigured":
+      return { status: 503, error: "This endpoint is not available." };
+    case "timeout":
+      return { status: 504, error: "The request timed out." };
+    case "unreachable":
+      return { status: 502, error: "The request could not be completed." };
+  }
+}
+
+export const EXCHANGE_DISCOVER_TIMEOUT_MS = 10_000;
+export const EXCHANGE_RETRIEVE_TIMEOUT_MS = 50_000;
+
+const dispatchers = new Map<number, Agent>();
+function dispatcherFor(timeout: number): Agent {
+  let agent = dispatchers.get(timeout);
+  if (!agent) {
+    agent = new Agent({
+      connectTimeout: timeout,
+      headersTimeout: timeout,
+      bodyTimeout: timeout,
+    });
+    dispatchers.set(timeout, agent);
+  }
+  return agent;
+}
+
+export function exchangeUpstreamBase(): string | null {
+  if (!config.FIRE_EXCHANGE_URL) return null;
+  return config.FIRE_EXCHANGE_URL.replace(/\/+$/, "");
+}
+
+export async function forwardToExchange(input: {
+  teamId: string;
+  method: "GET" | "POST";
+  path: string;
+  body?: unknown;
+  timeoutMs: number;
+  accept?: string;
+  requestId?: string;
+}): Promise<ExchangeUpstream> {
+  const base = exchangeUpstreamBase();
+  if (!base) throw new ExchangeProxyError("unconfigured");
+
+  const hasBody = input.method !== "GET";
+  let upstream: Awaited<ReturnType<typeof fetch>>;
+  try {
+    upstream = await fetch(base + input.path, {
+      method: input.method,
+      headers: {
+        ...(input.accept === undefined ? {} : { accept: input.accept }),
+        ...(input.requestId === undefined
+          ? {}
+          : { "x-request-id": input.requestId }),
+        ...(hasBody ? { "content-type": "application/json" } : {}),
+        "x-exchange-team-id": input.teamId,
+      },
+      body: hasBody ? JSON.stringify(input.body ?? {}) : undefined,
+      signal: AbortSignal.timeout(input.timeoutMs),
+      dispatcher: dispatcherFor(input.timeoutMs),
+    });
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new ExchangeProxyError("timeout", error);
+    }
+    throw new ExchangeProxyError("unreachable", error);
+  }
+
+  const text = await upstream.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return {
+    status: upstream.status,
+    body,
+    contentType: upstream.headers.get("content-type"),
+    requestId: upstream.headers.get("x-request-id"),
+  };
+}

--- a/apps/api/src/lib/exchange-proxy.ts
+++ b/apps/api/src/lib/exchange-proxy.ts
@@ -56,9 +56,23 @@ export function exchangeUpstreamBase(): string | null {
   return config.FIRE_EXCHANGE_URL.replace(/\/+$/, "");
 }
 
+const UNDICI_TIMEOUT_CODES = new Set([
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+function isTimeout(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return true;
+  }
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" && UNDICI_TIMEOUT_CODES.has(code);
+}
+
 export async function forwardToExchange(input: {
   teamId: string;
-  method: "GET" | "POST";
+  method: string;
   path: string;
   body?: unknown;
   timeoutMs: number;
@@ -68,11 +82,13 @@ export async function forwardToExchange(input: {
   const base = exchangeUpstreamBase();
   if (!base) throw new ExchangeProxyError("unconfigured");
 
-  const hasBody = input.method !== "GET";
+  const method = input.method.toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD";
   let upstream: Awaited<ReturnType<typeof fetch>>;
+  let text: string;
   try {
     upstream = await fetch(base + input.path, {
-      method: input.method,
+      method,
       headers: {
         ...(input.accept === undefined ? {} : { accept: input.accept }),
         ...(input.requestId === undefined
@@ -85,14 +101,14 @@ export async function forwardToExchange(input: {
       signal: AbortSignal.timeout(input.timeoutMs),
       dispatcher: dispatcherFor(input.timeoutMs),
     });
+    text = await upstream.text();
   } catch (error: unknown) {
-    if (error instanceof DOMException && error.name === "TimeoutError") {
+    if (isTimeout(error)) {
       throw new ExchangeProxyError("timeout", error);
     }
     throw new ExchangeProxyError("unreachable", error);
   }
 
-  const text = await upstream.text();
   let body: unknown;
   try {
     body = text ? JSON.parse(text) : null;

--- a/apps/api/src/lib/exchange-record-billing.test.ts
+++ b/apps/api/src/lib/exchange-record-billing.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { billExchangeRecord } from "./exchange-record-billing";
+import { billTeam } from "../services/billing/credit_billing";
+import { autumnService } from "../services/autumn/autumn.service";
+import { reportExchangeBilling } from "./exchange";
+vi.mock("../services/billing/credit_billing", () => ({ billTeam: vi.fn() }));
+vi.mock("../services/autumn/autumn.service", () => ({
+  autumnService: { checkCredits: vi.fn() },
+}));
+vi.mock("./exchange", () => ({ reportExchangeBilling: vi.fn() }));
+const receipt = {
+  success: true,
+  accessEventId: "6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60",
+  creditsCost: 32,
+};
+const context = { teamId: "consumer", apiKeyId: 1, maxCredits: 32 };
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(autumnService.checkCredits).mockResolvedValue({
+    allowed: true,
+    remaining: 100,
+  } as any);
+  vi.mocked(billTeam).mockResolvedValue({ success: true });
+});
+it("queues the exact accepted price with a stable callback receipt without confirming early", async () => {
+  expect(await billExchangeRecord(receipt, context)).toEqual({ success: true });
+  expect(billTeam).toHaveBeenCalledWith(
+    "consumer",
+    32,
+    1,
+    { endpoint: "scrape", chargeId: `exchange:${receipt.accessEventId}` },
+    undefined,
+    {
+      accessEventId: receipt.accessEventId,
+      billingReference: `exchange:${receipt.accessEventId}`,
+    },
+  );
+  expect(reportExchangeBilling).not.toHaveBeenCalled();
+});
+it("does not charge malformed or unexpectedly expensive responses", async () => {
+  for (const input of [
+    { ...receipt, creditsCost: -1 },
+    { ...receipt, creditsCost: 33 },
+    { success: false },
+    { ...receipt, accessEventId: undefined },
+  ]) {
+    expect((await billExchangeRecord(input, context)).success).toBe(false);
+  }
+  expect(billTeam).not.toHaveBeenCalled();
+});
+it("does not charge preview teams and voids the delivered event", async () => {
+  expect(
+    await billExchangeRecord(receipt, { ...context, teamId: "preview_test" }),
+  ).toEqual({ success: true });
+  expect(billTeam).not.toHaveBeenCalled();
+  expect(reportExchangeBilling).toHaveBeenCalledWith({
+    accessEventId: receipt.accessEventId,
+    status: "void",
+  });
+});
+it("fails closed if balance cannot be authorized and leaves ambiguous enqueue failures pending", async () => {
+  vi.mocked(autumnService.checkCredits).mockResolvedValue(null);
+  expect(await billExchangeRecord(receipt, context)).toMatchObject({
+    success: false,
+    status: 503,
+  });
+  expect(billTeam).not.toHaveBeenCalled();
+  vi.mocked(autumnService.checkCredits).mockResolvedValue({
+    allowed: true,
+    remaining: 100,
+  } as any);
+  vi.mocked(billTeam).mockResolvedValue({ success: false } as any);
+  vi.mocked(reportExchangeBilling).mockClear();
+  expect(await billExchangeRecord(receipt, context)).toMatchObject({
+    success: false,
+    status: 503,
+  });
+  expect(reportExchangeBilling).not.toHaveBeenCalled();
+});

--- a/apps/api/src/lib/exchange-record-billing.ts
+++ b/apps/api/src/lib/exchange-record-billing.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { billTeam } from "../services/billing/credit_billing";
+import { autumnService } from "../services/autumn/autumn.service";
+import { reportExchangeBilling } from "./exchange";
+
+const deliveredRecord = z.object({
+  success: z.literal(true),
+  accessEventId: z.string().uuid(),
+  creditsCost: z.number().int().nonnegative().safe(),
+});
+
+export async function billExchangeRecord(
+  body: unknown,
+  context: {
+    teamId: string;
+    apiKeyId: number | null;
+    maxCredits: number;
+  },
+): Promise<
+  { success: true } | { success: false; status: number; error: string }
+> {
+  const parsed = deliveredRecord.safeParse(body);
+  if (!parsed.success)
+    return {
+      success: false,
+      status: 502,
+      error: "Exchange returned an invalid billing receipt.",
+    };
+  const { accessEventId, creditsCost } = parsed.data;
+  if (creditsCost > context.maxCredits) {
+    await reportExchangeBilling({ accessEventId, status: "void" });
+    return {
+      success: false,
+      status: 409,
+      error: "The document price exceeds the accepted credit limit.",
+    };
+  }
+  if (
+    creditsCost === 0 ||
+    context.teamId === "preview" ||
+    context.teamId.startsWith("preview_")
+  ) {
+    await reportExchangeBilling({ accessEventId, status: "void" });
+    return { success: true };
+  }
+  const balance = await autumnService.checkCredits({
+    teamId: context.teamId,
+    value: creditsCost,
+    properties: { source: "exchange-record-fetch", apiKeyId: context.apiKeyId },
+  });
+  if (!balance?.allowed) {
+    await reportExchangeBilling({ accessEventId, status: "void" });
+    return {
+      success: false,
+      status: balance === null ? 503 : 402,
+      error: "Unable to authorize credits for this document.",
+    };
+  }
+  const billingReference = `exchange:${accessEventId}`;
+  const result = await billTeam(
+    context.teamId,
+    creditsCost,
+    context.apiKeyId,
+    { endpoint: "scrape", chargeId: billingReference },
+    undefined,
+    { accessEventId, billingReference },
+  );
+  if (!result.success)
+    return {
+      success: false,
+      status: 503,
+      error:
+        "Document billing is pending reconciliation. Please try again later.",
+    };
+  return { success: true };
+}

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -1,6 +1,10 @@
 import express, { Request, Response } from "express";
-import { Agent, fetch } from "undici";
-import { config } from "../config";
+import {
+  ExchangeProxyError,
+  exchangeProxyFailureResponse,
+  exchangeUpstreamBase,
+  forwardToExchange,
+} from "../lib/exchange-proxy";
 import { logger as rootLogger } from "../lib/logger";
 import type { RequestWithAuth } from "../controllers/v1/types";
 import { RateLimiterMode } from "../types";
@@ -13,24 +17,8 @@ const APPLICATIONS_TIMEOUT_MS = 15_000;
 const CLAIMS_TIMEOUT_MS = 20_000;
 const SUPPLY_TIMEOUT_MS = 30_000;
 
-const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
-const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
-
-function dispatcherFor(timeout: number) {
-  return new Agent({
-    connectTimeout: timeout,
-    headersTimeout: timeout,
-    bodyTimeout: timeout,
-  });
-}
-
 function exchangeError(res: Response, status: number, error: string) {
   return res.status(status).json({ success: false, error });
-}
-
-function upstreamBase(): string | null {
-  if (!config.FIRE_EXCHANGE_URL) return null;
-  return config.FIRE_EXCHANGE_URL.replace(/\/+$/, "");
 }
 
 function exchangeProxy(
@@ -38,7 +26,6 @@ function exchangeProxy(
   options: { requiresRetrieveFlag?: boolean } = {},
 ) {
   const requiresRetrieveFlag = options.requiresRetrieveFlag !== false;
-  const dispatcher = dispatcherFor(timeout);
 
   return async function controller(req: Request, res: Response) {
     const authedReq = req as RequestWithAuth<any, any, any>;
@@ -49,8 +36,7 @@ function exchangeProxy(
       teamId: authedReq.auth.team_id,
     });
 
-    const base = upstreamBase();
-    if (!base) {
+    if (!exchangeUpstreamBase()) {
       return exchangeError(res, 503, "This endpoint is not available.");
     }
 
@@ -62,48 +48,33 @@ function exchangeProxy(
       );
     }
 
-    const hasBody = req.method !== "GET";
-    const path = req.originalUrl.replace(/^\/exchange/, "/v1");
-
+    const accept = req.headers["accept"];
+    const requestId = req.headers["x-request-id"];
     try {
-      const upstream = await fetch(base + path, {
-        method: req.method,
-        headers: {
-          ...Object.fromEntries(
-            FORWARDED_REQUEST_HEADERS.flatMap(h => {
-              const value = req.headers[h];
-              return typeof value === "string" ? [[h, value]] : [];
-            }),
-          ),
-          ...(hasBody ? { "content-type": "application/json" } : {}),
-          "x-exchange-team-id": authedReq.auth.team_id,
-        },
-        body: hasBody ? JSON.stringify(req.body ?? {}) : undefined,
-        signal: AbortSignal.timeout(timeout),
-        dispatcher,
+      const upstream = await forwardToExchange({
+        teamId: authedReq.auth.team_id,
+        method: req.method === "GET" ? "GET" : "POST",
+        path: req.originalUrl.replace(/^\/exchange/, "/v1"),
+        body: req.body,
+        timeoutMs: timeout,
+        ...(typeof accept === "string" ? { accept } : {}),
+        ...(typeof requestId === "string" ? { requestId } : {}),
       });
 
-      for (const h of FORWARDED_RESPONSE_HEADERS) {
-        const value = upstream.headers.get(h);
-        if (value) res.setHeader(h, value);
-      }
+      if (upstream.contentType)
+        res.setHeader("content-type", upstream.contentType);
+      if (upstream.requestId) res.setHeader("x-request-id", upstream.requestId);
 
-      const text = await upstream.text();
-      let body: unknown;
-      try {
-        body = text ? JSON.parse(text) : null;
-      } catch {
-        body = text;
+      if (upstream.body === null || typeof upstream.body === "string") {
+        return res.status(upstream.status).send(upstream.body ?? "");
       }
-
-      if (body === null || typeof body === "string") {
-        return res.status(upstream.status).send(body ?? "");
-      }
-      return res.status(upstream.status).json(body);
+      return res.status(upstream.status).json(upstream.body);
     } catch (error: unknown) {
-      if (error instanceof DOMException && error.name === "TimeoutError") {
-        logger.error("Exchange proxy timed out");
-        return exchangeError(res, 504, "The request timed out.");
+      if (error instanceof ExchangeProxyError) {
+        if (error.kind === "timeout") logger.error("Exchange proxy timed out");
+        else logger.error("Exchange proxy error", { error: error.cause });
+        const failure = exchangeProxyFailureResponse(error.kind);
+        return exchangeError(res, failure.status, failure.error);
       }
       logger.error("Exchange proxy error", { error });
       return exchangeError(res, 502, "The request could not be completed.");

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -53,7 +53,7 @@ function exchangeProxy(
     try {
       const upstream = await forwardToExchange({
         teamId: authedReq.auth.team_id,
-        method: req.method === "GET" ? "GET" : "POST",
+        method: req.method,
         path: req.originalUrl.replace(/^\/exchange/, "/v1"),
         body: req.body,
         timeoutMs: timeout,

--- a/apps/api/src/search/exchange-source.test.ts
+++ b/apps/api/src/search/exchange-source.test.ts
@@ -69,6 +69,71 @@ describe("exchange search source", () => {
     ]);
   });
 
+  it("keeps the valid capabilities when one entry is malformed", async () => {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: null,
+      requestId: null,
+      body: {
+        capabilities: [
+          {
+            address: "prices/latest",
+            provider: "financial-datasets",
+            creditsCost: 1,
+          },
+          { address: "broken", provider: "x", creditsCost: 1.5 },
+          { provider: "no-address", creditsCost: 1 },
+        ],
+      },
+    });
+    const results = await searchExchangeCatalog(
+      { query: "q", limit: 5, teamId: "t" },
+      logger,
+    );
+    expect(results?.map(r => r.capability)).toEqual(["prices/latest"]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Exchange catalogue search dropped malformed entries",
+      { dropped: 2, kept: 1 },
+    );
+  });
+
+  it("answers null rather than throwing on a query that cannot be encoded", async () => {
+    const lone = "price \ud800";
+    expect(
+      await searchExchangeCatalog(
+        { query: lone, limit: 5, teamId: "t" },
+        logger,
+      ),
+    ).toBeNull();
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it("never waits longer than the caller's own timeout", async () => {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: null,
+      requestId: null,
+      body: { capabilities: [] },
+    });
+    await searchExchangeCatalog(
+      { query: "q", limit: 5, teamId: "t", timeoutMs: 3_000 },
+      logger,
+    );
+    expect(forward.mock.calls[0]![0].timeoutMs).toBe(3_000);
+
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: null,
+      requestId: null,
+      body: { capabilities: [] },
+    });
+    await searchExchangeCatalog(
+      { query: "q", limit: 5, teamId: "t", timeoutMs: 60_000 },
+      logger,
+    );
+    expect(forward.mock.calls[1]![0].timeoutMs).toBe(10_000);
+  });
+
   it("clamps the limit to the Exchange's ceiling", async () => {
     forward.mockResolvedValueOnce({
       status: 200,

--- a/apps/api/src/search/exchange-source.test.ts
+++ b/apps/api/src/search/exchange-source.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExchangeProxyError } from "../lib/exchange-proxy";
+import { searchExchangeCatalog } from "./exchange-source";
+
+vi.mock("../lib/exchange-proxy", async importOriginal => ({
+  ...(await importOriginal<typeof import("../lib/exchange-proxy")>()),
+  forwardToExchange: vi.fn(),
+}));
+
+import { forwardToExchange } from "../lib/exchange-proxy";
+const forward = vi.mocked(forwardToExchange);
+const logger = {
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as any;
+
+describe("exchange search source", () => {
+  beforeEach(() => forward.mockReset());
+
+  it("asks the catalogue with the query and maps address to capability", async () => {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: "application/json",
+      requestId: null,
+      body: {
+        capabilities: [
+          {
+            address: "prices/latest",
+            provider: "financial-datasets",
+            concept: "prices",
+            cohorts: ["finance"],
+            creditsCost: 1,
+            similarity: 0.83,
+          },
+        ],
+      },
+    });
+
+    const results = await searchExchangeCatalog(
+      {
+        query: "latest stock price by ticker",
+        limit: 10,
+        teamId: "team_a",
+        requestId: "rid",
+      },
+      logger,
+    );
+
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: "team_a",
+        method: "GET",
+        path: "/v1/discover?q=latest%20stock%20price%20by%20ticker&limit=10",
+        requestId: "rid",
+      }),
+    );
+
+    expect(results).toEqual([
+      {
+        provider: "financial-datasets",
+        capability: "prices/latest",
+        concept: "prices",
+        cohorts: ["finance"],
+        creditsCost: 1,
+        similarity: 0.83,
+      },
+    ]);
+  });
+
+  it("clamps the limit to the Exchange's ceiling", async () => {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: null,
+      requestId: null,
+      body: { capabilities: [] },
+    });
+    await searchExchangeCatalog(
+      { query: "q", limit: 100, teamId: "t" },
+      logger,
+    );
+    expect(forward.mock.calls[0]![0].path).toBe("/v1/discover?q=q&limit=24");
+  });
+
+  it("answers null, not an empty catalogue, when the Exchange cannot answer", async () => {
+    forward.mockResolvedValueOnce({
+      status: 503,
+      contentType: null,
+      requestId: null,
+      body: { code: "semantic_unavailable" },
+    });
+    expect(
+      await searchExchangeCatalog(
+        { query: "q", limit: 5, teamId: "t" },
+        logger,
+      ),
+    ).toBeNull();
+
+    forward.mockRejectedValueOnce(new ExchangeProxyError("timeout"));
+    expect(
+      await searchExchangeCatalog(
+        { query: "q", limit: 5, teamId: "t" },
+        logger,
+      ),
+    ).toBeNull();
+
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: null,
+      requestId: null,
+      body: { nope: true },
+    });
+    expect(
+      await searchExchangeCatalog(
+        { query: "q", limit: 5, teamId: "t" },
+        logger,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/search/exchange-source.test.ts
+++ b/apps/api/src/search/exchange-source.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExchangeProxyError } from "../lib/exchange-proxy";
-import { searchExchangeCatalog } from "./exchange-source";
+import {
+  searchExchangeCatalog,
+  searchExchangeContent,
+} from "./exchange-source";
 
 vi.mock("../lib/exchange-proxy", async importOriginal => ({
   ...(await importOriginal<typeof import("../lib/exchange-proxy")>()),
@@ -179,6 +182,52 @@ describe("exchange search source", () => {
     expect(
       await searchExchangeCatalog(
         { query: "q", limit: 5, teamId: "t" },
+        logger,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("Exchange indexed content", () => {
+  const hit = {
+    address: "firecrawl://exchange/website/pages/123",
+    url: null,
+    title: "Funding",
+    description: "Preview",
+    domain: null,
+    kind: "document",
+    provider: "website",
+    providerName: "Documents",
+    credits: 2,
+    relevance: 0.9,
+  };
+  beforeEach(() => forward.mockReset());
+  it("preserves the canonical address and price without inventing a public URL", async () => {
+    forward.mockResolvedValueOnce({
+      status: 200,
+      contentType: null,
+      requestId: null,
+      body: { success: true, hits: [hit, { ...hit, credits: -1 }] },
+    });
+    expect(
+      await searchExchangeContent(
+        { query: "funding & grants", limit: 100, teamId: "t", timeoutMs: 500 },
+        logger,
+      ),
+    ).toEqual([hit]);
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/v1/discover/content?query=funding%20%26%20grants&limit=30",
+        teamId: "t",
+        timeoutMs: 500,
+      }),
+    );
+  });
+  it("omits unavailable content instead of claiming no matches", async () => {
+    forward.mockRejectedValueOnce(new ExchangeProxyError("timeout"));
+    expect(
+      await searchExchangeContent(
+        { query: "q", limit: 10, teamId: "t" },
         logger,
       ),
     ).toBeNull();

--- a/apps/api/src/search/exchange-source.ts
+++ b/apps/api/src/search/exchange-source.ts
@@ -1,0 +1,70 @@
+import type { Logger } from "winston";
+import { z } from "zod";
+import type { ExchangeSearchResult } from "../lib/entities";
+import {
+  EXCHANGE_DISCOVER_TIMEOUT_MS,
+  ExchangeProxyError,
+  forwardToExchange,
+} from "../lib/exchange-proxy";
+
+const discoverSchema = z.object({
+  capabilities: z.array(
+    z
+      .object({
+        address: z.string(),
+        cohorts: z.array(z.string()).optional(),
+        concept: z.string().optional(),
+        creditsCost: z.number().int().nonnegative(),
+        provider: z.string(),
+        similarity: z.number().optional(),
+      })
+      .passthrough(),
+  ),
+});
+
+const EXCHANGE_DISCOVER_MAX = 24;
+
+export async function searchExchangeCatalog(
+  input: { query: string; limit: number; teamId: string; requestId?: string },
+  logger: Logger,
+): Promise<ExchangeSearchResult[] | null> {
+  const limit = Math.min(Math.max(input.limit, 1), EXCHANGE_DISCOVER_MAX);
+  const path = `/v1/discover?q=${encodeURIComponent(input.query)}&limit=${limit}`;
+  try {
+    const upstream = await forwardToExchange({
+      teamId: input.teamId,
+      method: "GET",
+      path,
+      timeoutMs: EXCHANGE_DISCOVER_TIMEOUT_MS,
+      ...(input.requestId === undefined ? {} : { requestId: input.requestId }),
+    });
+    if (upstream.status < 200 || upstream.status >= 300) {
+      logger.warn("Exchange catalogue search answered with an error", {
+        status: upstream.status,
+      });
+      return null;
+    }
+    const parsed = discoverSchema.safeParse(upstream.body);
+    if (!parsed.success) {
+      logger.warn("Exchange catalogue search answered in an unknown shape");
+      return null;
+    }
+    return parsed.data.capabilities.map(hit => ({
+      provider: hit.provider,
+      capability: hit.address,
+      concept: hit.concept ?? "",
+      cohorts: hit.cohorts ?? [],
+      creditsCost: hit.creditsCost,
+      similarity: hit.similarity ?? 0,
+    }));
+  } catch (error) {
+    if (error instanceof ExchangeProxyError) {
+      logger.warn("Exchange catalogue search unavailable", {
+        kind: error.kind,
+      });
+    } else {
+      logger.warn("Exchange catalogue search errored", { error });
+    }
+    return null;
+  }
+}

--- a/apps/api/src/search/exchange-source.ts
+++ b/apps/api/src/search/exchange-source.ts
@@ -7,35 +7,43 @@ import {
   forwardToExchange,
 } from "../lib/exchange-proxy";
 
-const discoverSchema = z.object({
-  capabilities: z.array(
-    z
-      .object({
-        address: z.string(),
-        cohorts: z.array(z.string()).optional(),
-        concept: z.string().optional(),
-        creditsCost: z.number().int().nonnegative(),
-        provider: z.string(),
-        similarity: z.number().optional(),
-      })
-      .passthrough(),
-  ),
-});
+const capabilitySchema = z
+  .object({
+    address: z.string(),
+    cohorts: z.array(z.string()).optional(),
+    concept: z.string().optional(),
+    creditsCost: z.number().int().nonnegative(),
+    provider: z.string(),
+    similarity: z.number().optional(),
+  })
+  .passthrough();
+
+const discoverSchema = z.object({ capabilities: z.array(z.unknown()) });
 
 const EXCHANGE_DISCOVER_MAX = 24;
 
 export async function searchExchangeCatalog(
-  input: { query: string; limit: number; teamId: string; requestId?: string },
+  input: {
+    query: string;
+    limit: number;
+    teamId: string;
+    requestId?: string;
+    timeoutMs?: number;
+  },
   logger: Logger,
 ): Promise<ExchangeSearchResult[] | null> {
   const limit = Math.min(Math.max(input.limit, 1), EXCHANGE_DISCOVER_MAX);
-  const path = `/v1/discover?q=${encodeURIComponent(input.query)}&limit=${limit}`;
+  const timeoutMs = Math.min(
+    input.timeoutMs ?? EXCHANGE_DISCOVER_TIMEOUT_MS,
+    EXCHANGE_DISCOVER_TIMEOUT_MS,
+  );
   try {
+    const path = `/v1/discover?q=${encodeURIComponent(input.query)}&limit=${limit}`;
     const upstream = await forwardToExchange({
       teamId: input.teamId,
       method: "GET",
       path,
-      timeoutMs: EXCHANGE_DISCOVER_TIMEOUT_MS,
+      timeoutMs,
       ...(input.requestId === undefined ? {} : { requestId: input.requestId }),
     });
     if (upstream.status < 200 || upstream.status >= 300) {
@@ -49,14 +57,30 @@ export async function searchExchangeCatalog(
       logger.warn("Exchange catalogue search answered in an unknown shape");
       return null;
     }
-    return parsed.data.capabilities.map(hit => ({
-      provider: hit.provider,
-      capability: hit.address,
-      concept: hit.concept ?? "",
-      cohorts: hit.cohorts ?? [],
-      creditsCost: hit.creditsCost,
-      similarity: hit.similarity ?? 0,
-    }));
+    const results: ExchangeSearchResult[] = [];
+    let dropped = 0;
+    for (const entry of parsed.data.capabilities) {
+      const hit = capabilitySchema.safeParse(entry);
+      if (!hit.success) {
+        dropped += 1;
+        continue;
+      }
+      results.push({
+        provider: hit.data.provider,
+        capability: hit.data.address,
+        concept: hit.data.concept ?? "",
+        cohorts: hit.data.cohorts ?? [],
+        creditsCost: hit.data.creditsCost,
+        similarity: hit.data.similarity ?? 0,
+      });
+    }
+    if (dropped > 0) {
+      logger.warn("Exchange catalogue search dropped malformed entries", {
+        dropped,
+        kept: results.length,
+      });
+    }
+    return results;
   } catch (error) {
     if (error instanceof ExchangeProxyError) {
       logger.warn("Exchange catalogue search unavailable", {

--- a/apps/api/src/search/exchange-source.ts
+++ b/apps/api/src/search/exchange-source.ts
@@ -92,3 +92,55 @@ export async function searchExchangeCatalog(
     return null;
   }
 }
+
+const contentHitSchema = z.object({
+  address: z
+    .string()
+    .regex(/^firecrawl:\/\/exchange\/[^/?#]+\/[^/?#]+\/[^/?#]+$/),
+  url: z.url().nullable(),
+  title: z.string(),
+  description: z.string(),
+  domain: z.string().nullable(),
+  kind: z.enum(["document", "page"]),
+  provider: z.string(),
+  providerName: z.string(),
+  credits: z.number().int().nonnegative().nullable(),
+  relevance: z.number().finite(),
+});
+
+export async function searchExchangeContent(
+  input: Parameters<typeof searchExchangeCatalog>[0],
+  logger: Logger,
+): Promise<import("../lib/entities").ExchangeContentResult[] | null> {
+  try {
+    const limit = Math.min(Math.max(input.limit, 1), 30);
+    const upstream = await forwardToExchange({
+      teamId: input.teamId,
+      method: "GET",
+      path: `/v1/discover/content?query=${encodeURIComponent(input.query)}&limit=${limit}`,
+      timeoutMs: Math.min(
+        input.timeoutMs ?? EXCHANGE_DISCOVER_TIMEOUT_MS,
+        EXCHANGE_DISCOVER_TIMEOUT_MS,
+      ),
+      ...(input.requestId === undefined ? {} : { requestId: input.requestId }),
+    });
+    const parsed = z
+      .object({ success: z.literal(true), hits: z.array(z.unknown()) })
+      .safeParse(upstream.body);
+    if (upstream.status < 200 || upstream.status >= 300 || !parsed.success) {
+      logger.warn("Exchange content search unavailable", {
+        status: upstream.status,
+      });
+      return null;
+    }
+    return parsed.data.hits
+      .flatMap(entry => {
+        const hit = contentHitSchema.safeParse(entry);
+        return hit.success ? [hit.data] : [];
+      })
+      .slice(0, limit);
+  } catch (error) {
+    logger.warn("Exchange content search failed", { error });
+    return null;
+  }
+}

--- a/apps/api/src/search/execute.test.ts
+++ b/apps/api/src/search/execute.test.ts
@@ -2,6 +2,7 @@ const mocks = vi.hoisted(() => ({
   search: vi.fn(),
   searchDeveloperCategory: vi.fn(),
   checkUrlsAgainstThreatPolicy: vi.fn(),
+  searchExchangeCatalog: vi.fn(),
 }));
 
 vi.mock("./v2", () => ({ search: mocks.search }));
@@ -13,6 +14,9 @@ vi.mock("./developer", () => ({
         : category.type === "developer",
     ),
   searchDeveloperCategory: mocks.searchDeveloperCategory,
+}));
+vi.mock("./exchange-source", () => ({
+  searchExchangeCatalog: mocks.searchExchangeCatalog,
 }));
 vi.mock("./scrape", () => ({
   getItemsToScrape: vi.fn(() => []),
@@ -94,12 +98,29 @@ describe("executeSearch developer category", () => {
     expect(result.developerResultsCount).toBe(1);
   });
 
-
   it("filters blocked developer results via threat protection and renumbers", async () => {
     mocks.searchDeveloperCategory.mockResolvedValue([
-      { url: "https://ok.example/a", title: "A", description: "", position: 1, category: "developer" },
-      { url: "https://blocked.example/b", title: "B", description: "", position: 2, category: "developer" },
-      { url: "https://ok.example/c", title: "C", description: "", position: 3, category: "developer" },
+      {
+        url: "https://ok.example/a",
+        title: "A",
+        description: "",
+        position: 1,
+        category: "developer",
+      },
+      {
+        url: "https://blocked.example/b",
+        title: "B",
+        description: "",
+        position: 2,
+        category: "developer",
+      },
+      {
+        url: "https://ok.example/c",
+        title: "C",
+        description: "",
+        position: 3,
+        category: "developer",
+      },
     ]);
     mocks.checkUrlsAgainstThreatPolicy.mockResolvedValue({
       decisionsByUrl: new Map([
@@ -138,5 +159,112 @@ describe("executeSearch developer category", () => {
       categories: ["developer"],
     });
     expect(sole.success).toBe(true);
+  });
+});
+
+describe("executeSearch exchange source", () => {
+  const webResult = {
+    url: "https://example.com/a",
+    title: "A",
+    description: "a",
+    position: 1,
+  };
+  const capability = {
+    provider: "financial-datasets",
+    capability: "prices/latest",
+    concept: "prices",
+    cohorts: ["finance"],
+    creditsCost: 1,
+    similarity: 0.9,
+  };
+
+  function sources(types: string[]) {
+    return {
+      query: "latest stock price by ticker",
+      limit: 10,
+      sources: types.map(type => ({ type })),
+      timeout: 1_000,
+    } as any;
+  }
+
+  beforeEach(() => {
+    mocks.search.mockResolvedValue({ web: [webResult] });
+    mocks.searchExchangeCatalog.mockResolvedValue([capability]);
+  });
+
+  it("leaves a web-only search exactly as it was: upstream called with web, no catalogue call, no exchange key", async () => {
+    const result = await executeSearch(sources(["web"]), context, logger);
+
+    expect(mocks.search).toHaveBeenCalledTimes(1);
+    expect(mocks.search.mock.calls[0][0].type).toEqual(["web"]);
+    expect(mocks.searchExchangeCatalog).not.toHaveBeenCalled();
+    expect(result.response).toEqual({ web: [webResult] });
+    expect(result.response).not.toHaveProperty("exchange");
+    expect(result.totalResultsCount).toBe(1);
+    expect(result.searchCredits).toBe(2);
+  });
+
+  it("keeps the exchange type away from the upstream when mixed with web, and adds the catalogue beside the web results", async () => {
+    const result = await executeSearch(
+      sources(["web", "exchange"]),
+      context,
+      logger,
+    );
+
+    expect(mocks.search.mock.calls[0][0].type).toEqual(["web"]);
+    expect(mocks.searchExchangeCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "latest stock price by ticker",
+        limit: 10,
+        teamId: "team-1",
+        requestId: "request-1",
+      }),
+      logger,
+    );
+    expect(result.response).toEqual({
+      web: [webResult],
+      exchange: [capability],
+    });
+    expect(result.totalResultsCount).toBe(1);
+    expect(result.searchCredits).toBe(2);
+  });
+
+  it("runs no upstream search and bills nothing for an exchange-only search", async () => {
+    const result = await executeSearch(sources(["exchange"]), context, logger);
+
+    expect(mocks.search).not.toHaveBeenCalled();
+    expect(result.response).toEqual({ exchange: [capability] });
+    expect(result.totalResultsCount).toBe(0);
+    expect(result.searchCredits).toBe(0);
+    expect(result.totalCredits).toBe(0);
+  });
+
+  it("omits the key rather than publishing an empty catalogue when the Exchange did not answer", async () => {
+    mocks.searchExchangeCatalog.mockResolvedValue(null);
+
+    const result = await executeSearch(
+      sources(["web", "exchange"]),
+      context,
+      logger,
+    );
+
+    expect(result.response).toEqual({ web: [webResult] });
+    expect(result.response).not.toHaveProperty("exchange");
+  });
+
+  it("still passes news and images through to the upstream untouched", async () => {
+    mocks.search.mockResolvedValue({ web: [webResult], news: [], images: [] });
+
+    await executeSearch(
+      sources(["web", "news", "images", "exchange"]),
+      context,
+      logger,
+    );
+
+    expect(mocks.search.mock.calls[0][0].type).toEqual([
+      "web",
+      "news",
+      "images",
+    ]);
   });
 });

--- a/apps/api/src/search/execute.test.ts
+++ b/apps/api/src/search/execute.test.ts
@@ -41,6 +41,7 @@ vi.mock("../lib/scrape-billing", () => ({
 }));
 
 import { executeSearch } from "./execute";
+import { trackSearchRequest } from "../lib/tracking";
 import { searchRequestSchema } from "../controllers/v2/types";
 
 const logger = {
@@ -250,6 +251,27 @@ describe("executeSearch exchange source", () => {
 
     expect(result.response).toEqual({ web: [webResult] });
     expect(result.response).not.toHaveProperty("exchange");
+  });
+
+  it("records every requested source in tracking, exchange included", async () => {
+    await executeSearch(sources(["web", "exchange"]), context, logger);
+    expect(vi.mocked(trackSearchRequest).mock.calls.at(-1)![0].sources).toEqual(
+      ["web", "exchange"],
+    );
+
+    await executeSearch(sources(["exchange"]), context, logger);
+    expect(vi.mocked(trackSearchRequest).mock.calls.at(-1)![0].sources).toEqual(
+      ["exchange"],
+    );
+  });
+
+  it("caps the catalogue wait at the caller's timeout", async () => {
+    await executeSearch(
+      { ...sources(["exchange"]), timeout: 2_500 },
+      context,
+      logger,
+    );
+    expect(mocks.searchExchangeCatalog.mock.calls[0][0].timeoutMs).toBe(2_500);
   });
 
   it("still passes news and images through to the upstream untouched", async () => {

--- a/apps/api/src/search/execute.test.ts
+++ b/apps/api/src/search/execute.test.ts
@@ -3,6 +3,7 @@ const mocks = vi.hoisted(() => ({
   searchDeveloperCategory: vi.fn(),
   checkUrlsAgainstThreatPolicy: vi.fn(),
   searchExchangeCatalog: vi.fn(),
+  searchExchangeContent: vi.fn(),
 }));
 
 vi.mock("./v2", () => ({ search: mocks.search }));
@@ -17,6 +18,7 @@ vi.mock("./developer", () => ({
 }));
 vi.mock("./exchange-source", () => ({
   searchExchangeCatalog: mocks.searchExchangeCatalog,
+  searchExchangeContent: mocks.searchExchangeContent,
 }));
 vi.mock("./scrape", () => ({
   getItemsToScrape: vi.fn(() => []),
@@ -200,14 +202,14 @@ describe("executeSearch exchange source", () => {
     expect(mocks.search.mock.calls[0][0].type).toEqual(["web"]);
     expect(mocks.searchExchangeCatalog).not.toHaveBeenCalled();
     expect(result.response).toEqual({ web: [webResult] });
-    expect(result.response).not.toHaveProperty("exchange");
+    expect(result.response).not.toHaveProperty("exchange-provider");
     expect(result.totalResultsCount).toBe(1);
     expect(result.searchCredits).toBe(2);
   });
 
   it("keeps the exchange type away from the upstream when mixed with web, and adds the catalogue beside the web results", async () => {
     const result = await executeSearch(
-      sources(["web", "exchange"]),
+      sources(["web", "exchange-provider"]),
       context,
       logger,
     );
@@ -224,17 +226,21 @@ describe("executeSearch exchange source", () => {
     );
     expect(result.response).toEqual({
       web: [webResult],
-      exchange: [capability],
+      "exchange-provider": [capability],
     });
     expect(result.totalResultsCount).toBe(1);
     expect(result.searchCredits).toBe(2);
   });
 
   it("runs no upstream search and bills nothing for an exchange-only search", async () => {
-    const result = await executeSearch(sources(["exchange"]), context, logger);
+    const result = await executeSearch(
+      sources(["exchange-provider"]),
+      context,
+      logger,
+    );
 
     expect(mocks.search).not.toHaveBeenCalled();
-    expect(result.response).toEqual({ exchange: [capability] });
+    expect(result.response).toEqual({ "exchange-provider": [capability] });
     expect(result.totalResultsCount).toBe(0);
     expect(result.searchCredits).toBe(0);
     expect(result.totalCredits).toBe(0);
@@ -244,30 +250,30 @@ describe("executeSearch exchange source", () => {
     mocks.searchExchangeCatalog.mockResolvedValue(null);
 
     const result = await executeSearch(
-      sources(["web", "exchange"]),
+      sources(["web", "exchange-provider"]),
       context,
       logger,
     );
 
     expect(result.response).toEqual({ web: [webResult] });
-    expect(result.response).not.toHaveProperty("exchange");
+    expect(result.response).not.toHaveProperty("exchange-provider");
   });
 
   it("records every requested source in tracking, exchange included", async () => {
-    await executeSearch(sources(["web", "exchange"]), context, logger);
+    await executeSearch(sources(["web", "exchange-provider"]), context, logger);
     expect(vi.mocked(trackSearchRequest).mock.calls.at(-1)![0].sources).toEqual(
-      ["web", "exchange"],
+      ["web", "exchange-provider"],
     );
 
-    await executeSearch(sources(["exchange"]), context, logger);
+    await executeSearch(sources(["exchange-provider"]), context, logger);
     expect(vi.mocked(trackSearchRequest).mock.calls.at(-1)![0].sources).toEqual(
-      ["exchange"],
+      ["exchange-provider"],
     );
   });
 
   it("caps the catalogue wait at the caller's timeout", async () => {
     await executeSearch(
-      { ...sources(["exchange"]), timeout: 2_500 },
+      { ...sources(["exchange-provider"]), timeout: 2_500 },
       context,
       logger,
     );
@@ -278,7 +284,7 @@ describe("executeSearch exchange source", () => {
     mocks.search.mockResolvedValue({ web: [webResult], news: [], images: [] });
 
     await executeSearch(
-      sources(["web", "news", "images", "exchange"]),
+      sources(["web", "news", "images", "exchange-provider"]),
       context,
       logger,
     );
@@ -289,4 +295,52 @@ describe("executeSearch exchange source", () => {
       "images",
     ]);
   });
+});
+
+it("routes content and provider sources independently alongside web search", async () => {
+  const content = {
+    address: "firecrawl://exchange/website/pages/123",
+    title: "Record",
+  };
+  mocks.search.mockResolvedValue({ web: [] });
+  mocks.searchExchangeCatalog.mockResolvedValue([]);
+  mocks.searchExchangeContent.mockResolvedValue([content]);
+  const result = await executeSearch(
+    searchRequestSchema.parse({
+      query: "funding",
+      sources: ["web", "exchange", "exchange-provider"],
+    }) as any,
+    context,
+    logger,
+  );
+  expect(mocks.search).toHaveBeenCalledWith(
+    expect.objectContaining({ type: ["web"] }),
+  );
+  expect(result.response.exchange).toEqual([content]);
+  expect(result.response["exchange-provider"]).toEqual([]);
+  expect(mocks.searchExchangeContent).toHaveBeenCalledWith(
+    expect.objectContaining({ query: "funding", teamId: "team-1" }),
+    logger,
+  );
+});
+
+it("filters blocked content URLs without dropping uploaded documents", async () => {
+  const uploaded = {
+    address: "firecrawl://exchange/website/pages/1",
+    url: null,
+  };
+  mocks.searchExchangeContent.mockResolvedValue([
+    { ...uploaded, url: "https://blocked.example" },
+    uploaded,
+  ]);
+  mocks.checkUrlsAgainstThreatPolicy.mockResolvedValue({
+    decisionsByUrl: new Map([["https://blocked.example", { allowed: false }]]),
+  });
+  const result = await executeSearch(
+    { ...options([]), sources: [{ type: "exchange" }] },
+    { ...context, threatProtectionPolicy: { mode: "block" } } as any,
+    logger,
+  );
+  expect(result.response.exchange).toEqual([uploaded]);
+  expect(mocks.search).not.toHaveBeenCalled();
 });

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -21,6 +21,7 @@ import {
 } from "./highlights";
 import { trackSearchResults, trackSearchRequest } from "../lib/tracking";
 import type { BillingMetadata } from "../services/billing/types";
+import { searchExchangeCatalog } from "./exchange-source";
 import type { ThreatProtectionPolicy } from "../lib/threat-protection/types";
 import { checkUrlsAgainstThreatPolicy } from "../lib/threat-protection/request";
 import { calculateThreatScanCredits } from "../lib/scrape-billing";
@@ -106,7 +107,16 @@ export async function executeSearch(
 
   logger.info("Searching for results");
 
-  const searchTypes = [...new Set(sources.map((s: any) => s.type))];
+  const wantsExchange = sources.some((s: any) => s.type === "exchange");
+  const searchTypes = [
+    ...new Set(sources.map((s: any) => s.type).filter(t => t !== "exchange")),
+  ];
+  const exchangeResultsPromise = wantsExchange
+    ? searchExchangeCatalog(
+        { query, limit, teamId, requestId: context.requestId },
+        logger,
+      )
+    : null;
   const { query: searchQuery, categoryMap } = buildSearchQuery(
     query,
     categories,
@@ -124,26 +134,31 @@ export async function executeSearch(
       )
     : null;
 
-  const searchResponse = hasOnlyDeveloperCategory(categories)
-    ? ({} as SearchV2Response)
-    : ((await search({
-        query: searchQuery,
-        logger,
-        requestId: context.requestId,
-        advanced: false,
-        num_results: num_results_buffer,
-        tbs: options.tbs,
-        filter: options.filter,
-        lang: options.lang,
-        country: options.country,
-        location: options.location,
-        safe: options.safe,
-        type: searchTypes,
-        enterprise: options.enterprise,
-      })) as SearchV2Response);
+  const searchResponse =
+    hasOnlyDeveloperCategory(categories) || searchTypes.length === 0
+      ? ({} as SearchV2Response)
+      : ((await search({
+          query: searchQuery,
+          logger,
+          requestId: context.requestId,
+          advanced: false,
+          num_results: num_results_buffer,
+          tbs: options.tbs,
+          filter: options.filter,
+          lang: options.lang,
+          country: options.country,
+          location: options.location,
+          safe: options.safe,
+          type: searchTypes,
+          enterprise: options.enterprise,
+        })) as SearchV2Response);
   let developerResults = developerResultsPromise
     ? await developerResultsPromise
     : [];
+  if (exchangeResultsPromise) {
+    const exchange = await exchangeResultsPromise;
+    if (exchange !== null) searchResponse.exchange = exchange;
+  }
 
   // Threat protection: remove blocked results entirely — before
   // slicing/counting, before scraping, and before returning. Checks are

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -107,13 +107,18 @@ export async function executeSearch(
 
   logger.info("Searching for results");
 
-  const wantsExchange = sources.some((s: any) => s.type === "exchange");
-  const searchTypes = [
-    ...new Set(sources.map((s: any) => s.type).filter(t => t !== "exchange")),
-  ];
+  const requestedTypes = [...new Set(sources.map((s: any) => s.type))];
+  const wantsExchange = requestedTypes.includes("exchange");
+  const searchTypes = requestedTypes.filter(t => t !== "exchange");
   const exchangeResultsPromise = wantsExchange
     ? searchExchangeCatalog(
-        { query, limit, teamId, requestId: context.requestId },
+        {
+          query,
+          limit,
+          teamId,
+          requestId: context.requestId,
+          timeoutMs: options.timeout,
+        },
         logger,
       )
     : null;
@@ -367,7 +372,7 @@ export async function executeSearch(
     apiVersion: context.apiVersion,
     lang: options.lang,
     country: options.country,
-    sources: searchTypes,
+    sources: requestedTypes,
     numResults: totalResultsCount,
     searchCredits,
     scrapeCredits,

--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -21,7 +21,10 @@ import {
 } from "./highlights";
 import { trackSearchResults, trackSearchRequest } from "../lib/tracking";
 import type { BillingMetadata } from "../services/billing/types";
-import { searchExchangeCatalog } from "./exchange-source";
+import {
+  searchExchangeCatalog,
+  searchExchangeContent,
+} from "./exchange-source";
 import type { ThreatProtectionPolicy } from "../lib/threat-protection/types";
 import { checkUrlsAgainstThreatPolicy } from "../lib/threat-protection/request";
 import { calculateThreatScanCredits } from "../lib/scrape-billing";
@@ -108,8 +111,10 @@ export async function executeSearch(
   logger.info("Searching for results");
 
   const requestedTypes = [...new Set(sources.map((s: any) => s.type))];
-  const wantsExchange = requestedTypes.includes("exchange");
-  const searchTypes = requestedTypes.filter(t => t !== "exchange");
+  const wantsExchange = requestedTypes.includes("exchange-provider");
+  const searchTypes = requestedTypes.filter(
+    t => t !== "exchange" && t !== "exchange-provider",
+  );
   const exchangeResultsPromise = wantsExchange
     ? searchExchangeCatalog(
         {
@@ -119,6 +124,12 @@ export async function executeSearch(
           requestId: context.requestId,
           timeoutMs: options.timeout,
         },
+        logger,
+      )
+    : null;
+  const contentResultsPromise = requestedTypes.includes("exchange")
+    ? searchExchangeContent(
+        { query, limit, teamId, requestId, timeoutMs: options.timeout },
         logger,
       )
     : null;
@@ -162,7 +173,12 @@ export async function executeSearch(
     : [];
   if (exchangeResultsPromise) {
     const exchange = await exchangeResultsPromise;
-    if (exchange !== null) searchResponse.exchange = exchange;
+    if (exchange !== null) searchResponse["exchange-provider"] = exchange;
+  }
+
+  if (contentResultsPromise) {
+    const content = await contentResultsPromise;
+    if (content !== null) searchResponse.exchange = content;
   }
 
   // Threat protection: remove blocked results entirely — before
@@ -177,6 +193,7 @@ export async function executeSearch(
       ...(searchResponse.web ?? []).map(x => x.url),
       ...(searchResponse.news ?? []).map(x => x.url),
       ...(searchResponse.images ?? []).map(x => x.url),
+      ...(searchResponse.exchange ?? []).map(x => x.url),
       ...developerResults.map(x => x.url),
     ].filter((x): x is string => !!x);
 
@@ -200,6 +217,11 @@ export async function executeSearch(
       }
       if (searchResponse.images) {
         searchResponse.images = searchResponse.images.filter(x =>
+          isAllowed(x.url),
+        );
+      }
+      if (searchResponse.exchange) {
+        searchResponse.exchange = searchResponse.exchange.filter(x =>
           isAllowed(x.url),
         );
       }

--- a/apps/api/src/services/billing/credit_billing.exchange.test.ts
+++ b/apps/api/src/services/billing/credit_billing.exchange.test.ts
@@ -1,0 +1,29 @@
+import { expect, it, vi } from "vitest";
+vi.mock("../../lib/withAuth", () => ({ withAuth: (fn: unknown) => fn }));
+vi.mock("./batch_billing", () => ({
+  queueBillingOperation: vi.fn(async () => ({ success: true })),
+}));
+vi.mock("../autumn/autumn.service", () => ({
+  autumnService: { trackCredits: vi.fn(async () => true) },
+  featureIdForBillingEndpoint: () => "credits",
+}));
+import { billTeam } from "./credit_billing";
+import { queueBillingOperation } from "./batch_billing";
+
+it("carries the Exchange receipt into the durable billing queue", async () => {
+  const exchange = {
+    accessEventId: "receipt",
+    billingReference: "exchange:receipt",
+  };
+  const billing = { endpoint: "scrape" as const, chargeId: "exchange:receipt" };
+  await billTeam("team", 2, 7, billing, undefined, exchange);
+  expect(queueBillingOperation).toHaveBeenCalledWith(
+    "team",
+    2,
+    7,
+    billing,
+    false,
+    true,
+    exchange,
+  );
+});

--- a/apps/api/src/services/billing/credit_billing.ts
+++ b/apps/api/src/services/billing/credit_billing.ts
@@ -13,6 +13,7 @@ export async function billTeam(
   api_key_id: number | null,
   billing: BillingMetadata,
   logger?: Logger,
+  exchange?: { accessEventId: string; billingReference?: string },
 ) {
   return withAuth(
     async (
@@ -21,6 +22,9 @@ export async function billTeam(
       api_key_id: number | null,
       billing: BillingMetadata,
       logger: Logger | undefined,
+      exchange:
+        | { accessEventId: string; billingReference?: string }
+        | undefined,
     ) => {
       const autumnProperties = {
         source: "billTeam",
@@ -47,6 +51,7 @@ export async function billTeam(
         billing,
         false,
         trackedInRequest,
+        exchange,
       );
 
       if (!result.success && trackedInRequest) {
@@ -77,5 +82,5 @@ export async function billTeam(
       return result;
     },
     { success: true, message: "No DB, bypassed." },
-  )(team_id, credits, api_key_id, billing, logger);
+  )(team_id, credits, api_key_id, billing, logger, exchange);
 }


### PR DESCRIPTION
Adds Exchange discovery and retrieval to the v2 search and scrape interfaces, using the existing team permission and shared Exchange proxy.

Search accepts `exchange` for indexed content previews and `exchange-provider` for callable provider capabilities, alongside web/news/images. Results use separate keys. Unavailable sources are omitted; available sources with no matches return empty arrays. Content source URLs participate in threat filtering.

Scrape accepts one provider call or the existing array of 1–10 calls. It also accepts one canonical content URL with a required `maxCredits` limit. Record delivery requires valid upstream data and successful billing authorization/queueing; the existing billing queue confirms the access event. Responses retain the `data.exchange` array.

**Preview compatibility:** `sources: ["exchange"]` previously discovered capabilities in this PR. Those callers must switch to `exchange-provider`. Existing provider scrape payloads remain supported. SDK and web search consumers need to adopt the split before rollout.

Validation: 50 focused tests passed across search routing, source parsing, scrape validation, proxy failures, billing, and threat filtering. API TypeScript check passed. Upstream and billing calls were mocked; live deployment testing remains. Request examples are in `apps/api/docs/exchange.md`.
