### PR TITLE
refactor(billing): parse firebill responses with Zod schemas

### DIFF
--- a/apps/api/src/services/autumn/__tests__/firebill.test.ts
+++ b/apps/api/src/services/autumn/__tests__/firebill.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   firebillCheck,
+  firebillFinalize,
+  firebillLock,
   firebillTrack,
   shouldRouteToFirebill,
 } from "../firebill";
@@ -661,5 +663,153 @@ describe("firebillCheck", () => {
     vi.stubGlobal("fetch", fetchMock);
     await firebillCheck(checkParams);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("firebillLock", () => {
+  const lockParams = {
+    customerId: "org-1",
+    entityId: "team-1",
+    featureId: "CREDITS",
+    value: 10,
+    lockId: "monitor_check-1",
+    expiresAt: Date.now() + 60_000,
+  };
+
+  const answer = (body: unknown, status = 200) =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status })),
+    );
+
+  it("locks and carries the operation token back on a gated hold", async () => {
+    answer({
+      success: true,
+      allowed: true,
+      lock_id: "monitor_check-1",
+      operation_token: "op-tok",
+    });
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "locked",
+      lockId: "monitor_check-1",
+      operationToken: "op-tok",
+    });
+  });
+
+  it("falls back to the caller's lock id when firebill echoes none", async () => {
+    answer({ success: true, allowed: true });
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "locked",
+      lockId: "monitor_check-1",
+    });
+  });
+
+  it("reads a denial and its reason", async () => {
+    answer({ success: true, allowed: false, reason: "out_of_credits" });
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "denied",
+      reason: "out_of_credits",
+    });
+  });
+
+  it("drops an unrecognised denial reason rather than passing it through", async () => {
+    answer({ success: true, allowed: false, reason: "some_new_reason" });
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "denied",
+    });
+  });
+
+  // A shape firebill sent on purpose (`success: false`) is `refused`; one we
+  // could not read is `unusable`. Both proceed unlocked, but slicing the cause
+  // counter must tell them apart.
+  it("calls an explicit success:false refused", async () => {
+    answer({ success: false });
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect(await failureCauses()).toEqual({ "lock/refused": 1 });
+  });
+
+  it.each([
+    ["a missing allowed", { success: true }],
+    ["a non-boolean allowed", { success: true, allowed: "yes" }],
+    ["a missing success", { locked: true }],
+  ])("calls %s unusable, not refused", async (_label, body) => {
+    answer(body);
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect(await failureCauses()).toEqual({ "lock/unusable": 1 });
+  });
+
+  it("calls an unreadable body unusable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response("<html>502</html>", { status: 200 })),
+    );
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect(await failureCauses()).toEqual({ "lock/unusable": 1 });
+  });
+
+  it("names a non-OK status as its own cause", async () => {
+    answer({ success: true, allowed: true }, 503);
+    await expect(firebillLock(lockParams)).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect(await failureCauses()).toEqual({ "lock/non_ok": 1 });
+  });
+});
+
+describe("firebillFinalize", () => {
+  const finalizeParams = {
+    lockId: "monitor_check-1",
+    action: "confirm" as const,
+  };
+
+  const answer = (body: unknown, status = 200) =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status })),
+    );
+
+  it("returns true when firebill accepted the settle", async () => {
+    answer({ success: true });
+    await expect(firebillFinalize(finalizeParams)).resolves.toBe(true);
+  });
+
+  it("calls an explicit success:false refused", async () => {
+    answer({ success: false });
+    await expect(firebillFinalize(finalizeParams)).resolves.toBe(false);
+    expect(await failureCauses()).toEqual({ "finalize/refused": 1 });
+  });
+
+  it.each([
+    ["a missing success", { queued: true }],
+    ["a non-boolean success", { success: "yes" }],
+  ])("calls %s unusable, not refused", async (_label, body) => {
+    answer(body);
+    await expect(firebillFinalize(finalizeParams)).resolves.toBe(false);
+    expect(await failureCauses()).toEqual({ "finalize/unusable": 1 });
+  });
+
+  it("calls an unreadable body unusable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response("<html>502</html>", { status: 200 })),
+    );
+    await expect(firebillFinalize(finalizeParams)).resolves.toBe(false);
+    expect(await failureCauses()).toEqual({ "finalize/unusable": 1 });
+  });
+
+  it("reads a 504 as ambiguous rather than refused", async () => {
+    answer({ success: false, ambiguous: true }, 504);
+    await expect(firebillFinalize(finalizeParams)).resolves.toBe(false);
+    expect(await failureCauses()).toEqual({ "finalize/ambiguous": 1 });
   });
 });

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -190,31 +190,16 @@ function saysAmbiguous(
   return (body !== UNUSABLE_BODY && body.ambiguous === true) || status === 504;
 }
 
-/**
- * firebill's answer bodies, as it actually serialises them (firebill
- * `src/api.rs`). Parsing through these replaces the hand-written shape guards:
- * a body that does not match is `unusable` — never a refusal — and that branch
- * now falls out of a failed `safeParse` rather than a stack of `typeof` checks.
- *
- * `success` is the discriminant on the two endpoints that carry more than a
- * bare boolean: firebill sends `allowed`/`remaining` (check) and
- * `allowed`/`lock_id`/… (lock) exactly when `success: true`, and a plain
- * `{ success: false }` otherwise. Keeping the two arms apart is what keeps an
- * explicit `success: false` (`refused`) distinct from a shape we could not read
- * (`unusable`): the former parses the `false` arm, the latter parses neither.
- */
+// firebill's answer bodies (firebill `src/api.rs`). `success` discriminates: it
+// sends `allowed`/`remaining` (check) and `allowed`/`lock_id`/… (lock) only when
+// `success: true`. Splitting the arms keeps an explicit `success: false`
+// (`refused`) distinct from a shape that matches neither (`unusable`).
 
-/** `/v1/track` and `/v1/finalize`: the bare boolean. `ambiguous` is read off
- * the raw body by {@link saysAmbiguous} before this, so it is not needed here. */
+// `ambiguous` is read off the raw body by saysAmbiguous before this.
 const usageAnswerSchema = z.object({ success: z.boolean() });
 
-/**
- * `/v1/check`. `remaining` is deliberately lenient: a missing or non-finite
- * figure must fall back to the allowed-inverted default in the clamp below, not
- * discard an otherwise-usable answer, so it is caught to `undefined` rather than
- * failing the parse. `allowed` is not — a `success: true` without a usable
- * `allowed` is `unusable`, exactly as the old `typeof` guard had it.
- */
+// `remaining` is lenient — a missing or non-finite figure falls back to the
+// clamp below rather than discarding the answer.
 const checkAnswerSchema = z.discriminatedUnion("success", [
   z.object({
     success: z.literal(true),
@@ -224,13 +209,8 @@ const checkAnswerSchema = z.discriminatedUnion("success", [
   z.object({ success: z.literal(false) }),
 ]);
 
-/**
- * `/v1/lock`. `reason` and `operation_token` stay `unknown`: an unrecognised
- * reason is dropped by {@link lockDeniedReason} and the token is validated where
- * it is read, so neither should fail the parse. `lock_id` is caught to
- * `undefined` so a mis-shaped echo falls back to the caller's own id rather than
- * turning a real lock into `unusable`.
- */
+// `lock_id` is caught to undefined so a mis-shaped echo falls back to the
+// caller's own id; reason/operation_token are validated where they are read.
 const lockAnswerSchema = z.discriminatedUnion("success", [
   z.object({
     success: z.literal(true),
@@ -639,12 +619,9 @@ export async function firebillCheck({
     }
 
     const parsed = checkAnswerSchema.safeParse(answered);
-    // Anything that matches neither arm is an answer we cannot read rather than
-    // one firebill gave — a missing `success`, or a `success: true` without a
-    // usable boolean `allowed`, which firebill does not send today and which
-    // read as a denial would 402 a paying customer. `refused` is documented as
-    // an explicit `success: false`; labelling an unreadable shape with it would
-    // have anyone slicing by cause counting these as declines. So it fails open.
+    // Unreadable, not refused: a missing `success` or a mis-shaped `allowed` read
+    // as a denial would 402 a paying customer, and counting it `refused` would
+    // have anyone slicing by cause counting it a decline. So it fails open.
     if (!parsed.success) {
       return unavailable("answered without a usable shape", "unusable");
     }
@@ -769,10 +746,8 @@ export async function firebillLock({
       return { status: "unavailable" };
     }
     const parsed = lockAnswerSchema.safeParse(answered);
-    // A `success: false` firebill sent on purpose is `refused`; a shape matching
-    // neither arm — no `success`, or a `success: true` without a boolean
-    // `allowed` firebill does not send today — is `unusable`. Both proceed
-    // unlocked, but the cause label has to tell them apart.
+    // Both proceed unlocked, but the cause has to tell them apart: an explicit
+    // `success: false` is `refused`, a shape matching neither arm is `unusable`.
     if (!parsed.success || parsed.data.success === false) {
       logger.error("firebill lock did not succeed", context);
       firebillFailureCauseTotal
@@ -795,11 +770,8 @@ export async function firebillLock({
       return { status: "denied", ...(reason ? { reason } : {}) };
     }
 
-    // `allowed` is a schema-guaranteed boolean here, and the denial above took
-    // the `false`, so this is `allowed: true`. A `success: true` with a missing
-    // or mis-shaped `allowed` — which firebill does not send today, and which
-    // read as a denial would hard-stop the check (skipped_no_credits) — never
-    // reaches here: it fails the parse and is reported `unusable` above.
+    // allowed is a schema-guaranteed boolean and the denial above took the
+    // false, so this is allowed: true.
     const operationToken =
       typeof body.operation_token === "string" &&
       body.operation_token.length > 0
@@ -949,8 +921,7 @@ export async function firebillFinalize({
     if (!parsed.success || parsed.data.success !== true) {
       logger.error("firebill finalize did not succeed", context);
       firebillFailureCauseTotal
-        // An explicit `success: false` is `refused`; a shape we could not read
-        // is `unusable`. The settle retries on the schedule either way.
+        // Explicit `success: false` is `refused`; an unreadable shape `unusable`.
         .labels("finalize", parsed.success ? "refused" : "unusable")
         .inc();
       return false;

--- a/apps/api/src/services/autumn/firebill.ts
+++ b/apps/api/src/services/autumn/firebill.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { z } from "zod";
 import { config } from "../../config";
 import { logger } from "../../lib/logger";
 import { sampled } from "../../lib/rollout";
@@ -188,6 +189,58 @@ function saysAmbiguous(
 ): boolean {
   return (body !== UNUSABLE_BODY && body.ambiguous === true) || status === 504;
 }
+
+/**
+ * firebill's answer bodies, as it actually serialises them (firebill
+ * `src/api.rs`). Parsing through these replaces the hand-written shape guards:
+ * a body that does not match is `unusable` — never a refusal — and that branch
+ * now falls out of a failed `safeParse` rather than a stack of `typeof` checks.
+ *
+ * `success` is the discriminant on the two endpoints that carry more than a
+ * bare boolean: firebill sends `allowed`/`remaining` (check) and
+ * `allowed`/`lock_id`/… (lock) exactly when `success: true`, and a plain
+ * `{ success: false }` otherwise. Keeping the two arms apart is what keeps an
+ * explicit `success: false` (`refused`) distinct from a shape we could not read
+ * (`unusable`): the former parses the `false` arm, the latter parses neither.
+ */
+
+/** `/v1/track` and `/v1/finalize`: the bare boolean. `ambiguous` is read off
+ * the raw body by {@link saysAmbiguous} before this, so it is not needed here. */
+const usageAnswerSchema = z.object({ success: z.boolean() });
+
+/**
+ * `/v1/check`. `remaining` is deliberately lenient: a missing or non-finite
+ * figure must fall back to the allowed-inverted default in the clamp below, not
+ * discard an otherwise-usable answer, so it is caught to `undefined` rather than
+ * failing the parse. `allowed` is not — a `success: true` without a usable
+ * `allowed` is `unusable`, exactly as the old `typeof` guard had it.
+ */
+const checkAnswerSchema = z.discriminatedUnion("success", [
+  z.object({
+    success: z.literal(true),
+    allowed: z.boolean(),
+    remaining: z.number().finite().optional().catch(undefined),
+  }),
+  z.object({ success: z.literal(false) }),
+]);
+
+/**
+ * `/v1/lock`. `reason` and `operation_token` stay `unknown`: an unrecognised
+ * reason is dropped by {@link lockDeniedReason} and the token is validated where
+ * it is read, so neither should fail the parse. `lock_id` is caught to
+ * `undefined` so a mis-shaped echo falls back to the caller's own id rather than
+ * turning a real lock into `unusable`.
+ */
+const lockAnswerSchema = z.discriminatedUnion("success", [
+  z.object({
+    success: z.literal(true),
+    allowed: z.boolean(),
+    lock_id: z.string().optional().catch(undefined),
+    reason: z.unknown().optional(),
+    operation_token: z.unknown().optional(),
+  }),
+  z.object({ success: z.literal(false) }),
+]);
 
 // FIREBILL_ORG_IDS is decoded once at startup by the config schema; the Set is
 // built lazily on first use and cached, keyed on the decoded array reference.
@@ -436,11 +489,13 @@ async function firebillAttempt(
     // telling us it took the event in a shape we did not understand — so it is
     // ambiguous, and the caller retries under the same key rather than logging
     // usage as lost.
-    if (body !== UNUSABLE_BODY && body.success === false) {
+    const parsed =
+      body === UNUSABLE_BODY ? undefined : usageAnswerSchema.safeParse(body);
+    if (parsed?.success && parsed.data.success === false) {
       logger.warn("firebill refused the event — it did not take it", context);
       return { ok: false, reason: "not_success", cause: "refused" };
     }
-    if (body === UNUSABLE_BODY || body.success !== true) {
+    if (!parsed?.success) {
       logger.warn("firebill answered with a body we could not read", {
         ...context,
         status: response.status,
@@ -582,29 +637,23 @@ export async function firebillCheck({
         status: response.status,
       });
     }
-    const body = answered as {
-      success?: boolean;
-      allowed?: boolean;
-      remaining?: number;
-    };
 
+    const parsed = checkAnswerSchema.safeParse(answered);
+    // Anything that matches neither arm is an answer we cannot read rather than
+    // one firebill gave — a missing `success`, or a `success: true` without a
+    // usable boolean `allowed`, which firebill does not send today and which
+    // read as a denial would 402 a paying customer. `refused` is documented as
+    // an explicit `success: false`; labelling an unreadable shape with it would
+    // have anyone slicing by cause counting these as declines. So it fails open.
+    if (!parsed.success) {
+      return unavailable("answered without a usable shape", "unusable");
+    }
     // `success: false` is firebill saying it does not know — an unanswered
     // balance, or a gateway lookup that failed. Never a denial.
-    if (body.success === false) {
+    if (parsed.data.success === false) {
       return unavailable("firebill could not answer", "refused");
     }
-    // Anything else that is not `success: true` is an answer we cannot read
-    // rather than one firebill gave: `refused` is documented as an explicit
-    // `success: false`, and labelling a shape we did not understand with it
-    // would have anyone slicing by cause counting these as declines.
-    if (body.success !== true) {
-      return unavailable("answered without a usable `success`", "unusable");
-    }
-    // A missing or mis-shaped `allowed` is not something firebill sends today.
-    // Reading it as a denial would 402 a paying customer, so it fails open.
-    if (typeof body.allowed !== "boolean") {
-      return unavailable("answered without a usable `allowed`", "unusable");
-    }
+    const body = parsed.data;
 
     // `remaining` clamps downstream limits, and the safe default inverts with
     // `allowed`, so there is no single one.
@@ -719,21 +768,19 @@ export async function firebillLock({
       firebillFailureCauseTotal.labels("lock", "unusable").inc();
       return { status: "unavailable" };
     }
-    const body = answered as {
-      success?: boolean;
-      allowed?: boolean;
-      lock_id?: string;
-      reason?: unknown;
-      operation_token?: unknown;
-    };
-
-    if (body.success !== true) {
+    const parsed = lockAnswerSchema.safeParse(answered);
+    // A `success: false` firebill sent on purpose is `refused`; a shape matching
+    // neither arm — no `success`, or a `success: true` without a boolean
+    // `allowed` firebill does not send today — is `unusable`. Both proceed
+    // unlocked, but the cause label has to tell them apart.
+    if (!parsed.success || parsed.data.success === false) {
       logger.error("firebill lock did not succeed", context);
       firebillFailureCauseTotal
-        .labels("lock", body.success === false ? "refused" : "unusable")
+        .labels("lock", parsed.success ? "refused" : "unusable")
         .inc();
       return { status: "unavailable" };
     }
+    const body = parsed.data;
 
     if (body.allowed === false) {
       const reason = lockDeniedReason(body.reason);
@@ -748,19 +795,11 @@ export async function firebillLock({
       return { status: "denied", ...(reason ? { reason } : {}) };
     }
 
-    // Only an explicit `allowed: false` is a denial. `success: true` with a
-    // missing or mis-shaped `allowed` is not an answer firebill sends today;
-    // treating it as a denial would hard-stop the check (skipped_no_credits),
-    // so it maps to unavailable — proceed unlocked — instead.
-    if (body.allowed !== true) {
-      logger.error(
-        "firebill lock answered without a usable `allowed`",
-        context,
-      );
-      firebillFailureCauseTotal.labels("lock", "unusable").inc();
-      return { status: "unavailable" };
-    }
-
+    // `allowed` is a schema-guaranteed boolean here, and the denial above took
+    // the `false`, so this is `allowed: true`. A `success: true` with a missing
+    // or mis-shaped `allowed` — which firebill does not send today, and which
+    // read as a denial would hard-stop the check (skipped_no_credits) — never
+    // reaches here: it fails the parse and is reported `unusable` above.
     const operationToken =
       typeof body.operation_token === "string" &&
       body.operation_token.length > 0
@@ -906,11 +945,13 @@ export async function firebillFinalize({
       firebillFailureCauseTotal.labels("finalize", "unusable").inc();
       return false;
     }
-    const body = answered as { success?: boolean };
-    if (body.success !== true) {
+    const parsed = usageAnswerSchema.safeParse(answered);
+    if (!parsed.success || parsed.data.success !== true) {
       logger.error("firebill finalize did not succeed", context);
       firebillFailureCauseTotal
-        .labels("finalize", body.success === false ? "refused" : "unusable")
+        // An explicit `success: false` is `refused`; a shape we could not read
+        // is `unusable`. The settle retries on the schedule either way.
+        .labels("finalize", parsed.success ? "refused" : "unusable")
         .inc();
       return false;
     }


### PR DESCRIPTION
## What

Replaces the hand-written shape validation in the firebill client ([firebill.ts](apps/api/src/services/autumn/firebill.ts)) — the `as {...}` casts followed by stacks of `typeof` / `!== true` guards across `track`, `check`, `lock` and `finalize` — with three small Zod schemas that encode firebill's actual response contract (firebill `src/api.rs`).

This is the follow-up to the review comment on #4514 ("a bit excessive error handling… maybe a Zod schema could reduce the footprint").

## Why a discriminated union

`success` is the discriminant on the two endpoints that carry more than a bare boolean: firebill sends `allowed`/`remaining` (check) and `allowed`/`lock_id`/… (lock) **exactly when `success: true`**, and a plain `{ success: false }` otherwise. Keeping those two arms apart is what preserves the distinction #4514 bought:

- explicit `success: false` → **`refused`** (parses the `false` arm)
- a shape matching neither arm → **`unusable`** (failed `safeParse`) — no longer a hand-written guard

## Behaviour is unchanged

Every outcome, cause label, log message and the `remaining` fail-open clamp are preserved:

- `remaining` is `.finite().optional().catch(undefined)` — a missing/non-finite figure still falls back to the allowed-inverted default in the clamp rather than discarding an otherwise-usable answer.
- `lock_id` is `.catch(undefined)` — a mis-shaped echo falls back to the caller's own id rather than turning a real lock into `unusable`.
- The now-dead `allowed !== true` guard in `lock` is removed: the schema guarantees `allowed` is a boolean, so after the `=== false` denial only `true` remains.

## What is deliberately *not* moved to Zod

Transport-error classification (`classifyTransportError`, `readJson`), the 504/`ambiguous` handling, and the fail-open policy stay as-is. Those are about *whether firebill answered at all*, not the JSON shape — and firebill's own source documents that the caller must own the fail direction. Zod validates shape, not billing semantics, so the footprint reduction is in the shape guards only, not the (load-bearing) outcome logic.

## Tests

- All existing `firebillTrack` / `firebillCheck` tests pass unchanged.
- Adds `firebillLock` and `firebillFinalize` coverage (previously untested in this file), pinning the refused-vs-unusable cause split through the new parse.

`pnpm vitest run` on the file: **67 passed**. `tsc --noEmit` clean, `knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hand-written shape guards in the firebill client across `track`, `check`, `lock`, and `finalize` with three Zod schemas that encode firebill's actual response contract. Behavior is unchanged — every outcome, cause label, and log message stays the same, and transport-error handling plus the 504/`ambiguous` logic are untouched.

**Refactors**
- Discriminated unions on `success` keep an explicit `success: false` (`refused`) distinct from an unreadable shape (`unusable`).
- `remaining` and `lock_id` parse leniently (`catch`) so a mis-shaped value falls back instead of discarding an otherwise-usable answer.
- Adds `firebillLock` and `firebillFinalize` test coverage pinning the refused-vs-unusable cause split through the new parse.

<sup>Written for commit 7427cc4dfa245fe4028b6265451fa53a20b5a32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

