### PR TITLE
docs: point AGENTS.md/CLAUDE.md test command at vitest, not jest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ When making changes to the API, here are the general steps you should take:
     - If it requires fire-engine: `!process.env.TEST_SUITE_SELF_HOSTED`
     - If it requires AI: `!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL`
 2. Write code to achieve your win conditions
-3. Run your tests using `pnpm harness jest ...`
+3. Run your tests using `pnpm harness pnpm exec vitest run <path/to/test.ts>`
   - `pnpm harness` is a command that gets the API server and workers up for you to run the tests. Don't try to `pnpm start` manually.
   - The full test suite takes a long time to run, so you should try to only execute the relevant tests locally, and let CI run the full test suite.
 4. Push to a branch, open a PR, and let CI run to verify your win condition.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ When making changes to the API, here are the general steps you should take:
     - If it requires fire-engine: `!process.env.TEST_SUITE_SELF_HOSTED`
     - If it requires AI: `!process.env.TEST_SUITE_SELF_HOSTED || process.env.OPENAI_API_KEY || process.env.OLLAMA_BASE_URL`
 2. Write code to achieve your win conditions
-3. Run your tests using `pnpm harness jest ...`
+3. Run your tests using `pnpm harness pnpm exec vitest run <path/to/test.ts>`
   - `pnpm harness` is a command that gets the API server and workers up for you to run the tests. Don't try to `pnpm start` manually.
   - The full test suite takes a long time to run, so you should try to only execute the relevant tests locally, and let CI run the full test suite.
 4. Push to a branch, open a PR, and let CI run to verify your win condition.


### PR DESCRIPTION
Both onboarding files instruct `pnpm harness jest ...`, but the repo has no jest dependency anywhere in `apps/api/package.json` — tests run on vitest (`pnpm harness pnpm exec vitest run <path>`, as CONTRIBUTING.md already documents). The documented command fails verbatim; updated both files to the working form.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the test command in `AGENTS.md` and `CLAUDE.md` from `pnpm harness jest ...` to `pnpm harness pnpm exec vitest run <path/to/test.ts>`, since the repo has no jest dependency and the old command failed verbatim.

<sup>Written for commit 52c210c8d645b6ec091ce5b34b217060079c14eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

