### PR TITLE
fix(api): never serve or store an empty FirePDF result for a raster image

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFCache.test.ts
@@ -611,3 +611,112 @@ describe("FirePDF page-markdown cache capabilities", () => {
     );
   });
 });
+
+describe("FirePDF cache and empty raster-image results", () => {
+  // Base64 of a PNG signature followed by padding: sniffs as image/png.
+  const PNG_BASE64 = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0, 0, 0, 0, 0,
+  ]).toString("base64");
+  // Base64 of "%PDF-1.7": not an image, so the PDF rules apply.
+  const PDF_BASE64 = Buffer.from(
+    "%PDF-1.7\n%\xe2\xe3\xcf\xd3\n",
+    "latin1",
+  ).toString("base64");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCached.mockResolvedValue(null);
+    saveCached.mockResolvedValue(null);
+  });
+
+  it("treats a cached empty result for an image as a miss", async () => {
+    getCached.mockResolvedValue({ markdown: "", html: "" });
+    const meta = makeMeta();
+
+    const result = await tryGetCached(
+      meta,
+      PNG_BASE64,
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toBeNull();
+    expect(meta.logger.info).toHaveBeenCalledWith(
+      "Ignoring cached empty FirePDF result for a raster image",
+      expect.objectContaining({ cacheVariant: "ocr" }),
+    );
+  });
+
+  it("still serves a cached image result that has text", async () => {
+    getCached.mockResolvedValueOnce({
+      markdown: "# Title",
+      html: "<h1>Title</h1>",
+    });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      PNG_BASE64,
+      "ocr",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toMatchObject({ markdown: "# Title" });
+  });
+
+  it("keeps serving cached empty results for PDFs", async () => {
+    getCached.mockResolvedValueOnce({ markdown: "", html: "" });
+
+    const result = await tryGetCached(
+      makeMeta(),
+      PDF_BASE64,
+      "auto",
+      undefined,
+      1,
+      false,
+      false,
+    );
+
+    expect(result).toMatchObject({ markdown: "", html: "" });
+  });
+
+  it("never writes an empty image result, but writes empty PDF and non-empty image results", async () => {
+    const save = (base64Content: string, markdown: string) =>
+      maybeSaveResult({
+        meta: makeMeta(),
+        base64Content,
+        mode: "ocr",
+        maxPages: undefined,
+        includePageMarkdown: false,
+        includeBlocks: false,
+        result: {
+          markdown,
+          html: markdown ? `<p>${markdown}</p>` : "",
+          pagesProcessed: 1,
+        },
+      });
+
+    await save(PNG_BASE64, "");
+    expect(saveCached).not.toHaveBeenCalled();
+
+    await save(PNG_BASE64, "   \n");
+    expect(saveCached).not.toHaveBeenCalled();
+
+    await save(PDF_BASE64, "");
+    expect(saveCached).toHaveBeenCalledTimes(1);
+
+    await save(PNG_BASE64, "text");
+    expect(saveCached).toHaveBeenCalledTimes(2);
+    expect(saveCached).toHaveBeenLastCalledWith(
+      PNG_BASE64,
+      expect.objectContaining({ markdown: "text" }),
+      "firepdf",
+      "ocr",
+    );
+  });
+});

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/cache.ts
@@ -6,7 +6,27 @@ import {
   savePdfResultToCache,
   type PdfCacheKeyInput,
 } from "../../../../../lib/gcs-pdf-cache";
+import { sniffImageContentTypeFromBase64 } from "../../../../../lib/image-formats";
 import { firePdfBlockPagesSchema } from "./schema";
+
+// Raster images ride the same cache as PDFs (the image engine posts their
+// bytes to the same FirePDF endpoint), but an EMPTY result for an image is
+// not worth remembering: it is cheap to recompute, and it usually records a
+// no-text gate decision or a transient failure rather than a property of the
+// bytes. Cached empties outlived a gate change once and kept legible images
+// blank for every later scrape of the same file, so they are neither served
+// nor written for images. PDFs keep their empty results — a blank scan is a
+// real, expensive-to-redo answer there. By-reference payloads (`{ key }`)
+// are always PDFs.
+function isRasterImagePayload(input: PdfCacheKeyInput): boolean {
+  return (
+    typeof input === "string" && sniffImageContentTypeFromBase64(input) !== null
+  );
+}
+
+function isEmptyMarkdown(markdown: string): boolean {
+  return markdown.trim().length === 0;
+}
 
 // Cache layout mirrors the sync `scrapePDFWithFirePDF` so async/sync share
 // entries. `fast` mode bypasses entirely (hard cost ceiling — must fail on
@@ -179,6 +199,23 @@ export async function tryGetCached(
           // never let a malformed/old artifact satisfy a cache lookup.
           continue;
         }
+        if (
+          isEmptyMarkdown(cached.markdown) &&
+          isRasterImagePayload(base64Content)
+        ) {
+          // See isRasterImagePayload: an empty image result is a stale
+          // verdict, not an answer. Re-run OCR and let the fresh result
+          // decide (an empty one is not written back either).
+          meta.logger.info(
+            "Ignoring cached empty FirePDF result for a raster image",
+            {
+              scrapeId: meta.id,
+              requestedMode: mode,
+              cacheVariant: variant ?? "base",
+            },
+          );
+          continue;
+        }
         meta.logger.info("Using cached FirePDF result", {
           scrapeId: meta.id,
           requestedMode: mode,
@@ -233,6 +270,9 @@ export async function maybeSaveResult(args: {
     pageMarkers,
   );
   if (!cacheable) return;
+  // See isRasterImagePayload: never remember an empty result for an image.
+  if (isEmptyMarkdown(result.markdown) && isRasterImagePayload(base64Content))
+    return;
 
   try {
     await savePdfResultToCache(base64Content, result, "firepdf", ownVariant);


### PR DESCRIPTION
## Why

Image OCR results share the FirePDF result cache with PDFs: the cache is keyed by the sha256 of the bytes and has no expiry. When fire-pdf's no-text gate emptied legible banners for a day (fixed in fire-pdf), every one of those images left an empty result in the cache. The gate fix is deployed, but a re-scrape of the same file still returns "Using cached FirePDF result" with empty markdown, billed, and would do so forever. Verified on production: a 760x220 text banner uploaded with fresh bytes OCRs correctly, the identical bytes served from cache come back empty.

An empty result for an image is not worth remembering. It is cheap to recompute, and it usually records a gate decision or a transient failure rather than a property of the bytes. For PDFs an empty result can be a real, expensive-to-redo answer (a blank scan), so their behaviour is unchanged.

## What changes

- `tryGetCached`: a cached result with empty markdown is treated as a miss when the payload sniffs as a raster image (PNG, JPEG, JPEG 2000, TIFF, GIF, BMP, WebP, AVIF), with an info log naming the variant. OCR re-runs and the fresh result decides. Existing poisoned entries self-heal on the next scrape.
- `maybeSaveResult`: an empty image result is never written, so a gate verdict or a transient failure cannot poison the cache again.
- By-reference payloads (`{ key }`) are always PDFs and are untouched; PDFs with empty markdown are still served and stored as before.

## Tests

`firePDFCache.test.ts`: cached empty image result is a miss (and logged), cached image result with text is served, cached empty PDF result is still served, empty image results are not written while empty PDF and non-empty image results are.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the FirePDF cache so empty OCR results for raster images are never served or stored, preventing legible images from staying blank on re-scrapes.

Cached empty image results are now treated as misses and re-OCRed, and empty image results are never written to the cache. PDFs keep their existing behavior—an empty result there can be a real answer (e.g. a blank scan) and is still served and stored. Existing poisoned cache entries self-heal on the next scrape of the same bytes.

- Image payloads are detected by sniffing the base64 content for a raster format (PNG, JPEG, JPEG 2000, TIFF, GIF, BMP, WebP, AVIF).
- By-reference payloads (`{ key }`) are always PDFs and are unaffected.

<sup>Written for commit dfbaff410c92949514355f405cf11dd92543ef27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

