### PR TITLE
fix(api): answer unmatched and wrong-method paths with JSON

### DIFF
--- a/apps/api/src/__tests__/routes/not-found-metrics.routes.test.ts
+++ b/apps/api/src/__tests__/routes/not-found-metrics.routes.test.ts
@@ -1,0 +1,101 @@
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../services/autumn/autumn.service", () => ({
+  autumnService: { checkCredits: vi.fn() },
+  CREDITS_FEATURE_ID: "CREDITS",
+}));
+vi.mock("../../services/autumn/usage", () => ({
+  getTeamBalance: vi.fn(),
+}));
+vi.mock("../../controllers/auth", () => ({
+  authenticateUser: vi.fn(),
+}));
+vi.mock("../../services/idempotency/create", () => ({
+  createIdempotencyKey: vi.fn(),
+}));
+vi.mock("../../services/idempotency/validate", () => ({
+  validateIdempotencyKey: vi.fn(),
+}));
+vi.mock("geoip-country", () => ({ lookup: vi.fn(() => null) }));
+
+import { notFoundHandler } from "../../lib/not-found";
+import { httpRequestDurationSeconds } from "../../lib/http-metrics";
+import { requestTimingMiddleware } from "../../routes/shared";
+
+// The real timing middleware patches res.json, so every JSON answer produced
+// after it runs -- including the terminal 404/405 -- is observed by the
+// histogram. Unmatched paths must not mint a new time series per URL.
+function appUnderTest() {
+  const app = express();
+
+  const v2 = express.Router();
+  v2.use(requestTimingMiddleware("v2"));
+  v2.post("/scrape", (_req, res) => res.status(200).json({ success: true }));
+
+  app.use("/v2", v2);
+  app.use(notFoundHandler);
+  return app;
+}
+
+async function recordedRoutes(): Promise<string[]> {
+  const metric = await httpRequestDurationSeconds.get();
+  return metric.values
+    .filter(value => value.metricName === "http_request_duration_seconds_count")
+    .map(value => String(value.labels.route));
+}
+
+describe("not-found handler metric labels", () => {
+  beforeEach(() => {
+    httpRequestDurationSeconds.reset();
+  });
+
+  it("labels unknown paths with a single constant instead of the raw path", async () => {
+    const app = appUnderTest();
+
+    await request(app).get("/v2/wp-login.php");
+    await request(app).get("/v2/.env");
+    await request(app).get("/v2/some/deep/scanner/path");
+
+    const routes = await recordedRoutes();
+
+    expect(routes.length).toBeGreaterThan(0);
+    expect(new Set(routes)).toEqual(new Set(["unmatched"]));
+  });
+
+  it("labels wrong-method hits on parameterised paths with the same constant", async () => {
+    const app = appUnderTest();
+
+    await request(app).get("/v2/scrape");
+    await request(app).delete("/v2/scrape");
+
+    const routes = await recordedRoutes();
+
+    expect(routes.length).toBeGreaterThan(0);
+    expect(new Set(routes)).toEqual(new Set(["unmatched"]));
+  });
+
+  it("leaves the label of a matched route untouched", async () => {
+    const app = appUnderTest();
+
+    await request(app).post("/v2/scrape");
+
+    expect(await recordedRoutes()).toEqual(["/scrape"]);
+  });
+});
+
+describe("terminal not-found handler security headers", () => {
+  it("sets nosniff on the JSON 404", async () => {
+    const res = await request(appUnderTest()).get("/v2/nonexistent-xyz");
+
+    expect(res.status).toBe(404);
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("sets nosniff on the JSON 405", async () => {
+    const res = await request(appUnderTest()).get("/v2/scrape");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+});

--- a/apps/api/src/__tests__/routes/not-found-metrics.routes.test.ts
+++ b/apps/api/src/__tests__/routes/not-found-metrics.routes.test.ts
@@ -67,7 +67,7 @@ describe("not-found handler metric labels", () => {
     expect(new Set(routes)).toEqual(new Set(["unmatched"]));
   });
 
-  it("labels wrong-method hits on parameterised paths with the same constant", async () => {
+  it("labels wrong-method hits on a static path with the same constant", async () => {
     const app = appUnderTest();
 
     await request(app).get("/v2/scrape");
@@ -87,6 +87,15 @@ describe("not-found handler metric labels", () => {
 
     expect(res.status).toBe(405);
     expect(res.headers["allow"]).toBe("DELETE, GET, HEAD");
+    expect(res.body).toEqual({
+      success: false,
+      code: "METHOD_NOT_ALLOWED",
+      error:
+        "PATCH /v2/crawl/abc-123 is not supported. Use DELETE, GET, HEAD instead.",
+      allowed_methods: ["DELETE", "GET", "HEAD"],
+      documentation_url:
+        "https://docs.firecrawl.dev/api-reference/introduction",
+    });
 
     const routes = await recordedRoutes();
 
@@ -109,6 +118,13 @@ describe("terminal not-found handler security headers", () => {
 
     expect(res.status).toBe(404);
     expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.body).toEqual({
+      success: false,
+      code: "NOT_FOUND",
+      error: "GET /v2/nonexistent-xyz is not a Firecrawl API endpoint.",
+      documentation_url:
+        "https://docs.firecrawl.dev/api-reference/introduction",
+    });
   });
 
   it("sets nosniff on the JSON 405", async () => {
@@ -116,5 +132,13 @@ describe("terminal not-found handler security headers", () => {
 
     expect(res.status).toBe(405);
     expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.body).toEqual({
+      success: false,
+      code: "METHOD_NOT_ALLOWED",
+      error: "GET /v2/scrape is not supported. Use POST instead.",
+      allowed_methods: ["POST"],
+      documentation_url:
+        "https://docs.firecrawl.dev/api-reference/introduction",
+    });
   });
 });

--- a/apps/api/src/__tests__/routes/not-found-metrics.routes.test.ts
+++ b/apps/api/src/__tests__/routes/not-found-metrics.routes.test.ts
@@ -32,6 +32,10 @@ function appUnderTest() {
   const v2 = express.Router();
   v2.use(requestTimingMiddleware("v2"));
   v2.post("/scrape", (_req, res) => res.status(200).json({ success: true }));
+  // Mirrors the real /v2/crawl/:jobId table (src/routes/v2.ts): only GET and
+  // DELETE are registered, never PATCH.
+  v2.get("/crawl/:jobId", (_req, res) => res.status(200).json({ success: true }));
+  v2.delete("/crawl/:jobId", (_req, res) => res.status(200).json({ success: true }));
 
   app.use("/v2", v2);
   app.use(notFoundHandler);
@@ -68,6 +72,21 @@ describe("not-found handler metric labels", () => {
 
     await request(app).get("/v2/scrape");
     await request(app).delete("/v2/scrape");
+
+    const routes = await recordedRoutes();
+
+    expect(routes.length).toBeGreaterThan(0);
+    expect(new Set(routes)).toEqual(new Set(["unmatched"]));
+  });
+
+  it("labels a wrong-method hit on a genuinely parameterised path with the same constant", async () => {
+    const app = appUnderTest();
+
+    // PATCH is not registered for /v2/crawl/:jobId -- only GET and DELETE are.
+    const res = await request(app).patch("/v2/crawl/abc-123");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("DELETE, GET, HEAD");
 
     const routes = await recordedRoutes();
 

--- a/apps/api/src/__tests__/routes/not-found.routes.test.ts
+++ b/apps/api/src/__tests__/routes/not-found.routes.test.ts
@@ -1,0 +1,119 @@
+import express from "express";
+import request from "supertest";
+import { notFoundHandler } from "../../lib/not-found";
+
+// A stand-in for the real app's mount structure: a versioned router mounted
+// under a prefix, a sub-router mounted inside it, and a root descriptor. The
+// real routers pull in the whole service graph, so the shape is replayed here
+// rather than imported.
+function appUnderTest() {
+  const app = express();
+
+  app.get("/", (_req, res) => {
+    res.json({
+      message: "Firecrawl API",
+      documentation_url: "https://docs.firecrawl.dev",
+    });
+  });
+
+  const nested = express.Router();
+  nested.post("/", (_req, res) => res.status(200).json({ success: true }));
+  nested.delete("/", (_req, res) => res.status(200).json({ success: true }));
+
+  const v2 = express.Router();
+  v2.post("/scrape", (_req, res) => res.status(200).json({ success: true }));
+  v2.post("/search", (_req, res) => res.status(200).json({ success: true }));
+  v2.get("/crawl/:id", (_req, res) => res.status(200).json({ success: true }));
+  v2.delete("/crawl/:id", (_req, res) =>
+    res.status(200).json({ success: true }),
+  );
+  v2.post("/scrape/:jobId/interact", (_req, res) =>
+    res.status(200).json({ success: true }),
+  );
+  v2.delete("/scrape/:jobId/interact", (_req, res) =>
+    res.status(200).json({ success: true }),
+  );
+  v2.use("/developer", nested);
+
+  app.use("/v2", v2);
+  app.use(notFoundHandler);
+  return app;
+}
+
+describe("terminal not-found handler", () => {
+  it("answers an unknown path with JSON, not Express's HTML page", async () => {
+    const res = await request(appUnderTest()).get("/v2/nonexistent-xyz");
+
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.text).not.toContain("Cannot GET");
+    expect(res.body).toEqual({
+      success: false,
+      code: "NOT_FOUND",
+      error: "GET /v2/nonexistent-xyz is not a Firecrawl API endpoint.",
+      documentation_url:
+        "https://docs.firecrawl.dev/api-reference/introduction",
+    });
+  });
+
+  it.each(["/v2/scrape", "/v2/search"])(
+    "answers GET %s with 405 and an Allow header",
+    async path => {
+      const res = await request(appUnderTest()).get(path);
+
+      expect(res.status).toBe(405);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(res.headers["allow"]).toBe("POST");
+      expect(res.text).not.toContain("Cannot GET");
+      expect(res.body.code).toBe("METHOD_NOT_ALLOWED");
+      expect(res.body.allowed_methods).toEqual(["POST"]);
+      expect(res.body.documentation_url).toBe(
+        "https://docs.firecrawl.dev/api-reference/introduction",
+      );
+    },
+  );
+
+  it("lists every other method for a path that has several", async () => {
+    const res = await request(appUnderTest()).post("/v2/crawl/abc");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("DELETE, GET, HEAD");
+    expect(res.body.allowed_methods).toEqual(["DELETE", "GET", "HEAD"]);
+  });
+
+  it("answers GET on the interact path with 405, not Cannot GET", async () => {
+    const res = await request(appUnderTest()).get("/v2/scrape/abc/interact");
+
+    expect(res.status).toBe(405);
+    expect(res.text).not.toContain("Cannot GET");
+    expect(res.headers["allow"]).toBe("DELETE, POST");
+  });
+
+  it("resolves paths inside a mounted sub-router", async () => {
+    const res = await request(appUnderTest()).get("/v2/developer");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("DELETE, POST");
+  });
+
+  it("leaves existing routes alone", async () => {
+    const app = appUnderTest();
+
+    const scrape = await request(app).post("/v2/scrape");
+    expect(scrape.status).toBe(200);
+    expect(scrape.body).toEqual({ success: true });
+
+    const status = await request(app).get("/v2/crawl/abc");
+    expect(status.status).toBe(200);
+
+    const interact = await request(app).post("/v2/scrape/abc/interact");
+    expect(interact.status).toBe(200);
+
+    const developer = await request(app).post("/v2/developer");
+    expect(developer.status).toBe(200);
+
+    const root = await request(app).get("/");
+    expect(root.status).toBe(200);
+    expect(root.body.message).toBe("Firecrawl API");
+  });
+});

--- a/apps/api/src/__tests__/routes/not-found.routes.test.ts
+++ b/apps/api/src/__tests__/routes/not-found.routes.test.ts
@@ -35,7 +35,25 @@ function appUnderTest() {
   );
   v2.use("/developer", nested);
 
+  // Mounted with no path, the way `v0Router` and `adminRouter` are in
+  // src/index.ts. Express flags such a layer as matching everything and never
+  // consults its matchers, so the walk has to handle it explicitly.
+  const rootMounted = express.Router();
+  rootMounted.post("/v0/scrape", (_req, res) =>
+    res.status(200).json({ success: true }),
+  );
+  rootMounted.get("/v0/health/liveness", (_req, res) =>
+    res.status(200).json({ success: true }),
+  );
+
+  const adminMounted = express.Router();
+  adminMounted.post("/admin/:key/queues", (_req, res) =>
+    res.status(200).json({ success: true }),
+  );
+
   app.use("/v2", v2);
+  app.use(rootMounted);
+  app.use(adminMounted);
   app.use(notFoundHandler);
   return app;
 }
@@ -96,6 +114,40 @@ describe("terminal not-found handler", () => {
     expect(res.headers["allow"]).toBe("DELETE, POST");
   });
 
+  it("answers GET on a POST-only route in a root-mounted router with 405", async () => {
+    const res = await request(appUnderTest()).get("/v0/scrape");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+    expect(res.text).not.toContain("Cannot GET");
+    expect(res.body.code).toBe("METHOD_NOT_ALLOWED");
+    expect(res.body.allowed_methods).toEqual(["POST"]);
+  });
+
+  it("answers POST on a GET-only route in a root-mounted router with 405", async () => {
+    const res = await request(appUnderTest()).post("/v0/health/liveness");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("GET, HEAD");
+    expect(res.body.allowed_methods).toEqual(["GET", "HEAD"]);
+  });
+
+  it("resolves admin paths in a second root-mounted router", async () => {
+    const res = await request(appUnderTest()).get("/admin/secret/queues");
+
+    expect(res.status).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+  });
+
+  it("still answers an unknown path under a root mount with a JSON 404", async () => {
+    const res = await request(appUnderTest()).get("/v0/nonexistent-xyz");
+
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.headers["allow"]).toBeUndefined();
+    expect(res.body.code).toBe("NOT_FOUND");
+  });
+
   it("leaves existing routes alone", async () => {
     const app = appUnderTest();
 
@@ -115,5 +167,15 @@ describe("terminal not-found handler", () => {
     const root = await request(app).get("/");
     expect(root.status).toBe(200);
     expect(root.body.message).toBe("Firecrawl API");
+
+    const v0Scrape = await request(app).post("/v0/scrape");
+    expect(v0Scrape.status).toBe(200);
+    expect(v0Scrape.body).toEqual({ success: true });
+
+    const liveness = await request(app).get("/v0/health/liveness");
+    expect(liveness.status).toBe(200);
+
+    const admin = await request(app).post("/admin/secret/queues");
+    expect(admin.status).toBe(200);
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -45,6 +45,7 @@ import { shutdownWebhookQueue } from "./services/webhook";
 import { shutdownIndexerQueue } from "./services/indexing/indexer-queue";
 import { isKeylessConfigured } from "./lib/keyless";
 import { shutdownPubSubLogging } from "./services/logging/log_job";
+import { notFoundHandler } from "./lib/not-found";
 
 const { createBullBoard } = require("@bull-board/api");
 const { BullMQAdapter } = require("@bull-board/api/bullMQAdapter");
@@ -211,6 +212,10 @@ if (require.main === module) {
 app.get("/is-production", (req, res) => {
   res.send({ isProduction: global.isProduction });
 });
+
+// Terminal handler for unmatched paths. Must stay after every route and before
+// the error middleware below, or Express falls back to its default HTML page.
+app.use(notFoundHandler);
 
 app.use(
   (

--- a/apps/api/src/lib/http-metrics.ts
+++ b/apps/api/src/lib/http-metrics.ts
@@ -11,9 +11,27 @@ export const httpRequestDurationSeconds = new Histogram({
   buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
 });
 
+/**
+ * Single `route` label for every request that matched no route. Without it the
+ * fallback below would mint a new time series per scanned URL, since unmatched
+ * requests reach the terminal handler and answer with `res.json`, which the
+ * timing middleware observes.
+ */
+const UNMATCHED_ROUTE = "unmatched";
+
+const UNMATCHED_FLAG = Symbol.for("firecrawl.httpMetrics.unmatchedRoute");
+
+/** Called by the terminal not-found handler before it answers. */
+export function markRouteUnmatched(req: Request): void {
+  (req as unknown as Record<symbol, boolean>)[UNMATCHED_FLAG] = true;
+}
+
 export function getRoutePattern(req: Request): string {
   if (req.route?.path) {
     return req.route.path;
+  }
+  if ((req as unknown as Record<symbol, boolean>)[UNMATCHED_FLAG] === true) {
+    return UNMATCHED_ROUTE;
   }
   return req.path.replace(UUID_REGEX, ":id");
 }

--- a/apps/api/src/lib/not-found.ts
+++ b/apps/api/src/lib/not-found.ts
@@ -1,0 +1,116 @@
+import type { NextFunction, Request, Response } from "express";
+
+const NOT_FOUND_DOCUMENTATION_URL =
+  "https://docs.firecrawl.dev/api-reference/introduction";
+
+// Express 5 router internals. Layers expose pure matcher functions, so this
+// walk never mutates routing state.
+type LayerMatch = { path: string } | false;
+type Matcher = (path: string) => LayerMatch;
+type Layer = {
+  matchers?: Matcher[];
+  route?: { methods?: Record<string, boolean> };
+  handle?: unknown;
+};
+type StackHolder = { stack?: Layer[] };
+
+function hasStack(value: unknown): value is { stack: Layer[] } {
+  if (typeof value !== "function" && typeof value !== "object") {
+    return false;
+  }
+  return value !== null && Array.isArray((value as StackHolder).stack);
+}
+
+function walk(stack: Layer[], path: string, found: Set<string>): void {
+  for (const layer of stack) {
+    const matchers = layer.matchers;
+    if (!Array.isArray(matchers)) {
+      continue;
+    }
+
+    if (layer.route) {
+      const methods = layer.route.methods ?? {};
+      if (!matchers.some(match => match(path) !== false)) {
+        continue;
+      }
+      for (const [method, enabled] of Object.entries(methods)) {
+        if (enabled && method !== "_all") {
+          found.add(method.toUpperCase());
+        }
+      }
+      continue;
+    }
+
+    // A mounted sub-router. Strip the prefix it matched and recurse.
+    if (!hasStack(layer.handle)) {
+      continue;
+    }
+    for (const match of matchers) {
+      const matched = match(path);
+      if (matched === false) {
+        continue;
+      }
+      const rest = path.slice(matched.path.length);
+      walk(layer.handle.stack, rest === "" ? "/" : rest, found);
+    }
+  }
+}
+
+/**
+ * Methods registered for `path` anywhere in the app, ignoring the method of the
+ * request that missed. Returns an empty set when the path itself is unknown.
+ */
+function allowedMethodsForPath(app: unknown, path: string): Set<string> {
+  const found = new Set<string>();
+  try {
+    const router = (app as { router?: StackHolder }).router;
+    if (router && Array.isArray(router.stack)) {
+      walk(router.stack, path, found);
+    }
+  } catch {
+    // Router internals are not part of Express's public API. If they ever move,
+    // fall back to a plain 404 rather than failing the request.
+    return new Set<string>();
+  }
+  if (found.has("GET")) {
+    found.add("HEAD");
+  }
+  return found;
+}
+
+/**
+ * Terminal handler for requests that matched no route. Replaces Express's
+ * default HTML "Cannot GET /v2/scrape" page with JSON in the same envelope the
+ * rest of the API uses, and answers 405 with an Allow header when the path
+ * exists under a different method.
+ *
+ * Must be registered after every router and before the error middleware.
+ */
+export function notFoundHandler(
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const allowed = [...allowedMethodsForPath(req.app, req.path)]
+    .filter(method => method !== req.method)
+    .sort();
+
+  if (allowed.length > 0) {
+    res.setHeader("Allow", allowed.join(", "));
+    res.status(405).json({
+      success: false,
+      code: "METHOD_NOT_ALLOWED",
+      error: `${req.method} ${req.path} is not supported. Use ${allowed.join(", ")} instead.`,
+      allowed_methods: allowed,
+      documentation_url: NOT_FOUND_DOCUMENTATION_URL,
+    });
+    return;
+  }
+
+  res.status(404).json({
+    success: false,
+    code: "NOT_FOUND",
+    error: `${req.method} ${req.path} is not a Firecrawl API endpoint.`,
+    documentation_url: NOT_FOUND_DOCUMENTATION_URL,
+  });
+}

--- a/apps/api/src/lib/not-found.ts
+++ b/apps/api/src/lib/not-found.ts
@@ -9,6 +9,10 @@ type LayerMatch = { path: string } | false;
 type Matcher = (path: string) => LayerMatch;
 type Layer = {
   matchers?: Matcher[];
+  // Set by Express for a router mounted with no path (`app.use(router)`).
+  // Express short-circuits on this flag and never consults `matchers`, whose
+  // patterns only match "/" for such a layer.
+  slash?: boolean;
   route?: { methods?: Record<string, boolean> };
   handle?: unknown;
 };
@@ -28,11 +32,24 @@ function walk(stack: Layer[], path: string, found: Set<string>): void {
       continue;
     }
 
+    // A root-mounted layer matches every path and consumes no prefix, so the
+    // full path is passed down. Reading the flag keeps the walk pure;
+    // `layer.match()` would assign `params`/`path` on the shared layer.
+    const matches: Exclude<LayerMatch, false>[] =
+      layer.slash === true
+        ? [{ path: "" }]
+        : matchers
+            .map(match => match(path))
+            .filter(
+              (match): match is Exclude<LayerMatch, false> => match !== false,
+            );
+
+    if (matches.length === 0) {
+      continue;
+    }
+
     if (layer.route) {
       const methods = layer.route.methods ?? {};
-      if (!matchers.some(match => match(path) !== false)) {
-        continue;
-      }
       for (const [method, enabled] of Object.entries(methods)) {
         if (enabled && method !== "_all") {
           found.add(method.toUpperCase());
@@ -45,11 +62,7 @@ function walk(stack: Layer[], path: string, found: Set<string>): void {
     if (!hasStack(layer.handle)) {
       continue;
     }
-    for (const match of matchers) {
-      const matched = match(path);
-      if (matched === false) {
-        continue;
-      }
+    for (const matched of matches) {
       const rest = path.slice(matched.path.length);
       walk(layer.handle.stack, rest === "" ? "/" : rest, found);
     }

--- a/apps/api/src/lib/not-found.ts
+++ b/apps/api/src/lib/not-found.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
+import { markRouteUnmatched } from "./http-metrics";
 
 const NOT_FOUND_DOCUMENTATION_URL =
   "https://docs.firecrawl.dev/api-reference/introduction";
@@ -104,6 +105,14 @@ export function notFoundHandler(
   res: Response,
   _next: NextFunction,
 ): void {
+  // `res.json` below is observed by the versioned timing middleware, which
+  // otherwise labels the sample with the raw request path — one time series per
+  // scanned URL. Collapse every unmatched request onto one label.
+  markRouteUnmatched(req);
+
+  // finalhandler's HTML page carried this; res.json does not set it.
+  res.setHeader("X-Content-Type-Options", "nosniff");
+
   const allowed = [...allowedMethodsForPath(req.app, req.path)]
     .filter(method => method !== req.method)
     .sort();


### PR DESCRIPTION
## Summary

Any path the API does not serve falls through to Express's default finalhandler, which returns an HTML page reading "Cannot GET /v2/scrape". This adds a terminal handler that answers JSON instead: 405 with an `Allow` header when the path exists under another method, 404 otherwise.

Two things to be aware of before merge:

- `GET /v2/scrape` and `GET /v2/search` change status from 404 to 405. The paths exist under POST, so 405 is the correct answer, but any external monitor asserting a 404 on them will see the change.
- The handler is mounted at the app level, not per router. So `/v1`, `/v0`, `/exchange` and the admin paths get JSON bodies too, not just `/v2`. `/labs` is not affected: `labsRouter.all(/(.*)/)` at `apps/api/src/routes/labs.ts:227` already answers every unmatched path and every wrong method under `/labs`, so nothing there reaches this handler.

## Why

Report DI-2026-09-04-WEEKLY, findings OB-05 claim 7 and OB-07 claim 1. Snapshot b8e20759dd59 of `api.firecrawl.dev/v2/search` is 29 bytes, exactly the string `Cannot GET /v2/search`. Snapshot ee52527f of `/v2/scrape` is the same shape.

Verified live on 2026-09-06:

```
GET https://api.firecrawl.dev/v2/scrape
404, content-type: text/html
<pre>Cannot GET /v2/scrape</pre>
```

The same holds for `/v2/search` and `/v2/scrape/{id}/interact`. An agent or crawler that probes an endpoint with a plain GET gets that page rather than anything naming the endpoint, the method it wants, or the docs.

The cause is that `apps/api/src/index.ts` has no terminal 404 handler. The last route mount is `app.use(adminRouter)`, and the two `app.use` blocks after it take four arguments, so Express treats them as error middleware and never runs them for a path that matched nothing.

## Changes

- New `apps/api/src/lib/not-found.ts`. `notFoundHandler` looks up which methods the requested path does serve by walking the app's router stack, including mounted sub-routers. If the path exists under another method it returns 405 with an `Allow` header and an `allowed_methods` array. Otherwise it returns 404. Both bodies use the `{ success, code, error }` envelope the rest of the API returns, plus the `documentation_url` field from the root descriptor at `index.ts`.
- `apps/api/src/index.ts` mounts it after every route and before the error middleware. One mount covers every path the app serves, so there is no per-path registration to keep in sync. The walk does have to understand how each router was mounted, though: routers attached with no path at all, which is how `v0Router` and `adminRouter` are attached, are flagged differently by Express and needed explicit handling. See the section below.
- New route test.

Router internals are read through the pure matcher functions Express 5 exposes on each layer, which mutate nothing, and the whole lookup is wrapped so any future change to those internals degrades to a plain JSON 404 rather than failing the request.

No route, auth or rate limiting behaviour changes. The root descriptor, `/e2e-test` and `/is-production` are untouched.

Answers after the change, read off the real v1 and v2 routers:

```
GET /v2/scrape   405  Allow: POST      (was 404 HTML)
GET /v2/search   405  Allow: POST      (was 404 HTML)
GET /v2/scrape/{id}/interact  405  Allow: DELETE, POST
POST /v2/crawl/{id}  405  Allow: DELETE, GET, HEAD
GET /v2/nope     404  JSON             (was 404 HTML)
GET /            200  unchanged
```

## Added 2026-09-07

External review of this PR caught a real gap in the first version, now fixed.

The method lookup found each mounted router by asking the router's own matcher functions whether they matched the requested path. That works for a router mounted under a prefix, such as `app.use("/v2", v2Router)`. It does not work for a router mounted with no prefix at all, and `index.ts` mounts two of those: `app.use(v0Router)` and `app.use(adminRouter)`. Express treats a no-prefix mount as a special case and marks the layer with a flag rather than relying on its matchers, and those matchers only ever match `/` for such a layer. The lookup consulted the matchers, got no match, and skipped both routers entirely.

The visible effect was that every `/v0/*` path and every admin path answered a wrong-method request with a JSON 404 rather than a 405 with an `Allow` header. `GET /v0/scrape`, which exists under POST, and `POST /v0/health/liveness`, which exists under GET, are the two clearest cases. The `/v1`, `/v2` and `/exchange` prefixes were never affected, because they are all mounted under a path.

The fix reads the flag Express itself uses and treats such a layer as matching every path while consuming no part of it, so the full path is handed down into the router. Reading the flag rather than calling Express's match function keeps the lookup free of side effects, which matters because this runs inside a request that has already missed.

The original tests all passed while this was broken, because every router in the test fixture was mounted under a prefix. The fixture now mounts two routers with no prefix and asserts 405 in both directions on them, that an unknown path under a no-prefix mount still gets a plain JSON 404, and that the routes those routers do serve still answer normally.

## Added 2026-09-08

A second review of this PR found two more things, both now fixed.

The first is a metrics problem. The `/v1` and `/v2` routers install a timing middleware that replaces `res.json` so it can record every response into the `http_request_duration_seconds` histogram. That middleware is attached to the router itself rather than to any single route, so it runs for requests that match nothing as well. Before this PR those requests were ended by Express's default handler, which does not go through `res.json`, so nothing was recorded. Now they answer with JSON, so every one of them is recorded, and the histogram labels each sample with the route it belongs to. For a request that matched no route there is no route pattern to use, so the label fell back to the raw request path. A scanner probing a thousand random URLs under `/v1` or `/v2` therefore created a thousand separate label values, and nothing bounded that growth.

The fix is that the terminal handler now marks the request as unmatched before it answers, and the route label lookup returns the single constant `unmatched` for any request carrying that mark. Requests that did match a route still use their route pattern exactly as before, so no label for real traffic changes. A new test drives the real timing middleware together with the new handler and asserts that three different scanner style URLs all collapse onto one label, that wrong method hits do the same, and that a matched route keeps its own label.

The second is a header. Express's default 404 page carried `X-Content-Type-Options: nosniff` and `res.json` does not set it, so replacing the page with JSON silently dropped the header. The handler now sets it explicitly on both the 404 and the 405, and the new test asserts it on each.

### 2026-09-08 verification

- `npx vitest run src/__tests__/routes` in `apps/api`: 7 files, 136 tests, all passed, including the 5 new cases.
- The new tests were written before the fix and 4 of the 5 failed against the previous commit, showing three distinct raw path labels where one constant was expected and no nosniff header on either response.
- `npx tsc --noEmit`: still 49 errors, all pre-existing, none in any changed file.
- `pnpm knip` and `lint-staged` ran as the pre-commit hook and passed.

## Verification

- `npx vitest run src/__tests__/routes` in `apps/api`: 6 files, 127 tests, all passed, including the 7 new cases.
- `npx tsc --noEmit`: 49 errors, identical to the base commit. All are in `scraper/scrapeURL/engines/pdf`, `engines/document`, `lib/crawl-regex.ts` and one snip test, none in the three files this touches.
- `pnpm knip` and `lint-staged` ran as the pre-commit hook and passed.
- Prettier clean on all three files.

### 2026-09-07 follow-up commit

- `pnpm vitest run src/__tests__/routes/not-found.routes.test.ts`: 11 tests, all passed. With the source fix reverted and the new tests kept, 3 of the 11 fail, so the tests do catch the defect they were written for.
- `npx tsc --noEmit`: still 49 errors, all pre-existing, none in either changed file.
- `pnpm knip --cache` and `lint-staged` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL5chNkWnr4Gy6uuB8PeKS

