### PR TITLE
fix(rust-sdk): accept negative creditsUsed in crawl and batch scrape status

### DIFF
--- a/apps/rust-sdk/src/batch_scrape.rs
+++ b/apps/rust-sdk/src/batch_scrape.rs
@@ -485,6 +485,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_batch_scrape_status_accepts_negative_credits_used() {
+        // Self-hosted instances without a billing record report creditsUsed: -1.
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/v2/batch/scrape/batch-selfhosted")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "success": true,
+                    "status": "completed",
+                    "total": 1,
+                    "completed": 1,
+                    "creditsUsed": -1,
+                    "data": [{ "markdown": "# Page" }]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = Client::new_selfhosted(server.url(), None::<&str>).unwrap();
+        let status = client
+            .get_batch_scrape_status("batch-selfhosted")
+            .await
+            .unwrap();
+
+        assert_eq!(status.status, JobStatus::Completed);
+        assert_eq!(status.credits_used, Some(-1));
+        assert_eq!(status.data.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
     async fn test_batch_scrape_with_invalid_urls() {
         let mut server = mockito::Server::new_async().await;
 

--- a/apps/rust-sdk/src/batch_scrape.rs
+++ b/apps/rust-sdk/src/batch_scrape.rs
@@ -83,8 +83,8 @@ pub struct BatchScrapeJob {
     pub completed: u32,
     /// Total number of URLs to scrape.
     pub total: u32,
-    /// Credits used by the batch scrape.
-    pub credits_used: Option<u32>,
+    /// Credits used by the batch scrape; `-1` when no billing record exists.
+    pub credits_used: Option<i64>,
     /// Expiry time of the batch data.
     pub expires_at: Option<String>,
     /// URL for the next page of results.

--- a/apps/rust-sdk/src/crawl.rs
+++ b/apps/rust-sdk/src/crawl.rs
@@ -105,8 +105,8 @@ pub struct CrawlJob {
     pub total: u32,
     /// Number of pages completed.
     pub completed: u32,
-    /// Credits used by the crawl.
-    pub credits_used: Option<u32>,
+    /// Credits used by the crawl; `-1` when no billing record exists.
+    pub credits_used: Option<i64>,
     /// Expiry time of the crawl data.
     pub expires_at: Option<String>,
     /// URL for the next page of results.
@@ -534,6 +534,38 @@ mod tests {
         assert_eq!(status.total, 5);
         assert_eq!(status.completed, 5);
         assert_eq!(status.data.len(), 2);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_get_crawl_status_accepts_negative_credits_used() {
+        // Self-hosted instances without a billing record report creditsUsed: -1.
+        let mut server = mockito::Server::new_async().await;
+
+        let mock = server
+            .mock("GET", "/v2/crawl/crawl-selfhosted")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "success": true,
+                    "status": "completed",
+                    "total": 1,
+                    "completed": 1,
+                    "creditsUsed": -1,
+                    "expiresAt": "2024-12-31T23:59:59Z",
+                    "data": [{ "markdown": "# Page" }]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = Client::new_selfhosted(server.url(), None::<&str>).unwrap();
+        let status = client.get_crawl_status("crawl-selfhosted").await.unwrap();
+
+        assert_eq!(status.status, JobStatus::Completed);
+        assert_eq!(status.credits_used, Some(-1));
+        assert_eq!(status.data.len(), 1);
         mock.assert();
     }
 


### PR DESCRIPTION
fix for [4579](https://github.com/firecrawl/firecrawl/issues/4579)
## Problem

The v2 crawl status endpoint returns `creditsUsed: -1` when no billing record exists for a job (`apps/api/src/controllers/v2/crawl-status.ts`, `creditsBilled?.[0]?.credits_billed ?? -1`). Every job on a self-hosted instance without database authentication hits this, and batch scrape status goes through the same controller.

The Rust SDK typed the field as `Option<u32>`, so serde rejected the response:

Error message before

> 
> == crawl ==
> Error: ResponseParseError(Error("invalid value: integer `-1`, expected u32", line: 0, column: 0))


As a result `get_crawl_status`, `crawl`, `get_batch_scrape_status`, and `batch_scrape` were unusable against self-hosted Firecrawl. The job completed server-side but the SDK could never read it. The JS SDK types the same field as a plain `number`, so the Rust SDK was the outlier.

## Fix

- Widen `credits_used` to `Option<i64>` on `CrawlJob` and `BatchScrapeJob`.
- Doc note on each field that `-1` means no billing record.
- Regression test `test_get_crawl_status_accepts_negative_credits_used` that feeds `creditsUsed: -1` through a mockito server and asserts the parsed value. Reverting the type back to `u32` fails this test at compile time.

## Verification

- `cargo test --lib`: 83 passed, including the new test.
- `cargo fmt --check` and `cargo clippy --lib`: clean for the touched files.
- Manually against a self-hosted stack from `docker compose up`: a crawl via the SDK failed with the parse error before this change and returns the completed job with its documents after it.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rust SDK rejecting `creditsUsed: -1` in crawl and batch scrape status, which made all crawl and batch scraping methods fail on self-hosted instances without billing records.

- Widens `credits_used` to `Option<i64>` on `CrawlJob` and `BatchScrapeJob`; the old `Option<u32>` could not deserialize the negative sentinel.
- Documents that `-1` means no billing record exists.
- Adds a mock regression test that asserts `credits_used` parses to `Some(-1)`.

<sup>Written for commit fa169f5ac63eae3de7ccf23518fe8f7a5f408e75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>


