### PR TITLE
fix(python-sdk): correct search() docstring param name page_options -> scrape_options

### DIFF
--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -435,7 +435,7 @@ class FirecrawlClient:
             timeout: Request timeout in milliseconds (default: 300000)
             highlights: Generate query-relevant highlights for search results
                 (default: true)
-            page_options: Options for scraping individual pages
+            scrape_options: Options for scraping individual pages
             enterprise: Enterprise search options. Use ["zdr"] for end-to-end
                 Zero Data Retention or ["anon"] for anonymized search. Must be
                 enabled for your team.


### PR DESCRIPTION
The `search()` docstring in `apps/python-sdk/firecrawl/v2/client.py` documents `page_options: Options for scraping individual pages` — a leftover from the v1 → v2 rename. The actual parameter is `scrape_options` (and the request payload builds `scrape_options=scrape_options`), so following the docstring raises `TypeError`. One-line docstring fix; verified via AST docstring/signature cross-check across the SDK (only remaining mismatch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `search()` docstring in the Python SDK so it names the actual `scrape_options` parameter instead of the leftover `page_options`. Following the old docstring caused a `TypeError`; the fix is documentation-only and has no runtime side effects.

<sup>Written for commit 8629ff89642163934a08d6c97ce9760998228333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

