### PR TITLE
fix(playwright): report the URL the browser actually landed on

### DIFF
--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -357,7 +357,12 @@ describe("Scrape tests", () => {
 
       expect(response.metadata.sourceURL).toBe("https://google.com/");
       expect(response.metadata.url).toBeDefined();
-      expect(new URL(response.metadata.url!).hostname).toBe("www.google.com");
+      // Not pinned to www.google.com: the target is region-dependent from
+      // whichever network the runner sits on. That the landed host is no
+      // longer the requested one is the whole invariant under test.
+      expect(new URL(response.metadata.url!).hostname).not.toBe(
+        new URL("https://google.com/").hostname,
+      );
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/scrape.test.ts
+++ b/apps/api/src/__tests__/snips/v2/scrape.test.ts
@@ -340,6 +340,50 @@ describe("Scrape tests", () => {
     scrapeTimeout,
   );
 
+  concurrentIf(TEST_SELF_HOST && HAS_PLAYWRIGHT)(
+    "playwright reports the landed URL after a cross-hostname redirect",
+    async () => {
+      // google.com 301s to www.google.com — the same stable redirect the
+      // threat-protection suite relies on. Before the playwright-service
+      // reported page.url(), metadata.url echoed the requested URL, so a page
+      // fetched from another host was indistinguishable from a real one.
+      const response = await scrape(
+        {
+          url: "https://google.com/",
+          waitFor: 100,
+        },
+        identity,
+      );
+
+      expect(response.metadata.sourceURL).toBe("https://google.com/");
+      expect(response.metadata.url).toBeDefined();
+      expect(new URL(response.metadata.url!).hostname).toBe("www.google.com");
+    },
+    scrapeTimeout,
+  );
+
+  concurrentIf(TEST_SELF_HOST && HAS_PLAYWRIGHT && ALLOW_TEST_SUITE_WEBSITE)(
+    "playwright reports the requested URL when there is no redirect",
+    async () => {
+      // The other half of the contract: reporting the landed URL must not
+      // invent a redirect where there is none.
+      const response = await scrape(
+        {
+          url: TEST_SUITE_WEBSITE,
+          waitFor: 100,
+        },
+        identity,
+      );
+
+      expect(response.metadata.sourceURL).toBe(TEST_SUITE_WEBSITE);
+      expect(response.metadata.url).toBeDefined();
+      expect(new URL(response.metadata.url!).hostname).toBe(
+        new URL(TEST_SUITE_WEBSITE).hostname,
+      );
+    },
+    scrapeTimeout,
+  );
+
   concurrentIf(TEST_PRODUCTION || (HAS_PLAYWRIGHT && ALLOW_TEST_SUITE_WEBSITE))(
     "waitFor works",
     async () => {

--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -27,6 +27,9 @@ export async function scrapeURLWithPlaywright(
       pageStatusCode: z.number(),
       pageError: z.string().optional(),
       contentType: z.string().optional(),
+      // Optional so an OLDER playwright-service (one that does not send it)
+      // still validates — the fallback below keeps today's behaviour.
+      url: z.string().optional(),
     }),
     mock: meta.mock,
     abort: meta.abort.asSignal(),
@@ -37,7 +40,12 @@ export async function scrapeURLWithPlaywright(
   }
 
   return {
-    url: meta.rewrittenUrl ?? meta.url, // TODO: impove redirect following
+    // The landed URL, reported by the service from page.url(). This is what
+    // metadata.url is supposed to carry — scrapeURL compares it against the
+    // initial URL for its own threat check, and callers rely on it to tell a
+    // redirect from a same-page load. Falls back to the requested URL when the
+    // service predates the field (keeps the previous, redirect-blind result).
+    url: response.url ?? meta.rewrittenUrl ?? meta.url,
     html: response.content,
     statusCode: response.pageStatusCode,
     error: response.pageError,

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -338,6 +338,13 @@ const scrapePage = async (
 
   return {
     content,
+    // Where the browser ACTUALLY ended up. page.url() reflects the post-
+    // navigation location, so it covers client-side redirects (location.href
+    // from a bot-detection script) as well as HTTP 3xx — neither of which the
+    // caller could previously see. Without this the API can only echo the
+    // REQUESTED url, so a page fetched from somebody else's site is
+    // indistinguishable from the real one.
+    url: page.url(),
     status: response ? response.status() : null,
     headers,
     contentType: ct,
@@ -537,6 +544,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
       content: result.content,
       pageStatusCode: result.status,
       contentType: result.contentType,
+      url: result.url,
       ...(pageError && { pageError }),
     });
   } catch (error) {


### PR DESCRIPTION
## The bug

The playwright engine reports the **requested** URL as the URL it scraped, never the one it landed on. `engines/playwright/index.ts` returned `meta.rewrittenUrl ?? meta.url`, carrying the existing `// TODO: impove redirect following` — and it had no alternative, because the microservice's response is `{content, pageStatusCode, contentType}` and simply never sent a URL.

Measured on an unpatched self-hosted instance: scraping `httpbin.org/redirect-to?url=https://example.com/` returns example.com's DOM (title "Example Domain"), while `metadata.url` **and** `metadata.sourceURL` both report the httpbin request URL. A page fetched from somebody else's site is indistinguishable from a real one.

## Why it isn't cosmetic

Three checks in the API are gated on `metadata.url` differing from `metadata.sourceURL`. On the playwright engine that comparison is structurally always false, so all three silently no-op:

1. **Threat-protection redirect re-check** — `scrapeURL/index.ts:1571`. Its own comment says it "closes the 'clean URL redirects to a blocked URL' bypass vector". It compares `result.document.metadata.url` against `meta.rewrittenUrl ?? meta.url`, which is precisely what the engine returned as its URL.
2. **Post-redirect blocklist re-check** — `scrape-worker.ts`, added in #4581 (merged yesterday), gated on `canonicalizeUrl(doc.metadata.url) !== canonicalizeUrl(doc.metadata.sourceURL)`.
3. **Crawl origin update on cross-hostname redirect** — `scrape-worker.ts:553`, the `isHostnameDifferent` branch (also the subject of #4049).

Callers are affected too: someone indexing a site has no way to notice they stored a foreign page. A real case produced 19 pages of Google's own paths indexed as one site's content — a theme's bot-detection script navigated the browser to google.com, and the root-relative links then resolved back onto the requested origin.

## The fix

`scrapePage` already holds `page` and calls `page.content()`, so the landed URL was one call away. It now returns `page.url()`, the service sends it, and the engine prefers it.

`page.url()` reflects the post-navigation location, so this covers client-side redirects as well as HTTP 3xx. Verified: a page whose only content is `location.href="https://example.com/"` reports `https://example.com/`, where the old path reported the data URL.

## Backwards compatibility

The response field is **optional** in the zod schema and the engine falls back to `meta.rewrittenUrl ?? meta.url`. A newer API talking to an older playwright-service keeps exactly today's behaviour rather than failing validation.

## Testing

- Redirect cases above measured against a self-hosted instance running the bundled playwright-service.
- `tsc --noEmit` in `apps/playwright-service-ts`: no new errors (two pre-existing ones, `proxy-chain` resolution and an implicit-any at `api.ts:103`, are present on `main` too).

## Related

No open issue seems to cover this directly. Adjacent: #4049 (its `isHostnameDifferent` branch can't fire on this engine), and this makes the guarantee shipped in #4581 actually hold for self-hosted playwright deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BS6eVPNfsTQEXcLtX5GoAd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Playwright engine reporting the requested URL instead of the URL the browser actually landed on. The service now returns `page.url()` and the API prefers it, so redirects (HTTP and client-side) are visible and the security checks comparing final vs. requested URL become effective. The response field is optional and falls back to the old behavior when talking to an older service, so no migration needed.

- Enables the redirect re-check, post-redirect blocklist re-check, and crawl origin update that previously never fired on this engine.
- Adds tests covering both cases: a cross-hostname redirect reports the landed host, and a non-redirecting page reports the requested URL.

<sup>Written for commit 8aed4aa82c33a8c3ea67c0bfeccd88bbd0aeebc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

