### PR TITLE
chore(api): bump pdf-inspector to 1.18.0

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -13,7 +13,7 @@ anydoc = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = "1.14.2"
+pdf-inspector = "1.18.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"
 nodesig = { git = "https://github.com/firecrawl/nodesig" }

--- a/apps/api/src/routes/exchange-blocklist.ts
+++ b/apps/api/src/routes/exchange-blocklist.ts
@@ -3,7 +3,7 @@ import { parse } from "tldts";
 import { isUrlBlocked } from "../scraper/WebScraper/utils/blocklist";
 import type { RequestWithAuth } from "../controllers/v1/types";
 
-export function bountyDomains(body: Record<string, unknown>): string[] {
+function bountyDomains(body: Record<string, unknown>): string[] {
   const fields = [
     body.title,
     body.description,

--- a/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/pdf/fire-pdf/schema.ts
@@ -36,7 +36,7 @@ export const SUBMIT_TRANSIENT_RETRY_DELAY_MS = 250;
 // Slack for the submit round trip: fire-pdf validates `deadline_at - now`
 // against MIN_DEADLINE_MS on arrival, so the advertised deadline must clear
 // it by at least the request's flight time.
-export const INLINE_SUBMIT_SLACK_MS = 5_000;
+const INLINE_SUBMIT_SLACK_MS = 5_000;
 // The smallest caller window async accepts. Below it, the margin would push
 // the inline job deadline to (or under) fire-pdf's minimum and the submit
 // would be rejected on arrival; such requests take the sync path instead.


### PR DESCRIPTION
## Summary

Bumps pdf-inspector from 1.14.2 to [1.18.0](https://github.com/firecrawl/pdf-inspector/releases/tag/v1.18.0).

- Better superscript/subscript extraction and rotated text handling.
- More reliable font styling and malformed PDF recovery.

Also removes two unused exports.
