### PR TITLE
docs(contributing): note pnpm --ignore-scripts for foundationdb build failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,12 @@ pnpm start
 
 `pnpm start` builds Firecrawl and launches the API, workers, and local dependency containers. Keep Redis running separately as described in the public guide.
 
+If `pnpm install` fails building the `foundationdb` native binding (`fatal error: 'foundationdb/fdb_c.h' file not found`), pass `--ignore-scripts`. The queue defaults to PostgreSQL and the module is required lazily only when `NUQ_BACKEND=fdb`, so skipping the build is safe for the default setup — CI does the same on the non-FDB matrix rows.
+
+```bash
+pnpm install --ignore-scripts
+```
+
 ## Make a focused change
 
 1. Fork the repository and create a branch whose name describes the change.


### PR DESCRIPTION
## Summary

`pnpm install` in `apps/api` on a fresh machine aborts while building the `foundationdb` native binding with `fatal error: 'foundationdb/fdb_c.h' file not found`. The FoundationDB C client is not listed as a prerequisite and most dev machines do not have it, so new contributors following `CONTRIBUTING.md` end up with an empty `node_modules/.bin` and no path forward.

The queue defaults to PostgreSQL and the `foundationdb` module is required lazily only when `NUQ_BACKEND=fdb` (`apps/api/src/services/worker/nuq-fdb/client.ts`), so skipping the native build is safe for the default setup. CI already takes the same shape on rows that do not exercise the FDB backend (`.github/workflows/test-server.yml` uses `pnpm install --frozen-lockfile --ignore-scripts` + `npm_config_ignore_scripts: 'true'`).

This adds one short paragraph in the *Set up API development* section pointing new contributors at the same escape hatch when they hit the error. Docs-only change — no code, no scripts, no dependency changes.

## Related

Fixes #4060

## Test plan

- [x] Rendered `CONTRIBUTING.md` — the new paragraph lands right after the existing `pnpm install` / `pnpm start` block; no other content moves.
- [x] `pnpm install --ignore-scripts` on macOS arm64 succeeds when a fresh install without the flag fails on the same box.
- [x] Ran the API on the default PostgreSQL queue backend after the flagged install — nothing lazy-requires `foundationdb`.
- [x] Diff is 6 additions, 0 deletions in a single file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a note to `CONTRIBUTING.md` for new contributors whose `pnpm install` fails building the `foundationdb` native binding because the FoundationDB C client header isn't installed.

- The fix is `pnpm install --ignore-scripts`, which is safe because the queue defaults to PostgreSQL and the `foundationdb` module is only loaded when `NUQ_BACKEND=fdb`.
- CI already skips scripts on non-FDB matrix rows, so this matches existing behavior.

<sup>Written for commit 61df0723873183a59af355ce799cda14b11f3afc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

