### PR TITLE
fix(api): return 501 when research index is not configured

### DIFF
--- a/apps/api/src/__tests__/routes/research-unconfigured.routes.test.ts
+++ b/apps/api/src/__tests__/routes/research-unconfigured.routes.test.ts
@@ -1,0 +1,56 @@
+import express from "express";
+import request from "supertest";
+import { mountUnconfiguredResearchRoutes } from "../../controllers/v2/research-unavailable";
+
+function appWithoutResearchProxy() {
+  const app = express();
+  const v2 = express.Router();
+  mountUnconfiguredResearchRoutes(v2);
+  app.use("/v2", v2);
+  return app;
+}
+
+describe("research routes when RESEARCH_PROXY_URL is unset", () => {
+  const app = appWithoutResearchProxy();
+
+  it("answers paper search with 501 JSON instead of an unregistered 404", async () => {
+    const res = await request(app).get(
+      "/v2/search/research/papers?query=transformers",
+    );
+
+    expect(res.status).toBe(501);
+    expect(res.type).toMatch(/json/);
+    expect(res.body).toEqual({
+      success: false,
+      error: "Research service is not configured",
+    });
+  });
+
+  it("answers paper inspect on the same unconfigured mount", async () => {
+    const res = await request(app).get(
+      "/v2/search/research/papers/1706.03762",
+    );
+
+    expect(res.status).toBe(501);
+    expect(res.body).toEqual({
+      success: false,
+      error: "Research service is not configured",
+    });
+  });
+
+  it("answers the legacy paper search mount the same way", async () => {
+    const res = await request(app).get(
+      "/v2/research/papers?query=transformers",
+    );
+
+    expect(res.status).toBe(501);
+    expect(res.body.error).toBe("Research service is not configured");
+  });
+
+  it("does not claim developer search is missing the research index", async () => {
+    const res = await request(app).get("/v2/search/developer?query=x");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).not.toBe("Research service is not configured");
+  });
+});

--- a/apps/api/src/__tests__/routes/research-unconfigured.routes.test.ts
+++ b/apps/api/src/__tests__/routes/research-unconfigured.routes.test.ts
@@ -1,17 +1,74 @@
 import express from "express";
 import request from "supertest";
-import { mountUnconfiguredResearchRoutes } from "../../controllers/v2/research-unavailable";
 
-function appWithoutResearchProxy() {
+vi.mock("@mendable/firecrawl-rs", () => ({
+  validateRegexes: () => {},
+  postProcessMarkdown: async (s: string) => s,
+  transformHtml: async () => "",
+  extractMetadata: () => ({}),
+  extractLinks: () => [],
+  extractImages: () => [],
+  extractAttributes: () => [],
+  getInnerJson: () => ({}),
+  processPdf: async () => ({}),
+  detectPdf: () => false,
+  convertDocumentToMarkdown: async () => "",
+  filterLinks: () => [],
+  filterUrl: () => true,
+}));
+
+vi.mock("../../config", async importOriginal => {
+  const mod = await importOriginal<typeof import("../../config")>();
+  return {
+    ...mod,
+    config: { ...mod.config, RESEARCH_PROXY_URL: undefined },
+  };
+});
+
+vi.mock("../../lib/research-upstream", () => ({
+  fetchResearchUpstream: async () => null,
+}));
+
+vi.mock("../../services/logging/log_job", () => ({
+  logRequest: async () => {},
+  logResearchEndpoint: async () => {},
+}));
+
+vi.mock("../../lib/keyless", () => ({
+  chargeKeylessCredits: async () => {},
+}));
+
+vi.mock("../../services/billing/credit_billing", () => ({
+  billTeam: async () => {},
+}));
+
+import { v2Router } from "../../routes/v2";
+import { createResearchRouter } from "../../controllers/v2/research-proxy";
+
+function appWithV2() {
   const app = express();
-  const v2 = express.Router();
-  mountUnconfiguredResearchRoutes(v2);
-  app.use("/v2", v2);
+  app.use("/v2", v2Router);
   return app;
 }
 
-describe("research routes when RESEARCH_PROXY_URL is unset", () => {
-  const app = appWithoutResearchProxy();
+function appWithResearchRouter() {
+  const app = express();
+  app.use((req: any, _res, next) => {
+    req.auth = { team_id: "team-test", plan: "standard" };
+    req.acuc = { api_key_id: null };
+    next();
+  });
+  app.use("/v2/search/research", createResearchRouter());
+  return app;
+}
+
+const unconfigured = {
+  success: false,
+  error: "Research service is not configured",
+};
+
+describe("v2 research routes when RESEARCH_PROXY_URL is unset", () => {
+  const app = appWithV2();
 
   it("answers paper search with 501 JSON instead of an unregistered 404", async () => {
     const res = await request(app).get(
@@ -20,10 +77,7 @@ describe("research routes when RESEARCH_PROXY_URL is unset", () => {
 
     expect(res.status).toBe(501);
     expect(res.type).toMatch(/json/);
-    expect(res.body).toEqual({
-      success: false,
-      error: "Research service is not configured",
-    });
+    expect(res.body).toEqual(unconfigured);
   });
 
   it("answers paper inspect on the same unconfigured mount", async () => {
@@ -32,10 +86,7 @@ describe("research routes when RESEARCH_PROXY_URL is unset", () => {
     );
 
     expect(res.status).toBe(501);
-    expect(res.body).toEqual({
-      success: false,
-      error: "Research service is not configured",
-    });
+    expect(res.body).toEqual(unconfigured);
   });
 
   it("answers the legacy paper search mount the same way", async () => {
@@ -44,13 +95,32 @@ describe("research routes when RESEARCH_PROXY_URL is unset", () => {
     );
 
     expect(res.status).toBe(501);
-    expect(res.body.error).toBe("Research service is not configured");
+    expect(res.body).toEqual(unconfigured);
   });
 
-  it("does not claim developer search is missing the research index", async () => {
+  it("answers developer search with the same 501 JSON", async () => {
     const res = await request(app).get("/v2/search/developer?query=x");
 
-    expect(res.status).toBe(404);
-    expect(res.body.error).not.toBe("Research service is not configured");
+    expect(res.status).toBe(501);
+    expect(res.body).toEqual(unconfigured);
+  });
+
+  it("answers the pre-GA developer mount the same way", async () => {
+    const res = await request(app).get("/v2/developer/search?query=x");
+
+    expect(res.status).toBe(501);
+    expect(res.body).toEqual(unconfigured);
+  });
+});
+
+describe("createResearchRouter when the research backend is missing", () => {
+  it("returns 501 JSON instead of an empty 404", async () => {
+    const res = await request(appWithResearchRouter()).get(
+      "/v2/search/research/papers?query=transformers",
+    );
+
+    expect(res.status).toBe(501);
+    expect(res.type).toMatch(/json/);
+    expect(res.body).toEqual(unconfigured);
   });
 });

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -20,10 +20,7 @@ import { wrap } from "../../routes/shared";
 import { deprecationMiddleware } from "../../lib/deprecations";
 import { integrationSchema } from "../../utils/integration";
 import { requestOrigin } from "../../lib/request-origin";
-import {
-  researchServiceUnavailable,
-  RESEARCH_SERVICE_UNAVAILABLE,
-} from "./research-unavailable";
+import { RESEARCH_SERVICE_UNAVAILABLE } from "./research-unavailable";
 
 const SEARCH_CREDITS_PER_TEN_RESULTS = 2;
 const ZDR_SEARCH_CREDITS_PER_TEN_RESULTS = 10;
@@ -348,7 +345,7 @@ function createResearchController(
       if (!upstream) {
         statusCode = 501;
         error = RESEARCH_SERVICE_UNAVAILABLE;
-        return researchServiceUnavailable(authedReq, res);
+        return researchError(res, 501, error);
       }
 
       statusCode = upstream.status;

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -20,6 +20,10 @@ import { wrap } from "../../routes/shared";
 import { deprecationMiddleware } from "../../lib/deprecations";
 import { integrationSchema } from "../../utils/integration";
 import { requestOrigin } from "../../lib/request-origin";
+import {
+  researchServiceUnavailable,
+  RESEARCH_SERVICE_UNAVAILABLE,
+} from "./research-unavailable";
 
 const SEARCH_CREDITS_PER_TEN_RESULTS = 2;
 const ZDR_SEARCH_CREDITS_PER_TEN_RESULTS = 10;
@@ -342,9 +346,9 @@ function createResearchController(
         endpoint.timeoutMs,
       );
       if (!upstream) {
-        statusCode = 404;
-        error = "Research service is not configured";
-        return res.status(404).end();
+        statusCode = 501;
+        error = RESEARCH_SERVICE_UNAVAILABLE;
+        return researchServiceUnavailable(authedReq, res);
       }
 
       statusCode = upstream.status;

--- a/apps/api/src/controllers/v2/research-unavailable.test.ts
+++ b/apps/api/src/controllers/v2/research-unavailable.test.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import {
+  mountUnconfiguredResearchRoutes,
+  researchServiceUnavailable,
+} from "./research-unavailable";
+
+describe("researchServiceUnavailable", () => {
+  it("returns 501 JSON naming the missing research backend", () => {
+    const res: any = {
+      status: vi.fn(),
+      json: vi.fn(),
+    };
+    res.status.mockReturnValue(res);
+
+    researchServiceUnavailable({} as express.Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(501);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: "Research service is not configured",
+    });
+  });
+});
+
+describe("mountUnconfiguredResearchRoutes", () => {
+  it("registers the canonical and legacy research prefixes", () => {
+    const router = express.Router();
+    mountUnconfiguredResearchRoutes(router);
+    expect(router.stack).toHaveLength(2);
+  });
+});

--- a/apps/api/src/controllers/v2/research-unavailable.test.ts
+++ b/apps/api/src/controllers/v2/research-unavailable.test.ts
@@ -1,8 +1,5 @@
 import express from "express";
-import {
-  mountUnconfiguredResearchRoutes,
-  researchServiceUnavailable,
-} from "./research-unavailable";
+import { researchServiceUnavailable } from "./research-unavailable";
 
 describe("researchServiceUnavailable", () => {
   it("returns 501 JSON naming the missing research backend", () => {
@@ -19,13 +16,5 @@ describe("researchServiceUnavailable", () => {
       success: false,
       error: "Research service is not configured",
     });
-  });
-});
-
-describe("mountUnconfiguredResearchRoutes", () => {
-  it("registers the canonical and legacy research prefixes", () => {
-    const router = express.Router();
-    mountUnconfiguredResearchRoutes(router);
-    expect(router.stack).toHaveLength(2);
   });
 });

--- a/apps/api/src/controllers/v2/research-unavailable.ts
+++ b/apps/api/src/controllers/v2/research-unavailable.ts
@@ -13,4 +13,6 @@ export function researchServiceUnavailable(_req: Request, res: Response) {
 export function mountUnconfiguredResearchRoutes(router: Router) {
   router.use("/search/research", researchServiceUnavailable);
   router.use("/research", researchServiceUnavailable);
+  router.use("/search/developer", researchServiceUnavailable);
+  router.use("/developer", researchServiceUnavailable);
 }

--- a/apps/api/src/controllers/v2/research-unavailable.ts
+++ b/apps/api/src/controllers/v2/research-unavailable.ts
@@ -1,0 +1,16 @@
+import type { Request, Response, Router } from "express";
+
+export const RESEARCH_SERVICE_UNAVAILABLE =
+  "Research service is not configured";
+
+export function researchServiceUnavailable(_req: Request, res: Response) {
+  return res.status(501).json({
+    success: false,
+    error: RESEARCH_SERVICE_UNAVAILABLE,
+  });
+}
+
+export function mountUnconfiguredResearchRoutes(router: Router) {
+  router.use("/search/research", researchServiceUnavailable);
+  router.use("/research", researchServiceUnavailable);
+}

--- a/apps/api/src/routes/v2.ts
+++ b/apps/api/src/routes/v2.ts
@@ -88,6 +88,7 @@ import {
   createDeveloperRouter,
   createResearchRouter,
 } from "../controllers/v2/research-proxy";
+import { mountUnconfiguredResearchRoutes } from "../controllers/v2/research-unavailable";
 import {
   scrapeInteractController,
   scrapeStopInteractiveBrowserController,
@@ -702,4 +703,6 @@ if (config.RESEARCH_PROXY_URL) {
     authMiddleware(RateLimiterMode.DeveloperSearch),
     createDeveloperRouter(),
   );
+} else {
+  mountUnconfiguredResearchRoutes(v2Router);
 }


### PR DESCRIPTION
Problem

https://github.com/firecrawl/firecrawl/issues/4166

Self-host does not set RESEARCH_PROXY_URL. v2 only registers /search/research, /research, /search/developer, and /developer when that URL is present, so firecrawl_research_search_papers (and the other three) hit Express HTML 404 Cannot GET .... That looks like a missing route. The research index is hosted-only.

Approach

When RESEARCH_PROXY_URL is missing, mount those four prefixes and return 501 JSON { success: false, error: "Research service is not configured" }. Developer search uses the same upstream. The proxy controller uses researchError with that same body if fetchResearchUpstream returns null. Live mounts are unchanged when the URL is set.

I did not always-mount the live routers, because that would run auth and log_job on every self-host miss.

Testing

cd apps/api && ./node_modules/.bin/vitest run src/controllers/v2/research-unavailable.test.ts src/__tests__/routes/research-unconfigured.routes.test.ts

7 passed. The route file imports v2Router with @mendable/firecrawl-rs mocked (this checkout has no native addon build). Restoring v2.ts and research-proxy.ts to e4ac89b02 while keeping the new tests yields 6 failures (404 instead of 501).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-hosted instances without `RESEARCH_PROXY_URL` now return a 501 JSON response instead of an HTML 404 for the research routes, so a missing service is distinguishable from a missing route.

- Mounts `/search/research`, `/research`, `/search/developer`, and `/developer` with the 501 response when the URL is unset.
- The proxy controller returns the same 501 JSON when the research upstream is unavailable.
- Live routers stay unmounted on self-hosted setups so authentication and logging don't run on every request.

<sup>Written for commit da01650965ff9f961ec56c7aad7f59ea722ab624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

