### PR TITLE
perf(api): detach search ledger writes

### DIFF
--- a/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/search-developer-ledger.test.ts
@@ -305,6 +305,38 @@ describe("developer category code_searches ledger", () => {
     expect(body.creditsUsed).toBe(2);
   });
 
+  it("returns before the request ledger insert completes", async () => {
+    let finishLogRequest!: () => void;
+    mockLogRequest.mockReturnValue(
+      new Promise<void>(resolve => {
+        finishLogRequest = resolve;
+      }),
+    );
+    const req = makeReq({
+      query: "vector database client",
+      categories: ["developer"],
+    });
+    const res = makeRes();
+
+    const controllerPromise = searchController(req, res);
+    await flushAsync();
+    const returnedBeforeInsert = res.status.mock.calls.some(
+      ([status]) => status === 200,
+    );
+    const loggedChildrenBeforeInsert =
+      mockLogSearch.mock.calls.length +
+      mockLogResearchEndpoint.mock.calls.length;
+
+    finishLogRequest();
+    await controllerPromise;
+    await flushAsync();
+
+    expect(returnedBeforeInsert).toBe(true);
+    expect(loggedChildrenBeforeInsert).toBe(0);
+    expect(mockLogSearch).toHaveBeenCalledTimes(1);
+    expect(mockLogResearchEndpoint).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the developer category for a team with no flags", async () => {
     mockExecuteSearch.mockResolvedValue(
       executeResult({ response: { web: [] } }),

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -297,66 +297,68 @@ export async function searchController(
     const endTime = new Date().getTime();
     const timeTakenInSeconds = (endTime - middlewareStartTime) / 1000;
 
-    // Ensure the parent `requests` row is committed before the child
-    // `searches` insert, to avoid a request_id FK violation. The insert has
-    // been in flight since the top of the controller, so this is ~free in
-    // practice; robustInsert never rejects, so this await cannot throw.
     const logStart = Date.now();
-    await logRequestPromise;
-    const waited = Date.now() - logStart;
-    if (waited >= 5)
-      logger.warn("Had to wait for log request promise to complete", {
-        timeMs: waited,
-      });
+    void Promise.resolve(logRequestPromise)
+      .then(() => {
+        const waited = Date.now() - logStart;
+        if (waited >= 5) {
+          logger.warn("Request ledger insert completed after the response", {
+            timeMs: waited,
+          });
+        }
 
-    logSearch(
-      {
-        id: jobId,
-        request_id: agentRequestId ?? jobId,
-        query: req.body.query,
-        is_successful: true,
-        error: undefined,
-        results: result.response as any,
-        num_results: result.totalResultsCount,
-        time_taken: timeTakenInSeconds,
-        team_id: req.auth.team_id,
-        options: req.body,
-        // Don't record preview tokens as billed in the ledger — only record
-        // credits when billing is actually applied.
-        credits_cost: !isSearchPreview && shouldBill ? result.searchCredits : 0,
-        zeroDataRetention,
-      },
-      false,
-    );
-
-    if (wantsDeveloperCategory(req.body.categories as CategoryOption[])) {
-      logResearchEndpoint({
-        table: "code_searches",
-        id: uuidv7(),
-        request_id: agentRequestId ?? jobId,
-        team_id: req.auth.team_id,
-        target: req.body.query,
-        options: {
-          origin: requestOrigin({ origin: rawOrigin }, req),
-          integration: req.body.integration ?? null,
-          api_version: "v2",
-          categories: req.body.categories,
-          via: "search_category",
-        },
-        response: null,
-        num_results: result.developerResultsCount,
-        time_taken: timeTakenInSeconds,
-        // Ensure preview-mode searches don't get a non-zero credits_cost
-        // in the research ledger when preview tokens are used.
-        credits_cost: !isSearchPreview && shouldBill ? result.searchCredits : 0,
-        is_successful: true,
-        zeroDataRetention,
-      }).catch(ledgerError => {
-        logger.warn("Failed to log developer category usage", {
-          error: ledgerError,
+        void logSearch(
+          {
+            id: jobId,
+            request_id: agentRequestId ?? jobId,
+            query: req.body.query,
+            is_successful: true,
+            error: undefined,
+            results: result.response as any,
+            num_results: result.totalResultsCount,
+            time_taken: timeTakenInSeconds,
+            team_id: req.auth.team_id,
+            options: req.body,
+            credits_cost:
+              !isSearchPreview && shouldBill ? result.searchCredits : 0,
+            zeroDataRetention,
+          },
+          false,
+        ).catch(logError => {
+          logger.warn("Failed to log search", { error: logError });
         });
+
+        if (wantsDeveloperCategory(req.body.categories as CategoryOption[])) {
+          void logResearchEndpoint({
+            table: "code_searches",
+            id: uuidv7(),
+            request_id: agentRequestId ?? jobId,
+            team_id: req.auth.team_id,
+            target: req.body.query,
+            options: {
+              origin: requestOrigin({ origin: rawOrigin }, req),
+              integration: req.body.integration ?? null,
+              api_version: "v2",
+              categories: req.body.categories,
+              via: "search_category",
+            },
+            response: null,
+            num_results: result.developerResultsCount,
+            time_taken: timeTakenInSeconds,
+            credits_cost:
+              !isSearchPreview && shouldBill ? result.searchCredits : 0,
+            is_successful: true,
+            zeroDataRetention,
+          }).catch(ledgerError => {
+            logger.warn("Failed to log developer category usage", {
+              error: ledgerError,
+            });
+          });
+        }
+      })
+      .catch(logError => {
+        logger.warn("Failed to order search logs", { error: logError });
       });
-    }
 
     const totalRequestTime = new Date().getTime() - middlewareStartTime;
     const controllerTime = new Date().getTime() - controllerStartTime;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detaches the search request ledger write from the response path so the API returns before the ledger insert finishes. The insert now runs detached in the background.

Child `searches` and developer-ledger writes still start only after the parent `requests` insert settles. The tradeoff: if the process exits right after responding, the ledger row and its children can be lost. Adds a test covering the early return and ordering.

<sup>Written for commit 9f83497591f4dcea8a341a5a02b043d4b9b81321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

