### PR TITLE
feat(api): add the image parser and OCR images by default behind the team flag

### DIFF
--- a/apps/api/src/__tests__/pdf-parser-options.test.ts
+++ b/apps/api/src/__tests__/pdf-parser-options.test.ts
@@ -1,8 +1,11 @@
 import {
   getPDFBlocks,
+  getPDFMode,
   getPDFPageMarkdown,
   getPDFPageMarkers,
   scrapeOptions,
+  shouldParseImages,
+  shouldParsePDF,
 } from "../controllers/v2/types";
 
 function parsePdfParser(parser: Record<string, unknown>) {
@@ -61,5 +64,45 @@ describe("deprecated pageMarkdown alias", () => {
     expect(
       parsePdfParser({ type: "pdf", pages: true, pageMarkdown: false }).pages,
     ).toBe(true);
+  });
+});
+
+describe("image parser opt-in", () => {
+  it("is never on by default", () => {
+    expect(shouldParseImages(undefined)).toBe(false);
+    expect(shouldParseImages([])).toBe(false);
+    expect(shouldParseImages(["pdf"])).toBe(false);
+    expect(shouldParseImages([{ type: "pdf", mode: "ocr" }])).toBe(false);
+    expect(scrapeOptions.parse({}).parsers).toEqual(["pdf"]);
+  });
+
+  it("accepts the string and object forms", () => {
+    expect(shouldParseImages(["image"])).toBe(true);
+    expect(shouldParseImages(["pdf", "image"])).toBe(true);
+    expect(shouldParseImages([{ type: "image" }])).toBe(true);
+    expect(shouldParseImages([{ type: "pdf", mode: "ocr" }, "image"])).toBe(
+      true,
+    );
+    expect(
+      scrapeOptions.parse({ parsers: ["pdf", { type: "image" }] }).parsers,
+    ).toEqual(["pdf", { type: "image" }]);
+  });
+
+  it("leaves the pdf parser alone", () => {
+    expect(shouldParsePDF(["image"])).toBe(false);
+    expect(shouldParsePDF(["pdf", "image"])).toBe(true);
+    expect(getPDFMode([{ type: "image" }, { type: "pdf", mode: "ocr" }])).toBe(
+      "ocr",
+    );
+  });
+
+  it("rejects the plural and unknown options", () => {
+    expect(scrapeOptions.safeParse({ parsers: ["images"] }).success).toBe(
+      false,
+    );
+    expect(
+      scrapeOptions.safeParse({ parsers: [{ type: "image", mode: "ocr" }] })
+        .success,
+    ).toBe(false);
   });
 });

--- a/apps/api/src/__tests__/pdf-parser-options.test.ts
+++ b/apps/api/src/__tests__/pdf-parser-options.test.ts
@@ -67,18 +67,23 @@ describe("deprecated pageMarkdown alias", () => {
   });
 });
 
-describe("image parser opt-in", () => {
-  it("is never on by default", () => {
-    expect(shouldParseImages(undefined)).toBe(false);
+describe("image parser", () => {
+  it("is on by default, like pdf", () => {
+    expect(scrapeOptions.parse({}).parsers).toEqual(["pdf", "image"]);
+    expect(shouldParseImages(undefined)).toBe(true);
+    expect(shouldParseImages(["pdf", "image"])).toBe(true);
+    expect(shouldParsePDF(["pdf", "image"])).toBe(true);
+  });
+
+  it("opts out with an explicit list that omits it", () => {
     expect(shouldParseImages([])).toBe(false);
     expect(shouldParseImages(["pdf"])).toBe(false);
     expect(shouldParseImages([{ type: "pdf", mode: "ocr" }])).toBe(false);
-    expect(scrapeOptions.parse({}).parsers).toEqual(["pdf"]);
+    expect(scrapeOptions.parse({ parsers: ["pdf"] }).parsers).toEqual(["pdf"]);
   });
 
   it("accepts the string and object forms", () => {
     expect(shouldParseImages(["image"])).toBe(true);
-    expect(shouldParseImages(["pdf", "image"])).toBe(true);
     expect(shouldParseImages([{ type: "image" }])).toBe(true);
     expect(shouldParseImages([{ type: "pdf", mode: "ocr" }, "image"])).toBe(
       true,
@@ -90,7 +95,7 @@ describe("image parser opt-in", () => {
 
   it("leaves the pdf parser alone", () => {
     expect(shouldParsePDF(["image"])).toBe(false);
-    expect(shouldParsePDF(["pdf", "image"])).toBe(true);
+    expect(getPDFMode(["pdf", "image"])).toBe("auto");
     expect(getPDFMode([{ type: "image" }, { type: "pdf", mode: "ocr" }])).toBe(
       "ocr",
     );

--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -483,6 +483,7 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
           {
             url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
             formats: ["markdown"],
+            parsers: ["pdf", "image"],
           },
           identity,
         );
@@ -501,21 +502,43 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
     );
 
     it(
-      "OCRs images regardless of the pdf parsers option",
+      "OCRs images with the image parser alone",
       async () => {
-        // `parsers` describes PDFs: an empty list disables PDF parsing, but
-        // images have no text layer to fall back on and are still OCR'd.
+        // The object form is reserved for future options, and the pdf parser
+        // is not needed for an image.
         const response = await scrape(
           {
             url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
             formats: ["markdown"],
-            parsers: [],
+            parsers: [{ type: "image" }],
           },
           identity,
         );
 
         expect(response.markdown).toMatch(/fire/i);
         expect(response.metadata.contentType).toBe("image/png");
+      },
+      scrapeTimeout,
+    );
+
+    it(
+      "does not OCR images unless the image parser is requested",
+      async () => {
+        // The default parsers list is ["pdf"]: image OCR is opt-in, so a
+        // request that did not ask for it keeps the unsupported-file
+        // rejection, and the error names the parser to add. The tests above
+        // OCR'd this URL already, so this also checks that the index does
+        // not hand that cached output to a request that did not opt in.
+        const response = await scrapeWithFailure(
+          {
+            url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
+            formats: ["markdown"],
+          },
+          identity,
+        );
+
+        expect(response.error).toContain("cannot process");
+        expect(response.error).toContain('"image"');
       },
       scrapeTimeout,
     );
@@ -546,6 +569,7 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
           {
             urls: [`${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`],
             formats: ["markdown"],
+            parsers: ["image"],
           },
           identity,
         );
@@ -568,6 +592,7 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
         {
           url: "https://www.gstatic.com/webp/gallery/1.jpg",
           formats: ["markdown"],
+          parsers: ["pdf", "image"],
         },
         identity,
       );
@@ -585,6 +610,7 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
         {
           url: "https://www.gstatic.com/webp/gallery/1.webp",
           formats: ["markdown"],
+          parsers: ["pdf", "image"],
         },
         identity,
       );
@@ -674,12 +700,13 @@ describe("Image OCR for a team without the imageOcr flag", () => {
     "scrape (f-e dependent)",
     () => {
       it(
-        "keeps failing image URLs as unsupported files",
+        "keeps failing image URLs as unsupported files even with the image parser",
         async () => {
           const response = await scrapeWithFailure(
             {
               url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
               formats: ["markdown"],
+              parsers: ["pdf", "image"],
             },
             ungatedIdentity,
           );

--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -501,8 +501,10 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
     );
 
     it(
-      "returns the raw image when parsing is disabled",
+      "OCRs images regardless of the pdf parsers option",
       async () => {
+        // `parsers` describes PDFs: an empty list disables PDF parsing, but
+        // images have no text layer to fall back on and are still OCR'd.
         const response = await scrape(
           {
             url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
@@ -512,9 +514,25 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
           identity,
         );
 
-        // Base64 of the PNG signature.
-        expect(response.markdown).toMatch(/^iVBORw0KGgo/);
+        expect(response.markdown).toMatch(/fire/i);
         expect(response.metadata.contentType).toBe("image/png");
+      },
+      scrapeTimeout,
+    );
+
+    it(
+      "serves the raw image through the rawBase64 format",
+      async () => {
+        const response = await scrape(
+          {
+            url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
+            formats: ["rawBase64"],
+          },
+          identity,
+        );
+
+        // Base64 of the PNG signature.
+        expect(response.rawBase64).toMatch(/^iVBORw0KGgo/);
       },
       scrapeTimeout,
     );

--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -479,11 +479,12 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
     it(
       "OCRs a PNG URL as a one-page document",
       async () => {
+        // Image OCR is on by default for a flagged team: no parsers option
+        // needed.
         const response = await scrape(
           {
             url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
             formats: ["markdown"],
-            parsers: ["pdf", "image"],
           },
           identity,
         );
@@ -522,17 +523,18 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
     );
 
     it(
-      "does not OCR images unless the image parser is requested",
+      "does not OCR images when the parsers list omits the image parser",
       async () => {
-        // The default parsers list is ["pdf"]: image OCR is opt-in, so a
-        // request that did not ask for it keeps the unsupported-file
-        // rejection, and the error names the parser to add. The tests above
-        // OCR'd this URL already, so this also checks that the index does
-        // not hand that cached output to a request that did not opt in.
+        // An explicit list without "image" opts out: the request keeps the
+        // unsupported-file rejection, and the error names the parser. The
+        // tests above OCR'd this URL already, so this also checks that the
+        // index does not hand that cached output to a request that opted
+        // out.
         const response = await scrapeWithFailure(
           {
             url: `${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`,
             formats: ["markdown"],
+            parsers: ["pdf"],
           },
           identity,
         );
@@ -569,7 +571,6 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
           {
             urls: [`${TEST_SUITE_WEBSITE}/firecrawl-wordmark.png`],
             formats: ["markdown"],
-            parsers: ["image"],
           },
           identity,
         );
@@ -587,12 +588,13 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
     async () => {
       // A long-lived public sample photo: exercises the image/jpeg browser
       // handoff. The scrape itself only succeeds with non-empty markdown, so
-      // the assertions stick to the stable handoff properties.
+      // the assertions stick to the stable handoff properties. The bare
+      // string form of the image parser is exercised here.
       const response = await scrape(
         {
           url: "https://www.gstatic.com/webp/gallery/1.jpg",
           formats: ["markdown"],
-          parsers: ["pdf", "image"],
+          parsers: ["image"],
         },
         identity,
       );
@@ -610,7 +612,6 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
         {
           url: "https://www.gstatic.com/webp/gallery/1.webp",
           formats: ["markdown"],
-          parsers: ["pdf", "image"],
         },
         identity,
       );

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -522,8 +522,26 @@ const pdfParserWithOptions = z
     return normalized;
   });
 
+/**
+ * Raster image OCR (PNG, JPEG, TIFF, GIF, BMP) is opt-in: unlike `pdf`, the
+ * `image` parser is never part of the default list, so a request that does
+ * not ask for it keeps the historical unsupported-file rejection for image
+ * URLs. The object form carries no options yet; it exists so options can be
+ * added later without a breaking change.
+ */
+const imageParserWithOptions = z.strictObject({
+  type: z.literal("image"),
+});
+
 const parsersSchema = z
-  .array(z.union([z.literal("pdf"), pdfParserWithOptions]))
+  .array(
+    z.union([
+      z.literal("pdf"),
+      pdfParserWithOptions,
+      z.literal("image"),
+      imageParserWithOptions,
+    ]),
+  )
   .prefault(["pdf"]);
 
 type Parsers = z.infer<typeof parsersSchema>;
@@ -537,6 +555,21 @@ export function shouldParsePDF(parsers?: Parsers): boolean {
     }
     return false;
   });
+}
+
+/**
+ * Whether the request opted into raster image OCR. Unlike PDFs, images are
+ * never parsed by default: `undefined` and `[]` both mean no.
+ */
+export function shouldParseImages(parsers?: Parsers): boolean {
+  if (!parsers) return false;
+  return parsers.some(
+    parser =>
+      parser === "image" ||
+      (typeof parser === "object" &&
+        parser !== null &&
+        parser.type === "image"),
+  );
 }
 
 export function getPDFMaxPages(parsers?: Parsers): number | undefined {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -523,11 +523,12 @@ const pdfParserWithOptions = z
   });
 
 /**
- * Raster image OCR (PNG, JPEG, TIFF, GIF, BMP) is opt-in: unlike `pdf`, the
- * `image` parser is never part of the default list, so a request that does
- * not ask for it keeps the historical unsupported-file rejection for image
- * URLs. The object form carries no options yet; it exists so options can be
- * added later without a breaking change.
+ * Raster image OCR (PNG, JPEG, TIFF, GIF, BMP). Like `pdf` it is part of the
+ * default list, so a request that says nothing about parsers OCRs image URLs
+ * (behind the imageOcr team flag while it rolls out); an explicit list that
+ * omits it (`["pdf"]`, `[]`) opts out and keeps the historical
+ * unsupported-file rejection. The object form carries no options yet; it
+ * exists so options can be added later without a breaking change.
  */
 const imageParserWithOptions = z.strictObject({
   type: z.literal("image"),
@@ -542,7 +543,7 @@ const parsersSchema = z
       imageParserWithOptions,
     ]),
   )
-  .prefault(["pdf"]);
+  .prefault(["pdf", "image"]);
 
 type Parsers = z.infer<typeof parsersSchema>;
 
@@ -558,11 +559,12 @@ export function shouldParsePDF(parsers?: Parsers): boolean {
 }
 
 /**
- * Whether the request opted into raster image OCR. Unlike PDFs, images are
- * never parsed by default: `undefined` and `[]` both mean no.
+ * Whether the request wants raster image OCR. Like PDFs, images are parsed
+ * by default: `undefined` means the default list, while an explicit list
+ * that omits `image` (including `[]`) opts out.
  */
 export function shouldParseImages(parsers?: Parsers): boolean {
-  if (!parsers) return false;
+  if (!parsers) return true;
   return parsers.some(
     parser =>
       parser === "image" ||
@@ -2030,7 +2032,7 @@ export function fromV0ScrapeOptions(
       parsers:
         pageOptions.parsePDF !== undefined
           ? pageOptions.parsePDF
-            ? ["pdf"]
+            ? ["pdf", "image"]
             : []
           : undefined,
       actions: pageOptions.actions,
@@ -2153,7 +2155,7 @@ export function fromV1ScrapeOptions(
       parsers:
         v1ScrapeOptions.parsePDF !== undefined
           ? v1ScrapeOptions.parsePDF
-            ? ["pdf"]
+            ? ["pdf", "image"]
             : []
           : undefined,
     }),

--- a/apps/api/src/lib/image-ocr-gate.test.ts
+++ b/apps/api/src/lib/image-ocr-gate.test.ts
@@ -45,11 +45,19 @@ describe("imageOcrGate", () => {
     mockedGetACUCTeam.mockReset();
   });
 
+  it("is off without the image parser and never looks the team up", async () => {
+    await expect(
+      imageOcrGate("team", { imageOcr: true }, false)(),
+    ).resolves.toBe(false);
+    await expect(imageOcrGate("team", undefined, false)()).resolves.toBe(false);
+    expect(mockedGetACUCTeam).not.toHaveBeenCalled();
+  });
+
   it("uses the flags carried on the job without a lookup", async () => {
-    await expect(imageOcrGate("team", { imageOcr: true })()).resolves.toBe(
-      true,
-    );
-    await expect(imageOcrGate("team", null)()).resolves.toBe(false);
+    await expect(
+      imageOcrGate("team", { imageOcr: true }, true)(),
+    ).resolves.toBe(true);
+    await expect(imageOcrGate("team", null, true)()).resolves.toBe(false);
     expect(mockedGetACUCTeam).not.toHaveBeenCalled();
   });
 
@@ -57,19 +65,21 @@ describe("imageOcrGate", () => {
     mockedGetACUCTeam.mockResolvedValueOnce({
       flags: { imageOcr: true },
     } as Awaited<ReturnType<typeof getACUCTeam>>);
-    const gate = imageOcrGate("team", undefined);
+    const gate = imageOcrGate("team", undefined, true);
     await expect(gate()).resolves.toBe(true);
     await expect(gate()).resolves.toBe(true);
     expect(mockedGetACUCTeam).toHaveBeenCalledTimes(1);
     expect(mockedGetACUCTeam).toHaveBeenCalledWith("team");
 
     mockedGetACUCTeam.mockResolvedValueOnce(null);
-    await expect(imageOcrGate("team", undefined)()).resolves.toBe(false);
+    await expect(imageOcrGate("team", undefined, true)()).resolves.toBe(false);
   });
 
   it("leaves image OCR off when the lookup fails or there is no team", async () => {
     mockedGetACUCTeam.mockRejectedValueOnce(new Error("redis down"));
-    await expect(imageOcrGate("team", undefined)()).resolves.toBe(false);
-    await expect(imageOcrGate(undefined, undefined)()).resolves.toBe(false);
+    await expect(imageOcrGate("team", undefined, true)()).resolves.toBe(false);
+    await expect(imageOcrGate(undefined, undefined, true)()).resolves.toBe(
+      false,
+    );
   });
 });

--- a/apps/api/src/lib/image-ocr-gate.ts
+++ b/apps/api/src/lib/image-ocr-gate.ts
@@ -23,10 +23,10 @@ const OFF: Promise<boolean> = Promise.resolve(false);
 /**
  * Builds the per-scrape gate: whether this request may OCR raster images.
  *
- * Two conditions fold into it. OCR is opt-in per request — the caller has to
- * ask for the `image` parser (a parse upload of an image asks implicitly) —
- * and rolled out per team through the `imageOcr` flag. A request that did
- * not opt in is settled up front without any I/O.
+ * Two conditions fold into it. The request's `parsers` must include the
+ * `image` parser — it does by default, and a parse upload of an image counts
+ * regardless — and the team must have the `imageOcr` flag while the feature
+ * rolls out. A request that opted out is settled up front without any I/O.
  *
  * For the team side, single scrapes and parse uploads carry the
  * authenticated team's flags in their internalOptions and resolve without

--- a/apps/api/src/lib/image-ocr-gate.ts
+++ b/apps/api/src/lib/image-ocr-gate.ts
@@ -18,19 +18,31 @@ export function isImageOcrEnabled(
 /** Per-scrape gate: resolved lazily on first call and memoized. */
 export type ImageOcrGate = () => Promise<boolean>;
 
+const OFF: Promise<boolean> = Promise.resolve(false);
+
 /**
- * Builds the per-scrape gate. Single scrapes and parse uploads carry the
- * authenticated team's flags in their internalOptions and resolve without any
+ * Builds the per-scrape gate: whether this request may OCR raster images.
+ *
+ * Two conditions fold into it. OCR is opt-in per request — the caller has to
+ * ask for the `image` parser (a parse upload of an image asks implicitly) —
+ * and rolled out per team through the `imageOcr` flag. A request that did
+ * not opt in is settled up front without any I/O.
+ *
+ * For the team side, single scrapes and parse uploads carry the
+ * authenticated team's flags in their internalOptions and resolve without
  * I/O; batch-scrape and crawl jobs do not, so for those the flags come from
- * the cached team ACUC. The lookup is deferred until a caller actually needs
- * the answer (an image-extension URL, an image handoff, the image engine) and
- * memoized, so the ordinary HTML documents that make up almost every crawl
- * never pay for it. Any lookup failure keeps the pre-existing behaviour.
+ * the cached team ACUC. That lookup is deferred until a caller actually needs
+ * the answer (an image-extension URL, an image handoff, the image engine, a
+ * cached image document) and memoized, so the ordinary HTML documents that
+ * make up almost every crawl never pay for it. Any lookup failure keeps the
+ * pre-existing behaviour.
  */
 export function imageOcrGate(
   teamId: string | undefined,
   teamFlags: TeamFlags | null | undefined,
+  requested: boolean,
 ): ImageOcrGate {
+  if (!requested) return () => OFF;
   let pending: Promise<boolean> | undefined;
   return () => {
     pending ??= resolveImageOcrEnabled(teamId, teamFlags);

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -5,17 +5,7 @@ import { EngineUnsuccessfulError, UnsupportedFileError } from "../../error";
 import { readFile, stat, unlink } from "node:fs/promises";
 import { useFireEngine } from "../fire-engine/available";
 import { scrapePDFWithFirePDF } from "../pdf/firePDF";
-import { toPublicBlocks } from "../pdf/blocks";
-import {
-  FIRE_PDF_INLINE_HARD_MAX_FILE_SIZE,
-  PDF_DOWNLOAD_MAX_FILE_SIZE,
-} from "../pdf/types";
-import {
-  getPDFBlocks,
-  getPDFPageMarkdown,
-  getPDFPageMarkers,
-  shouldParsePDF,
-} from "../../../../controllers/v2/types";
+import { FIRE_PDF_INLINE_HARD_MAX_FILE_SIZE } from "../pdf/types";
 import {
   imageExtensionFromUrlPath,
   sniffImageContentType,
@@ -25,10 +15,12 @@ import {
  * Raster images are OCR'd as one-page scanned documents through the FirePDF
  * pipeline. FirePDF opens the bytes as a single-page image document
  * (PNG/JPEG/TIFF/GIF/BMP), finds no text layer, and runs the same layout +
- * OCR path a scanned PDF page takes. The
- * pdf parser's `mode` is deliberately not consulted: an image has no text
- * layer to extract, so OCR is the only way to read it and `fast` would just
- * be a guaranteed failure.
+ * OCR path a scanned PDF page takes.
+ *
+ * The `parsers` option is deliberately not consulted: it describes PDFs, and
+ * an image has no text layer to fall back on, so every image is OCR'd. A
+ * caller who wants the bytes instead uses the `rawBase64` format, which the
+ * browser engine serves without ever reaching this engine.
  */
 
 // Images reach fire-pdf inline (base64 JSON) and have no by-reference
@@ -142,29 +134,7 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
       throw new UnsupportedFileError(contentType);
     }
 
-    if (!shouldParsePDF(meta.options.parsers)) {
-      // `parsers: []` asks for the raw file, mirroring the pdf engine down to
-      // its tighter cap: the bytes go back base64'd inline in the response,
-      // so the cap is checked before the base64 string is built.
-      if (buffer.length > PDF_DOWNLOAD_MAX_FILE_SIZE) {
-        throw new UnsupportedFileError("File exceeds size limit");
-      }
-      const rawBase64 = buffer.toString("base64");
-      return {
-        url,
-        statusCode,
-        html: rawBase64,
-        markdown: rawBase64,
-        contentType,
-        proxyUsed,
-      };
-    }
-
     const base64Content = buffer.toString("base64");
-
-    const includePageMarkdown = getPDFPageMarkdown(meta.options.parsers);
-    const includeBlocks = getPDFBlocks(meta.options.parsers);
-    const pageMarkers = getPDFPageMarkers(meta.options.parsers);
 
     let result: Awaited<ReturnType<typeof scrapePDFWithFirePDF>>;
     try {
@@ -179,9 +149,6 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
         undefined,
         1,
         "ocr",
-        includePageMarkdown,
-        includeBlocks,
-        pageMarkers,
       );
     } catch (error) {
       // FirePDF answers 400 when it cannot open the bytes (truncated or
@@ -200,17 +167,6 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
       statusCode,
       html: result.html,
       markdown: result.markdown,
-      ...(includePageMarkdown && result.pageMarkdown
-        ? {
-            pages: result.pageMarkdown.map(page => ({
-              pageNumber: page.page,
-              markdown: page.markdown,
-            })),
-          }
-        : {}),
-      ...(includeBlocks && result.blocks
-        ? { blocks: toPublicBlocks(result.blocks) }
-        : {}),
       contentType,
       proxyUsed,
     };

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -17,10 +17,13 @@ import {
  * (PNG/JPEG/TIFF/GIF/BMP), finds no text layer, and runs the same layout +
  * OCR path a scanned PDF page takes.
  *
- * The `parsers` option is deliberately not consulted: it describes PDFs, and
- * an image has no text layer to fall back on, so every image is OCR'd. A
- * caller who wants the bytes instead uses the `rawBase64` format, which the
- * browser engine serves without ever reaching this engine.
+ * OCR is opt-in per request (`parsers: ["image"]`; a parse upload of an
+ * image opts in implicitly) and rolled out per team (imageOcr flag); both
+ * are folded into `meta.imageOcrEnabled`. The pdf parser's options (mode,
+ * maxPages, pages, blocks, pageMarkers) are not consulted: an image has no
+ * text layer to fall back on, so every admitted image is OCR'd. A caller who
+ * wants the bytes instead uses the `rawBase64` format, which the browser
+ * engine serves without ever reaching this engine.
  */
 
 // Images reach fire-pdf inline (base64 JSON) and have no by-reference
@@ -67,9 +70,9 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
         new URL(meta.rewrittenUrl ?? meta.url).pathname,
       ) !== null;
     if (knownImage && !(await meta.imageOcrEnabled())) {
-      // Image OCR is per team (imageOcr flag, with FirePDF configured); a
-      // team without it gets the unsupported-file error the URL path has
-      // always produced.
+      // No opt-in (image parser) or no team flag: the request gets the
+      // unsupported-file error the URL path has always produced, whose
+      // message names the parser to add.
       throw new UnsupportedFileError(
         meta.imagePrefetch?.contentType ?? "image",
       );

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -17,13 +17,13 @@ import {
  * (PNG/JPEG/TIFF/GIF/BMP), finds no text layer, and runs the same layout +
  * OCR path a scanned PDF page takes.
  *
- * OCR is opt-in per request (`parsers: ["image"]`; a parse upload of an
- * image opts in implicitly) and rolled out per team (imageOcr flag); both
- * are folded into `meta.imageOcrEnabled`. The pdf parser's options (mode,
- * maxPages, pages, blocks, pageMarkers) are not consulted: an image has no
- * text layer to fall back on, so every admitted image is OCR'd. A caller who
- * wants the bytes instead uses the `rawBase64` format, which the browser
- * engine serves without ever reaching this engine.
+ * OCR is on by default and opt-out per request (a `parsers` list without
+ * `image`; a parse upload of an image always counts), and rolled out per
+ * team (imageOcr flag); both are folded into `meta.imageOcrEnabled`. The pdf
+ * parser's options (mode, maxPages, pages, blocks, pageMarkers) are not
+ * consulted: an image has no text layer to fall back on, so every admitted
+ * image is OCR'd. A caller who wants the bytes instead uses the `rawBase64`
+ * format, which the browser engine serves without ever reaching this engine.
  */
 
 // Images reach fire-pdf inline (base64 JSON) and have no by-reference
@@ -70,9 +70,9 @@ export async function scrapeImage(meta: Meta): Promise<EngineScrapeResult> {
         new URL(meta.rewrittenUrl ?? meta.url).pathname,
       ) !== null;
     if (knownImage && !(await meta.imageOcrEnabled())) {
-      // No opt-in (image parser) or no team flag: the request gets the
-      // unsupported-file error the URL path has always produced, whose
-      // message names the parser to add.
+      // Opted out (parsers without image) or no team flag: the request gets
+      // the unsupported-file error the URL path has always produced, whose
+      // message names the parser.
       throw new UnsupportedFileError(
         meta.imagePrefetch?.contentType ?? "image",
       );

--- a/apps/api/src/scraper/scrapeURL/engines/index/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index/index.ts
@@ -567,6 +567,18 @@ export async function scrapeURLWithIndex(
     }
   }
 
+  // A cached image document is OCR output. The live path only OCRs images
+  // for requests that opted in with the image parser on a team with the
+  // flag, so serving that output to any other request would hand out what a
+  // fresh scrape refuses: report a miss and let the waterfall decide.
+  if (
+    doc.contentType?.startsWith("image/") &&
+    !(await meta.imageOcrEnabled())
+  ) {
+    logLookup("debug", "hit", { imageMismatch: "cached_ocr_not_requested" });
+    throw new IndexMissError();
+  }
+
   logLookup("debug", "hit", {
     age: Date.now() - new Date(selectedRow.created_at).getTime(),
     status: selectedRow.status,

--- a/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/utils/specialtyHandler.ts
@@ -117,9 +117,9 @@ async function feResToImagePrefetch(
 /**
  * Sniffs a browser handoff for a raster image the image engine can OCR.
  * Returns the canonical content type from the magic bytes, or null when the
- * payload is missing, is not a supported format, or image OCR is not
- * enabled for the requesting team — in which case the caller falls through
- * to the historical unsupported-file rejection.
+ * payload is missing, is not a supported format, or the request may not OCR
+ * images (no image parser, or a team without the flag) — in which case the
+ * caller falls through to the historical unsupported-file rejection.
  */
 async function sniffImageHandoff(
   feRes: FireEngineCheckStatusSuccess | undefined,
@@ -129,8 +129,8 @@ async function sniffImageHandoff(
   if (content === undefined) return null;
   const contentType = sniffImageContentTypeFromBase64(content);
   if (contentType === null) return null;
-  // Only now consult the per-team gate: this is the one lookup an image
-  // request may cost, and non-image responses never reach it.
+  // Only now consult the gate (image parser + team flag): this is the one
+  // lookup an image request may cost, and non-image responses never reach it.
   return (await imageOcrEnabled()) ? contentType : null;
 }
 
@@ -145,9 +145,9 @@ export async function specialtyScrapeCheck(
    * the FirePDF by-reference route is unreachable for this request, so an
    * unusable large handoff never consumes network and temp disk. */
   maxFileBytes?: number,
-  /** Per-team image OCR gate (lazy, memoized), consulted only once the bytes
-   * sniff as a supported image; off means images keep the unsupported-file
-   * rejection below. */
+  /** Per-request image OCR gate (image parser + team flag; lazy, memoized),
+   * consulted only once the bytes sniff as a supported image; off means
+   * images keep the unsupported-file rejection below. */
   imageOcrEnabled: ImageOcrGate = async () => false,
 ) {
   const contentType = (Object.entries(headers ?? {}).find(

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -232,7 +232,7 @@ export class UnsupportedFileError extends TransportableError {
   constructor(public reason: string) {
     super(
       "SCRAPE_UNSUPPORTED_FILE_ERROR",
-      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats, and OCRs raster images (PNG, JPEG, TIFF, GIF, BMP) where image parsing is available. Other binary files like videos, executables, archives, and other image formats are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
+      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Raster images (PNG, JPEG, TIFF, GIF, BMP) are OCR'd only when "image" is included in the parsers option, where image parsing is available. Other binary files like videos, executables, archives, and other image formats are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
     );
   }
 

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -232,7 +232,7 @@ export class UnsupportedFileError extends TransportableError {
   constructor(public reason: string) {
     super(
       "SCRAPE_UNSUPPORTED_FILE_ERROR",
-      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Raster images (PNG, JPEG, TIFF, GIF, BMP) are OCR'd only when "image" is included in the parsers option, where image parsing is available. Other binary files like videos, executables, archives, and other image formats are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
+      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Raster images (PNG, JPEG, TIFF, GIF, BMP) are OCR'd when the parsers option includes "image" (the default), where image parsing is available. Other binary files like videos, executables, archives, and other image formats are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
     );
   }
 

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -8,6 +8,7 @@ import {
   applyScrapeOptionsDefaults,
   type Document,
   getPDFMaxPages,
+  shouldParseImages,
   scrapeOptions,
   type ScrapeOptions,
   type TeamFlags,
@@ -154,10 +155,12 @@ export type Meta = {
   abort: AbortManager;
   featureFlags: Set<FeatureFlag>;
   mock: MockState | null;
-  /** Whether this scrape's team may OCR raster images (imageOcr team flag
-   * with FirePDF configured). Lazy and memoized: the browser handoff and the
-   * image engine only ask once a request actually looks like an image, so
-   * plain documents never pay for the team lookup. */
+  /** Whether this scrape may OCR raster images: the request opted in with
+   * the `image` parser (or is a parse upload of an image) and the team has
+   * the imageOcr flag with FirePDF configured. Lazy and memoized: the
+   * browser handoff, the image engine and the index only ask once a request
+   * actually looks like an image, so plain documents never pay for the team
+   * lookup. */
   imageOcrEnabled: ImageOcrGate;
   pdfPrefetch:
     | {
@@ -329,9 +332,10 @@ function buildFeatureFlags(
     // Only add PDF flag if it's not a document
     flags.add("pdf");
   } else if (imageExtensionFromUrlPath(lowerPath) !== null && imageOcrEnabled) {
-    // Raster images are OCR'd through FirePDF for teams with the imageOcr
-    // flag (see engines/image). Everyone else stays on the ordinary
-    // waterfall and fails as an unsupported file, exactly as before.
+    // Raster images are OCR'd through FirePDF when the request opted in with
+    // the `image` parser and the team has the imageOcr flag (see
+    // engines/image). Everyone else stays on the ordinary waterfall and
+    // fails as an unsupported file, exactly as before.
     flags.add("image");
   }
 
@@ -519,9 +523,14 @@ async function buildMetaObject(
   }
 
   const effectiveOptions = applyScrapeOptionsDefaults(options);
+  // Image OCR is opt-in: the request has to carry the `image` parser. A parse
+  // upload of an image is an explicit request to parse that file, so it opts
+  // in on its own. The team flag is checked lazily behind this.
   const imageOcrEnabled = imageOcrGate(
     internalOptions.teamId,
     internalOptions.teamFlags,
+    shouldParseImages(effectiveOptions.parsers) ||
+      internalOptions.uploadedFile?.kind === "image",
   );
   // Only an image-extension URL needs the answer up front; everything else
   // resolves lazily on an image handoff, if one ever happens.

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -155,12 +155,12 @@ export type Meta = {
   abort: AbortManager;
   featureFlags: Set<FeatureFlag>;
   mock: MockState | null;
-  /** Whether this scrape may OCR raster images: the request opted in with
-   * the `image` parser (or is a parse upload of an image) and the team has
-   * the imageOcr flag with FirePDF configured. Lazy and memoized: the
-   * browser handoff, the image engine and the index only ask once a request
-   * actually looks like an image, so plain documents never pay for the team
-   * lookup. */
+  /** Whether this scrape may OCR raster images: the request's parsers
+   * include `image` (the default; a parse upload of an image always counts)
+   * and the team has the imageOcr flag with FirePDF configured. Lazy and
+   * memoized: the browser handoff, the image engine and the index only ask
+   * once a request actually looks like an image, so plain documents never
+   * pay for the team lookup. */
   imageOcrEnabled: ImageOcrGate;
   pdfPrefetch:
     | {
@@ -332,8 +332,8 @@ function buildFeatureFlags(
     // Only add PDF flag if it's not a document
     flags.add("pdf");
   } else if (imageExtensionFromUrlPath(lowerPath) !== null && imageOcrEnabled) {
-    // Raster images are OCR'd through FirePDF when the request opted in with
-    // the `image` parser and the team has the imageOcr flag (see
+    // Raster images are OCR'd through FirePDF when the request's parsers
+    // include `image` (the default) and the team has the imageOcr flag (see
     // engines/image). Everyone else stays on the ordinary waterfall and
     // fails as an unsupported file, exactly as before.
     flags.add("image");
@@ -523,9 +523,10 @@ async function buildMetaObject(
   }
 
   const effectiveOptions = applyScrapeOptionsDefaults(options);
-  // Image OCR is opt-in: the request has to carry the `image` parser. A parse
-  // upload of an image is an explicit request to parse that file, so it opts
-  // in on its own. The team flag is checked lazily behind this.
+  // Image OCR follows the parsers option: on by default, off when the caller
+  // sends a list without `image`. A parse upload of an image is a request to
+  // parse that file, so it counts regardless. The team flag is checked lazily
+  // behind this.
   const imageOcrEnabled = imageOcrGate(
     internalOptions.teamId,
     internalOptions.teamFlags,


### PR DESCRIPTION
## Why

Image OCR (#4489) reused the pdf parser's options on the way to fire-pdf: `parsers: []` returned raw bytes, and the pdf `pages`/`blocks`/`pageMarkers` options applied to images. An option named `pdf` steering images is confusing, and there was no way to say "parse PDFs but leave images alone". This gives images their own parser entry with the same shape and the same default PDFs already have.

## What changes

- `parsers` accepts `"image"` and `{ type: "image" }`, and the default list is now `["pdf", "image"]`. A request that says nothing about parsers OCRs image URLs, exactly as it parses PDFs. An explicit list that omits `"image"` (`["pdf"]`, `[]`, a pdf object on its own) opts out and keeps the historical unsupported-file rejection, whose message now names the parser. v1's `parsePDF: true` maps to the same default list.
- The image engine no longer reads the pdf parser: `parsers: []` does not return raw bytes, and mode/maxPages/pages/blocks/pageMarkers do not apply to images. Raw bytes stay available through `formats: ["rawBase64"]`.
- Parse uploads of an image always count as a request to parse that file.
- The URL index does not serve a cached OCR'd image to a request that may not OCR images (opted out, or a team without the flag). It reports a miss and the live path decides, so the cache cannot hand out what a fresh scrape refuses.
- The `imageOcr` team flag stays as the rollout gate. For a team without it nothing changes: image URLs fail as before, and requests that opted out never trigger the team lookup.

## Behaviour for an image URL, team flagged

| Request | Result |
| --- | --- |
| `parsers` omitted (default `["pdf", "image"]`) | OCR markdown |
| `parsers: ["image"]` or `[{ type: "image" }]` | OCR markdown |
| `parsers: ["pdf"]` or `[]` | unsupported file |
| `formats: ["rawBase64"]` | raw bytes, unchanged |
| parse upload of an image | OCR markdown |

Without the flag every row except `rawBase64` is the unsupported-file error, as today.

Callers that already send `parsers: ["pdf"]` explicitly are opting out under this shape and need `["pdf", "image"]` to get images. Sending `parsers: ["image"]` alone turns PDF parsing off, the same way an explicit pdf object always has.

## Tests

- `scrape-image-ocr.test.ts`: the default request OCRs a PNG, the string and object forms, `["pdf"]` opting out with the parser named in the error (after the URL was OCR'd earlier in the suite, so the index path is covered too), batch-scrape on the default, an unflagged team rejected even with the parser, `rawBase64` unaffected, parse uploads unchanged.
- Unit: `shouldParseImages` and the schema (default list, opt-out lists, both forms, `"images"` and unknown options rejected, pdf getters unaffected); the gate stays off without a team lookup when the request opted out.

Both SDKs already type `parsers` loosely enough to pass `"image"`. Typed `ImageParser` entries and the docs page are follow-ups.
