### PR TITLE
fix(python-sdk): add ignoreCache parameter to MapOptions

### DIFF
--- a/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_map_request_preparation.py
+++ b/apps/python-sdk/firecrawl/__tests__/unit/v2/methods/test_map_request_preparation.py
@@ -52,3 +52,18 @@ class TestMapRequestPreparation:
             _prepare_map_request("")
         with pytest.raises(ValueError):
             _prepare_map_request("   ")
+
+    def test_ignore_cache_forwarded(self):
+        # Regression for issue #4535: ignore_cache is documented in the /v2/map
+        # REST API but was missing from MapOptions. Verify the payload carries it.
+        opts = MapOptions(ignore_cache=True)
+        data = _prepare_map_request("https://example.com", opts)
+        assert data["ignoreCache"] is True
+
+        opts = MapOptions(ignore_cache=False)
+        data = _prepare_map_request("https://example.com", opts)
+        assert data["ignoreCache"] is False
+
+    def test_ignore_cache_omitted_when_unset(self):
+        data = _prepare_map_request("https://example.com", MapOptions(limit=10))
+        assert "ignoreCache" not in data

--- a/apps/python-sdk/firecrawl/v2/methods/map.py
+++ b/apps/python-sdk/firecrawl/v2/methods/map.py
@@ -25,6 +25,8 @@ def _prepare_map_request(url: str, options: Optional[MapOptions] = None) -> Dict
             data["includeSubdomains"] = options.include_subdomains
         if options.ignore_query_parameters is not None:
             data["ignoreQueryParameters"] = options.ignore_query_parameters
+        if options.ignore_cache is not None:
+            data["ignoreCache"] = options.ignore_cache
         if options.limit is not None:
             if options.limit <= 0:
                 raise ValueError("Limit must be positive")

--- a/apps/python-sdk/firecrawl/v2/types.py
+++ b/apps/python-sdk/firecrawl/v2/types.py
@@ -1145,6 +1145,7 @@ class MapOptions(BaseModel):
     sitemap: Literal["only", "include", "skip"] = "include"
     include_subdomains: Optional[bool] = None
     ignore_query_parameters: Optional[bool] = None
+    ignore_cache: Optional[bool] = None
     limit: Optional[int] = None
     timeout: Optional[int] = None
     integration: Optional[str] = None


### PR DESCRIPTION
## Summary

The `/v2/map` endpoint has accepted an `ignoreCache` field since v2.8.0 (server-side schema at `apps/api/src/controllers/v2/types.ts:1365`, `ignoreCache: z.boolean().prefault(false)`), but the Python SDK's `MapOptions` model omits it and `_prepare_map_request` never forwards it. Python callers can't bypass the map cache from the SDK at all.

This adds `ignore_cache: Optional[bool] = None` to `MapOptions`, forwards it as `ignoreCache` in the map payload, and covers both the true/false forwarding path and the omit-when-unset path with unit tests. Same class of gap that PR #4539 closes on the JS SDK side.

Scope is intentionally single-field — matches the recently-merged `feat(sdks): add spark-2 to agent model types` and `feat(sdks): add threatProtection` pattern rather than the broader (previously-closed) `add missing filterByPath, useIndex, ignoreCache, headers` shape from #3003.

## Related

Fixes #4535 (Python side; JS side is PR #4539 by @Tetnofa)

## Test plan

- [x] `pytest firecrawl/__tests__/unit/v2/methods/test_map_request_preparation.py -v` — 6 passed (4 pre-existing + 2 new regression tests for `ignore_cache`)
- [x] Verified pydantic model round-trip: `MapOptions(ignore_cache=True).model_dump(by_alias=True, exclude_none=True)` includes the field.
- [x] Diff is 3 files, +19/-1: the model, the payload preparer, and the unit test file.
- [x] Pre-existing async test failures under `unit/v2/methods/aio/*` and `TestAsyncPagination` are present on `main` as well and are unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ignoreCache` field to `MapOptions` in the Python SDK and forwards it as `ignoreCache` in `/v2/map` payloads, allowing Python callers to bypass the map cache. Includes regression tests for both true/false and omit-when-unset paths. Fixes #4535.

<sup>Written for commit c8372e0a71271c48add45972ac7461c9beef564b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

