### PR TITLE
Expose Exchange bounty write routes

### DIFF
--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -169,6 +169,30 @@ exchangeRouter.get(
 );
 
 exchangeRouter.post(
+  "/publisher/bounties",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/publisher/bounties/:id/claim",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/publisher/bounties/:id/submit",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
+  "/publisher/bounties/:id/skill",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.post(
   "/applications",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(APPLICATIONS_TIMEOUT_MS, { requiresRetrieveFlag: false })),


### PR DESCRIPTION
Bounty publishing through the Firecrawl API returns 404 because only publisher GET requests are proxied. Add explicit authenticated POST routes for creating bounties, claiming them, submitting data solutions, and submitting skill proposals.

The four routes reuse the existing Exchange proxy, Labs authentication/rate limiting, and publisher timeout. This change contains only route declarations.

Validation: `git diff --check` passed. Live listing and reading succeeded before this change; publishing reproduced the 404. End-to-end write verification requires deployment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds authenticated POST routes for Exchange bounty write operations so publishing through the Firecrawl API no longer returns 404.

- Routes cover creating bounties, claiming them, submitting data solutions, and submitting skill proposals.
- They reuse the existing Exchange proxy, Labs authentication/rate limiting, and publisher timeout.
- `git diff --check` passes; end-to-end write verification requires deployment.

<sup>Written for commit dca65fc7164e95b2db8dde33d54cfe8df9af39af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

