### PR TITLE
fix(api): standardize error response format and improve error handling in Rust SDK client

### DIFF
--- a/apps/api/src/controllers/v2/crawl-cancel.ts
+++ b/apps/api/src/controllers/v2/crawl-cancel.ts
@@ -20,17 +20,19 @@ export async function crawlCancelController(
   try {
     const group = await crawlGroup.getGroup(req.params.jobId);
     if (!group) {
-      return res.status(404).json({ error: "Job not found" });
+      return res.status(404).json({ success: false, error: "Job not found" });
     }
 
     // group.ownerId is normalized to a UUID in NuQ, so the raw team_id
     // (e.g. "bypass" when self-hosted) must be normalized before comparing
     if (group.ownerId !== normalizeOwnerId(req.auth.team_id)) {
-      return res.status(404).json({ error: "Job not found" });
+      return res.status(404).json({ success: false, error: "Job not found" });
     }
 
     if (group.status === "completed") {
-      return res.status(409).json({ error: "Crawl is already completed" });
+      return res
+        .status(409)
+        .json({ success: false, error: "Crawl is already completed" });
     }
 
     const sc: StoredCrawl = (await getCrawl(req.params.jobId)) ?? {
@@ -59,10 +61,11 @@ export async function crawlCancelController(
     }
 
     res.json({
+      success: true,
       status: "cancelled",
     });
   } catch (error) {
     logger.error(error);
-    return res.status(500).json({ error: error.message });
+    return res.status(500).json({ success: false, error: error.message });
   }
 }

--- a/apps/rust-sdk/src/batch_scrape.rs
+++ b/apps/rust-sdk/src/batch_scrape.rs
@@ -318,14 +318,19 @@ impl Client {
                     tokio::time::sleep(tokio::time::Duration::from_millis(poll_interval)).await;
                 }
                 JobStatus::Failed => {
+                    // Use the server's own reason when it sent one, e.g. a kickoff failure.
                     return Err(FirecrawlError::JobFailed(
-                        "Batch scrape job failed".to_string(),
+                        status
+                            .error
+                            .unwrap_or("Batch scrape job failed".to_string()),
                         JobStatus::Failed,
                     ));
                 }
                 JobStatus::Cancelled => {
                     return Err(FirecrawlError::JobFailed(
-                        "Batch scrape job was cancelled".to_string(),
+                        status
+                            .error
+                            .unwrap_or("Batch scrape job was cancelled".to_string()),
                         JobStatus::Cancelled,
                     ));
                 }

--- a/apps/rust-sdk/src/batch_scrape.rs
+++ b/apps/rust-sdk/src/batch_scrape.rs
@@ -645,6 +645,13 @@ mod tests {
     async fn test_batch_scrape_failed_uses_server_error() {
         let mut server = mockito::Server::new_async().await;
 
+        let start_mock = server
+            .mock("POST", "/v2/batch/scrape")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({"success": true, "id": "batch-failed", "url": "x"}).to_string())
+            .create();
+
         let status_mock = server
             .mock("GET", "/v2/batch/scrape/batch-failed")
             .with_status(200)
@@ -663,7 +670,7 @@ mod tests {
 
         let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
         let err = client
-            .wait_for_batch_scrape("batch-failed", 1000)
+            .batch_scrape(vec!["https://bad.invalid".to_string()], None)
             .await
             .unwrap_err();
 
@@ -673,12 +680,20 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+        start_mock.assert();
         status_mock.assert();
     }
 
     #[tokio::test]
     async fn test_batch_scrape_cancelled_uses_fallback_message() {
         let mut server = mockito::Server::new_async().await;
+
+        let start_mock = server
+            .mock("POST", "/v2/batch/scrape")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({"success": true, "id": "batch-cancelled", "url": "x"}).to_string())
+            .create();
 
         let status_mock = server
             .mock("GET", "/v2/batch/scrape/batch-cancelled")
@@ -697,7 +712,7 @@ mod tests {
 
         let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
         let err = client
-            .wait_for_batch_scrape("batch-cancelled", 1000)
+            .batch_scrape(vec!["https://example.com".to_string()], None)
             .await
             .unwrap_err();
 
@@ -707,6 +722,7 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+        start_mock.assert();
         status_mock.assert();
     }
 }

--- a/apps/rust-sdk/src/batch_scrape.rs
+++ b/apps/rust-sdk/src/batch_scrape.rs
@@ -640,4 +640,73 @@ mod tests {
         assert_eq!(errors.errors[0].error, "Connection timeout");
         mock.assert();
     }
+
+    #[tokio::test]
+    async fn test_batch_scrape_failed_uses_server_error() {
+        let mut server = mockito::Server::new_async().await;
+
+        let status_mock = server
+            .mock("GET", "/v2/batch/scrape/batch-failed")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "status": "failed",
+                    "error": "could not resolve host",
+                    "total": 0,
+                    "completed": 0,
+                    "data": []
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
+        let err = client
+            .wait_for_batch_scrape("batch-failed", 1000)
+            .await
+            .unwrap_err();
+
+        match err {
+            FirecrawlError::JobFailed(message, JobStatus::Failed) => {
+                assert_eq!(message, "could not resolve host");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        status_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_batch_scrape_cancelled_uses_fallback_message() {
+        let mut server = mockito::Server::new_async().await;
+
+        let status_mock = server
+            .mock("GET", "/v2/batch/scrape/batch-cancelled")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "status": "cancelled",
+                    "total": 0,
+                    "completed": 0,
+                    "data": []
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
+        let err = client
+            .wait_for_batch_scrape("batch-cancelled", 1000)
+            .await
+            .unwrap_err();
+
+        match err {
+            FirecrawlError::JobFailed(message, JobStatus::Cancelled) => {
+                assert_eq!(message, "Batch scrape job was cancelled");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        status_mock.assert();
+    }
 }

--- a/apps/rust-sdk/src/batch_scrape.rs
+++ b/apps/rust-sdk/src/batch_scrape.rs
@@ -79,6 +79,8 @@ pub struct BatchScrapeResponse {
 pub struct BatchScrapeJob {
     /// Current status of the batch scrape job.
     pub status: JobStatus,
+    /// Failure reason, present when status is failed (e.g. a kickoff failure).
+    pub error: Option<String>,
     /// Number of URLs completed.
     pub completed: u32,
     /// Total number of URLs to scrape.

--- a/apps/rust-sdk/src/client.rs
+++ b/apps/rust-sdk/src/client.rs
@@ -145,48 +145,44 @@ impl Client {
         action: impl AsRef<str>,
     ) -> Result<T, FirecrawlError> {
         let (is_success, status) = (response.status().is_success(), response.status());
-
-        let response = response
+        let body = response
             .text()
             .await
-            .map_err(FirecrawlError::ResponseParseErrorText)
-            .and_then(|response_json| {
-                serde_json::from_str::<Value>(&response_json)
-                    .map_err(FirecrawlError::ResponseParseError)
-            })
+            .map_err(FirecrawlError::ResponseParseErrorText)?;
+
+        let response = serde_json::from_str::<Value>(&body)
+            .map_err(FirecrawlError::ResponseParseError)
             .and_then(|response_value| {
-                // Check for success field, or allow responses without it for status checks
-                if action.as_ref().contains("status")
-                    || action.as_ref().contains("cancel")
-                    || response_value["success"].as_bool().unwrap_or(false)
-                    || response_value.get("success").is_none()
-                {
-                    serde_json::from_value::<T>(response_value)
-                        .map_err(FirecrawlError::ResponseParseError)
-                } else {
+                // Only an explicit success: false routes to APIError; everything else parses as T.
+                if response_value["success"].as_bool() == Some(false) {
                     Err(FirecrawlError::APIError(
                         action.as_ref().to_string(),
                         serde_json::from_value(response_value)
                             .map_err(FirecrawlError::ResponseParseError)?,
                     ))
+                } else {
+                    serde_json::from_value::<T>(response_value)
+                        .map_err(FirecrawlError::ResponseParseError)
                 }
             });
 
-        match &response {
-            Ok(_) => response,
-            Err(FirecrawlError::ResponseParseError(_))
-            | Err(FirecrawlError::ResponseParseErrorText(_)) => {
-                if is_success {
-                    response
+        match response {
+            // A non-2xx response that isn't a Firecrawl error body: report the real reason and body, not just the code.
+            Err(FirecrawlError::ResponseParseError(_)) if !is_success => {
+                let reason = status.canonical_reason().unwrap_or("unknown status");
+                let snippet: String = body.chars().take(200).collect();
+                let detail = if snippet.is_empty() {
+                    reason.to_string()
                 } else {
-                    Err(FirecrawlError::HttpRequestFailed(
-                        action.as_ref().to_string(),
-                        status.as_u16(),
-                        status.as_str().to_string(),
-                    ))
-                }
+                    format!("{reason}: {snippet}")
+                };
+                Err(FirecrawlError::HttpRequestFailed(
+                    action.as_ref().to_string(),
+                    status.as_u16(),
+                    detail,
+                ))
             }
-            Err(_) => response,
+            other => other,
         }
     }
 

--- a/apps/rust-sdk/src/client.rs
+++ b/apps/rust-sdk/src/client.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::error::FirecrawlError;
+use crate::types::JobStatus;
 
 pub(crate) const API_VERSION: &str = "/v2";
 const CLOUD_API_URL: &str = "https://api.firecrawl.dev";
@@ -145,16 +146,28 @@ impl Client {
         action: impl AsRef<str>,
     ) -> Result<T, FirecrawlError> {
         let (is_success, status) = (response.status().is_success(), response.status());
-        let body = response
-            .text()
-            .await
-            .map_err(FirecrawlError::ResponseParseErrorText)?;
+        // A body-read failure on a non-2xx response still carries a status worth reporting.
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(e) if is_success => return Err(FirecrawlError::ResponseParseErrorText(e)),
+            Err(_) => {
+                let reason = status.canonical_reason().unwrap_or("unknown status");
+                return Err(FirecrawlError::HttpRequestFailed(
+                    action.as_ref().to_string(),
+                    status.as_u16(),
+                    reason.to_string(),
+                ));
+            }
+        };
 
         let response = serde_json::from_str::<Value>(&body)
             .map_err(FirecrawlError::ResponseParseError)
             .and_then(|response_value| {
-                // Only an explicit success: false routes to APIError; everything else parses as T.
-                if response_value["success"].as_bool() == Some(false) {
+                // success:false is an APIError unless the body also carries a job status (e.g. a
+                // crawl that failed at kickoff), in which case it's routed through T instead.
+                if response_value["success"].as_bool() == Some(false)
+                    && !has_job_status(&response_value)
+                {
                     Err(FirecrawlError::APIError(
                         action.as_ref().to_string(),
                         serde_json::from_value(response_value)
@@ -190,6 +203,13 @@ impl Client {
     pub(crate) fn url(&self, path: &str) -> String {
         format!("{}{}{}", self.api_url, API_VERSION, path)
     }
+}
+
+/// True when `value["status"]` is a recognized `JobStatus`, marking a crawl/batch job payload.
+fn has_job_status(value: &Value) -> bool {
+    value
+        .get("status")
+        .is_some_and(|s| serde_json::from_value::<JobStatus>(s.clone()).is_ok())
 }
 
 #[cfg(test)]

--- a/apps/rust-sdk/src/crawl.rs
+++ b/apps/rust-sdk/src/crawl.rs
@@ -686,4 +686,73 @@ mod tests {
         start_mock.assert();
         status_mock.assert();
     }
+
+    #[tokio::test]
+    async fn test_crawl_failed_uses_server_error() {
+        let mut server = mockito::Server::new_async().await;
+
+        let status_mock = server
+            .mock("GET", "/v2/crawl/crawl-failed")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "status": "failed",
+                    "error": "could not resolve host",
+                    "total": 0,
+                    "completed": 0,
+                    "data": []
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
+        let err = client
+            .wait_for_crawl("crawl-failed", 1000)
+            .await
+            .unwrap_err();
+
+        match err {
+            FirecrawlError::JobFailed(message, JobStatus::Failed) => {
+                assert_eq!(message, "could not resolve host");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        status_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_crawl_cancelled_uses_fallback_message() {
+        let mut server = mockito::Server::new_async().await;
+
+        let status_mock = server
+            .mock("GET", "/v2/crawl/crawl-cancelled")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "status": "cancelled",
+                    "total": 0,
+                    "completed": 0,
+                    "data": []
+                })
+                .to_string(),
+            )
+            .create();
+
+        let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
+        let err = client
+            .wait_for_crawl("crawl-cancelled", 1000)
+            .await
+            .unwrap_err();
+
+        match err {
+            FirecrawlError::JobFailed(message, JobStatus::Cancelled) => {
+                assert_eq!(message, "Crawl job was cancelled");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        status_mock.assert();
+    }
 }

--- a/apps/rust-sdk/src/crawl.rs
+++ b/apps/rust-sdk/src/crawl.rs
@@ -323,14 +323,17 @@ impl Client {
                     tokio::time::sleep(tokio::time::Duration::from_millis(poll_interval)).await;
                 }
                 JobStatus::Failed => {
+                    // Use the server's own reason when it sent one, e.g. a kickoff failure.
                     return Err(FirecrawlError::JobFailed(
-                        "Crawl job failed".to_string(),
+                        status.error.unwrap_or("Crawl job failed".to_string()),
                         JobStatus::Failed,
                     ));
                 }
                 JobStatus::Cancelled => {
                     return Err(FirecrawlError::JobFailed(
-                        "Crawl job was cancelled".to_string(),
+                        status
+                            .error
+                            .unwrap_or("Crawl job was cancelled".to_string()),
                         JobStatus::Cancelled,
                     ));
                 }

--- a/apps/rust-sdk/src/crawl.rs
+++ b/apps/rust-sdk/src/crawl.rs
@@ -691,6 +691,13 @@ mod tests {
     async fn test_crawl_failed_uses_server_error() {
         let mut server = mockito::Server::new_async().await;
 
+        let start_mock = server
+            .mock("POST", "/v2/crawl")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({"success": true, "id": "crawl-failed", "url": "x"}).to_string())
+            .create();
+
         let status_mock = server
             .mock("GET", "/v2/crawl/crawl-failed")
             .with_status(200)
@@ -708,10 +715,7 @@ mod tests {
             .create();
 
         let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
-        let err = client
-            .wait_for_crawl("crawl-failed", 1000)
-            .await
-            .unwrap_err();
+        let err = client.crawl("https://bad.invalid", None).await.unwrap_err();
 
         match err {
             FirecrawlError::JobFailed(message, JobStatus::Failed) => {
@@ -719,12 +723,20 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+        start_mock.assert();
         status_mock.assert();
     }
 
     #[tokio::test]
     async fn test_crawl_cancelled_uses_fallback_message() {
         let mut server = mockito::Server::new_async().await;
+
+        let start_mock = server
+            .mock("POST", "/v2/crawl")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({"success": true, "id": "crawl-cancelled", "url": "x"}).to_string())
+            .create();
 
         let status_mock = server
             .mock("GET", "/v2/crawl/crawl-cancelled")
@@ -742,10 +754,7 @@ mod tests {
             .create();
 
         let client = Client::new_selfhosted(server.url(), Some("test_key")).unwrap();
-        let err = client
-            .wait_for_crawl("crawl-cancelled", 1000)
-            .await
-            .unwrap_err();
+        let err = client.crawl("https://example.com", None).await.unwrap_err();
 
         match err {
             FirecrawlError::JobFailed(message, JobStatus::Cancelled) => {
@@ -753,6 +762,7 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+        start_mock.assert();
         status_mock.assert();
     }
 }

--- a/apps/rust-sdk/src/crawl.rs
+++ b/apps/rust-sdk/src/crawl.rs
@@ -101,6 +101,8 @@ pub struct CrawlResponse {
 pub struct CrawlJob {
     /// Current status of the crawl job.
     pub status: JobStatus,
+    /// Failure reason, present when status is failed (e.g. a kickoff failure).
+    pub error: Option<String>,
     /// Total number of pages to crawl.
     pub total: u32,
     /// Number of pages completed.


### PR DESCRIPTION
Fixes #4601

## Problem

`handle_response` decided how to read a response by checking whether the
caller's action label contained "status" or "cancel", not by checking the
body's own `success` field. Any status/cancel call skipped the check and
force-parsed the response as a success type, so a real error body like
`{"success":false,"error":"Job not found"}` failed to parse and surfaced as
a bare `HTTP error 404: 404` — the actual message was never read.

| File : line | Action string |
|---|---|
| `crawl.rs:230` | `"crawl status {id}"` |
| `crawl.rs:378` | `"cancel crawl"` |
| `batch_scrape.rs:209` | `"batch scrape status {id}"` |
| `agent.rs:555` | `"agent status {id}"` |
| `agent.rs:828` | `"cancel agent {id}"` |

## Fix

- `success == false` in the body now always means `APIError`, regardless of
  action name — unless the body also carries a recognized job `status`
  (e.g. a crawl that fails at kickoff), in which case it's parsed as the
  job type instead of being swallowed into a generic error.
- Added `error: Option<String>` to `CrawlJob`/`BatchScrapeJob` so that
  kickoff-failure reason isn't lost once it's routed through the job type,
  and wired it into `crawl()`/`batch_scrape()`'s failure messages.
- A non-2xx response with no Firecrawl error body now reports the status's
  reason phrase (and a body snippet) instead of repeating the numeric code.
- A body-read failure on a non-2xx response still reports the HTTP status
  instead of losing it.
- `crawlCancelController` (`apps/api`) was missing `success` on its error
  and success responses, unlike every other v2 endpoint — added it, since
  no client-side fix can recover a signal the server never sent.

## Verification

`cargo test --lib`: 84 passing. `cargo fmt --check` / clippy: clean.
Verified live against a self-hosted stack, before → after:

- `get_crawl_status`, job not found: `HTTP error 404: 404` → `crawl status <id> failed: Job not found`
- `cancel_crawl`, job not found: `HTTP error 404: 404` → `cancel crawl failed: Job not found`
- `crawl()`, kickoff failure: job status returned, real reason preserved
