### PR TITLE
fix(api): do not interpolate BULL_AUTH_KEY into Express paths

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -122,7 +122,7 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
 if (config.BULL_AUTH_KEY) {
   serverAdapter.setBasePath(`/admin/${config.BULL_AUTH_KEY}/queues`);
   app.use(
-    `/admin/:bullAuthKey/queues`,
+    `/admin/*bullAuthKey/queues`,
     createRequireBullAuth(config.BULL_AUTH_KEY),
     serverAdapter.getRouter(),
   );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,7 +16,7 @@ import { v0Router } from "./routes/v0";
 import os from "os";
 import { logger } from "./lib/logger";
 import { adminRouter } from "./routes/admin";
-import { createRequireBullAuth } from "./lib/bull-auth";
+import { bullAuthRoute, createRequireBullAuth } from "./lib/bull-auth";
 import http from "node:http";
 import https from "node:https";
 import { v1Router } from "./routes/v1";
@@ -122,7 +122,7 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
 if (config.BULL_AUTH_KEY) {
   serverAdapter.setBasePath(`/admin/${config.BULL_AUTH_KEY}/queues`);
   app.use(
-    `/admin/*bullAuthKey/queues`,
+    bullAuthRoute(config.BULL_AUTH_KEY, "/queues"),
     createRequireBullAuth(config.BULL_AUTH_KEY),
     serverAdapter.getRouter(),
   );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,7 @@ import { v0Router } from "./routes/v0";
 import os from "os";
 import { logger } from "./lib/logger";
 import { adminRouter } from "./routes/admin";
+import { createRequireBullAuth } from "./lib/bull-auth";
 import http from "node:http";
 import https from "node:https";
 import { v1Router } from "./routes/v1";
@@ -120,7 +121,11 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
 
 if (config.BULL_AUTH_KEY) {
   serverAdapter.setBasePath(`/admin/${config.BULL_AUTH_KEY}/queues`);
-  app.use(`/admin/${config.BULL_AUTH_KEY}/queues`, serverAdapter.getRouter());
+  app.use(
+    `/admin/:bullAuthKey/queues`,
+    createRequireBullAuth(config.BULL_AUTH_KEY),
+    serverAdapter.getRouter(),
+  );
 } else {
   logger.warn("BULL_AUTH_KEY is not set; admin routes are disabled.");
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,7 +16,11 @@ import { v0Router } from "./routes/v0";
 import os from "os";
 import { logger } from "./lib/logger";
 import { adminRouter } from "./routes/admin";
-import { bullAuthRoute, createRequireBullAuth } from "./lib/bull-auth";
+import {
+  bullAuthPublicPath,
+  bullAuthRoute,
+  createRequireBullAuth,
+} from "./lib/bull-auth";
 import http from "node:http";
 import https from "node:https";
 import { v1Router } from "./routes/v1";
@@ -120,7 +124,9 @@ const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
 });
 
 if (config.BULL_AUTH_KEY) {
-  serverAdapter.setBasePath(`/admin/${config.BULL_AUTH_KEY}/queues`);
+  serverAdapter.setBasePath(
+    `/admin/${bullAuthPublicPath(config.BULL_AUTH_KEY)}/queues`,
+  );
   app.use(
     bullAuthRoute(config.BULL_AUTH_KEY, "/queues"),
     createRequireBullAuth(config.BULL_AUTH_KEY),

--- a/apps/api/src/lib/__tests__/bull-auth.test.ts
+++ b/apps/api/src/lib/__tests__/bull-auth.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import http from "node:http";
+import { createRequireBullAuth } from "../bull-auth";
+
+function listen(app: express.Express): Promise<http.Server> {
+  const server = http.createServer(app);
+  return new Promise(resolve => {
+    server.listen(0, () => resolve(server));
+  });
+}
+
+async function get(server: http.Server, path: string) {
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no port");
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`);
+  return { status: res.status, text: await res.text() };
+}
+
+describe("createRequireBullAuth", () => {
+  it("refuses to interpolate ) into an Express path", () => {
+    const app = express();
+    expect(() => {
+      app.get("/admin/secret)oops/redis-health", (_req, res) => res.send("ok"));
+    }).toThrow(/Unexpected \)/);
+  });
+
+  it("refuses to interpolate ) into app.use", () => {
+    const app = express();
+    expect(() => {
+      app.use("/admin/secret)oops/queues", (_req, _res, next) => next());
+    }).toThrow(/Unexpected \)/);
+  });
+
+  it("serves a key containing ) via :bullAuthKey", async () => {
+    const key = "secret)oops";
+    const app = express();
+    app.get(
+      "/admin/:bullAuthKey/redis-health",
+      createRequireBullAuth(key),
+      (_req, res) => res.send("ok"),
+    );
+    const server = await listen(app);
+    try {
+      const hit = await get(server, `/admin/${key}/redis-health`);
+      expect(hit.status).toBe(200);
+      expect(hit.text).toBe("ok");
+      const miss = await get(server, "/admin/wrong/redis-health");
+      expect(miss.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("serves a key containing braces", async () => {
+    const key = "sec{ret}";
+    const app = express();
+    app.get(
+      "/admin/:bullAuthKey/redis-health",
+      createRequireBullAuth(key),
+      (_req, res) => res.send("ok"),
+    );
+    const server = await listen(app);
+    try {
+      const hit = await get(server, `/admin/${key}/redis-health`);
+      expect(hit.status).toBe(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("mounts a Bull Board-style prefix with a ) key", async () => {
+    const key = "secret)oops";
+    const app = express();
+    const inner = express.Router();
+    inner.get("/", (_req, res) => res.send("queues"));
+    app.use(
+      "/admin/:bullAuthKey/queues",
+      createRequireBullAuth(key),
+      inner,
+    );
+    const server = await listen(app);
+    try {
+      const hit = await get(server, `/admin/${key}/queues`);
+      expect(hit.status).toBe(200);
+      expect(hit.text).toBe("queues");
+      const miss = await get(server, "/admin/wrong/queues");
+      expect(miss.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/apps/api/src/lib/__tests__/bull-auth.test.ts
+++ b/apps/api/src/lib/__tests__/bull-auth.test.ts
@@ -181,10 +181,7 @@ describe("createRequireBullAuth", () => {
         );
         expect(item.status).toBe(200);
         expect(item.text).toBe("q/1");
-        const miss = await get(
-          server,
-          `${adminPath(wrong)}/queues/api/queues`,
-        );
+        const miss = await get(server, `${adminPath(wrong)}/queues/api/queues`);
         expect(miss.status).toBe(404);
         expect(miss.text).toBe(JSON.stringify({ error: "Not found" }));
       } finally {

--- a/apps/api/src/lib/__tests__/bull-auth.test.ts
+++ b/apps/api/src/lib/__tests__/bull-auth.test.ts
@@ -1,6 +1,10 @@
 import express from "express";
 import http from "node:http";
-import { bullAuthRoute, createRequireBullAuth } from "../bull-auth";
+import {
+  bullAuthPublicPath,
+  bullAuthRoute,
+  createRequireBullAuth,
+} from "../bull-auth";
 
 function listen(app: express.Express): Promise<http.Server> {
   const server = http.createServer(app);
@@ -14,6 +18,10 @@ async function get(server: http.Server, path: string) {
   if (!addr || typeof addr === "string") throw new Error("no port");
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`);
   return { status: res.status, text: await res.text() };
+}
+
+function adminPath(key: string): string {
+  return `/admin/${bullAuthPublicPath(key)}`;
 }
 
 function mountHealth(app: express.Express, key: string) {
@@ -60,13 +68,22 @@ describe("createRequireBullAuth", () => {
     );
   });
 
+  it("percent-encodes non-empty segments for client URLs", () => {
+    expect(bullAuthPublicPath("foo?bar")).toBe("foo%3Fbar");
+    expect(bullAuthPublicPath("a%2Fb")).toBe("a%252Fb");
+    expect(bullAuthPublicPath("abc/def")).toBe("abc/def");
+    expect(bullAuthPublicPath("a//b")).toBe("a//b");
+    expect(bullAuthPublicPath("trail/")).toBe("trail/");
+    expect(bullAuthPublicPath("secret)oops")).toBe("secret)oops");
+  });
+
   it("serves a key containing )", async () => {
     const key = "secret)oops";
     const app = express();
     mountHealth(app, key);
     const server = await listen(app);
     try {
-      const hit = await get(server, `/admin/${key}/redis-health`);
+      const hit = await get(server, `${adminPath(key)}/redis-health`);
       expect(hit.status).toBe(200);
       expect(hit.text).toBe("ok");
       const miss = await get(server, "/admin/wrong/redis-health");
@@ -83,7 +100,7 @@ describe("createRequireBullAuth", () => {
     mountHealth(app, key);
     const server = await listen(app);
     try {
-      const hit = await get(server, `/admin/${key}/redis-health`);
+      const hit = await get(server, `${adminPath(key)}/redis-health`);
       expect(hit.status).toBe(200);
       expect(hit.text).toBe("ok");
     } finally {
@@ -97,7 +114,7 @@ describe("createRequireBullAuth", () => {
     mountHealth(app, key);
     const server = await listen(app);
     try {
-      const hit = await get(server, `/admin/${key}/redis-health`);
+      const hit = await get(server, `${adminPath(key)}/redis-health`);
       expect(hit.status).toBe(200);
     } finally {
       server.close();
@@ -110,13 +127,13 @@ describe("createRequireBullAuth", () => {
     mountQueues(app, key);
     const server = await listen(app);
     try {
-      const shell = await get(server, `/admin/${key}/queues`);
+      const shell = await get(server, `${adminPath(key)}/queues`);
       expect(shell.status).toBe(200);
       expect(shell.text).toBe("queues");
-      const api = await get(server, `/admin/${key}/queues/api/queues`);
+      const api = await get(server, `${adminPath(key)}/queues/api/queues`);
       expect(api.status).toBe(200);
       expect(api.text).toBe("api-queues");
-      const item = await get(server, `/admin/${key}/queues/api/queues/q/1`);
+      const item = await get(server, `${adminPath(key)}/queues/api/queues/q/1`);
       expect(item.status).toBe(200);
       expect(item.text).toBe("q/1");
       const miss = await get(server, "/admin/wrong/queues/api/queues");
@@ -132,10 +149,10 @@ describe("createRequireBullAuth", () => {
     mountQueues(app, key);
     const server = await listen(app);
     try {
-      const api = await get(server, `/admin/${key}/queues/api/queues`);
+      const api = await get(server, `${adminPath(key)}/queues/api/queues`);
       expect(api.status).toBe(200);
       expect(api.text).toBe("api-queues");
-      const item = await get(server, `/admin/${key}/queues/api/queues/q/1`);
+      const item = await get(server, `${adminPath(key)}/queues/api/queues/q/1`);
       expect(item.status).toBe(200);
       expect(item.text).toBe("q/1");
       const miss = await get(server, "/admin/xxx/yyy/queues/api/queues");
@@ -147,20 +164,68 @@ describe("createRequireBullAuth", () => {
   });
 
   it("forwards Bull Board sub-paths for a key with empty segments", async () => {
-    for (const key of ["a//b", "trail/"]) {
+    for (const [key, wrong] of [
+      ["a//b", "x//y"],
+      ["trail/", "wrong/"],
+    ] as const) {
       const app = express();
       mountQueues(app, key);
       const server = await listen(app);
       try {
-        const api = await get(server, `/admin/${key}/queues/api/queues`);
+        const api = await get(server, `${adminPath(key)}/queues/api/queues`);
         expect(api.status).toBe(200);
         expect(api.text).toBe("api-queues");
-        const item = await get(server, `/admin/${key}/queues/api/queues/q/1`);
+        const item = await get(
+          server,
+          `${adminPath(key)}/queues/api/queues/q/1`,
+        );
         expect(item.status).toBe(200);
         expect(item.text).toBe("q/1");
+        const miss = await get(
+          server,
+          `${adminPath(wrong)}/queues/api/queues`,
+        );
+        expect(miss.status).toBe(404);
+        expect(miss.text).toBe(JSON.stringify({ error: "Not found" }));
       } finally {
         server.close();
       }
+    }
+  });
+
+  it("serves a key containing ? via the encoded client URL", async () => {
+    const key = "foo?bar";
+    const app = express();
+    mountHealth(app, key);
+    mountQueues(app, key);
+    const server = await listen(app);
+    try {
+      const hit = await get(server, `${adminPath(key)}/redis-health`);
+      expect(hit.status).toBe(200);
+      expect(hit.text).toBe("ok");
+      const api = await get(server, `${adminPath(key)}/queues/api/queues`);
+      expect(api.status).toBe(200);
+      expect(api.text).toBe("api-queues");
+      const asQuery = await get(server, `/admin/${key}/redis-health`);
+      expect(asQuery.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("serves a key containing a literal %2F via the encoded client URL", async () => {
+    const key = "a%2Fb";
+    const app = express();
+    mountHealth(app, key);
+    const server = await listen(app);
+    try {
+      const hit = await get(server, `${adminPath(key)}/redis-health`);
+      expect(hit.status).toBe(200);
+      expect(hit.text).toBe("ok");
+      const decodedSlash = await get(server, "/admin/a%2Fb/redis-health");
+      expect(decodedSlash.status).toBe(404);
+    } finally {
+      server.close();
     }
   });
 });

--- a/apps/api/src/lib/__tests__/bull-auth.test.ts
+++ b/apps/api/src/lib/__tests__/bull-auth.test.ts
@@ -52,6 +52,12 @@ describe("createRequireBullAuth", () => {
     expect(bullAuthRoute("abc/def", "/queues")).toBe(
       "/admin/:bullAuth0/:bullAuth1/queues",
     );
+    expect(bullAuthRoute("a//b", "/queues")).toBe(
+      "/admin/:bullAuth0//:bullAuth2/queues",
+    );
+    expect(bullAuthRoute("trail/", "/queues")).toBe(
+      "/admin/:bullAuth0//queues",
+    );
   });
 
   it("serves a key containing )", async () => {
@@ -137,6 +143,24 @@ describe("createRequireBullAuth", () => {
       expect(miss.text).toBe(JSON.stringify({ error: "Not found" }));
     } finally {
       server.close();
+    }
+  });
+
+  it("forwards Bull Board sub-paths for a key with empty segments", async () => {
+    for (const key of ["a//b", "trail/"]) {
+      const app = express();
+      mountQueues(app, key);
+      const server = await listen(app);
+      try {
+        const api = await get(server, `/admin/${key}/queues/api/queues`);
+        expect(api.status).toBe(200);
+        expect(api.text).toBe("api-queues");
+        const item = await get(server, `/admin/${key}/queues/api/queues/q/1`);
+        expect(item.status).toBe(200);
+        expect(item.text).toBe("q/1");
+      } finally {
+        server.close();
+      }
     }
   });
 });

--- a/apps/api/src/lib/__tests__/bull-auth.test.ts
+++ b/apps/api/src/lib/__tests__/bull-auth.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import http from "node:http";
-import { createRequireBullAuth } from "../bull-auth";
+import { bullAuthRoute, createRequireBullAuth } from "../bull-auth";
 
 function listen(app: express.Express): Promise<http.Server> {
   const server = http.createServer(app);
@@ -18,10 +18,20 @@ async function get(server: http.Server, path: string) {
 
 function mountHealth(app: express.Express, key: string) {
   app.get(
-    "/admin/*bullAuthKey/redis-health",
+    bullAuthRoute(key, "/redis-health"),
     createRequireBullAuth(key),
     (_req, res) => res.send("ok"),
   );
+}
+
+function mountQueues(app: express.Express, key: string) {
+  const inner = express.Router();
+  inner.get("/", (_req, res) => res.send("queues"));
+  inner.get("/api/queues", (_req, res) => res.send("api-queues"));
+  inner.get("/api/queues/:name/:id", (_req, res) =>
+    res.send(`${_req.params.name}/${_req.params.id}`),
+  );
+  app.use(bullAuthRoute(key, "/queues"), createRequireBullAuth(key), inner);
 }
 
 describe("createRequireBullAuth", () => {
@@ -35,6 +45,15 @@ describe("createRequireBullAuth", () => {
     }).toThrow(/Unexpected \)/);
   });
 
+  it("builds one param per key segment", () => {
+    expect(bullAuthRoute("secret)oops", "/redis-health")).toBe(
+      "/admin/:bullAuth0/redis-health",
+    );
+    expect(bullAuthRoute("abc/def", "/queues")).toBe(
+      "/admin/:bullAuth0/:bullAuth1/queues",
+    );
+  });
+
   it("serves a key containing )", async () => {
     const key = "secret)oops";
     const app = express();
@@ -46,6 +65,7 @@ describe("createRequireBullAuth", () => {
       expect(hit.text).toBe("ok");
       const miss = await get(server, "/admin/wrong/redis-health");
       expect(miss.status).toBe(404);
+      expect(miss.text).toBe(JSON.stringify({ error: "Not found" }));
     } finally {
       server.close();
     }
@@ -78,19 +98,43 @@ describe("createRequireBullAuth", () => {
     }
   });
 
-  it("mounts a Bull Board-style prefix with a ) key", async () => {
+  it("forwards Bull Board sub-paths for a ) key", async () => {
     const key = "secret)oops";
     const app = express();
-    const inner = express.Router();
-    inner.get("/", (_req, res) => res.send("queues"));
-    app.use("/admin/*bullAuthKey/queues", createRequireBullAuth(key), inner);
+    mountQueues(app, key);
     const server = await listen(app);
     try {
-      const hit = await get(server, `/admin/${key}/queues`);
-      expect(hit.status).toBe(200);
-      expect(hit.text).toBe("queues");
-      const miss = await get(server, "/admin/wrong/queues");
+      const shell = await get(server, `/admin/${key}/queues`);
+      expect(shell.status).toBe(200);
+      expect(shell.text).toBe("queues");
+      const api = await get(server, `/admin/${key}/queues/api/queues`);
+      expect(api.status).toBe(200);
+      expect(api.text).toBe("api-queues");
+      const item = await get(server, `/admin/${key}/queues/api/queues/q/1`);
+      expect(item.status).toBe(200);
+      expect(item.text).toBe("q/1");
+      const miss = await get(server, "/admin/wrong/queues/api/queues");
       expect(miss.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("forwards Bull Board sub-paths for a key containing a slash", async () => {
+    const key = "abc/def";
+    const app = express();
+    mountQueues(app, key);
+    const server = await listen(app);
+    try {
+      const api = await get(server, `/admin/${key}/queues/api/queues`);
+      expect(api.status).toBe(200);
+      expect(api.text).toBe("api-queues");
+      const item = await get(server, `/admin/${key}/queues/api/queues/q/1`);
+      expect(item.status).toBe(200);
+      expect(item.text).toBe("q/1");
+      const miss = await get(server, "/admin/xxx/yyy/queues/api/queues");
+      expect(miss.status).toBe(404);
+      expect(miss.text).toBe(JSON.stringify({ error: "Not found" }));
     } finally {
       server.close();
     }

--- a/apps/api/src/lib/__tests__/bull-auth.test.ts
+++ b/apps/api/src/lib/__tests__/bull-auth.test.ts
@@ -16,29 +16,29 @@ async function get(server: http.Server, path: string) {
   return { status: res.status, text: await res.text() };
 }
 
+function mountHealth(app: express.Express, key: string) {
+  app.get(
+    "/admin/*bullAuthKey/redis-health",
+    createRequireBullAuth(key),
+    (_req, res) => res.send("ok"),
+  );
+}
+
 describe("createRequireBullAuth", () => {
-  it("refuses to interpolate ) into an Express path", () => {
+  it("throws if the key is interpolated into the Express path", () => {
     const app = express();
     expect(() => {
       app.get("/admin/secret)oops/redis-health", (_req, res) => res.send("ok"));
     }).toThrow(/Unexpected \)/);
-  });
-
-  it("refuses to interpolate ) into app.use", () => {
-    const app = express();
     expect(() => {
       app.use("/admin/secret)oops/queues", (_req, _res, next) => next());
     }).toThrow(/Unexpected \)/);
   });
 
-  it("serves a key containing ) via :bullAuthKey", async () => {
+  it("serves a key containing )", async () => {
     const key = "secret)oops";
     const app = express();
-    app.get(
-      "/admin/:bullAuthKey/redis-health",
-      createRequireBullAuth(key),
-      (_req, res) => res.send("ok"),
-    );
+    mountHealth(app, key);
     const server = await listen(app);
     try {
       const hit = await get(server, `/admin/${key}/redis-health`);
@@ -51,14 +51,24 @@ describe("createRequireBullAuth", () => {
     }
   });
 
+  it("serves a key containing a slash, which a single-segment param would 404", async () => {
+    const key = "abc/def";
+    const app = express();
+    mountHealth(app, key);
+    const server = await listen(app);
+    try {
+      const hit = await get(server, `/admin/${key}/redis-health`);
+      expect(hit.status).toBe(200);
+      expect(hit.text).toBe("ok");
+    } finally {
+      server.close();
+    }
+  });
+
   it("serves a key containing braces", async () => {
     const key = "sec{ret}";
     const app = express();
-    app.get(
-      "/admin/:bullAuthKey/redis-health",
-      createRequireBullAuth(key),
-      (_req, res) => res.send("ok"),
-    );
+    mountHealth(app, key);
     const server = await listen(app);
     try {
       const hit = await get(server, `/admin/${key}/redis-health`);
@@ -73,11 +83,7 @@ describe("createRequireBullAuth", () => {
     const app = express();
     const inner = express.Router();
     inner.get("/", (_req, res) => res.send("queues"));
-    app.use(
-      "/admin/:bullAuthKey/queues",
-      createRequireBullAuth(key),
-      inner,
-    );
+    app.use("/admin/*bullAuthKey/queues", createRequireBullAuth(key), inner);
     const server = await listen(app);
     try {
       const hit = await get(server, `/admin/${key}/queues`);

--- a/apps/api/src/lib/bull-auth.ts
+++ b/apps/api/src/lib/bull-auth.ts
@@ -1,18 +1,21 @@
 import crypto from "node:crypto";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 
+function bullAuthKeyFromRequest(req: Request): string | undefined {
+  const p = req.params.bullAuthKey;
+  if (Array.isArray(p)) return p.join("/");
+  return p;
+}
+
 export function createRequireBullAuth(expected: string): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
-    const provided = req.params.bullAuthKey;
+    const provided = bullAuthKeyFromRequest(req);
     if (!provided) {
       return res.status(404).json({ error: "Not found" });
     }
     const left = Buffer.from(provided);
     const right = Buffer.from(expected);
-    if (
-      left.length !== right.length ||
-      !crypto.timingSafeEqual(left, right)
-    ) {
+    if (left.length !== right.length || !crypto.timingSafeEqual(left, right)) {
       return res.status(404).json({ error: "Not found" });
     }
     return next();

--- a/apps/api/src/lib/bull-auth.ts
+++ b/apps/api/src/lib/bull-auth.ts
@@ -11,20 +11,24 @@ export function secretsMatch(
   return left.length === right.length && crypto.timingSafeEqual(left, right);
 }
 
-/** Express path for `/admin/<key><rest>` with one `:bullAuthN` per key segment. */
+/** Express path for `/admin/<key><rest>` with one `:bullAuthN` per non-empty key segment. */
 export function bullAuthRoute(key: string, rest: string): string {
   const params = key
     .split("/")
-    .map((_, i) => `:bullAuth${i}`)
+    .map((s, i) => (s === "" ? "" : `:bullAuth${i}`))
     .join("/");
   return `/admin/${params}${rest}`;
 }
 
 export function createRequireBullAuth(expected: string): RequestHandler {
-  const n = expected.split("/").length;
+  const segs = expected.split("/");
   return (req: Request, res: Response, next: NextFunction) => {
     const parts: string[] = [];
-    for (let i = 0; i < n; i++) {
+    for (let i = 0; i < segs.length; i++) {
+      if (segs[i] === "") {
+        parts.push("");
+        continue;
+      }
       const p = req.params[`bullAuth${i}`];
       if (typeof p !== "string") {
         return res.status(404).json({ error: "Not found" });

--- a/apps/api/src/lib/bull-auth.ts
+++ b/apps/api/src/lib/bull-auth.ts
@@ -1,0 +1,20 @@
+import crypto from "node:crypto";
+import { NextFunction, Request, RequestHandler, Response } from "express";
+
+export function createRequireBullAuth(expected: string): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const provided = req.params.bullAuthKey;
+    if (!provided) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    const left = Buffer.from(provided);
+    const right = Buffer.from(expected);
+    if (
+      left.length !== right.length ||
+      !crypto.timingSafeEqual(left, right)
+    ) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    return next();
+  };
+}

--- a/apps/api/src/lib/bull-auth.ts
+++ b/apps/api/src/lib/bull-auth.ts
@@ -1,21 +1,37 @@
 import crypto from "node:crypto";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 
-function bullAuthKeyFromRequest(req: Request): string | undefined {
-  const p = req.params.bullAuthKey;
-  if (Array.isArray(p)) return p.join("/");
-  return p;
+export function secretsMatch(
+  provided: string | null | undefined,
+  expected?: string,
+): boolean {
+  if (!provided || !expected) return false;
+  const left = Buffer.from(provided);
+  const right = Buffer.from(expected);
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
+/** Express path for `/admin/<key><rest>` with one `:bullAuthN` per key segment. */
+export function bullAuthRoute(key: string, rest: string): string {
+  const params = key
+    .split("/")
+    .map((_, i) => `:bullAuth${i}`)
+    .join("/");
+  return `/admin/${params}${rest}`;
 }
 
 export function createRequireBullAuth(expected: string): RequestHandler {
+  const n = expected.split("/").length;
   return (req: Request, res: Response, next: NextFunction) => {
-    const provided = bullAuthKeyFromRequest(req);
-    if (!provided) {
-      return res.status(404).json({ error: "Not found" });
+    const parts: string[] = [];
+    for (let i = 0; i < n; i++) {
+      const p = req.params[`bullAuth${i}`];
+      if (typeof p !== "string") {
+        return res.status(404).json({ error: "Not found" });
+      }
+      parts.push(p);
     }
-    const left = Buffer.from(provided);
-    const right = Buffer.from(expected);
-    if (left.length !== right.length || !crypto.timingSafeEqual(left, right)) {
+    if (!secretsMatch(parts.join("/"), expected)) {
       return res.status(404).json({ error: "Not found" });
     }
     return next();

--- a/apps/api/src/lib/bull-auth.ts
+++ b/apps/api/src/lib/bull-auth.ts
@@ -11,6 +11,14 @@ export function secretsMatch(
   return left.length === right.length && crypto.timingSafeEqual(left, right);
 }
 
+/** Encode each non-empty key segment for client URLs (`setBasePath`). Empty segments stay literal. */
+export function bullAuthPublicPath(key: string): string {
+  return key
+    .split("/")
+    .map(s => (s === "" ? "" : encodeURIComponent(s)))
+    .join("/");
+}
+
 /** Express path for `/admin/<key><rest>` with one `:bullAuthN` per non-empty key segment. */
 export function bullAuthRoute(key: string, rest: string): string {
   const params = key

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -33,85 +33,85 @@ if (config.BULL_AUTH_KEY) {
   const requireBullAuth = createRequireBullAuth(config.BULL_AUTH_KEY);
 
   adminRouter.get(
-    `/admin/:bullAuthKey/redis-health`,
+    `/admin/*bullAuthKey/redis-health`,
     requireBullAuth,
     redisHealthController,
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/autumn-health`,
+    `/admin/*bullAuthKey/autumn-health`,
     requireBullAuth,
     autumnHealthController,
   );
 
   adminRouter.post(
-    `/admin/:bullAuthKey/acuc-cache-clear`,
+    `/admin/*bullAuthKey/acuc-cache-clear`,
     requireBullAuth,
     wrap(acucCacheClearController),
   );
 
   adminRouter.post(
-    `/admin/:bullAuthKey/ip-restriction-cache-clear`,
+    `/admin/*bullAuthKey/ip-restriction-cache-clear`,
     requireBullAuth,
     wrap(ipRestrictionCacheClearController),
   );
 
   adminRouter.post(
-    `/admin/:bullAuthKey/key-restriction-cache-clear`,
+    `/admin/*bullAuthKey/key-restriction-cache-clear`,
     requireBullAuth,
     wrap(keyRestrictionCacheClearController),
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/feng-check`,
+    `/admin/*bullAuthKey/feng-check`,
     requireBullAuth,
     wrap(checkFireEngine),
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/index-queue-prometheus`,
+    `/admin/*bullAuthKey/index-queue-prometheus`,
     requireBullAuth,
     wrap(indexQueuePrometheus),
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/precrawl`,
+    `/admin/*bullAuthKey/precrawl`,
     requireBullAuth,
     wrap(triggerPrecrawl),
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/metrics`,
+    `/admin/*bullAuthKey/metrics`,
     requireBullAuth,
     wrap(metricsController),
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/nuq-metrics`,
+    `/admin/*bullAuthKey/nuq-metrics`,
     requireBullAuth,
     wrap(nuqMetricsController),
   );
 
   adminRouter.get(
-    `/admin/:bullAuthKey/nuq-fdb-metrics`,
+    `/admin/*bullAuthKey/nuq-fdb-metrics`,
     requireBullAuth,
     wrap(nuqFdbMetricsController),
   );
 
   adminRouter.post(
-    `/admin/:bullAuthKey/fsearch`,
+    `/admin/*bullAuthKey/fsearch`,
     requireBullAuth,
     wrap(realtimeSearchController),
   );
 
   adminRouter.post(
-    `/admin/:bullAuthKey/concurrency-queue-backfill`,
+    `/admin/*bullAuthKey/concurrency-queue-backfill`,
     requireBullAuth,
     wrap(concurrencyQueueBackfillController),
   );
 
   adminRouter.post(
-    `/admin/:bullAuthKey/crawl-monitor`,
+    `/admin/*bullAuthKey/crawl-monitor`,
     requireBullAuth,
     authMiddleware(RateLimiterMode.Crawl),
     checkCreditsMiddleware(2),
@@ -132,7 +132,11 @@ if (config.S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY) {
     return left.length === right.length && crypto.timingSafeEqual(left, right);
   }
 
-  function firecrawlIntegrationsMiddleware(req: Request, res: Response, next: NextFunction) {
+  function firecrawlIntegrationsMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) {
     if (
       !secretsMatch(
         bearerToken(req.headers.authorization),
@@ -141,7 +145,9 @@ if (config.S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY) {
     ) {
       return res.status(401).json({ error: "Unauthorized" });
     }
-    logger.info(`firecrawl-integrations service calling ${req.method} ${req.path}`);
+    logger.info(
+      `firecrawl-integrations service calling ${req.method} ${req.path}`,
+    );
     next();
   }
 
@@ -152,8 +158,17 @@ if (config.S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY) {
   );
 }
 
-adminRouter.post(`/admin/integration/create-user`, wrap(handleIntegrationAdminCreateUserProxy));
+adminRouter.post(
+  `/admin/integration/create-user`,
+  wrap(handleIntegrationAdminCreateUserProxy),
+);
 
-adminRouter.post(`/admin/integration/validate-api-key`, wrap(handleIntegrationAdminValidateProxy));
+adminRouter.post(
+  `/admin/integration/validate-api-key`,
+  wrap(handleIntegrationAdminValidateProxy),
+);
 
-adminRouter.post(`/admin/integration/rotate-api-key`, wrap(handleIntegrationAdminRotateProxy));
+adminRouter.post(
+  `/admin/integration/rotate-api-key`,
+  wrap(handleIntegrationAdminRotateProxy),
+);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,5 +1,4 @@
 import express, { NextFunction, Request, Response } from "express";
-import crypto from "node:crypto";
 import { config } from "../config";
 import { acucCacheClearController } from "../controllers/v0/admin/acuc-cache-clear";
 import { autumnHealthController } from "../controllers/v0/admin/autumn-health";
@@ -25,93 +24,87 @@ import {
 import { logger } from "../lib/logger";
 import { RateLimiterMode } from "../types";
 import { authMiddleware, checkCreditsMiddleware, wrap } from "./shared";
-import { createRequireBullAuth } from "../lib/bull-auth";
+import {
+  bullAuthRoute,
+  createRequireBullAuth,
+  secretsMatch,
+} from "../lib/bull-auth";
 
 export const adminRouter = express.Router();
 
 if (config.BULL_AUTH_KEY) {
-  const requireBullAuth = createRequireBullAuth(config.BULL_AUTH_KEY);
+  const key = config.BULL_AUTH_KEY;
+  const requireBullAuth = createRequireBullAuth(key);
+  const bull = (rest: string) => bullAuthRoute(key, rest);
 
   adminRouter.get(
-    `/admin/*bullAuthKey/redis-health`,
+    bull("/redis-health"),
     requireBullAuth,
     redisHealthController,
   );
 
   adminRouter.get(
-    `/admin/*bullAuthKey/autumn-health`,
+    bull("/autumn-health"),
     requireBullAuth,
     autumnHealthController,
   );
 
   adminRouter.post(
-    `/admin/*bullAuthKey/acuc-cache-clear`,
+    bull("/acuc-cache-clear"),
     requireBullAuth,
     wrap(acucCacheClearController),
   );
 
   adminRouter.post(
-    `/admin/*bullAuthKey/ip-restriction-cache-clear`,
+    bull("/ip-restriction-cache-clear"),
     requireBullAuth,
     wrap(ipRestrictionCacheClearController),
   );
 
   adminRouter.post(
-    `/admin/*bullAuthKey/key-restriction-cache-clear`,
+    bull("/key-restriction-cache-clear"),
     requireBullAuth,
     wrap(keyRestrictionCacheClearController),
   );
 
-  adminRouter.get(
-    `/admin/*bullAuthKey/feng-check`,
-    requireBullAuth,
-    wrap(checkFireEngine),
-  );
+  adminRouter.get(bull("/feng-check"), requireBullAuth, wrap(checkFireEngine));
 
   adminRouter.get(
-    `/admin/*bullAuthKey/index-queue-prometheus`,
+    bull("/index-queue-prometheus"),
     requireBullAuth,
     wrap(indexQueuePrometheus),
   );
 
-  adminRouter.get(
-    `/admin/*bullAuthKey/precrawl`,
-    requireBullAuth,
-    wrap(triggerPrecrawl),
-  );
+  adminRouter.get(bull("/precrawl"), requireBullAuth, wrap(triggerPrecrawl));
+
+  adminRouter.get(bull("/metrics"), requireBullAuth, wrap(metricsController));
 
   adminRouter.get(
-    `/admin/*bullAuthKey/metrics`,
-    requireBullAuth,
-    wrap(metricsController),
-  );
-
-  adminRouter.get(
-    `/admin/*bullAuthKey/nuq-metrics`,
+    bull("/nuq-metrics"),
     requireBullAuth,
     wrap(nuqMetricsController),
   );
 
   adminRouter.get(
-    `/admin/*bullAuthKey/nuq-fdb-metrics`,
+    bull("/nuq-fdb-metrics"),
     requireBullAuth,
     wrap(nuqFdbMetricsController),
   );
 
   adminRouter.post(
-    `/admin/*bullAuthKey/fsearch`,
+    bull("/fsearch"),
     requireBullAuth,
     wrap(realtimeSearchController),
   );
 
   adminRouter.post(
-    `/admin/*bullAuthKey/concurrency-queue-backfill`,
+    bull("/concurrency-queue-backfill"),
     requireBullAuth,
     wrap(concurrencyQueueBackfillController),
   );
 
   adminRouter.post(
-    `/admin/*bullAuthKey/crawl-monitor`,
+    bull("/crawl-monitor"),
     requireBullAuth,
     authMiddleware(RateLimiterMode.Crawl),
     checkCreditsMiddleware(2),
@@ -123,13 +116,6 @@ if (config.S2S_FIRECRAWL_INTEGRATIONS_TO_FIRECRAWL_API_KEY) {
   function bearerToken(value: string | string[] | undefined): string | null {
     const header = Array.isArray(value) ? value[0] : value;
     return header?.startsWith("Bearer ") ? header.slice(7) : null;
-  }
-
-  function secretsMatch(provided: string | null, expected?: string): boolean {
-    if (!provided || !expected) return false;
-    const left = Buffer.from(provided);
-    const right = Buffer.from(expected);
-    return left.length === right.length && crypto.timingSafeEqual(left, right);
   }
 
   function firecrawlIntegrationsMiddleware(

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -25,53 +25,94 @@ import {
 import { logger } from "../lib/logger";
 import { RateLimiterMode } from "../types";
 import { authMiddleware, checkCreditsMiddleware, wrap } from "./shared";
+import { createRequireBullAuth } from "../lib/bull-auth";
 
 export const adminRouter = express.Router();
 
 if (config.BULL_AUTH_KEY) {
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/redis-health`, redisHealthController);
+  const requireBullAuth = createRequireBullAuth(config.BULL_AUTH_KEY);
 
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/autumn-health`, autumnHealthController);
+  adminRouter.get(
+    `/admin/:bullAuthKey/redis-health`,
+    requireBullAuth,
+    redisHealthController,
+  );
+
+  adminRouter.get(
+    `/admin/:bullAuthKey/autumn-health`,
+    requireBullAuth,
+    autumnHealthController,
+  );
 
   adminRouter.post(
-    `/admin/${config.BULL_AUTH_KEY}/acuc-cache-clear`,
+    `/admin/:bullAuthKey/acuc-cache-clear`,
+    requireBullAuth,
     wrap(acucCacheClearController),
   );
 
   adminRouter.post(
-    `/admin/${config.BULL_AUTH_KEY}/ip-restriction-cache-clear`,
+    `/admin/:bullAuthKey/ip-restriction-cache-clear`,
+    requireBullAuth,
     wrap(ipRestrictionCacheClearController),
   );
 
   adminRouter.post(
-    `/admin/${config.BULL_AUTH_KEY}/key-restriction-cache-clear`,
+    `/admin/:bullAuthKey/key-restriction-cache-clear`,
+    requireBullAuth,
     wrap(keyRestrictionCacheClearController),
   );
 
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/feng-check`, wrap(checkFireEngine));
+  adminRouter.get(
+    `/admin/:bullAuthKey/feng-check`,
+    requireBullAuth,
+    wrap(checkFireEngine),
+  );
 
   adminRouter.get(
-    `/admin/${config.BULL_AUTH_KEY}/index-queue-prometheus`,
+    `/admin/:bullAuthKey/index-queue-prometheus`,
+    requireBullAuth,
     wrap(indexQueuePrometheus),
   );
 
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/precrawl`, wrap(triggerPrecrawl));
+  adminRouter.get(
+    `/admin/:bullAuthKey/precrawl`,
+    requireBullAuth,
+    wrap(triggerPrecrawl),
+  );
 
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/metrics`, wrap(metricsController));
+  adminRouter.get(
+    `/admin/:bullAuthKey/metrics`,
+    requireBullAuth,
+    wrap(metricsController),
+  );
 
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/nuq-metrics`, wrap(nuqMetricsController));
+  adminRouter.get(
+    `/admin/:bullAuthKey/nuq-metrics`,
+    requireBullAuth,
+    wrap(nuqMetricsController),
+  );
 
-  adminRouter.get(`/admin/${config.BULL_AUTH_KEY}/nuq-fdb-metrics`, wrap(nuqFdbMetricsController));
-
-  adminRouter.post(`/admin/${config.BULL_AUTH_KEY}/fsearch`, wrap(realtimeSearchController));
+  adminRouter.get(
+    `/admin/:bullAuthKey/nuq-fdb-metrics`,
+    requireBullAuth,
+    wrap(nuqFdbMetricsController),
+  );
 
   adminRouter.post(
-    `/admin/${config.BULL_AUTH_KEY}/concurrency-queue-backfill`,
+    `/admin/:bullAuthKey/fsearch`,
+    requireBullAuth,
+    wrap(realtimeSearchController),
+  );
+
+  adminRouter.post(
+    `/admin/:bullAuthKey/concurrency-queue-backfill`,
+    requireBullAuth,
     wrap(concurrencyQueueBackfillController),
   );
 
   adminRouter.post(
-    `/admin/${config.BULL_AUTH_KEY}/crawl-monitor`,
+    `/admin/:bullAuthKey/crawl-monitor`,
+    requireBullAuth,
     authMiddleware(RateLimiterMode.Crawl),
     checkCreditsMiddleware(2),
     wrap(crawlMonitorController),


### PR DESCRIPTION
Fixes https://github.com/firecrawl/firecrawl/issues/1791.

Express 5.2.1 compiles `/admin/${BULL_AUTH_KEY}/...` as a route pattern. A key containing `)` throws PathError at boot and the process never listens. Same for `(`, `+`, `?`, `{`, `}`, `[`, `]`. `apps/api/.env.example` line 68 sets `BULL_AUTH_KEY=@`, which registers. Both admin.ts and the Bull Board `app.use` in index.ts interpolate the key.

The secret is no longer in the pattern. `bullAuthRoute` emits one `:bullAuthN` per non-empty `key.split("/")` segment, with a literal empty segment for `//` or a trailing `/` (path-to-regexp `:name` needs 1+ chars). Middleware joins the params and `timingSafeEqual`s them against `BULL_AUTH_KEY`. `setBasePath` uses `bullAuthPublicPath`, which `encodeURIComponent`s each segment so `?` is not a query delimiter and a literal `%2F` survives Express decoding. `*bullAuthKey` was rejected because it is greedy in path-to-regexp v8, so `/admin/<key>/queues/api/queues` captures `<key>/queues/api`.

Wrong key with the same segment count returns JSON 404 `{ error: "Not found" }`. No env change. Keys that already worked as a literal path, including `/`, `//`, and trailing `/`, keep the same URLs. S2S bearer compare uses `secretsMatch` from bull-auth.ts. MCP ingest keeps its own `timingSafeSecretEqual`. prettier also rewrapped a few existing long lines in admin.ts.

`cd apps/api && ./node_modules/.bin/vitest run src/lib/__tests__/bull-auth.test.ts` on 03f71585a: 11 passed. Covers GET `/admin/<encoded-key>/queues/api/queues` for `secret)oops`, `abc/def`, `a//b`, `trail/`, `foo?bar`. Encoded GET for `a%2Fb` is 200, raw `/admin/a%2Fb/...` is 404. Same-segment-count misses `x//y` and `wrong/` return JSON 404. With `encodeURIComponent` removed from `bullAuthPublicPath`, 3 of 11 fail (the public-path asserts plus GET 200 for `foo?bar` and `a%2Fb`). `./node_modules/.bin/knip --cache` exit 0.
