### PR TITLE
Nsc/new agent threads fix

### DIFF
--- a/apps/api/src/controllers/v2/agent-skill.ts
+++ b/apps/api/src/controllers/v2/agent-skill.ts
@@ -1,0 +1,41 @@
+import { Response } from "express";
+import { config } from "../../config";
+import { supabaseGetAgentRequestByIdDirect } from "../../lib/supabase-jobs";
+import { AgentSkillResponse, RequestWithAuth } from "./types";
+
+export async function agentSkillController(
+  req: RequestWithAuth<{ jobId: string }, AgentSkillResponse, any>,
+  res: Response<AgentSkillResponse>,
+) {
+  const agentRequest = await supabaseGetAgentRequestByIdDirect(
+    req.params.jobId,
+  );
+
+  if (!agentRequest || agentRequest.team_id !== req.auth.team_id) {
+    return res.status(404).json({
+      success: false,
+      error: "Agent job not found",
+    });
+  }
+
+  if (!config.EXTRACT_V3_BETA_URL) {
+    throw new Error("Agent beta is not enabled.");
+  }
+
+  const query = req.query.refresh === "1" ? "?refresh=1" : "";
+  const upstream = await fetch(
+    `${config.EXTRACT_V3_BETA_URL}/internal/extracts/${req.params.jobId}/skill${query}`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.AGENT_INTEROP_SECRET}`,
+      },
+    },
+  );
+
+  const body = (await upstream.json()) as AgentSkillResponse;
+
+  // 404 (skills off, or nothing stored) and 409 (run still going, or it
+  // produced no data) both mean "no skill yet" to the caller, so the upstream
+  // status carries through rather than collapsing into a 500.
+  return res.status(upstream.status).json(body);
+}

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1690,6 +1690,28 @@ export type AgentTraceResponse =
       }>;
     };
 
+/**
+ * A finished run distilled into something reusable: a SKILL.md to paste into a
+ * coding agent, and a workflow script that reproduces the run through the API.
+ * The upstream shape is passed through verbatim.
+ */
+export type AgentSkillResponse =
+  | ErrorResponse
+  | {
+      success: true;
+      id: string;
+      skill: {
+        name: string;
+        spec: object;
+        skillMd: string;
+        workflow: string;
+        schema: string;
+      };
+      blueprint: object;
+      generatedAt: string;
+      generated: boolean;
+    };
+
 export type AgentSnapshotResponse =
   | ErrorResponse
   | {

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1003,7 +1003,7 @@ const agentWebhookSchema = createWebhookSchema([
 // per-thread inheritance rules; the gateway only validates the shape.
 const agentExchangeSchema = z.strictObject({
   enabled: z.boolean().optional(),
-  toolkits: z.array(z.string()).max(5).optional(),
+  toolkits: z.array(z.string()).optional(),
   maxCalls: z.number().int().min(1).max(30).optional(),
   requireApproval: z.boolean().optional(),
   approve: z

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -57,6 +57,7 @@ import { agentStatusController } from "../controllers/v2/agent-status";
 import { agentCancelController } from "../controllers/v2/agent-cancel";
 import { agentTraceController } from "../controllers/v2/agent-trace";
 import { agentSnapshotController } from "../controllers/v2/agent-snapshot";
+import { agentSkillController } from "../controllers/v2/agent-skill";
 import { agentThreadController } from "../controllers/v2/agent-thread";
 import {
   browserCreateController,
@@ -412,6 +413,13 @@ v2Router.get(
   authMiddleware(RateLimiterMode.ExtractStatus),
   validateJobIdParam,
   wrap(agentTraceController),
+);
+
+v2Router.get(
+  "/agent/:jobId/skill",
+  authMiddleware(RateLimiterMode.ExtractStatus),
+  validateJobIdParam,
+  wrap(agentSkillController),
 );
 
 v2Router.get(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Agent exchanges no longer reject more than five toolkit names, allowing any number of providers as filters. The API also adds an authenticated `GET /agent/:jobId/skill` route for retrieving a run’s generated skill.

- The route verifies that the job belongs to the caller’s team and forwards `refresh=1` when requested.
- Upstream payloads and statuses pass through, including 404 and 409 responses for runs without an available skill.

<sup>Written for commit c3c2d8e276846f337307f43aeae06bf668d1758f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

