### PR TITLE
fix(js-sdk): allow zeroDataRetention on v2 scrape

### DIFF
--- a/apps/js-sdk/firecrawl/src/__tests__/unit/v2/scrape-zero-data-retention.unit.test.ts
+++ b/apps/js-sdk/firecrawl/src/__tests__/unit/v2/scrape-zero-data-retention.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { scrape } from "../../../v2/methods/scrape";
+
+function httpMock() {
+  return {
+    post: jest.fn(async () => ({
+      status: 200,
+      data: { success: true, data: {} },
+    })),
+    getTimeoutMs: jest.fn(() => 0),
+  } as any;
+}
+
+describe("v2 scrape zeroDataRetention", () => {
+  test("forwards zeroDataRetention at the top level", async () => {
+    const http = httpMock();
+
+    await scrape(http, "https://example.com", { zeroDataRetention: true });
+
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.zeroDataRetention).toBe(true);
+  });
+
+  test("omits zeroDataRetention when the caller does not set it", async () => {
+    const http = httpMock();
+
+    await scrape(http, "https://example.com", { formats: ["markdown"] });
+
+    const payload = http.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("zeroDataRetention");
+  });
+});

--- a/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts
+++ b/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts
@@ -71,6 +71,12 @@ export type ScrapeCallOptions = ScrapeOptions & {
    * immediately instead.
    */
   autoResume?: boolean;
+  /**
+   * Top-level API option (like crawl and batch scrape): when true, scraped
+   * data is deleted after 24 hours. Sent as a top-level payload field, not
+   * inside nested scrape options.
+   */
+  zeroDataRetention?: boolean;
 };
 
 export async function scrape(


### PR DESCRIPTION
Fixes #4593.

Adds `zeroDataRetention` to `ScrapeCallOptions`. It goes out as a top-level payload field, matching the API schema and the existing crawl/batch scrape methods. Deliberately not added to the shared `ScrapeOptions` type so it can't leak into nested `scrapeOptions` payloads.

Test: new `scrape-zero-data-retention.unit.test.ts` checks the flag is forwarded and omitted when unset. Neighbors pass (34/34 across scrape, scrape-browser, auto-resume, audit-metadata, validation, search-country suites).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4593 by adding `zeroDataRetention` to `ScrapeCallOptions` for v2 `scrape`, matching the API schema and the existing crawl and batch scrape methods. The flag is sent as a top-level payload field and is intentionally excluded from `ScrapeOptions` so it can't leak into nested `scrapeOptions`.

Added a unit test confirming the flag is forwarded when set and omitted when unset.

<sup>Written for commit 7f79cd5b72352e546fa0d200725c857840f0beb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

