### PR TITLE
chore(api): bump pdf-inspector to 1.19.0

### DIFF
--- a/apps/api/native/Cargo.toml
+++ b/apps/api/native/Cargo.toml
@@ -13,7 +13,7 @@ anydoc = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }
 kuchikiki = "0.8.2"
 lol_html = "2.6.0"
-pdf-inspector = "1.18.0"
+pdf-inspector = "1.19.0"
 napi = { version = "3.0.0", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3.0.0"
 nodesig = { git = "https://github.com/firecrawl/nodesig" }


### PR DESCRIPTION
## Summary

Bumps pdf-inspector from 1.18.0 to [1.19.0](https://github.com/firecrawl/pdf-inspector/releases/tag/v1.19.0).

- Better bold detection and horizontal text scaling.
- Keeps separately clipped text runs apart.
- Recovers stale single-byte font mappings.
