### PR TITLE
fix(api/redis): improve error handling on evictable redis

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -44,6 +44,7 @@ import {
 import type { OAuthIntrospectionResponse } from "../services/oauth-token-introspection";
 import { verifyMcpDelegatedCredential } from "../lib/mcp-delegated-credential";
 import { autumnService } from "../services/autumn/autumn.service";
+import { ReplyError } from "ioredis";
 
 function normalizedApiIsUuid(potentialUuid: string): boolean {
   // Check if the string is a valid UUID
@@ -84,7 +85,10 @@ async function setCachedACUC(
       await setValue(cacheKeyACUC, JSON.stringify(acuc), 600, true);
     });
   } catch (error) {
-    logger.error(`Error updating cached ACUC ${cacheKeyACUC}: ${error}`);
+    logger.error("Error updating cached ACUC", {
+      cacheKey: cacheKeyACUC,
+      error,
+    });
   }
 }
 
@@ -172,7 +176,23 @@ async function getACUC(
   const cacheKeyACUC = `acuc_${credentialPurpose}_${api_key}_${isExtract ? "extract" : "scrape"}`;
 
   if (useCache) {
-    const cachedACUC = await getValue(cacheKeyACUC);
+    let cachedACUC: string | null;
+    try {
+      cachedACUC = await getValue(cacheKeyACUC);
+    } catch (error) {
+      if (error instanceof ReplyError) {
+        logger.warn(
+          "Reading ACUC out of cache redis failed, treating as miss",
+          {
+            cacheKey: cacheKeyACUC,
+            error,
+          },
+        );
+        cachedACUC = null;
+      } else {
+        throw error;
+      }
+    }
     if (cachedACUC !== null) {
       try {
         return JSON.parse(cachedACUC);
@@ -279,7 +299,10 @@ async function setCachedACUCTeam(
       await setValue(cacheKeyACUC, JSON.stringify(acuc), 600, true);
     });
   } catch (error) {
-    logger.error(`Error updating cached ACUC ${cacheKeyACUC}: ${error}`);
+    logger.error("Error updating cached ACUC", {
+      cacheKey: cacheKeyACUC,
+      error,
+    });
   }
 }
 
@@ -308,7 +331,23 @@ export async function getACUCTeam(
   const cacheKeyACUC = `acuc_team_${team_id}_${isExtract ? "extract" : "scrape"}`;
 
   if (useCache) {
-    const cachedACUC = await getValue(cacheKeyACUC);
+    let cachedACUC: string | null;
+    try {
+      cachedACUC = await getValue(cacheKeyACUC);
+    } catch (error) {
+      if (error instanceof ReplyError) {
+        logger.warn(
+          "Reading ACUC out of cache redis failed, treating as miss",
+          {
+            cacheKey: cacheKeyACUC,
+            error,
+          },
+        );
+        cachedACUC = null;
+      } else {
+        throw error;
+      }
+    }
     if (cachedACUC !== null) {
       return JSON.parse(cachedACUC);
     }

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -86,7 +86,6 @@ async function setCachedACUC(
     });
   } catch (error) {
     logger.error("Error updating cached ACUC", {
-      cacheKey: cacheKeyACUC,
       error,
     });
   }
@@ -184,7 +183,6 @@ async function getACUC(
         logger.warn(
           "Reading ACUC out of cache redis failed, treating as miss",
           {
-            cacheKey: cacheKeyACUC,
             error,
           },
         );
@@ -198,12 +196,10 @@ async function getACUC(
         return JSON.parse(cachedACUC);
       } catch (error) {
         logger.warn("Ignoring malformed ACUC cache entry", {
-          cacheKey: cacheKeyACUC,
           error,
         });
         void deleteKey(cacheKeyACUC).catch(deleteError => {
           logger.warn("Failed to delete malformed ACUC cache entry", {
-            cacheKey: cacheKeyACUC,
             error: deleteError,
           });
         });

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -184,7 +184,8 @@ async function getACUC(
         (error instanceof Error &&
           (error as any).address &&
           (error as any).code &&
-          error.name === "Error")
+          error.name === "Error") ||
+        (error instanceof Error && error.name === "MaxRetriesPerRequestError")
       ) {
         logger.warn(
           "Reading ACUC out of cache redis failed, treating as miss",
@@ -342,7 +343,8 @@ export async function getACUCTeam(
         (error instanceof Error &&
           (error as any).address &&
           (error as any).code &&
-          error.name === "Error")
+          error.name === "Error") ||
+        (error instanceof Error && error.name === "MaxRetriesPerRequestError")
       ) {
         logger.warn(
           "Reading ACUC out of cache redis failed, treating as miss",

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -179,7 +179,13 @@ async function getACUC(
     try {
       cachedACUC = await getValue(cacheKeyACUC);
     } catch (error) {
-      if (error instanceof ReplyError) {
+      if (
+        error instanceof ReplyError ||
+        (error instanceof Error &&
+          (error as any).address &&
+          (error as any).code &&
+          error.name === "Error")
+      ) {
         logger.warn(
           "Reading ACUC out of cache redis failed, treating as miss",
           {
@@ -331,7 +337,13 @@ export async function getACUCTeam(
     try {
       cachedACUC = await getValue(cacheKeyACUC);
     } catch (error) {
-      if (error instanceof ReplyError) {
+      if (
+        error instanceof ReplyError ||
+        (error instanceof Error &&
+          (error as any).address &&
+          (error as any).code &&
+          error.name === "Error")
+      ) {
         logger.warn(
           "Reading ACUC out of cache redis failed, treating as miss",
           {


### PR DESCRIPTION
Some of our cache keys are stored on a Redis that is both key-evictable, and pod-evictable in Kubernetes.

Added some code to handle the Redis going missing more gracefully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves error handling for ACUC cache reads on the evictable Redis so a missing or evicted Redis no longer fails the request.

- `ReplyError`, `MaxRetriesPerRequestError`, and TCP connection errors on cache reads now log a warning and treat the cache as a miss, falling through to the source data; other errors still propagate.
- Cache failure logs now use structured fields and no longer include cache keys that contain raw API keys; team-based keys are still logged.

<sup>Written for commit 27d3266ac90be125e1fe12543b4dea5980dd0cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

