### PR TITLE
feat(playwright-service): add STEALTH_MODE to control the automation fingerprint

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -62,6 +62,12 @@ security, availability, capacity, upgrades, data retention, and compliance.
   the default `postgres` database.
 - **If you publish dependency ports,** secure them explicitly. PostgreSQL,
   Redis, RabbitMQ, and worker ports should remain private by default.
+- **If you turn on `STEALTH_MODE`,** decide first whether evading bot
+  detection is appropriate for the sites you scrape, under the terms and law
+  that apply to them. It defaults to `off`. `basic` stops Chromium advertising
+  `navigator.webdriver`; `full` additionally injects `window.chrome` and
+  `navigator.plugins` shims into every page the bundled Playwright service
+  loads.
 - **If you have availability or scale targets,** define monitoring, resource
   limits, scaling triggers, and upgrade and rollback procedures. The checked-in
   Compose file is a source-aligned starting point, not a production

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -112,6 +112,13 @@ PARTNER_EGRESS_PROXY_URL=
 # set if you'd like to block media requests to save proxy bandwidth
 BLOCK_MEDIA=
 
+# How hard the bundled Playwright service works at not looking automated:
+# off (default), basic, or full. basic launches Chromium with
+# --disable-blink-features=AutomationControlled so navigator.webdriver is
+# false; full additionally shims window.chrome and navigator.plugins on every
+# page. This changes how your scraper represents itself to the sites it visits.
+STEALTH_MODE=
+
 # Set this to the URL of your webhook when using the self-hosted version of FireCrawl
 SELF_HOSTED_WEBHOOK_URL=
 

--- a/apps/playwright-service-ts/README.md
+++ b/apps/playwright-service-ts/README.md
@@ -26,6 +26,43 @@ OR
 npm run dev
 ```
 
+## CONFIGURATION
+
+All settings are environment variables. None are required.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PORT` | `3003` | Port the service listens on. |
+| `PROXY_SERVER` | none | Upstream proxy for all page traffic. |
+| `PROXY_USERNAME` | none | Username, if the proxy authenticates. |
+| `PROXY_PASSWORD` | none | Password, if the proxy authenticates. |
+| `BLOCK_MEDIA` | `false` | Drop images, audio and video to save bandwidth. |
+| `ALLOW_LOCAL_WEBHOOKS` | `false` | Permit scraping local and private-network addresses. Leave off unless the deployment is airgapped or you have another control in front of it. |
+| `MAX_CONCURRENT_PAGES` | `10` | Pages open at once across all contexts. |
+| `STEALTH_MODE` | `off` | How hard to work at not looking automated — see below. |
+
+### STEALTH_MODE
+
+Sites that fingerprint headless browsers can serve a scraper something other
+than the page — in one observed case a Shopify theme navigated the browser to
+google.com instead. This controls how much of that fingerprint the service
+hides. It is off by default because it changes how the scraper represents
+itself to the sites it visits, which is the operator's call.
+
+| Value | Effect | Measured fingerprint |
+| --- | --- | --- |
+| `off` (default) | Nothing added. | `webdriver=true`, `plugins=0`, `hasChrome=false` |
+| `basic` | Launches Chromium with `--disable-blink-features=AutomationControlled`. | `webdriver=false`, `plugins=0`, `hasChrome=false` |
+| `full` | `basic`, plus init-script shims for `window.chrome` and `navigator.plugins`. | `webdriver=false`, `plugins=2`, `hasChrome=true` |
+
+Prefer `basic`: it clears the tell detectors check first, and unlike `full` it
+runs no init script on the pages you load. The `full` shims only define a
+property that is absent, so a future Playwright or Chromium that populates
+them natively takes precedence.
+
+Note that the service already randomises the user-agent per context regardless
+of this setting.
+
 ## USE
 
 ```bash

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -30,6 +30,46 @@ const MAX_CONCURRENT_PAGES = Math.max(
 const ALLOW_LOCAL_WEBHOOKS =
   (process.env.ALLOW_LOCAL_WEBHOOKS || 'False').toUpperCase() === 'TRUE';
 
+/**
+ * How hard the browser should work at not looking automated.
+ *
+ *   off   (default)  nothing added — the behaviour you get today
+ *   basic            launch with --disable-blink-features=AutomationControlled,
+ *                    which is what makes navigator.webdriver false
+ *   full             basic, plus init-script shims for window.chrome and
+ *                    navigator.plugins
+ *
+ * Off by default because this changes how the scraper represents itself to the
+ * sites it visits — that is the operator's call to make, not a default. Reach
+ * for `basic` first: it clears the tell that detectors check first without
+ * running an init script on every page.
+ */
+type StealthMode = 'off' | 'basic' | 'full';
+
+const parseStealthMode = (raw: string | undefined): StealthMode => {
+  // true/false are accepted because every other flag here is a boolean, so
+  // that is what an operator will reasonably guess this one is.
+  switch ((raw ?? '').trim().toLowerCase()) {
+    case '':
+    case 'off':
+    case 'false':
+      return 'off';
+    case 'basic':
+      return 'basic';
+    case 'full':
+    case 'true':
+      return 'full';
+    default:
+      console.warn(
+        `Unrecognised STEALTH_MODE ${JSON.stringify(raw)} — ` +
+          'expected off, basic or full. Using off.',
+      );
+      return 'off';
+  }
+};
+
+const STEALTH_MODE = parseStealthMode(process.env.STEALTH_MODE);
+
 const PROXY_SERVER = process.env.PROXY_SERVER || null;
 const PROXY_USERNAME = process.env.PROXY_USERNAME || null;
 const PROXY_PASSWORD = process.env.PROXY_PASSWORD || null;
@@ -197,6 +237,14 @@ const initializeBrowser = async () => {
       '--no-first-run',
       '--no-zygote',
       '--disable-gpu',
+      // AutomationControlled is what makes navigator.webdriver true, and that
+      // is the first thing commodity headless detectors test. Client sites
+      // branch on it: an observed Shopify theme did, and navigated the browser
+      // to google.com, so the scrape returned a foreign page under the
+      // requested URL.
+      ...(STEALTH_MODE !== 'off'
+        ? ['--disable-blink-features=AutomationControlled']
+        : []),
     ],
   });
 };
@@ -226,6 +274,27 @@ const createContext = async (
   };
 
   const newContext = await browser.newContext(contextOptions);
+
+  if (STEALTH_MODE === 'full') {
+    // Second-tier headless tells, checked by the same detectors that check
+    // navigator.webdriver: a real Chrome always exposes window.chrome and a
+    // non-empty navigator.plugins, headless exposes neither. Shim ONLY when
+    // absent, so a future Playwright or Chromium that populates them natively
+    // wins and nothing here overwrites it.
+    await newContext.addInitScript(() => {
+      if (navigator.plugins.length === 0) {
+        Object.defineProperty(navigator, 'plugins', {
+          get: () => [{ name: 'PDF Viewer' }, { name: 'Chrome PDF Viewer' }],
+        });
+      }
+      const w = window as unknown as Record<string, unknown>;
+      if (typeof w.chrome === 'undefined') {
+        Object.defineProperty(window, 'chrome', {
+          get: () => ({ runtime: {} }),
+        });
+      }
+    });
+  }
 
   if (BLOCK_MEDIA) {
     await newContext.route(

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -283,15 +283,55 @@ const createContext = async (
     // wins and nothing here overwrites it.
     await newContext.addInitScript(() => {
       if (navigator.plugins.length === 0) {
-        Object.defineProperty(navigator, 'plugins', {
-          get: () => [{ name: 'PDF Viewer' }, { name: 'Chrome PDF Viewer' }],
+        // Shaped as the real host objects rather than a plain Array. Headless
+        // already exposes a genuine, empty PluginArray, so substituting an
+        // Array would flip Array.isArray to true (false in any real browser),
+        // report [object Array], and drop item()/namedItem() — trading one
+        // weak tell for several strong ones.
+        const makePlugin = (name: string, description: string) => {
+          const plugin = Object.create(Plugin.prototype);
+          Object.defineProperties(plugin, {
+            name: { value: name, enumerable: true },
+            filename: { value: 'internal-pdf-viewer', enumerable: true },
+            description: { value: description, enumerable: true },
+            length: { value: 0, enumerable: true },
+          });
+          return plugin as Plugin;
+        };
+
+        const plugins = [
+          makePlugin('PDF Viewer', 'Portable Document Format'),
+          makePlugin('Chrome PDF Viewer', 'Portable Document Format'),
+        ];
+        const list = Object.create(PluginArray.prototype);
+        plugins.forEach((plugin, index) =>
+          Object.defineProperty(list, index, {
+            value: plugin,
+            enumerable: true,
+          }),
+        );
+        plugins.forEach(plugin =>
+          Object.defineProperty(list, plugin.name, { value: plugin }),
+        );
+        Object.defineProperty(list, 'length', { value: plugins.length });
+        Object.defineProperty(list, 'item', {
+          value: (index: number) => plugins[index] ?? null,
         });
+        Object.defineProperty(list, 'namedItem', {
+          value: (name: string) =>
+            plugins.find(plugin => plugin.name === name) ?? null,
+        });
+        Object.defineProperty(list, 'refresh', { value: () => {} });
+        Object.defineProperty(navigator, 'plugins', { get: () => list });
       }
+
       const w = window as unknown as Record<string, unknown>;
       if (typeof w.chrome === 'undefined') {
-        Object.defineProperty(window, 'chrome', {
-          get: () => ({ runtime: {} }),
-        });
+        // One object built once, not a fresh literal per access: page code
+        // must see `window.chrome === window.chrome`, and a write to
+        // chrome.runtime has to survive being read back.
+        const chrome = { runtime: {} };
+        Object.defineProperty(window, 'chrome', { get: () => chrome });
       }
     });
   }

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -283,46 +283,104 @@ const createContext = async (
     // wins and nothing here overwrites it.
     await newContext.addInitScript(() => {
       if (navigator.plugins.length === 0) {
-        // Shaped as the real host objects rather than a plain Array. Headless
-        // already exposes a genuine, empty PluginArray, so substituting an
-        // Array would flip Array.isArray to true (false in any real browser),
-        // report [object Array], and drop item()/namedItem() — trading one
-        // weak tell for several strong ones.
-        const makePlugin = (name: string, description: string) => {
-          const plugin = Object.create(Plugin.prototype);
-          Object.defineProperties(plugin, {
-            name: { value: name, enumerable: true },
-            filename: { value: 'internal-pdf-viewer', enumerable: true },
-            description: { value: description, enumerable: true },
-            length: { value: 0, enumerable: true },
+        // Shaped as the real host objects rather than plain Arrays. Headless
+        // already exposes genuine, empty PluginArray and MimeTypeArray, so
+        // substituting Arrays would flip Array.isArray to true (false in any
+        // real browser), report [object Array], and drop item()/namedItem() —
+        // trading one weak tell for several strong ones.
+        //
+        // The whole plugin/mimeType graph is built, not just the plugin list:
+        // inheriting a native prototype without defining the methods leaves
+        // brand-checked natives in place, so plugins[0].item(0) would throw
+        // Illegal invocation, which no real browser does. Plugins that carry
+        // no MIME types would be incoherent for the same reason.
+        const PDF = 'Portable Document Format';
+        const INTERNAL_PDF = 'internal-pdf-viewer';
+
+        // Own item/namedItem/length/indices, so no brand-checked native
+        // method inherited from the prototype is ever reached.
+        const collection = <T>(
+          proto: object,
+          entries: T[],
+          keyOf: (entry: T) => string,
+        ) => {
+          const list = Object.create(proto);
+          entries.forEach((entry, index) =>
+            Object.defineProperty(list, index, {
+              value: entry,
+              enumerable: true,
+            }),
+          );
+          entries.forEach(entry =>
+            Object.defineProperty(list, keyOf(entry), { value: entry }),
+          );
+          Object.defineProperty(list, 'length', { value: entries.length });
+          Object.defineProperty(list, 'item', {
+            value: (index: number) => entries[index] ?? null,
           });
-          return plugin as Plugin;
+          Object.defineProperty(list, 'namedItem', {
+            value: (name: string) =>
+              entries.find(entry => keyOf(entry) === name) ?? null,
+          });
+          return list;
         };
 
+        const mimeTypes = [
+          { type: 'application/pdf', suffixes: 'pdf', description: PDF },
+          { type: 'text/pdf', suffixes: 'pdf', description: PDF },
+        ].map(spec => {
+          const mimeType = Object.create(MimeType.prototype);
+          Object.defineProperties(mimeType, {
+            type: { value: spec.type, enumerable: true },
+            suffixes: { value: spec.suffixes, enumerable: true },
+            description: { value: spec.description, enumerable: true },
+          });
+          return mimeType as MimeType;
+        });
+
         const plugins = [
-          makePlugin('PDF Viewer', 'Portable Document Format'),
-          makePlugin('Chrome PDF Viewer', 'Portable Document Format'),
-        ];
-        const list = Object.create(PluginArray.prototype);
-        plugins.forEach((plugin, index) =>
-          Object.defineProperty(list, index, {
-            value: plugin,
+          { name: 'PDF Viewer', description: PDF },
+          { name: 'Chrome PDF Viewer', description: PDF },
+        ].map(spec => {
+          const plugin = collection(
+            Plugin.prototype,
+            mimeTypes,
+            mimeType => mimeType.type,
+          );
+          Object.defineProperties(plugin, {
+            name: { value: spec.name, enumerable: true },
+            filename: { value: INTERNAL_PDF, enumerable: true },
+            description: { value: spec.description, enumerable: true },
+          });
+          return plugin as Plugin;
+        });
+
+        // Real MIME types point back at the plugin serving them.
+        mimeTypes.forEach(mimeType =>
+          Object.defineProperty(mimeType, 'enabledPlugin', {
+            value: plugins[0],
             enumerable: true,
           }),
         );
-        plugins.forEach(plugin =>
-          Object.defineProperty(list, plugin.name, { value: plugin }),
+
+        const pluginArray = collection(
+          PluginArray.prototype,
+          plugins,
+          plugin => plugin.name,
         );
-        Object.defineProperty(list, 'length', { value: plugins.length });
-        Object.defineProperty(list, 'item', {
-          value: (index: number) => plugins[index] ?? null,
+        Object.defineProperty(pluginArray, 'refresh', { value: () => {} });
+        const mimeTypeArray = collection(
+          MimeTypeArray.prototype,
+          mimeTypes,
+          mimeType => mimeType.type,
+        );
+
+        Object.defineProperty(navigator, 'plugins', {
+          get: () => pluginArray,
         });
-        Object.defineProperty(list, 'namedItem', {
-          value: (name: string) =>
-            plugins.find(plugin => plugin.name === name) ?? null,
+        Object.defineProperty(navigator, 'mimeTypes', {
+          get: () => mimeTypeArray,
         });
-        Object.defineProperty(list, 'refresh', { value: () => {} });
-        Object.defineProperty(navigator, 'plugins', { get: () => list });
       }
 
       const w = window as unknown as Record<string, unknown>;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,6 +72,8 @@ services:
       PROXY_PASSWORD: ${PROXY_PASSWORD}
       ALLOW_LOCAL_WEBHOOKS: ${ALLOW_LOCAL_WEBHOOKS}
       BLOCK_MEDIA: ${BLOCK_MEDIA}
+      # Anti-bot-detection posture: off (default), basic, or full
+      STEALTH_MODE: ${STEALTH_MODE}
       # Configure maximum concurrent pages for Playwright browser instances
       MAX_CONCURRENT_PAGES: ${CRAWL_CONCURRENT_REQUESTS:-10}
     networks:

--- a/examples/kubernetes/firecrawl-helm/templates/playwright-configmap.yaml
+++ b/examples/kubernetes/firecrawl-helm/templates/playwright-configmap.yaml
@@ -6,4 +6,5 @@ data:
   PORT: {{ default (printf "%v" .Values.service.playwright.port) .Values.playwrightConfig.PORT | quote }}
   ALLOW_LOCAL_WEBHOOKS: {{ .Values.playwrightConfig.ALLOW_LOCAL_WEBHOOKS | quote }}
   BLOCK_MEDIA: {{ .Values.playwrightConfig.BLOCK_MEDIA | quote }}
+  STEALTH_MODE: {{ .Values.playwrightConfig.STEALTH_MODE | quote }}
   MAX_CONCURRENT_PAGES: {{ .Values.playwrightConfig.MAX_CONCURRENT_PAGES | quote }}

--- a/examples/kubernetes/firecrawl-helm/values.yaml
+++ b/examples/kubernetes/firecrawl-helm/values.yaml
@@ -175,6 +175,7 @@ playwrightConfig:
   PORT: "3000"
   ALLOW_LOCAL_WEBHOOKS: ""
   BLOCK_MEDIA: ""
+  STEALTH_MODE: ""
   MAX_CONCURRENT_PAGES: "10"
 
 secret:


### PR DESCRIPTION
## The problem

Sites that fingerprint headless browsers can serve the bundled Playwright service something other than the page. The three signals commodity detection scripts test are `navigator.webdriver`, `window.chrome` and `navigator.plugins`, and the service currently fails all three: `initializeBrowser` omits `--disable-blink-features=AutomationControlled`, and the context exposes neither of the other two.

In one observed case a Shopify theme detected automation and navigated the browser to google.com. Because the links there are root-relative they resolved back onto the requested origin, and 19 pages of Google's own paths were indexed as one site's content.

## The change

Rather than alter the fingerprint for every self-hosted deployment, this adds a `STEALTH_MODE` variable, **off by default**:

| Value | Effect | Measured fingerprint |
| --- | --- | --- |
| `off` *(default)* | Nothing added — today's behaviour. | `webdriver=true`, `plugins=0`, `hasChrome=false` |
| `basic` | `--disable-blink-features=AutomationControlled` at launch. | `webdriver=false`, `plugins=0`, `hasChrome=false` |
| `full` | `basic`, plus init-script shims for `window.chrome` and `navigator.plugins`. | `webdriver=false`, `plugins=2`, `hasChrome=true` |

Measured on the chromium this service pins, with the fingerprint read off the page.

**`basic` is the one to reach for first.** It clears the signal detectors check first, and unlike `full` it runs no init script on the pages you load. The `full` shims only define a property that is *absent*, so a future Playwright or Chromium that populates them natively takes precedence and nothing here overwrites it.

## Design notes

**Why ordered levels instead of two independent booleans.** The combination they exclude — shims without the flag — is strictly worse than either: the page would claim to be Chrome, with plugins, while still reporting `webdriver=true`. Making the levels ordered puts that state out of reach by construction, and it mirrors the three rows of the measurement above.

**Why off by default.** This changes how the scraper represents itself to the sites it visits. That is the operator's call to make against the terms and law covering their targets, not something to switch on underneath existing deployments. `true` and `false` are accepted as aliases for `full` and `off`, since every other flag in this service is a boolean and that is what an operator will guess; an unrecognised value warns and falls back to `off`.

**Not addressed here.** The default user-agent is `new UserAgent().toString()`, randomised per context, which can present as mobile Safari while the page is a Linux chromium. That is arguably a more distinctive fingerprint than a plain headless UA, but making the default coherent is a separate change. Callers can already override it with the `user-agent` request header.

## Documentation

Wired the same way as the service's three existing variables — `docker-compose.yaml`, `apps/api/.env.example`, and the Helm `values.yaml` and configmap. Two additions beyond parity:

- `apps/playwright-service-ts/README.md` gains a configuration section covering **all** the service's environment variables, which were previously undocumented.
- `SELF_HOST.md` gains one "Before production" bullet, since whether evading bot detection is appropriate is a decision the operator has to make deliberately.

I left `examples/kubernetes/cluster-install/playwright-service.yaml` alone — it carries only `PORT` and `ALLOW_LOCAL_WEBHOOKS`, not even `BLOCK_MEDIA`, so adding this would break its minimalism rather than match it.

## Testing

- Fingerprint table above measured directly, launching this chromium with each mode's real arguments.
- `tsc --noEmit` in `apps/playwright-service-ts`: no new errors (two pre-existing ones, `proxy-chain` resolution and an implicit-any, are present on `main` too).

## Related

Sibling of #4591, which is what makes this class of failure *visible* — without it the scrape reports the requested URL no matter where the browser ended up, so an off-site bounce looks like a normal result. The two are independent and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BS6eVPNfsTQEXcLtX5GoAd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `STEALTH_MODE` variable to the bundled Playwright service so operators can quiet the automation fingerprint that makes headless browsers detectable. Off by default; `basic` clears `navigator.webdriver` via `--disable-blink-features=AutomationControlled`, and `full` additionally shims `window.chrome`, `navigator.plugins`, and `navigator.mimeTypes` to match the real host objects. This matters because sites that fingerprint headless browsers can serve scrapers a foreign page — one observed Shopify theme bounced the browser to google.com.

**Configuration & docs**
- Wires the variable through `docker-compose.yaml`, `apps/api/.env.example`, and the Helm values and configmap.
- `apps/playwright-service-ts/README.md` now documents all of the service's environment variables; `SELF_HOST.md` gains a note to confirm evading bot detection is appropriate before enabling.
- The `full` shims build a closed plugin/mimeType graph on the native prototypes with `item()`/`namedItem()` and back-references, so the shim adds no tells of its own.

<sup>Written for commit dd0adce34046d0b4a12df8821baada086f6f363f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

