### PR TITLE
fix(api): correct error message on the scrape-status endpoint

### DIFF
--- a/apps/api/src/controllers/v2/scrape-status.ts
+++ b/apps/api/src/controllers/v2/scrape-status.ts
@@ -9,7 +9,7 @@ export async function scrapeStatusController(req: any, res: any) {
   if (!req.params.jobId || !uuidReg.test(req.params.jobId)) {
     return res.status(400).json({
       success: false,
-      error: "Invalid crawl ID",
+      error: "Invalid job ID format. Job ID must be a valid UUID.",
     });
   }
 


### PR DESCRIPTION
`GET /v2/scrape/:jobId` rejects invalid job ids with `Invalid crawl ID` — copy-pasted from the crawl endpoint when the v2 scrape system landed (8a8d64996). Sibling v2 endpoints return `Invalid job ID format. Job ID must be a valid UUID.`, which `apps/api/src/__tests__/snips/v2/scrape.test.ts` asserts for this family of endpoints. Aligned the message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the error message on `GET /v2/scrape/:jobId` so invalid job IDs return `Invalid job ID format. Job ID must be a valid UUID.` instead of the copy-pasted `Invalid crawl ID`. This aligns the endpoint with sibling v2 endpoints and the existing scrape tests.

<sup>Written for commit e231ae131225b372fc0ecf1bd052ebd02f2f257b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

