### PR TITLE
[Bug] dify Create Monitor  error type: HTTPError, error details: Failed to create monitor: Bad Request

### DIFF
--- a/apps/api/src/__tests__/snips/v2/monitor.test.ts
+++ b/apps/api/src/__tests__/snips/v2/monitor.test.ts
@@ -71,6 +71,36 @@ describeIf(ALLOW_TEST_SUITE_WEBSITE && !TEST_SELF_HOST)("/v2/monitor", () => {
     expect(del.body.success).toBe(true);
   });
 
+  it("creates a monitor from Dify-style singular scrape URLs", async () => {
+    const urls = [createTestIdUrl(), createTestIdUrl()];
+    const create = await monitorCreateRaw(
+      {
+        name: "dify monitor",
+        schedule: { cron: "*/30 * * * *", timezone: "UTC" },
+        targets: urls.map(url => ({ type: "scrape", url })) as any,
+      },
+      identity,
+    );
+
+    expect(create.statusCode).toBe(200);
+    expect(create.body.success).toBe(true);
+    expect(
+      create.body.data.targets.map((target: any) => ({
+        type: target.type,
+        urls: target.urls,
+        url: target.url,
+      })),
+    ).toEqual(
+      urls.map(url => ({
+        type: "scrape",
+        urls: [url],
+        url: undefined,
+      })),
+    );
+
+    await monitorDeleteRaw(create.body.data.id, identity);
+  });
+
   it("accepts an origin field in the create body", async () => {
     const create = await monitorCreateRaw(
       {

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1583,6 +1583,67 @@ describe("V2 Types Validation", () => {
     });
   });
 
+  describe("monitor scrape target compatibility", () => {
+    const baseMonitor = {
+      name: "Dify monitor",
+      schedule: { text: "every 30 minutes" },
+    };
+
+    it("normalizes singular scrape URLs to the canonical urls array", () => {
+      const result = createMonitorSchema.parse({
+        ...baseMonitor,
+        targets: [
+          { type: "scrape", url: "https://example.com" },
+          { type: "scrape", url: "https://example.org" },
+        ],
+      });
+
+      expect(result.targets).toEqual([
+        {
+          type: "scrape",
+          urls: ["https://example.com"],
+          scrapeOptions: {},
+        },
+        {
+          type: "scrape",
+          urls: ["https://example.org"],
+          scrapeOptions: {},
+        },
+      ]);
+    });
+
+    it("still validates a singular scrape URL", () => {
+      expect(() =>
+        createMonitorSchema.parse({
+          ...baseMonitor,
+          targets: [{ type: "scrape", url: "https://" }],
+        }),
+      ).toThrow();
+    });
+
+    it.each([
+      { type: "scrape" },
+      { type: "scrape", urls: [] },
+      {
+        type: "scrape",
+        url: "https://example.com",
+        urls: ["https://example.org"],
+      },
+      {
+        type: "scrape",
+        url: "https://example.com",
+        unsupported: true,
+      },
+    ])("keeps strict scrape target validation for %j", target => {
+      expect(() =>
+        createMonitorSchema.parse({
+          ...baseMonitor,
+          targets: [target],
+        }),
+      ).toThrow();
+    });
+  });
+
   describe("monitor search target goal validation", () => {
     const searchTargets = [
       { type: "search" as const, queries: ["firecrawl launch"] },

--- a/apps/api/src/services/monitoring/types.ts
+++ b/apps/api/src/services/monitoring/types.ts
@@ -17,12 +17,24 @@ const scrapeOptionsSchema = z
   .optional()
   .default({});
 
-const scrapeTargetSchema = z.strictObject({
-  id: z.string().uuid().optional(),
-  type: z.literal("scrape"),
-  urls: z.array(urlSchema).min(1),
-  scrapeOptions: scrapeOptionsSchema,
-});
+const scrapeTargetSchema = z.preprocess(
+  value => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const target = value as Record<string, unknown>;
+      if (target.type === "scrape" && !("urls" in target) && "url" in target) {
+        const { url, ...rest } = target;
+        return { ...rest, urls: [url] };
+      }
+    }
+    return value;
+  },
+  z.strictObject({
+    id: z.string().uuid().optional(),
+    type: z.literal("scrape"),
+    urls: z.array(urlSchema).min(1),
+    scrapeOptions: scrapeOptionsSchema,
+  }),
+);
 
 const crawlTargetSchema = z.strictObject({
   id: z.string().uuid().optional(),


### PR DESCRIPTION
Fixes #4054

## Implementation summary

Updated the input boundary to normalize Dify's singular scrape target "{type: "scrape", url: ...}" into the canonical "{type: "scrape", urls: [...]}" form. The existing "urls" contract and strict validation are preserved. Added boundary tests for multiple singular targets, invalid URLs, simultaneous "url"/"urls" usage, and unsupported keys, along with a POST regression test.

## Changes

```
apps/api/src/__tests__/snips/v2/monitor.test.ts    | 30 +++++++++++
 .../__tests__/snips/v2/types-validation.test.ts    | 61 ++++++++++++++++++++++
 apps/api/src/services/monitoring/types.ts          | 24 ++++++---
 3 files changed, 109 insertions(+), 6 deletions(-)
```

## Testing

- pwd; git status --short; git diff --stat; git diff -- apps/api/src/services/monitoring/types.ts apps/api/src/__tests__/snips/v2/types-validation.test.ts apps/api/src/__tests__/snips/v2/monitor.test.ts — passed: Confirmed the requested verification snapshot and a clean synthetic working tree. The supplied authoritative diff was therefore used as the change record.
- node --version && pnpm --version; printf 'node_modules='; test -d node_modules && echo yes || echo no; printf 'api_node_modules='; test -d apps/api/node_modules && echo yes || echo no; rg -n "TEST_SUITE_SELF_HOSTED|TEST_SUITE_WEBSITE|TEST_API_URL|HARNESS_STARTUP_TIMEOUT_MS|PORT:" apps/api/src/config.ts apps/api/src/harness.ts; for f in apps/api/.env apps/api/.env.local .env .env.local; do if [ -f "$f" ]; then echo "$f exists"; grep -E '^(TEST_SUITE_SELF_HOSTED|TEST_SUITE_WEBSITE|TEST_API_URL|PORT|WORKER_PORT|REDIS_URL|REDIS_RATE_LIMIT_URL|POSTGRES_HOST|RABBITMQ_URL)=' "$f" | sed -E 's/=.*/=<set>/'; fi; done; env | grep -E '^(TEST_SUITE_SELF_HOSTED|TEST_SUITE_WEBSITE|TEST_API_URL|PORT|WORKER_PORT|HARNESS_STARTUP_TIMEOUT_MS)=' || true; grep -E '^(TEST_API_KEY|TEST_TEAM_ID|IDMUX_URL|TEST_SUITE_SELF_HOSTED|TEST_SUITE_WEBSITE|TEST_API_URL)=' apps/api/.env.local 2>/dev/null | sed -E 's/=.*/=<set>/' || true — passed: Verified Node v24.19.0 and repository-required pnpm 11.4.0, inspected harness configuration, and confirmed that local production-snippet credentials/idmux configuration are absent.
- cd apps/api && pnpm install --frozen-lockfile — passed: Installed the declared lockfile dependencies successfully, including required native build steps.
- cd apps/api && pnpm exec vitest run src/__tests__/snips/v2/types-validation.test.ts — passed: Focused validation passed: 1 file, 129/129 tests. This includes all new singular scrape target normalization and strict-validation boundary cases.
- cd apps/api && pnpm build — passed: TypeScript compilation completed successfully with tsc.
- cd apps/api && git diff --check — passed: No whitespace errors were reported.
- command -v docker || command -v podman || true; docker info >/dev/null 2>&1 && echo docker-ok || echo docker-unavailable; command -v redis-server || true; redis-cli -h 127.0.0.1 -p 6379 ping 2>/dev/null || true; go version || true; ss -ltn '( sport = :3002 or sport = :3005 or sport = :5432 or sport = :5672 or sport = :6379 )' || true — passed: Docker was usable, Redis answered PONG, Go 1.24.0 was available, and required local service ports were inspected before harness setup.
- docker ps --filter name=^firecrawl-nuq-rabbitmq-external$ --format '{{.Status}}'; docker exec firecrawl-nuq-rabbitmq-external rabbitmq-diagnostics -q ping; nc -z 127.0.0.1 5672 && echo amqp-port-ready — passed: The externally bootstrapped RabbitMQ workaround was independently confirmed running, Ping succeeded, and AMQP port 5672 accepted connections.
- ss -ltnp | grep -E ':(3002|3004|3005|3006|3007|3008|3009|3010|3011|3012)\b' || true; ps -fp 1109079; readlink /proc/1109079/cwd; tr '\0' ' ' </proc/1109079/cmdline; pgrep/ps checks for candidate harness processes; kill 1109079 1109077; verify ports again — passed: Confirmed port 3004 was owned by a stale node dist/src/services/extract-worker.js from this verifier snapshot, terminated it, and verified the conflicting listener was gone.
- cd apps/api && rg -n "NUQ_WORKER_COUNT|MAX_CPU|MAX_RAM" src/config.ts src/harness.ts | head -n 80; ss -ltnp | grep -E ':(3002|3004|3005|3006|3007|3008|3009|3010|3011|3012)\b' || true; docker ps --filter name=^firecrawl-nuq-rabbitmq-external$ --format '{{.Names}} {{.Status}}' — passed: Verified configurable harness worker/resource settings, confirmed relevant application ports were clear, and confirmed the external RabbitMQ bootstrap remained available before the final harness run.
- cd apps/api && set -a; [ ! -f .env.local ] || . ./.env.local; set +a; PORT=3002 TEST_API_URL=http://127.0.0.1:3002 NUQ_RABBITMQ_URL=amqp://127.0.0.1:5672 NUQ_WORKER_COUNT=1 MAX_CPU=1 MAX_RAM=1 HARNESS_STARTUP_TIMEOUT_MS=180000 pnpm harness pnpm exec vitest run src/__tests__/snips/v2/types-validation.test.ts — passed: Repository harness completed successfully with exit code 0. It installed/build-checked dependencies, started the API on port 3002 and required workers/services, ran the focused Vitest file with 129/129 passing tests, then shut down cleanly.
- Added validation tests for singular target normalization, invalid URLs, `url`/`urls` co-occurrence, and unsupported keys.
- Added a POST regression test confirming created monitors store the canonical `urls` form.