### PR TITLE
fix(api): accept fire-engine's GCS PDF handoff on the POST /scrape fast path

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/__tests__/fileSchema.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/__tests__/fileSchema.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+
+// fireEngineScrape talks to fire-engine through robustFetch; swap it for a
+// controllable stub so the POST /scrape response shape is the only variable.
+const fetchFake = vi.hoisted(() => ({
+  status: {} as Record<string, unknown>,
+}));
+
+vi.mock("../../../lib/fetch", () => ({
+  robustFetch: vi.fn(async () => fetchFake.status),
+}));
+
+vi.mock("../../../../../lib/gcs-jobs", () => ({
+  getDocFromGCS: vi.fn(async () => null),
+}));
+
+import { fireEngineFileSchema } from "../fileSchema";
+import { fireEngineScrape } from "../scrape";
+
+const fakeLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child() {
+    return this;
+  },
+} as any;
+
+const fakeMeta = {
+  options: { proxy: "auto" },
+  featureFlags: new Set<string>(),
+} as any;
+
+const request = {
+  url: "https://example.com/report.pdf",
+  engine: "chrome-cdp",
+  timeout: 30000,
+} as any;
+
+// Mirrors the shape fire-engine returns for a large-PDF handoff: no inline
+// bytes, a GCS reference plus the content identity, and an empty `content`.
+const handoffStatus = {
+  timeTaken: 20.5,
+  content: "",
+  url: "https://example.com/report.pdf",
+  pageStatusCode: 200,
+  responseHeaders: {
+    "content-type": "application/pdf",
+    "content-length": "59163826",
+  },
+  screenshots: [],
+  actionContent: [],
+  actionResults: [],
+  file: {
+    name: "report.pdf",
+    gcs_uri: "gs://fire-engine-handoff/pdf-handoff/0f1e2d3c-job.pdf",
+    sha256: "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0",
+    size_bytes: 59163826,
+  },
+  usedMobileProxy: true,
+  timezone: "America/New_York",
+};
+
+describe("fireEngineFileSchema", () => {
+  it("accepts an inline file", () => {
+    expect(
+      fireEngineFileSchema.safeParse({ name: "a.pdf", content: "JVBERi0=" })
+        .success,
+    ).toBe(true);
+  });
+
+  it("accepts a GCS handoff reference", () => {
+    expect(fireEngineFileSchema.safeParse(handoffStatus.file).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts a missing or null file", () => {
+    expect(fireEngineFileSchema.safeParse(undefined).success).toBe(true);
+    expect(fireEngineFileSchema.safeParse(null).success).toBe(true);
+  });
+
+  it("rejects a file carrying both or neither transport", () => {
+    expect(
+      fireEngineFileSchema.safeParse({
+        name: "a.pdf",
+        content: "JVBERi0=",
+        gcs_uri: "gs://b/k.pdf",
+      }).success,
+    ).toBe(false);
+    expect(fireEngineFileSchema.safeParse({ name: "a.pdf" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("fireEngineScrape response parsing", () => {
+  it("accepts a finished job carrying a GCS handoff on the POST /scrape fast path", async () => {
+    fetchFake.status = handoffStatus;
+    const result = await fireEngineScrape(
+      fakeMeta,
+      fakeLogger,
+      request,
+      null,
+      undefined,
+      "http://fire-engine.test",
+    );
+    expect("file" in result && result.file).toMatchObject({
+      gcs_uri: handoffStatus.file.gcs_uri,
+      sha256: handoffStatus.file.sha256,
+      size_bytes: handoffStatus.file.size_bytes,
+    });
+  });
+
+  it("still accepts a finished job carrying an inline file", async () => {
+    fetchFake.status = {
+      ...handoffStatus,
+      file: { name: "report.pdf", content: "JVBERi0=" },
+    };
+    const result = await fireEngineScrape(
+      fakeMeta,
+      fakeLogger,
+      request,
+      null,
+      undefined,
+      "http://fire-engine.test",
+    );
+    expect("file" in result && result.file).toMatchObject({
+      content: "JVBERi0=",
+    });
+  });
+
+  it("rejects a file that carries both transports as an unmatched response", async () => {
+    fetchFake.status = {
+      ...handoffStatus,
+      file: { ...handoffStatus.file, content: "JVBERi0=" },
+    };
+    await expect(
+      fireEngineScrape(
+        fakeMeta,
+        fakeLogger,
+        request,
+        null,
+        undefined,
+        "http://fire-engine.test",
+      ),
+    ).rejects.toThrow("not matched by any schema");
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/checkStatus.ts
@@ -16,6 +16,7 @@ import {
 } from "../../error";
 import { MockState } from "../../lib/mock";
 import { fireEngineURL } from "./scrape";
+import { fireEngineFileSchema } from "./fileSchema";
 import { getDocFromGCS } from "../../../../lib/gcs-jobs";
 import { Meta } from "../..";
 
@@ -104,24 +105,9 @@ const successSchema = z.object({
     .array()
     .optional(),
 
-  // chrome-cdp only -- file download handler. Small files arrive inline as
-  // base64 `content`; large PDFs arrive as a GCS reference instead
-  // (fire-engine uploads them to its handoff bucket rather than inlining
-  // hundreds of MB of base64 into this response). Exactly one of
-  // `content` / `gcs_uri` is expected.
-  file: z
-    .object({
-      name: z.string(),
-      content: z.string().optional(),
-      gcs_uri: z.string().optional(),
-      sha256: z.string().optional(),
-      size_bytes: z.number().optional(),
-    })
-    .refine(f => (f.content !== undefined) !== (f.gcs_uri !== undefined), {
-      message: "file must carry exactly one of content or gcs_uri",
-    })
-    .optional()
-    .or(z.null()),
+  // chrome-cdp only -- file download handler (inline base64 or a GCS
+  // handoff reference; see fileSchema.ts).
+  file: fireEngineFileSchema,
 
   docUrl: z.string().optional(),
 

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/fileSchema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/fileSchema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/**
+ * The `file` member of a fire-engine chrome-cdp success response (the file
+ * download handler). Small files arrive inline as base64 `content`; large
+ * PDFs arrive as a GCS reference instead (fire-engine uploads them to its
+ * handoff bucket rather than inlining hundreds of MB of base64 into the
+ * response). Exactly one of `content` / `gcs_uri` is expected.
+ *
+ * Shared by BOTH response parsers on purpose. fire-engine can return the
+ * finished job from `POST /scrape` directly (fireEngineScrape) or from the
+ * `GET /scrape/:id` poll (fireEngineCheckStatus); a handoff that only one of
+ * them understood was rejected as "response not matched by any schema" on
+ * the fast path, which made every quick large-PDF download look like an
+ * engine failure and re-ran the download on the next engine.
+ */
+export const fireEngineFileSchema = z
+  .object({
+    name: z.string(),
+    content: z.string().optional(),
+    gcs_uri: z.string().optional(),
+    sha256: z.string().optional(),
+    size_bytes: z.number().optional(),
+  })
+  .refine(f => (f.content !== undefined) !== (f.gcs_uri !== undefined), {
+    message: "file must carry exactly one of content or gcs_uri",
+  })
+  .optional()
+  .or(z.null());

--- a/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/fire-engine/scrape.ts
@@ -5,6 +5,7 @@ import { InternalAction } from "../../../../controllers/v1/types";
 import { robustFetch } from "../../lib/fetch";
 import { MockState } from "../../lib/mock";
 import { getDocFromGCS } from "../../../../lib/gcs-jobs";
+import { fireEngineFileSchema } from "./fileSchema";
 import {
   ActionError,
   AddFeatureError,
@@ -155,14 +156,12 @@ const successSchema = z.object({
     .array()
     .optional(),
 
-  // chrome-cdp only -- file download handler
-  file: z
-    .object({
-      name: z.string(),
-      content: z.string(),
-    })
-    .optional()
-    .or(z.null()),
+  // chrome-cdp only -- file download handler (inline base64 or a GCS
+  // handoff reference; see fileSchema.ts). Must accept exactly what the
+  // poll parser in checkStatus.ts accepts: fire-engine returns finished
+  // jobs from POST /scrape too, and a handoff rejected here surfaced as
+  // "response not matched by any schema" -> a spurious engine failure.
+  file: fireEngineFileSchema,
 
   docUrl: z.string().optional(),
 


### PR DESCRIPTION
## Problem

fire-engine returns finished chrome-cdp jobs in two places: directly from `POST /scrape` (parsed by `fireEngineScrape` in `scrape.ts`) and from the `GET /scrape/:id` poll (parsed by `fireEngineCheckStatus` in `checkStatus.ts`). #4411 taught the poll parser about the large-PDF GCS handoff (`file.gcs_uri` + `sha256` + `size_bytes`, no inline `content`), but the fast-path parser in `scrape.ts` still required `file.content`.

Whenever a large PDF downloaded fast enough for fire-engine to return the finished job from `POST /scrape`, the handoff response failed the fast-path schema and surfaced as `Check status returned response not matched by any schema`, i.e. an ordinary engine failure. The waterfall then moved to the next browser engine and downloaded (and re-uploaded) the same file again. In production logs the pattern is three quick attempts rejected this way, then the fourth, slower one accepted through the poll path, adding one to two minutes to every large-PDF scrape and tripling the download volume for those files.

## Fix

- Extract the `file` member into a shared `fire-engine/fileSchema.ts` (inline base64 **or** GCS reference, exactly one of the two) and use it from both parsers so they cannot drift again.
- Unit tests for the schema and a regression test that drives `fireEngineScrape` with a handoff-shaped `POST /scrape` response (fails on the old parser, passes now); inline files and invalid double-transport files are covered too.

## Verification

- `pnpm exec vitest run src/scraper/scrapeURL/engines/fire-engine/__tests__/fileSchema.test.ts`: 7 passed (the fast-path handoff test fails against the previous `scrape.ts`).
- `pnpm exec tsc --noEmit` and `pnpm knip` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the POST /scrape fast path rejecting fire-engine's large-PDF GCS handoff, which made quick large-PDF downloads fail as "response not matched by any schema" and get re-downloaded by the next browser engine.

- Extracts the `file` member into a shared `fire-engine/fileSchema.ts` used by both the POST /scrape and GET /scrape/:id parsers; it accepts inline base64 or a GCS reference, exactly one of the two.
- Adds unit tests for the schema and a regression test covering the fast-path handoff, inline files, and invalid double-transport responses.

<sup>Written for commit 198dc374e3b092a1a38a1244e1168bbadbb90670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

