### PR TITLE
feat(api): add BetterStack heartbeat to cclog worker

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -594,6 +594,8 @@ const configSchema = z.object({
 
   ZDRCLEANER_HEARTBEAT_URL: z.string().optional(),
 
+  CCLOG_WORKER_HEARTBEAT_URL: z.string().optional(),
+
   // Deterministic JSON extraction (reusable-json-mode)
   EXTRACT_CODEGEN_MODEL: z.string().default("gemini-3.1-flash-lite"),
   EXTRACT_ANCHOR_MODEL: z.string().default("openai/gpt-oss-120b"),

--- a/apps/api/src/services/cclog-worker.ts
+++ b/apps/api/src/services/cclog-worker.ts
@@ -16,6 +16,18 @@ const CCLOG_WORKER_LOCK_TTL_SECONDS = 55;
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+async function sendHeartbeat() {
+  if (config.CCLOG_WORKER_HEARTBEAT_URL) {
+    try {
+      await fetch(config.CCLOG_WORKER_HEARTBEAT_URL, {
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (error) {
+      _logger.warn("Failed to send cclog heartbeat", { error });
+    }
+  }
+}
+
 (async () => {
   setSentryServiceTag("cclog-worker");
 
@@ -88,6 +100,7 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
           at: at.toISOString(),
           ...summary,
         });
+        await sendHeartbeat();
       } else {
         _logger.info("Skipping cclog tick because another worker holds lock", {
           at: at.toISOString(),

--- a/apps/api/src/services/cclog-worker.ts
+++ b/apps/api/src/services/cclog-worker.ts
@@ -19,9 +19,14 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 async function sendHeartbeat() {
   if (config.CCLOG_WORKER_HEARTBEAT_URL) {
     try {
-      await fetch(config.CCLOG_WORKER_HEARTBEAT_URL, {
+      const response = await fetch(config.CCLOG_WORKER_HEARTBEAT_URL, {
         signal: AbortSignal.timeout(5000),
       });
+      if (!response.ok) {
+        _logger.warn("cclog heartbeat got non-OK response", {
+          status: response.status,
+        });
+      }
     } catch (error) {
       _logger.warn("Failed to send cclog heartbeat", { error });
     }


### PR DESCRIPTION
## What

Adds an optional BetterStack heartbeat to the cclog worker via a new `CCLOG_WORKER_HEARTBEAT_URL` env var.

## Why

The cclog worker ticks once per minute and writes per-minute concurrency samples plus a 10-minute aggregate to ClickHouse. Today, if the worker dies or its ticks start failing persistently, nothing pages — the only signals are absence of logs or gaps in `concurrency_logs`.

## How

- After each successful `runCclogTick`, the worker pings `CCLOG_WORKER_HEARTBEAT_URL` (if configured).
- Only the replica holding the tick lock pings, so there's exactly one ping per minute regardless of replica count.
- A failed tick suppresses the ping, so persistent tick failures also trip the BetterStack alert.
- The fetch has a 5s timeout and failures only log a warning, so a BetterStack outage never stalls the tick loop or graceful shutdown.

Follows the existing `ZDRCLEANER_HEARTBEAT_URL` pattern.

## Deployment note

The production deployment already does `envFrom: secretRef: secret`, so no chart change is needed — just add `CCLOG_WORKER_HEARTBEAT_URL` to the shared secret with the heartbeat URL from BetterStack (expected period: 1 minute).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional BetterStack heartbeat to the cclog worker via a new `CCLOG_WORKER_HEARTBEAT_URL` env var. The worker now pings this URL after each successful minute tick, so BetterStack pages if the worker dies or ticks start failing persistently; previously, failures were only visible as missing logs or gaps in `concurrency_logs`.

- Only the lock-holding replica pings, keeping exactly one ping per minute regardless of replica count.
- A failed tick suppresses the ping, so persistent tick failures trip the alert.
- The fetch has a 5s timeout; network failures and non-OK responses only log a warning, so a BetterStack outage never stalls the tick loop or shutdown.

**Migration**
- Add `CCLOG_WORKER_HEARTBEAT_URL` to the existing shared secret with the BetterStack heartbeat URL (expected period: 1 minute). No chart change needed since production uses `envFrom: secretRef: secret`.

<sup>Written for commit 42834ab0ea78ebda740b97017965c0ac46d6b1c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

