### PR TITLE
feat(api): pass the team id to the browser service on interact create

### DIFF
--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -331,6 +331,7 @@ export async function browserCreateController(
         {
           ttl,
           record: recordSession,
+          customerId: req.auth.team_id,
           ...(activityTtl !== undefined ? { activityTtl } : {}),
           ...(persistentStorage !== undefined ? { persistentStorage } : {}),
         },

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -656,6 +656,7 @@ async function createSessionForScrape(
           // relying on the browser service's implicit default, matching the
           // standalone browser create path.
           record: true,
+          customerId: req.auth.team_id,
           ...(activityTtl !== undefined ? { activityTtl } : {}),
           ...(persistentStorage !== undefined ? { persistentStorage } : {}),
         },


### PR DESCRIPTION
The browser service picks where a session runs (Fly, or a Flare fork for allowlisted teams and a sticky rollout share) and needs the team to do it. It already carries a customer id on its session.ended webhook; this fills it in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interact-created browser sessions now pass the authenticated team ID to the browser service, covering both standalone and scrape-attached sessions. This lets the service route sessions between Fly and Flare for allowlisted teams and sticky rollouts, instead of choosing without team context.

<sup>Written for commit 22f2ac34009c17343d2fdd79540b2aed795953a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

