### PR TITLE
fix(api): FirePDF async live submits fast-fail to the sync path on admission rejection

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -367,6 +367,13 @@ const configSchema = z.object({
   FIRE_PDF_ASYNC_FORCE_TEAM_IDS: z.string().optional(),
   FIRE_PDF_ASYNC_DISABLE_TEAM_IDS: z.string().optional(),
   FIRE_PDF_ASYNC_ALLOW_REQUEST_OVERRIDE: z.stringbool().default(false),
+  // Live (non-crawl) inline submits ask fire-pdf to ENFORCE lane admission:
+  // when the async queue cannot drain inside the caller's window, fire-pdf
+  // answers 503 admission_rejected and we run the document on the
+  // synchronous FirePDF path immediately instead of letting it die
+  // unstarted in the queue. Off by default; by-reference submits never
+  // opt in (they have no inline fallback).
+  FIRE_PDF_ASYNC_LIVE_FASTFAIL: z.stringbool().default(false),
   // Large-PDF by-reference submits (30-256MB files uploaded to GCS and
   // handed to fire-pdf via `input_gcs_uri`). This is an explicit on/off
   // switch, not a percentage: no alternative engine exists at this size,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -212,7 +212,9 @@ describe("scrapePDFWithFirePDFAsync", () => {
         },
       },
     ]);
-    const fallback = vi.fn(async () => ({ markdown: "sync result" }));
+    const fallback = vi.fn(async (..._args: unknown[]) => ({
+      markdown: "sync result",
+    }));
     const doc = await scrapePDFWithFirePDFAsync(
       makeMeta(),
       "BASE64",
@@ -226,6 +228,59 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect((doc as any).markdown).toBe("sync result");
     // Exactly one request: the rejected POST. No polling, no cancel.
     expect(calls).toHaveLength(1);
+  });
+
+  it("does not send an admission policy when the fast-fail flag is off", async () => {
+    const original = (config as any).FIRE_PDF_ASYNC_LIVE_FASTFAIL;
+    (config as any).FIRE_PDF_ASYNC_LIVE_FASTFAIL = false;
+    try {
+      const { fetchImpl, calls } = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs$/,
+          matchMethod: "POST",
+          response: {
+            status: 202,
+            body: {
+              scrape_id: "scrape-id-test",
+              status: "queued",
+              retry_after_ms: 1,
+            },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test$/,
+          response: {
+            status: 200,
+            body: { scrape_id: "scrape-id-test", status: "done" },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test\/result$/,
+          response: {
+            status: 200,
+            body: {
+              schema_version: 1,
+              markdown: "ok",
+              pages_processed: 1,
+              failed_pages: null,
+              partial_pages: null,
+            },
+          },
+        },
+      ]);
+      await scrapePDFWithFirePDFAsync(
+        makeMeta(),
+        "BASE64",
+        undefined,
+        undefined,
+        undefined,
+        { fetchImpl, sleepImpl: noopSleep },
+      );
+      // The default deployment keeps fire-pdf's own admission policy.
+      expect("admission" in (calls[0].body as any)).toBe(false);
+    } finally {
+      (config as any).FIRE_PDF_ASYNC_LIVE_FASTFAIL = original;
+    }
   });
 
   it("asks fire-pdf to enforce admission only for live inline submits when enabled", async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/__tests__/firePDFAsync.test.ts
@@ -194,6 +194,144 @@ describe("scrapePDFWithFirePDFAsync", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("falls back to the synchronous path when fire-pdf rejects admission", async () => {
+    // Live inline submit: fire-pdf says its queue cannot drain inside our
+    // window (503 admission_rejected). Nothing was accepted server-side, so
+    // the document must run synchronously now — never die unstarted.
+    const { fetchImpl, calls } = makeFetchFromSequence([
+      {
+        matchUrl: /\/jobs$/,
+        matchMethod: "POST",
+        response: {
+          status: 503,
+          body: {
+            error: "admission_rejected",
+            message: "queue cannot drain within the submitted deadline",
+            reason: "estimated drain 90s exceeds deadline budget 45s",
+          },
+        },
+      },
+    ]);
+    const fallback = vi.fn(async () => ({ markdown: "sync result" }));
+    const doc = await scrapePDFWithFirePDFAsync(
+      makeMeta(),
+      "BASE64",
+      undefined,
+      undefined,
+      undefined,
+      { fetchImpl, fallbackImpl: fallback as any, sleepImpl: noopSleep },
+    );
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(fallback.mock.calls[0]?.[1]).toBe("BASE64");
+    expect((doc as any).markdown).toBe("sync result");
+    // Exactly one request: the rejected POST. No polling, no cancel.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("asks fire-pdf to enforce admission only for live inline submits when enabled", async () => {
+    const original = (config as any).FIRE_PDF_ASYNC_LIVE_FASTFAIL;
+    (config as any).FIRE_PDF_ASYNC_LIVE_FASTFAIL = true;
+    try {
+      const { fetchImpl, calls } = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs$/,
+          matchMethod: "POST",
+          response: {
+            status: 202,
+            body: {
+              scrape_id: "scrape-id-test",
+              status: "queued",
+              retry_after_ms: 1,
+            },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test$/,
+          response: {
+            status: 200,
+            body: { scrape_id: "scrape-id-test", status: "done" },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test\/result$/,
+          response: {
+            status: 200,
+            body: {
+              schema_version: 1,
+              markdown: "ok",
+              pages_processed: 1,
+              failed_pages: null,
+              partial_pages: null,
+            },
+          },
+        },
+      ]);
+      await scrapePDFWithFirePDFAsync(
+        makeMeta(),
+        "BASE64",
+        undefined,
+        undefined,
+        undefined,
+        { fetchImpl, sleepImpl: noopSleep },
+      );
+      expect((calls[0].body as any).admission).toBe("enforce");
+
+      // A crawl-origin submit never opts in: it has no synchronous fallback.
+      const second = makeFetchFromSequence([
+        {
+          matchUrl: /\/jobs$/,
+          matchMethod: "POST",
+          response: {
+            status: 202,
+            body: {
+              scrape_id: "scrape-id-test",
+              status: "queued",
+              retry_after_ms: 1,
+            },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test$/,
+          response: {
+            status: 200,
+            body: { scrape_id: "scrape-id-test", status: "done" },
+          },
+        },
+        {
+          matchUrl: /\/jobs\/scrape-id-test\/result$/,
+          response: {
+            status: 200,
+            body: {
+              schema_version: 1,
+              markdown: "ok",
+              pages_processed: 1,
+              failed_pages: null,
+              partial_pages: null,
+            },
+          },
+        },
+      ]);
+      await scrapePDFWithFirePDFAsync(
+        makeMeta({
+          internalOptions: {
+            zeroDataRetention: false,
+            teamId: "team-x",
+            teamConcurrency: 12,
+            crawlId: "crawl-1",
+          },
+        }),
+        "BASE64",
+        undefined,
+        undefined,
+        undefined,
+        { fetchImpl: second.fetchImpl, sleepImpl: noopSleep },
+      );
+      expect((second.calls[0].body as any).admission).toBeUndefined();
+    } finally {
+      (config as any).FIRE_PDF_ASYNC_LIVE_FASTFAIL = original;
+    }
+  });
+
   it("happy path: POST 202 queued → poll done → result returns markdown", async () => {
     const { fetchImpl, calls } = makeFetchFromSequence([
       {

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/async.ts
@@ -226,20 +226,49 @@ export async function scrapePDFWithFirePDFAsync(
         };
       }
     } else {
-      const submit = await submitJob({
-        meta,
-        baseUrl,
-        input: wireInput,
-        maxPages,
-        pagesProcessed,
-        mode,
-        includePageMarkdown,
-        includeBlocks,
-        pageMarkers,
-        deadlineAt,
-        teamConcurrency,
-        fetchImpl,
-      });
+      let submit: Awaited<ReturnType<typeof submitJob>>;
+      try {
+        submit = await submitJob({
+          meta,
+          baseUrl,
+          input: wireInput,
+          maxPages,
+          pagesProcessed,
+          mode,
+          includePageMarkdown,
+          includeBlocks,
+          pageMarkers,
+          deadlineAt,
+          teamConcurrency,
+          fetchImpl,
+        });
+      } catch (error) {
+        // fire-pdf refused the job because its queue cannot drain inside
+        // our window (we asked it to enforce that — see submit.ts). Nothing
+        // was accepted server-side, so run the document synchronously now:
+        // the caller gets a result instead of a job that dies unstarted.
+        if (
+          error instanceof FirePdfAsyncFailure &&
+          error.reason === "admission_rejected" &&
+          wireInput.kind === "inline"
+        ) {
+          meta.logger.info(
+            "FirePDF async admission rejected — processing synchronously",
+            { scrapeId: meta.id, reason: error.extra.reason },
+          );
+          return fallbackImpl(
+            meta,
+            wireInput.base64Content,
+            maxPages,
+            pagesProcessed,
+            mode,
+            includePageMarkdown,
+            includeBlocks,
+            pageMarkers,
+          );
+        }
+        throw error;
+      }
       submissionAccepted = true;
       alreadyDone = submit.alreadyDone;
       initialDelay = submit.retryAfterMs ?? POLL_FLOOR_MS;

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/metrics.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/metrics.ts
@@ -37,6 +37,7 @@ export type FallbackReason =
   | "http_413"
   | "http_502"
   | "http_503"
+  | "admission_rejected"
   | "http_429"
   | "http_5xx"
   | "network_error"

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/submit.ts
@@ -1,4 +1,5 @@
 import type { Meta } from "../../..";
+import { config } from "../../../../../config";
 import type { PDFMode } from "../../../../../controllers/v2/types";
 import { fetch as undiciFetch } from "undici";
 import { AbortManagerThrownError } from "../../../lib/abortManager";
@@ -110,6 +111,12 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
     ...(teamConcurrency !== undefined && {
       team_concurrency: teamConcurrency,
     }),
+    // Live inline submits have a synchronous fallback, so ask fire-pdf to
+    // reject up front when its queue cannot drain in our window rather
+    // than let the job die unstarted (see FIRE_PDF_ASYNC_LIVE_FASTFAIL).
+    ...(config.FIRE_PDF_ASYNC_LIVE_FASTFAIL &&
+      input.kind === "inline" &&
+      !meta.internalOptions.crawlId && { admission: "enforce" as const }),
     // Shared with the POST /jobs/lookup adoption client — the two must
     // build identical options or adoption never matches this job.
     options: buildFirePdfJobOptions({
@@ -146,7 +153,15 @@ export async function submitJob(args: SubmitArgs): Promise<SubmitOutcome> {
   if (status === 413) failAsync(meta, "http_413");
   if (status === 429) failAsync(meta, "http_429");
   if (status === 502) failAsync(meta, "http_502", { body: json });
-  if (status === 503) failAsync(meta, "http_503");
+  if (status === 503) {
+    const err = (json as { error?: unknown; reason?: unknown } | null)?.error;
+    if (err === "admission_rejected") {
+      failAsync(meta, "admission_rejected", {
+        reason: (json as { reason?: unknown }).reason,
+      });
+    }
+    failAsync(meta, "http_503");
+  }
 
   if (status === 409) {
     meta.logger.error(


### PR DESCRIPTION
## What

- New flag `FIRE_PDF_ASYNC_LIVE_FASTFAIL` (default **off**). When on, live (non-crawl) **inline** FirePDF async submits include `admission: "enforce"`, asking fire-pdf to reject up front if its lane queue cannot drain inside the caller's window.
- On `503 admission_rejected`, nothing was accepted server-side, so the document runs on the synchronous FirePDF path immediately (`scrapePDFWithFirePDF`) — the caller gets a result instead of a job that dies unstarted. Surfaced as a new `admission_rejected` fallback reason in the existing async-fallback metric.
- By-reference submits never opt in (they have no inline fallback); other 503s keep the existing `http_503` handling.

## Why

Interactive PDF scrapes have 30–60s windows. When an async lane queues behind a crawl dump or a surge, those jobs die unstarted while the sync path — which serves a 30-page document in ~6s — sits idle. This turns "died in queue" into "served synchronously". Companion to firecrawl/fire-pdf's request-level admission enforcement.

## Verification

- New tests: 503 `admission_rejected` → exactly one request, fallback called with the same base64, result returned; the `admission: "enforce"` field is sent for live inline submits when the flag is on and never for crawl-origin submits
- `vitest` firePDFAsync + routing suites green (47 tests), `tsc` clean, local cubic no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets FirePDF async live submits fast-fail to the synchronous path on admission rejection, so interactive PDF scrapes get a result instead of dying unstarted in the queue.

When `FIRE_PDF_ASYNC_LIVE_FASTFAIL` is enabled (default off), live inline submits send `admission: "enforce"`; a 503 `admission_rejected` — meaning nothing was accepted server-side — runs the document synchronously via FirePDF immediately. Adds an `admission_rejected` reason to the async-fallback metric. By-reference submits never opt in, and other 503s keep the existing `http_503` handling.

<sup>Written for commit 408810452b44529c39f94375f101ff453aae28a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

