### PR TITLE
fix(billing): read firebill's "I do not know", and stop blaming it for our own stalls

### DIFF
--- a/apps/api/src/services/autumn/__tests__/firebill.test.ts
+++ b/apps/api/src/services/autumn/__tests__/firebill.test.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from "../../../lib/logger";
 import {
   firebillCheckTotal,
+  firebillFailureCauseTotal,
   firebillRetryTotal,
   firebillTrackTotal,
 } from "../metrics";
@@ -66,6 +67,7 @@ beforeEach(() => {
   firebillTrackTotal.reset();
   firebillRetryTotal.reset();
   firebillCheckTotal.reset();
+  firebillFailureCauseTotal.reset();
   vi.mocked(logger.info).mockClear();
   vi.mocked(logger.warn).mockClear();
   vi.mocked(logger.error).mockClear();
@@ -111,20 +113,31 @@ describe("shouldRouteToFirebill", () => {
   });
 });
 
-/** Outcome and cause together, as `outcome/cause`. */
+/**
+ * The outcome counter alone — the one the alerts read, which must keep exactly
+ * the labels it always had.
+ */
 const trackOutcomes = async () =>
   Object.fromEntries(
     (await firebillTrackTotal.get()).values.map(v => [
-      `${v.labels.outcome}/${v.labels.cause}`,
+      v.labels.outcome,
       v.value,
     ]),
   );
 
-/** The same, for the check counter. */
 const checkOutcomes = async () =>
   Object.fromEntries(
     (await firebillCheckTotal.get()).values.map(v => [
-      `${v.labels.outcome}/${v.labels.cause}`,
+      v.labels.outcome,
+      v.value,
+    ]),
+  );
+
+/** The separate cause counter, as `operation/cause`. */
+const failureCauses = async () =>
+  Object.fromEntries(
+    (await firebillFailureCauseTotal.get()).values.map(v => [
+      `${v.labels.operation}/${v.labels.cause}`,
       v.value,
     ]),
   );
@@ -191,13 +204,50 @@ describe("firebillTrack", () => {
       vi.fn().mockImplementation(async () => refused()),
     );
     await firebillTrack(params);
-    expect(await trackOutcomes()).toEqual({ "refused/refused": 1 });
+    expect(await trackOutcomes()).toEqual({ refused: 1 });
+    expect(await failureCauses()).toEqual({ "track/refused": 1 });
 
     firebillTrackTotal.reset();
+    firebillFailureCauseTotal.reset();
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
     await firebillTrack(params);
     // A timeout is not proof the usage was lost — firebill may have taken it.
-    expect(await trackOutcomes()).toEqual({ "ambiguous/connection": 1 });
+    expect(await trackOutcomes()).toEqual({ ambiguous: 1 });
+    expect(await failureCauses()).toEqual({ "track/connection": 1 });
+  });
+
+  // -----------------------------------------------------------------------
+  // The alerts' own series
+  // -----------------------------------------------------------------------
+
+  it("leaves the alerted counters with exactly the labels they had", async () => {
+    // `increase()` evaluates per series, so a `cause` label here would turn
+    // `increase(firecrawl_firebill_track_total{outcome="refused"}[15m]) > 0`
+    // into one threshold per cause. The detail lives beside it instead.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => refused()),
+    );
+    await firebillTrack(params);
+
+    const [series] = (await firebillTrackTotal.get()).values;
+    expect(Object.keys(series.labels).sort()).toEqual(["operation", "outcome"]);
+
+    const [cause] = (await firebillFailureCauseTotal.get()).values;
+    expect(Object.keys(cause.labels).sort()).toEqual(["cause", "operation"]);
+    expect(cause.labels).toMatchObject({
+      operation: "track",
+      cause: "refused",
+    });
+  });
+
+  it("counts a refund's cause under its own operation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => refused()),
+    );
+    await firebillTrack({ ...params, value: -7 });
+    expect(await failureCauses()).toEqual({ "refund/refused": 1 });
   });
 
   // -----------------------------------------------------------------------
@@ -226,19 +276,79 @@ describe("firebillTrack", () => {
     );
 
     await expect(firebillTrack(params)).resolves.toBe(false);
-    expect(await trackOutcomes()).toEqual({ "ambiguous/ambiguous": 1 });
+    expect(await trackOutcomes()).toEqual({ ambiguous: 1 });
+    expect(await failureCauses()).toEqual({ "track/ambiguous": 1 });
   });
 
-  it("still calls a plain success:false a refusal", async () => {
-    // The one outcome that is proof the usage is gone, and the one the alert
-    // means. It must not widen just because a sibling case was added.
+  // **An answer we cannot read is not proof of anything.** firebill may have
+  // taken the event and said so in a shape we did not understand, so calling it
+  // `refused` would log billed usage as lost — the same class of untruth this
+  // PR exists to remove, one layer down.
+  it.each([
+    ["an empty 200", () => new Response("", { status: 200 })],
+    [
+      "a 200 that is not JSON",
+      () => new Response("<html>502</html>", { status: 200 }),
+    ],
+    [
+      "a 200 with no success field",
+      () => new Response(JSON.stringify({ queued: true }), { status: 200 }),
+    ],
+    [
+      "a 200 whose success is not a boolean",
+      () => new Response(JSON.stringify({ success: "yes" }), { status: 200 }),
+    ],
+  ])("reads %s as unusable, not as a refusal", async (_label, respond) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => respond()),
+    );
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(await trackOutcomes()).toEqual({ ambiguous: 1 });
+    expect(await failureCauses()).toEqual({ "track/unusable": 1 });
+    expect(vi.mocked(logger.error).mock.calls.map(c => c[0])).not.toContain(
+      "firebill refused a usage event; it will not be billed",
+    );
+  });
+
+  it("still reads success:false as a refusal", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation(async () => refused()),
     );
 
     await expect(firebillTrack(params)).resolves.toBe(false);
-    expect(await trackOutcomes()).toEqual({ "refused/refused": 1 });
+    expect(await trackOutcomes()).toEqual({ refused: 1 });
+  });
+
+  // A body that never finished arriving is the network failing, not firebill
+  // answering — it has to reach the transport classifier, not be swallowed as
+  // an unusable body.
+  it("treats a body that dies mid-read as a transport failure", async () => {
+    const dying = () => {
+      const response = new Response(JSON.stringify({ success: true }), {
+        status: 200,
+      });
+      vi.spyOn(response, "json").mockRejectedValue(
+        Object.assign(new TypeError("terminated"), {
+          cause: Object.assign(new Error("aborted"), {
+            code: "UND_ERR_BODY_TIMEOUT",
+          }),
+        }),
+      );
+      return response;
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => dying()),
+    );
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(await failureCauses()).toEqual({ "track/timeout": 1 });
+    expect(vi.mocked(logger.warn).mock.calls.map(c => c[0])).toContain(
+      "firebill track request did not complete — client-side timeout or connection error; firebill did not answer",
+    );
   });
 
   it("logs an ambiguous answer as unknown rather than as unbilled usage", async () => {
@@ -287,7 +397,8 @@ describe("firebillTrack", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error()));
 
     await expect(firebillTrack(params)).resolves.toBe(false);
-    expect(await trackOutcomes()).toEqual({ [`ambiguous/${cause}`]: 1 });
+    expect(await trackOutcomes()).toEqual({ ambiguous: 1 });
+    expect(await failureCauses()).toEqual({ [`track/${cause}`]: 1 });
   });
 
   it("stops blaming firebill for a request that never reached it", async () => {
@@ -325,10 +436,15 @@ describe("firebillTrack", () => {
     );
 
     await expect(firebillTrack(params)).resolves.toBe(false);
-    expect(await trackOutcomes()).toEqual({ "ambiguous/non_ok": 1 });
-    expect(vi.mocked(logger.warn).mock.calls.map(c => c[0])).toContain(
-      "firebill answered a non-OK status: 502",
+    expect(await trackOutcomes()).toEqual({ ambiguous: 1 });
+    expect(await failureCauses()).toEqual({ "track/non_ok": 1 });
+    // A static message; the status is context, so log search can group these.
+    const [message, fields] = vi.mocked(logger.warn).mock
+      .calls[0] as unknown as [string, Record<string, unknown>];
+    expect(message).toBe(
+      "firebill track attempt failed — firebill answered a non-OK status",
     );
+    expect(fields).toMatchObject({ status: 502 });
   });
 
   it("retries a thrown error too", async () => {
@@ -465,15 +581,11 @@ describe("firebillCheck", () => {
   });
 
   it.each([
-    [
-      "our own deadline firing",
-      () => wrapped(abortError()),
-      "unavailable/timeout",
-    ],
+    ["our own deadline firing", () => wrapped(abortError()), "check/timeout"],
     [
       "a refused connection",
       () => wrapped(connectionError("ECONNREFUSED")),
-      "unavailable/connection",
+      "check/connection",
     ],
   ])(
     "blames the client, not firebill, for %s",
@@ -483,28 +595,65 @@ describe("firebillCheck", () => {
       await expect(firebillCheck(checkParams)).resolves.toEqual({
         status: "unavailable",
       });
-      expect(await checkOutcomes()).toEqual({ [expected]: 1 });
+      expect(await checkOutcomes()).toEqual({ unavailable: 1 });
+      expect(await failureCauses()).toEqual({ [expected]: 1 });
       expect(vi.mocked(logger.error).mock.calls.map(c => c[0])).toContain(
         "firebill check unavailable — the request did not complete (client-side timeout or connection error); firebill did not answer",
       );
     },
   );
 
-  it("names the status when firebill answered one", async () => {
+  it("names the status in context when firebill answered one", async () => {
     answer({ success: true, allowed: true }, 503);
 
     await firebillCheck(checkParams);
 
-    expect(await checkOutcomes()).toEqual({ "unavailable/non_ok": 1 });
-    expect(vi.mocked(logger.error).mock.calls.map(c => c[0])).toContain(
-      "firebill check unavailable — firebill answered a non-OK status: 503",
+    expect(await checkOutcomes()).toEqual({ unavailable: 1 });
+    expect(await failureCauses()).toEqual({ "check/non_ok": 1 });
+    const [message, fields] = vi.mocked(logger.error).mock
+      .calls[0] as unknown as [string, Record<string, unknown>];
+    expect(message).toBe(
+      "firebill check unavailable — firebill answered a non-OK status",
     );
+    expect(fields).toMatchObject({ status: 503 });
   });
 
-  it("labels a real answer with no cause at all", async () => {
+  it("records no cause at all for a real answer", async () => {
     answer({ success: true, allowed: true, remaining: 500 });
     await firebillCheck(checkParams);
-    expect(await checkOutcomes()).toEqual({ "allowed/none": 1 });
+    expect(await checkOutcomes()).toEqual({ allowed: 1 });
+    expect(await failureCauses()).toEqual({});
+  });
+
+  // `refused` is documented as an explicit `success: false`. An answer we could
+  // not read is not one, and labelling it so would have anyone slicing by cause
+  // counting unreadable answers as declines.
+  it.each([
+    ["a missing allowed", { success: true }, 200],
+    ["a non-boolean allowed", { success: true, allowed: "yes" }, 200],
+  ])("calls %s unusable rather than refused", async (_label, body, status) => {
+    answer(body, status);
+    await firebillCheck(checkParams);
+    expect(await failureCauses()).toEqual({ "check/unusable": 1 });
+  });
+
+  it("calls an unreadable body unusable rather than refused", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response("<html>502</html>", { status: 200 })),
+    );
+    await expect(firebillCheck(checkParams)).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect(await failureCauses()).toEqual({ "check/unusable": 1 });
+  });
+
+  it("keeps refused for an explicit success:false", async () => {
+    answer({ success: false });
+    await firebillCheck(checkParams);
+    expect(await failureCauses()).toEqual({ "check/refused": 1 });
   });
 
   it("does not retry — this is on the request path", async () => {

--- a/apps/api/src/services/autumn/__tests__/firebill.test.ts
+++ b/apps/api/src/services/autumn/__tests__/firebill.test.ts
@@ -4,6 +4,7 @@ import {
   firebillTrack,
   shouldRouteToFirebill,
 } from "../firebill";
+import { logger } from "../../../lib/logger";
 import {
   firebillCheckTotal,
   firebillRetryTotal,
@@ -30,6 +31,23 @@ const ok = () =>
   new Response(JSON.stringify({ success: true }), { status: 200 });
 const refused = () =>
   new Response(JSON.stringify({ success: false }), { status: 200 });
+/** firebill's confirm timed out: it does not know whether it took the event. */
+const ambiguous = () =>
+  new Response(JSON.stringify({ success: false, ambiguous: true }), {
+    status: 504,
+  });
+
+/** What undici actually throws: the real error nested under a bare TypeError. */
+const wrapped = (inner: Error) =>
+  Object.assign(new TypeError("fetch failed"), { cause: inner });
+
+const abortError = () =>
+  Object.assign(new Error("The operation was aborted due to timeout"), {
+    name: "TimeoutError",
+  });
+
+const connectionError = (code: string) =>
+  Object.assign(new Error(`connect ${code} 10.0.0.1:8080`), { code });
 
 const params = {
   customerId: "org-1",
@@ -48,6 +66,9 @@ beforeEach(() => {
   firebillTrackTotal.reset();
   firebillRetryTotal.reset();
   firebillCheckTotal.reset();
+  vi.mocked(logger.info).mockClear();
+  vi.mocked(logger.warn).mockClear();
+  vi.mocked(logger.error).mockClear();
 });
 afterEach(() => vi.unstubAllGlobals());
 
@@ -89,6 +110,24 @@ describe("shouldRouteToFirebill", () => {
     expect(shouldRouteToFirebill("allow-listed-org")).toBe(false);
   });
 });
+
+/** Outcome and cause together, as `outcome/cause`. */
+const trackOutcomes = async () =>
+  Object.fromEntries(
+    (await firebillTrackTotal.get()).values.map(v => [
+      `${v.labels.outcome}/${v.labels.cause}`,
+      v.value,
+    ]),
+  );
+
+/** The same, for the check counter. */
+const checkOutcomes = async () =>
+  Object.fromEntries(
+    (await firebillCheckTotal.get()).values.map(v => [
+      `${v.labels.outcome}/${v.labels.cause}`,
+      v.value,
+    ]),
+  );
 
 describe("firebillTrack", () => {
   it("retries a refusal and reports success if the retry lands", async () => {
@@ -147,26 +186,149 @@ describe("firebillTrack", () => {
   });
 
   it("separates an explicit refusal from an ambiguous transport failure", async () => {
-    const outcomes = async () =>
-      Object.fromEntries(
-        (await firebillTrackTotal.get()).values.map(v => [
-          v.labels.outcome,
-          v.value,
-        ]),
-      );
-
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation(async () => refused()),
     );
     await firebillTrack(params);
-    expect(await outcomes()).toEqual({ refused: 1 });
+    expect(await trackOutcomes()).toEqual({ "refused/refused": 1 });
 
     firebillTrackTotal.reset();
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
     await firebillTrack(params);
     // A timeout is not proof the usage was lost — firebill may have taken it.
-    expect(await outcomes()).toEqual({ ambiguous: 1 });
+    expect(await trackOutcomes()).toEqual({ "ambiguous/connection": 1 });
+  });
+
+  // -----------------------------------------------------------------------
+  // firebill saying "I do not know"
+  //
+  // A publish whose broker confirm timed out may have been taken anyway. Over
+  // eight days ~2,100 of these were answered `{"success": false}` — the same
+  // body a refusal sends — and every one of those events had in fact settled,
+  // while this client logged each as usage that would never be billed.
+  // -----------------------------------------------------------------------
+
+  it.each([
+    ["a 504 carrying the field", () => ambiguous()],
+    ["a 504 with no body at all", () => new Response(null, { status: 504 })],
+    [
+      "a 200 that says so by field",
+      () =>
+        new Response(JSON.stringify({ success: false, ambiguous: true }), {
+          status: 200,
+        }),
+    ],
+  ])("reads %s as ambiguous, never as refused", async (_label, respond) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => respond()),
+    );
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(await trackOutcomes()).toEqual({ "ambiguous/ambiguous": 1 });
+  });
+
+  it("still calls a plain success:false a refusal", async () => {
+    // The one outcome that is proof the usage is gone, and the one the alert
+    // means. It must not widen just because a sibling case was added.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => refused()),
+    );
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(await trackOutcomes()).toEqual({ "refused/refused": 1 });
+  });
+
+  it("logs an ambiguous answer as unknown rather than as unbilled usage", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => ambiguous()),
+    );
+
+    await firebillTrack(params);
+
+    const messages = vi.mocked(logger.error).mock.calls.map(c => c[0]);
+    expect(messages).toContain(
+      "firebill did not answer; the event may or may not have been accepted",
+    );
+    expect(messages).not.toContain(
+      "firebill refused a usage event; it will not be billed",
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Whose failure was it
+  //
+  // ~1,800 warnings per 30h said "firebill may be unavailable" against a
+  // firebill whose server-side p99 was 73ms. They were our own 5s deadline.
+  // -----------------------------------------------------------------------
+
+  it.each([
+    ["our own deadline firing", () => abortError(), "timeout"],
+    ["an undici-wrapped deadline", () => wrapped(abortError()), "timeout"],
+    [
+      "a refused connection",
+      () => wrapped(connectionError("ECONNREFUSED")),
+      "connection",
+    ],
+    [
+      "a reset connection",
+      () => wrapped(connectionError("ECONNRESET")),
+      "connection",
+    ],
+    [
+      "a DNS failure",
+      () => wrapped(connectionError("ENOTFOUND")),
+      "connection",
+    ],
+  ])("labels %s as a client-side %s", async (_label, error, cause) => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error()));
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(await trackOutcomes()).toEqual({ [`ambiguous/${cause}`]: 1 });
+  });
+
+  it("stops blaming firebill for a request that never reached it", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(wrapped(abortError())));
+
+    await firebillTrack(params);
+
+    // The logger's own overloads make `calls` a one-element tuple to TS; every
+    // call site here passes (message, fields).
+    const warnings = vi.mocked(logger.warn).mock.calls as unknown as [
+      string,
+      Record<string, unknown>,
+    ][];
+    const messages = warnings.map(c => c[0]);
+    expect(messages).toContain(
+      "firebill track request did not complete — client-side timeout or connection error; firebill did not answer",
+    );
+    expect(messages.join(" ")).not.toContain("firebill may be unavailable");
+    // The error's own identity, so the class of stall is greppable.
+    // The innermost error's identity, not the `TypeError: fetch failed` undici
+    // wraps it in — so the class of stall is greppable.
+    expect(warnings[0][1]).toMatchObject({
+      cause: "timeout",
+      errorName: "TimeoutError",
+      timeoutMs: 5000,
+    });
+  });
+
+  it("names the status when firebill really did answer", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation(async () => new Response("nope", { status: 502 })),
+    );
+
+    await expect(firebillTrack(params)).resolves.toBe(false);
+    expect(await trackOutcomes()).toEqual({ "ambiguous/non_ok": 1 });
+    expect(vi.mocked(logger.warn).mock.calls.map(c => c[0])).toContain(
+      "firebill answered a non-OK status: 502",
+    );
   });
 
   it("retries a thrown error too", async () => {
@@ -300,6 +462,49 @@ describe("firebillCheck", () => {
       value: 10,
       properties: { source: "checkCreditsMiddleware" },
     });
+  });
+
+  it.each([
+    [
+      "our own deadline firing",
+      () => wrapped(abortError()),
+      "unavailable/timeout",
+    ],
+    [
+      "a refused connection",
+      () => wrapped(connectionError("ECONNREFUSED")),
+      "unavailable/connection",
+    ],
+  ])(
+    "blames the client, not firebill, for %s",
+    async (_label, error, expected) => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error()));
+
+      await expect(firebillCheck(checkParams)).resolves.toEqual({
+        status: "unavailable",
+      });
+      expect(await checkOutcomes()).toEqual({ [expected]: 1 });
+      expect(vi.mocked(logger.error).mock.calls.map(c => c[0])).toContain(
+        "firebill check unavailable — the request did not complete (client-side timeout or connection error); firebill did not answer",
+      );
+    },
+  );
+
+  it("names the status when firebill answered one", async () => {
+    answer({ success: true, allowed: true }, 503);
+
+    await firebillCheck(checkParams);
+
+    expect(await checkOutcomes()).toEqual({ "unavailable/non_ok": 1 });
+    expect(vi.mocked(logger.error).mock.calls.map(c => c[0])).toContain(
+      "firebill check unavailable — firebill answered a non-OK status: 503",
+    );
+  });
+
+  it("labels a real answer with no cause at all", async () => {
+    answer({ success: true, allowed: true, remaining: 500 });
+    await firebillCheck(checkParams);
+    expect(await checkOutcomes()).toEqual({ "allowed/none": 1 });
   });
 
   it("does not retry — this is on the request path", async () => {

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -5,6 +5,7 @@ import { sampled } from "../../lib/rollout";
 import type { LockDeniedReason, TrackParams } from "./types";
 import {
   firebillCheckTotal,
+  firebillFailureCauseTotal,
   firebillRetryTotal,
   firebillTrackTotal,
 } from "./metrics";
@@ -54,14 +55,25 @@ const FIREBILL_RETRY_DELAY_MS = 150;
 
 /**
  * Why a firebill call did not produce a usable answer, at a cardinality safe to
- * put on a counter. **The first two are ours, not firebill's**: the request
- * never completed, so firebill never answered and may never have been reached.
+ * put on a counter. **`timeout` and `connection` are ours, not firebill's**:
+ * the request never completed, so firebill never answered and may never have
+ * been reached.
+ *
+ * - `non_ok` — firebill answered, with a status we cannot use.
+ * - `unusable` — firebill answered, and the answer is not one we can read: an
+ *   empty or malformed body, or a shape missing the field we asked for. **Not a
+ *   refusal**: an event may well have been accepted and said so in a body we
+ *   could not parse.
+ * - `refused` — firebill answered `success: false`. On `/v1/track` that means
+ *   it did not take the event; on `/v1/check` it means it declined to answer.
+ * - `ambiguous` — firebill answered "I do not know" (a 504, or `ambiguous:
+ *   true`): the broker may hold the event already.
  */
 type FirebillCause =
-  | "none"
   | "timeout"
   | "connection"
   | "non_ok"
+  | "unusable"
   | "refused"
   | "ambiguous";
 
@@ -121,19 +133,43 @@ function classifyTransportError(error: unknown): TransportFailure {
 }
 
 /**
- * Read a JSON body without letting a non-JSON one throw, and without leaving
- * the socket pinned: undici holds the connection until the body is consumed, so
- * a firebill that is erroring would otherwise exhaust the pool and turn one
- * failure into a run of them.
+ * A body that arrived and would not parse — as distinct from one that never
+ * finished arriving, which is a transport failure and is thrown.
+ */
+const UNUSABLE_BODY = Symbol("unusable body");
+
+/** Whether a thrown error is, anywhere down its `cause` chain, a parse error. */
+function isSyntaxError(error: unknown): boolean {
+  for (let node: unknown = error, depth = 0; node && depth < 5; depth++) {
+    if (node instanceof SyntaxError) return true;
+    node = (node as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * Read a JSON body, separating "firebill sent something we cannot read" from
+ * "the body never arrived".
+ *
+ * **Only a parse error is caught.** A body that times out or loses its
+ * connection after the headers arrived throws here too, and swallowing it would
+ * report a transport failure as an answer firebill gave — the exact confusion
+ * this file is being changed to remove. Those are re-thrown so
+ * {@link classifyTransportError} sees them.
+ *
+ * Releases the socket either way: undici holds the connection until the body is
+ * consumed, so a firebill that is erroring would otherwise exhaust the pool and
+ * turn one failure into a run of them.
  */
 async function readJson(
   response: Response,
-): Promise<Record<string, unknown> | undefined> {
+): Promise<Record<string, unknown> | typeof UNUSABLE_BODY> {
   try {
     return (await response.json()) as Record<string, unknown>;
-  } catch {
+  } catch (error) {
+    if (!isSyntaxError(error)) throw error;
     response.body?.cancel().catch(() => {});
-    return undefined;
+    return UNUSABLE_BODY;
   }
 }
 
@@ -148,9 +184,9 @@ async function readJson(
  */
 function saysAmbiguous(
   status: number,
-  body: Record<string, unknown> | undefined,
+  body: Record<string, unknown> | typeof UNUSABLE_BODY,
 ): boolean {
-  return body?.ambiguous === true || status === 504;
+  return (body !== UNUSABLE_BODY && body.ambiguous === true) || status === 504;
 }
 
 // FIREBILL_ORG_IDS is decoded once at startup by the config schema; the Set is
@@ -250,7 +286,7 @@ export async function firebillTrack(params: TrackParams): Promise<boolean> {
   for (let attempt = 1; attempt < FIREBILL_ATTEMPTS; attempt++) {
     const result = await firebillAttempt(path, attempted);
     if (result.ok) {
-      firebillTrackTotal.labels(operation, "accepted", "none").inc();
+      firebillTrackTotal.labels(operation, "accepted").inc();
       return true;
     }
     firebillRetryTotal.labels(result.reason).inc();
@@ -259,7 +295,7 @@ export async function firebillTrack(params: TrackParams): Promise<boolean> {
 
   const last = await firebillAttempt(path, attempted);
   if (last.ok) {
-    firebillTrackTotal.labels(operation, "accepted", "none").inc();
+    firebillTrackTotal.labels(operation, "accepted").inc();
     return true;
   }
 
@@ -296,7 +332,11 @@ export async function firebillTrack(params: TrackParams): Promise<boolean> {
       ...(last.errorCode ? { errorCode: last.errorCode } : {}),
     },
   );
-  firebillTrackTotal.labels(operation, outcome, last.cause).inc();
+  firebillTrackTotal.labels(operation, outcome).inc();
+  // Beside the outcome, never inside it: the alerts read `outcome` with
+  // `increase()`, which evaluates per series, so a `cause` label on that counter
+  // would quietly turn one threshold into one threshold per cause.
+  firebillFailureCauseTotal.labels(operation, last.cause).inc();
   return false;
 }
 
@@ -353,20 +393,15 @@ async function firebillAttempt(
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });
 
+    const context = { customerId, entityId, featureId, value, path };
+
     if (!response.ok) {
       const body = await readJson(response);
       if (saysAmbiguous(response.status, body)) {
-        logger.warn(
-          `firebill did not know whether it took the event — answered ${response.status} ambiguous`,
-          {
-            customerId,
-            entityId,
-            featureId,
-            value,
-            path,
-            status: response.status,
-          },
-        );
+        logger.warn("firebill did not know whether it took the event", {
+          ...context,
+          status: response.status,
+        });
         return {
           ok: false,
           reason: "ambiguous",
@@ -374,14 +409,13 @@ async function firebillAttempt(
           status: response.status,
         };
       }
-      logger.warn(`firebill answered a non-OK status: ${response.status}`, {
-        customerId,
-        entityId,
-        featureId,
-        value,
-        path,
-        status: response.status,
-      });
+      logger.warn(
+        "firebill track attempt failed — firebill answered a non-OK status",
+        {
+          ...context,
+          status: response.status,
+        },
+      );
       return {
         ok: false,
         reason: "not_ok",
@@ -390,38 +424,31 @@ async function firebillAttempt(
       };
     }
 
-    const body = (await readJson(response)) as
-      | { success?: boolean; ambiguous?: boolean }
-      | undefined;
+    const body = await readJson(response);
     // Belt and braces: a 200 that still says it does not know is not a refusal.
     if (saysAmbiguous(response.status, body)) {
-      logger.warn("firebill did not know whether it took the event", {
-        customerId,
-        entityId,
-        featureId,
-        value,
-        path,
-      });
+      logger.warn("firebill did not know whether it took the event", context);
       return { ok: false, reason: "ambiguous", cause: "ambiguous" };
     }
-    if (body?.success !== true) {
-      logger.warn("firebill refused the event — it did not take it", {
-        customerId,
-        entityId,
-        featureId,
-        value,
-        path,
-      });
+    // **Only `success: false` is a refusal.** It is the one answer that is proof
+    // the event is gone, and it is what the `refused` alert means. A body we
+    // could not read, or one with no `success` in it, may well be firebill
+    // telling us it took the event in a shape we did not understand — so it is
+    // ambiguous, and the caller retries under the same key rather than logging
+    // usage as lost.
+    if (body !== UNUSABLE_BODY && body.success === false) {
+      logger.warn("firebill refused the event — it did not take it", context);
       return { ok: false, reason: "not_success", cause: "refused" };
     }
+    if (body === UNUSABLE_BODY || body.success !== true) {
+      logger.warn("firebill answered with a body we could not read", {
+        ...context,
+        status: response.status,
+      });
+      return { ok: false, reason: "ambiguous", cause: "unusable" };
+    }
 
-    logger.info("firebill track succeeded", {
-      customerId,
-      entityId,
-      featureId,
-      value,
-      path,
-    });
+    logger.info("firebill track succeeded", context);
     return { ok: true };
   } catch (error) {
     // DO NOT fall back to Autumn directly: firebill may have accepted the event
@@ -495,6 +522,9 @@ export async function firebillCheck({
   value: number;
   properties?: Record<string, unknown>;
 }): Promise<FirebillCheckResult> {
+  // `reason` is always a literal from the call sites below, so the rendered
+  // message stays a closed set that log search can group on; anything variable
+  // goes in `extra`.
   const unavailable = (
     reason: string,
     cause: FirebillCause,
@@ -508,7 +538,8 @@ export async function firebillCheck({
       cause,
       ...extra,
     });
-    firebillCheckTotal.labels("unavailable", cause).inc();
+    firebillCheckTotal.labels("unavailable").inc();
+    firebillFailureCauseTotal.labels("check", cause).inc();
     return { status: "unavailable" };
   };
 
@@ -539,31 +570,40 @@ export async function firebillCheck({
       // skipped.
       const errorBody = await readJson(response);
       return unavailable(
-        `firebill answered a non-OK status: ${response.status}`,
+        "firebill answered a non-OK status",
         saysAmbiguous(response.status, errorBody) ? "ambiguous" : "non_ok",
         { status: response.status },
       );
     }
 
-    const body = (await readJson(response)) as
-      | {
-          success?: boolean;
-          allowed?: boolean;
-          remaining?: number;
-        }
-      | undefined;
+    const answered = await readJson(response);
+    if (answered === UNUSABLE_BODY) {
+      return unavailable("answered with a body we could not read", "unusable", {
+        status: response.status,
+      });
+    }
+    const body = answered as {
+      success?: boolean;
+      allowed?: boolean;
+      remaining?: number;
+    };
 
     // `success: false` is firebill saying it does not know — an unanswered
     // balance, or a gateway lookup that failed. Never a denial.
-    if (body?.success !== true) {
+    if (body.success === false) {
       return unavailable("firebill could not answer", "refused");
+    }
+    // Anything else that is not `success: true` is an answer we cannot read
+    // rather than one firebill gave: `refused` is documented as an explicit
+    // `success: false`, and labelling a shape we did not understand with it
+    // would have anyone slicing by cause counting these as declines.
+    if (body.success !== true) {
+      return unavailable("answered without a usable `success`", "unusable");
     }
     // A missing or mis-shaped `allowed` is not something firebill sends today.
     // Reading it as a denial would 402 a paying customer, so it fails open.
-    // `refused` rather than a label of its own: firebill answered, and the
-    // message is what tells these two apart without widening the label set.
     if (typeof body.allowed !== "boolean") {
-      return unavailable("answered without a usable `allowed`", "refused");
+      return unavailable("answered without a usable `allowed`", "unusable");
     }
 
     // `remaining` clamps downstream limits, and the safe default inverts with
@@ -585,9 +625,7 @@ export async function firebillCheck({
           ? Infinity
           : 0;
 
-    firebillCheckTotal
-      .labels(body.allowed ? "allowed" : "denied", "none")
-      .inc();
+    firebillCheckTotal.labels(body.allowed ? "allowed" : "denied").inc();
     if (!body.allowed) {
       logger.info("firebill check denied", {
         customerId,
@@ -657,23 +695,31 @@ export async function firebillLock({
       ),
     });
 
+    const context = { customerId, entityId, featureId, value, lockId };
+
     if (!response.ok) {
       response.body?.cancel().catch(() => {});
-      logger.error(
-        `firebill lock failed — firebill answered a non-OK status: ${response.status}`,
-        {
-          customerId,
-          entityId,
-          featureId,
-          value,
-          lockId,
-          status: response.status,
-        },
-      );
+      logger.error("firebill lock failed — firebill answered a non-OK status", {
+        ...context,
+        status: response.status,
+      });
+      firebillFailureCauseTotal.labels("lock", "non_ok").inc();
       return { status: "unavailable" };
     }
 
-    const body = (await response.json()) as {
+    const answered = await readJson(response);
+    // An answer we could not parse is firebill answering, not the network
+    // failing — so it must not fall through to the transport catch below and be
+    // reported as a connection error.
+    if (answered === UNUSABLE_BODY) {
+      logger.error("firebill lock answered with a body we could not read", {
+        ...context,
+        status: response.status,
+      });
+      firebillFailureCauseTotal.labels("lock", "unusable").inc();
+      return { status: "unavailable" };
+    }
+    const body = answered as {
       success?: boolean;
       allowed?: boolean;
       lock_id?: string;
@@ -682,13 +728,10 @@ export async function firebillLock({
     };
 
     if (body.success !== true) {
-      logger.error("firebill lock did not succeed", {
-        customerId,
-        entityId,
-        featureId,
-        value,
-        lockId,
-      });
+      logger.error("firebill lock did not succeed", context);
+      firebillFailureCauseTotal
+        .labels("lock", body.success === false ? "refused" : "unusable")
+        .inc();
       return { status: "unavailable" };
     }
 
@@ -710,13 +753,11 @@ export async function firebillLock({
     // treating it as a denial would hard-stop the check (skipped_no_credits),
     // so it maps to unavailable — proceed unlocked — instead.
     if (body.allowed !== true) {
-      logger.error("firebill lock answered without a usable `allowed`", {
-        customerId,
-        entityId,
-        featureId,
-        value,
-        lockId,
-      });
+      logger.error(
+        "firebill lock answered without a usable `allowed`",
+        context,
+      );
+      firebillFailureCauseTotal.labels("lock", "unusable").inc();
       return { status: "unavailable" };
     }
 
@@ -756,6 +797,7 @@ export async function firebillLock({
         error,
       },
     );
+    firebillFailureCauseTotal.labels("lock", failure.cause).inc();
     return { status: "unavailable" };
   }
 }
@@ -833,35 +875,47 @@ export async function firebillFinalize({
       signal: AbortSignal.timeout(FIREBILL_TIMEOUT_MS),
     });
 
+    const context = { lockId, action, overrideValue };
+
     if (!response.ok) {
       const errorBody = await readJson(response);
       // A settle firebill did not know it took is not a settle it refused. The
       // finalize contract is a boolean either way — the schedule is what
       // retries — but the log has to say which happened.
+      const ambiguous = saysAmbiguous(response.status, errorBody);
       logger.error(
-        saysAmbiguous(response.status, errorBody)
-          ? `firebill did not know whether it took the settle — answered ${response.status} ambiguous`
-          : `firebill finalize failed — firebill answered a non-OK status: ${response.status}`,
-        { lockId, action, overrideValue, status: response.status },
+        ambiguous
+          ? "firebill did not know whether it took the settle"
+          : "firebill finalize failed — firebill answered a non-OK status",
+        { ...context, status: response.status },
       );
+      firebillFailureCauseTotal
+        .labels("finalize", ambiguous ? "ambiguous" : "non_ok")
+        .inc();
       return false;
     }
 
-    const body = (await response.json()) as { success?: boolean };
-    if (body.success !== true) {
-      logger.error("firebill finalize did not succeed", {
-        lockId,
-        action,
-        overrideValue,
+    const answered = await readJson(response);
+    // Answered but unreadable, which is not the network failing — the transport
+    // catch below must not claim it was.
+    if (answered === UNUSABLE_BODY) {
+      logger.error("firebill finalize answered with a body we could not read", {
+        ...context,
+        status: response.status,
       });
+      firebillFailureCauseTotal.labels("finalize", "unusable").inc();
+      return false;
+    }
+    const body = answered as { success?: boolean };
+    if (body.success !== true) {
+      logger.error("firebill finalize did not succeed", context);
+      firebillFailureCauseTotal
+        .labels("finalize", body.success === false ? "refused" : "unusable")
+        .inc();
       return false;
     }
 
-    logger.info("firebill finalize succeeded", {
-      lockId,
-      action,
-      overrideValue,
-    });
+    logger.info("firebill finalize succeeded", context);
     return true;
   } catch (error) {
     const failure = classifyTransportError(error);
@@ -876,6 +930,7 @@ export async function firebillFinalize({
         error,
       },
     );
+    firebillFailureCauseTotal.labels("finalize", failure.cause).inc();
     return false;
   }
 }

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -52,6 +52,107 @@ const FIREBILL_GATED_LOCK_TIMEOUT_MS = 10000;
 const FIREBILL_ATTEMPTS = 2;
 const FIREBILL_RETRY_DELAY_MS = 150;
 
+/**
+ * Why a firebill call did not produce a usable answer, at a cardinality safe to
+ * put on a counter. **The first two are ours, not firebill's**: the request
+ * never completed, so firebill never answered and may never have been reached.
+ */
+type FirebillCause =
+  | "none"
+  | "timeout"
+  | "connection"
+  | "non_ok"
+  | "refused"
+  | "ambiguous";
+
+/** What a thrown fetch tells us, once it is unwrapped. */
+type TransportFailure = {
+  cause: "timeout" | "connection";
+  errorName?: string;
+  errorCode?: string;
+};
+
+const TIMEOUT_NAMES = new Set(["AbortError", "TimeoutError"]);
+const TIMEOUT_CODES = new Set([
+  "ABORT_ERR",
+  "UND_ERR_ABORTED",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+/**
+ * Classify a thrown fetch: a deadline we imposed, or a socket/DNS failure.
+ *
+ * Walks `cause`, because undici reports the real error nested inside a bare
+ * `TypeError: fetch failed` — reading only the top level would call every
+ * ECONNREFUSED a generic exception.
+ *
+ * Anything that is not recognisably one of our deadlines is `connection`:
+ * ECONNREFUSED, ECONNRESET, EPIPE, ENOTFOUND, EAI_AGAIN and their kin all mean
+ * the request never got an answer, which is the distinction that matters.
+ */
+function classifyTransportError(error: unknown): TransportFailure {
+  let name: string | undefined;
+  let code: string | undefined;
+  let cause: "timeout" | "connection" = "connection";
+
+  // Innermost wins: the outer frame of a wrapped error is always
+  // `TypeError: fetch failed`, which identifies nothing.
+  for (let node: unknown = error, depth = 0; node && depth < 5; depth++) {
+    const candidate = node as { name?: string; code?: string; cause?: unknown };
+    if (typeof candidate.name === "string") name = candidate.name;
+    if (typeof candidate.code === "string") code = candidate.code;
+    if (
+      (candidate.name && TIMEOUT_NAMES.has(candidate.name)) ||
+      (candidate.code && TIMEOUT_CODES.has(candidate.code))
+    ) {
+      cause = "timeout";
+      break;
+    }
+    node = candidate.cause;
+  }
+
+  return {
+    cause,
+    ...(name ? { errorName: name } : {}),
+    ...(code ? { errorCode: code } : {}),
+  };
+}
+
+/**
+ * Read a JSON body without letting a non-JSON one throw, and without leaving
+ * the socket pinned: undici holds the connection until the body is consumed, so
+ * a firebill that is erroring would otherwise exhaust the pool and turn one
+ * failure into a run of them.
+ */
+async function readJson(
+  response: Response,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch {
+    response.body?.cancel().catch(() => {});
+    return undefined;
+  }
+}
+
+/**
+ * **firebill saying "I do not know".** A publish whose broker confirm timed out
+ * may have been taken anyway, so firebill answers `504` with
+ * `{"success": false, "ambiguous": true}` rather than the `{"success": false}`
+ * it sends when it is certain it took nothing.
+ *
+ * Read by field first and status second: the field is the contract, and the
+ * status is what an older firebill and every proxy in between would give us.
+ */
+function saysAmbiguous(
+  status: number,
+  body: Record<string, unknown> | undefined,
+): boolean {
+  return body?.ambiguous === true || status === 504;
+}
+
 // FIREBILL_ORG_IDS is decoded once at startup by the config schema; the Set is
 // built lazily on first use and cached, keyed on the decoded array reference.
 let allowlistCache: { source: string[] | undefined; ids: Set<string> } | null =
@@ -149,7 +250,7 @@ export async function firebillTrack(params: TrackParams): Promise<boolean> {
   for (let attempt = 1; attempt < FIREBILL_ATTEMPTS; attempt++) {
     const result = await firebillAttempt(path, attempted);
     if (result.ok) {
-      firebillTrackTotal.labels(operation, "accepted").inc();
+      firebillTrackTotal.labels(operation, "accepted", "none").inc();
       return true;
     }
     firebillRetryTotal.labels(result.reason).inc();
@@ -158,16 +259,22 @@ export async function firebillTrack(params: TrackParams): Promise<boolean> {
 
   const last = await firebillAttempt(path, attempted);
   if (last.ok) {
-    firebillTrackTotal.labels(operation, "accepted").inc();
+    firebillTrackTotal.labels(operation, "accepted", "none").inc();
     return true;
   }
 
-  // `refused` only for an explicit `success: false`, which is firebill saying it
-  // did not take the event. A transport failure is `ambiguous`: firebill may
-  // have accepted it and be delivering it right now, so this is not proof of
-  // lost usage. Either way the caller is told false and must not assume a
-  // charge landed. A counter rather than a throw: billing must not fail the
-  // customer's request, and a log alone is too quiet to alert on.
+  // **`refused` only for an explicit `success: false`.** That is firebill
+  // saying it did not take the event, and it is the one case that is proof the
+  // usage is gone — which is what the alert on this label means. Everything
+  // else is `ambiguous`: firebill may have accepted it and be delivering it
+  // right now. A confirm timeout now says so itself (a 504, or `ambiguous:
+  // true`); before that it arrived as a plain `success: false` and was logged
+  // 2,100 times over eight days as usage that would never be billed, all of
+  // which had in fact settled.
+  //
+  // Either way the caller is told false and must not assume a charge landed. A
+  // counter rather than a throw: billing must not fail the customer's request,
+  // and a log alone is too quiet to alert on.
   const outcome = last.reason === "not_success" ? "refused" : "ambiguous";
   logger.error(
     outcome === "refused"
@@ -183,15 +290,31 @@ export async function firebillTrack(params: TrackParams): Promise<boolean> {
       path,
       attempts: FIREBILL_ATTEMPTS,
       reason: last.reason,
+      cause: last.cause,
+      ...(last.status !== undefined ? { status: last.status } : {}),
+      ...(last.errorName ? { errorName: last.errorName } : {}),
+      ...(last.errorCode ? { errorCode: last.errorCode } : {}),
     },
   );
-  firebillTrackTotal.labels(operation, outcome).inc();
+  firebillTrackTotal.labels(operation, outcome, last.cause).inc();
   return false;
 }
 
 type AttemptResult =
   | { ok: true }
-  | { ok: false; reason: "not_ok" | "not_success" | "exception" };
+  | {
+      ok: false;
+      /**
+       * Kept as-is for `firebillRetryTotal`, plus `ambiguous` for the answer
+       * firebill did not used to be able to give.
+       */
+      reason: "not_ok" | "not_success" | "ambiguous" | "exception";
+      /** Who failed. See {@link FirebillCause}. */
+      cause: FirebillCause;
+      status?: number;
+      errorName?: string;
+      errorCode?: string;
+    };
 
 async function firebillAttempt(
   path: string,
@@ -231,7 +354,27 @@ async function firebillAttempt(
     });
 
     if (!response.ok) {
-      logger.warn("firebill track attempt failed — non-OK response", {
+      const body = await readJson(response);
+      if (saysAmbiguous(response.status, body)) {
+        logger.warn(
+          `firebill did not know whether it took the event — answered ${response.status} ambiguous`,
+          {
+            customerId,
+            entityId,
+            featureId,
+            value,
+            path,
+            status: response.status,
+          },
+        );
+        return {
+          ok: false,
+          reason: "ambiguous",
+          cause: "ambiguous",
+          status: response.status,
+        };
+      }
+      logger.warn(`firebill answered a non-OK status: ${response.status}`, {
         customerId,
         entityId,
         featureId,
@@ -239,19 +382,37 @@ async function firebillAttempt(
         path,
         status: response.status,
       });
-      return { ok: false, reason: "not_ok" };
+      return {
+        ok: false,
+        reason: "not_ok",
+        cause: "non_ok",
+        status: response.status,
+      };
     }
 
-    const body = (await response.json()) as { success?: boolean };
-    if (body.success !== true) {
-      logger.warn("firebill track attempt did not succeed", {
+    const body = (await readJson(response)) as
+      | { success?: boolean; ambiguous?: boolean }
+      | undefined;
+    // Belt and braces: a 200 that still says it does not know is not a refusal.
+    if (saysAmbiguous(response.status, body)) {
+      logger.warn("firebill did not know whether it took the event", {
         customerId,
         entityId,
         featureId,
         value,
         path,
       });
-      return { ok: false, reason: "not_success" };
+      return { ok: false, reason: "ambiguous", cause: "ambiguous" };
+    }
+    if (body?.success !== true) {
+      logger.warn("firebill refused the event — it did not take it", {
+        customerId,
+        entityId,
+        featureId,
+        value,
+        path,
+      });
+      return { ok: false, reason: "not_success", cause: "refused" };
     }
 
     logger.info("firebill track succeeded", {
@@ -266,15 +427,24 @@ async function firebillAttempt(
     // DO NOT fall back to Autumn directly: firebill may have accepted the event
     // before this failed, and the Autumn SDK sends no idempotency key, so the
     // pair could not be deduped and the customer would be billed twice.
-    logger.warn("firebill track attempt failed — firebill may be unavailable", {
-      customerId,
-      entityId,
-      featureId,
-      value,
-      path,
-      error,
-    });
-    return { ok: false, reason: "exception" };
+    const failure = classifyTransportError(error);
+    // **Not "firebill may be unavailable".** The request never completed, which
+    // says nothing about firebill: these are almost all our own 5s deadline
+    // firing against a service whose server-side p99 is 73ms.
+    logger.warn(
+      "firebill track request did not complete — client-side timeout or connection error; firebill did not answer",
+      {
+        customerId,
+        entityId,
+        featureId,
+        value,
+        path,
+        timeoutMs: FIREBILL_TIMEOUT_MS,
+        ...failure,
+        error,
+      },
+    );
+    return { ok: false, reason: "exception", ...failure };
   }
 }
 
@@ -327,6 +497,7 @@ export async function firebillCheck({
 }): Promise<FirebillCheckResult> {
   const unavailable = (
     reason: string,
+    cause: FirebillCause,
     extra?: Record<string, unknown>,
   ): FirebillCheckResult => {
     logger.error(`firebill check unavailable — ${reason}`, {
@@ -334,9 +505,10 @@ export async function firebillCheck({
       entityId,
       featureId,
       value,
+      cause,
       ...extra,
     });
-    firebillCheckTotal.labels("unavailable").inc();
+    firebillCheckTotal.labels("unavailable", cause).inc();
     return { status: "unavailable" };
   };
 
@@ -358,31 +530,40 @@ export async function firebillCheck({
     });
 
     if (!response.ok) {
-      // Release the socket. Returning without reading or cancelling leaves the
-      // body unconsumed, and undici keeps the connection pinned until it is —
-      // so a firebill that is erroring would exhaust the pool and turn one
-      // failure into a run of them. Matters most here: this path is the one
-      // that fails open, so the leak would be silently widening the window in
-      // which credit checks are skipped.
-      response.body?.cancel().catch(() => {});
-      return unavailable("non-OK response", { status: response.status });
+      // `readJson` releases the socket whatever the body turns out to be.
+      // Returning without reading or cancelling leaves it unconsumed, and
+      // undici keeps the connection pinned until it is — so a firebill that is
+      // erroring would exhaust the pool and turn one failure into a run of
+      // them. Matters most here: this path is the one that fails open, so the
+      // leak would be silently widening the window in which credit checks are
+      // skipped.
+      const errorBody = await readJson(response);
+      return unavailable(
+        `firebill answered a non-OK status: ${response.status}`,
+        saysAmbiguous(response.status, errorBody) ? "ambiguous" : "non_ok",
+        { status: response.status },
+      );
     }
 
-    const body = (await response.json()) as {
-      success?: boolean;
-      allowed?: boolean;
-      remaining?: number;
-    };
+    const body = (await readJson(response)) as
+      | {
+          success?: boolean;
+          allowed?: boolean;
+          remaining?: number;
+        }
+      | undefined;
 
     // `success: false` is firebill saying it does not know — an unanswered
     // balance, or a gateway lookup that failed. Never a denial.
-    if (body.success !== true) {
-      return unavailable("firebill could not answer");
+    if (body?.success !== true) {
+      return unavailable("firebill could not answer", "refused");
     }
     // A missing or mis-shaped `allowed` is not something firebill sends today.
     // Reading it as a denial would 402 a paying customer, so it fails open.
+    // `refused` rather than a label of its own: firebill answered, and the
+    // message is what tells these two apart without widening the label set.
     if (typeof body.allowed !== "boolean") {
-      return unavailable("answered without a usable `allowed`");
+      return unavailable("answered without a usable `allowed`", "refused");
     }
 
     // `remaining` clamps downstream limits, and the safe default inverts with
@@ -404,7 +585,9 @@ export async function firebillCheck({
           ? Infinity
           : 0;
 
-    firebillCheckTotal.labels(body.allowed ? "allowed" : "denied").inc();
+    firebillCheckTotal
+      .labels(body.allowed ? "allowed" : "denied", "none")
+      .inc();
     if (!body.allowed) {
       logger.info("firebill check denied", {
         customerId,
@@ -416,7 +599,15 @@ export async function firebillCheck({
     }
     return { status: "answered", allowed: body.allowed, remaining };
   } catch (error) {
-    return unavailable("request threw", { error });
+    const failure = classifyTransportError(error);
+    // **Not "firebill is unavailable".** The request never completed, which is
+    // a statement about this process's socket, DNS or deadline — not about
+    // firebill, which never got the chance to answer.
+    return unavailable(
+      "the request did not complete (client-side timeout or connection error); firebill did not answer",
+      failure.cause,
+      { timeoutMs: FIREBILL_TIMEOUT_MS, ...failure, error },
+    );
   }
 }
 
@@ -467,14 +658,18 @@ export async function firebillLock({
     });
 
     if (!response.ok) {
-      logger.error("firebill lock failed — non-OK response", {
-        customerId,
-        entityId,
-        featureId,
-        value,
-        lockId,
-        status: response.status,
-      });
+      response.body?.cancel().catch(() => {});
+      logger.error(
+        `firebill lock failed — firebill answered a non-OK status: ${response.status}`,
+        {
+          customerId,
+          entityId,
+          featureId,
+          value,
+          lockId,
+          status: response.status,
+        },
+      );
       return { status: "unavailable" };
     }
 
@@ -545,14 +740,22 @@ export async function firebillLock({
       ...(operationToken ? { operationToken } : {}),
     };
   } catch (error) {
-    logger.error("firebill lock failed — firebill may be unavailable", {
-      customerId,
-      entityId,
-      featureId,
-      value,
-      lockId,
-      error,
-    });
+    const failure = classifyTransportError(error);
+    logger.error(
+      "firebill lock request did not complete — client-side timeout or connection error; firebill did not answer",
+      {
+        customerId,
+        entityId,
+        featureId,
+        value,
+        lockId,
+        timeoutMs: partnerJobToken
+          ? FIREBILL_GATED_LOCK_TIMEOUT_MS
+          : FIREBILL_TIMEOUT_MS,
+        ...failure,
+        error,
+      },
+    );
     return { status: "unavailable" };
   }
 }
@@ -631,12 +834,16 @@ export async function firebillFinalize({
     });
 
     if (!response.ok) {
-      logger.error("firebill finalize failed — non-OK response", {
-        lockId,
-        action,
-        overrideValue,
-        status: response.status,
-      });
+      const errorBody = await readJson(response);
+      // A settle firebill did not know it took is not a settle it refused. The
+      // finalize contract is a boolean either way — the schedule is what
+      // retries — but the log has to say which happened.
+      logger.error(
+        saysAmbiguous(response.status, errorBody)
+          ? `firebill did not know whether it took the settle — answered ${response.status} ambiguous`
+          : `firebill finalize failed — firebill answered a non-OK status: ${response.status}`,
+        { lockId, action, overrideValue, status: response.status },
+      );
       return false;
     }
 
@@ -657,12 +864,18 @@ export async function firebillFinalize({
     });
     return true;
   } catch (error) {
-    logger.error("firebill finalize failed — firebill may be unavailable", {
-      lockId,
-      action,
-      overrideValue,
-      error,
-    });
+    const failure = classifyTransportError(error);
+    logger.error(
+      "firebill finalize request did not complete — client-side timeout or connection error; firebill did not answer",
+      {
+        lockId,
+        action,
+        overrideValue,
+        timeoutMs: FIREBILL_TIMEOUT_MS,
+        ...failure,
+        error,
+      },
+    );
     return false;
   }
 }

--- a/apps/api/src/services/autumn/metrics.ts
+++ b/apps/api/src/services/autumn/metrics.ts
@@ -13,6 +13,25 @@ export const billingRouteTotal = new Counter({
 });
 
 /**
+ * **Why an outcome happened, at a cardinality you can group by.** `outcome`
+ * says what the caller did; `cause` says who failed, which the outcome alone
+ * could not distinguish:
+ *
+ * - `timeout` / `connection` — the request never completed. **This is a
+ *   client-side or transport failure, not firebill**: firebill never answered,
+ *   and its own server-side p99 may be fine (73ms while ~1,800 of these were
+ *   logged per 30h against a 5s client deadline).
+ * - `non_ok` — firebill answered, with a status we cannot use.
+ * - `refused` — firebill answered `success: false`: it did not take the event.
+ * - `ambiguous` — firebill answered "I do not know" (a 504, or `ambiguous:
+ *   true`): the broker may hold the event already.
+ * - `none` — nothing failed.
+ *
+ * Existing `outcome` values are unchanged, so every alert on them still reads
+ * the same number; `cause` only splits it.
+ */
+
+/**
  * What firebill said. `refused` is an explicit `success: false` — firebill does
  * not own the event and nobody else does, so usage is being dropped.
  * `ambiguous` is a transport failure: firebill may have accepted it before the
@@ -23,7 +42,8 @@ export const firebillTrackTotal = new Counter({
   name: "firecrawl_firebill_track_total",
   help: "Outcomes of usage events sent to firebill",
   // operation: track|refund   outcome: accepted|refused|ambiguous
-  labelNames: ["operation", "outcome"] as const,
+  // cause: none|timeout|connection|non_ok|refused|ambiguous
+  labelNames: ["operation", "outcome", "cause"] as const,
 });
 
 /** Retries of a firebill call that answered `false` or threw. */
@@ -46,5 +66,7 @@ export const firebillRetryTotal = new Counter({
 export const firebillCheckTotal = new Counter({
   name: "firecrawl_firebill_check_total",
   help: "Outcomes of credit checks sent to firebill",
-  labelNames: ["outcome"] as const, // allowed | denied | unavailable
+  // outcome: allowed|denied|unavailable
+  // cause: none|timeout|connection|non_ok|refused|ambiguous
+  labelNames: ["outcome", "cause"] as const,
 });

--- a/apps/api/src/services/autumn/metrics.ts
+++ b/apps/api/src/services/autumn/metrics.ts
@@ -13,25 +13,6 @@ export const billingRouteTotal = new Counter({
 });
 
 /**
- * **Why an outcome happened, at a cardinality you can group by.** `outcome`
- * says what the caller did; `cause` says who failed, which the outcome alone
- * could not distinguish:
- *
- * - `timeout` / `connection` — the request never completed. **This is a
- *   client-side or transport failure, not firebill**: firebill never answered,
- *   and its own server-side p99 may be fine (73ms while ~1,800 of these were
- *   logged per 30h against a 5s client deadline).
- * - `non_ok` — firebill answered, with a status we cannot use.
- * - `refused` — firebill answered `success: false`: it did not take the event.
- * - `ambiguous` — firebill answered "I do not know" (a 504, or `ambiguous:
- *   true`): the broker may hold the event already.
- * - `none` — nothing failed.
- *
- * Existing `outcome` values are unchanged, so every alert on them still reads
- * the same number; `cause` only splits it.
- */
-
-/**
  * What firebill said. `refused` is an explicit `success: false` — firebill does
  * not own the event and nobody else does, so usage is being dropped.
  * `ambiguous` is a transport failure: firebill may have accepted it before the
@@ -42,8 +23,40 @@ export const firebillTrackTotal = new Counter({
   name: "firecrawl_firebill_track_total",
   help: "Outcomes of usage events sent to firebill",
   // operation: track|refund   outcome: accepted|refused|ambiguous
-  // cause: none|timeout|connection|non_ok|refused|ambiguous
-  labelNames: ["operation", "outcome", "cause"] as const,
+  labelNames: ["operation", "outcome"] as const,
+});
+
+/**
+ * **Who failed, when a firebill call did not produce a usable answer.**
+ *
+ * A separate series rather than a `cause` label on the counters above, and that
+ * is the whole point. `increase()` evaluates per series, so
+ * `increase(firecrawl_firebill_check_total{outcome="unavailable"}[15m]) > 5` —
+ * the live `FirebillCheckUnavailable` rule — would silently start comparing 5
+ * against each cause on its own: two causes sitting at 4 apiece would be 8
+ * unanswered credit checks that nobody is paged about. The counters those rules
+ * read stay byte-for-byte what they were; this one adds the detail beside them.
+ *
+ * - `timeout` / `connection` — the request never completed. **A client-side or
+ *   transport failure, not firebill**: it never answered, and its own
+ *   server-side p99 may be fine (73ms, while ~1,800 of these were logged per
+ *   30h against a 5s client deadline).
+ * - `non_ok` — firebill answered, with a status we cannot use.
+ * - `unusable` — firebill answered, and the answer is not one we can read.
+ *   Never proof that anything was lost.
+ * - `refused` — firebill answered `success: false`: on a track it did not take
+ *   the event, on a check it declined to answer.
+ * - `ambiguous` — firebill answered "I do not know" (a 504, or
+ *   `ambiguous: true`).
+ *
+ * Only incremented on failure, so a healthy service produces no series at all.
+ */
+export const firebillFailureCauseTotal = new Counter({
+  name: "firecrawl_firebill_failure_cause_total",
+  help: "Why a firebill call did not produce a usable answer",
+  // operation: track|refund|check|lock|finalize
+  // cause: timeout|connection|non_ok|unusable|refused|ambiguous
+  labelNames: ["operation", "cause"] as const,
 });
 
 /** Retries of a firebill call that answered `false` or threw. */
@@ -66,7 +79,5 @@ export const firebillRetryTotal = new Counter({
 export const firebillCheckTotal = new Counter({
   name: "firecrawl_firebill_check_total",
   help: "Outcomes of credit checks sent to firebill",
-  // outcome: allowed|denied|unavailable
-  // cause: none|timeout|connection|non_ok|refused|ambiguous
-  labelNames: ["outcome", "cause"] as const,
+  labelNames: ["outcome"] as const, // allowed | denied | unavailable
 });


### PR DESCRIPTION
Two logging and metric corrections in `apps/api/src/services/autumn/firebill.ts`.
Both are about *what we say happened*, not about what gets billed. No existing
`outcome` value changes, so `firecrawl_firebill_track_total{outcome="refused"}`
and `firecrawl_firebill_check_total{outcome="unavailable"}` — the two series the
firebill VMRule alerts on — keep counting exactly what they counted before.

## 1. Read firebill's "I do not know" instead of hearing a refusal

firebill now answers a publish whose broker confirm timed out with
**`504 {"success": false, "ambiguous": true}`**, rather than the plain
`{"success": false}` it sends when it is certain it took nothing
(firecrawl/firebill#24).

That distinction matters because this client keys `refused` on `success:false`,
and `refused` means "this usage is gone" — it is what `FirebillEventsRefused`
pages on. Over eight days ~2,100 `/v1/track` calls hit firebill's 1000ms
publisher-confirm timeout; cross-checking `firebill_settle_total` against
`firebill_publish_total{outcome="confirmed"}` showed **every one of those events
had in fact been committed by the broker and settled to Autumn**. We logged
`firebill refused a usage event; it will not be billed` 2,100 times about usage
that was billed. Nothing was double-charged — the retry carried the same
idempotency key and Autumn deduped — this was purely a bad record.

`firebillAttempt` now reads `ambiguous` **by field first and status second**, on
both the non-OK and the 200 path, and maps it to the existing
"may or may not have been accepted" log line. Only a plain `success: false` is
still `refused`.

## 2. Stop blaming firebill for stalls that never left this process

`firebill track attempt failed — firebill may be unavailable` and
`firebill check unavailable — request threw` fire ~1,800 times per 30h. The
attached errors are almost all Node `TimeoutError: The operation was aborted due
to timeout` — **our own `FIREBILL_TIMEOUT_MS = 5000`** — against a firebill whose
server-side p99 is 73ms, plus a few `ECONNREFUSED`/`ECONNRESET`. The message
sends whoever reads it to look at the wrong service.

The track, check, lock and finalize paths now separate:

- **(a) the request never completed** — `AbortError`/`TimeoutError`,
  ECONNREFUSED/ECONNRESET, DNS. Logged as
  `… request did not complete — client-side timeout or connection error;
  firebill did not answer`, with `timeoutMs` and the error's own `name`/`code`.
- **(b) firebill answered with a status we cannot use** — the message names the
  status.

`classifyTransportError` walks `cause`, because undici reports the real error
nested inside a bare `TypeError: fetch failed`; reading only the top level would
call every ECONNREFUSED a generic exception.

## 3. Only `success: false` is a refusal

An empty, malformed, or `success`-less 200 was being counted as `refused` —
logging usage as lost when firebill may well have taken the event and said so in
a shape we could not parse. Those are `ambiguous` now, with cause `unusable`.
The same correction on `/v1/check`, where `refused` was labelling a missing
`allowed`.

And a body that never finished arriving is not an answer at all: `readJson` was
swallowing every throw from `response.json()`, including a body timeout or a
connection lost after the headers, and reporting a transport failure as
something firebill said — the exact confusion this PR exists to remove, one
layer down. Only a parse error is caught now; everything else re-throws to
`classifyTransportError`. Conversely, the lock and finalize paths parsed inside
their broad `try`, so a malformed 200 was logged as a connection failure; both
read through `readJson` and report an unusable answer instead.

Incidentally fixes a socket leak: the track path returned on a non-OK response
without consuming or cancelling the body, which undici keeps the connection
pinned for. `readJson` always releases it.

## The failure-cause counter — and why it is not a label

**`firecrawl_firebill_failure_cause_total{operation, cause}`**, where
`operation` is `track` | `refund` | `check` | `lock` | `finalize` and `cause` is
`timeout` | `connection` | `non_ok` | `unusable` | `refused` | `ambiguous`. It is
incremented beside the existing counters on every failure and never on success,
so a healthy service produces no series at all.

**`firebillTrackTotal` and `firebillCheckTotal` are unchanged — byte-for-byte,
same labels, same values.** An earlier revision of this PR added `cause` to them
directly, which would have broken the live alerts:
`increase()` evaluates **per series**, so
`increase(firecrawl_firebill_check_total{outcome="unavailable"}[15m]) > 5` — the
`FirebillCheckUnavailable` rule in firecrawl-infra — would have started
comparing 5 against each cause on its own. Two causes sitting at 4 apiece is 8
unanswered credit checks that nobody gets paged about, on the alert whose own
description says it is "the only place it shows". `FirebillEventsRefused`
(`> 0`) and `FirebillEventsAmbiguous` (`> 5`) have the same shape.

Keeping the two contracts separate means the alerts keep reading exactly what
they read today, and `sum by (cause) (increase(firecrawl_firebill_failure_cause_total[15m]))`
answers "who failed" without anyone having to touch a rule file. A test asserts
the alerted counters still carry only their original label names.

## Checks

`vitest run src/services/autumn/__tests__/firebill.test.ts` — 51 passed (23 new,
covering the ambiguous shapes, the unusable-body shapes, the transport classes,
a body that dies mid-read, and that a plain `success:false` is still `refused`).
`tsc --noEmit` reports nothing in the files touched.

## Rollout — deploy this AFTER firecrawl/firebill#24

The client must understand 504/`ambiguous` before firebill starts sending it.

**It is safe in either order, though.** An `apps/api` that has not learned about
`ambiguous` reads a 504 as an ordinary non-OK response, which `firebillAttempt`
already routes to `ambiguous` — the same outcome, reached by status rather than
by contract. Nothing regresses if the order slips; the ordering is about the log
line being right from the first event, not about correctness.

Opened as a draft for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the firebill client so firebill's "I do not know" answer (`504`/`ambiguous`) is no longer counted as a refusal, and client-side stalls stop being logged as "firebill may be unavailable."

**Changes**
- Only a plain `success: false` is now `refused`; `ambiguous: true` or 504 is logged as may-or-may-not-have-been-accepted. Previously ~2,100 events over eight days were logged as refused despite settling.
- The track, check, lock, and finalize paths now tell apart a request that never completed (client-side timeout or connection error) from firebill answering an unusable status. The old "firebill may be unavailable" message fired ~1,800 times per 30h against a firebill with a 73ms server-side p99.
- A new `firebillFailureCauseTotal` counter (`operation`, `cause`) records the failure cause beside the existing outcomes; the alert-read counters keep exactly their old labels, so `increase()` rules stay intact.
- An unreadable or malformed answer counts as `ambiguous` with cause `unusable`, never as a refusal; a body that dies mid-read is a transport failure, not something firebill said.
- Fixes a socket leak: non-OK track responses now release the body.

**Rollout**
- Deploy this after `firecrawl/firebill#24`, which makes firebill send the 504/`ambiguous` response. Either order is safe, but this keeps the log line right from the first event.

<sup>Written for commit fc3dd570515a8370ba7692a1ae34f6fd00747952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

