### PR TITLE
fix(native): pin tinyvec below 1.13 to unblock native lib builds

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -26,6 +26,10 @@ strsim = "0.11"
 texting_robots = "0.2.2"
 url = "2.5.7"
 tokio = "1.48.0"
+# Transitive dep (pdf-inspector -> unicode-normalization -> tinyvec). Pinned because
+# tinyvec 1.13.0 fails to compile (https://github.com/Lokathor/tinyvec/issues/225)
+# and Cargo.lock is not committed, so fresh builds would otherwise pick it up.
+tinyvec = ">=1.12, <1.13"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`tinyvec 1.13.0` was published to crates.io on 2026-09-03 21:13 UTC and does not compile:

```
error: cannot find macro `vec` in this scope
   --> tinyvec-1.13.0/src/tinyvec.rs:710:21
```

Upstream: [Lokathor/tinyvec#225](https://github.com/Lokathor/tinyvec/issues/225) (bug), [Lokathor/tinyvec#226](https://github.com/Lokathor/tinyvec/pull/226) (fix). At time of writing 1.13.0 is still live and not yanked.

`apps/api/native` gitignores `Cargo.lock`, so any fresh build of the Rust addon resolves the newest `tinyvec` via `pdf-inspector -> unicode-normalization -> tinyvec`. In CI this surfaces as the **Build native lib** step failing in all "Self-hosted environment tests" jobs whenever a branch gets a cache miss on the prebuilt `.node` binary (Actions caches created on other feature branches aren't visible to new branches). Re-running does not help.

## Fix

Pin the transitive dependency in `apps/api/native/Cargo.toml`:

```toml
tinyvec = ">=1.12, <1.13"
```

The lower bound keeps the direct dep in the same semver-major as `unicode-normalization`'s requirement so the resolver unifies them to a single `tinyvec 1.12.0` rather than pulling two copies.

This changes the `hashFiles('apps/api/native/Cargo.toml', ...)` cache key, so CI will do a fresh source build on this PR, which is exactly what exercises the fix.

## Verification (local, Rust 1.98.1 stable)

- Reproduced the `1.13.0` failure on unmodified `main` with `cargo build -p tinyvec`.
- With the pin, `cargo tree -i tinyvec` shows a single `tinyvec v1.12.0` node shared by `firecrawl_rs` and `unicode-normalization`.
- Full `napi build --platform --release` of the native lib completes successfully (see PR status / comment for final confirmation).

## Follow-up

Once a fixed `tinyvec` release ships (1.13.1 or 1.13.0 is yanked), this pin can be relaxed or removed. Longer term, committing `Cargo.lock` for the native lib would prevent this class of breakage entirely; that is left out of scope here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc7b4ff-3100-4fd7-bf51-302d48039541?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc7b4ff-3100-4fd7-bf51-302d48039541&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `tinyvec` to `<1.13` so fresh native lib builds don't pick up the broken 1.13.0 release, which fails to compile. Because `Cargo.lock` is not committed, any new build resolves the latest version, so this pin keeps builds working until upstream fixes the issue. Also changes the CI cache key, forcing a fresh build that verifies the fix.

<sup>Written for commit c6ddef0d6d5bf80aef2986a25e395ff542acc4b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

