### PR TITLE
test(api): respect local fixture availability in robots tests

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape-robots.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape-robots.test.ts
@@ -5,7 +5,7 @@ import { CrawlDenialError } from "../../../lib/error";
 import * as robots from "../../../lib/robots-txt";
 import { scrapeURL } from "../../../scraper/scrapeURL";
 import * as engines from "../../../scraper/scrapeURL/engines";
-import { TEST_SUITE_WEBSITE } from "../lib";
+import { ALLOW_TEST_SUITE_WEBSITE, itIf, TEST_SUITE_WEBSITE } from "../lib";
 import { scrapeTimeout } from "./lib";
 
 // Exercise the pipeline directly so team flags are covered in self-hosted
@@ -53,7 +53,9 @@ describe("Scrape robots policy", () => {
     scrapeTimeout,
   );
 
-  it(
+  // External proxies cannot reach the local test site. Keep the denial test
+  // above unconditional because it must finish before any engine is invoked.
+  itIf(ALLOW_TEST_SUITE_WEBSITE)(
     "scrapes an allowed URL",
     async () => {
       vi.mocked(robots.fetchRobotsTxt).mockResolvedValue({
@@ -70,7 +72,7 @@ describe("Scrape robots policy", () => {
     scrapeTimeout,
   );
 
-  it(
+  itIf(ALLOW_TEST_SUITE_WEBSITE)(
     "scrapes without checking robots when the team flag is disabled",
     async () => {
       const result = await runScrape(false);
@@ -82,7 +84,7 @@ describe("Scrape robots policy", () => {
     scrapeTimeout,
   );
 
-  it(
+  itIf(ALLOW_TEST_SUITE_WEBSITE)(
     "allows scraping when robots.txt retrieval fails",
     async () => {
       vi.mocked(robots.fetchRobotsTxt).mockRejectedValue(


### PR DESCRIPTION
Use the existing `ALLOW_TEST_SUITE_WEBSITE` guard for the three robots-policy tests that fetch the local test site. External proxies cannot reach that fixture. The denial test continues to run in every configuration and asserts that no engine is invoked.

Validation: targeted tests pass with no proxy (8 passed) and with a proxy configured (5 passed, 3 local-site cases skipped). Knip and formatting checks pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the robots-policy tests that fetch the local test site behind `ALLOW_TEST_SUITE_WEBSITE` so external proxies skip them. The denial test still runs everywhere because it must finish before any engine is invoked.

<sup>Written for commit d8c945e1c60d01d7c90cf13df7de297ff8854da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

