### PR TITLE
fix(api): use PSL-backed parseHostname for isSameDomain extraction

### DIFF
--- a/apps/api/src/lib/validateUrl.test.ts
+++ b/apps/api/src/lib/validateUrl.test.ts
@@ -47,6 +47,45 @@ describe("isSameDomain", () => {
     );
     expect(result).toBe(true);
   });
+
+  it("should return false for different domains with multi-part TLDs", () => {
+    const result1 = isSameDomain(
+      "https://example.co.uk",
+      "https://attacker.co.uk",
+    );
+    expect(result1).toBe(false);
+
+    const result2 = isSameDomain(
+      "https://example.com.au",
+      "https://different.com.au",
+    );
+    expect(result2).toBe(false);
+  });
+
+  it("should return true for subdomains on multi-part TLDs", () => {
+    const result = isSameDomain(
+      "https://sub.example.co.uk",
+      "https://example.co.uk",
+    );
+    expect(result).toBe(true);
+  });
+
+  it("should return false for different IP addresses", () => {
+    const result = isSameDomain(
+      "http://192.168.1.1",
+      "http://10.0.1.1",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("should return true for identical IP addresses or localhost", () => {
+    expect(isSameDomain("http://192.168.1.1:3000", "http://192.168.1.1:8080")).toBe(true);
+    expect(isSameDomain("http://localhost:3000", "http://localhost:8080")).toBe(true);
+  });
+
+  it("should return true when domain label itself is www on a multi-part TLD", () => {
+    expect(isSameDomain("https://www.co.uk", "https://sub.www.co.uk")).toBe(true);
+  });
 });
 
 describe("isSameSubdomain", () => {

--- a/apps/api/src/lib/validateUrl.ts
+++ b/apps/api/src/lib/validateUrl.ts
@@ -1,5 +1,6 @@
 import * as undici from "undici";
 import { getSecureDispatcher } from "../scraper/scrapeURL/engines/utils/safeFetch";
+import { parseHostname } from "./url-utils";
 
 export const protocolIncluded = (url: string) => {
   // if :// not in the start of the url assume http (maybe https?)
@@ -76,18 +77,16 @@ export function isSameDomain(url: string, baseUrl: string) {
   const typedUrlObj1 = urlObj1 as URL;
   const typedUrlObj2 = urlObj2 as URL;
 
-  const cleanHostname = (hostname: string) => {
+  const getRegistrableDomain = (hostname: string) => {
+    const parsed = parseHostname(hostname);
+    if (parsed.domain) {
+      return parsed.domain;
+    }
     return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
   };
 
-  const domain1 = cleanHostname(typedUrlObj1.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
-  const domain2 = cleanHostname(typedUrlObj2.hostname)
-    .split(".")
-    .slice(-2)
-    .join(".");
+  const domain1 = getRegistrableDomain(typedUrlObj1.hostname);
+  const domain2 = getRegistrableDomain(typedUrlObj2.hostname);
 
   return domain1 === domain2;
 }

--- a/apps/api/src/routes/exchange-blocklist.ts
+++ b/apps/api/src/routes/exchange-blocklist.ts
@@ -3,7 +3,7 @@ import { parse } from "tldts";
 import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";
 import type { RequestWithAuth } from "../controllers/v1/types";
 
-export function bountyDomains(body: Record<string, unknown>): string[] {
+function bountyDomains(body: Record<string, unknown>): string[] {
   const fields = [
     body.title,
     body.description,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -36,7 +36,7 @@ export const SUBMIT_TRANSIENT_RETRY_DELAY_MS = 250;
 // Slack for the submit round trip: fire-pdf validates `deadline_at - now`
 // against MIN_DEADLINE_MS on arrival, so the advertised deadline must clear
 // it by at least the request's flight time.
-export const INLINE_SUBMIT_SLACK_MS = 5_000;
+const INLINE_SUBMIT_SLACK_MS = 5_000;
 // The smallest caller window async accepts. Below it, the margin would push
 // the inline job deadline to (or under) fire-pdf's minimum and the submit
 // would be rejected on arrival; such requests take the sync path instead.


### PR DESCRIPTION
## Problem

`isSameDomain()` in `apps/api/src/lib/validateUrl.ts` extracted the registrable domain via `.split(".").slice(-2).join(".")`. For hostnames with multi-part public suffixes (e.g. `.co.uk`, `.com.au`, `.org.uk`, `.co.in`), `.slice(-2)` isolates only the public suffix itself (e.g. `co.uk`). As a result:
- Cross-domain URLs sharing a multi-part TLD (such as `https://example.co.uk` and `https://attacker.co.uk`) were falsely treated as the same domain (`true`).
- Distinct IP addresses (such as `192.168.1.1` and `10.0.1.1`) were also treated as the same domain because only their trailing octets were compared.

## Root Cause

Manual extraction using a fixed offset of 2 labels assumes all TLDs consist of a single segment. Multi-part suffixes on the Public Suffix List require dictionary-based parsing to distinguish the public suffix from the actual registrable domain.

## Fix

1. Utilize the existing PSL-backed `parseHostname` from `apps/api/src/lib/url-utils.ts` to resolve `parsed.domain`.
2. Keep an exact-host fallback to `cleanHostname` for addresses without an ICANN/private domain (such as IPv4/IPv6 literals and `localhost`), ensuring different IP addresses return `false` while identical IP addresses or localhost on differing ports evaluate to `true`.
3. Preserve `www` labels that are part of the registered domain on multi-part TLDs (e.g. `www.co.uk`).
4. Resolve unused exports flagged by pre-commit `knip` check per project contributor standards.

## Testing

- Unit tests added to `apps/api/src/lib/validateUrl.test.ts`:
  - Verified RED reproduction on unpatched code (`example.co.uk` vs `attacker.co.uk` failing with `expected false, received true`).
  - Verified GREEN on all 27 unit tests post-fix.
- Ran `pnpm run knip` confirming 0 unused exports.

Fixes #4296

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4296 — `isSameDomain()` previously extracted the registrable domain by taking the last two hostname labels, which falsely matched different domains sharing a multi-part public suffix (e.g. `example.co.uk` vs `attacker.co.uk`) and different IP addresses. It now uses the PSL-backed `parseHostname` to compare actual registered domains.

- Falls back to the cleaned hostname when `parseHostname` returns no domain (IP literals, `localhost`), so identical IPs compare equal and distinct IPs do not.
- Adds unit tests for multi-part TLDs, subdomains, IP addresses, and `www`-only labels.
- Removes unused exports in `exchange-blocklist.ts` and `fire-pdf/schema.ts` flagged by the `knip` check.

<sup>Written for commit e10aa7678c9811daae52779d4185c5f1dc2ec3d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

