### PR TITLE
feat(api): OCR JPEG 2000 images

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -816,6 +816,7 @@ describeIf(SHOULD_RUN)("Image OCR parse upload (fire-pdf dependent)", () => {
       expect(failure.code).toBe("UNSUPPORTED_FILE_TYPE");
       expect(failure.error).toContain(".jp2");
       expect(failure.error).toContain(".jpx");
+      expect(failure.error).toContain(".jpf");
       expect(failure.error).toContain(".j2k");
       expect(failure.error).toContain(".j2c");
     },

--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -817,6 +817,7 @@ describeIf(SHOULD_RUN)("Image OCR parse upload (fire-pdf dependent)", () => {
       expect(failure.error).toContain(".jp2");
       expect(failure.error).toContain(".jpx");
       expect(failure.error).toContain(".j2k");
+      expect(failure.error).toContain(".j2c");
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -474,6 +474,83 @@ const OCR_FIXTURE_JPEG_BASE64 =
   "BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE" +
   "BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBB//2Q==";
 
+// The same fixture re-encoded as a grayscale JPEG 2000 (JP2 container).
+const OCR_FIXTURE_JP2_BASE64 =
+  "AAAADGpQICANCocKAAAAFGZ0eXBqcDIgAAAAAGpwMiAAAAAtanAyaAAAABZpaGRyAAAA3AAAAvgA" +
+  "AQcHAAAAAAAPY29scgEAAAAAABEAAA/1anAyY/9P/1EAKQAAAAAC+AAAANwAAAAAAAAAAAAAAvgA" +
+  "AADcAAAAAAAAAAAAAQcBAf9SAAwAAAABAAUEBAAA/1wAI0J3IHbwdvB2wG8AbwBu4GdQZ1BnaFAF" +
+  "UAVQR1fTV9NXYv9kACUAAUNyZWF0ZWQgYnkgT3BlbkpQRUcgdmVyc2lvbiAyLjUuNP+QAAoAAAAA" +
+  "D2QAAf+Tz6bMFAFarCo3KuNFvKt5jkrcUCKcAP1yEoeeVvkpLcoqxwxlh65hEQQrWvo7OMac2UHQ" +
+  "VGuUEmbtmImGsm0prWrxhCfegVrygeenDNVVBNgOFPtZhHqUywBXzw1jKQR2M8HBzfo45R4tw+Wj" +
+  "Q+Wmw+RyLdz64Ec2cUR9hRrt+g2v3Q58G7rOCw8mNSyB1CPQA9UtuJeW0q06FSOB2UEOiKzqcR5p" +
+  "rdezJ2gNP5fYA0/NnGJW80pjMTVo9Hm+BWmmTPVBIubL/qVLDyV5mK7RUx7yfwg75daitme2Qk2g" +
+  "X36Yedw4n9ICso18I1iFcYGIrypXe1y3YQ7+p4p5z72O4QzQhYFaQ+Cq8fM0W0AttydWZLt8JKQ6" +
+  "epbruTfqRsLsCIIqc4sbap7+mJc3tQI/4u4v/jfSoafslgUCQ3WJz5tRx8u1o+TSoK5f6aNR/F/5" +
+  "nWI3tTnfRc8/65xqCY5PubYJ6K2p+hSgFa3jFub/etR1L0C49tJbqsK2XMMorUd++MoTBqavKlVu" +
+  "XfhIEoW2wUKtWxrya9NIgVN8VcHdQQB4KWn/MQiCq2cnp/Y7aMy/TOtGjKFHx21GCTU8RJDmC9v4" +
+  "yrsKdtOQqYtTotnrmta1j7ZZOoKJavUgJ3T6ICE/ldQNRgS5zkmZ+YlDhv1duZoXfvX7zCvBFAH2" +
+  "OlhYzEHwygVeiW44NRmRdDO2A6S+7HC5/eIRIJJ4T/Ay6kBjrlJqk+kc9a78em/bLc1iwSSrB4tc" +
+  "gDF4Pz+LLSsNJGg0ioBKD6KbG+dUuBb8WsEMEOoWvpmocxIugKDcYreUICyzsyHn+QRNbF1FPF8q" +
+  "atNs+/ei75A6eqRryDWsVZFucJZa4wICILoDGgKwrkWEwuSb/0UjV+xBTb8SY4F0AwRUv5A27nhc" +
+  "MJ1qrzmzONOQKfE2Jy/887wvxgOyiTJnZayGh0F/uDT1roTgUdFVAT/gc6ZgH8G7lKcTnJEEv3AX" +
+  "eDk865Uy+3w8Kq+xHofHBfjFY3Bbty2TvGmFBLhADmvnwbvybNhrnQTuMup5ves91atXkIN6hiIC" +
+  "f1Hr56HMn+tHCSr22OsEp1f3zJdyTS6sqFo0+Ls8FlCdPXp+CbrNtIhub1h0GJuIqdh1NQzWsWTB" +
+  "Y9rHtDHn4+nv5bLn5Oj/clQx+Hs38N+Aw649cuKUQEAhJl1+OAOSLCHBNJJHpCNwN2H1RO76Srp9" +
+  "rgpNo6QCdTADsqUy9+hIzmbKf4v8hB9hb3rHkcLfTVab0HrtHo4lm1Jbeh9aNBzqNMMzpMeq3VVo" +
+  "/LUpbSP1bap1sPaovM5Gc49lDkS1Ud2co6dZlDdGqViF49Kfq2KKq0kfaYtBjqDNajtrU1vAvuzK" +
+  "x/fZfSDCh5CZxV/YTfbSbYaMaTrojTvuKUCF25nBR0chtkOsS3eZYuECjObcT7molOAu5wwy1DpP" +
+  "TzkNjhw5GpwnyTKrA8FiSJSSO3lC+hk8pwLC8L7gO1SlTX7+oe8hZmWSpAjvLztQNee1VbfkaiGq" +
+  "syqMc1ZQsfqT83aXZDJfYRcb7AC44H1J1JlvdAkeP/yr8co8kaA6CqQRlFSIQWJOKFHpAOyhHUrc" +
+  "qF3Mi6hARqRZ91A1yHl3dSixOZVhb2eMP7YB1smjD4PdOWDPnD46DlYMc37gK/Md3eXaerKlMHWc" +
+  "L5d/vIU8rEr/ZYj+ygov4Bq0IcNUa5j0ZSJXdSfZwuDOwNx7MAxVKExhOb2giRkpb8HnmcTancpY" +
+  "ezpAWJwLl3aeB/RD5CXuFfyp/3cSyJcjScvy+Qq1kvUFS3miHY9//3CFmTasBYLHs0b1nDeoKM7d" +
+  "rdZj9guxTKf7bzNtM2oFDLKRg/YIUf9p6N+QMNN/bTjs9HUGMQa6Xh5PBBH5NU+QR3gi+jyOnZB4" +
+  "wQTfIey8qhQ7iuF9vjXGNcgDc9wYbv93GYxP4E7/a1rd2lUE6Au5H/TwPHiHNiMCyEci6Jrkd+Zo" +
+  "HdTj0o0lQ4JDqOUMTnn5JQmF2GaXlQr2YELjaowIWg6KnXNPOxQXQjo+cKNtiHKU2a5/5V1MzOlv" +
+  "tixtE1/EULC71gcYgdhAyFERYQAiJB6ohhbn0hohIHUJLnkkFUJjBhEjyg8nj9sGVLvVLh1nvyIZ" +
+  "zIth+kEslCyPN+Tz5N6T/Is/zP801eO5kvMXrTeJHQr9QlQ/bQ9HmN8I3l6NOhV/sBGWCKNrgRmI" +
+  "O5Kdir1klOo35Bbkgg+dx7X4vcnd+IrrB4UB2krlUCxX0+yPrpYW6rfEwgjr7zFkPwgmf5kWC2XW" +
+  "AsRgqWQ8D/rgHBAOyFU2QHeamR1e1grAZ3sJi0Xyn9ImhszB8EK06ieqofqmjtKUJCNdO7q6UQqi" +
+  "pz5Yj4ckBNiw64Idzt+k/ydxRcf6FijdEI1EyPc/ifGheFfUjQpEtyp1QSEgZATb1x4eAouj/ylZ" +
+  "PNfKdCxzMeItFs9ctNVIl2ixwN1SwBKW2daIbVRT/DcQx+ytjuhx+9e2fLP01x/5/zrLuNr7+Bh1" +
+  "53gWFbSRRDMzwEQzrS1ME68VkQQJMhFrwf30AzeXychwp3EOgBUVe0ecUXIL2ym2qonI9/D3T+Hv" +
+  "j/D0R171172l/h3jjuw3dvFvCFkCww5i6Na06R9NzV2Q9GIQdypgmuqxqeZklkmOzcgsISl9OxH2" +
+  "J8NKst15T8IigShZZ/27lkDzy2+p9wpDnoMN1ANcJURbXaCiP+wHl/5+5O3QGY29j2WIx4tm5rGP" +
+  "gk79IS7Evw00C+xI6FHAi/OKgyNOg0Ce2fM62vev/4HAXEmrAtcH5EeqF9k51kbrP8yQrwLuiukf" +
+  "krmuiKyGPENZDFp0Z5rovPVsAza6EDKTG01Fuf8jAPiqkol+eQ3YKFBKj41oXscfdvSjOfVcq9Ax" +
+  "riwZIXT2kasvgC18CgmjQrucr2Jk8f9xWs74Jimej+S2Z02tSZXSZqyAFBDjY3gCxFctwKuxn+qR" +
+  "kI51muxZqfTW7zIflfV2URPKQTHZU/NTB43AbW+z8vCVPI7JDs/DlsZ1VUYbK7OVn9oqutBdkseT" +
+  "ysRJzZRykt1M2RUl8295x7RKbOrgXxPzOwxrhrw7aXR/ddbHRnWlXe+eB9EHyARSJO+qEOIkDJly" +
+  "B6ekvxeT4ihHxNneMdI3/svUTut3EImdlPdssDeqbfPcNzQ3s+OvHwRN9ptjddJ2J2VS2BENGM0B" +
+  "ccvX5JwSHnwuwpinvPLsOAMA8bRIWDIA23nPWiFdh5WDlaNdWJ2zXf72GWvXWWjZtssqB8c/rhpP" +
+  "y1pNyBZ1CwRBN+ZsWKOTnebpMvRI0EKAZAKgW4zedcam1vPQs9a9xRzbfYOpaHviJVUnUUktgdRl" +
+  "LJg8ZZwxXI2h/i89gjiTfRoh7rz8BhYtlz5Gl2kb2hU/UCRcyuK/BScrUyr7ubtn3S2SfOV8Po94" +
+  "77/RyTc04JFakZsZ1+3aqiXzT5CJdaTZtyDzgkMmYTDXJ5u+Oq6nIm+X4zVzzb60X3/waStc05hw" +
+  "tX+EWiuxY2c7TLl5NbYUc+U5tiu8MgMcVi02jxpqqV7tgWHUpcTAbiXxHaQnS2LShR1rNBuRPGpB" +
+  "oECSbSZSQiMCoFxyPk6d7VBrfeBaJ0k/5IZ0MKitpqCm3BpUYSai0FPro/yYIIXY9G/sdkyZjZNT" +
+  "uWk8gFLT8iS6OCe8OEXQPdkjg5gE2x7YdzZrmHiy520DL0FbkgC7UurGohNvoJCzx/n6o+MKS3Kq" +
+  "/E+YQ02zKDvX33gz8+r8Zu/kQxf1zhsUvqCYgAPd7+r2wlUrkXGXi5k9yzzfIuSjpKE0yzGAfob2" +
+  "zKj4gt4h4wh9gYDFRi1nylb06XPfPDr26bXZBD5E5XySHgbRKge1phO8pFNipIqw4B28UO3qSOXL" +
+  "nk6SmZKczsrMVK9zL5ekkEg49u59s/B7vrXWNQLQ2AFjVsaZ17tRm0q+JzoDNYsBTIFBk4I8kHFi" +
+  "yXbz9iOPxGcwqIGHcIZYvCk3wkNcmnd3cRzwFN0dLcLx0ReII0aS/iKMWq3GYTo43qYcnpaUz4Hi" +
+  "fNo9L+iWudyuVWYGQKdoD83nbhR7QJ0xYTK9glAel4G9wU56L/KP9AFDhgRTOJdy3pWmHeUfYlx9" +
+  "6SgBsGUw1E7P4Stohz1jgrZmKi9M6g9f1+yKt/mqjQtHdZqd0KYuzCrg1ZlEr+UCCkXrCygJkYGK" +
+  "0Pz+dYtusxAKoCDWekrvBW5xK72IsNCunARt1kaEsp325HfrD29wfqj9C1zubyTjSpje9a5hONv7" +
+  "hLf4/KG6D80nl/9j3mk86Pul86B5udT4/LHmp/NP5ewede/OjADo1iuumdXCCnrrcN/ZVLrr7Ryw" +
+  "Whxdrv1jk+/T0fPbsIHzvRP9ZquO3rvSI9QQL9Dq+WaD0FDbpvP/SB37enOqtzB9NBpkRmECObYv" +
+  "P8B3fXBl7fvo5r0dkQc577GAC2tKufjSh/jrT5pPXMcLteLVfpR27IXwgnl+Ut03h/k2zijxwWwa" +
+  "w+ijX8cxjy2x02qZM/DRb9geUsBamKgZ1LjWyuS+4QV6diThy5kQQYmGCFmPztDko6ZvFyh15Pk5" +
+  "tgK7KjqAKIWwJVTQT21L6JqS5fESRPaw83U61+AsjhmZJxY4Ajz3/kCaOTIkp8hYE4OtjK1X/t8O" +
+  "u3FIYSVRh3oupuGbq3UUaCIqbQWB1Ebb9c10hz4d8q4moAIvvdrkZM11b4ffW+UYPEd2tt1bqC0d" +
+  "P/4FGU7eWLlzv9YAOa8da/cSDhTa/YlCw/PMyAq1h31CHWGmPR69QermT2uSVp+T8b3l8pjFmTKf" +
+  "m39v0vtsWmGBAGM+s7eK6ivXpB5ek7YJJ2LtzFvb/JCT5Or00p6clBewNO40nY6W3tXKkaSnB5uf" +
+  "d9dham5pYZhu3uwr5Ejmm4efEAJzMEqf7c8q0aauSUBzeAMMeH15D/xTdm8fYghTMSno6PNVf2p4" +
+  "g8r5r/7yp7LAzyIDiotU9lFfB5SoO/cqHKyJlE+ecW+H6NDHzJlMu5cGZR3jTyZ9V/ZN42KJxmg4" +
+  "6G9wt+EsFqZYLp/PEDoLC84RpjTdeA8e1vNfqlytdffuaKEwvumb704Nng/uKZvCccAkW1PWzj9Q" +
+  "UTdvzWc5wpudxWjKkaclMmgjyTcf4RGpJzwSbbskm5bDnDPAr3hscpPudSJGPAnTQpzaNdW3K/0r" +
+  "wWiAJ85RZmEBZOZjEmoF5XbgcZNIN1VUf9NE0kbl4iaExL0bNMcDTVp6KQ88SmFhCkEGf+JB6x//" +
+  "2Q==";
+
 describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
   describeIf(ALLOW_TEST_SUITE_WEBSITE)("test-site fixtures", () => {
     it(
@@ -606,6 +683,27 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
   );
 
   it(
+    "OCRs a JPEG 2000 URL through the scrape path",
+    async () => {
+      // A JPEG 2000 conformance image from the OpenJPEG test data: exercises
+      // the JP2 signature sniff on a browser handoff served as image/jp2,
+      // the container digitized book scans usually arrive in. Same stable
+      // assertions as the JPEG photo above.
+      const response = await scrape(
+        {
+          url: "https://raw.githubusercontent.com/uclouvain/openjpeg-data/master/input/conformance/file1.jp2",
+          formats: ["markdown"],
+        },
+        identity,
+      );
+
+      expect(response.metadata.contentType).toBe("image/jp2");
+      expect(response.metadata.statusCode).toBe(200);
+    },
+    scrapeTimeout,
+  );
+
+  it(
     "keeps rejecting image formats OCR cannot open",
     async () => {
       const response = await scrapeWithFailure(
@@ -669,6 +767,56 @@ describeIf(SHOULD_RUN)("Image OCR parse upload (fire-pdf dependent)", () => {
 
       expect(result.markdown).toMatch(/firecrawl/i);
       expect(result.metadata.contentType).toBe("image/jpeg");
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "OCRs an uploaded JPEG 2000",
+    async () => {
+      const result = await parse(
+        {
+          options: {
+            formats: ["markdown"],
+          },
+          file: {
+            content: Buffer.from(OCR_FIXTURE_JP2_BASE64, "base64"),
+            filename: "ocr-fixture.jp2",
+            contentType: "image/jp2",
+          },
+        },
+        identity,
+      );
+
+      expect(result.markdown).toMatch(/firecrawl/i);
+      expect(result.metadata.contentType).toBe("image/jp2");
+    },
+    scrapeTimeout,
+  );
+
+  it(
+    "advertises JPEG 2000 among the supported upload types",
+    async () => {
+      // The rejection message lists every accepted extension, so an
+      // unsupported upload is the cheapest way to read the advertised set.
+      const failure = await parseWithFailure(
+        {
+          options: {
+            formats: ["markdown"],
+          },
+          file: {
+            content: Buffer.from("MZ"),
+            filename: "upload.exe",
+            contentType: "application/octet-stream",
+          },
+        },
+        identity,
+      );
+
+      expect(failure.code).toBe("UNSUPPORTED_FILE_TYPE");
+      expect(failure.error).toContain(".jp2");
+      expect(failure.error).toContain(".jpx");
+      expect(failure.error).toContain(".j2k");
     },
     scrapeTimeout,
   );

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -523,10 +523,10 @@ const pdfParserWithOptions = z
   });
 
 /**
- * Raster image OCR (PNG, JPEG, TIFF, GIF, BMP). Like `pdf` it is part of the
- * default list, so a request that says nothing about parsers OCRs image URLs
- * (behind the imageOcr team flag while it rolls out); an explicit list that
- * omits it (`["pdf"]`, `[]`) opts out and keeps the historical
+ * Raster image OCR (PNG, JPEG, JPEG 2000, TIFF, GIF, BMP). Like `pdf` it is
+ * part of the default list, so a request that says nothing about parsers OCRs
+ * image URLs (behind the imageOcr team flag while it rolls out); an explicit
+ * list that omits it (`["pdf"]`, `[]`) opts out and keeps the historical
  * unsupported-file rejection. The object form carries no options yet; it
  * exists so options can be added later without a breaking change.
  */

--- a/apps/api/src/lib/image-formats.test.ts
+++ b/apps/api/src/lib/image-formats.test.ts
@@ -7,6 +7,11 @@ import {
   sniffImageContentTypeFromBase64,
 } from "./image-formats";
 
+// The 12-byte JP2 signature box: length, "jP  ", then the CR LF 0x87 LF check.
+const JP2_SIGNATURE = [
+  0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a,
+];
+
 describe("image-formats", () => {
   it("maps content types to extensions, ignoring parameters and case", () => {
     expect(imageExtensionFromContentType("image/png")).toBe(".png");
@@ -18,6 +23,8 @@ describe("image-formats", () => {
     expect(imageExtensionFromContentType("image/pjpeg")).toBe(".jpg");
     expect(imageExtensionFromContentType("image/x-tiff")).toBe(".tif");
     expect(imageExtensionFromContentType("image/tiff")).toBe(".tif");
+    expect(imageExtensionFromContentType("image/jp2")).toBe(".jp2");
+    expect(imageExtensionFromContentType("image/jpx")).toBe(".jp2");
     expect(imageExtensionFromContentType("image/webp")).toBeNull();
     expect(imageExtensionFromContentType("image/svg+xml")).toBeNull();
     expect(imageExtensionFromContentType(undefined)).toBeNull();
@@ -29,6 +36,9 @@ describe("image-formats", () => {
     expect(imageContentTypeFromExtension(".tiff")).toBe("image/tiff");
     expect(imageContentTypeFromExtension(".tif")).toBe("image/tiff");
     expect(imageContentTypeFromExtension(".png")).toBe("image/png");
+    expect(imageContentTypeFromExtension(".jp2")).toBe("image/jp2");
+    expect(imageContentTypeFromExtension(".JPX")).toBe("image/jp2");
+    expect(imageContentTypeFromExtension(".j2k")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".webp")).toBeNull();
   });
 
@@ -36,6 +46,8 @@ describe("image-formats", () => {
     expect(imageExtensionFromUrlPath("/images/gallery/photo.jpg")).toBe(".jpg");
     expect(imageExtensionFromUrlPath("/assets/scan.png")).toBe(".png");
     expect(imageExtensionFromUrlPath("/scan.TIFF")).toBe(".tiff");
+    expect(imageExtensionFromUrlPath("/scans/page-0001.jp2")).toBe(".jp2");
+    expect(imageExtensionFromUrlPath("/tiles/region.j2k")).toBe(".j2k");
     expect(imageExtensionFromUrlPath("/img.png/viewer")).toBeNull();
     expect(imageExtensionFromUrlPath("/photo.webp")).toBeNull();
     expect(imageExtensionFromUrlPath("/paper.pdf")).toBeNull();
@@ -60,6 +72,24 @@ describe("image-formats", () => {
     expect(sniffImageContentType(Buffer.from("BM\x36\x00"))).toBe("image/bmp");
   });
 
+  it("sniffs JPEG 2000 containers and raw codestreams", () => {
+    // Signature box followed by the file-type box header, as real encoders
+    // write it.
+    const jp2 = Buffer.concat([
+      Buffer.from(JP2_SIGNATURE),
+      Buffer.from("\x00\x00\x00\x14ftyp", "latin1"),
+    ]);
+    expect(sniffImageContentType(jp2)).toBe("image/jp2");
+    // Raw codestream: SOC marker then SIZ marker.
+    expect(
+      sniffImageContentType(Buffer.from([0xff, 0x4f, 0xff, 0x51, 0x00, 0x2f])),
+    ).toBe("image/jp2");
+    // The box length and type alone are not the full signature.
+    expect(
+      sniffImageContentType(Buffer.from(JP2_SIGNATURE.slice(0, 8))),
+    ).toBeNull();
+  });
+
   it("rejects non-image and truncated payloads", () => {
     expect(sniffImageContentType(Buffer.from("<!DOCTYPE html>"))).toBeNull();
     expect(sniffImageContentType(Buffer.from("%PDF-1.7"))).toBeNull();
@@ -80,6 +110,12 @@ describe("image-formats", () => {
       Buffer.alloc(64, 1),
     ]).toString("base64");
     expect(sniffImageContentTypeFromBase64(png)).toBe("image/png");
+    // The JP2 signature is the longest one; the prefix window must cover it.
+    const jp2 = Buffer.concat([
+      Buffer.from(JP2_SIGNATURE),
+      Buffer.alloc(64, 1),
+    ]).toString("base64");
+    expect(sniffImageContentTypeFromBase64(jp2)).toBe("image/jp2");
     expect(
       sniffImageContentTypeFromBase64(Buffer.from("<html>").toString("base64")),
     ).toBeNull();

--- a/apps/api/src/lib/image-formats.test.ts
+++ b/apps/api/src/lib/image-formats.test.ts
@@ -25,6 +25,9 @@ describe("image-formats", () => {
     expect(imageExtensionFromContentType("image/tiff")).toBe(".tif");
     expect(imageExtensionFromContentType("image/jp2")).toBe(".jp2");
     expect(imageExtensionFromContentType("image/jpx")).toBe(".jp2");
+    expect(imageExtensionFromContentType("image/j2k")).toBe(".jp2");
+    expect(imageExtensionFromContentType("image/j2c")).toBe(".jp2");
+    expect(imageExtensionFromContentType("image/x-j2c")).toBe(".jp2");
     expect(imageExtensionFromContentType("image/webp")).toBeNull();
     expect(imageExtensionFromContentType("image/svg+xml")).toBeNull();
     expect(imageExtensionFromContentType(undefined)).toBeNull();
@@ -38,6 +41,7 @@ describe("image-formats", () => {
     expect(imageContentTypeFromExtension(".png")).toBe("image/png");
     expect(imageContentTypeFromExtension(".jp2")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".JPX")).toBe("image/jp2");
+    expect(imageContentTypeFromExtension(".jpf")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".j2k")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".j2c")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".webp")).toBeNull();
@@ -50,6 +54,7 @@ describe("image-formats", () => {
     expect(imageExtensionFromUrlPath("/scans/page-0001.jp2")).toBe(".jp2");
     expect(imageExtensionFromUrlPath("/tiles/region.j2k")).toBe(".j2k");
     expect(imageExtensionFromUrlPath("/tiles/region.j2c")).toBe(".j2c");
+    expect(imageExtensionFromUrlPath("/photos/frame.jpf")).toBe(".jpf");
     expect(imageExtensionFromUrlPath("/img.png/viewer")).toBeNull();
     expect(imageExtensionFromUrlPath("/photo.webp")).toBeNull();
     expect(imageExtensionFromUrlPath("/paper.pdf")).toBeNull();

--- a/apps/api/src/lib/image-formats.test.ts
+++ b/apps/api/src/lib/image-formats.test.ts
@@ -39,6 +39,7 @@ describe("image-formats", () => {
     expect(imageContentTypeFromExtension(".jp2")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".JPX")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".j2k")).toBe("image/jp2");
+    expect(imageContentTypeFromExtension(".j2c")).toBe("image/jp2");
     expect(imageContentTypeFromExtension(".webp")).toBeNull();
   });
 
@@ -48,6 +49,7 @@ describe("image-formats", () => {
     expect(imageExtensionFromUrlPath("/scan.TIFF")).toBe(".tiff");
     expect(imageExtensionFromUrlPath("/scans/page-0001.jp2")).toBe(".jp2");
     expect(imageExtensionFromUrlPath("/tiles/region.j2k")).toBe(".j2k");
+    expect(imageExtensionFromUrlPath("/tiles/region.j2c")).toBe(".j2c");
     expect(imageExtensionFromUrlPath("/img.png/viewer")).toBeNull();
     expect(imageExtensionFromUrlPath("/photo.webp")).toBeNull();
     expect(imageExtensionFromUrlPath("/paper.pdf")).toBeNull();

--- a/apps/api/src/lib/image-formats.ts
+++ b/apps/api/src/lib/image-formats.ts
@@ -20,12 +20,18 @@ const CONTENT_TYPE_TO_EXTENSION = new Map<string, string>([
   // .j2c) share the type: FirePDF opens them the same way.
   ["image/jp2", ".jp2"],
   ["image/jpx", ".jp2"],
+  // Raw codestreams have no registered type; these are the labels servers
+  // use for them.
+  ["image/j2k", ".jp2"],
+  ["image/j2c", ".jp2"],
+  ["image/x-j2c", ".jp2"],
 ]);
 
 const EXTENSION_ALIASES = new Map<string, string>([
   [".jpeg", ".jpg"],
   [".tiff", ".tif"],
   [".jpx", ".jp2"],
+  [".jpf", ".jp2"],
   [".j2k", ".jp2"],
   [".j2c", ".jp2"],
 ]);

--- a/apps/api/src/lib/image-formats.ts
+++ b/apps/api/src/lib/image-formats.ts
@@ -1,8 +1,8 @@
 // Raster image formats the image engine can hand to FirePDF for OCR: the
-// formats FirePDF opens as a one-page image document (PNG, JPEG, TIFF, GIF,
-// BMP). WebP, SVG, AVIF and HEIC are deliberately absent: FirePDF cannot open
-// them, so they keep failing fast as unsupported files instead of burning a
-// round trip.
+// formats FirePDF opens as a one-page image document (PNG, JPEG, JPEG 2000,
+// TIFF, GIF, BMP). WebP, SVG, AVIF and HEIC are deliberately absent: FirePDF
+// cannot open them, so they keep failing fast as unsupported files instead of
+// burning a round trip.
 
 const CONTENT_TYPE_TO_EXTENSION = new Map<string, string>([
   ["image/png", ".png"],
@@ -15,11 +15,18 @@ const CONTENT_TYPE_TO_EXTENSION = new Map<string, string>([
   ["image/gif", ".gif"],
   ["image/bmp", ".bmp"],
   ["image/x-ms-bmp", ".bmp"],
+  // JPEG 2000: the JP2 container digitized book scans and IIIF tile sources
+  // are served in, and its extended JPX sibling. Raw codestreams (.j2k)
+  // share the type: FirePDF opens them the same way.
+  ["image/jp2", ".jp2"],
+  ["image/jpx", ".jp2"],
 ]);
 
 const EXTENSION_ALIASES = new Map<string, string>([
   [".jpeg", ".jpg"],
   [".tiff", ".tif"],
+  [".jpx", ".jp2"],
+  [".j2k", ".jp2"],
 ]);
 
 export const IMAGE_EXTENSIONS = new Set([
@@ -69,6 +76,16 @@ const MAGIC_SIGNATURES: Array<{ contentType: string; bytes: number[] }> = [
   { contentType: "image/tiff", bytes: [0x49, 0x49, 0x2a, 0x00] },
   { contentType: "image/tiff", bytes: [0x4d, 0x4d, 0x00, 0x2a] },
   { contentType: "image/bmp", bytes: [0x42, 0x4d] },
+  // JPEG 2000: the JP2/JPX container's 12-byte signature box, and a raw
+  // codestream (SOC then SIZ marker). FirePDF opens both through the same
+  // loader, so both report the container type.
+  {
+    contentType: "image/jp2",
+    bytes: [
+      0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a,
+    ],
+  },
+  { contentType: "image/jp2", bytes: [0xff, 0x4f, 0xff, 0x51] },
 ];
 
 const SNIFF_WINDOW = Math.max(...MAGIC_SIGNATURES.map(s => s.bytes.length));

--- a/apps/api/src/lib/image-formats.ts
+++ b/apps/api/src/lib/image-formats.ts
@@ -16,8 +16,8 @@ const CONTENT_TYPE_TO_EXTENSION = new Map<string, string>([
   ["image/bmp", ".bmp"],
   ["image/x-ms-bmp", ".bmp"],
   // JPEG 2000: the JP2 container digitized book scans and IIIF tile sources
-  // are served in, and its extended JPX sibling. Raw codestreams (.j2k)
-  // share the type: FirePDF opens them the same way.
+  // are served in, and its extended JPX sibling. Raw codestreams (.j2k,
+  // .j2c) share the type: FirePDF opens them the same way.
   ["image/jp2", ".jp2"],
   ["image/jpx", ".jp2"],
 ]);
@@ -27,6 +27,7 @@ const EXTENSION_ALIASES = new Map<string, string>([
   [".tiff", ".tif"],
   [".jpx", ".jp2"],
   [".j2k", ".jp2"],
+  [".j2c", ".jp2"],
 ]);
 
 export const IMAGE_EXTENSIONS = new Set([

--- a/apps/api/src/scraper/scrapeURL/engines/image/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/image/index.ts
@@ -14,8 +14,8 @@ import {
 /**
  * Raster images are OCR'd as one-page scanned documents through the FirePDF
  * pipeline. FirePDF opens the bytes as a single-page image document
- * (PNG/JPEG/TIFF/GIF/BMP), finds no text layer, and runs the same layout +
- * OCR path a scanned PDF page takes.
+ * (PNG/JPEG/JPEG 2000/TIFF/GIF/BMP), finds no text layer, and runs the same
+ * layout + OCR path a scanned PDF page takes.
  *
  * OCR is on by default and opt-out per request (a `parsers` list without
  * `image`; a parse upload of an image always counts), and rolled out per

--- a/apps/api/src/scraper/scrapeURL/error.ts
+++ b/apps/api/src/scraper/scrapeURL/error.ts
@@ -232,7 +232,7 @@ export class UnsupportedFileError extends TransportableError {
   constructor(public reason: string) {
     super(
       "SCRAPE_UNSUPPORTED_FILE_ERROR",
-      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Raster images (PNG, JPEG, TIFF, GIF, BMP) are OCR'd when the parsers option includes "image" (the default), where image parsing is available. Other binary files like videos, executables, archives, and other image formats are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
+      `The URL returned a file type that Firecrawl cannot process: ${reason}. Firecrawl supports HTML web pages, PDFs, and common document formats. Raster images (PNG, JPEG, JPEG 2000, TIFF, GIF, BMP) are OCR'd when the parsers option includes "image" (the default), where image parsing is available. Other binary files like videos, executables, archives, and other image formats are not supported. If you expected this URL to return a web page, the server may be misconfigured or returning the wrong content type.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Raster image OCR sniffs the bytes it receives to decide whether the OCR backend can open them. JPEG 2000 was missing from that sniff, so `.jp2` files were rejected as unsupported (`cannot process: image/jpeg` when the server labels them as JPEG) even though the backend opens them natively. JPEG 2000 is the format digitized book scans and IIIF tile servers commonly serve.

- Add `image/jp2` (plus the `image/jpx` alias) with the `.jp2`, `.jpx` and `.j2k` extensions to the image format tables.
- Sniff both the 12-byte JP2 signature box and raw codestreams (`FF 4F FF 51`); both report `image/jp2`, since the backend opens them the same way.
- Name JPEG 2000 in the unsupported-file error and the parser docs. The parse upload allowlist derives from the same table, so `.jp2`, `.jpx` and `.j2k` uploads are accepted for teams with image OCR.

## Verification

- The OCR backend's document loader opens JP2 containers and raw codestreams as one-page image documents and renders them identically to the PNG they were encoded from; a live OCR request with each variant returned the fixture text.
- Unit tests cover the new mappings, both signatures, a truncated signature, and the wider base64 sniff window.
- Snips: a JP2 scrape through the browser handoff (an OpenJPEG conformance image served as `image/jp2`), a JP2 parse upload with an inline fixture, and the advertised upload types. Ran locally through the harness with fire-engine and FirePDF available: all three new tests pass, and the unflagged rejection suites plus the parse unsupported-type test still pass. Unit tests, `tsc` and `knip` are green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JPEG 2000 support to raster image OCR so `.jp2`, `.jpx`, `.j2k`, `.j2c`, and `.jpf` files are no longer rejected as unsupported. The OCR backend already opened them; the byte sniff just didn't recognize a format common in digitized book scans and IIIF tile servers.

- Sniffs the 12-byte JP2 container signature and raw codestreams (`FF 4F FF 51`) as `image/jp2`.
- Adds `image/jp2`, `image/jpx`, and the raw-codestream labels (`image/j2k`, `image/j2c`, `image/x-j2c`) to the format tables, and maps the `.jpx`, `.jpf`, `.j2k`, and `.j2c` extensions to `.jp2`, which also expands the parse upload allowlist.
- Updates the unsupported-file error and parser docs to name JPEG 2000.

<sup>Written for commit 6efb42bdd893a615e4e96e090fe7818c71a8df7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

