### PR TITLE
perf(api): cap fail-open Firebill checks

### DIFF
--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -924,6 +924,24 @@ describe("firebill routing", () => {
     expect(mockCheck).not.toHaveBeenCalled();
   });
 
+  it("limits the fail-open check to the interactive request budget", async () => {
+    state.configRef = firebillConfig();
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    const svc = makeService();
+
+    try {
+      await svc.checkCredits({
+        teamId: "team-1",
+        value: 100,
+        properties: {},
+      });
+
+      expect(timeout).toHaveBeenCalledWith(200);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
+
   it("checks directly in Autumn for orgs NOT on the allowlist", async () => {
     state.configRef = {
       ...firebillConfig(),

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -38,6 +38,7 @@ function lockDeniedReason(value: unknown): LockDeniedReason | undefined {
 // ~3.5s worst case, so this is deliberately looser than the 2s timeout on the
 // direct Autumn client.
 const FIREBILL_TIMEOUT_MS = 5000;
+const FIREBILL_CHECK_TIMEOUT_MS = 200;
 
 // A gated lock legitimately does more: firebill asks the partner (2.5s ceiling)
 // before the Autumn hold (2s), on top of the funding lookup. Giving up at 5s
@@ -354,7 +355,7 @@ export async function firebillCheck({
         value,
         properties,
       }),
-      signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
+      signal: AbortSignal.timeout(FIREBILL_CHECK_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- Cap the fail-open Firebill credit check at 200 ms.
- Apply the budget to routed teams using `checkCreditsMiddleware`; direct Autumn checks retain their existing timeout.
- Leave billing and credit accounting unchanged.

## Caveat

A slow Firebill response can now admit work after 200 ms because this check fails open. This affects every team routed through `checkCreditsMiddleware`, not only search traffic.

## Checks

- `pnpm exec vitest run src/services/autumn/__tests__/autumn.service.test.ts --reporter=default`
- `pnpm exec prettier --check src/services/autumn/firebill.ts src/services/autumn/__tests__/autumn.service.test.ts`
- `pnpm build`
- `pnpm knip --cache`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces the fail-open Firebill credit check timeout from 5s to 200ms to prevent slow responses from blocking request handling. A slow response now admits work after 200ms, affecting all teams routed through `checkCreditsMiddleware`.

<sup>Written for commit 155c96179daa37d52f646d781ae3e869fabfffd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

