### PR TITLE
fix(api): create Autumn entities only after 404

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -228,6 +228,11 @@ jobs:
           --reporter=default
         working-directory: apps/api
 
+      - name: Run Autumn entity provisioning regression tests
+        if: matrix.engine == 'fetch' && matrix.proxy == 'no-proxy' && matrix.nuq == 'postgres'
+        run: pnpm exec vitest run src/services/autumn/__tests__/autumn.service.test.ts --reporter=default
+        working-directory: apps/api
+
       - name: Install test site dependencies
         run: pnpm install --frozen-lockfile
         working-directory: apps/test-site

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -258,10 +258,13 @@ describe("ensureTeamProvisioned", () => {
     expect(mockEntityGet).toHaveBeenCalledTimes(1);
   });
 
-  it("marks team as ensured without a second getEntity when createEntity succeeds", async () => {
+  it.each([
+    { statusCode: 404 },
+    { status: 404 },
+    { response: { status: 404 } },
+  ])("creates and caches a missing entity after %j", async error => {
     const svc = makeService();
-    // First getEntity returns null → entity doesn't exist yet.
-    mockEntityGet.mockResolvedValue(null);
+    mockEntityGet.mockRejectedValue(error);
     mockEntityCreate.mockResolvedValue({ id: "team-1" });
 
     await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
@@ -269,14 +272,50 @@ describe("ensureTeamProvisioned", () => {
     // Only one getEntity call (no confirmation get).
     expect(mockEntityGet).toHaveBeenCalledTimes(1);
     expect(mockEntityCreate).toHaveBeenCalledTimes(1);
-    expect(mockEntityCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ featureId: "TEAM" }),
-    );
+    expect(mockEntityCreate).toHaveBeenCalledWith({
+      customerId: "org-1",
+      entityId: "team-1",
+      featureId: "TEAM",
+    });
+
+    await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+    expect(mockEntityGet).toHaveBeenCalledTimes(1);
+    expect(mockEntityCreate).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    { statusCode: 429 },
+    { status: 429 },
+    { response: { status: 429 } },
+    { statusCode: 500 },
+    { status: 503 },
+    new Error("ECONNRESET"),
+  ])(
+    "does not create or cache an entity after lookup failure %j",
+    async error => {
+      const svc = makeService();
+      mockEntityGet.mockRejectedValueOnce(error);
+
+      // Provisioning remains best-effort: a lookup failure must not stop billing.
+      await expect(
+        svc.trackCredits({ teamId: "team-1", value: 5 }),
+      ).resolves.toBe(true);
+      expect(mockEntityCreate).not.toHaveBeenCalled();
+      expect(mockTrack).toHaveBeenCalledTimes(1);
+
+      // The failed lookup must not mark the team as provisioned; retry can recover.
+      await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+      expect(mockEntityGet).toHaveBeenCalledTimes(2);
+      expect(mockEntityCreate).not.toHaveBeenCalled();
+
+      await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+      expect(mockEntityGet).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("marks team as ensured on 409 conflict without a second getEntity", async () => {
     const svc = makeService();
-    mockEntityGet.mockResolvedValue(null);
+    mockEntityGet.mockRejectedValue({ statusCode: 404 });
     // createEntity returns null to simulate 409 — the mock throws a 409 error
     // to exercise the conflict branch inside createEntity.
     mockEntityCreate.mockRejectedValue(
@@ -294,7 +333,7 @@ describe("ensureTeamProvisioned", () => {
 
   it("does NOT mark team as ensured when createEntity has a genuine error", async () => {
     const svc = makeService();
-    mockEntityGet.mockResolvedValue(null);
+    mockEntityGet.mockRejectedValue({ statusCode: 404 });
     mockEntityCreate.mockRejectedValue(
       Object.assign(new Error("server error"), { status: 500 }),
     );

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -231,7 +231,9 @@ export class AutumnService {
         entityId,
         error,
       });
-      return null;
+      // Only a 404 establishes that the entity is missing. Let provisioning's
+      // catch handle other failures without attempting to create the entity.
+      throw error;
     }
   }
 


### PR DESCRIPTION
Entity lookup failures, including HTTP 429 and server/network errors, were returned as `null`, causing provisioning to attempt `entities.create` without knowing whether the entity was missing. Rethrow non-404 lookup errors into the existing best-effort provisioning handler so creation only follows a not-found response. Billing can continue and a later provisioning attempt can retry the lookup.

Regression coverage verifies all supported 404 status shapes, prevents creation after 429/5xx/network failures, and checks successful cache warming after recovery. Existing creation-success and 409-conflict coverage now uses actual 404 responses. The service suite is also added to the existing CI matrix so these regressions run on pull requests.

Validation:
- Reproduced six regression failures before the implementation change.
- All 173 Autumn tests pass across three test files.
- Knip and formatting/diff checks pass.
- Full local typecheck is blocked by a generated native binding missing the existing `validateRegexes` export in `src/lib/crawl-regex.ts`; neither file is changed by this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Autumn entity provisioning so entities are created only after a 404 lookup response. Previously, any lookup failure—including HTTP 429 and server/network errors—was treated as a missing entity and triggered an `entities.create` call; now non-404 errors rethrow to the existing best-effort handler so billing continues and a later provisioning attempt can retry the lookup.

- Adds regression tests covering all 404 status shapes, blocking creation after 429/5xx/network failures, and cache recovery after a failed lookup.
- Runs the Autumn test suite in CI on pull requests.

<sup>Written for commit 38f60244f6ac51869f80776c1762ac97cb1289e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

