### PR TITLE
fix(api): stop warning about skipTlsVerification on file-engine scrapes

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -495,6 +495,7 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
         expect(response.metadata.statusCode).toBe(200);
         // An image is not a PDF: no page count is reported for it.
         expect(response.metadata.numPages).toBeUndefined();
+        expect(response.warning).toBeUndefined();
       },
       scrapeTimeout,
     );

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -1505,6 +1505,8 @@ describe("Scrape tests", () => {
           expect(response.markdown).toContain("PDF Test File");
           expect(response.metadata.title).toContain("PDF Test Page");
           expect(response.metadata.numPages).toBe(1);
+          // A complete parse must not carry the partial-scrape warning.
+          expect(response.warning).toBeUndefined();
         },
         scrapeTimeout,
       );

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -489,6 +489,11 @@ const engineOptions: {
     },
     quality: 5,
   },
+  // The file engines (pdf, document, image) pass skipTlsVerification through
+  // to their direct downloads, and a browser handoff already applied it
+  // upstream, so they declare it supported: otherwise every cache-miss file
+  // scrape carries a misleading "may be partial" warning, since v2 defaults
+  // the option to true.
   pdf: {
     features: {
       actions: false,
@@ -503,7 +508,7 @@ const engineOptions: {
       atsv: false,
       location: false,
       mobile: false,
-      skipTlsVerification: false,
+      skipTlsVerification: true,
       useFastMode: true,
       stealthProxy: true, // kinda...
       branding: false,
@@ -525,7 +530,7 @@ const engineOptions: {
       atsv: false,
       location: false,
       mobile: false,
-      skipTlsVerification: false,
+      skipTlsVerification: true,
       useFastMode: true,
       stealthProxy: true, // kinda...
       branding: false,
@@ -547,7 +552,7 @@ const engineOptions: {
       atsv: false,
       location: false,
       mobile: false,
-      skipTlsVerification: false,
+      skipTlsVerification: true,
       useFastMode: true,
       stealthProxy: true, // kinda...
       branding: false,


### PR DESCRIPTION
## Why

Every cache-miss scrape that ends in the pdf, document or image engine comes back with

```
warning: "The engine used does not support the following features: skipTlsVerification -- your scrape may be partial."
```

v2 defaults `skipTlsVerification` to true whenever a request carries no headers or actions, so the feature flag is present on almost every scrape, and the three file engines declared it unsupported. The result is complete, so the warning is misleading noise on PDF, document and image responses.

## What

Declare `skipTlsVerification` as supported on the pdf, document and image engines. All three pass the option through to their direct downloads, and a browser handoff has already applied it upstream, so the declaration matches what happens.

Regression assertions on the cache-miss PDF snip and the PNG OCR snip check that no warning is attached to a complete result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cache-miss scrapes through the pdf, document, and image engines from warning that `skipTlsVerification` is unsupported when the scrape result is complete.

**Bug Fixes**

- Declares `skipTlsVerification` as supported on the three file engines because they pass it through to direct downloads and browser handoffs apply it upstream.
- Adds regression assertions on cache-miss PDF and PNG OCR snips that no warning is attached to complete results.

<sup>Written for commit 0202617906e4407f3f7652e740d7521c5076a874. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

