### PR TITLE
feat(api): add indexed highlight object resolver

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -166,6 +166,7 @@ const configSchema = z.object({
   PREVIEW_TOKEN: z.string().optional(),
   SEARCH_PREVIEW_TOKEN: z.string().optional(),
   SEARCH_SERVICE_API_SECRET: z.string().optional(),
+  SEARCH_INDEX_LOOKUP_TOKEN: emptyStringAsUndefined(z.string().trim().min(1)),
   SEARCH_FEEDBACK_MAX_AGE_SEC: z.coerce.number().int().positive().default(120),
   SEARCH_FEEDBACK_DAILY_CAP_CREDITS: z.coerce
     .number()

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,7 @@ import { v2Router } from "./routes/v2";
 import { exchangeRouter } from "./routes/exchange";
 import { labsRouter } from "./routes/labs";
 import { registerMcpActionLogIngestRoute } from "./routes/mcp-action-logs";
+import { registerIndexedHighlightObjectRoute } from "./routes/indexed-highlight-objects";
 import { startMcpActionLogRetentionWorkerIfEnabled } from "./services/mcp/action-logs";
 import { db } from "./db/connection";
 import { nuqShutdown } from "./services/worker/nuq";
@@ -89,6 +90,7 @@ const captureRawBody = (
 };
 
 registerMcpActionLogIngestRoute(app);
+registerIndexedHighlightObjectRoute(app);
 
 app.use(bodyParser.urlencoded({ extended: true, verify: captureRawBody }));
 app.use(bodyParser.json({ limit: "10mb", verify: captureRawBody }));

--- a/apps/api/src/routes/indexed-highlight-objects.test.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.test.ts
@@ -1,0 +1,91 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../config", () => ({
+  config: { SEARCH_INDEX_LOOKUP_TOKEN: "resolver-secret" },
+}));
+vi.mock("../lib/logger", () => ({
+  logger: { info: vi.fn() },
+}));
+vi.mock("../search/highlights", () => ({
+  resolveHighlightIndexObject: vi.fn(),
+}));
+
+import { logger } from "../lib/logger";
+import { resolveHighlightIndexObject } from "../search/highlights";
+import { registerIndexedHighlightObjectRoute } from "./indexed-highlight-objects";
+
+function app() {
+  const server = express();
+  registerIndexedHighlightObjectRoute(server);
+  return server;
+}
+
+const pages = [
+  { id: "0", url: "https://example.com/a" },
+  { id: "1", url: "https://example.com/b" },
+  { id: "2", url: "https://example.com/c" },
+];
+
+afterEach(() => vi.clearAllMocks());
+
+describe("POST /internal/indexed-highlight-objects", () => {
+  it("returns one ordered outcome per URL when siblings hit, miss, and fail", async () => {
+    vi.mocked(resolveHighlightIndexObject)
+      .mockResolvedValueOnce({ name: "018f1234.json", createdAt: null })
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("database unavailable"));
+
+    const response = await request(app())
+      .post("/internal/indexed-highlight-objects")
+      .set("Authorization", "Bearer resolver-secret")
+      .set("X-Request-ID", "request-1")
+      .send({ pages });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      pages: [
+        { ...pages[0], outcome: "hit", indexObject: "018f1234.json" },
+        { ...pages[1], outcome: "miss" },
+        { ...pages[2], outcome: "error" },
+      ],
+    });
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Indexed highlight lookup completed",
+      expect.objectContaining({
+        attempted: 3,
+        hits: 1,
+        misses: 1,
+        errors: 1,
+        requestId: "request-1",
+      }),
+    );
+  });
+
+  it("rejects bad authentication before looking up a URL", async () => {
+    const response = await request(app())
+      .post("/internal/indexed-highlight-objects")
+      .set("Authorization", "Bearer wrong")
+      .send({ pages: pages.slice(0, 1) });
+
+    expect(response.status).toBe(401);
+    expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { pages: [...pages, ...pages, ...pages, ...pages, pages[0]] },
+    { pages: [pages[0], pages[0]] },
+    { pages: [{ id: "12", url: "https://example.com" }] },
+    { pages: [{ id: "0", url: "ftp://example.com/file" }] },
+  ])("rejects an invalid batch", async body => {
+    const response = await request(app())
+      .post("/internal/indexed-highlight-objects")
+      .set("Authorization", "Bearer resolver-secret")
+      .send(body);
+
+    expect(response.status).toBe(400);
+    expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/indexed-highlight-objects.test.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.test.ts
@@ -96,16 +96,31 @@ describe("POST /internal/indexed-highlight-objects", () => {
       .set("Content-Type", "application/json")
       .send('{"pages": [');
     expect(malformed.status).toBe(400);
+    expect(malformed.body).toEqual({ error: "Invalid request body" });
 
+    // A schema-valid batch is at most 12 x 8 KiB, so the body limit is only
+    // reachable with padding. The parser-specific message proves the 400 came
+    // from the body limit and not from the strict schema.
     const oversized = await request(app())
+      .post("/internal/indexed-highlight-objects")
+      .set("Authorization", "Bearer resolver-secret")
+      .send({ pages: pages.slice(0, 1), padding: "a".repeat(129 * 1024) });
+    expect(oversized.status).toBe(400);
+    expect(oversized.body).toEqual({ error: "Invalid request body" });
+    expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects one URL over 8 KiB", async () => {
+    const response = await request(app())
       .post("/internal/indexed-highlight-objects")
       .set("Authorization", "Bearer resolver-secret")
       .send({
         pages: [
-          { id: "0", url: "https://example.com/" + "a".repeat(129 * 1024) },
+          { id: "0", url: "https://example.com/" + "a".repeat(8 * 1024) },
         ],
       });
-    expect(oversized.status).toBe(400);
+
+    expect(response.status).toBe(400);
     expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/indexed-highlight-objects.test.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.test.ts
@@ -89,6 +89,26 @@ describe("POST /internal/indexed-highlight-objects", () => {
     expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed JSON and an oversized body without a lookup", async () => {
+    const malformed = await request(app())
+      .post("/internal/indexed-highlight-objects")
+      .set("Authorization", "Bearer resolver-secret")
+      .set("Content-Type", "application/json")
+      .send('{"pages": [');
+    expect(malformed.status).toBe(400);
+
+    const oversized = await request(app())
+      .post("/internal/indexed-highlight-objects")
+      .set("Authorization", "Bearer resolver-secret")
+      .send({
+        pages: [
+          { id: "0", url: "https://example.com/" + "a".repeat(129 * 1024) },
+        ],
+      });
+    expect(oversized.status).toBe(400);
+    expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
+  });
+
   it.each([
     { pages: [...pages, ...pages, ...pages, ...pages, pages[0]] },
     { pages: [pages[0], pages[0]] },

--- a/apps/api/src/routes/indexed-highlight-objects.test.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.test.ts
@@ -2,9 +2,10 @@ import express from "express";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../config", () => ({
-  config: { SEARCH_INDEX_LOOKUP_TOKEN: "resolver-secret" },
+const mockConfig = vi.hoisted(() => ({
+  SEARCH_INDEX_LOOKUP_TOKEN: "resolver-secret" as string | undefined,
 }));
+vi.mock("../config", () => ({ config: mockConfig }));
 vi.mock("../lib/logger", () => ({
   logger: { info: vi.fn() },
 }));
@@ -28,7 +29,10 @@ const pages = [
   { id: "2", url: "https://example.com/c" },
 ];
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  mockConfig.SEARCH_INDEX_LOOKUP_TOKEN = "resolver-secret";
+});
 
 describe("POST /internal/indexed-highlight-objects", () => {
   it("returns one ordered outcome per URL when siblings hit, miss, and fail", async () => {
@@ -68,6 +72,17 @@ describe("POST /internal/indexed-highlight-objects", () => {
     const response = await request(app())
       .post("/internal/indexed-highlight-objects")
       .set("Authorization", "Bearer wrong")
+      .send({ pages: pages.slice(0, 1) });
+
+    expect(response.status).toBe(401);
+    expect(resolveHighlightIndexObject).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the service token is not configured", async () => {
+    mockConfig.SEARCH_INDEX_LOOKUP_TOKEN = undefined;
+
+    const response = await request(app())
+      .post("/internal/indexed-highlight-objects")
       .send({ pages: pages.slice(0, 1) });
 
     expect(response.status).toBe(401);

--- a/apps/api/src/routes/indexed-highlight-objects.test.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.test.ts
@@ -55,6 +55,10 @@ describe("POST /internal/indexed-highlight-objects", () => {
         { ...pages[2], outcome: "error" },
       ],
     });
+    expect(resolveHighlightIndexObject).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(resolveHighlightIndexObject).mock.calls).toEqual(
+      pages.map(page => [page.url]),
+    );
     expect(logger.info).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith(
       "Indexed highlight lookup completed",

--- a/apps/api/src/routes/indexed-highlight-objects.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.ts
@@ -1,0 +1,138 @@
+import crypto from "node:crypto";
+import express, { Application, NextFunction, Request, Response } from "express";
+import { z } from "zod";
+import { config } from "../config";
+import { logger } from "../lib/logger";
+import { resolveHighlightIndexObject } from "../search/highlights";
+
+const BODY_LIMIT = "128kb";
+const pageSchema = z
+  .object({
+    id: z.string().regex(/^(?:[0-9]|1[01])$/),
+    url: z
+      .string()
+      .refine(value => Buffer.byteLength(value) <= 8 * 1024)
+      .refine(value => {
+        try {
+          return ["http:", "https:"].includes(new URL(value).protocol);
+        } catch {
+          return false;
+        }
+      }),
+  })
+  .strict();
+const requestSchema = z
+  .object({ pages: z.array(pageSchema).min(1).max(12) })
+  .strict()
+  .superRefine(({ pages }, context) => {
+    const ids = new Set<string>();
+    const urls = new Set<string>();
+    for (const [index, page] of pages.entries()) {
+      if (ids.has(page.id)) {
+        context.addIssue({
+          code: "custom",
+          message: "page IDs must be unique",
+          path: ["pages", index, "id"],
+        });
+      }
+      if (urls.has(page.url)) {
+        context.addIssue({
+          code: "custom",
+          message: "page URLs must be unique",
+          path: ["pages", index, "url"],
+        });
+      }
+      ids.add(page.id);
+      urls.add(page.url);
+    }
+  });
+
+function bearerToken(value: string | string[] | undefined) {
+  const header = Array.isArray(value) ? value[0] : value;
+  return header?.startsWith("Bearer ") ? header.slice(7) : null;
+}
+
+function tokenMatches(provided: string | null, expected: string) {
+  if (!provided) return false;
+  const left = Buffer.from(provided);
+  const right = Buffer.from(expected);
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
+function authenticate(req: Request, res: Response, next: NextFunction) {
+  const expected = config.SEARCH_INDEX_LOOKUP_TOKEN;
+  if (
+    !expected ||
+    tokenMatches(bearerToken(req.headers.authorization), expected)
+  ) {
+    next();
+    return;
+  }
+  logger.info("Indexed highlight lookup rejected", {
+    canonicalLog: "internal/indexed-highlight-objects",
+    outcome: "unauthorized",
+    requestId: req.headers["x-request-id"],
+    timeTakenMs: 0,
+  });
+  res.status(401).json({ error: "Unauthorized" });
+}
+
+async function resolve(req: Request, res: Response) {
+  const start = Date.now();
+  const parsed = requestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    logger.info("Indexed highlight lookup rejected", {
+      canonicalLog: "internal/indexed-highlight-objects",
+      outcome: "invalid",
+      requestId: req.headers["x-request-id"],
+      timeTakenMs: Date.now() - start,
+    });
+    res.status(400).json({ error: "Invalid request" });
+    return;
+  }
+
+  const pages = await Promise.all(
+    parsed.data.pages.map(async page => {
+      try {
+        const object = await resolveHighlightIndexObject(page.url);
+        return object
+          ? {
+              id: page.id,
+              url: page.url,
+              outcome: "hit" as const,
+              indexObject: object.name,
+            }
+          : { id: page.id, url: page.url, outcome: "miss" as const };
+      } catch {
+        return { id: page.id, url: page.url, outcome: "error" as const };
+      }
+    }),
+  );
+  const hits = pages.filter(page => page.outcome === "hit").length;
+  const misses = pages.filter(page => page.outcome === "miss").length;
+  const errors = pages.length - hits - misses;
+  logger.info("Indexed highlight lookup completed", {
+    canonicalLog: "internal/indexed-highlight-objects",
+    outcome: "completed",
+    requestId: req.headers["x-request-id"],
+    attempted: pages.length,
+    hits,
+    misses,
+    errors,
+    timeTakenMs: Date.now() - start,
+  });
+  res.json({ pages });
+}
+
+export function registerIndexedHighlightObjectRoute(
+  app: Pick<Application, "post">,
+) {
+  app.post(
+    "/internal/indexed-highlight-objects",
+    authenticate,
+    express.json({ limit: BODY_LIMIT, type: () => true }),
+    (req, res, next) => {
+      resolve(req, res).catch(next);
+    },
+  );
+}

--- a/apps/api/src/routes/indexed-highlight-objects.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.ts
@@ -77,23 +77,30 @@ function authenticate(req: Request, res: Response, next: NextFunction) {
   res.status(401).json({ error: "Unauthorized" });
 }
 
-function rejectInvalid(req: Request, res: Response, start: number) {
+function rejectInvalid(
+  req: Request,
+  res: Response,
+  start: number,
+  error: "Invalid request body" | "Invalid request",
+) {
   logger.info("Indexed highlight lookup rejected", {
     canonicalLog: "internal/indexed-highlight-objects",
     outcome: "invalid",
     requestId: req.headers["x-request-id"],
     timeTakenMs: Date.now() - start,
   });
-  res.status(400).json({ error: "Invalid request" });
+  res.status(400).json({ error });
 }
 
 // Malformed JSON and bodies over BODY_LIMIT are the caller's fault. Answer
 // them here so they never reach the app-wide error handler or Sentry.
+const jsonBody = express.json({ limit: BODY_LIMIT, type: () => true });
+
 function parseBody(req: Request, res: Response, next: NextFunction) {
   const start = Date.now();
-  express.json({ limit: BODY_LIMIT, type: () => true })(req, res, error => {
+  jsonBody(req, res, error => {
     if (error) {
-      rejectInvalid(req, res, start);
+      rejectInvalid(req, res, start, "Invalid request body");
       return;
     }
     next();
@@ -104,7 +111,7 @@ async function resolve(req: Request, res: Response) {
   const start = Date.now();
   const parsed = requestSchema.safeParse(req.body);
   if (!parsed.success) {
-    rejectInvalid(req, res, start);
+    rejectInvalid(req, res, start, "Invalid request");
     return;
   }
 

--- a/apps/api/src/routes/indexed-highlight-objects.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.ts
@@ -77,17 +77,34 @@ function authenticate(req: Request, res: Response, next: NextFunction) {
   res.status(401).json({ error: "Unauthorized" });
 }
 
+function rejectInvalid(req: Request, res: Response, start: number) {
+  logger.info("Indexed highlight lookup rejected", {
+    canonicalLog: "internal/indexed-highlight-objects",
+    outcome: "invalid",
+    requestId: req.headers["x-request-id"],
+    timeTakenMs: Date.now() - start,
+  });
+  res.status(400).json({ error: "Invalid request" });
+}
+
+// Malformed JSON and bodies over BODY_LIMIT are the caller's fault. Answer
+// them here so they never reach the app-wide error handler or Sentry.
+function parseBody(req: Request, res: Response, next: NextFunction) {
+  const start = Date.now();
+  express.json({ limit: BODY_LIMIT, type: () => true })(req, res, error => {
+    if (error) {
+      rejectInvalid(req, res, start);
+      return;
+    }
+    next();
+  });
+}
+
 async function resolve(req: Request, res: Response) {
   const start = Date.now();
   const parsed = requestSchema.safeParse(req.body);
   if (!parsed.success) {
-    logger.info("Indexed highlight lookup rejected", {
-      canonicalLog: "internal/indexed-highlight-objects",
-      outcome: "invalid",
-      requestId: req.headers["x-request-id"],
-      timeTakenMs: Date.now() - start,
-    });
-    res.status(400).json({ error: "Invalid request" });
+    rejectInvalid(req, res, start);
     return;
   }
 
@@ -130,7 +147,7 @@ export function registerIndexedHighlightObjectRoute(
   app.post(
     "/internal/indexed-highlight-objects",
     authenticate,
-    express.json({ limit: BODY_LIMIT, type: () => true }),
+    parseBody,
     (req, res, next) => {
       resolve(req, res).catch(next);
     },

--- a/apps/api/src/routes/indexed-highlight-objects.ts
+++ b/apps/api/src/routes/indexed-highlight-objects.ts
@@ -62,7 +62,7 @@ function tokenMatches(provided: string | null, expected: string) {
 function authenticate(req: Request, res: Response, next: NextFunction) {
   const expected = config.SEARCH_INDEX_LOOKUP_TOKEN;
   if (
-    !expected ||
+    expected &&
     tokenMatches(bearerToken(req.headers.authorization), expected)
   ) {
     next();

--- a/apps/api/src/search/__fixtures__/indexed-highlight-lookup/normalized-url-hashes.json
+++ b/apps/api/src/search/__fixtures__/indexed-highlight-lookup/normalized-url-hashes.json
@@ -1,0 +1,110 @@
+[
+  {
+    "name": "scheme",
+    "url": "http://example.com/docs",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "www",
+    "url": "https://www.example.com/docs",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "default port 443",
+    "url": "https://example.com:443/docs",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "default port 80",
+    "url": "http://example.com:80/docs",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "non-default port kept",
+    "url": "https://example.com:8443/docs",
+    "normalized": "https://example.com:8443/docs",
+    "sha256": "4f398aba8448a77354205e434a646b3abb21fa58ef9805ca2c11fe68095c4cc0"
+  },
+  {
+    "name": "terminal index.html",
+    "url": "https://example.com/docs/index.html",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "terminal index.php",
+    "url": "https://example.com/docs/index.php",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "terminal index.htm",
+    "url": "https://example.com/docs/index.htm",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "terminal index.shtml",
+    "url": "https://example.com/docs/index.shtml",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "terminal index.xml",
+    "url": "https://example.com/docs/index.xml",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "trailing slash",
+    "url": "https://example.com/docs/",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "root",
+    "url": "https://example.com/",
+    "normalized": "https://example.com/",
+    "sha256": "0f115db062b7c0dd030b16878c99dea5c354b49dc37b38eb8846179c7783e9d7"
+  },
+  {
+    "name": "ordinary fragment",
+    "url": "https://example.com/docs#section-2",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "short hash-router fragment",
+    "url": "https://example.com/docs#/",
+    "normalized": "https://example.com/docs",
+    "sha256": "de106e607d0e711199de3fb7eb98fe5d412ee49ac326eadd3db848ee272ad2cb"
+  },
+  {
+    "name": "hash-router fragment",
+    "url": "https://example.com/app#/settings/profile",
+    "normalized": "https://example.com/app#/settings/profile",
+    "sha256": "d0c7a556841c649a87ee45a439d90db90ae9e5c9b84684405b459e5f029bfa7e"
+  },
+  {
+    "name": "hash-bang fragment",
+    "url": "https://example.com/app#!/settings",
+    "normalized": "https://example.com/app#!/settings",
+    "sha256": "ccb5872f48e1ce7501d8a7dc2281ef653f95e1708c80e66b6a216319c2660f80"
+  },
+  {
+    "name": "query kept",
+    "url": "https://example.com/search?q=cancer+drug&page=2",
+    "normalized": "https://example.com/search?q=cancer+drug&page=2",
+    "sha256": "35be3ec952a4ab2ba41ef0624ec632b87d148f70258da2875c613f473c97a7d8"
+  },
+  {
+    "name": "combined",
+    "url": "http://www.example.com:80/guide/index.html?lang=en#top",
+    "normalized": "https://example.com/guide?lang=en",
+    "sha256": "13c4c849744b60fe7521d671d302207ba7dcf72e3886c56f31439ff806b92568"
+  }
+]

--- a/apps/api/src/search/highlights.test.ts
+++ b/apps/api/src/search/highlights.test.ts
@@ -36,11 +36,15 @@ vi.mock("./highlight-model", () => ({
 
 import { generateHighlightsIndexedBatch } from "./highlight-model";
 import { config } from "../config";
+import { indexGetRecent5 } from "../db/rpc";
+import { hashURL, normalizeURLForIndex } from "../services";
 import { logger as rootLogger } from "../lib/logger";
 import {
   highlightsEnvReady,
+  resolveHighlightIndexObject,
   runIndexedSearchHighlights,
   searchHighlightsMode,
+  selectHighlightIndexRow,
 } from "./highlights";
 
 const logger = {
@@ -55,6 +59,47 @@ const logger = {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe("indexed highlight lookup", () => {
+  it("uses the exact recent desktop index variant", async () => {
+    await resolveHighlightIndexObject("http://www.example.com/index.html");
+
+    expect(normalizeURLForIndex).toHaveBeenCalledWith(
+      "http://www.example.com/index.html",
+    );
+    expect(hashURL).toHaveBeenCalledWith("http://www.example.com/index.html");
+    expect(indexGetRecent5).toHaveBeenCalledWith({
+      url_hash: "http://www.example.com/index.html",
+      max_age_ms: 2_592_000_000,
+      is_mobile: false,
+      block_ads: true,
+      feature_screenshot: false,
+      feature_screenshot_fullscreen: false,
+      location_country: null,
+      location_languages: null,
+      wait_time_ms: 0,
+      is_stealth: false,
+      min_age_ms: null,
+    });
+  });
+
+  it.each([
+    { successIndex: 0, selected: "ok" },
+    { successIndex: 1, selected: "ok" },
+    { successIndex: 2, selected: "ok" },
+    { successIndex: 3, selected: "error-0" },
+  ])(
+    "selects the expected row when the newest 2xx is at $successIndex",
+    ({ successIndex, selected }) => {
+      const rows = [0, 1, 2, 3].map(index => ({
+        id: index === successIndex ? "ok" : `error-${index}`,
+        status: index === successIndex ? 200 : 500,
+        created_at: null,
+      })) as any;
+      expect(selectHighlightIndexRow(rows)?.id).toBe(selected);
+    },
+  );
 });
 
 describe("runIndexedSearchHighlights", () => {

--- a/apps/api/src/search/highlights.test.ts
+++ b/apps/api/src/search/highlights.test.ts
@@ -63,8 +63,14 @@ afterEach(() => {
 
 describe("indexed highlight lookup", () => {
   it("uses the exact recent desktop index variant", async () => {
-    await resolveHighlightIndexObject("http://www.example.com/index.html");
+    const resolved = await resolveHighlightIndexObject(
+      "http://www.example.com/index.html",
+    );
 
+    expect(resolved).toEqual({
+      name: "index:http://www.example.com/index.html.json",
+      createdAt: new Date("2026-07-11T00:00:00Z"),
+    });
     expect(normalizeURLForIndex).toHaveBeenCalledWith(
       "http://www.example.com/index.html",
     );
@@ -82,6 +88,24 @@ describe("indexed highlight lookup", () => {
       is_stealth: false,
       min_age_ms: null,
     });
+  });
+
+  it("misses when the index has no recent row", async () => {
+    vi.mocked(indexGetRecent5).mockResolvedValueOnce([]);
+
+    await expect(
+      resolveHighlightIndexObject("https://example.com/missing"),
+    ).resolves.toBeNull();
+  });
+
+  it("selects nothing from no rows and the newest row when no row is 2xx", () => {
+    expect(selectHighlightIndexRow([])).toBeNull();
+    const errors = [0, 1, 2].map(index => ({
+      id: `error-${index}`,
+      status: 500 + index,
+      created_at: null,
+    })) as any;
+    expect(selectHighlightIndexRow(errors)?.id).toBe("error-0");
   });
 
   it.each([

--- a/apps/api/src/search/highlights.ts
+++ b/apps/api/src/search/highlights.ts
@@ -54,51 +54,52 @@ export function searchHighlightsMode(options: {
 // this many more-recent error entries, in which case we surface the newest one.
 const ERROR_COUNT_TO_REGISTER = 3;
 
+type RecentIndexRow = NonNullable<
+  Awaited<ReturnType<typeof indexGetRecent5>>
+>[number];
+
+export function selectHighlightIndexRow(
+  rows: RecentIndexRow[],
+): RecentIndexRow | null {
+  if (rows.length === 0) return null;
+  const newest200Index = rows.findIndex(x => x.status >= 200 && x.status < 300);
+  return newest200Index >= ERROR_COUNT_TO_REGISTER || newest200Index === -1
+    ? rows[0]
+    : rows[newest200Index];
+}
+
+export async function resolveHighlightIndexObject(
+  url: string,
+): Promise<{ name: string; createdAt: string | null } | null> {
+  if (!useIndex) return null;
+  const normalizedURL = normalizeURLForIndex(url);
+  const urlHash = hashURL(normalizedURL);
+  const rows = await indexGetRecent5({
+    url_hash: urlHash,
+    max_age_ms: HIGHLIGHTS_INDEX_MAX_AGE_MS,
+    is_mobile: false,
+    block_ads: true,
+    feature_screenshot: false,
+    feature_screenshot_fullscreen: false,
+    location_country: null,
+    location_languages: null,
+    wait_time_ms: 0,
+    is_stealth: false,
+    min_age_ms: null,
+  });
+  const selected = selectHighlightIndexRow(rows ?? []);
+  return selected
+    ? { name: selected.id + ".json", createdAt: selected.created_at }
+    : null;
+}
+
 async function getIndexObjectForURL(
   url: string,
   logger: Logger,
   logUrl = true,
 ): Promise<{ name: string; createdAt: string | null } | null> {
-  if (!useIndex) {
-    return null;
-  }
-
   try {
-    const normalizedURL = normalizeURLForIndex(url);
-    const urlHash = hashURL(normalizedURL);
-
-    // Match the most common index variant (default scrape options) to maximize
-    // hit rate: desktop, ads blocked, no screenshot, no location, no stealth.
-    const rows = await indexGetRecent5({
-      url_hash: urlHash,
-      max_age_ms: HIGHLIGHTS_INDEX_MAX_AGE_MS,
-      is_mobile: false,
-      block_ads: true,
-      feature_screenshot: false,
-      feature_screenshot_fullscreen: false,
-      location_country: null,
-      location_languages: null,
-      wait_time_ms: 0,
-      is_stealth: false,
-      min_age_ms: null,
-    });
-
-    if (!rows || rows.length === 0) {
-      return null;
-    }
-
-    const newest200Index = rows.findIndex(
-      x => x.status >= 200 && x.status < 300,
-    );
-    const selected =
-      newest200Index >= ERROR_COUNT_TO_REGISTER || newest200Index === -1
-        ? rows[0]
-        : rows[newest200Index];
-
-    return {
-      name: selected.id + ".json",
-      createdAt: selected.created_at,
-    };
+    return await resolveHighlightIndexObject(url);
   } catch (error) {
     logger.warn("highlights: index lookup failed", {
       error: error instanceof Error ? error.message : String(error),

--- a/apps/api/src/services/index.test.ts
+++ b/apps/api/src/services/index.test.ts
@@ -60,7 +60,45 @@ vi.mock("./index-cache", () => ({
 
 vi.mock("../db/schema", () => ({}));
 
-import { getIndexFromGCS, saveIndexToGCS } from "./index";
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import {
+  getIndexFromGCS,
+  hashURL,
+  normalizeURLForIndex,
+  saveIndexToGCS,
+} from "./index";
+
+// The indexed highlight resolver (Search -> /internal/indexed-highlight-objects)
+// looks an index row up by SHA-256(normalizeURLForIndex(url)). The recorded
+// pairs pin that identity: a normalization "cleanup" that changes any of them
+// silently turns every previously indexed page into a lookup miss.
+describe("normalizeURLForIndex recorded lookup identity", () => {
+  const recordedHashes: {
+    name: string;
+    url: string;
+    normalized: string;
+    sha256: string;
+  }[] = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        "../search/__fixtures__/indexed-highlight-lookup/normalized-url-hashes.json",
+      ),
+      "utf8",
+    ),
+  );
+
+  it.each(recordedHashes)("$name: $url", ({ url, normalized, sha256 }) => {
+    const actual = normalizeURLForIndex(url);
+    expect(actual).toBe(normalized);
+    expect(hashURL(actual).toString("hex")).toBe(sha256);
+    expect(crypto.createHash("sha256").update(normalized).digest("hex")).toBe(
+      sha256,
+    );
+  });
+});
 
 describe("index GCS documents", () => {
   beforeEach(() => {


### PR DESCRIPTION
Adds the authenticated cluster-internal URL-to-index-object batch resolver needed by Search.

The route reuses the existing normalization, hash, index_get_recent_5 variant, and three-newer-errors selection logic. It returns ordered hit/miss/error outcomes, caps batches at 12, and never enters a scrape engine.

Tests cover mixed per-row outcomes, authentication, input bounds, exact RPC arguments, and row selection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authenticated cluster-internal batch endpoint so Search can map page URLs to indexed highlight objects without starting a scrape.

**New Features**

- `POST /internal/indexed-highlight-objects` accepts up to 12 unique HTTP(S) pages and returns ordered `hit`, `miss`, or `error` results.
- Reuses URL normalization, SHA-256 lookup keys, the desktop `index_get_recent_5` variant, and recent-error selection.
- Requires `SEARCH_INDEX_LOOKUP_TOKEN`, fails closed when unset, and logs lookup totals.
- Returns 400 for malformed JSON, bodies over 128 KiB, invalid batches, and URLs over 8 KiB without invoking the app-wide error handler.
- Pins normalized URL hashes and covers authentication, validation, row selection, per-URL lookups, and mixed outcomes in tests.

<sup>Written for commit e4f1bd86e2392987415c58cf4e6b315404a0530a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Authentication fails closed when the service token is absent. The focused suite passes 19 tests; Superagent's missing-token finding was fixed and resolved.