### PR TITLE
Proxy removal of unused Exchange bounties

### DIFF
--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -174,6 +174,12 @@ exchangeRouter.post(
   wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
 );
 
+exchangeRouter.delete(
+  "/publisher/bounties/:id",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(ANALYTICS_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
 exchangeRouter.post(
   "/publisher/bounties/:id/claim",
   authMiddleware(RateLimiterMode.Labs),


### PR DESCRIPTION
Forward DELETE /exchange/publisher/bounties/:id to Exchange so an internal publisher can remove an unused bounty. Reuse authenticated team forwarding and the analytics timeout; Exchange checks ownership, revision, claims and campaign membership.

Validation: isolated proxy handler checks pass for route authentication, URL/revision forwarding, authenticated team identity, success and upstream 409. The full proxy service was not run locally; the matching Exchange route has PostgreSQL integration coverage.
