### PR TITLE
feat(api): add request-id middleware for scrape/search responses (#4290)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -45,6 +45,7 @@ import { shutdownWebhookQueue } from "./services/webhook";
 import { shutdownIndexerQueue } from "./services/indexing/indexer-queue";
 import { isKeylessConfigured } from "./lib/keyless";
 import { shutdownPubSubLogging } from "./services/logging/log_job";
+import { requestIdMiddleware } from "./lib/request-id";
 
 const { createBullBoard } = require("@bull-board/api");
 const { BullMQAdapter } = require("@bull-board/api/bullMQAdapter");
@@ -89,12 +90,14 @@ const captureRawBody = (
   }
 };
 
+app.use(requestIdMiddleware);
+
 registerMcpActionLogIngestRoute(app);
 
 app.use(bodyParser.urlencoded({ extended: true, verify: captureRawBody }));
 app.use(bodyParser.json({ limit: "10mb", verify: captureRawBody }));
 
-app.use(cors()); // Add this line to enable CORS
+app.use(cors({ exposedHeaders: ["X-Request-ID"] }));
 
 app.use(responseTime());
 
@@ -300,6 +303,7 @@ app.use(
       {
         error: err,
         errorId: id,
+        requestId: (req as Request & { requestId?: string }).requestId,
         path: req.path,
         teamId: req.acuc?.team_id,
         team_id: req.acuc?.team_id,

--- a/apps/api/src/lib/request-id.test.ts
+++ b/apps/api/src/lib/request-id.test.ts
@@ -1,0 +1,54 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { requestIdMiddleware } from "./request-id";
+
+describe("requestIdMiddleware", () => {
+  function createApp() {
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.get("/ok", (req, res) => res.json({ requestId: req.requestId }));
+    app.get("/error", (_req, _res, next) => next(new Error("test error")));
+    app.use((_error: unknown, _req, res, _next) =>
+      res.status(500).json({ success: false }),
+    );
+    return app;
+  }
+
+  it("returns and attaches the incoming request ID", async () => {
+    const response = await request(createApp())
+      .get("/ok")
+      .set("X-Request-ID", "client-request-123");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["x-request-id"]).toBe("client-request-123");
+    expect(response.body.requestId).toBe("client-request-123");
+  });
+
+  it("generates a request ID when one is not provided", async () => {
+    const response = await request(createApp()).get("/ok");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["x-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(response.body.requestId).toBe(response.headers["x-request-id"]);
+  });
+
+  it("returns a generated ID for error responses", async () => {
+    const response = await request(createApp()).get("/error");
+
+    expect(response.status).toBe(500);
+    expect(response.headers["x-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("replaces an oversized incoming ID", async () => {
+    const response = await request(createApp())
+      .get("/ok")
+      .set("X-Request-ID", "a".repeat(257));
+
+    expect(response.headers["x-request-id"]).not.toBe("a".repeat(257));
+  });
+});

--- a/apps/api/src/lib/request-id.test.ts
+++ b/apps/api/src/lib/request-id.test.ts
@@ -51,4 +51,16 @@ describe("requestIdMiddleware", () => {
 
     expect(response.headers["x-request-id"]).not.toBe("a".repeat(257));
   });
+
+  it.each(["\x80", "\x9f"])(
+    "replaces an incoming ID containing C1 control character %s",
+    async controlCharacter => {
+      const requestId = `client${controlCharacter}request`;
+      const response = await request(createApp())
+        .get("/ok")
+        .set("X-Request-ID", requestId);
+
+      expect(response.headers["x-request-id"]).not.toBe(requestId);
+    },
+  );
 });

--- a/apps/api/src/lib/request-id.ts
+++ b/apps/api/src/lib/request-id.ts
@@ -20,7 +20,7 @@ function getIncomingRequestId(req: Request): string | undefined {
   if (
     value.length === 0 ||
     Buffer.byteLength(value) > REQUEST_ID_MAX_BYTES ||
-    /[\x00-\x1f\x7f]/.test(value)
+    /[\x00-\x1f\x7f-\x9f]/.test(value)
   ) {
     return undefined;
   }

--- a/apps/api/src/lib/request-id.ts
+++ b/apps/api/src/lib/request-id.ts
@@ -1,0 +1,40 @@
+import type { NextFunction, Request, Response } from "express";
+import { v7 as uuidv7 } from "uuid";
+
+const REQUEST_ID_HEADER = "X-Request-ID";
+const REQUEST_ID_MAX_BYTES = 256;
+
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+    }
+  }
+}
+
+function getIncomingRequestId(req: Request): string | undefined {
+  const raw = req.get(REQUEST_ID_HEADER);
+  if (!raw) return undefined;
+
+  const value = raw.trim();
+  if (
+    value.length === 0 ||
+    Buffer.byteLength(value) > REQUEST_ID_MAX_BYTES ||
+    /[\x00-\x1f\x7f]/.test(value)
+  ) {
+    return undefined;
+  }
+
+  return value;
+}
+
+export function requestIdMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  const requestId = getIncomingRequestId(req) ?? uuidv7();
+  req.requestId = requestId;
+  res.setHeader(REQUEST_ID_HEADER, requestId);
+  next();
+}

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -499,6 +499,7 @@ export function requestTimingMiddleware(version: string) {
           startTime,
           requestTime,
           statusCode: res.statusCode,
+          requestId: req.requestId,
         });
       }
 


### PR DESCRIPTION
Closes #4290

### Summary of Changes:
- Implemented requestIdMiddleware with UUIDv7 generation.
- Added security guards (byte-length limits and control character filtering) to prevent injection risks.
- Integrated request ID tracking into global error handlers and completion logs.
- Added comprehensive unit test coverage via Vitest/Supertest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds request ID middleware that sets an `X-Request-ID` header on every API response and includes that ID in error and request timing logs, closing #4290.

- Generates a UUIDv7 ID when the incoming header is missing or invalid.
- Replaces oversized or control-character-containing incoming IDs with a generated ID.
- Exposes the header via CORS.

<sup>Written for commit 3624bbca5bf804d8914d291dcdd7db1fa5493fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

