### PR TITLE
fix(v2/agent): stop capping pinned toolkits at five

### DIFF
--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1003,7 +1003,7 @@ const agentWebhookSchema = createWebhookSchema([
 // per-thread inheritance rules; the gateway only validates the shape.
 const agentExchangeSchema = z.strictObject({
   enabled: z.boolean().optional(),
-  toolkits: z.array(z.string()).max(5).optional(),
+  toolkits: z.array(z.string()).optional(),
   maxCalls: z.number().int().min(1).max(30).optional(),
   requireApproval: z.boolean().optional(),
   approve: z


### PR DESCRIPTION
The cap rejected a request naming more than five providers, which is a legitimate way to narrow a run. The agent service treats the list as a filter over the catalog, so its length costs nothing the whole catalog would not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the five-toolkit cap on pinned exchange toolkits so requests can name more than five providers when narrowing a run. The cap was unnecessary because the agent service treats the list as a filter over the catalog, so a longer list doesn't cost more than the full catalog would.

<sup>Written for commit 2bbc2a23ddd2a6ebb1453bdb16cac5b300a11e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

