### PR TITLE
fix(docker): reap zombie worker subprocesses in the api container

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -71,7 +71,8 @@
     "tsc-watch": "^7.1.1",
     "tsx": "^4.20.3",
     "undici-types": "^7.16.0",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "yaml": "^2.9.0"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.84",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@22.19.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.20.3)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   native:
     devDependencies:
@@ -4804,11 +4807,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -7762,7 +7760,7 @@ snapshots:
       nano-spawn: 1.0.2
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.3
+      yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8957,8 +8955,6 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
-
-  yaml@2.8.3: {}
 
   yaml@2.9.0: {}
 

--- a/apps/api/src/__tests__/docker-compose-init.test.ts
+++ b/apps/api/src/__tests__/docker-compose-init.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Regression test for zombie process accumulation under self-hosted Docker
+// Compose: harness.js runs as PID 1 in the `api` container and spawns
+// detached worker subprocesses (see src/harness.ts) that node never reaps
+// on its own. `init: true` runs tini as PID 1 to reap them.
+describe("docker-compose.yaml api service", () => {
+  it("enables an init process to reap detached worker subprocesses", () => {
+    const composePath = join(__dirname, "../../../../docker-compose.yaml");
+    const compose = readFileSync(composePath, "utf8");
+
+    const apiServiceMatch = compose.match(/\n {2}api:\n([\s\S]*?)(?=\n {2}\S)/);
+    expect(apiServiceMatch).not.toBeNull();
+
+    const apiServiceBlock = apiServiceMatch![1];
+    expect(apiServiceBlock).toMatch(/^\s{4}init:\s*true\s*$/m);
+  });
+});

--- a/apps/api/src/__tests__/docker-compose-init.test.ts
+++ b/apps/api/src/__tests__/docker-compose-init.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { join } from "path";
+import { parse } from "yaml";
 
 // Regression test for zombie process accumulation under self-hosted Docker
 // Compose: harness.js runs as PID 1 in the `api` container and spawns
@@ -9,11 +10,9 @@ describe("docker-compose.yaml api service", () => {
   it("enables an init process to reap detached worker subprocesses", () => {
     const composePath = join(__dirname, "../../../../docker-compose.yaml");
     const compose = readFileSync(composePath, "utf8");
+    const composeConfig = parse(compose);
 
-    const apiServiceMatch = compose.match(/\n {2}api:\n([\s\S]*?)(?=\n {2}\S)/);
-    expect(apiServiceMatch).not.toBeNull();
-
-    const apiServiceBlock = apiServiceMatch![1];
-    expect(apiServiceBlock).toMatch(/^\s{4}init:\s*true\s*$/m);
+    expect(composeConfig.services?.api).toBeDefined();
+    expect(composeConfig.services.api.init).toBe(true);
   });
 });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,6 +95,10 @@ services:
 
   api:
     <<: *common-service
+    # node runs as PID 1 in this container and does not reap the detached
+    # worker subprocesses harness.js spawns (see apps/api/src/harness.ts),
+    # so an init process is required to prevent zombie accumulation.
+    init: true
     environment:
       <<: *common-env
       HOST: "0.0.0.0"


### PR DESCRIPTION
## Why

Fixes #4527.

In the official `docker-compose.yaml`, the `api` container runs `node dist/src/harness.js --start-docker` directly as PID 1 (see `apps/api/Dockerfile` `CMD`). `harness.ts`'s `execForward` spawns the API server, worker, and extract-worker as detached child processes and signals them via process-group kills. Node running as PID 1 does not reap orphaned grandchildren the way a real init process does, so under sustained load (reported: ~20–25 concurrent jobs, ~5,800 dispatches/hour over 6 hours) zombie processes parented to PID 1 accumulate — 467 were observed in the reporter's incident, all `ppid=1`.

## What changed

Added `init: true` to the `api` service in `docker-compose.yaml`. This is Docker Compose's built-in flag to run `tini` as PID 1 inside the container, which correctly reaps zombie/orphaned processes. No Dockerfile or application code changes are needed since Compose injects `tini` at container-start time.

## Test plan

Added `apps/api/src/__tests__/docker-compose-init.test.ts`, which reads the repository's `docker-compose.yaml` and asserts the `api` service block sets `init: true`.

Verified the test fails without the fix and passes with it:

```
$ git stash push -- docker-compose.yaml   # temporarily remove the fix
$ pnpm exec vitest run src/__tests__/docker-compose-init.test.ts
 ❯ src/__tests__/docker-compose-init.test.ts:17:29
     expect(apiServiceBlock).toMatch(/^\s{4}init:\s*true\s*$/m);
 Test Files  1 failed (1)
      Tests  1 failed (1)

$ git stash pop   # restore the fix
$ pnpm exec vitest run src/__tests__/docker-compose-init.test.ts
 ✓ src/__tests__/docker-compose-init.test.ts (1 test) 3ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Also validated the compose file resolves correctly and carries the new field through to the final config:

```
$ docker compose -f docker-compose.yaml config | sed -n '/^  api:/,/^  redis:/p' | grep init
    init: true
```

Ran `pnpm run knip` in `apps/api` to confirm no new unused-export findings were introduced (only pre-existing configuration hints, unrelated to this change).

## AI assistance disclosure

This change was written with AI assistance (Claude Code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents zombie worker subprocesses from accumulating in the API container by adding `init: true` to the `api` service in `docker-compose.yaml`. Node previously ran as PID 1 and didn't reap detached workers, causing zombies under load; now Docker Compose runs tini as PID 1 to handle reaping. Fixes #4527.

- Adds a regression test that parses `docker-compose.yaml` structurally to assert `init: true` is set.
- Adds `yaml` as a dev dependency in `apps/api` to support the test's YAML parsing.

<sup>Written for commit d343ce3f6e256cf2cbcc05f6b8fb692e306a84f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

