### PR TITLE
fix(sdks): forward recordSession in browser-create (JS + Python)

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/browser-record-session.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/browser-record-session.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { browser } from "../../../v2/methods/browser";
+
+function httpMock() {
+  return {
+    post: jest.fn(
+      async () => ({ status: 200, data: { success: true, id: "sess_123" } }),
+    ),
+  } as any;
+}
+
+describe("v2 browser recordSession", () => {
+  test("forwards recordSession: false so session recording can be disabled", async () => {
+    const http = httpMock();
+
+    await browser(http, { recordSession: false });
+
+    expect(http.post).toHaveBeenCalledWith(
+      "/v2/browser",
+      { recordSession: false },
+    );
+  });
+
+  test("omits recordSession when the caller does not set it (server default applies)", async () => {
+    const http = httpMock();
+
+    await browser(http, { ttl: 600 });
+
+    expect(http.post).toHaveBeenCalledWith("/v2/browser", { ttl: 600 });
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("recordSession");
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/client.ts
+++ b/apps/js-sdk/firecrawl/src/v2/client.ts
@@ -582,7 +582,7 @@ export class FirecrawlClient {
   // Browser
   /**
    * Create a new browser session.
-   * @param args Session options (ttl, activityTtl, streamWebView, profile).
+   * @param args Session options (ttl, activityTtl, streamWebView, recordSession, profile).
    * @returns Session id, CDP URL, live view URL, and expiration time.
    */
   async browser(

--- a/apps/js-sdk/firecrawl/src/v2/methods/browser.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/browser.ts
@@ -16,6 +16,7 @@ export async function browser(
     ttl?: number;
     activityTtl?: number;
     streamWebView?: boolean;
+    recordSession?: boolean;
     profile?: {
       name: string;
       saveChanges?: boolean;
@@ -28,6 +29,7 @@ export async function browser(
   if (args.ttl != null) body.ttl = args.ttl;
   if (args.activityTtl != null) body.activityTtl = args.activityTtl;
   if (args.streamWebView != null) body.streamWebView = args.streamWebView;
+  if (args.recordSession != null) body.recordSession = args.recordSession;
   if (args.profile != null) body.profile = args.profile;
   if (args.integration != null) body.integration = args.integration;
   if (args.origin) body.origin = args.origin;

--- a/apps/python-sdk/firecrawl/v2/client.py
+++ b/apps/python-sdk/firecrawl/v2/client.py
@@ -1617,6 +1617,7 @@ class FirecrawlClient:
         ttl: Optional[int] = None,
         activity_ttl: Optional[int] = None,
         stream_web_view: Optional[bool] = None,
+        record_session: Optional[bool] = None,
         profile: Optional[Dict[str, Any]] = None,
     ):
         """Create a new browser session.
@@ -1625,6 +1626,7 @@ class FirecrawlClient:
             ttl: Total time-to-live in seconds (30-3600, default 300)
             activity_ttl: Inactivity TTL in seconds (10-3600)
             stream_web_view: Whether to enable webview streaming
+            record_session: Whether to record the session (default True server-side)
             profile: Profile config with ``name`` (str) and
                 optional ``save_changes`` (bool, default ``True``)
 
@@ -1636,6 +1638,7 @@ class FirecrawlClient:
             ttl=ttl,
             activity_ttl=activity_ttl,
             stream_web_view=stream_web_view,
+            record_session=record_session,
             profile=profile,
         )
 

--- a/apps/python-sdk/firecrawl/v2/client_async.py
+++ b/apps/python-sdk/firecrawl/v2/client_async.py
@@ -882,6 +882,7 @@ class AsyncFirecrawlClient:
         ttl: Optional[int] = None,
         activity_ttl: Optional[int] = None,
         stream_web_view: Optional[bool] = None,
+        record_session: Optional[bool] = None,
         profile: Optional[Dict[str, Any]] = None,
     ):
         """Create a new browser session.
@@ -890,6 +891,7 @@ class AsyncFirecrawlClient:
             ttl: Total time-to-live in seconds (30-3600, default 300)
             activity_ttl: Inactivity TTL in seconds (10-3600)
             stream_web_view: Whether to enable webview streaming
+            record_session: Whether to record the session (default True server-side)
             profile: Profile config with ``name`` (str) and
                 optional ``save_changes`` (bool, default ``True``)
 
@@ -901,6 +903,7 @@ class AsyncFirecrawlClient:
             ttl=ttl,
             activity_ttl=activity_ttl,
             stream_web_view=stream_web_view,
+            record_session=record_session,
             profile=profile,
         )
 

--- a/apps/python-sdk/firecrawl/v2/methods/aio/browser.py
+++ b/apps/python-sdk/firecrawl/v2/methods/aio/browser.py
@@ -57,6 +57,7 @@ async def browser(
     ttl: Optional[int] = None,
     activity_ttl: Optional[int] = None,
     stream_web_view: Optional[bool] = None,
+    record_session: Optional[bool] = None,
     profile: Optional[Dict[str, Any]] = None,
 ) -> BrowserCreateResponse:
     """Create a new browser session.
@@ -66,6 +67,7 @@ async def browser(
         ttl: Total time-to-live in seconds (30-3600, default 300)
         activity_ttl: Inactivity TTL in seconds (10-3600)
         stream_web_view: Whether to enable webview streaming
+        record_session: Whether to record the session (default True server-side)
         profile: Profile config with ``name`` (str) and
             optional ``save_changes`` (bool, default ``True``)
 
@@ -79,6 +81,8 @@ async def browser(
         body["activityTtl"] = activity_ttl
     if stream_web_view is not None:
         body["streamWebView"] = stream_web_view
+    if record_session is not None:
+        body["recordSession"] = record_session
     if profile is not None:
         body["profile"] = {
             "name": profile["name"],

--- a/apps/python-sdk/firecrawl/v2/methods/browser.py
+++ b/apps/python-sdk/firecrawl/v2/methods/browser.py
@@ -58,6 +58,7 @@ def browser(
     ttl: Optional[int] = None,
     activity_ttl: Optional[int] = None,
     stream_web_view: Optional[bool] = None,
+    record_session: Optional[bool] = None,
     profile: Optional[Dict[str, Any]] = None,
 ) -> BrowserCreateResponse:
     """Create a new browser session.
@@ -67,6 +68,7 @@ def browser(
         ttl: Total time-to-live in seconds (30-3600, default 300)
         activity_ttl: Inactivity TTL in seconds (10-3600)
         stream_web_view: Whether to enable webview streaming
+        record_session: Whether to record the session (default True server-side)
         profile: Profile config with ``name`` (str) and
             optional ``save_changes`` (bool, default ``True``)
 
@@ -80,6 +82,8 @@ def browser(
         body["activityTtl"] = activity_ttl
     if stream_web_view is not None:
         body["streamWebView"] = stream_web_view
+    if record_session is not None:
+        body["recordSession"] = record_session
     if profile is not None:
         body["profile"] = {
             "name": profile["name"],

--- a/apps/python-sdk/tests/test_browser_record_session.py
+++ b/apps/python-sdk/tests/test_browser_record_session.py
@@ -1,0 +1,53 @@
+"""v2 browser.create should forward record_session (opt-out of session recording)."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from firecrawl.v2.client import FirecrawlClient
+from firecrawl.v2.methods import browser as browser_module
+
+
+def _ok_response(payload):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.ok = True
+    mock_response.json.return_value = {"success": True, **payload}
+    return mock_response
+
+
+class TestBrowserRecordSession(unittest.TestCase):
+    def _client(self):
+        return FirecrawlClient(api_key="dummy-api-key-for-testing")
+
+    @patch("requests.post")
+    def test_browser_forwards_record_session_false(self, mock_post):
+        mock_post.return_value = _ok_response({"id": "sess_123"})
+        client = self._client()
+
+        client.browser(record_session=False)
+
+        _, kwargs = mock_post.call_args
+        self.assertIn("recordSession", kwargs["json"])
+        self.assertIs(kwargs["json"]["recordSession"], False)
+
+    @patch("requests.post")
+    def test_browser_omits_record_session_by_default(self, mock_post):
+        mock_post.return_value = _ok_response({"id": "sess_123"})
+        client = self._client()
+
+        client.browser(ttl=600)
+
+        _, kwargs = mock_post.call_args
+        self.assertNotIn("recordSession", kwargs["json"])
+
+    def test_browser_module_forwards_record_session_false(self):
+        client = MagicMock()
+        client.post.return_value = _ok_response({"id": "sess_123"})
+
+        browser_module.browser(client, record_session=False)
+
+        sent_body = client.post.call_args[0][1]
+        self.assertIs(sent_body.get("recordSession"), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/python-sdk/tests/test_browser_record_session_async.py
+++ b/apps/python-sdk/tests/test_browser_record_session_async.py
@@ -1,0 +1,54 @@
+"""Async mirror of test_browser_record_session: public async facade -> real
+HTTP serialization -> in-memory MockTransport."""
+import asyncio
+import json
+
+import httpx
+import pytest
+from firecrawl.v2.client_async import AsyncFirecrawlClient
+
+
+@pytest.mark.parametrize("case", ["false", "true", "none", "omitted"])
+def test_async_browser_recording_payload(case):
+    async def run():
+        requests = []
+
+        def handler(request):
+            requests.append(request)
+            return httpx.Response(200, json={"success": True, "id": "test-session"})
+
+        client = AsyncFirecrawlClient(api_key="dummy-test-key", max_retries=1)
+        await client.async_http_client.close()
+        client.async_http_client._client = httpx.AsyncClient(
+            base_url="https://example.test", transport=httpx.MockTransport(handler)
+        )
+        try:
+            if case == "omitted":
+                result = await client.browser(
+                    ttl=600, activity_ttl=120, stream_web_view=False,
+                    profile={"name": "test-profile", "save_changes": False},
+                )
+            else:
+                result = await client.browser(
+                    record_session={"false": False, "true": True, "none": None}[case],
+                    ttl=600, activity_ttl=120, stream_web_view=False,
+                    profile={"name": "test-profile", "save_changes": False},
+                )
+        finally:
+            await client.async_http_client.close()
+        assert result.id == "test-session"
+        assert len(requests) == 1
+        assert requests[0].method == "POST"
+        assert requests[0].url.path == "/v2/browser"
+        payload = json.loads(requests[0].content)
+        expected = {"ttl": 600, "activityTtl": 120, "streamWebView": False,
+                    "profile": {"name": "test-profile", "saveChanges": False}}
+        if case in ("false", "true"):
+            expected["recordSession"] = case == "true"
+            assert payload["recordSession"] is expected["recordSession"]
+        else:
+            assert "recordSession" not in payload
+        assert payload.pop("origin").startswith("python-sdk@")
+        assert payload == expected
+
+    asyncio.run(run())


### PR DESCRIPTION
I noticed the API supports `recordSession` on `POST /v2/browser` (wired through to the browser service as `record`), but the JS and Python SDKs had no way to send it — sessions created from either SDK are always recorded.

What I changed:
- JS: added `recordSession` to `browser()` args and the request payload in `src/v2/methods/browser.ts` (left unset by default so the server default still applies).
- Python: added `record_session` to `browser()` in the sync + async method modules and both client wrappers, sent as `recordSession`.

Tests I ran:
- New unit tests on both sides asserting `recordSession: false` is forwarded and that the key is omitted when unset: `src/__tests__/unit/v2/browser-record-session.unit.test.ts` (jest, 2 passed) and `apps/python-sdk/tests/test_browser_record_session.py` (pytest, 3 passed).
- Proved they fail without the fix by stashing the source changes and re-running (both suites go red, then green again after popping).
- Neighboring suites: JS unit dir is 161 passed with 2 pre-existing failures (`threat-protection`, `scrape` — both fail identically on the clean tree); Python `tests/` shows the same 13 pre-existing failures before and after my change, with my 3 new tests passing. `tsc --noEmit` reports only pre-existing errors in files I didn't touch.

No config, migration, or deployment impact — purely additive optional params.

Fixes #4589

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `#4589` — adds `recordSession` to browser-create in the JS and Python SDKs. Sessions created from either SDK were always recorded because the API's `recordSession` option was never sent; now the SDKs pass it through, and callers who omit it still get the server's default.

- JS: optional `recordSession` arg on `browser()` is forwarded to the request body.
- Python: optional `record_session` arg added to sync and async `browser()` methods, sent as `recordSession`.
- New unit tests on JS, sync Python, and async Python verify `recordSession: false` is forwarded and the key is omitted when unset.
- Purely additive — no config, migration, or deployment impact.

<sup>Written for commit 3f93acc686e0c2a1786282d16706f5a38a38c7c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

