### PR TITLE
feat(api): floor agent interop traffic at the hobby rate-limit multiplier

### DIFF
--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -9,6 +9,7 @@ import { deleteKey, getValue, setValue } from "../../services/redis";
 import {
   getAutumnRateLimiter,
   getRateLimiter,
+  HOBBY_RATE_LIMIT_MULTIPLIER,
 } from "../../services/rate-limiter";
 import {
   consumeKeylessRequest,
@@ -102,6 +103,7 @@ describe("authenticateUser", () => {
   const originalIntrospectUrl = config.OAUTH_INTROSPECT_URL;
   const originalIntrospectSecret = config.OAUTH_INTROSPECT_SECRET;
   const originalPreviewToken = config.PREVIEW_TOKEN;
+  const originalAgentInteropSecret = config.AGENT_INTEROP_SECRET;
 
   beforeEach(() => {
     vi.mocked(isKeylessConfigured).mockReturnValue(false);
@@ -120,6 +122,7 @@ describe("authenticateUser", () => {
     config.OAUTH_INTROSPECT_URL = originalIntrospectUrl;
     config.OAUTH_INTROSPECT_SECRET = originalIntrospectSecret;
     config.PREVIEW_TOKEN = originalPreviewToken;
+    config.AGENT_INTEROP_SECRET = originalAgentInteropSecret;
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -588,6 +591,101 @@ describe("authenticateUser", () => {
       50,
       flags,
     );
+  });
+
+  describe("agent interop rate-limit floor", () => {
+    const flags = {};
+    const agentRequest = (auth: string) => ({
+      headers: {
+        authorization: "Bearer 00000000-0000-4000-8000-000000000000",
+      },
+      socket: { remoteAddress: "127.0.0.1" },
+      body: { __agentInterop: { auth, requestId: "req-1", shouldBill: true } },
+    });
+
+    beforeEach(() => {
+      config.USE_DB_AUTHENTICATION = true;
+      config.AGENT_INTEROP_SECRET = "agent-secret";
+      vi.mocked(getValue).mockResolvedValue(null);
+      vi.mocked(authCreditUsageChunk).mockResolvedValue([
+        {
+          api_key: "00000000-0000-4000-8000-000000000000",
+          api_key_id: 1,
+          team_id: "team-1",
+          org_id: "org-1",
+          flags,
+        },
+      ]);
+      vi.mocked(redlock.using).mockImplementation(
+        async (_keys, _ttl, _options, fn) => fn({ aborted: false } as never),
+      );
+    });
+
+    it("floors a free team's multiplier at hobby for a trusted agent request", async () => {
+      vi.mocked(autumnService.getRateLimitMultiplier).mockResolvedValue(1);
+
+      const auth = await authenticateUser(
+        agentRequest("agent-secret"),
+        {},
+        RateLimiterMode.Scrape,
+      );
+
+      expect(auth.success).toBe(true);
+      expect(getAutumnRateLimiter).toHaveBeenCalledWith(
+        RateLimiterMode.Scrape,
+        HOBBY_RATE_LIMIT_MULTIPLIER,
+        flags,
+      );
+    });
+
+    it("leaves a paid plan's multiplier alone for a trusted agent request", async () => {
+      vi.mocked(autumnService.getRateLimitMultiplier).mockResolvedValue(50);
+
+      await authenticateUser(
+        agentRequest("agent-secret"),
+        {},
+        RateLimiterMode.Scrape,
+      );
+
+      expect(getAutumnRateLimiter).toHaveBeenCalledWith(
+        RateLimiterMode.Scrape,
+        50,
+        flags,
+      );
+    });
+
+    it("does not floor the multiplier when the agent interop secret is wrong", async () => {
+      vi.mocked(autumnService.getRateLimitMultiplier).mockResolvedValue(1);
+
+      await authenticateUser(
+        agentRequest("not-the-secret"),
+        {},
+        RateLimiterMode.Scrape,
+      );
+
+      expect(getAutumnRateLimiter).toHaveBeenCalledWith(
+        RateLimiterMode.Scrape,
+        1,
+        flags,
+      );
+    });
+
+    it("does not floor the multiplier when no agent interop secret is configured", async () => {
+      config.AGENT_INTEROP_SECRET = undefined;
+      vi.mocked(autumnService.getRateLimitMultiplier).mockResolvedValue(1);
+
+      await authenticateUser(
+        agentRequest("agent-secret"),
+        {},
+        RateLimiterMode.Scrape,
+      );
+
+      expect(getAutumnRateLimiter).toHaveBeenCalledWith(
+        RateLimiterMode.Scrape,
+        1,
+        flags,
+      );
+    });
   });
 
   it("leaves the preview token on the static rate limiter", async () => {

--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -686,6 +686,35 @@ describe("authenticateUser", () => {
         flags,
       );
     });
+
+    it("lets a per-team override win over the floor for a trusted agent request", async () => {
+      const overrideFlags = { rateLimitOverrides: { scrape: 42 } };
+      vi.mocked(authCreditUsageChunk).mockResolvedValue([
+        {
+          api_key: "00000000-0000-4000-8000-000000000000",
+          api_key_id: 1,
+          team_id: "team-1",
+          org_id: "org-1",
+          flags: overrideFlags,
+        },
+      ]);
+      vi.mocked(autumnService.getRateLimitMultiplier).mockResolvedValue(1);
+
+      await authenticateUser(
+        agentRequest("agent-secret"),
+        {},
+        RateLimiterMode.Scrape,
+      );
+
+      // The override replaces the whole base × multiplier computation, so the
+      // floor never applies and the Autumn multiplier is never fetched.
+      expect(autumnService.getRateLimitMultiplier).not.toHaveBeenCalled();
+      expect(getAutumnRateLimiter).toHaveBeenCalledWith(
+        RateLimiterMode.Scrape,
+        1,
+        overrideFlags,
+      );
+    });
   });
 
   it("leaves the preview token on the static rate limiter", async () => {

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -9,7 +9,9 @@ import {
   getRateLimiter,
   getAutumnRateLimiter,
   getRateLimitOverride,
+  HOBBY_RATE_LIMIT_MULTIPLIER,
 } from "../services/rate-limiter";
+import { isAgentInteropSecretValid } from "../lib/agent-interop";
 import {
   KEYLESS_FREE_TIER_LIMIT_MESSAGE,
   consumeKeylessRequest,
@@ -639,18 +641,38 @@ export async function authenticateUser(
  * on to getAutumnRateLimiter, which stays the only place deciding the final
  * limit. An override makes the multiplier irrelevant, so we skip fetching it
  * from Autumn in that case rather than paying for a value that is discarded.
+ *
+ * `minMultiplier` floors the Autumn multiplier (trusted agent traffic passes
+ * the hobby multiplier). It never applies on top of an override, which already
+ * replaces the whole computation.
  */
 async function buildAuthenticatedRateLimiter(
   teamId: string,
   orgId: string | null | undefined,
   mode: RateLimiterMode,
   flags: TeamFlags,
+  minMultiplier?: number,
 ): Promise<RateLimiterRedis> {
-  const multiplier =
-    getRateLimitOverride(mode, flags?.rateLimitOverrides) !== undefined
-      ? 1
-      : await autumnService.getRateLimitMultiplier(teamId, orgId);
+  let multiplier: number;
+  if (getRateLimitOverride(mode, flags?.rateLimitOverrides) !== undefined) {
+    multiplier = 1;
+  } else {
+    multiplier = await autumnService.getRateLimitMultiplier(teamId, orgId);
+    if (minMultiplier !== undefined) {
+      multiplier = Math.max(multiplier, minMultiplier);
+    }
+  }
   return getAutumnRateLimiter(mode, multiplier, flags);
+}
+
+/**
+ * Whether the request carries a valid `__agentInterop` secret, i.e. comes from
+ * the trusted internal agent service. Read from the raw body because auth runs
+ * before the controller's zod parse — the same shape checkCreditsMiddleware
+ * relies on. Presence of the block alone is never trusted; only the secret.
+ */
+function isTrustedAgentInteropRequest(req): boolean {
+  return isAgentInteropSecretValid(req.body?.__agentInterop?.auth);
 }
 
 async function supaAuthenticateUser(
@@ -680,6 +702,14 @@ async function supaAuthenticateUser(
     req.headers["x-forwarded-for"] ||
     req.socket.remoteAddress) as string;
   const iptoken = incomingIP + token;
+
+  // An agent run fans one customer request out into ~10 sub-requests against
+  // the team's own bucket, so a free team (×1) gets throttled by its own agent.
+  // Floor trusted agent traffic at the hobby multiplier; paid plans already
+  // meet it and are unchanged.
+  const minRateMultiplier = isTrustedAgentInteropRequest(req)
+    ? HOBBY_RATE_LIMIT_MULTIPLIER
+    : undefined;
 
   let rateLimiter: RateLimiterRedis;
   let subscriptionData: { team_id: string } | null = null;
@@ -737,6 +767,7 @@ async function supaAuthenticateUser(
       chunk.org_id,
       mode,
       chunk.flags,
+      minRateMultiplier,
     );
   } else if (token.startsWith("fco_")) {
     // OAuth access token — resolve via introspection endpoint
@@ -806,6 +837,7 @@ async function supaAuthenticateUser(
       chunk.org_id,
       mode,
       chunk.flags,
+      minRateMultiplier,
     );
   } else {
     normalizedApi = parseApi(token);
@@ -837,6 +869,7 @@ async function supaAuthenticateUser(
       chunk.org_id,
       mode,
       chunk.flags,
+      minRateMultiplier,
     );
   }
 

--- a/apps/api/src/services/rate-limiter.ts
+++ b/apps/api/src/services/rate-limiter.ts
@@ -125,6 +125,15 @@ export function getAutumnRateLimiter(
 }
 
 /**
+ * Autumn rate-limit multiplier granted to the hobby plan. Trusted agent
+ * traffic (a valid `__agentInterop` secret) is floored at this multiplier so a
+ * free team's agent runs are limited like hobby rather than at ×1; see
+ * buildAuthenticatedRateLimiter in controllers/auth.ts. Paid plans already
+ * meet or exceed it, so the floor only ever lifts free.
+ */
+export const HOBBY_RATE_LIMIT_MULTIPLIER = 10;
+
+/**
  * Plan-priority tiers keyed by the minimum Autumn rate-limit multiplier that
  * qualifies. Values mirror the tuned production `plan_priority` for each plan.
  * A customer's multiplier selects the highest tier they meet or exceed, so
@@ -140,7 +149,11 @@ const PLAN_PRIORITY_TIERS: {
   planModifier: number;
 }[] = [
   { minMultiplier: 1, bucketLimit: 25, planModifier: 0.5 }, // free
-  { minMultiplier: 10, bucketLimit: 100, planModifier: 0.3 }, // hobby
+  {
+    minMultiplier: HOBBY_RATE_LIMIT_MULTIPLIER,
+    bucketLimit: 100,
+    planModifier: 0.3,
+  }, // hobby
   { minMultiplier: 50, bucketLimit: 200, planModifier: 0.2 }, // standard
   { minMultiplier: 500, bucketLimit: 400, planModifier: 0.1 }, // growth
   { minMultiplier: 1000, bucketLimit: 400, planModifier: 0.1 }, // scale


### PR DESCRIPTION
## Summary

Trusted agent traffic (requests carrying a valid `__agentInterop.auth` secret) now has its Autumn rate-limit multiplier floored at hobby's **×10**, so a free team's agent runs are limited like hobby (scrape/search 100/min, crawl/extract 20/min) instead of ×1.

## Why

An agent run fans one customer request out into ~10 Firecrawl sub-requests against the team's own per-minute bucket. Measured over the last 3 days (83,999 runs via `fct_unified_jobs`): avg 9.96 calls/run, **median peak 5/min, p90 15/min, p99 48/min**. On the free plan (scrape 10/min) a free team gets throttled by its own agent; every paid plan already has ≥×10.

## Changes

- `services/rate-limiter.ts` — new exported `HOBBY_RATE_LIMIT_MULTIPLIER = 10`, also used in the hobby `PLAN_PRIORITY_TIERS` row so the two can't drift.
- `controllers/auth.ts` — `buildAuthenticatedRateLimiter` takes an optional `minMultiplier` and applies `Math.max` to the Autumn value. Not applied on top of a per-team `rateLimitOverrides` entry (that already replaces the whole computation). New `isTrustedAgentInteropRequest(req)` validates the secret with the existing constant-time `isAgentInteropSecretValid`; the block's presence alone is never trusted. Computed once in `supaAuthenticateUser` and passed to all three auth paths (API key, OAuth, MCP-delegated).
- `controllers/__tests__/auth.test.ts` — 4 new tests: free → ×10 with a valid secret; paid plan (×50) unchanged; wrong secret → no floor; no secret configured → no floor.

## Notes

- Decoupled from `shouldBill`: any valid-secret agent call gets the floor, whether or not it bills credits (the existing credit bypass in `checkCreditsMiddleware` stays gated on `shouldBill === false`).
- Agent calls and the user's direct calls still share one Redis counter per team+mode; agent requests are checked against the ×10 limit, direct requests against the plan's own. Heavy agent fan-out on a free team can therefore still 429 that user's *direct* calls — same as today, it just no longer starves the agent itself.

## Test plan

- [x] `vitest run src/controllers/__tests__/auth.test.ts src/services/rate-limiter.test.ts` — 33/33 pass
- [x] `tsc --noEmit` — 0 errors in changed files (remaining errors are pre-existing: missing `@mendable/firecrawl-rs` native module, pubsub, pdf engine)
- [x] `prettier --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trusted agent traffic now gets a minimum rate-limit multiplier of ×10 (hobby tier) instead of the free ×1, so free teams' agent runs no longer throttle themselves on their own fan-out (~10 sub-requests per customer request).

- Requests with a valid `__agentInterop.auth` secret are floored at `HOBBY_RATE_LIMIT_MULTIPLIER`; paid plans already meet or exceed this and are unchanged.
- Per-team `rateLimitOverrides` entries still win outright, and the floor never stacks on top of them.
- The secret is checked with the existing constant-time validator; presence of the block alone is never trusted, and the floor applies across API key, OAuth, and MCP-delegated paths.
- Agent calls and the user's direct calls still share one Redis counter per team and mode, so heavy fan-out on a free team can still 429 that user's direct calls while the agent itself is no longer starved.

<sup>Written for commit 9aa3677165f758e63d14b1990c7d0e203b44208b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

