### PR TITLE
fix(api): return an empty document for images whose OCR finds no text

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-image-ocr.test.ts
@@ -623,6 +623,27 @@ describeIf(SHOULD_RUN)("Image OCR (f-e and fire-pdf dependent)", () => {
     );
 
     it(
+      "returns an empty document for an image without text",
+      async () => {
+        // A 16x16 JPEG 2000 image: the browser hands it to image OCR, which
+        // finds nothing to read. That is a complete, empty result billed like
+        // any other image, not an engine failure that exhausts the waterfall.
+        const response = await scrape(
+          {
+            url: `${TEST_SUITE_WEBSITE}/tiny-image.jp2`,
+            formats: ["markdown"],
+          },
+          identity,
+        );
+
+        expect(response.metadata.contentType).toBe("image/jp2");
+        expect(response.metadata.statusCode).toBe(200);
+        expect((response.markdown ?? "").trim()).toBe("");
+      },
+      scrapeTimeout,
+    );
+
+    it(
       "serves the raw image through the rawBase64 format",
       async () => {
         const response = await scrape(

--- a/apps/api/src/__tests__/snips/v2/scrape-mislabeled-files.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-mislabeled-files.test.ts
@@ -25,8 +25,10 @@ beforeAll(async () => {
 // routes them to a parser by content type — and servers mislabel. Static
 // hosts serve a `.jp2` file as image/jp2 whatever its bytes are, so
 // mislabeled-pdf.jp2 reproduces a PDF served with an image content type,
-// while tiny-image.jp2 is a real JPEG 2000 image. Only fire-engine performs
-// the handoff, hence the gate.
+// while tiny-image.jp2 is a real JPEG 2000 image. This identity has no
+// imageOcr team flag, so the real image must keep the historical rejection
+// (the flagged behaviour lives in scrape-image-ocr.test.ts). Only
+// fire-engine performs the handoff, hence the gate.
 describeIf(!process.env.TEST_SUITE_SELF_HOSTED && ALLOW_TEST_SUITE_WEBSITE)(
   "Mislabeled file handoff (f-e dependent)",
   () => {
@@ -50,7 +52,7 @@ describeIf(!process.env.TEST_SUITE_SELF_HOSTED && ALLOW_TEST_SUITE_WEBSITE)(
     );
 
     it(
-      "keeps rejecting a real JPEG 2000 image as unsupported",
+      "keeps rejecting a real JPEG 2000 image for a team without image OCR",
       async () => {
         const response = await scrapeWithFailure(
           {

--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -735,9 +735,16 @@ async function scrapeURLLoopIter(
       (engineResult.statusCode >= 200 && engineResult.statusCode < 300) ||
       engineResult.statusCode === 304;
     const hasNoPageError = engineResult.error === undefined;
+    // A parsed image is a complete result even when OCR found no text: the
+    // image engine has already verified the bytes and run them through OCR,
+    // so a blank scan or a photo legitimately comes back as an empty document.
+    // Without this it would be "deemed unsuccessful" below and, as the last
+    // engine in its waterfall, surface as an all-engines failure.
+    const isParsedImage =
+      engine === "image" && isGoodStatusCode && hasNoPageError;
     const hasRequiredOutput = hasRawBase64
       ? engineResult.rawBase64 !== undefined
-      : isLongEnough || !isGoodStatusCode;
+      : isParsedImage || isLongEnough || !isGoodStatusCode;
     const isLikelyProxyError = [401, 403, 429].includes(
       engineResult.statusCode,
     );
@@ -765,7 +772,12 @@ async function scrapeURLLoopIter(
     // should we just use all the fallbacks and pick the one with the longest text? - mogery
     if (hasRequiredOutput) {
       meta.logger.info("Scrape via " + engine + " deemed successful.", {
-        factors: { isLongEnough, isGoodStatusCode, hasNoPageError },
+        factors: {
+          isLongEnough,
+          isGoodStatusCode,
+          hasNoPageError,
+          isParsedImage,
+        },
       });
       return engineResult;
     } else {


### PR DESCRIPTION
## Why

An image whose OCR finds no text (a blank scan, a photo, a tiny thumbnail) currently fails the whole scrape. The image engine returns an honest empty document, but the engine success check requires non-empty markdown for a 2xx result, so the result is "deemed unsuccessful", and because the image engine is the last engine in its waterfall the caller gets `SCRAPE_ALL_ENGINES_FAILED` with `Engines tried: [index;documents, image]`. In production this is a steady share of image-OCR failures, and it also bit the JPEG 2000 fixture added in #4502.

## What changes

- `scrapeURL`: a result from the `image` engine with a good status and no page error counts as complete even when the markdown is empty. The image engine has already verified the bytes and run OCR by then, so "no text" is the answer, not a failed engine. Nothing changes for HTML engines, PDFs or documents.
- `scrape-mislabeled-files.test.ts`: the tiny JPEG 2000 test is renamed to say what it actually covers, a team without the image OCR flag still getting the historical rejection. Its identity was never flagged, so the old name ("keeps rejecting a real JPEG 2000 image as unsupported") described the wrong reason once #4501 made JPEG 2000 a supported format.
- `scrape-image-ocr.test.ts`: new snip for the flagged team, the same 16x16 fixture comes back as a 200 with `image/jp2` and empty markdown.

## Behaviour

| Request (team flagged) | Before | After |
| --- | --- | --- |
| image with text | OCR markdown | unchanged |
| image with no text | `SCRAPE_ALL_ENGINES_FAILED` | 200, empty markdown, `contentType` of the image |
| team without the flag | unsupported file | unchanged |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops image OCR failures from failing the whole scrape when an image has no text to read. Blank scans, photos, and tiny thumbnails now return a 200 with empty markdown and the image's content type instead of `SCRAPE_ALL_ENGINES_FAILED`. Behavior for HTML engines, PDFs, documents, and teams without the image OCR flag is unchanged.

<sup>Written for commit 768a31fb6fdd51b6a91a0c27c9046eb8b1ee3891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

