### PR TITLE
refactor(api): require the org id on every billing call; AutumnService resolves nothing

### DIFF
--- a/apps/api/src/__tests__/controllers/fireclaw.test.ts
+++ b/apps/api/src/__tests__/controllers/fireclaw.test.ts
@@ -19,6 +19,9 @@ vi.mock("../../controllers/auth", () => ({
   getACUCTeam: vi.fn(),
 }));
 
+// orgIdFromAcuc answers null without it, so the billable path needs it on.
+vi.mock("../../config", () => ({ config: { USE_DB_AUTHENTICATION: true } }));
+
 vi.mock("../../lib/logger", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));

--- a/apps/api/src/__tests__/controllers/fireclaw.test.ts
+++ b/apps/api/src/__tests__/controllers/fireclaw.test.ts
@@ -40,7 +40,9 @@ function buildReq(overrides: any = {}): any {
   return {
     body: { plays: 1 },
     auth: { team_id: "team_test", org_id: "org_test" },
-    acuc: { api_key_id: 1 },
+    // A real org: it is what gates the Autumn credit check, so the billable
+    // path is the one under test here.
+    acuc: { api_key_id: 1, org_id: "org_test" },
     ...overrides,
   };
 }
@@ -104,6 +106,7 @@ describe("fireclawController credit gating (Autumn)", () => {
     );
     expect(billTeamMock).toHaveBeenCalledWith(
       "team_test",
+      "org_test",
       200,
       1,
       expect.objectContaining({ endpoint: "fireclaw" }),
@@ -128,6 +131,7 @@ describe("fireclawController credit gating (Autumn)", () => {
 
     expect(billTeamMock).toHaveBeenCalledWith(
       "team_test",
+      "org_test",
       300,
       1,
       expect.objectContaining({ endpoint: "fireclaw" }),

--- a/apps/api/src/__tests__/controllers/fireclaw.test.ts
+++ b/apps/api/src/__tests__/controllers/fireclaw.test.ts
@@ -30,6 +30,7 @@ import { fireclawController } from "../../controllers/v1/fireclaw";
 import { autumnService } from "../../services/autumn/autumn.service";
 import { getTeamBalance } from "../../services/autumn/usage";
 import { billTeam } from "../../services/billing/credit_billing";
+import { getACUCTeam } from "../../controllers/auth";
 
 const checkCreditsMock = autumnService.checkCredits as MockedFunction<
   typeof autumnService.checkCredits
@@ -38,6 +39,7 @@ const getTeamBalanceMock = getTeamBalance as MockedFunction<
   typeof getTeamBalance
 >;
 const billTeamMock = billTeam as MockedFunction<typeof billTeam>;
+const getACUCTeamMock = getACUCTeam as MockedFunction<typeof getACUCTeam>;
 
 function buildReq(overrides: any = {}): any {
   return {
@@ -123,6 +125,31 @@ describe("fireclawController credit gating (Autumn)", () => {
         remaining_credits: 4000, // from getTeamBalance
       }),
     );
+  });
+
+  it("bills against the fallback ACUC's org when req.acuc is absent", async () => {
+    const req = buildReq({ acuc: undefined });
+    const res = buildRes();
+    checkCreditsMock.mockResolvedValue({ allowed: true, remaining: 5000 });
+    getACUCTeamMock.mockResolvedValue({
+      api_key_id: 7,
+      org_id: "org_test",
+    } as any);
+
+    await fireclawController(req, res);
+
+    expect(checkCreditsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org_test" }),
+    );
+    // The charge lands on the identity the check gated, not on the absent acuc
+    expect(billTeamMock).toHaveBeenCalledWith(
+      "team_test",
+      "org_test",
+      100,
+      7,
+      expect.objectContaining({ endpoint: "fireclaw" }),
+    );
+    expect(res.statusCode).toBe(200);
   });
 
   it("fails open and bills when Autumn is unavailable (checkCredits null)", async () => {

--- a/apps/api/src/__tests__/routes/check-credits-middleware.test.ts
+++ b/apps/api/src/__tests__/routes/check-credits-middleware.test.ts
@@ -183,6 +183,22 @@ describe("checkCreditsMiddleware – Autumn overage handling", () => {
     );
   });
 
+  it("hands the ACUC's org to both checks, so neither reads teams.org_id", async () => {
+    checkCreditsMock
+      .mockResolvedValueOnce({ allowed: false, remaining: 5 })
+      .mockResolvedValueOnce({ allowed: true, remaining: 5 });
+
+    const req = buildReq({ body: { limit: 100 } });
+    await runMiddleware(req);
+
+    expect(checkCreditsMock).toHaveBeenCalledTimes(2);
+    for (const [params] of checkCreditsMock.mock.calls) {
+      expect(params).toEqual(
+        expect.objectContaining({ orgId: "org_test", teamId: "team_test" }),
+      );
+    }
+  });
+
   it("sends a null apiKeyId when the request has no resolved api key id", async () => {
     checkCreditsMock.mockResolvedValue({ allowed: true, remaining: 100 });
 

--- a/apps/api/src/__tests__/routes/check-credits-middleware.test.ts
+++ b/apps/api/src/__tests__/routes/check-credits-middleware.test.ts
@@ -199,6 +199,25 @@ describe("checkCreditsMiddleware – Autumn overage handling", () => {
     }
   });
 
+  // Keyless and preview identities carry no org, and neither does the DB-auth
+  // bypass. checkCredits answered null for all of them, so the middleware takes
+  // that fail-open answer itself rather than asking with an org it hasn't got.
+  it.each([null, undefined])(
+    "fails open without asking Autumn when org_id is %s",
+    async orgId => {
+      const req = buildReq({
+        auth: { team_id: "preview_1.2.3.4", org_id: orgId },
+      });
+      const { res, nextCalled } = await runMiddleware(req);
+
+      expect(checkCreditsMock).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(nextCalled).toBe(true);
+      expect(req.account.remainingCredits).toBe(Infinity);
+      expect(req.body.limit).toBe(100);
+    },
+  );
+
   it("sends a null apiKeyId when the request has no resolved api key id", async () => {
     checkCreditsMock.mockResolvedValue({ allowed: true, remaining: 100 });
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -171,16 +171,6 @@ const configSchema = z.object({
   LLAMAPARSE_API_KEY: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),
   AUTUMN_SECRET_KEY: z.string().optional(),
-  // How long a team → org mapping is trusted in-process before it is re-read
-  // from the DB. Bounded because a team's org changes when accounts are merged
-  // or moved: every warm pod otherwise keeps billing the old Autumn customer
-  // (and 404s on the entity that no longer lives there) until it restarts.
-  AUTUMN_ORG_CACHE_TTL_SECONDS: z.coerce
-    .number()
-    .int()
-    .min(0)
-    .max(3600)
-    .default(300),
   RESEND_API_KEY: z.string().optional(),
   PREVIEW_TOKEN: z.string().optional(),
   SEARCH_PREVIEW_TOKEN: z.string().optional(),

--- a/apps/api/src/controllers/__tests__/auth.test.ts
+++ b/apps/api/src/controllers/__tests__/auth.test.ts
@@ -1,9 +1,12 @@
 import { vi } from "vitest";
 import { createHmac } from "node:crypto";
-import { authenticateUser, clearACUC } from "../auth";
+import { authenticateUser, clearACUC, getACUCTeam } from "../auth";
 import { config } from "../../config";
 import { RateLimiterMode } from "../../types";
-import { authCreditUsageChunk } from "../../db/rpc";
+import {
+  authCreditUsageChunk,
+  authCreditUsageChunkFromTeam,
+} from "../../db/rpc";
 import { redlock } from "../../services/redlock";
 import { deleteKey, getValue, setValue } from "../../services/redis";
 import {
@@ -736,6 +739,26 @@ describe("authenticateUser", () => {
     expect(auth.success).toBe(true);
     expect(getRateLimiter).toHaveBeenCalledWith(RateLimiterMode.Preview);
     expect(getAutumnRateLimiter).not.toHaveBeenCalled();
+  });
+
+  it("treats a malformed team ACUC cache entry as a miss", async () => {
+    config.USE_DB_AUTHENTICATION = true;
+    vi.mocked(getValue).mockResolvedValue("{not-json");
+    vi.mocked(deleteKey).mockResolvedValue(undefined);
+    vi.mocked(authCreditUsageChunkFromTeam).mockResolvedValue([
+      { team_id: "team-1", org_id: "org-1" },
+    ] as never);
+
+    // The DB answers, rather than the corrupt entry failing the caller: every
+    // `.catch(() => null)` on this lookup would otherwise fail open.
+    await expect(getACUCTeam("team-1")).resolves.toMatchObject({
+      team_id: "team-1",
+      org_id: "org-1",
+    });
+    expect(authCreditUsageChunkFromTeam).toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(deleteKey).toHaveBeenCalledWith("acuc_team_team-1_scrape"),
+    );
   });
 
   it("clears purpose-qualified and legacy ACUC cache entries", async () => {

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -361,7 +361,22 @@ export async function getACUCTeam(
       }
     }
     if (cachedACUC !== null) {
-      return JSON.parse(cachedACUC);
+      // A corrupt entry is a miss, not a failure: callers that fall back to a
+      // null org on a throw would otherwise take the high fail-open limits.
+      try {
+        return JSON.parse(cachedACUC);
+      } catch (error) {
+        logger.warn("Ignoring malformed ACUC cache entry", {
+          cacheKey: cacheKeyACUC,
+          error,
+        });
+        void deleteKey(cacheKeyACUC).catch(deleteError => {
+          logger.warn("Failed to delete malformed ACUC cache entry", {
+            cacheKey: cacheKeyACUC,
+            error: deleteError,
+          });
+        });
+      }
     }
   }
 

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -657,7 +657,10 @@ async function buildAuthenticatedRateLimiter(
   if (getRateLimitOverride(mode, flags?.rateLimitOverrides) !== undefined) {
     multiplier = 1;
   } else {
-    multiplier = await autumnService.getRateLimitMultiplier(teamId, orgId);
+    multiplier = await autumnService.getRateLimitMultiplier(
+      teamId,
+      orgId ?? null,
+    );
     if (minMultiplier !== undefined) {
       multiplier = Math.max(multiplier, minMultiplier);
     }

--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -282,6 +282,7 @@ export async function crawlController(req: Request, res: Response) {
 
           let jobPriority = await getJobPriority({
             team_id,
+            org_id: orgId,
             basePriority: 21,
           });
           const billing = { endpoint: "crawl" as const, jobId: id };
@@ -347,7 +348,7 @@ export async function crawlController(req: Request, res: Response) {
           apiKeyId: chunk?.api_key_id ?? null,
         },
         jobId,
-        await getJobPriority({ team_id, basePriority: 15 }),
+        await getJobPriority({ team_id, org_id: orgId, basePriority: 15 }),
       );
       await addCrawlJob(id, jobId, logger);
     }

--- a/apps/api/src/controllers/v0/crawl.ts
+++ b/apps/api/src/controllers/v0/crawl.ts
@@ -140,11 +140,20 @@ export async function crawlController(req: Request, res: Response) {
 
     const limitCheck = req.body?.crawlerOptions?.limit ?? 1;
     // Autumn is the source of truth for credits.
-    const autumnResult = await autumnService.checkCredits({
-      teamId: team_id,
-      value: limitCheck,
-      properties: { source: "v0/crawl", apiKeyId: chunk?.api_key_id ?? null },
-    });
+    // No org, no Autumn customer to gate against: fail open, exactly as
+    // checkCredits answered for an identity it could not name.
+    const orgId = chunk?.org_id ?? null;
+    const autumnResult = orgId
+      ? await autumnService.checkCredits({
+          teamId: team_id,
+          orgId,
+          value: limitCheck,
+          properties: {
+            source: "v0/crawl",
+            apiKeyId: chunk?.api_key_id ?? null,
+          },
+        })
+      : null;
 
     if (autumnResult !== null && !autumnResult.allowed) {
       return res.status(402).json({

--- a/apps/api/src/controllers/v0/scrape.ts
+++ b/apps/api/src/controllers/v0/scrape.ts
@@ -270,14 +270,20 @@ export async function scrapeController(req: Request, res: Response) {
 
     // checkCredits — Autumn is the source of truth for credits.
     try {
-      const autumnResult = await autumnService.checkCredits({
-        teamId: team_id,
-        value: 1,
-        properties: {
-          source: "v0/scrape",
-          apiKeyId: chunk?.api_key_id ?? null,
-        },
-      });
+      // No org, no Autumn customer to gate against: fail open, exactly as
+      // checkCredits answered for an identity it could not name.
+      const orgId = chunk?.org_id ?? null;
+      const autumnResult = orgId
+        ? await autumnService.checkCredits({
+            teamId: team_id,
+            orgId,
+            value: 1,
+            properties: {
+              source: "v0/scrape",
+              apiKeyId: chunk?.api_key_id ?? null,
+            },
+          })
+        : null;
       // null = Autumn unavailable / self-hosted -> fail open, matching v1/v2.
       if (autumnResult !== null && !autumnResult.allowed) {
         earlyReturn = true;

--- a/apps/api/src/controllers/v0/scrape.ts
+++ b/apps/api/src/controllers/v0/scrape.ts
@@ -111,7 +111,7 @@ async function scrapeHelper(
       apiKeyId,
     },
     jobId,
-    await getJobPriority({ team_id, basePriority: 10 }),
+    await getJobPriority({ team_id, org_id, basePriority: 10 }),
     false,
     true,
   );

--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -88,6 +88,7 @@ async function searchHelper(
     const searchCredits = Math.ceil(res.length / 10) * 2;
     billTeam(
       team_id,
+      org_id,
       searchCredits,
       api_key_id,
       { endpoint: "search", jobId, chargeId: jobId },
@@ -247,14 +248,20 @@ export async function searchController(req: Request, res: Response) {
     const searchOptions = req.body.searchOptions ?? { limit: 5 };
 
     try {
-      const autumnResult = await autumnService.checkCredits({
-        teamId: team_id,
-        value: 1,
-        properties: {
-          source: "v0/search",
-          apiKeyId: chunk?.api_key_id ?? null,
-        },
-      });
+      // No org, no Autumn customer to gate against: fail open, exactly as
+      // checkCredits answered for an identity it could not name.
+      const orgId = chunk?.org_id ?? null;
+      const autumnResult = orgId
+        ? await autumnService.checkCredits({
+            teamId: team_id,
+            orgId,
+            value: 1,
+            properties: {
+              source: "v0/search",
+              apiKeyId: chunk?.api_key_id ?? null,
+            },
+          })
+        : null;
       // null = Autumn unavailable / self-hosted -> fail open, matching v1/v2.
       if (autumnResult !== null && !autumnResult.allowed) {
         return res.status(402).json({ error: "Insufficient credits" });

--- a/apps/api/src/controllers/v0/search.ts
+++ b/apps/api/src/controllers/v0/search.ts
@@ -118,7 +118,11 @@ async function searchHelper(
     return { success: true, error: "No search results found", returnCode: 200 };
   }
 
-  const jobPriority = await getJobPriority({ team_id, basePriority: 20 });
+  const jobPriority = await getJobPriority({
+    team_id,
+    org_id,
+    basePriority: 20,
+  });
   const billing = { endpoint: "search" as const, jobId };
 
   // filter out social media links

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -213,6 +213,7 @@ export async function batchScrapeController(
       if (threatScanCredits > 0) {
         billTeam(
           req.auth.team_id,
+          req.acuc?.org_id ?? null,
           threatScanCredits,
           req.acuc?.api_key_id ?? null,
           {

--- a/apps/api/src/controllers/v1/batch-scrape.ts
+++ b/apps/api/src/controllers/v1/batch-scrape.ts
@@ -365,6 +365,7 @@ export async function batchScrapeController(
     // set base to 21
     jobPriority = await getJobPriority({
       team_id: req.auth.team_id,
+      org_id: req.acuc?.org_id ?? null,
       basePriority: 21,
     });
   }

--- a/apps/api/src/controllers/v1/concurrency-check.ts
+++ b/apps/api/src/controllers/v1/concurrency-check.ts
@@ -19,7 +19,9 @@ export async function concurrencyCheckController(
     concurrency: activeJobsOfTeam,
     maxConcurrency: await getEffectiveConcurrencyLimit(
       req.auth.team_id,
-      req.acuc?.org_id,
+      // acuc is optional on the v1 request; null is the same org-less answer
+      // the limit already gave when it could not name one.
+      req.acuc?.org_id ?? null,
     ),
   });
 }

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -236,7 +236,7 @@ export async function crawlController(
             req.body.maxConcurrency,
             await getEffectiveConcurrencyLimit(
               req.auth.team_id,
-              req.acuc?.org_id,
+              req.acuc?.org_id ?? null,
             ),
           )
         : undefined,

--- a/apps/api/src/controllers/v1/crawl.ts
+++ b/apps/api/src/controllers/v1/crawl.ts
@@ -86,6 +86,7 @@ export async function crawlController(
       if (threatScanCredits > 0) {
         billTeam(
           req.auth.team_id,
+          req.acuc?.org_id ?? null,
           threatScanCredits,
           req.acuc?.api_key_id ?? null,
           // No chargeId: a fresh crawl id is minted per request and the

--- a/apps/api/src/controllers/v1/extract.ts
+++ b/apps/api/src/controllers/v1/extract.ts
@@ -191,6 +191,7 @@ export async function extractController(
     if (threatScanCredits > 0) {
       billTeam(
         req.auth.team_id,
+        req.acuc?.org_id ?? null,
         threatScanCredits,
         req.acuc?.api_key_id ?? null,
         {

--- a/apps/api/src/controllers/v1/fireclaw.ts
+++ b/apps/api/src/controllers/v1/fireclaw.ts
@@ -49,11 +49,17 @@ export async function fireclawController(
   // full multi-play cost is checked here. Fail open on an Autumn outage
   // (checkCredits returns null), matching checkCreditsMiddleware — don't turn an
   // Autumn outage into a customer outage.
-  const creditCheck = await autumnService.checkCredits({
-    teamId: req.auth.team_id,
-    value: totalCredits,
-    properties: { source: "fireclaw", apiKeyId: chunk?.api_key_id ?? null },
-  });
+  // No org, no Autumn customer to gate against: fail open, exactly as
+  // checkCredits answered for an identity it could not name.
+  const orgId = chunk?.org_id ?? null;
+  const creditCheck = orgId
+    ? await autumnService.checkCredits({
+        teamId: req.auth.team_id,
+        orgId,
+        value: totalCredits,
+        properties: { source: "fireclaw", apiKeyId: chunk?.api_key_id ?? null },
+      })
+    : null;
 
   if (creditCheck !== null && !creditCheck.allowed) {
     res.status(402).json({
@@ -66,6 +72,7 @@ export async function fireclawController(
   try {
     await billTeam(
       req.auth.team_id,
+      req.acuc?.org_id ?? null,
       totalCredits,
       req.acuc?.api_key_id ?? null,
       // No chargeId: fireclaw has no per-charge identity to key on — a

--- a/apps/api/src/controllers/v1/fireclaw.ts
+++ b/apps/api/src/controllers/v1/fireclaw.ts
@@ -73,9 +73,11 @@ export async function fireclawController(
   try {
     await billTeam(
       req.auth.team_id,
-      orgIdFromAcuc(req.acuc),
+      // The same chunk the credit check ran against: with req.acuc absent, the
+      // fallback ACUC is what named the org, so billing must use it too.
+      orgId,
       totalCredits,
-      req.acuc?.api_key_id ?? null,
+      chunk?.api_key_id ?? null,
       // No chargeId: fireclaw has no per-charge identity to key on — a
       // server-minted UUID here would be equivalent to firebill's own
       // per-request key, so this stays keyless until fireclaw carries one.

--- a/apps/api/src/controllers/v1/fireclaw.ts
+++ b/apps/api/src/controllers/v1/fireclaw.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import { RequestWithAuth } from "./types";
 import { billTeam } from "../../services/billing/credit_billing";
 import { getACUCTeam } from "../auth";
+import { orgIdFromAcuc } from "../../lib/team-org";
 import { RateLimiterMode } from "../../types";
 import { logger } from "../../lib/logger";
 import { autumnService } from "../../services/autumn/autumn.service";
@@ -51,7 +52,7 @@ export async function fireclawController(
   // Autumn outage into a customer outage.
   // No org, no Autumn customer to gate against: fail open, exactly as
   // checkCredits answered for an identity it could not name.
-  const orgId = chunk?.org_id ?? null;
+  const orgId = orgIdFromAcuc(chunk);
   const creditCheck = orgId
     ? await autumnService.checkCredits({
         teamId: req.auth.team_id,
@@ -72,7 +73,7 @@ export async function fireclawController(
   try {
     await billTeam(
       req.auth.team_id,
-      req.acuc?.org_id ?? null,
+      orgIdFromAcuc(req.acuc),
       totalCredits,
       req.acuc?.api_key_id ?? null,
       // No chargeId: fireclaw has no per-charge identity to key on — a

--- a/apps/api/src/controllers/v1/map.ts
+++ b/apps/api/src/controllers/v1/map.ts
@@ -516,11 +516,17 @@ export async function mapController(
 
   // Bill the team
   const creditsToBill = 1 + threatScanCredits;
-  billTeam(req.auth.team_id, creditsToBill, req.acuc?.api_key_id ?? null, {
-    endpoint: "map",
-    jobId: mapId,
-    chargeId: mapId,
-  }).catch(error => {
+  billTeam(
+    req.auth.team_id,
+    req.acuc?.org_id ?? null,
+    creditsToBill,
+    req.acuc?.api_key_id ?? null,
+    {
+      endpoint: "map",
+      jobId: mapId,
+      chargeId: mapId,
+    },
+  ).catch(error => {
     logger.error(
       `Failed to bill team ${req.auth.team_id} for ${creditsToBill} credit(s): ${error}`,
     );

--- a/apps/api/src/controllers/v1/queue-status.ts
+++ b/apps/api/src/controllers/v1/queue-status.ts
@@ -79,7 +79,7 @@ export async function queueStatusController(
     waitingJobsInQueue: queuedJobsOfTeam,
     maxConcurrency: await getEffectiveConcurrencyLimit(
       req.auth.team_id,
-      req.acuc?.org_id,
+      req.acuc?.org_id ?? null,
     ),
 
     mostRecentSuccess: mostRecentSuccess

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -228,6 +228,7 @@ async function scrapeControllerInner(
       async limited => {
         const jobPriority = await getJobPriority({
           team_id: req.auth.team_id,
+          org_id: req.acuc?.org_id ?? null,
           basePriority: 10,
         });
 

--- a/apps/api/src/controllers/v1/scrape.ts
+++ b/apps/api/src/controllers/v1/scrape.ts
@@ -222,7 +222,10 @@ async function scrapeControllerInner(
     doc = await teamConcurrencySemaphore.withSemaphore(
       req.auth.team_id,
       jobId,
-      await getEffectiveConcurrencyLimit(req.auth.team_id, req.acuc?.org_id),
+      await getEffectiveConcurrencyLimit(
+        req.auth.team_id,
+        req.acuc?.org_id ?? null,
+      ),
       aborter.signal,
       timeout ?? 60_000,
       async limited => {

--- a/apps/api/src/controllers/v1/search.ts
+++ b/apps/api/src/controllers/v1/search.ts
@@ -283,6 +283,7 @@ export async function searchController(
     if (!isSearchPreview) {
       billTeam(
         req.auth.team_id,
+        req.acuc?.org_id ?? null,
         result.searchCredits,
         req.acuc?.api_key_id ?? null,
         { endpoint: "search", jobId, chargeId: jobId },

--- a/apps/api/src/controllers/v2/__tests__/developer-access.test.ts
+++ b/apps/api/src/controllers/v2/__tests__/developer-access.test.ts
@@ -151,6 +151,8 @@ describe.each([
     // Ordinary team billing runs for the real (non-keyless) team id.
     expect(billTeam).toHaveBeenCalledWith(
       TEAM_ID,
+      // This fixture's ACUC carries no org.
+      null,
       expect.any(Number),
       expect.anything(),
       expect.anything(),

--- a/apps/api/src/controllers/v2/agent.ts
+++ b/apps/api/src/controllers/v2/agent.ts
@@ -103,6 +103,7 @@ export async function agentController(
       if (threatScanCredits > 0) {
         billTeam(
           req.auth.team_id,
+          req.acuc?.org_id ?? null,
           threatScanCredits,
           req.acuc?.api_key_id ?? null,
           { endpoint: "agent", jobId: agentId, chargeId: `${agentId}:threat` },

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -390,6 +390,7 @@ export async function batchScrapeController(
     // set base to 21
     jobPriority = await getJobPriority({
       team_id: req.auth.team_id,
+      org_id: req.acuc?.org_id ?? null,
       basePriority: 21,
     });
   }

--- a/apps/api/src/controllers/v2/batch-scrape.ts
+++ b/apps/api/src/controllers/v2/batch-scrape.ts
@@ -242,6 +242,7 @@ export async function batchScrapeController(
       ) {
         billTeam(
           req.auth.team_id,
+          req.acuc?.org_id ?? null,
           threatScanCredits,
           req.acuc?.api_key_id ?? null,
           {

--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -35,6 +35,7 @@ import {
   calculateBrowserSessionCredits,
 } from "../../lib/browser-billing";
 import { autumnService } from "../../services/autumn/autumn.service";
+import { getACUCTeam } from "../auth";
 import { isAgentInteropSecretValid } from "../../lib/agent-interop";
 
 // ---------------------------------------------------------------------------
@@ -266,15 +267,21 @@ export async function browserCreateController(
   // 0a. Check if team has enough credits for the full TTL
   if (shouldBill) {
     const estimatedCredits = calculateBrowserSessionCredits(ttl * 1000);
-    const autumnResult = await autumnService.checkCredits({
-      teamId: req.auth.team_id,
-      value: estimatedCredits,
-      properties: {
-        source: "browserCreate",
-        path: req.path,
-        apiKeyId: req.acuc?.api_key_id ?? null,
-      },
-    });
+    // No org, no Autumn customer to gate against: fail open, exactly as
+    // checkCredits answered for an identity it could not name.
+    const orgId = req.acuc?.org_id ?? null;
+    const autumnResult = orgId
+      ? await autumnService.checkCredits({
+          teamId: req.auth.team_id,
+          orgId,
+          value: estimatedCredits,
+          properties: {
+            source: "browserCreate",
+            path: req.path,
+            apiKeyId: req.acuc?.api_key_id ?? null,
+          },
+        })
+      : null;
 
     if (autumnResult !== null && !autumnResult.allowed) {
       logger.warn("Insufficient credits for browser session TTL", {
@@ -666,16 +673,26 @@ export async function browserDeleteController(
       session.request_id && session.request_id !== session.id
         ? session.request_id
         : null;
-    billTeam(req.auth.team_id, creditsBilled, req.acuc?.api_key_id ?? null, {
-      endpoint: agentRequestId ? "agent" : usedPrompt ? "interact" : "browser",
-      jobId: agentRequestId ?? session.id,
-      // Keyed on the session rather than on jobId, deliberately: one agent
-      // request can drive several sessions, and each is its own charge — a key
-      // built from the shared agent id would collapse them into one. The
-      // per-path suffix guards the other direction: the webhook teardown below
-      // bills the same session through a different path.
-      chargeId: `${session.id}:destroy`,
-    }).catch(error => {
+    billTeam(
+      req.auth.team_id,
+      req.acuc?.org_id ?? null,
+      creditsBilled,
+      req.acuc?.api_key_id ?? null,
+      {
+        endpoint: agentRequestId
+          ? "agent"
+          : usedPrompt
+            ? "interact"
+            : "browser",
+        jobId: agentRequestId ?? session.id,
+        // Keyed on the session rather than on jobId, deliberately: one agent
+        // request can drive several sessions, and each is its own charge — a key
+        // built from the shared agent id would collapse them into one. The
+        // per-path suffix guards the other direction: the webhook teardown below
+        // bills the same session through a different path.
+        chargeId: `${session.id}:destroy`,
+      },
+    ).catch(error => {
       logger.error("Failed to bill team for browser session", {
         error,
         creditsBilled,
@@ -824,14 +841,26 @@ export async function browserWebhookDestroyedController(
       session.request_id && session.request_id !== session.id
         ? session.request_id
         : null;
-    billTeam(session.team_id, creditsBilled, null, {
-      endpoint: agentRequestId ? "agent" : usedPrompt ? "interact" : "browser",
-      jobId: agentRequestId ?? session.id,
-      // Same reasoning as the destroy path above: keyed on the session, not on
-      // jobId, and suffixed per path so the two teardown routes cannot dedupe
-      // each other's charge away.
-      chargeId: `${session.id}:webhook`,
-    }).catch(error => {
+    // The webhook carries no request context, so the team's ACUC answers for
+    // the org — the same lookup the biller used to make for itself.
+    billTeam(
+      session.team_id,
+      (await getACUCTeam(session.team_id).catch(() => null))?.org_id ?? null,
+      creditsBilled,
+      null,
+      {
+        endpoint: agentRequestId
+          ? "agent"
+          : usedPrompt
+            ? "interact"
+            : "browser",
+        jobId: agentRequestId ?? session.id,
+        // Same reasoning as the destroy path above: keyed on the session, not on
+        // jobId, and suffixed per path so the two teardown routes cannot dedupe
+        // each other's charge away.
+        chargeId: `${session.id}:webhook`,
+      },
+    ).catch(error => {
       logger.error("Failed to bill team for browser session via webhook", {
         error,
         teamId: session.team_id,

--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -35,7 +35,7 @@ import {
   calculateBrowserSessionCredits,
 } from "../../lib/browser-billing";
 import { autumnService } from "../../services/autumn/autumn.service";
-import { getACUCTeam } from "../auth";
+import { orgIdForTeam } from "../../lib/team-org";
 import { isAgentInteropSecretValid } from "../../lib/agent-interop";
 
 // ---------------------------------------------------------------------------
@@ -845,7 +845,7 @@ export async function browserWebhookDestroyedController(
     // the org — the same lookup the biller used to make for itself.
     billTeam(
       session.team_id,
-      (await getACUCTeam(session.team_id).catch(() => null))?.org_id ?? null,
+      await orgIdForTeam(session.team_id),
       creditsBilled,
       null,
       {

--- a/apps/api/src/controllers/v2/browser.ts
+++ b/apps/api/src/controllers/v2/browser.ts
@@ -298,7 +298,7 @@ export async function browserCreateController(
   // 0b. Enforce concurrency limit (shared pool with scrape/crawl/interact)
   const concurrencyLimit = await getEffectiveConcurrencyLimit(
     req.auth.team_id,
-    req.acuc?.org_id,
+    req.acuc?.org_id ?? null,
   );
   const activeCount = await getCombinedTeamActiveCount(req.auth.team_id);
   if (activeCount >= concurrencyLimit) {

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -90,6 +90,7 @@ export async function crawlController(
       if (threatScanCredits > 0) {
         billTeam(
           req.auth.team_id,
+          req.acuc?.org_id ?? null,
           threatScanCredits,
           req.acuc?.api_key_id ?? null,
           // No chargeId: a fresh crawl id is minted per request and the

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -279,7 +279,7 @@ export async function crawlController(
 
   const effectiveConcurrency = await getEffectiveConcurrencyLimit(
     req.auth.team_id,
-    req.acuc?.org_id,
+    req.acuc?.org_id ?? null,
   );
   const sc: StoredCrawl = {
     originUrl: req.body.url,

--- a/apps/api/src/controllers/v2/extract.ts
+++ b/apps/api/src/controllers/v2/extract.ts
@@ -131,6 +131,7 @@ export async function extractController(
     if (threatScanCredits > 0) {
       billTeam(
         req.auth.team_id,
+        req.acuc?.org_id ?? null,
         threatScanCredits,
         req.acuc?.api_key_id ?? null,
         {

--- a/apps/api/src/controllers/v2/feedback/record.ts
+++ b/apps/api/src/controllers/v2/feedback/record.ts
@@ -218,9 +218,18 @@ async function refundCredits(params: {
   const { req, options, feedbackId, cappedRefund, policy, logger } = params;
   if (cappedRefund <= 0) return 0;
 
+  const orgId = req.acuc?.org_id ?? null;
+  if (!orgId) {
+    // No org, no Autumn customer to credit back. Reported as refunded anyway,
+    // which is what a refund that could not name its org already did.
+    logger.error("Feedback refund skipped: no org for the team");
+    return cappedRefund;
+  }
+
   try {
     await autumnService.refundCredits({
       teamId: req.auth.team_id,
+      orgId,
       value: cappedRefund,
       // One refund per feedback record; a retried refund dedupes (firebill
       // route) instead of crediting twice.

--- a/apps/api/src/controllers/v2/map.ts
+++ b/apps/api/src/controllers/v2/map.ts
@@ -102,13 +102,19 @@ export async function mapController(
     if (avgrabResults !== null) {
       const creditsCost = avgrabResults.length;
 
-      billTeam(req.auth.team_id, creditsCost, req.acuc?.api_key_id ?? null, {
-        endpoint: "map",
-        jobId: mapId,
-        // Suffixed so this early-return path can never collide with the main
-        // map charge below, even if both ever billed the same mapId.
-        chargeId: `${mapId}:avgrab`,
-      }).catch(error => {
+      billTeam(
+        req.auth.team_id,
+        req.acuc?.org_id ?? null,
+        creditsCost,
+        req.acuc?.api_key_id ?? null,
+        {
+          endpoint: "map",
+          jobId: mapId,
+          // Suffixed so this early-return path can never collide with the main
+          // map charge below, even if both ever billed the same mapId.
+          chargeId: `${mapId}:avgrab`,
+        },
+      ).catch(error => {
         logger.error(
           `Failed to bill team ${req.auth.team_id} for ${creditsCost} credits: ${error}`,
         );
@@ -240,11 +246,17 @@ export async function mapController(
 
   // Bill the team
   const creditsToBill = 1 + threatScanCredits;
-  billTeam(req.auth.team_id, creditsToBill, req.acuc?.api_key_id ?? null, {
-    endpoint: "map",
-    jobId: mapId,
-    chargeId: mapId,
-  }).catch(error => {
+  billTeam(
+    req.auth.team_id,
+    req.acuc?.org_id ?? null,
+    creditsToBill,
+    req.acuc?.api_key_id ?? null,
+    {
+      endpoint: "map",
+      jobId: mapId,
+      chargeId: mapId,
+    },
+  ).catch(error => {
     logger.error("Failed to bill team for map credits", {
       teamId: req.auth.team_id,
       creditsToBill,

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -485,7 +485,7 @@ export async function parseController(
 
         const baseConcurrency = await getEffectiveConcurrencyLimit(
           req.auth.team_id,
-          req.acuc?.org_id,
+          req.acuc?.org_id ?? null,
         );
         const concurrency = boostConcurrency
           ? baseConcurrency * AGENT_INTEROP_CONCURRENCY_BOOST

--- a/apps/api/src/controllers/v2/parse.ts
+++ b/apps/api/src/controllers/v2/parse.ts
@@ -500,6 +500,7 @@ export async function parseController(
           async limited => {
             const jobPriority = await getJobPriority({
               team_id: req.auth.team_id,
+              org_id: req.acuc?.org_id ?? null,
               basePriority: 10,
             });
 

--- a/apps/api/src/controllers/v2/queue-status.ts
+++ b/apps/api/src/controllers/v2/queue-status.ts
@@ -79,7 +79,7 @@ export async function queueStatusController(
     waitingJobsInQueue: queuedJobsOfTeam,
     maxConcurrency: await getEffectiveConcurrencyLimit(
       req.auth.team_id,
-      req.acuc?.org_id,
+      req.acuc?.org_id ?? null,
     ),
 
     mostRecentSuccess: mostRecentSuccess

--- a/apps/api/src/controllers/v2/research-proxy.ts
+++ b/apps/api/src/controllers/v2/research-proxy.ts
@@ -365,6 +365,7 @@ function createResearchController(
         if (credits > 0) {
           billTeam(
             authedReq.auth.team_id,
+            authedReq.acuc?.org_id ?? null,
             credits,
             authedReq.acuc?.api_key_id ?? null,
             {

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -494,11 +494,17 @@ export async function scrapeStopInteractiveBrowserController(
     });
   });
 
-  billTeam(req.auth.team_id, creditsBilled, req.acuc?.api_key_id ?? null, {
-    endpoint: "interact",
-    jobId: session.id,
-    chargeId: `${session.id}:scrape-browser`,
-  }).catch(error => {
+  billTeam(
+    req.auth.team_id,
+    req.acuc?.org_id ?? null,
+    creditsBilled,
+    req.acuc?.api_key_id ?? null,
+    {
+      endpoint: "interact",
+      jobId: session.id,
+      chargeId: `${session.id}:scrape-browser`,
+    },
+  ).catch(error => {
     logger.error("Failed to bill team for interact session", {
       error,
       creditsBilled,
@@ -587,15 +593,21 @@ async function createSessionForScrape(
   }
   const keylessReserved = estimatedCredits;
 
-  const autumnResult = await autumnService.checkCredits({
-    teamId: req.auth.team_id,
-    value: estimatedCredits,
-    properties: {
-      source: "scrapeBrowserCreate",
-      path: req.path,
-      apiKeyId: req.acuc?.api_key_id ?? null,
-    },
-  });
+  // No org, no Autumn customer to gate against: fail open, exactly as
+  // checkCredits answered for an identity it could not name.
+  const orgId = req.acuc?.org_id ?? null;
+  const autumnResult = orgId
+    ? await autumnService.checkCredits({
+        teamId: req.auth.team_id,
+        orgId,
+        value: estimatedCredits,
+        properties: {
+          source: "scrapeBrowserCreate",
+          path: req.path,
+          apiKeyId: req.acuc?.api_key_id ?? null,
+        },
+      })
+    : null;
 
   if (autumnResult !== null && !autumnResult.allowed) {
     adjustKeylessCredits(req.auth.team_id, -keylessReserved).catch(() => {});

--- a/apps/api/src/controllers/v2/scrape-browser.ts
+++ b/apps/api/src/controllers/v2/scrape-browser.ts
@@ -624,7 +624,7 @@ async function createSessionForScrape(
   // Active session limit — uses the same concurrency pool as scrape/crawl
   const concurrencyLimit = await getEffectiveConcurrencyLimit(
     req.auth.team_id,
-    req.acuc?.org_id,
+    req.acuc?.org_id ?? null,
   );
   const activeCount = await getCombinedTeamActiveCount(req.auth.team_id);
   if (activeCount >= concurrencyLimit) {

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -278,7 +278,7 @@ export async function scrapeController(
 
         const baseConcurrency = await getEffectiveConcurrencyLimit(
           req.auth.team_id,
-          req.acuc?.org_id,
+          req.acuc?.org_id ?? null,
         );
         const concurrency = boostConcurrency
           ? baseConcurrency * AGENT_INTEROP_CONCURRENCY_BOOST

--- a/apps/api/src/controllers/v2/scrape.ts
+++ b/apps/api/src/controllers/v2/scrape.ts
@@ -293,6 +293,7 @@ export async function scrapeController(
           async limited => {
             const jobPriority = await getJobPriority({
               team_id: req.auth.team_id,
+              org_id: req.acuc?.org_id ?? null,
               basePriority: 10,
             });
 

--- a/apps/api/src/controllers/v2/search.ts
+++ b/apps/api/src/controllers/v2/search.ts
@@ -302,6 +302,7 @@ async function searchControllerInner(
     if (!isSearchPreview && shouldBill) {
       billTeam(
         req.auth.team_id,
+        req.acuc?.org_id ?? null,
         result.searchCredits,
         req.acuc?.api_key_id ?? null,
         { ...billing, chargeId: jobId },

--- a/apps/api/src/lib/__tests__/job-priority.test.ts
+++ b/apps/api/src/lib/__tests__/job-priority.test.ts
@@ -6,6 +6,8 @@ import {
 } from "../job-priority";
 import { redisEvictConnection } from "../../services/redis";
 import {} from "../../types";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 vi.mock("../../services/queue-service", () => ({
   redisConnection: {
@@ -50,11 +52,11 @@ describe("Job Priority Tests", () => {
     const plan = "standard";
     (redisEvictConnection.scard as Mock).mockResolvedValue(150);
 
-    const priority = await getJobPriority({ team_id });
+    const priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(10);
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(250);
-    const priorityExceeded = await getJobPriority({ team_id });
+    const priorityExceeded = await getJobPriority({ team_id, org_id: null });
     expect(priorityExceeded).toBe(20); // basePriority + Math.ceil((250 - 200) * 0.4)
   });
 
@@ -63,22 +65,22 @@ describe("Job Priority Tests", () => {
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(50);
     let plan = "hobby";
-    let priority = await getJobPriority({ team_id });
+    let priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(10);
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(150);
     plan = "hobby";
-    priority = await getJobPriority({ team_id });
+    priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(25); // basePriority + Math.ceil((150 - 50) * 0.3)
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(25);
     plan = "free";
-    priority = await getJobPriority({ team_id });
+    priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(10);
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(60);
     plan = "free";
-    priority = await getJobPriority({ team_id });
+    priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(28); // basePriority + Math.ceil((60 - 25) * 0.5)
   });
 
@@ -133,5 +135,25 @@ describe("Job Priority Tests", () => {
     expect(setSize).toBe(0);
 
     vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Where the org comes from: the caller, and nowhere else.
+// ---------------------------------------------------------------------------
+
+describe("the org the caller supplies", () => {
+  // getJobPriority runs once per discovered link inside a crawl, so an ACUC
+  // lookup here is one Redis GET per link. The org must be threaded in by the
+  // caller, which already holds it.
+  it("cannot be resolved here: no ACUC lookup is even imported", () => {
+    const source = readFileSync(
+      join(__dirname, "..", "job-priority.ts"),
+      "utf-8",
+    );
+    expect(source).not.toContain("getACUCTeam");
+    expect(source).toMatch(
+      /getRateLimitMultiplier\(\s*team_id,\s*org_id,?\s*\)/,
+    );
   });
 });

--- a/apps/api/src/lib/__tests__/job-priority.test.ts
+++ b/apps/api/src/lib/__tests__/job-priority.test.ts
@@ -1,22 +1,50 @@
 import type { Mock } from "vitest";
-import {
-  getJobPriority,
-  addJobPriority,
-  deleteJobPriority,
-} from "../job-priority";
-import { redisEvictConnection } from "../../services/redis";
-import {} from "../../types";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { vi } from "vitest";
 
-vi.mock("../../services/queue-service", () => ({
-  redisConnection: {
+// Hermetic: job-priority talks to services/redis (not queue-service) and to
+// Autumn, so both are stubbed here. controllers/auth is stubbed too and
+// asserted never to be called — the org is the caller's to pass, because
+// getJobPriority runs once per discovered link inside a crawl and must not
+// turn into a Redis GET per link.
+vi.mock("../../services/redis", () => ({
+  redisEvictConnection: {
     sadd: vi.fn(),
     srem: vi.fn(),
     scard: vi.fn(),
     expire: vi.fn(),
   },
 }));
+
+vi.mock("../../services/autumn/autumn.service", () => ({
+  autumnService: {
+    getRateLimitMultiplier: vi.fn(),
+  },
+}));
+
+vi.mock("../../controllers/auth", () => ({
+  getACUCTeam: vi.fn(),
+}));
+
+import {
+  getJobPriority,
+  addJobPriority,
+  deleteJobPriority,
+} from "../job-priority";
+import { redisEvictConnection } from "../../services/redis";
+import { autumnService } from "../../services/autumn/autumn.service";
+import { getACUCTeam } from "../../controllers/auth";
+import {} from "../../types";
+
+const getRateLimitMultiplier = autumnService.getRateLimitMultiplier as Mock;
+
+// Multipliers that land on the plan tiers the priority cases below assume.
+const STANDARD_MULTIPLIER = 50;
+const HOBBY_MULTIPLIER = 10;
+const FREE_MULTIPLIER = 1;
+
+beforeEach(() => {
+  getRateLimitMultiplier.mockResolvedValue(FREE_MULTIPLIER);
+});
 
 describe("Job Priority Tests", () => {
   afterEach(() => {
@@ -49,7 +77,7 @@ describe("Job Priority Tests", () => {
 
   test("getJobPriority should return correct priority based on plan and set length", async () => {
     const team_id = "team1";
-    const plan = "standard";
+    getRateLimitMultiplier.mockResolvedValue(STANDARD_MULTIPLIER);
     (redisEvictConnection.scard as Mock).mockResolvedValue(150);
 
     const priority = await getJobPriority({ team_id, org_id: null });
@@ -57,29 +85,27 @@ describe("Job Priority Tests", () => {
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(250);
     const priorityExceeded = await getJobPriority({ team_id, org_id: null });
-    expect(priorityExceeded).toBe(20); // basePriority + Math.ceil((250 - 200) * 0.4)
+    expect(priorityExceeded).toBe(20); // basePriority + Math.ceil((250 - 200) * 0.2)
   });
 
   test("getJobPriority should handle different plans correctly", async () => {
     const team_id = "team1";
 
+    getRateLimitMultiplier.mockResolvedValue(HOBBY_MULTIPLIER);
     (redisEvictConnection.scard as Mock).mockResolvedValue(50);
-    let plan = "hobby";
     let priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(10);
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(150);
-    plan = "hobby";
     priority = await getJobPriority({ team_id, org_id: null });
-    expect(priority).toBe(25); // basePriority + Math.ceil((150 - 50) * 0.3)
+    expect(priority).toBe(25); // basePriority + Math.ceil((150 - 100) * 0.3)
 
+    getRateLimitMultiplier.mockResolvedValue(FREE_MULTIPLIER);
     (redisEvictConnection.scard as Mock).mockResolvedValue(25);
-    plan = "free";
     priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(10);
 
     (redisEvictConnection.scard as Mock).mockResolvedValue(60);
-    plan = "free";
     priority = await getJobPriority({ team_id, org_id: null });
     expect(priority).toBe(28); // basePriority + Math.ceil((60 - 25) * 0.5)
   });
@@ -143,17 +169,21 @@ describe("Job Priority Tests", () => {
 // ---------------------------------------------------------------------------
 
 describe("the org the caller supplies", () => {
-  // getJobPriority runs once per discovered link inside a crawl, so an ACUC
-  // lookup here is one Redis GET per link. The org must be threaded in by the
-  // caller, which already holds it.
-  it("cannot be resolved here: no ACUC lookup is even imported", () => {
-    const source = readFileSync(
-      join(__dirname, "..", "job-priority.ts"),
-      "utf-8",
-    );
-    expect(source).not.toContain("getACUCTeam");
-    expect(source).toMatch(
-      /getRateLimitMultiplier\(\s*team_id,\s*org_id,?\s*\)/,
-    );
+  it("goes straight to the rate-limit multiplier, with no ACUC lookup", async () => {
+    (redisEvictConnection.scard as Mock).mockResolvedValue(1);
+
+    await getJobPriority({ team_id: "team1", org_id: "org-1" });
+
+    expect(getRateLimitMultiplier).toHaveBeenCalledWith("team1", "org-1");
+    expect(getACUCTeam).not.toHaveBeenCalled();
+  });
+
+  it("passes a null org through as the caller gave it", async () => {
+    (redisEvictConnection.scard as Mock).mockResolvedValue(1);
+
+    await getJobPriority({ team_id: "team1", org_id: null });
+
+    expect(getRateLimitMultiplier).toHaveBeenCalledWith("team1", null);
+    expect(getACUCTeam).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/lib/__tests__/team-org.test.ts
+++ b/apps/api/src/lib/__tests__/team-org.test.ts
@@ -1,0 +1,77 @@
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config", () => ({
+  config: { USE_DB_AUTHENTICATION: true },
+}));
+
+vi.mock("../../controllers/auth", () => ({
+  getACUCTeam: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+import { config } from "../../config";
+import { getACUCTeam } from "../../controllers/auth";
+import { orgIdForTeam } from "../team-org";
+
+const mutableConfig = config as { USE_DB_AUTHENTICATION?: boolean };
+const mockedGetACUCTeam = getACUCTeam as unknown as Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutableConfig.USE_DB_AUTHENTICATION = true;
+});
+
+describe("orgIdForTeam", () => {
+  it("answers null without reading the ACUC when DB auth is off", async () => {
+    mutableConfig.USE_DB_AUTHENTICATION = false;
+    // The mock ACUC's org is the sentinel "bypass"; handing that to Autumn
+    // would bill a fake customer where the old lookup failed open.
+    mockedGetACUCTeam.mockResolvedValue({
+      team_id: "bypass",
+      org_id: "bypass",
+    });
+
+    expect(await orgIdForTeam("team-1")).toBeNull();
+    expect(mockedGetACUCTeam).not.toHaveBeenCalled();
+  });
+
+  it("answers null without reading the ACUC for a preview team", async () => {
+    mockedGetACUCTeam.mockResolvedValue({
+      team_id: "preview_abc",
+      org_id: "preview",
+    });
+
+    expect(await orgIdForTeam("preview")).toBeNull();
+    expect(await orgIdForTeam("preview_abc")).toBeNull();
+    expect(mockedGetACUCTeam).not.toHaveBeenCalled();
+  });
+
+  it("answers the org on the team's ACUC", async () => {
+    mockedGetACUCTeam.mockResolvedValue({ team_id: "team-1", org_id: "org-1" });
+
+    expect(await orgIdForTeam("team-1")).toBe("org-1");
+    expect(mockedGetACUCTeam).toHaveBeenCalledWith("team-1");
+  });
+
+  it("answers null when the team has no ACUC", async () => {
+    mockedGetACUCTeam.mockResolvedValue(null);
+
+    expect(await orgIdForTeam("team-1")).toBeNull();
+  });
+
+  it("answers null when the ACUC carries no org", async () => {
+    mockedGetACUCTeam.mockResolvedValue({ team_id: "team-1", org_id: null });
+
+    expect(await orgIdForTeam("team-1")).toBeNull();
+  });
+
+  it("answers null when the ACUC lookup throws", async () => {
+    mockedGetACUCTeam.mockRejectedValue(new Error("acuc unavailable"));
+
+    expect(await orgIdForTeam("team-1")).toBeNull();
+  });
+});

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -34,7 +34,10 @@ export async function getEffectiveConcurrencyLimit(
   teamId: string,
   orgId?: string | null,
 ): Promise<number> {
-  const autumnValue = await autumnService.getConcurrencyLimit(teamId, orgId);
+  const autumnValue = await autumnService.getConcurrencyLimit(
+    teamId,
+    orgId ?? null,
+  );
   return autumnValue ?? DEFAULT_CONCURRENCY_LIMIT;
 }
 

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -19,7 +19,7 @@ import {
   removeConcurrencyLimitActiveJob,
 } from "./concurrency-redis";
 import { autumnService } from "../services/autumn/autumn.service";
-import { getACUCTeam } from "../controllers/auth";
+import { orgIdForTeam } from "./team-org";
 import { reportPipelineError } from "./redis-pipeline";
 
 // Fallback when Autumn can't give us a concurrency value.
@@ -347,9 +347,7 @@ export async function concurrentJobDone(job: NuQJob<any>) {
     // not once per job promoted below.
     const maxTeamConcurrency = await getEffectiveConcurrencyLimit(
       job.data.team_id,
-      job.data.internalOptions?.orgId ??
-        (await getACUCTeam(job.data.team_id).catch(() => null))?.org_id ??
-        null,
+      job.data.internalOptions?.orgId ?? (await orgIdForTeam(job.data.team_id)),
     );
 
     let staleSkipped = 0;

--- a/apps/api/src/lib/concurrency-limit.ts
+++ b/apps/api/src/lib/concurrency-limit.ts
@@ -19,6 +19,7 @@ import {
   removeConcurrencyLimitActiveJob,
 } from "./concurrency-redis";
 import { autumnService } from "../services/autumn/autumn.service";
+import { getACUCTeam } from "../controllers/auth";
 import { reportPipelineError } from "./redis-pipeline";
 
 // Fallback when Autumn can't give us a concurrency value.
@@ -32,12 +33,12 @@ const DEFAULT_CONCURRENCY_LIMIT = 2;
  */
 export async function getEffectiveConcurrencyLimit(
   teamId: string,
-  orgId?: string | null,
+  /** The team's org, from the ACUC the caller already holds. Required so a
+   * caller cannot silently omit it and take the high fail-open limit; pass
+   * null only when the team genuinely has no org. */
+  orgId: string | null,
 ): Promise<number> {
-  const autumnValue = await autumnService.getConcurrencyLimit(
-    teamId,
-    orgId ?? null,
-  );
+  const autumnValue = await autumnService.getConcurrencyLimit(teamId, orgId);
   return autumnValue ?? DEFAULT_CONCURRENCY_LIMIT;
 }
 
@@ -341,8 +342,14 @@ export async function concurrentJobDone(job: NuQJob<any>) {
       await cleanOldCrawlConcurrencyLimitEntries(job.data.crawl_id);
     }
 
+    // The org rides the job payload; the ACUC answers for a job enqueued
+    // without one (monitor jobs null the field deliberately). Once per call,
+    // not once per job promoted below.
     const maxTeamConcurrency = await getEffectiveConcurrencyLimit(
       job.data.team_id,
+      job.data.internalOptions?.orgId ??
+        (await getACUCTeam(job.data.team_id).catch(() => null))?.org_id ??
+        null,
     );
 
     let staleSkipped = 0;

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -16,6 +16,7 @@ import {
 } from "./concurrency-limit";
 import { getCrawl } from "./crawl-redis";
 import { logger as _logger } from "./logger";
+import { getACUCTeam } from "../controllers/auth";
 
 interface ReconcileOptions {
   teamId?: string;
@@ -82,6 +83,7 @@ async function getQueuedJobIDs(teamId: string): Promise<Set<string>> {
 
 async function reconcileTeam(
   ownerId: string,
+  orgId: string | null,
   teamLogger: Logger,
 ): Promise<{ jobsStarted: number; jobsRequeued: number } | null> {
   const backloggedJobIDs = new Set(
@@ -111,7 +113,7 @@ async function reconcileTeam(
   // TODO: gate crawl + extract against one combined pool (sum of both active
   // counts vs the single limit) instead of applying the same limit to each
   // type independently.
-  const teamConcurrency = await getEffectiveConcurrencyLimit(ownerId);
+  const teamConcurrency = await getEffectiveConcurrencyLimit(ownerId, orgId);
   const maxCrawlConcurrency = teamConcurrency;
   const maxExtractConcurrency = teamConcurrency;
 
@@ -201,6 +203,7 @@ async function reconcileTeam(
 
 async function drainQueue(
   ownerId: string,
+  orgId: string | null,
   teamLogger: Logger,
 ): Promise<{ jobsPromoted: number; staleSkipped: number }> {
   // Autumn's CONCURRENCY balance is a single per-team pool, so crawl and
@@ -208,7 +211,7 @@ async function drainQueue(
   // TODO: gate crawl + extract against one combined pool (sum of both active
   // counts vs the single limit) instead of applying the same limit to each
   // type independently.
-  const teamConcurrency = await getEffectiveConcurrencyLimit(ownerId);
+  const teamConcurrency = await getEffectiveConcurrencyLimit(ownerId, orgId);
   const maxCrawlConcurrency = teamConcurrency;
   const maxExtractConcurrency = teamConcurrency;
 
@@ -335,14 +338,20 @@ export async function reconcileConcurrencyQueue(
     const teamLogger = logger.child({ teamId: ownerId });
 
     try {
-      const teamResult = await reconcileTeam(ownerId, teamLogger);
+      // The reconciler has no request ACUC and no job payload to read, so the
+      // team's ACUC is the only org source; once per team per pass, shared by
+      // both limit lookups below.
+      const orgId =
+        (await getACUCTeam(ownerId).catch(() => null))?.org_id ?? null;
+
+      const teamResult = await reconcileTeam(ownerId, orgId, teamLogger);
       if (teamResult !== null) {
         result.teamsWithDrift++;
         result.jobsStarted += teamResult.jobsStarted;
         result.jobsRequeued += teamResult.jobsRequeued;
       }
 
-      const drainResult = await drainQueue(ownerId, teamLogger);
+      const drainResult = await drainQueue(ownerId, orgId, teamLogger);
       if (drainResult.jobsPromoted > 0 || drainResult.staleSkipped > 0) {
         result.jobsStarted += drainResult.jobsPromoted;
         teamLogger.info("Queue drain promoted jobs", {

--- a/apps/api/src/lib/concurrency-queue-reconciler.ts
+++ b/apps/api/src/lib/concurrency-queue-reconciler.ts
@@ -16,7 +16,7 @@ import {
 } from "./concurrency-limit";
 import { getCrawl } from "./crawl-redis";
 import { logger as _logger } from "./logger";
-import { getACUCTeam } from "../controllers/auth";
+import { orgIdForTeam } from "./team-org";
 
 interface ReconcileOptions {
   teamId?: string;
@@ -341,8 +341,7 @@ export async function reconcileConcurrencyQueue(
       // The reconciler has no request ACUC and no job payload to read, so the
       // team's ACUC is the only org source; once per team per pass, shared by
       // both limit lookups below.
-      const orgId =
-        (await getACUCTeam(ownerId).catch(() => null))?.org_id ?? null;
+      const orgId = await orgIdForTeam(ownerId);
 
       const teamResult = await reconcileTeam(ownerId, orgId, teamLogger);
       if (teamResult !== null) {

--- a/apps/api/src/lib/deep-research/deep-research-service.ts
+++ b/apps/api/src/lib/deep-research/deep-research-service.ts
@@ -7,6 +7,7 @@ import { billTeam } from "../../services/billing/credit_billing";
 import { ExtractOptions } from "../../controllers/v1/types";
 import { CostTracking } from "../cost-tracking";
 import { getACUCTeam } from "../../controllers/auth";
+import { orgIdFromAcuc } from "../team-org";
 import { includesFormat } from "../format-utils";
 export interface DeepResearchServiceOptions {
   researchId: string;
@@ -427,7 +428,7 @@ export async function performDeepResearch(options: DeepResearchServiceOptions) {
     // Bill team for usage based on URLs analyzed
     billTeam(
       teamId,
-      acuc?.org_id ?? null,
+      orgIdFromAcuc(acuc),
       credits_billed,
       apiKeyId,
       { endpoint: "deep_research", jobId: researchId, chargeId: researchId },

--- a/apps/api/src/lib/deep-research/deep-research-service.ts
+++ b/apps/api/src/lib/deep-research/deep-research-service.ts
@@ -427,6 +427,7 @@ export async function performDeepResearch(options: DeepResearchServiceOptions) {
     // Bill team for usage based on URLs analyzed
     billTeam(
       teamId,
+      acuc?.org_id ?? null,
       credits_billed,
       apiKeyId,
       { endpoint: "deep_research", jobId: researchId, chargeId: researchId },

--- a/apps/api/src/lib/extract/document-scraper.ts
+++ b/apps/api/src/lib/extract/document-scraper.ts
@@ -52,6 +52,7 @@ export async function scrapeDocument(
     const jobId = uuidv7();
     const jobPriority = await getJobPriority({
       team_id: options.teamId,
+      org_id: options.orgId ?? null,
       basePriority: 10,
     });
 

--- a/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/document-scraper-f0.ts
@@ -54,6 +54,7 @@ export async function scrapeDocument_F0(
     const jobId = uuidv7();
     const jobPriority = await getJobPriority({
       team_id: options.teamId,
+      org_id: options.orgId ?? null,
       basePriority: 10,
     });
 

--- a/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
@@ -871,6 +871,7 @@ export async function performExtraction_F0(
   // Bill team for usage
   billTeam(
     teamId,
+    acuc?.org_id ?? null,
     creditsToBill,
     apiKeyId,
     { endpoint: "extract", jobId: extractId, chargeId: extractId },

--- a/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
+++ b/apps/api/src/lib/extract/fire-0/extraction-service-f0.ts
@@ -39,6 +39,7 @@ import {
 } from "./usage/llm-cost-f0";
 import { SourceTracker_F0 } from "./helpers/source-tracker-f0";
 import { getACUCTeam } from "../../../controllers/auth";
+import { orgIdFromAcuc } from "../../team-org";
 import { resolveThreatProtection } from "../../threat-protection/request";
 
 interface ExtractServiceOptions {
@@ -871,7 +872,7 @@ export async function performExtraction_F0(
   // Bill team for usage
   billTeam(
     teamId,
-    acuc?.org_id ?? null,
+    orgIdFromAcuc(acuc),
     creditsToBill,
     apiKeyId,
     { endpoint: "extract", jobId: extractId, chargeId: extractId },

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -280,6 +280,7 @@ export async function performGenerateLlmsTxt(
     // Bill team for usage
     billTeam(
       teamId,
+      acuc?.org_id ?? null,
       urls.length,
       apiKeyId,
       { endpoint: "llms_txt", jobId: generationId, chargeId: generationId },

--- a/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
+++ b/apps/api/src/lib/generate-llmstxt/generate-llmstxt-service.ts
@@ -14,6 +14,7 @@ import { getModel } from "../generic-ai";
 import { generateCompletions } from "../../scraper/scrapeURL/transformers/llmExtract";
 import { CostTracking } from "../cost-tracking";
 import { getACUCTeam } from "../../controllers/auth";
+import { orgIdFromAcuc } from "../team-org";
 interface GenerateLLMsTextServiceOptions {
   generationId: string;
   teamId: string;
@@ -280,7 +281,7 @@ export async function performGenerateLlmsTxt(
     // Bill team for usage
     billTeam(
       teamId,
-      acuc?.org_id ?? null,
+      orgIdFromAcuc(acuc),
       urls.length,
       apiKeyId,
       { endpoint: "llms_txt", jobId: generationId, chargeId: generationId },

--- a/apps/api/src/lib/job-priority.ts
+++ b/apps/api/src/lib/job-priority.ts
@@ -1,7 +1,6 @@
 import { redisEvictConnection } from "../services/redis";
 import { logger } from "./logger";
 import { autumnService } from "../services/autumn/autumn.service";
-import { getACUCTeam } from "../controllers/auth";
 import { inferPlanPriorityFromMultiplier } from "../services/rate-limiter";
 
 const SET_KEY_PREFIX = "limit_team_id:";
@@ -32,9 +31,14 @@ export async function deleteJobPriority(team_id, job_id) {
 
 export async function getJobPriority({
   team_id,
+  org_id,
   basePriority = 10,
 }: {
   team_id: string;
+  /** The team's org, from the ACUC the caller already holds. Required so a
+   * caller cannot silently omit it and fall back to the high fail-open
+   * limits; pass null only when the caller genuinely has no org. */
+  org_id: string | null;
   basePriority?: number;
   from_extract?: boolean;
 }): Promise<number> {
@@ -49,13 +53,11 @@ export async function getJobPriority({
     const setLength = await redisEvictConnection.scard(setKey);
 
     // Plan priority is inferred from the team's Autumn rate-limit multiplier.
-    // The org comes from the team's ACUC — the same lookup the multiplier used
-    // to make for itself, now that the billing service resolves nothing.
-    const orgId =
-      (await getACUCTeam(team_id).catch(() => null))?.org_id ?? null;
+    // The org is threaded in by the caller: this runs once per discovered link
+    // inside a crawl, so it must not do an ACUC lookup of its own.
     const multiplier = await autumnService.getRateLimitMultiplier(
       team_id,
-      orgId,
+      org_id,
     );
     const { bucketLimit, planModifier } =
       inferPlanPriorityFromMultiplier(multiplier);

--- a/apps/api/src/lib/job-priority.ts
+++ b/apps/api/src/lib/job-priority.ts
@@ -1,6 +1,7 @@
 import { redisEvictConnection } from "../services/redis";
 import { logger } from "./logger";
 import { autumnService } from "../services/autumn/autumn.service";
+import { getACUCTeam } from "../controllers/auth";
 import { inferPlanPriorityFromMultiplier } from "../services/rate-limiter";
 
 const SET_KEY_PREFIX = "limit_team_id:";
@@ -48,7 +49,14 @@ export async function getJobPriority({
     const setLength = await redisEvictConnection.scard(setKey);
 
     // Plan priority is inferred from the team's Autumn rate-limit multiplier.
-    const multiplier = await autumnService.getRateLimitMultiplier(team_id);
+    // The org comes from the team's ACUC — the same lookup the multiplier used
+    // to make for itself, now that the billing service resolves nothing.
+    const orgId =
+      (await getACUCTeam(team_id).catch(() => null))?.org_id ?? null;
+    const multiplier = await autumnService.getRateLimitMultiplier(
+      team_id,
+      orgId,
+    );
     const { bucketLimit, planModifier } =
       inferPlanPriorityFromMultiplier(multiplier);
 

--- a/apps/api/src/lib/team-org.ts
+++ b/apps/api/src/lib/team-org.ts
@@ -1,0 +1,40 @@
+import { config } from "../config";
+import { getACUCTeam } from "../controllers/auth";
+import { logger } from "./logger";
+
+// mockPreviewACUC's org. A real org is a uuid, so this cannot collide.
+const PREVIEW_ORG_SENTINEL = "preview";
+
+/**
+ * The org out of an ACUC the caller already holds — same rule as
+ * orgIdForTeam, for the callers that fetch the ACUC for its flags anyway.
+ */
+export function orgIdFromAcuc(
+  acuc: { org_id?: string | null } | null | undefined,
+): string | null {
+  // Without DB auth every ACUC is mockACUC, whose org is the sentinel
+  // "bypass" rather than a customer.
+  if (config.USE_DB_AUTHENTICATION !== true) return null;
+  const orgId = acuc?.org_id ?? null;
+  return orgId === PREVIEW_ORG_SENTINEL ? null : orgId;
+}
+
+/** The org a team bills against, from its ACUC. Null when DB auth is off (the
+ *  mock ACUC's org is a sentinel, not a customer) or the team has no org. */
+export async function orgIdForTeam(teamId: string): Promise<string | null> {
+  // Neither mock's ACUC is worth fetching: the DB lookup this replaced threw
+  // for both, and every caller reads null as "no billable identity" and fails
+  // open, which is the answer that throw produced.
+  if (config.USE_DB_AUTHENTICATION !== true) return null;
+  if (teamId === "preview" || teamId.startsWith("preview_")) return null;
+
+  try {
+    return orgIdFromAcuc(await getACUCTeam(teamId));
+  } catch (error) {
+    logger.warn("Failed to resolve the team's org from its ACUC", {
+      teamId,
+      error,
+    });
+    return null;
+  }
+}

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -143,6 +143,9 @@ export function checkCreditsMiddleware(
 
       const autumnResult = await autumnService.checkCredits({
         teamId: req.auth.team_id,
+        // The ACUC already carries the org, so the credit check does not have
+        // to read `teams.org_id` for it.
+        orgId: req.auth.org_id,
         value: requestedCredits,
         properties: {
           source: "checkCreditsMiddleware",
@@ -183,6 +186,7 @@ export function checkCreditsMiddleware(
           // to the 402 below. A null re-check keeps the fail-open behavior.
           const clampedResult = await autumnService.checkCredits({
             teamId: req.auth.team_id,
+            orgId: req.auth.org_id,
             value: clampedLimit,
             properties: {
               source: "checkCreditsMiddleware:clamp",

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -141,11 +141,21 @@ export function checkCreditsMiddleware(
 
       const requestedCredits = minimum ?? 1;
 
+      // No org means no billable identity to gate: keyless and preview teams
+      // carry none, and neither does the DB-authentication bypass. `checkCredits`
+      // answered null for exactly those, so take its fail-open branch here
+      // rather than hand the service an org it would have to go and find.
+      const orgId = req.auth.org_id;
+      if (!orgId) {
+        req.account = { remainingCredits: Infinity };
+        return next();
+      }
+
       const autumnResult = await autumnService.checkCredits({
         teamId: req.auth.team_id,
         // The ACUC already carries the org, so the credit check does not have
         // to read `teams.org_id` for it.
-        orgId: req.auth.org_id,
+        orgId,
         value: requestedCredits,
         properties: {
           source: "checkCreditsMiddleware",
@@ -186,7 +196,7 @@ export function checkCreditsMiddleware(
           // to the 402 below. A null re-check keeps the fail-open behavior.
           const clampedResult = await autumnService.checkCredits({
             teamId: req.auth.team_id,
-            orgId: req.auth.org_id,
+            orgId,
             value: clampedLimit,
             properties: {
               source: "checkCreditsMiddleware:clamp",

--- a/apps/api/src/search/scrape.ts
+++ b/apps/api/src/search/scrape.ts
@@ -220,6 +220,7 @@ export async function scrapeSearchResults(
 
   const jobPriority = await getJobPriority({
     team_id: options.teamId,
+    org_id: options.orgId ?? null,
     basePriority: 10,
   });
 

--- a/apps/api/src/services/autumn/__tests__/autumn.service.org-source.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.org-source.test.ts
@@ -1,8 +1,9 @@
 /**
  * The org comes from the caller, and nowhere else: AutumnService must have no
- * way to look one up. controllers/auth is mocked with a factory that throws, so
- * a service that reaches for the ACUC again — directly or through a helper —
- * fails this file at import time rather than quietly resolving its own org.
+ * way to look one up. controllers/auth and lib/team-org are mocked with
+ * factories that throw, so a service that reaches for the ACUC again — directly
+ * or through the shared helper — fails this file at import time rather than
+ * quietly resolving its own org.
  */
 
 import { vi } from "vitest";
@@ -30,9 +31,13 @@ const { mockCheck, mockTrack, mockAutumnClient } = vi.hoisted(() => {
   };
 });
 
-// The seam: importing this module at all is the failure.
+// The seam: importing either module at all is the failure.
 vi.mock("../../../controllers/auth", () => {
   throw new Error("autumn.service must not import controllers/auth");
+});
+
+vi.mock("../../../lib/team-org", () => {
+  throw new Error("autumn.service must not import lib/team-org");
 });
 
 vi.mock("../client", () => ({

--- a/apps/api/src/services/autumn/__tests__/autumn.service.org-source.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.org-source.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The org comes from the caller, and nowhere else: AutumnService must have no
+ * way to look one up. controllers/auth is mocked with a factory that throws, so
+ * a service that reaches for the ACUC again — directly or through a helper —
+ * fails this file at import time rather than quietly resolving its own org.
+ */
+
+import { vi } from "vitest";
+
+const { mockCheck, mockTrack, mockAutumnClient } = vi.hoisted(() => {
+  const mockCheck = vi
+    .fn<(args: any) => Promise<any>>()
+    .mockResolvedValue({ allowed: true, customerId: "org-1", balance: null });
+  const mockTrack = vi
+    .fn<(args: any) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  return {
+    mockCheck,
+    mockTrack,
+    mockAutumnClient: {
+      customers: { getOrCreate: vi.fn().mockResolvedValue({ id: "org-1" }) },
+      entities: {
+        get: vi.fn().mockResolvedValue({ balances: { CREDITS: { usage: 0 } } }),
+        create: vi.fn().mockResolvedValue({ id: "team-1" }),
+      },
+      balances: { finalize: vi.fn().mockResolvedValue(undefined) },
+      check: mockCheck,
+      track: mockTrack,
+    },
+  };
+});
+
+// The seam: importing this module at all is the failure.
+vi.mock("../../../controllers/auth", () => {
+  throw new Error("autumn.service must not import controllers/auth");
+});
+
+vi.mock("../client", () => ({
+  autumnClient: mockAutumnClient,
+}));
+
+vi.mock("../../../db/connection", () => ({
+  dbRr: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }),
+    }),
+  },
+}));
+
+vi.mock("../../../config", () => ({
+  // Stubbed so importing the real config (which parses env) is avoided.
+  config: {},
+}));
+
+// Import AFTER the mocks are wired up.
+import { AutumnService } from "../autumn.service";
+
+const CALLER_ORG = "3f2c1b8e-7a4d-4c1e-9b6a-0d5e8f2a1c74";
+
+describe("AutumnService resolves no org of its own", () => {
+  it("checks credits against the org the caller handed in", async () => {
+    const result = await new AutumnService().checkCredits({
+      teamId: "team-1",
+      orgId: CALLER_ORG,
+      value: 42,
+    });
+
+    expect(result).toEqual({ allowed: true, remaining: 0 });
+    expect(mockCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: CALLER_ORG, entityId: "team-1" }),
+    );
+  });
+
+  it("tracks credits against the org the caller handed in", async () => {
+    await new AutumnService().trackCredits({
+      teamId: "team-1",
+      orgId: CALLER_ORG,
+      value: 7,
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: CALLER_ORG, entityId: "team-1" }),
+    );
+  });
+});

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -1961,6 +1961,52 @@ describe("org id hint", () => {
     );
   });
 
+  // A read already in flight is what a hintless caller awaits today and costs
+  // nothing extra, so it wins over the hint. Otherwise the hint would seed the
+  // cache and the older read would land after it, for a whole TTL.
+  it("awaits an in-flight hintless lookup rather than using the hint", async () => {
+    const svc = makeService();
+
+    let resolveLookup!: (rows: unknown[]) => void;
+    state.dbLimitOverride = () => {
+      orgLookups++;
+      return new Promise<unknown[]>(resolve => {
+        resolveLookup = resolve;
+      });
+    };
+
+    const hintless = svc.trackCredits({ teamId: "team-1", value: 1 });
+    await Promise.resolve();
+    expect(orgLookups).toBe(1);
+
+    // Reaches resolveOrgId while that read is still open.
+    const hinted = svc.checkCredits({
+      teamId: "team-1",
+      value: 42,
+      orgId: HINT_ORG,
+    });
+
+    // Counted, not held open: a second read would show up in orgLookups.
+    state.dbLimitOverride = () => {
+      orgLookups++;
+      return Promise.resolve([{ org_id: "org-2" }]);
+    };
+    resolveLookup([{ org_id: "org-2" }]);
+    await Promise.all([hintless, hinted]);
+
+    expect(orgLookups).toBe(1);
+    expect(mockCheck).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customerId: "org-2" }),
+    );
+
+    // The hint seeded nothing, so a later hintless biller still bills org-2.
+    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    expect(orgLookups).toBe(1);
+    expect(mockTrack).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customerId: "org-2" }),
+    );
+  });
+
   // The synthetic ACUCs carry these, and no `teams.org_id` read could ever
   // return one, so a team holding one has to keep taking today's path.
   it.each(["preview", "bypass", "", "org-1", "not a uuid"])(
@@ -2065,6 +2111,17 @@ describe("inline provisioning counters", () => {
     await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
 
     expect(await entityCreates("ensureTeamProvisioned")).toBe(0);
+  });
+
+  // The counter measures load put on Autumn, so a call that got there and
+  // failed counts the same as one that succeeded.
+  it("counts a customer call that reached Autumn and failed", async () => {
+    const svc = makeService();
+    mockGetOrCreate.mockRejectedValueOnce(new Error("autumn unavailable"));
+
+    await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+
+    expect(await customerCalls()).toBe(1);
   });
 
   it("counts nothing when the entity is already present", async () => {

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -3,7 +3,8 @@
  *
  * All external I/O is mocked:
  *   - autumnClient  →  vi.fn() stubs on customers / entities / track
- *   - dbRr          →  stubbed Drizzle query builder
+ *   - getACUCTeam   →  the team's ACUC, which carries the org
+ *   - dbRr          →  stubbed Drizzle query builder (gateway lookup only)
  */
 
 import { vi } from "vitest";
@@ -20,6 +21,7 @@ const {
   mockGetOrCreate,
   mockEntityGet,
   mockEntityCreate,
+  mockGetACUCTeam,
   mockAutumnClient,
   makeDbStub,
   state,
@@ -47,35 +49,25 @@ const {
     track: mockTrack,
   };
 
-  // Minimal Drizzle query-builder stub: .select().from().where().limit() → rows.
-  //
-  // Table-aware by the selected columns, because two different lookups share it:
-  // the team → org_id resolution, and the gateway-provisioning check. Returning
-  // one row for both would make every team look partner-provisioned.
-  const makeDbStub = (
-    data: unknown,
-    gatewayRow: unknown,
-    gatewayThrows = false,
-  ) => ({
-    select: (fields?: Record<string, unknown>) => {
-      const isGatewayLookup = !!fields && "team_id" in fields;
-      if (isGatewayLookup && gatewayThrows) {
+  // The team's ACUC, which is where the org now comes from. `null` is a team
+  // the lookup cannot name — the shape that makes every biller fail open.
+  const mockGetACUCTeam = vi.fn(async (teamId: string) =>
+    state.acucOrgId === null
+      ? null
+      : { team_id: teamId, org_id: state.acucOrgId },
+  );
+
+  // Minimal Drizzle query-builder stub for the one lookup still on the
+  // replica: .select().from().where().limit() → the gateway-provisioning rows.
+  const makeDbStub = (gatewayRow: unknown, gatewayThrows = false) => ({
+    select: () => {
+      if (gatewayThrows) {
         throw new Error("replica unavailable");
       }
-      const rows = isGatewayLookup
-        ? gatewayRow
-          ? [gatewayRow]
-          : []
-        : data
-          ? [data]
-          : [];
       return {
         from: () => ({
           where: () => ({
-            limit: () =>
-              !isGatewayLookup && state.dbLimitOverride
-                ? state.dbLimitOverride()
-                : Promise.resolve(rows),
+            limit: () => Promise.resolve(gatewayRow ? [gatewayRow] : []),
           }),
         }),
       };
@@ -89,24 +81,20 @@ const {
     mockGetOrCreate,
     mockEntityGet,
     mockEntityCreate,
+    mockGetACUCTeam,
     mockAutumnClient,
     makeDbStub,
     // Mutable state individual tests tweak (e.g. set state.autumnClientRef = null to
     // simulate a missing API key).
     state: {
       autumnClientRef: mockAutumnClient as typeof mockAutumnClient | null,
-      supabaseStubData: { data: { org_id: "org-1" }, error: null } as {
-        data: unknown;
-        error: unknown;
-      },
+      // Org the team's ACUC carries; null = no ACUC, so no org can be named.
+      acucOrgId: "org-1" as string | null,
       // Row the partner_provisioned_accounts lookup finds. null = not
       // which is what almost every team is.
       gatewayStubRow: null as unknown,
       // Makes the gateway lookup throw, to prove a failure is never cached.
       gatewayStubThrows: false,
-      // When set, replaces the team → org_id query result (e.g. to hold a
-      // lookup open and observe how many are issued).
-      dbLimitOverride: null as (() => Promise<unknown[]>) | null,
       configRef: {} as Record<string, unknown>,
     },
   };
@@ -120,12 +108,12 @@ vi.mock("../client", () => ({
 
 vi.mock("../../../db/connection", () => ({
   get dbRr() {
-    return makeDbStub(
-      state.supabaseStubData.data,
-      state.gatewayStubRow,
-      state.gatewayStubThrows,
-    );
+    return makeDbStub(state.gatewayStubRow, state.gatewayStubThrows);
   },
+}));
+
+vi.mock("../../../controllers/auth", () => ({
+  getACUCTeam: mockGetACUCTeam,
 }));
 
 vi.mock("../../../config", () => ({
@@ -167,7 +155,7 @@ function makeEntity(usage: number) {
 beforeEach(() => {
   vi.clearAllMocks();
   state.autumnClientRef = mockAutumnClient;
-  state.supabaseStubData = { data: { org_id: "org-1" }, error: null };
+  state.acucOrgId = "org-1";
   state.configRef = {};
   mockCheck.mockResolvedValue({
     allowed: true,
@@ -378,35 +366,12 @@ describe("ensureTrackingContext warm-cache short-circuit", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Org moves: the team → org cache must expire and re-provision under the new org
+// Org moves: the ACUC names the org on every billing call, so a move follows it
+// — including re-provisioning the entity under the new customer.
 // ---------------------------------------------------------------------------
 
 describe("team org change", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("keeps billing the cached org while the mapping is fresh", async () => {
-    vi.useFakeTimers();
-    const svc = makeService();
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    expect(mockTrack).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: "org-1" }),
-    );
-
-    // Org moves in the DB, but the cache has not expired yet (default 300s).
-    state.supabaseStubData = { data: { org_id: "org-2" }, error: null };
-    vi.advanceTimersByTime(299_000);
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    expect(mockTrack).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: "org-1" }),
-    );
-  });
-
-  it("re-reads the org after the TTL and provisions the entity under the new org", async () => {
-    vi.useFakeTimers();
+  it("bills the new org and provisions the entity under it", async () => {
     const svc = makeService();
 
     await svc.trackCredits({ teamId: "team-1", value: 1 });
@@ -415,10 +380,9 @@ describe("team org change", () => {
     );
     const entityGetsBefore = mockEntityGet.mock.calls.length;
 
-    state.supabaseStubData = { data: { org_id: "org-2" }, error: null };
+    state.acucOrgId = "org-2";
     // The entity does not exist under the new customer yet.
     mockEntityGet.mockResolvedValue(null);
-    vi.advanceTimersByTime(301_000);
 
     await svc.trackCredits({ teamId: "team-1", value: 1 });
 
@@ -441,7 +405,6 @@ describe("team org change", () => {
   });
 
   it("checkCredits follows the org move too", async () => {
-    vi.useFakeTimers();
     const svc = makeService();
 
     await svc.checkCredits({ teamId: "team-1", value: 1 });
@@ -449,59 +412,10 @@ describe("team org change", () => {
       expect.objectContaining({ customerId: "org-1" }),
     );
 
-    state.supabaseStubData = { data: { org_id: "org-2" }, error: null };
-    vi.advanceTimersByTime(301_000);
+    state.acucOrgId = "org-2";
 
     await svc.checkCredits({ teamId: "team-1", value: 1 });
     expect(mockCheck).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: "org-2" }),
-    );
-  });
-
-  it("collapses concurrent expired-cache refreshes into one DB lookup", async () => {
-    vi.useFakeTimers();
-    const svc = makeService();
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    vi.advanceTimersByTime(301_000);
-
-    // Make the org lookup observable and slow.
-    let resolveLookup!: (rows: unknown[]) => void;
-    let lookups = 0;
-    state.dbLimitOverride = () => {
-      lookups++;
-      return new Promise<unknown[]>(resolve => {
-        resolveLookup = resolve;
-      });
-    };
-
-    const a = svc.trackCredits({ teamId: "team-1", value: 1 });
-    const b = svc.trackCredits({ teamId: "team-1", value: 1 });
-    const c = svc.trackCredits({ teamId: "team-1", value: 1 });
-    await Promise.resolve();
-    expect(lookups).toBe(1);
-
-    state.dbLimitOverride = null;
-    resolveLookup([{ org_id: "org-2" }]);
-    await Promise.all([a, b, c]);
-
-    expect(lookups).toBe(1);
-    for (const call of mockTrack.mock.calls.slice(-3)) {
-      expect(call[0]).toEqual(expect.objectContaining({ customerId: "org-2" }));
-    }
-  });
-
-  it("honours AUTUMN_ORG_CACHE_TTL_SECONDS", async () => {
-    vi.useFakeTimers();
-    state.configRef = { AUTUMN_ORG_CACHE_TTL_SECONDS: 10 };
-    const svc = makeService();
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    state.supabaseStubData = { data: { org_id: "org-2" }, error: null };
-    vi.advanceTimersByTime(11_000);
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    expect(mockTrack).toHaveBeenLastCalledWith(
       expect.objectContaining({ customerId: "org-2" }),
     );
   });
@@ -904,7 +818,6 @@ describe("firebill routing", () => {
     // Default every test to not partner-provisioned, which almost every team is.
     state.gatewayStubRow = null;
     state.gatewayStubThrows = false;
-    state.dbLimitOverride = null;
   });
 
   afterEach(() => {
@@ -1676,8 +1589,8 @@ describe("firebill routing", () => {
   // well as unreported — a worse loss than the missing label.
   it("still finalizes when it cannot name the org, rather than abandoning the settle", async () => {
     state.configRef = firebillConfig();
-    // No org row for this team, so resolving the customer throws.
-    state.supabaseStubData = { data: null, error: null };
+    // No ACUC for this team, so resolving the customer throws.
+    state.acucOrgId = null;
     const svc = makeService();
 
     await expect(
@@ -1876,166 +1789,73 @@ describe("firebill routing", () => {
 });
 
 // ---------------------------------------------------------------------------
-// The org id hint: the request's ACUC already carries the org, so the credit
-// check should not read `teams.org_id` for it.
+// Where the org comes from: the caller's, else the team's ACUC — nothing else.
 // ---------------------------------------------------------------------------
 
-describe("org id hint", () => {
-  // Shaped like the column (`teams.org_id` is a uuid), which is what makes it
-  // usable at all.
-  const HINT_ORG = "3f2c1b8e-7a4d-4c1e-9b6a-0d5e8f2a1c74";
+describe("org resolution", () => {
+  const CALLER_ORG = "3f2c1b8e-7a4d-4c1e-9b6a-0d5e8f2a1c74";
 
-  // Counts team → org_id reads only; the stub answers the gateway lookup
-  // separately.
-  let orgLookups = 0;
-
-  beforeEach(() => {
-    orgLookups = 0;
-    state.dbLimitOverride = () => {
-      orgLookups++;
-      return Promise.resolve([{ org_id: "org-1" }]);
-    };
-  });
-
-  afterEach(() => {
-    state.dbLimitOverride = null;
-    vi.useRealTimers();
-  });
-
-  it("checks the hinted org against Autumn with no DB read", async () => {
+  it("bills the caller's org without reading the ACUC", async () => {
     const svc = makeService();
 
     const result = await svc.checkCredits({
       teamId: "team-1",
       value: 42,
-      orgId: HINT_ORG,
+      orgId: CALLER_ORG,
     });
 
     expect(result).toEqual({ allowed: true, remaining: 0 });
-    expect(orgLookups).toBe(0);
+    expect(mockGetACUCTeam).not.toHaveBeenCalled();
     expect(mockCheck).toHaveBeenCalledWith(
-      expect.objectContaining({ customerId: HINT_ORG, entityId: "team-1" }),
+      expect.objectContaining({ customerId: CALLER_ORG, entityId: "team-1" }),
     );
   });
 
-  it("reads the DB exactly once when the caller has no hint", async () => {
+  it("reads the ACUC exactly once when the caller has no org", async () => {
     const svc = makeService();
 
     await svc.checkCredits({ teamId: "team-1", value: 42 });
 
-    expect(orgLookups).toBe(1);
+    expect(mockGetACUCTeam).toHaveBeenCalledTimes(1);
+    expect(mockGetACUCTeam).toHaveBeenCalledWith("team-1");
     expect(mockCheck).toHaveBeenCalledWith(
       expect.objectContaining({ customerId: "org-1" }),
     );
   });
 
-  // The ACUC is Redis-cached for longer than this cache lives, so a hint can
-  // arrive staler than what a warm pod already read. The cache keeps winning.
-  it("a fresh cached org wins over a differing hint", async () => {
-    const svc = makeService();
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    expect(orgLookups).toBe(1);
-
-    await svc.checkCredits({ teamId: "team-1", value: 42, orgId: HINT_ORG });
-
-    expect(orgLookups).toBe(1);
-    expect(mockCheck).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: "org-1" }),
-    );
-  });
-
-  it("an expired entry is replaced by the hint without a DB read", async () => {
-    vi.useFakeTimers();
-    const svc = makeService();
-
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    expect(orgLookups).toBe(1);
-    vi.advanceTimersByTime(301_000);
-
-    await svc.checkCredits({ teamId: "team-1", value: 42, orgId: HINT_ORG });
-
-    expect(orgLookups).toBe(1);
-    expect(mockCheck).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: HINT_ORG }),
-    );
-  });
-
-  // A read already in flight is what a hintless caller awaits today and costs
-  // nothing extra, so it wins over the hint. Otherwise the hint would seed the
-  // cache and the older read would land after it, for a whole TTL.
-  it("awaits an in-flight hintless lookup rather than using the hint", async () => {
-    const svc = makeService();
-
-    let resolveLookup!: (rows: unknown[]) => void;
-    state.dbLimitOverride = () => {
-      orgLookups++;
-      return new Promise<unknown[]>(resolve => {
-        resolveLookup = resolve;
-      });
-    };
-
-    const hintless = svc.trackCredits({ teamId: "team-1", value: 1 });
-    await Promise.resolve();
-    expect(orgLookups).toBe(1);
-
-    // Reaches resolveOrgId while that read is still open.
-    const hinted = svc.checkCredits({
-      teamId: "team-1",
-      value: 42,
-      orgId: HINT_ORG,
+  // An unnameable org is what every biller already fails open on, so the
+  // answers here are the ones a missing `teams.org_id` produced before.
+  describe("when the ACUC names no org", () => {
+    beforeEach(() => {
+      state.acucOrgId = null;
     });
 
-    // Counted, not held open: a second read would show up in orgLookups.
-    state.dbLimitOverride = () => {
-      orgLookups++;
-      return Promise.resolve([{ org_id: "org-2" }]);
-    };
-    resolveLookup([{ org_id: "org-2" }]);
-    await Promise.all([hintless, hinted]);
-
-    expect(orgLookups).toBe(1);
-    expect(mockCheck).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: "org-2" }),
-    );
-
-    // The hint seeded nothing, so a later hintless biller still bills org-2.
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-    expect(orgLookups).toBe(1);
-    expect(mockTrack).toHaveBeenLastCalledWith(
-      expect.objectContaining({ customerId: "org-2" }),
-    );
-  });
-
-  // The synthetic ACUCs carry these, and no `teams.org_id` read could ever
-  // return one, so a team holding one has to keep taking today's path.
-  it.each(["preview", "bypass", "", "org-1", "not a uuid"])(
-    "ignores %j as a hint and resolves the org from the DB",
-    async orgId => {
+    it("checkCredits falls back with null", async () => {
       const svc = makeService();
+      await expect(
+        svc.checkCredits({ teamId: "team-1", value: 42 }),
+      ).resolves.toBeNull();
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
 
-      await svc.checkCredits({ teamId: "team-1", value: 42, orgId });
+    it("trackCredits reports that nothing was tracked", async () => {
+      const svc = makeService();
+      await expect(
+        svc.trackCredits({ teamId: "team-1", value: 42 }),
+      ).resolves.toBe(false);
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
 
-      expect(orgLookups).toBe(1);
-      expect(mockCheck).toHaveBeenCalledWith(
-        expect.objectContaining({ customerId: "org-1" }),
-      );
-    },
-  );
-
-  it("seeds the org cache, so a later biller with no hint reads nothing", async () => {
-    const svc = makeService();
-
-    await svc.checkCredits({ teamId: "team-1", value: 1, orgId: HINT_ORG });
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
-
-    expect(orgLookups).toBe(0);
-    expect(mockTrack).toHaveBeenCalledWith(
-      expect.objectContaining({ customerId: HINT_ORG }),
-    );
+    it("lockCredits skips the hold", async () => {
+      const svc = makeService();
+      await expect(
+        svc.lockCredits({ teamId: "team-1", value: 42 }),
+      ).resolves.toEqual({ status: "skipped" });
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
   });
 
-  it("sends the hinted org to firebill as the customer", async () => {
+  it("sends the caller's org to firebill as the customer", async () => {
     const mockFetch = vi.fn<(url: any, init?: any) => Promise<Response>>();
     mockFetch.mockResolvedValue(
       new Response(
@@ -2047,7 +1867,7 @@ describe("org id hint", () => {
     state.configRef = {
       FIREBILL_URL: "http://firebill.test",
       FIREBILL_SECRET: "fb-secret",
-      FIREBILL_ORG_IDS: [HINT_ORG],
+      FIREBILL_ORG_IDS: [CALLER_ORG],
     };
 
     try {
@@ -2057,15 +1877,15 @@ describe("org id hint", () => {
         teamId: "team-1",
         value: 100,
         properties: { source: "checkCreditsMiddleware" },
-        orgId: HINT_ORG,
+        orgId: CALLER_ORG,
       });
 
       expect(result).toEqual({ allowed: true, remaining: 500 });
-      expect(orgLookups).toBe(0);
+      expect(mockGetACUCTeam).not.toHaveBeenCalled();
       expect(mockCheck).not.toHaveBeenCalled();
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(String(url)).toBe("http://firebill.test/v1/check");
-      expect(JSON.parse(init.body).customer_id).toBe(HINT_ORG);
+      expect(JSON.parse(init.body).customer_id).toBe(CALLER_ORG);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -119,8 +119,10 @@ vi.mock("../../../controllers/auth", () => ({
 vi.mock("../../../config", () => ({
   // Stubbed so importing the real config (which parses env) is avoided.
   // A getter so individual tests can swap the config (e.g. firebill routing).
+  // DB auth is on by default — the deployed shape, and the only one in which a
+  // team's ACUC carries a real org — so a test must opt out of it explicitly.
   get config() {
-    return state.configRef;
+    return { USE_DB_AUTHENTICATION: true, ...state.configRef };
   },
 }));
 
@@ -1852,6 +1854,58 @@ describe("org resolution", () => {
         svc.lockCredits({ teamId: "team-1", value: 42 }),
       ).resolves.toEqual({ status: "skipped" });
       expect(mockCheck).not.toHaveBeenCalled();
+    });
+  });
+
+  // Without DB auth getACUCTeam hands back a mock ACUC carrying a synthetic
+  // org, so the ACUC must not be consulted at all: these are the same fail-open
+  // answers the DB lookup gave when it had no database to read.
+  describe("when DB authentication is off", () => {
+    beforeEach(() => {
+      state.configRef = { USE_DB_AUTHENTICATION: false };
+    });
+
+    it("checkCredits falls back with null without reading the ACUC", async () => {
+      const svc = makeService();
+      await expect(
+        svc.checkCredits({ teamId: "team-1", value: 42 }),
+      ).resolves.toBeNull();
+      expect(mockGetACUCTeam).not.toHaveBeenCalled();
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
+
+    it("trackCredits reports that nothing was tracked", async () => {
+      const svc = makeService();
+      await expect(
+        svc.trackCredits({ teamId: "team-1", value: 42 }),
+      ).resolves.toBe(false);
+      expect(mockGetACUCTeam).not.toHaveBeenCalled();
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+
+    it("lockCredits skips the hold", async () => {
+      const svc = makeService();
+      await expect(
+        svc.lockCredits({ teamId: "team-1", value: 42 }),
+      ).resolves.toEqual({ status: "skipped" });
+      expect(mockGetACUCTeam).not.toHaveBeenCalled();
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
+
+    it("still bills a caller-supplied org", async () => {
+      const svc = makeService();
+
+      const result = await svc.checkCredits({
+        teamId: "team-1",
+        value: 42,
+        orgId: CALLER_ORG,
+      });
+
+      expect(result).toEqual({ allowed: true, remaining: 0 });
+      expect(mockGetACUCTeam).not.toHaveBeenCalled();
+      expect(mockCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ customerId: CALLER_ORG, entityId: "team-1" }),
+      );
     });
   });
 

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -9,8 +9,6 @@
  * every org below is one the caller hands in.
  */
 
-import { readFileSync } from "fs";
-import { join } from "path";
 import { vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -1885,17 +1883,8 @@ describe("firebill routing", () => {
 describe("the org the caller supplies", () => {
   const CALLER_ORG = "3f2c1b8e-7a4d-4c1e-9b6a-0d5e8f2a1c74";
 
-  // The point of the change this file guards: the service has no way to look an
-  // org up, so a later edit cannot quietly reach for one instead of threading
-  // the org its caller already holds.
-  it("cannot be resolved by the service: no ACUC lookup is even imported", () => {
-    const source = readFileSync(
-      join(__dirname, "..", "autumn.service.ts"),
-      "utf-8",
-    );
-    expect(source).not.toContain("getACUCTeam");
-    expect(source).not.toContain("resolveOrgId");
-  });
+  // That the service has no way to look an org up at all is guarded by
+  // autumn.service.org-source.test.ts, which mocks controllers/auth to throw.
 
   it("bills the caller's org", async () => {
     const svc = makeService();

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -3,10 +3,14 @@
  *
  * All external I/O is mocked:
  *   - autumnClient  →  vi.fn() stubs on customers / entities / track
- *   - getACUCTeam   →  the team's ACUC, which carries the org
  *   - dbRr          →  stubbed Drizzle query builder (gateway lookup only)
+ *
+ * There is deliberately no getACUCTeam mock: the service cannot reach it, and
+ * every org below is one the caller hands in.
  */
 
+import { readFileSync } from "fs";
+import { join } from "path";
 import { vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -21,7 +25,6 @@ const {
   mockGetOrCreate,
   mockEntityGet,
   mockEntityCreate,
-  mockGetACUCTeam,
   mockAutumnClient,
   makeDbStub,
   state,
@@ -49,14 +52,6 @@ const {
     track: mockTrack,
   };
 
-  // The team's ACUC, which is where the org now comes from. `null` is a team
-  // the lookup cannot name — the shape that makes every biller fail open.
-  const mockGetACUCTeam = vi.fn(async (teamId: string) =>
-    state.acucOrgId === null
-      ? null
-      : { team_id: teamId, org_id: state.acucOrgId },
-  );
-
   // Minimal Drizzle query-builder stub for the one lookup still on the
   // replica: .select().from().where().limit() → the gateway-provisioning rows.
   const makeDbStub = (gatewayRow: unknown, gatewayThrows = false) => ({
@@ -81,15 +76,12 @@ const {
     mockGetOrCreate,
     mockEntityGet,
     mockEntityCreate,
-    mockGetACUCTeam,
     mockAutumnClient,
     makeDbStub,
     // Mutable state individual tests tweak (e.g. set state.autumnClientRef = null to
     // simulate a missing API key).
     state: {
       autumnClientRef: mockAutumnClient as typeof mockAutumnClient | null,
-      // Org the team's ACUC carries; null = no ACUC, so no org can be named.
-      acucOrgId: "org-1" as string | null,
       // Row the partner_provisioned_accounts lookup finds. null = not
       // which is what almost every team is.
       gatewayStubRow: null as unknown,
@@ -112,17 +104,11 @@ vi.mock("../../../db/connection", () => ({
   },
 }));
 
-vi.mock("../../../controllers/auth", () => ({
-  getACUCTeam: mockGetACUCTeam,
-}));
-
 vi.mock("../../../config", () => ({
   // Stubbed so importing the real config (which parses env) is avoided.
   // A getter so individual tests can swap the config (e.g. firebill routing).
-  // DB auth is on by default — the deployed shape, and the only one in which a
-  // team's ACUC carries a real org — so a test must opt out of it explicitly.
   get config() {
-    return { USE_DB_AUTHENTICATION: true, ...state.configRef };
+    return { ...state.configRef };
   },
 }));
 
@@ -157,7 +143,6 @@ function makeEntity(usage: number) {
 beforeEach(() => {
   vi.clearAllMocks();
   state.autumnClientRef = mockAutumnClient;
-  state.acucOrgId = "org-1";
   state.configRef = {};
   mockCheck.mockResolvedValue({
     allowed: true,
@@ -298,7 +283,7 @@ describe("ensureTeamProvisioned", () => {
 
       // Provisioning remains best-effort: a lookup failure must not stop billing.
       await expect(
-        svc.trackCredits({ teamId: "team-1", value: 5 }),
+        svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 5 }),
       ).resolves.toBe(true);
       expect(mockEntityCreate).not.toHaveBeenCalled();
       expect(mockTrack).toHaveBeenCalledTimes(1);
@@ -356,11 +341,11 @@ describe("ensureTrackingContext warm-cache short-circuit", () => {
     mockEntityGet.mockResolvedValue(makeEntity(0));
 
     // Warm the caches.
-    await svc.trackCredits({ teamId: "team-1", value: 5 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 5 });
     const callsAfterWarm = mockEntityGet.mock.calls.length;
 
     // Subsequent call — should not touch provisioning.
-    await svc.trackCredits({ teamId: "team-1", value: 5 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 5 });
 
     // No additional getEntity calls for provisioning.
     expect(mockEntityGet.mock.calls.length).toBe(callsAfterWarm);
@@ -368,25 +353,24 @@ describe("ensureTrackingContext warm-cache short-circuit", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Org moves: the ACUC names the org on every billing call, so a move follows it
-// — including re-provisioning the entity under the new customer.
+// Org moves: the caller names the org on every billing call, so a move follows
+// it — including re-provisioning the entity under the new customer.
 // ---------------------------------------------------------------------------
 
 describe("team org change", () => {
   it("bills the new org and provisions the entity under it", async () => {
     const svc = makeService();
 
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
     expect(mockTrack).toHaveBeenLastCalledWith(
       expect.objectContaining({ customerId: "org-1", entityId: "team-1" }),
     );
     const entityGetsBefore = mockEntityGet.mock.calls.length;
 
-    state.acucOrgId = "org-2";
     // The entity does not exist under the new customer yet.
     mockEntityGet.mockResolvedValue(null);
 
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-2", value: 1 });
 
     // Provisioning ran again for the (org-2, team-1) pair...
     expect(mockEntityGet.mock.calls.length).toBe(entityGetsBefore + 1);
@@ -402,21 +386,19 @@ describe("team org change", () => {
     );
 
     // Warm again under org-2: no further provisioning calls.
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-2", value: 1 });
     expect(mockEntityGet.mock.calls.length).toBe(entityGetsBefore + 1);
   });
 
   it("checkCredits follows the org move too", async () => {
     const svc = makeService();
 
-    await svc.checkCredits({ teamId: "team-1", value: 1 });
+    await svc.checkCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
     expect(mockCheck).toHaveBeenLastCalledWith(
       expect.objectContaining({ customerId: "org-1" }),
     );
 
-    state.acucOrgId = "org-2";
-
-    await svc.checkCredits({ teamId: "team-1", value: 1 });
+    await svc.checkCredits({ teamId: "team-1", orgId: "org-2", value: 1 });
     expect(mockCheck).toHaveBeenLastCalledWith(
       expect.objectContaining({ customerId: "org-2" }),
     );
@@ -431,7 +413,11 @@ describe("lockCredits", () => {
   it("returns skipped when autumnClient is null", async () => {
     state.autumnClientRef = null;
     const svc = makeService();
-    const result = await svc.lockCredits({ teamId: "team-1", value: 10 });
+    const result = await svc.lockCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 10,
+    });
     expect(result).toEqual({ status: "skipped" });
     expect(mockCheck).not.toHaveBeenCalled();
   });
@@ -440,6 +426,7 @@ describe("lockCredits", () => {
     const svc = makeService();
     const result = await svc.lockCredits({
       teamId: "preview_abc",
+      orgId: "org-1",
       value: 10,
     });
     expect(result).toEqual({ status: "skipped" });
@@ -451,6 +438,7 @@ describe("lockCredits", () => {
 
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 42,
       lockId: "lock-123",
       properties: { source: "billTeam", endpoint: "extract" },
@@ -481,6 +469,7 @@ describe("lockCredits", () => {
     const svc = makeService();
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "lock-123",
     });
@@ -492,6 +481,7 @@ describe("lockCredits", () => {
     const svc = makeService();
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "lock-123",
     });
@@ -507,7 +497,11 @@ describe("checkCredits", () => {
   it("returns null when autumnClient is null", async () => {
     state.autumnClientRef = null;
     const svc = makeService();
-    const result = await svc.checkCredits({ teamId: "team-1", value: 10 });
+    const result = await svc.checkCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 10,
+    });
     expect(result).toBeNull();
     expect(mockCheck).not.toHaveBeenCalled();
   });
@@ -521,6 +515,7 @@ describe("checkCredits", () => {
     const svc = makeService();
     const result = await svc.checkCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 42,
       properties: { source: "checkCreditsMiddleware" },
     });
@@ -547,7 +542,11 @@ describe("checkCredits", () => {
       balance: null,
     });
     const svc = makeService();
-    const result = await svc.checkCredits({ teamId: "team-1", value: 10 });
+    const result = await svc.checkCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 10,
+    });
     expect(result).toEqual({ allowed: false, remaining: 0 });
   });
 
@@ -555,6 +554,7 @@ describe("checkCredits", () => {
     const svc = makeService();
     await svc.checkCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 5,
       featureId: "SEARCH_CREDITS",
     });
@@ -572,7 +572,11 @@ describe("trackCredits", () => {
   it("returns false when autumnClient is null", async () => {
     state.autumnClientRef = null;
     const svc = makeService();
-    const result = await svc.trackCredits({ teamId: "team-1", value: 10 });
+    const result = await svc.trackCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 10,
+    });
     expect(result).toBe(false);
     expect(mockTrack).not.toHaveBeenCalled();
   });
@@ -581,6 +585,7 @@ describe("trackCredits", () => {
     const svc = makeService();
     const result = await svc.trackCredits({
       teamId: "preview_abc",
+      orgId: "org-1",
       value: 10,
     });
     expect(result).toBe(false);
@@ -592,6 +597,7 @@ describe("trackCredits", () => {
 
     const result = await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 42,
       properties: { source: "test", endpoint: "extract" },
     });
@@ -611,7 +617,9 @@ describe("trackCredits", () => {
     mockTrack.mockRejectedValueOnce(new Error("track failed"));
     const svc = makeService();
 
-    expect(await svc.trackCredits({ teamId: "team-1", value: 42 })).toBe(false);
+    expect(
+      await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 42 }),
+    ).toBe(false);
   });
 
   it("tracks against SEARCH_CREDITS when featureId is provided", async () => {
@@ -619,6 +627,7 @@ describe("trackCredits", () => {
 
     const result = await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 7,
       properties: { source: "test", endpoint: "search" },
       featureId: "SEARCH_CREDITS",
@@ -669,6 +678,7 @@ describe("refundCredits", () => {
     const svc = makeService();
     await svc.refundCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 30,
       properties: { endpoint: "extract" },
     });
@@ -687,6 +697,7 @@ describe("refundCredits", () => {
     const svc = makeService();
     await svc.refundCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 1,
       properties: { endpoint: "search" },
       featureId: "SEARCH_CREDITS",
@@ -702,13 +713,17 @@ describe("refundCredits", () => {
   it("is a no-op when autumnClient is null", async () => {
     state.autumnClientRef = null;
     const svc = makeService();
-    await svc.refundCredits({ teamId: "team-1", value: 30 });
+    await svc.refundCredits({ teamId: "team-1", orgId: "org-1", value: 30 });
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
   it("is a no-op for preview teams", async () => {
     const svc = makeService();
-    await svc.refundCredits({ teamId: "preview_abc", value: 30 });
+    await svc.refundCredits({
+      teamId: "preview_abc",
+      orgId: "org-1",
+      value: 30,
+    });
     expect(mockTrack).not.toHaveBeenCalled();
   });
 });
@@ -835,6 +850,7 @@ describe("firebill routing", () => {
     const svc = makeService();
     await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 3,
       properties: { source: "billTeam", endpoint: "scrape" },
     });
@@ -849,6 +865,7 @@ describe("firebill routing", () => {
 
     await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 5,
       properties: { source: "billScrapeJob", endpoint: "scrape" },
       idempotencyKey: "fc:track:scrape:job-123",
@@ -859,6 +876,7 @@ describe("firebill routing", () => {
 
     await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 5,
       properties: { source: "billTeam", endpoint: "search" },
     });
@@ -881,12 +899,14 @@ describe("firebill routing", () => {
     // track and silently drop the refund.
     await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 5,
       properties: { source: "billScrapeJob", endpoint: "scrape" },
       idempotencyKey: "fc:track:scrape:job-123",
     });
     await svc.refundCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 5,
       properties: { source: "billScrapeJob", endpoint: "scrape" },
       idempotencyKey: "fc:refund:scrape:job-123",
@@ -909,6 +929,7 @@ describe("firebill routing", () => {
 
     const result = await svc.trackCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 42,
       properties: { source: "test", endpoint: "extract" },
     });
@@ -949,6 +970,7 @@ describe("firebill routing", () => {
 
     const result = await svc.checkCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 100,
       properties: { source: "checkCreditsMiddleware" },
     });
@@ -991,6 +1013,7 @@ describe("firebill routing", () => {
 
     const result = await svc.checkCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 100,
       properties: {},
     });
@@ -1014,7 +1037,12 @@ describe("firebill routing", () => {
     const svc = makeService();
 
     await expect(
-      svc.checkCredits({ teamId: "team-1", value: 100, properties: {} }),
+      svc.checkCredits({
+        teamId: "team-1",
+        orgId: "org-1",
+        value: 100,
+        properties: {},
+      }),
     ).resolves.toBeNull();
     expect(mockCheck).not.toHaveBeenCalled();
   });
@@ -1026,7 +1054,12 @@ describe("firebill routing", () => {
     };
     const svc = makeService();
 
-    await svc.checkCredits({ teamId: "team-1", value: 1, properties: {} });
+    await svc.checkCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 1,
+      properties: {},
+    });
 
     expect(mockCheck).toHaveBeenCalledTimes(1);
     expect(mockFetch).not.toHaveBeenCalled();
@@ -1038,6 +1071,7 @@ describe("firebill routing", () => {
 
     await svc.refundCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 30,
       properties: { endpoint: "extract" },
     });
@@ -1066,7 +1100,11 @@ describe("firebill routing", () => {
     state.gatewayStubRow = { team_id: "team-1" };
     const svc = makeService();
 
-    const result = await svc.trackCredits({ teamId: "team-1", value: 42 });
+    const result = await svc.trackCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 42,
+    });
 
     expect(result).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1085,11 +1123,11 @@ describe("firebill routing", () => {
     mockFetch.mockImplementation(async () => firebillResponse(true));
     const svc = makeService();
 
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
     // The row vanishing must not un-route the team: provisioning is one-way,
     // and re-reading would put a query on every billing event.
     state.gatewayStubRow = null;
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockTrack).not.toHaveBeenCalled();
@@ -1108,11 +1146,11 @@ describe("firebill routing", () => {
     mockFetch.mockImplementation(async () => firebillResponse(true));
     const svc = makeService();
 
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
     expect(mockFetch).not.toHaveBeenCalled();
 
     state.gatewayStubThrows = false;
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -1123,7 +1161,11 @@ describe("firebill routing", () => {
     };
     const svc = makeService();
 
-    const result = await svc.trackCredits({ teamId: "team-1", value: 42 });
+    const result = await svc.trackCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 42,
+    });
 
     expect(result).toBe(true);
     expect(mockFetch).not.toHaveBeenCalled();
@@ -1134,7 +1176,7 @@ describe("firebill routing", () => {
     state.configRef = { ...firebillConfig(), FIREBILL_SECRET: undefined };
     const svc = makeService();
 
-    await svc.trackCredits({ teamId: "team-1", value: 42 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 42 });
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(mockTrack).toHaveBeenCalledTimes(1);
@@ -1147,7 +1189,7 @@ describe("firebill routing", () => {
     };
     const svc = makeService();
 
-    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    await svc.trackCredits({ teamId: "team-1", orgId: "org-1", value: 1 });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockTrack).not.toHaveBeenCalled();
@@ -1158,7 +1200,11 @@ describe("firebill routing", () => {
     mockFetch.mockResolvedValue(firebillResponse(false));
     const svc = makeService();
 
-    const result = await svc.trackCredits({ teamId: "team-1", value: 42 });
+    const result = await svc.trackCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 42,
+    });
 
     expect(result).toBe(false);
     // CRITICAL: firebill may have durably recorded the event; falling back to
@@ -1171,7 +1217,11 @@ describe("firebill routing", () => {
     mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
     const svc = makeService();
 
-    const result = await svc.trackCredits({ teamId: "team-1", value: 42 });
+    const result = await svc.trackCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 42,
+    });
 
     expect(result).toBe(false);
     expect(mockTrack).not.toHaveBeenCalled();
@@ -1182,7 +1232,11 @@ describe("firebill routing", () => {
     mockFetch.mockResolvedValue(new Response("unauthorized", { status: 401 }));
     const svc = makeService();
 
-    const result = await svc.trackCredits({ teamId: "team-1", value: 42 });
+    const result = await svc.trackCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 42,
+    });
 
     expect(result).toBe(false);
     expect(mockTrack).not.toHaveBeenCalled();
@@ -1209,6 +1263,7 @@ describe("firebill routing", () => {
     const expiresAt = Date.now() + 60 * 60 * 1000;
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "monitor_check-1",
       expiresAt,
@@ -1242,7 +1297,12 @@ describe("firebill routing", () => {
     const svc = makeService();
 
     const before = Date.now();
-    await svc.lockCredits({ teamId: "team-1", value: 1, lockId: "lock-1" });
+    await svc.lockCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 1,
+      lockId: "lock-1",
+    });
 
     const lockCall = mockFetch.mock.calls.find(([url]) =>
       String(url).endsWith("/v1/lock"),
@@ -1260,6 +1320,7 @@ describe("firebill routing", () => {
 
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "lock-1",
     });
@@ -1277,6 +1338,7 @@ describe("firebill routing", () => {
 
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "lock-1",
     });
@@ -1291,12 +1353,22 @@ describe("firebill routing", () => {
 
     mockFetch.mockResolvedValueOnce(lockResponse({ success: false }));
     expect(
-      await svc.lockCredits({ teamId: "team-1", value: 10, lockId: "lock-1" }),
+      await svc.lockCredits({
+        teamId: "team-1",
+        orgId: "org-1",
+        value: 10,
+        lockId: "lock-1",
+      }),
     ).toEqual({ status: "skipped" });
 
     mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
     expect(
-      await svc.lockCredits({ teamId: "team-1", value: 10, lockId: "lock-1" }),
+      await svc.lockCredits({
+        teamId: "team-1",
+        orgId: "org-1",
+        value: 10,
+        lockId: "lock-1",
+      }),
     ).toEqual({ status: "skipped" });
 
     // A firebill-side hold may exist under this lock id; a direct-Autumn
@@ -1322,6 +1394,7 @@ describe("firebill routing", () => {
 
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "monitor_check-1",
       partnerJobToken: "job-token-abc",
@@ -1351,6 +1424,7 @@ describe("firebill routing", () => {
     for (const partnerJobToken of [undefined, null]) {
       await svc.lockCredits({
         teamId: "team-1",
+        orgId: "org-1",
         value: 10,
         lockId: "lock-1",
         partnerJobToken,
@@ -1387,13 +1461,19 @@ describe("firebill routing", () => {
         return realTimeout(ms);
       });
 
-    await svc.lockCredits({ teamId: "team-1", value: 1, lockId: "lock-1" });
+    await svc.lockCredits({
+      teamId: "team-1",
+      orgId: "org-1",
+      value: 1,
+      lockId: "lock-1",
+    });
     const plain = mockFetch.mock.calls
       .filter(([url]) => String(url).endsWith("/v1/lock"))
       .pop();
 
     await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 1,
       lockId: "lock-1",
       partnerJobToken: "job-token-abc",
@@ -1424,6 +1504,7 @@ describe("firebill routing", () => {
       expect(
         await svc.lockCredits({
           teamId: "team-1",
+          orgId: "org-1",
           value: 10,
           lockId: "lock-1",
           partnerJobToken: "job-token-abc",
@@ -1439,6 +1520,7 @@ describe("firebill routing", () => {
     expect(
       await svc.lockCredits({
         teamId: "team-1",
+        orgId: "org-1",
         value: 10,
         lockId: "lock-1",
         partnerJobToken: "job-token-abc",
@@ -1457,6 +1539,7 @@ describe("firebill routing", () => {
     expect(
       await svc.lockCredits({
         teamId: "team-1",
+        orgId: "org-1",
         value: 10,
         lockId: "lock-1",
         partnerJobToken: "job-token-abc",
@@ -1471,6 +1554,7 @@ describe("firebill routing", () => {
     const svc = makeService();
     const gated = {
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "lock-1",
       partnerJobToken: "job-token-abc",
@@ -1506,7 +1590,12 @@ describe("firebill routing", () => {
 
     mockFetch.mockResolvedValueOnce(lockResponse({ success: false }));
     expect(
-      await svc.lockCredits({ teamId: "team-1", value: 10, lockId: "lock-1" }),
+      await svc.lockCredits({
+        teamId: "team-1",
+        orgId: "org-1",
+        value: 10,
+        lockId: "lock-1",
+      }),
     ).toEqual({ status: "skipped" });
   });
 
@@ -1523,7 +1612,7 @@ describe("firebill routing", () => {
       lockId: "monitor_check-1",
       action: "confirm",
       overrideValue: 7,
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
       externalRequestId: "run-42",
     });
 
@@ -1545,7 +1634,7 @@ describe("firebill routing", () => {
       lockId: "monitor_check-1",
       action: "confirm",
       overrideValue: 7,
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
       externalRequestId: "run-42",
     });
 
@@ -1567,7 +1656,7 @@ describe("firebill routing", () => {
       lockId: "monitor_check-1",
       action: "confirm",
       overrideValue: 7,
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
       externalRequestId: "run-42",
       heldValue: 12,
     });
@@ -1589,10 +1678,8 @@ describe("firebill routing", () => {
   // billing_status "failed", and nothing reads that back. Throwing would
   // abandon the finalize, so the hold expires and the run goes unbilled as
   // well as unreported — a worse loss than the missing label.
-  it("still finalizes when it cannot name the org, rather than abandoning the settle", async () => {
+  it("still finalizes when the caller cannot name the org, rather than abandoning the settle", async () => {
     state.configRef = firebillConfig();
-    // No ACUC for this team, so resolving the customer throws.
-    state.acucOrgId = null;
     const svc = makeService();
 
     await expect(
@@ -1600,7 +1687,7 @@ describe("firebill routing", () => {
         lockId: "monitor_check-1",
         action: "confirm",
         overrideValue: 7,
-        teamId: "team-99",
+        // No org for this team, so the caller passes no team at all.
         externalRequestId: "run-42",
       }),
     ).resolves.not.toThrow();
@@ -1634,7 +1721,7 @@ describe("firebill routing", () => {
         lockId: "monitor_check-1",
         action: "confirm",
         overrideValue: 7,
-        teamId: "team-1",
+        team: { teamId: "team-1", orgId: "org-1" },
       }),
     ).resolves.toBe(true);
 
@@ -1647,7 +1734,7 @@ describe("firebill routing", () => {
         lockId: "monitor_check-2",
         action: "confirm",
         overrideValue: 7,
-        teamId: "team-1",
+        team: { teamId: "team-1", orgId: "org-1" },
       }),
     ).resolves.toBe(false);
 
@@ -1658,7 +1745,7 @@ describe("firebill routing", () => {
         lockId: "monitor_check-3",
         action: "confirm",
         overrideValue: 7,
-        teamId: "team-1",
+        team: { teamId: "team-1", orgId: "org-1" },
       }),
     ).resolves.toBe(false);
   });
@@ -1671,7 +1758,7 @@ describe("firebill routing", () => {
       lockId: "monitor_check-1",
       action: "confirm",
       overrideValue: 7,
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
     });
 
     const body = JSON.parse(
@@ -1690,7 +1777,7 @@ describe("firebill routing", () => {
     await svc.finalizeCreditsLock({
       lockId: "monitor_check-1",
       action: "confirm",
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
       externalRequestId: null,
     });
 
@@ -1711,6 +1798,7 @@ describe("firebill routing", () => {
 
     const result = await svc.lockCredits({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       lockId: "lock-1",
     });
@@ -1729,7 +1817,7 @@ describe("firebill routing", () => {
       action: "confirm",
       overrideValue: 7,
       properties: { source: "monitorCheck", endpoint: "monitor" },
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
     });
 
     expect(mockFinalize).not.toHaveBeenCalled();
@@ -1754,7 +1842,7 @@ describe("firebill routing", () => {
     await svc.finalizeCreditsLock({
       lockId: "monitor_check-1",
       action: "release",
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
     });
 
     const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
@@ -1782,7 +1870,7 @@ describe("firebill routing", () => {
     await svc.finalizeCreditsLock({
       lockId: "lock-1",
       action: "confirm",
-      teamId: "team-1",
+      team: { teamId: "team-1", orgId: "org-1" },
     });
 
     expect(mockFetch).not.toHaveBeenCalled();
@@ -1791,122 +1879,37 @@ describe("firebill routing", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Where the org comes from: the caller's, else the team's ACUC — nothing else.
+// Where the org comes from: the caller, and nowhere else.
 // ---------------------------------------------------------------------------
 
-describe("org resolution", () => {
+describe("the org the caller supplies", () => {
   const CALLER_ORG = "3f2c1b8e-7a4d-4c1e-9b6a-0d5e8f2a1c74";
 
-  it("bills the caller's org without reading the ACUC", async () => {
+  // The point of the change this file guards: the service has no way to look an
+  // org up, so a later edit cannot quietly reach for one instead of threading
+  // the org its caller already holds.
+  it("cannot be resolved by the service: no ACUC lookup is even imported", () => {
+    const source = readFileSync(
+      join(__dirname, "..", "autumn.service.ts"),
+      "utf-8",
+    );
+    expect(source).not.toContain("getACUCTeam");
+    expect(source).not.toContain("resolveOrgId");
+  });
+
+  it("bills the caller's org", async () => {
     const svc = makeService();
 
     const result = await svc.checkCredits({
       teamId: "team-1",
-      value: 42,
       orgId: CALLER_ORG,
+      value: 42,
     });
 
     expect(result).toEqual({ allowed: true, remaining: 0 });
-    expect(mockGetACUCTeam).not.toHaveBeenCalled();
     expect(mockCheck).toHaveBeenCalledWith(
       expect.objectContaining({ customerId: CALLER_ORG, entityId: "team-1" }),
     );
-  });
-
-  it("reads the ACUC exactly once when the caller has no org", async () => {
-    const svc = makeService();
-
-    await svc.checkCredits({ teamId: "team-1", value: 42 });
-
-    expect(mockGetACUCTeam).toHaveBeenCalledTimes(1);
-    expect(mockGetACUCTeam).toHaveBeenCalledWith("team-1");
-    expect(mockCheck).toHaveBeenCalledWith(
-      expect.objectContaining({ customerId: "org-1" }),
-    );
-  });
-
-  // An unnameable org is what every biller already fails open on, so the
-  // answers here are the ones a missing `teams.org_id` produced before.
-  describe("when the ACUC names no org", () => {
-    beforeEach(() => {
-      state.acucOrgId = null;
-    });
-
-    it("checkCredits falls back with null", async () => {
-      const svc = makeService();
-      await expect(
-        svc.checkCredits({ teamId: "team-1", value: 42 }),
-      ).resolves.toBeNull();
-      expect(mockCheck).not.toHaveBeenCalled();
-    });
-
-    it("trackCredits reports that nothing was tracked", async () => {
-      const svc = makeService();
-      await expect(
-        svc.trackCredits({ teamId: "team-1", value: 42 }),
-      ).resolves.toBe(false);
-      expect(mockTrack).not.toHaveBeenCalled();
-    });
-
-    it("lockCredits skips the hold", async () => {
-      const svc = makeService();
-      await expect(
-        svc.lockCredits({ teamId: "team-1", value: 42 }),
-      ).resolves.toEqual({ status: "skipped" });
-      expect(mockCheck).not.toHaveBeenCalled();
-    });
-  });
-
-  // Without DB auth getACUCTeam hands back a mock ACUC carrying a synthetic
-  // org, so the ACUC must not be consulted at all: these are the same fail-open
-  // answers the DB lookup gave when it had no database to read.
-  describe("when DB authentication is off", () => {
-    beforeEach(() => {
-      state.configRef = { USE_DB_AUTHENTICATION: false };
-    });
-
-    it("checkCredits falls back with null without reading the ACUC", async () => {
-      const svc = makeService();
-      await expect(
-        svc.checkCredits({ teamId: "team-1", value: 42 }),
-      ).resolves.toBeNull();
-      expect(mockGetACUCTeam).not.toHaveBeenCalled();
-      expect(mockCheck).not.toHaveBeenCalled();
-    });
-
-    it("trackCredits reports that nothing was tracked", async () => {
-      const svc = makeService();
-      await expect(
-        svc.trackCredits({ teamId: "team-1", value: 42 }),
-      ).resolves.toBe(false);
-      expect(mockGetACUCTeam).not.toHaveBeenCalled();
-      expect(mockTrack).not.toHaveBeenCalled();
-    });
-
-    it("lockCredits skips the hold", async () => {
-      const svc = makeService();
-      await expect(
-        svc.lockCredits({ teamId: "team-1", value: 42 }),
-      ).resolves.toEqual({ status: "skipped" });
-      expect(mockGetACUCTeam).not.toHaveBeenCalled();
-      expect(mockCheck).not.toHaveBeenCalled();
-    });
-
-    it("still bills a caller-supplied org", async () => {
-      const svc = makeService();
-
-      const result = await svc.checkCredits({
-        teamId: "team-1",
-        value: 42,
-        orgId: CALLER_ORG,
-      });
-
-      expect(result).toEqual({ allowed: true, remaining: 0 });
-      expect(mockGetACUCTeam).not.toHaveBeenCalled();
-      expect(mockCheck).toHaveBeenCalledWith(
-        expect.objectContaining({ customerId: CALLER_ORG, entityId: "team-1" }),
-      );
-    });
   });
 
   it("sends the caller's org to firebill as the customer", async () => {
@@ -1929,13 +1932,12 @@ describe("org resolution", () => {
 
       const result = await svc.checkCredits({
         teamId: "team-1",
+        orgId: CALLER_ORG,
         value: 100,
         properties: { source: "checkCreditsMiddleware" },
-        orgId: CALLER_ORG,
       });
 
       expect(result).toEqual({ allowed: true, remaining: 500 });
-      expect(mockGetACUCTeam).not.toHaveBeenCalled();
       expect(mockCheck).not.toHaveBeenCalled();
       const [url, init] = mockFetch.mock.calls[0]!;
       expect(String(url)).toBe("http://firebill.test/v1/check");

--- a/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
+++ b/apps/api/src/services/autumn/__tests__/autumn.service.test.ts
@@ -143,6 +143,10 @@ import {
   BoundedSet,
   featureIdForBillingEndpoint,
 } from "../autumn.service";
+import {
+  autumnCustomerGetOrCreateTotal,
+  autumnEntityCreatedInlineTotal,
+} from "../metrics";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1868,5 +1872,208 @@ describe("firebill routing", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(mockFinalize).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The org id hint: the request's ACUC already carries the org, so the credit
+// check should not read `teams.org_id` for it.
+// ---------------------------------------------------------------------------
+
+describe("org id hint", () => {
+  // Shaped like the column (`teams.org_id` is a uuid), which is what makes it
+  // usable at all.
+  const HINT_ORG = "3f2c1b8e-7a4d-4c1e-9b6a-0d5e8f2a1c74";
+
+  // Counts team → org_id reads only; the stub answers the gateway lookup
+  // separately.
+  let orgLookups = 0;
+
+  beforeEach(() => {
+    orgLookups = 0;
+    state.dbLimitOverride = () => {
+      orgLookups++;
+      return Promise.resolve([{ org_id: "org-1" }]);
+    };
+  });
+
+  afterEach(() => {
+    state.dbLimitOverride = null;
+    vi.useRealTimers();
+  });
+
+  it("checks the hinted org against Autumn with no DB read", async () => {
+    const svc = makeService();
+
+    const result = await svc.checkCredits({
+      teamId: "team-1",
+      value: 42,
+      orgId: HINT_ORG,
+    });
+
+    expect(result).toEqual({ allowed: true, remaining: 0 });
+    expect(orgLookups).toBe(0);
+    expect(mockCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: HINT_ORG, entityId: "team-1" }),
+    );
+  });
+
+  it("reads the DB exactly once when the caller has no hint", async () => {
+    const svc = makeService();
+
+    await svc.checkCredits({ teamId: "team-1", value: 42 });
+
+    expect(orgLookups).toBe(1);
+    expect(mockCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: "org-1" }),
+    );
+  });
+
+  // The ACUC is Redis-cached for longer than this cache lives, so a hint can
+  // arrive staler than what a warm pod already read. The cache keeps winning.
+  it("a fresh cached org wins over a differing hint", async () => {
+    const svc = makeService();
+
+    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    expect(orgLookups).toBe(1);
+
+    await svc.checkCredits({ teamId: "team-1", value: 42, orgId: HINT_ORG });
+
+    expect(orgLookups).toBe(1);
+    expect(mockCheck).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customerId: "org-1" }),
+    );
+  });
+
+  it("an expired entry is replaced by the hint without a DB read", async () => {
+    vi.useFakeTimers();
+    const svc = makeService();
+
+    await svc.trackCredits({ teamId: "team-1", value: 1 });
+    expect(orgLookups).toBe(1);
+    vi.advanceTimersByTime(301_000);
+
+    await svc.checkCredits({ teamId: "team-1", value: 42, orgId: HINT_ORG });
+
+    expect(orgLookups).toBe(1);
+    expect(mockCheck).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customerId: HINT_ORG }),
+    );
+  });
+
+  // The synthetic ACUCs carry these, and no `teams.org_id` read could ever
+  // return one, so a team holding one has to keep taking today's path.
+  it.each(["preview", "bypass", "", "org-1", "not a uuid"])(
+    "ignores %j as a hint and resolves the org from the DB",
+    async orgId => {
+      const svc = makeService();
+
+      await svc.checkCredits({ teamId: "team-1", value: 42, orgId });
+
+      expect(orgLookups).toBe(1);
+      expect(mockCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ customerId: "org-1" }),
+      );
+    },
+  );
+
+  it("seeds the org cache, so a later biller with no hint reads nothing", async () => {
+    const svc = makeService();
+
+    await svc.checkCredits({ teamId: "team-1", value: 1, orgId: HINT_ORG });
+    await svc.trackCredits({ teamId: "team-1", value: 1 });
+
+    expect(orgLookups).toBe(0);
+    expect(mockTrack).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: HINT_ORG }),
+    );
+  });
+
+  it("sends the hinted org to firebill as the customer", async () => {
+    const mockFetch = vi.fn<(url: any, init?: any) => Promise<Response>>();
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({ success: true, allowed: true, remaining: 500 }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    state.configRef = {
+      FIREBILL_URL: "http://firebill.test",
+      FIREBILL_SECRET: "fb-secret",
+      FIREBILL_ORG_IDS: [HINT_ORG],
+    };
+
+    try {
+      const svc = makeService();
+
+      const result = await svc.checkCredits({
+        teamId: "team-1",
+        value: 100,
+        properties: { source: "checkCreditsMiddleware" },
+        orgId: HINT_ORG,
+      });
+
+      expect(result).toEqual({ allowed: true, remaining: 500 });
+      expect(orgLookups).toBe(0);
+      expect(mockCheck).not.toHaveBeenCalled();
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(String(url)).toBe("http://firebill.test/v1/check");
+      expect(JSON.parse(init.body).customer_id).toBe(HINT_ORG);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline-provisioning counters (§5 of the middleware credit-check spec): how
+// much the request path is still back-filling.
+// ---------------------------------------------------------------------------
+
+describe("inline provisioning counters", () => {
+  const entityCreates = async (path: string) =>
+    (await autumnEntityCreatedInlineTotal.get()).values.find(
+      v => v.labels.path === path,
+    )?.value ?? 0;
+
+  const customerCalls = async () =>
+    (await autumnCustomerGetOrCreateTotal.get()).values[0]?.value ?? 0;
+
+  beforeEach(() => {
+    autumnEntityCreatedInlineTotal.reset();
+    autumnCustomerGetOrCreateTotal.reset();
+  });
+
+  it("counts an entity created inline, labelled with the method that did it", async () => {
+    const svc = makeService();
+    mockEntityGet.mockRejectedValue({ statusCode: 404 });
+
+    await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+
+    expect(await entityCreates("ensureTeamProvisioned")).toBe(1);
+    expect(await customerCalls()).toBe(1);
+  });
+
+  it("does not count a 409: the entity was already there", async () => {
+    const svc = makeService();
+    mockEntityGet.mockRejectedValue({ statusCode: 404 });
+    mockEntityCreate.mockRejectedValue(
+      Object.assign(new Error("conflict"), { status: 409 }),
+    );
+
+    await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+
+    expect(await entityCreates("ensureTeamProvisioned")).toBe(0);
+  });
+
+  it("counts nothing when the entity is already present", async () => {
+    const svc = makeService();
+    mockEntityGet.mockResolvedValue(makeEntity(0));
+
+    await svc.ensureTeamProvisioned({ teamId: "team-1", orgId: "org-1" });
+
+    expect(await entityCreates("ensureTeamProvisioned")).toBe(0);
+    expect(await customerCalls()).toBe(1);
   });
 });

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -13,7 +13,11 @@ import {
   firebillConfigured,
   shouldRouteToFirebill,
 } from "./firebill";
-import { billingRouteTotal } from "./metrics";
+import {
+  autumnCustomerGetOrCreateTotal,
+  autumnEntityCreatedInlineTotal,
+  billingRouteTotal,
+} from "./metrics";
 import type {
   CreateEntityParams,
   CreateEntityResult,
@@ -116,6 +120,9 @@ export class AutumnService {
   // moves orgs has to be provisioned again under the new one.
   private ensuredTeams = new BoundedSet<string>(50_000);
 
+  private static readonly ORG_ID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
   private ensuredTeamKey(orgId: string, teamId: string): string {
     return `${orgId}:${teamId}`;
   }
@@ -133,6 +140,20 @@ export class AutumnService {
 
   private isPreviewTeam(teamId: string): boolean {
     return teamId === "preview" || teamId.startsWith("preview_");
+  }
+
+  /**
+   * A caller-supplied org id we may bill against without reading the DB.
+   *
+   * `teams.org_id` is a non-null uuid, so only a uuid can be what the read
+   * would have returned. That rejects the synthetic ACUC org ids ("preview",
+   * "bypass") and anything else odd, which keeps every team whose lookup
+   * throws today on exactly that path.
+   */
+  private usableOrgIdHint(orgId?: string | null): string | null {
+    return typeof orgId === "string" && AutumnService.ORG_ID_PATTERN.test(orgId)
+      ? orgId
+      : null;
   }
 
   private async lookupOrgIdForTeam(teamId: string): Promise<string> {
@@ -228,6 +249,7 @@ export class AutumnService {
         email: email ?? undefined,
         autoEnablePlanId,
       });
+      autumnCustomerGetOrCreateTotal.inc();
       logger.info("Autumn getOrCreateCustomer succeeded", { customerId });
       return customer;
     } catch (error) {
@@ -269,6 +291,7 @@ export class AutumnService {
     entityId,
     featureId,
     name,
+    path,
   }: CreateEntityParams): Promise<CreateEntityResult> {
     if (!autumnClient) return { ok: false, conflict: false };
 
@@ -279,6 +302,7 @@ export class AutumnService {
         featureId,
         name: name ?? undefined,
       });
+      autumnEntityCreatedInlineTotal.labels(path).inc();
       logger.info("Autumn createEntity succeeded", {
         customerId,
         entityId,
@@ -312,14 +336,17 @@ export class AutumnService {
    * enqueues behave differently). Never throws: an error means "not routed",
    * falling back to the pre-firebill behavior.
    */
-  async isRoutedThroughFirebill(teamId: string): Promise<boolean> {
+  async isRoutedThroughFirebill(
+    teamId: string,
+    orgId?: string | null,
+  ): Promise<boolean> {
     if (this.isPreviewTeam(teamId)) return false;
     try {
-      const [orgId, gatewayProvisioned] = await Promise.all([
-        this.resolveOrgId(teamId),
+      const [resolvedOrgId, gatewayProvisioned] = await Promise.all([
+        this.resolveOrgId(teamId, orgId),
         this.isGatewayProvisioned(teamId),
       ]);
-      return shouldRouteToFirebill(orgId, { gatewayProvisioned });
+      return shouldRouteToFirebill(resolvedOrgId, { gatewayProvisioned });
     } catch {
       return false;
     }
@@ -440,6 +467,7 @@ export class AutumnService {
           entityId: teamId,
           featureId: TEAM_FEATURE_ID,
           name,
+          path: "ensureTeamProvisioned",
         });
         if (result.ok || ("conflict" in result && result.conflict)) {
           // Entity was just created, or already existed (409 race) — either way
@@ -463,10 +491,23 @@ export class AutumnService {
    * Resolves the orgId for a team, returning the cached value while it is
    * fresh and re-reading the DB once it has expired.  Does NOT provision
    * anything.
+   *
+   * A usable `orgId` hint (the request's ACUC carries one) stands in for the
+   * DB read once the cache is cold, and seeds the cache. A fresh entry still
+   * wins, so a warm pod resolves exactly what it resolved before the hint.
    */
-  private async resolveOrgId(teamId: string): Promise<string> {
+  private async resolveOrgId(
+    teamId: string,
+    orgId?: string | null,
+  ): Promise<string> {
     const cached = this.customerOrgCache.get(teamId);
     if (cached && cached.expiresAt > Date.now()) return cached.orgId;
+
+    const hint = this.usableOrgIdHint(orgId);
+    if (hint) {
+      this.cacheOrgId(teamId, hint);
+      return hint;
+    }
 
     const pending = this.pendingOrgLookups.get(teamId);
     if (pending) return pending;
@@ -490,12 +531,15 @@ export class AutumnService {
    * immediately without calling ensureTeamProvisioned, avoiding redundant
    * map/set lookups on every billing operation.
    */
-  private async ensureTrackingContext(teamId: string): Promise<string> {
-    const orgId = await this.resolveOrgId(teamId);
-    if (!this.ensuredTeams.has(this.ensuredTeamKey(orgId, teamId))) {
-      await this.ensureTeamProvisioned({ teamId, orgId });
+  private async ensureTrackingContext(
+    teamId: string,
+    orgId?: string | null,
+  ): Promise<string> {
+    const resolvedOrgId = await this.resolveOrgId(teamId, orgId);
+    if (!this.ensuredTeams.has(this.ensuredTeamKey(resolvedOrgId, teamId))) {
+      await this.ensureTeamProvisioned({ teamId, orgId: resolvedOrgId });
     }
-    return orgId;
+    return resolvedOrgId;
   }
 
   /**
@@ -507,6 +551,7 @@ export class AutumnService {
     value,
     properties,
     featureId = CREDITS_FEATURE_ID,
+    orgId,
   }: TrackCreditsParams): Promise<{
     allowed: boolean;
     remaining: number;
@@ -515,7 +560,7 @@ export class AutumnService {
       return null;
     }
     try {
-      const customerId = await this.ensureTrackingContext(teamId);
+      const customerId = await this.ensureTrackingContext(teamId, orgId);
 
       // Mirrors track() and lockCredits(). Without this branch the gate reads
       // the ghost's balance alone, and a gateway ghost is designed to spend
@@ -592,6 +637,7 @@ export class AutumnService {
     properties,
     featureId = CREDITS_FEATURE_ID,
     partnerJobToken,
+    orgId,
   }: LockCreditsParams): Promise<LockCreditsResult> {
     if (!autumnClient || this.isPreviewTeam(teamId)) {
       return { status: "skipped" };
@@ -609,7 +655,7 @@ export class AutumnService {
         : { status: "skipped" };
 
     try {
-      const customerId = await this.ensureTrackingContext(teamId);
+      const customerId = await this.ensureTrackingContext(teamId, orgId);
 
       // Gradual firebill rollout, mirroring track(): allowlisted orgs take
       // their holds through firebill. The hold still lives in Autumn (firebill
@@ -732,9 +778,13 @@ export class AutumnService {
     externalRequestId,
     featureId = CREDITS_FEATURE_ID,
     heldValue,
+    orgId,
   }: FinalizeCreditsLockParams): Promise<boolean> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
-    if (gated || (teamId && (await this.isRoutedThroughFirebill(teamId)))) {
+    if (
+      gated ||
+      (teamId && (await this.isRoutedThroughFirebill(teamId, orgId)))
+    ) {
       // Only resolved for a gated settle: firebill needs the org to split the
       // settle and to find the integration to report to. An ordinary finalize
       // does neither, so it does not pay for the lookup.
@@ -748,7 +798,7 @@ export class AutumnService {
       // the lost label as `partner_events_total{outcome="no_customer"}`.
       const customerId =
         externalRequestId && teamId
-          ? await this.ensureTrackingContext(teamId).catch(error => {
+          ? await this.ensureTrackingContext(teamId, orgId).catch(error => {
               logger.error(
                 "Could not resolve the org for a gated settle; finalizing anyway, but this run cannot be reported to its partner",
                 { teamId, lockId, error },
@@ -811,12 +861,13 @@ export class AutumnService {
     properties,
     featureId = CREDITS_FEATURE_ID,
     idempotencyKey,
+    orgId,
   }: TrackCreditsParams): Promise<boolean> {
     if (!autumnClient) return false;
     if (this.isPreviewTeam(teamId)) return false;
 
     try {
-      const customerId = await this.ensureTrackingContext(teamId);
+      const customerId = await this.ensureTrackingContext(teamId, orgId);
       return await this.track({
         customerId,
         entityId: teamId,
@@ -990,12 +1041,13 @@ export class AutumnService {
     properties,
     featureId = CREDITS_FEATURE_ID,
     idempotencyKey,
+    orgId,
   }: TrackCreditsParams): Promise<void> {
     if (!autumnClient) return;
     if (this.isPreviewTeam(teamId)) return;
 
     try {
-      const customerId = await this.ensureTrackingContext(teamId);
+      const customerId = await this.ensureTrackingContext(teamId, orgId);
       await this.track({
         customerId,
         entityId: teamId,

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { config } from "../../config";
+import { getACUCTeam } from "../../controllers/auth";
 import { autumnClient } from "./client";
 import {
   firebillFinalize,
@@ -102,17 +103,6 @@ export class BoundedSet<V> extends Set<V> {
  * Wraps Autumn customer/entity provisioning and usage tracking for team credit billing.
  */
 export class AutumnService {
-  // team → org, trusted only until `expiresAt`. A team's org changes when an
-  // account is merged or moved; without a bound every warm pod keeps billing
-  // the old Autumn customer until it restarts.
-  private customerOrgCache = new BoundedMap<
-    string,
-    { orgId: string; expiresAt: number }
-  >(50_000);
-  // One DB lookup in flight per team. Without this, N requests that all see
-  // an expired entry each read the DB, and if the org moved mid-flight an
-  // older read can land last and overwrite the newer org for another TTL.
-  private pendingOrgLookups = new Map<string, Promise<string>>();
   private gatewayTeams = new BoundedSet<string>(50_000);
   private nonGatewayTeamsUntil = new BoundedMap<string, number>(50_000);
   private ensuredOrgs = new BoundedSet<string>(50_000);
@@ -120,54 +110,12 @@ export class AutumnService {
   // moves orgs has to be provisioned again under the new one.
   private ensuredTeams = new BoundedSet<string>(50_000);
 
-  private static readonly ORG_ID_PATTERN =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
   private ensuredTeamKey(orgId: string, teamId: string): string {
     return `${orgId}:${teamId}`;
   }
 
-  private orgCacheTtlMs(): number {
-    return (config.AUTUMN_ORG_CACHE_TTL_SECONDS ?? 300) * 1000;
-  }
-
-  private cacheOrgId(teamId: string, orgId: string): void {
-    this.customerOrgCache.set(teamId, {
-      orgId,
-      expiresAt: Date.now() + this.orgCacheTtlMs(),
-    });
-  }
-
   private isPreviewTeam(teamId: string): boolean {
     return teamId === "preview" || teamId.startsWith("preview_");
-  }
-
-  /**
-   * A caller-supplied org id we may bill against without reading the DB.
-   *
-   * `teams.org_id` is a non-null uuid, so only a uuid can be what the read
-   * would have returned. That rejects the synthetic ACUC org ids ("preview",
-   * "bypass") and anything else odd, which keeps every team whose lookup
-   * throws today on exactly that path.
-   */
-  private usableOrgIdHint(orgId?: string | null): string | null {
-    return typeof orgId === "string" && AutumnService.ORG_ID_PATTERN.test(orgId)
-      ? orgId
-      : null;
-  }
-
-  private async lookupOrgIdForTeam(teamId: string): Promise<string> {
-    const [data] = await dbRr
-      .select({ org_id: schema.teams.org_id })
-      .from(schema.teams)
-      .where(eq(schema.teams.id, teamId))
-      .limit(1);
-
-    if (!data?.org_id) {
-      throw new Error(`Missing org_id for team ${teamId}`);
-    }
-
-    return data.org_id;
   }
 
   /**
@@ -450,12 +398,11 @@ export class AutumnService {
     if (this.isPreviewTeam(teamId)) return;
 
     try {
-      const resolvedOrgId = orgId ?? (await this.resolveOrgId(teamId));
+      const resolvedOrgId = await this.resolveOrgId(teamId, orgId);
       // Fast path: team is already fully provisioned under this org.
       if (this.ensuredTeams.has(this.ensuredTeamKey(resolvedOrgId, teamId))) {
         return;
       }
-      if (orgId) this.cacheOrgId(teamId, orgId);
       await this.ensureOrgProvisioned({ orgId: resolvedOrgId });
 
       const entity = await this.getEntity({
@@ -490,49 +437,27 @@ export class AutumnService {
   }
 
   /**
-   * Resolves the orgId for a team, returning the cached value while it is
-   * fresh and re-reading the DB once it has expired.  Does NOT provision
-   * anything.
-   *
-   * A usable `orgId` hint (the request's ACUC carries one) stands in for the
-   * DB read only when nothing is cached and no lookup is in flight, and seeds
-   * the cache. A fresh entry or a pending read still wins, so the hint never
-   * races an already-running lookup that would resolve after it.
+   * The org to bill a team against. The caller's own `orgId` wins; otherwise
+   * the team's ACUC answers, which makes it the one source of the org and its
+   * Redis cache the one cache. Throws when no org can be named, which every
+   * caller catches and turns into its fail-open answer.
    */
   private async resolveOrgId(
     teamId: string,
     orgId?: string | null,
   ): Promise<string> {
-    const cached = this.customerOrgCache.get(teamId);
-    if (cached && cached.expiresAt > Date.now()) return cached.orgId;
+    if (typeof orgId === "string" && orgId.length > 0) return orgId;
 
-    const pending = this.pendingOrgLookups.get(teamId);
-    if (pending) return pending;
+    const acuc = await getACUCTeam(teamId);
+    if (acuc?.org_id) return acuc.org_id;
 
-    const hint = this.usableOrgIdHint(orgId);
-    if (hint) {
-      this.cacheOrgId(teamId, hint);
-      return hint;
-    }
-
-    const lookup = this.lookupOrgIdForTeam(teamId)
-      .then(orgId => {
-        this.cacheOrgId(teamId, orgId);
-        return orgId;
-      })
-      .finally(() => {
-        this.pendingOrgLookups.delete(teamId);
-      });
-    this.pendingOrgLookups.set(teamId, lookup);
-    return lookup;
+    throw new Error(`Missing org_id for team ${teamId}`);
   }
 
   /**
-   * Resolves and warms the Autumn customer/entity context needed before tracking usage.
-   *
-   * When both caches are warm (orgId known + team fully provisioned) we return
-   * immediately without calling ensureTeamProvisioned, avoiding redundant
-   * map/set lookups on every billing operation.
+   * Resolves and warms the Autumn customer/entity context needed before
+   * tracking usage. A team already provisioned under this org skips
+   * ensureTeamProvisioned entirely.
    */
   private async ensureTrackingContext(
     teamId: string,

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -448,6 +448,12 @@ export class AutumnService {
   ): Promise<string> {
     if (typeof orgId === "string" && orgId.length > 0) return orgId;
 
+    // Without DB auth there is no real org to bill: getACUCTeam answers with a
+    // mock ACUC whose synthetic org must never become an Autumn customer.
+    if (config.USE_DB_AUTHENTICATION !== true) {
+      throw new Error(`Missing org_id for team ${teamId}`);
+    }
+
     const acuc = await getACUCTeam(teamId);
     if (acuc?.org_id) return acuc.org_id;
 

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -243,13 +243,15 @@ export class AutumnService {
     if (!customerId) return null;
 
     try {
+      // Counted before the await so a call that reached Autumn and failed is
+      // still counted; the counter measures attempts, not successes.
+      autumnCustomerGetOrCreateTotal.inc();
       const customer = await autumnClient.customers.getOrCreate({
         customerId,
         name: name ?? undefined,
         email: email ?? undefined,
         autoEnablePlanId,
       });
-      autumnCustomerGetOrCreateTotal.inc();
       logger.info("Autumn getOrCreateCustomer succeeded", { customerId });
       return customer;
     } catch (error) {
@@ -493,8 +495,9 @@ export class AutumnService {
    * anything.
    *
    * A usable `orgId` hint (the request's ACUC carries one) stands in for the
-   * DB read once the cache is cold, and seeds the cache. A fresh entry still
-   * wins, so a warm pod resolves exactly what it resolved before the hint.
+   * DB read only when nothing is cached and no lookup is in flight, and seeds
+   * the cache. A fresh entry or a pending read still wins, so the hint never
+   * races an already-running lookup that would resolve after it.
    */
   private async resolveOrgId(
     teamId: string,
@@ -503,14 +506,14 @@ export class AutumnService {
     const cached = this.customerOrgCache.get(teamId);
     if (cached && cached.expiresAt > Date.now()) return cached.orgId;
 
+    const pending = this.pendingOrgLookups.get(teamId);
+    if (pending) return pending;
+
     const hint = this.usableOrgIdHint(orgId);
     if (hint) {
       this.cacheOrgId(teamId, hint);
       return hint;
     }
-
-    const pending = this.pendingOrgLookups.get(teamId);
-    if (pending) return pending;
 
     const lookup = this.lookupOrgIdForTeam(teamId)
       .then(orgId => {

--- a/apps/api/src/services/autumn/autumn.service.ts
+++ b/apps/api/src/services/autumn/autumn.service.ts
@@ -4,7 +4,6 @@ import { eq } from "drizzle-orm";
 import { dbRr } from "../../db/connection";
 import * as schema from "../../db/schema";
 import { config } from "../../config";
-import { getACUCTeam } from "../../controllers/auth";
 import { autumnClient } from "./client";
 import {
   firebillFinalize,
@@ -288,15 +287,12 @@ export class AutumnService {
    */
   async isRoutedThroughFirebill(
     teamId: string,
-    orgId?: string | null,
+    orgId: string,
   ): Promise<boolean> {
     if (this.isPreviewTeam(teamId)) return false;
     try {
-      const [resolvedOrgId, gatewayProvisioned] = await Promise.all([
-        this.resolveOrgId(teamId, orgId),
-        this.isGatewayProvisioned(teamId),
-      ]);
-      return shouldRouteToFirebill(resolvedOrgId, { gatewayProvisioned });
+      const gatewayProvisioned = await this.isGatewayProvisioned(teamId);
+      return shouldRouteToFirebill(orgId, { gatewayProvisioned });
     } catch {
       return false;
     }
@@ -398,21 +394,20 @@ export class AutumnService {
     if (this.isPreviewTeam(teamId)) return;
 
     try {
-      const resolvedOrgId = await this.resolveOrgId(teamId, orgId);
       // Fast path: team is already fully provisioned under this org.
-      if (this.ensuredTeams.has(this.ensuredTeamKey(resolvedOrgId, teamId))) {
+      if (this.ensuredTeams.has(this.ensuredTeamKey(orgId, teamId))) {
         return;
       }
-      await this.ensureOrgProvisioned({ orgId: resolvedOrgId });
+      await this.ensureOrgProvisioned({ orgId });
 
       const entity = await this.getEntity({
-        customerId: resolvedOrgId,
+        customerId: orgId,
         entityId: teamId,
       });
 
       if (!entity) {
         const result = await this.createEntity({
-          customerId: resolvedOrgId,
+          customerId: orgId,
           entityId: teamId,
           featureId: TEAM_FEATURE_ID,
           name,
@@ -421,13 +416,13 @@ export class AutumnService {
         if (result.ok || ("conflict" in result && result.conflict)) {
           // Entity was just created, or already existed (409 race) — either way
           // it's present. No need for a second getEntity confirmation call.
-          this.ensuredTeams.add(this.ensuredTeamKey(resolvedOrgId, teamId));
+          this.ensuredTeams.add(this.ensuredTeamKey(orgId, teamId));
         }
         // Genuine error: leave ensuredTeams empty so the next request retries.
         return;
       }
 
-      this.ensuredTeams.add(this.ensuredTeamKey(resolvedOrgId, teamId));
+      this.ensuredTeams.add(this.ensuredTeamKey(orgId, teamId));
     } catch (error) {
       logger.error(
         "Autumn ensureTeamProvisioned failed — billing API may be unavailable",
@@ -437,43 +432,19 @@ export class AutumnService {
   }
 
   /**
-   * The org to bill a team against. The caller's own `orgId` wins; otherwise
-   * the team's ACUC answers, which makes it the one source of the org and its
-   * Redis cache the one cache. Throws when no org can be named, which every
-   * caller catches and turns into its fail-open answer.
-   */
-  private async resolveOrgId(
-    teamId: string,
-    orgId?: string | null,
-  ): Promise<string> {
-    if (typeof orgId === "string" && orgId.length > 0) return orgId;
-
-    // Without DB auth there is no real org to bill: getACUCTeam answers with a
-    // mock ACUC whose synthetic org must never become an Autumn customer.
-    if (config.USE_DB_AUTHENTICATION !== true) {
-      throw new Error(`Missing org_id for team ${teamId}`);
-    }
-
-    const acuc = await getACUCTeam(teamId);
-    if (acuc?.org_id) return acuc.org_id;
-
-    throw new Error(`Missing org_id for team ${teamId}`);
-  }
-
-  /**
-   * Resolves and warms the Autumn customer/entity context needed before
-   * tracking usage. A team already provisioned under this org skips
+   * Warms the Autumn customer/entity context needed before tracking usage and
+   * answers with the customer to bill — the caller's org, which this service
+   * never looks up for itself. A team already provisioned under this org skips
    * ensureTeamProvisioned entirely.
    */
   private async ensureTrackingContext(
     teamId: string,
-    orgId?: string | null,
+    orgId: string,
   ): Promise<string> {
-    const resolvedOrgId = await this.resolveOrgId(teamId, orgId);
-    if (!this.ensuredTeams.has(this.ensuredTeamKey(resolvedOrgId, teamId))) {
-      await this.ensureTeamProvisioned({ teamId, orgId: resolvedOrgId });
+    if (!this.ensuredTeams.has(this.ensuredTeamKey(orgId, teamId))) {
+      await this.ensureTeamProvisioned({ teamId, orgId });
     }
-    return resolvedOrgId;
+    return orgId;
   }
 
   /**
@@ -692,7 +663,7 @@ export class AutumnService {
   /**
    * Finalizes a previously-acquired Autumn lock.
    *
-   * When the caller supplies the lock's teamId and that team's org is on the
+   * When the caller supplies the lock's team and that team's org is on the
    * firebill rollout, the settle goes through firebill, which queues it
    * durably and retries delivery — a dropped direct finalize means the hold
    * just expires, leaving a confirm's work unbilled. Either route lands on the
@@ -708,16 +679,15 @@ export class AutumnService {
     action,
     overrideValue,
     properties,
-    teamId,
+    team,
     externalRequestId,
     featureId = CREDITS_FEATURE_ID,
     heldValue,
-    orgId,
   }: FinalizeCreditsLockParams): Promise<boolean> {
     const gated = Boolean(externalRequestId) && firebillConfigured();
     if (
       gated ||
-      (teamId && (await this.isRoutedThroughFirebill(teamId, orgId)))
+      (team && (await this.isRoutedThroughFirebill(team.teamId, team.orgId)))
     ) {
       // Only resolved for a gated settle: firebill needs the org to split the
       // settle and to find the integration to report to. An ordinary finalize
@@ -731,14 +701,16 @@ export class AutumnService {
       // Settling and losing the label is the lesser loss, and firebill counts
       // the lost label as `partner_events_total{outcome="no_customer"}`.
       const customerId =
-        externalRequestId && teamId
-          ? await this.ensureTrackingContext(teamId, orgId).catch(error => {
-              logger.error(
-                "Could not resolve the org for a gated settle; finalizing anyway, but this run cannot be reported to its partner",
-                { teamId, lockId, error },
-              );
-              return null;
-            })
+        externalRequestId && team
+          ? await this.ensureTrackingContext(team.teamId, team.orgId).catch(
+              error => {
+                logger.error(
+                  "Could not provision the customer for a gated settle; finalizing anyway, but this run cannot be reported to its partner",
+                  { teamId: team.teamId, lockId, error },
+                );
+                return null;
+              },
+            )
           : null;
       // Surfaced, not discarded. firebill answers `false` for a refusal, a
       // timeout, or a non-OK — none of which throw — so a caller that ignores
@@ -857,12 +829,13 @@ export class AutumnService {
    * Returns nulls when Autumn is not configured, the entity is missing (404),
    * or a balance isn't present — these mean "no elevated entitlement", so
    * callers fall back to the low defaults. When Autumn itself errors (network /
-   * 5xx / unexpected exception) we instead fail OPEN, returning the high
-   * ERROR_FALLBACK_* limits so a billing outage doesn't throttle real teams.
+   * 5xx / unexpected exception), or the caller can name no org, we instead fail
+   * OPEN, returning the high ERROR_FALLBACK_* limits so a billing outage
+   * doesn't throttle real teams.
    */
   private async getEntityLimits(
     teamId: string,
-    orgId?: string | null,
+    orgId: string | null,
   ): Promise<{
     concurrency: number | null;
     rateLimitMultiplier: number | null;
@@ -892,13 +865,24 @@ export class AutumnService {
       return { concurrency, rateLimitMultiplier };
     };
 
-    try {
-      const resolvedOrgId = orgId ?? (await this.resolveOrgId(teamId));
-      if (!resolvedOrgId)
-        return { concurrency: null, rateLimitMultiplier: null };
+    // No org means no Autumn entity to ask about. Fail OPEN on the high
+    // limits, the same answer this method already gives when it cannot reach
+    // Autumn — and the same one the service's own org lookup produced by
+    // throwing into the catch below. Not cached, for the same reason.
+    if (!orgId) {
+      logger.error(
+        "Autumn getEntityLimits has no org for the team, falling back to high limits",
+        { teamId },
+      );
+      return {
+        concurrency: AutumnService.ERROR_FALLBACK_CONCURRENCY,
+        rateLimitMultiplier: AutumnService.ERROR_FALLBACK_RATE_MULTIPLIER,
+      };
+    }
 
+    try {
       const entity: any = await autumnClient.entities.get({
-        customerId: resolvedOrgId,
+        customerId: orgId,
         entityId: teamId,
       });
       const balances = entity?.balances ?? {};
@@ -946,7 +930,7 @@ export class AutumnService {
    */
   async getConcurrencyLimit(
     teamId: string,
-    orgId?: string | null,
+    orgId: string | null,
   ): Promise<number | null> {
     return (await this.getEntityLimits(teamId, orgId)).concurrency;
   }
@@ -961,7 +945,7 @@ export class AutumnService {
    */
   async getRateLimitMultiplier(
     teamId: string,
-    orgId?: string | null,
+    orgId: string | null,
   ): Promise<number> {
     return (await this.getEntityLimits(teamId, orgId)).rateLimitMultiplier ?? 1;
   }

--- a/apps/api/src/services/autumn/metrics.ts
+++ b/apps/api/src/services/autumn/metrics.ts
@@ -81,3 +81,26 @@ export const firebillCheckTotal = new Counter({
   help: "Outcomes of credit checks sent to firebill",
   labelNames: ["outcome"] as const, // allowed | denied | unavailable
 });
+
+/**
+ * Entities the request path had to create for itself, by the method that did
+ * it. Provisioning is meant to happen at team creation, so anything counted
+ * here is the back-fill still being needed, and is what the per-request
+ * provisioning prefix is buying. A 409 is not counted: the entity was already
+ * there.
+ */
+export const autumnEntityCreatedInlineTotal = new Counter({
+  name: "firecrawl_autumn_entity_created_inline_total",
+  help: "Autumn entities created inline on a billing path",
+  labelNames: ["path"] as const, // the method that created it
+});
+
+/**
+ * Calls to `customers.get_or_create` that reached Autumn. Deliberately not
+ * "created": the endpoint answers 200 either way and autumn-js parses only the
+ * customer body, so nothing in the response tells a creation from a get.
+ */
+export const autumnCustomerGetOrCreateTotal = new Counter({
+  name: "firecrawl_autumn_customer_get_or_create_total",
+  help: "Autumn customers.get_or_create calls made from a billing path",
+});

--- a/apps/api/src/services/autumn/metrics.ts
+++ b/apps/api/src/services/autumn/metrics.ts
@@ -96,11 +96,12 @@ export const autumnEntityCreatedInlineTotal = new Counter({
 });
 
 /**
- * Calls to `customers.get_or_create` that reached Autumn. Deliberately not
- * "created": the endpoint answers 200 either way and autumn-js parses only the
- * customer body, so nothing in the response tells a creation from a get.
+ * Calls to `customers.get_or_create` attempted against Autumn, counted before
+ * the response so a failure counts too. Deliberately not "created": the
+ * endpoint answers 200 either way and autumn-js parses only the customer body,
+ * so nothing in the response tells a creation from a get.
  */
 export const autumnCustomerGetOrCreateTotal = new Counter({
   name: "firecrawl_autumn_customer_get_or_create_total",
-  help: "Autumn customers.get_or_create calls made from a billing path",
+  help: "Autumn customers.get_or_create calls attempted from a billing path",
 });

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -116,8 +116,7 @@ export type TrackCreditsParams = {
   idempotencyKey?: string;
   /**
    * The team's org, when the caller already has it (a request's ACUC does).
-   * Saves the `teams.org_id` read; ignored unless it is shaped like one, so a
-   * caller that has no real org id changes nothing.
+   * Saves resolving it from the team's ACUC.
    */
   orgId?: string | null;
 };

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -43,7 +43,8 @@ export type EnsureOrgProvisionedParams = {
 
 export type EnsureTeamProvisionedParams = {
   teamId: string;
-  orgId?: string | null;
+  /** See TrackCreditsParams.orgId. */
+  orgId: string;
   name?: string | null;
 };
 
@@ -55,7 +56,7 @@ export type LockCreditsParams = {
   properties?: Record<string, unknown>;
   featureId?: string;
   /** See TrackCreditsParams.orgId. */
-  orgId?: string | null;
+  orgId: string;
   /** Arms firebill's partner credit gate, which is asked before Autumn holds anything. */
   partnerJobToken?: string | null;
 };
@@ -89,13 +90,14 @@ export type FinalizeCreditsLockParams = {
   overrideValue?: number;
   properties?: Record<string, unknown>;
   /**
-   * The team the lock was taken for. Needed to route the settle through
-   * firebill for allowlisted orgs — a finalize carries no customer context of
-   * its own. When omitted, the settle goes directly to Autumn (which also
-   * works for a firebill-taken lock: the hold lives in Autumn either way, but
-   * loses firebill's durable retry).
+   * The team the lock was taken for, and its org. Needed to route the settle
+   * through firebill for allowlisted orgs — a finalize carries no customer
+   * context of its own. When omitted, the settle goes directly to Autumn
+   * (which also works for a firebill-taken lock: the hold lives in Autumn
+   * either way, but loses firebill's durable retry). A caller that cannot name
+   * the org omits this, which is the route an unnameable org already took.
    */
-  teamId?: string;
+  team?: { teamId: string; orgId: string };
   /** For a gated run, the `operationToken` its lock handed back. */
   externalRequestId?: string | null;
   /** Which balance the hold was against; lets firebill split the settle. */
@@ -103,8 +105,6 @@ export type FinalizeCreditsLockParams = {
   /** What the lock reserved. Autumn nets outstanding holds out of a reported
    * balance, so firebill adds this back to see what the ghost can really pay. */
   heldValue?: number | null;
-  /** See TrackCreditsParams.orgId. */
-  orgId?: string | null;
 };
 
 export type TrackCreditsParams = {
@@ -115,10 +115,12 @@ export type TrackCreditsParams = {
   /** See TrackParams.idempotencyKey. */
   idempotencyKey?: string;
   /**
-   * The team's org, when the caller already has it (a request's ACUC does).
-   * Saves resolving it from the team's ACUC.
+   * The team's org — the Autumn customer this usage bills against. The service
+   * never looks it up: callers hold it already (a request's ACUC, a job's
+   * payload), and a lookup buried in here is one an agentic edit reaches for
+   * instead of passing the org it has.
    */
-  orgId?: string | null;
+  orgId: string;
 };
 
 export type CreateEntityResult =

--- a/apps/api/src/services/autumn/types.ts
+++ b/apps/api/src/services/autumn/types.ts
@@ -15,6 +15,8 @@ export type CreateEntityParams = {
   entityId: string;
   featureId: string;
   name?: string | null;
+  /** Method doing the creation, for the inline-creation counter's `path`. */
+  path: string;
 };
 
 export type TrackParams = {
@@ -52,6 +54,8 @@ export type LockCreditsParams = {
   expiresAt?: number;
   properties?: Record<string, unknown>;
   featureId?: string;
+  /** See TrackCreditsParams.orgId. */
+  orgId?: string | null;
   /** Arms firebill's partner credit gate, which is asked before Autumn holds anything. */
   partnerJobToken?: string | null;
 };
@@ -99,6 +103,8 @@ export type FinalizeCreditsLockParams = {
   /** What the lock reserved. Autumn nets outstanding holds out of a reported
    * balance, so firebill adds this back to see what the ghost can really pay. */
   heldValue?: number | null;
+  /** See TrackCreditsParams.orgId. */
+  orgId?: string | null;
 };
 
 export type TrackCreditsParams = {
@@ -108,6 +114,12 @@ export type TrackCreditsParams = {
   featureId?: string;
   /** See TrackParams.idempotencyKey. */
   idempotencyKey?: string;
+  /**
+   * The team's org, when the caller already has it (a request's ACUC does).
+   * Saves the `teams.org_id` read; ignored unless it is shaped like one, so a
+   * caller that has no real org id changes nothing.
+   */
+  orgId?: string | null;
 };
 
 export type CreateEntityResult =

--- a/apps/api/src/services/billing/__tests__/batch_billing.test.ts
+++ b/apps/api/src/services/billing/__tests__/batch_billing.test.ts
@@ -97,11 +97,11 @@ const redis = {
     }
     return queue.length;
   }),
-  rpush: vi.fn(async (key: string, value: string) => {
+  rpush: vi.fn(async (key: string, ...values: string[]) => {
     if (key !== "billing_batch") {
       throw new Error("unexpected redis.rpush key");
     }
-    queue.push(value);
+    queue.push(...values);
     return queue.length;
   }),
   sadd: vi.fn(async (key: string, teamId: string) => {
@@ -253,6 +253,40 @@ describe("processBillingBatch", () => {
     expect(refundCredits).toHaveBeenCalledWith(
       expect.objectContaining({ teamId: "team-1", orgId: "org-legacy" }),
     );
+  });
+
+  it("requeues legacy operations when the org lookup throws", async () => {
+    queue = [
+      makeOp({ org_id: undefined, autumnTrackInRequest: true }),
+      makeOp({ org_id: undefined, autumnTrackInRequest: true }),
+    ];
+    getACUCTeam.mockRejectedValue(new Error("acuc unavailable"));
+
+    await processBillingBatch();
+
+    // Nothing billed and nothing refunded for them; both are back on the
+    // queue in their original shape, still without org_id.
+    expect(billTeam7).not.toHaveBeenCalled();
+    expect(refundCredits).not.toHaveBeenCalled();
+    expect(queue).toHaveLength(2);
+    expect(JSON.parse(queue[0])).not.toHaveProperty("org_id");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Requeueing legacy billing operations whose org could not be resolved",
+      { count: 2 },
+    );
+  });
+
+  it("bills a legacy operation whose team is confirmed to have no org", async () => {
+    queue = [makeOp({ org_id: undefined, autumnTrackInRequest: true })];
+    getACUCTeam.mockResolvedValue({ team_id: "team-1", org_id: null });
+    billTeam7.mockRejectedValueOnce(new Error("db failed"));
+
+    await processBillingBatch();
+
+    expect(billTeam7).toHaveBeenCalled();
+    // A confirmed null is an org-less team: the refund is skipped, not deferred.
+    expect(refundCredits).not.toHaveBeenCalled();
+    expect(queue).toHaveLength(0);
   });
 
   it("does not look anything up for an operation whose org is a known null", async () => {

--- a/apps/api/src/services/billing/__tests__/batch_billing.test.ts
+++ b/apps/api/src/services/billing/__tests__/batch_billing.test.ts
@@ -49,6 +49,9 @@ vi.mock("../../../db/rpc", () => ({
   billTeam7,
 }));
 
+// orgIdFromAcuc answers null without it, so the legacy op resolves no org.
+vi.mock("../../../config", () => ({ config: { USE_DB_AUTHENTICATION: true } }));
+
 vi.mock("../../../controllers/auth", () => ({
   getACUCTeam,
 }));

--- a/apps/api/src/services/billing/__tests__/batch_billing.test.ts
+++ b/apps/api/src/services/billing/__tests__/batch_billing.test.ts
@@ -4,23 +4,29 @@ import { vi } from "vitest";
 // reads at build time must be created in vi.hoisted(). (Jest left jest.mock
 // un-hoisted here because `jest` was imported from @jest/globals.) The `redis`
 // stub below stays module-level: its factory only captures it lazily.
-const { logger, withAuth, trackCredits, refundCredits, billTeam7 } = vi.hoisted(
-  () => {
-    const logger: any = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      child: vi.fn(() => logger),
-    };
-    return {
-      logger,
-      withAuth: vi.fn((fn: any) => fn),
-      trackCredits: vi.fn<(args: any) => Promise<boolean>>(),
-      refundCredits: vi.fn<(args: any) => Promise<void>>(),
-      billTeam7: vi.fn<(params: any) => Promise<{ api_key: string }[]>>(),
-    };
-  },
-);
+const {
+  logger,
+  withAuth,
+  trackCredits,
+  refundCredits,
+  billTeam7,
+  getACUCTeam,
+} = vi.hoisted(() => {
+  const logger: any = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return {
+    logger,
+    withAuth: vi.fn((fn: any) => fn),
+    trackCredits: vi.fn<(args: any) => Promise<boolean>>(),
+    refundCredits: vi.fn<(args: any) => Promise<void>>(),
+    billTeam7: vi.fn<(params: any) => Promise<{ api_key: string }[]>>(),
+    getACUCTeam: vi.fn<(teamId: string) => Promise<any>>(),
+  };
+});
 
 vi.mock("../../../lib/logger", () => ({
   logger,
@@ -41,6 +47,10 @@ vi.mock("../../autumn/autumn.service", () => ({
 
 vi.mock("../../../db/rpc", () => ({
   billTeam7,
+}));
+
+vi.mock("../../../controllers/auth", () => ({
+  getACUCTeam,
 }));
 
 let queue: string[] = [];
@@ -109,8 +119,11 @@ vi.mock("../../queue-service", () => ({
 import { processBillingBatch } from "../batch_billing";
 
 function makeOp(overrides: Record<string, unknown> = {}) {
+  // `org_id: undefined` in an override drops the key entirely, which is the
+  // shape of an operation enqueued before the field existed.
   return JSON.stringify({
     team_id: "team-1",
+    org_id: "org-1",
     credits: 10,
     billing: { endpoint: "extract" },
     is_extract: false,
@@ -128,6 +141,7 @@ beforeEach(() => {
   billTeam7.mockResolvedValue([]);
   trackCredits.mockResolvedValue(true);
   refundCredits.mockResolvedValue(undefined);
+  getACUCTeam.mockResolvedValue({ team_id: "team-1", org_id: "org-legacy" });
 });
 
 describe("processBillingBatch", () => {
@@ -160,6 +174,7 @@ describe("processBillingBatch", () => {
 
     expect(refundCredits).toHaveBeenCalledWith({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       properties: {
         source: "processBillingBatch",
@@ -178,6 +193,7 @@ describe("processBillingBatch", () => {
 
     expect(refundCredits).toHaveBeenCalledWith({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       properties: {
         source: "processBillingBatch",
@@ -208,6 +224,7 @@ describe("processBillingBatch", () => {
 
     expect(refundCredits).toHaveBeenCalledWith({
       teamId: "team-1",
+      orgId: "org-1",
       value: 10,
       properties: {
         source: "processBillingBatch",
@@ -219,5 +236,32 @@ describe("processBillingBatch", () => {
     expect(billTeam7).toHaveBeenCalledTimes(2);
     // The batch never tracks usage to Autumn, regardless of the request-time flag.
     expect(trackCredits).not.toHaveBeenCalled();
+  });
+
+  // Transitional: operations enqueued before org_id was carried. Remove with
+  // the lookup they exist for, after one deploy.
+  it("resolves the org once for operations that predate the field", async () => {
+    queue = [
+      makeOp({ org_id: undefined, autumnTrackInRequest: true }),
+      makeOp({ org_id: undefined, autumnTrackInRequest: true }),
+    ];
+    billTeam7.mockRejectedValue(new Error("db failed"));
+
+    await processBillingBatch();
+
+    expect(getACUCTeam).toHaveBeenCalledTimes(1);
+    expect(refundCredits).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: "team-1", orgId: "org-legacy" }),
+    );
+  });
+
+  it("does not look anything up for an operation whose org is a known null", async () => {
+    queue = [makeOp({ org_id: null, autumnTrackInRequest: true })];
+    billTeam7.mockRejectedValueOnce(new Error("db failed"));
+
+    await processBillingBatch();
+
+    expect(getACUCTeam).not.toHaveBeenCalled();
+    expect(refundCredits).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/billing/__tests__/credit_billing.test.ts
+++ b/apps/api/src/services/billing/__tests__/credit_billing.test.ts
@@ -13,7 +13,8 @@ const {
   queueBillingOperation: vi.fn<(args: any[]) => Promise<any>>(),
   trackCredits: vi.fn<(args: any) => Promise<boolean>>(),
   refundCredits: vi.fn<(args: any) => Promise<void>>(),
-  isRoutedThroughFirebill: vi.fn<(teamId: string) => Promise<boolean>>(),
+  isRoutedThroughFirebill:
+    vi.fn<(teamId: string, orgId: string) => Promise<boolean>>(),
 }));
 
 vi.mock("../../../lib/withAuth", () => ({
@@ -61,7 +62,7 @@ beforeEach(() => {
 
 describe("billTeam", () => {
   it("derives firebill idempotency keys from chargeId, and omits them without one", async () => {
-    await billTeam("team-1", 3, 123, {
+    await billTeam("team-1", "org-1", 3, 123, {
       endpoint: "search",
       jobId: "job-9",
       chargeId: "job-9",
@@ -70,7 +71,10 @@ describe("billTeam", () => {
       expect.objectContaining({ idempotencyKey: "fc:track:search:job-9" }),
     );
 
-    await billTeam("team-1", 3, 123, { endpoint: "search", jobId: "job-9" });
+    await billTeam("team-1", "org-1", 3, 123, {
+      endpoint: "search",
+      jobId: "job-9",
+    });
     expect(trackCredits).toHaveBeenLastCalledWith(
       expect.objectContaining({ idempotencyKey: undefined }),
     );
@@ -84,7 +88,7 @@ describe("billTeam", () => {
     });
     trackCredits.mockResolvedValueOnce(true);
 
-    await billTeam("team-1", 3, 123, {
+    await billTeam("team-1", "org-1", 3, 123, {
       endpoint: "map",
       jobId: "map-1",
       chargeId: "map-1",
@@ -100,7 +104,7 @@ describe("billTeam", () => {
     });
     trackCredits.mockResolvedValueOnce(true);
 
-    await billTeam("team-1", 3, 123, {
+    await billTeam("team-1", "org-1", 3, 123, {
       endpoint: "map",
       jobId: "map-1",
       chargeId: "map-1",
@@ -112,13 +116,14 @@ describe("billTeam", () => {
   });
 
   it("marks billing as already tracked when request tracking succeeds", async () => {
-    await billTeam("team-1", 3, 123, {
+    await billTeam("team-1", "org-1", 3, 123, {
       endpoint: "search",
       jobId: "job-1",
     });
 
     expect(queueBillingOperation).toHaveBeenCalledWith([
       "team-1",
+      "org-1",
       3,
       123,
       { endpoint: "search", jobId: "job-1" },
@@ -127,6 +132,7 @@ describe("billTeam", () => {
     ]);
     expect(trackCredits).toHaveBeenCalledWith({
       teamId: "team-1",
+      orgId: "org-1",
       value: 3,
       properties: {
         source: "billTeam",
@@ -141,13 +147,14 @@ describe("billTeam", () => {
   it("refunds Autumn when queueing fails after request tracking", async () => {
     queueBillingOperation.mockResolvedValueOnce({ success: false });
 
-    await billTeam("team-1", 3, 123, {
+    await billTeam("team-1", "org-1", 3, 123, {
       endpoint: "search",
       jobId: "job-1",
     });
 
     expect(refundCredits).toHaveBeenCalledWith({
       teamId: "team-1",
+      orgId: "org-1",
       value: 3,
       properties: {
         source: "billTeam",
@@ -159,16 +166,38 @@ describe("billTeam", () => {
     });
   });
 
+  // preview/keyless teams have no org, and this is the one boundary that
+  // accepts that: the ledger is still enqueued, Autumn is simply not told.
+  it("skips Autumn entirely when the team has no org", async () => {
+    await billTeam("preview_abc", null, 3, null, {
+      endpoint: "search",
+      jobId: "job-1",
+    });
+
+    expect(trackCredits).not.toHaveBeenCalled();
+    expect(refundCredits).not.toHaveBeenCalled();
+    expect(queueBillingOperation).toHaveBeenCalledWith([
+      "preview_abc",
+      null,
+      3,
+      null,
+      { endpoint: "search", jobId: "job-1" },
+      false,
+      false,
+    ]);
+  });
+
   it("leaves batch tracking enabled when request tracking is off", async () => {
     trackCredits.mockResolvedValueOnce(false);
 
-    await billTeam("team-1", 3, 123, {
+    await billTeam("team-1", "org-1", 3, 123, {
       endpoint: "search",
       jobId: "job-1",
     });
 
     expect(queueBillingOperation).toHaveBeenCalledWith([
       "team-1",
+      "org-1",
       3,
       123,
       { endpoint: "search", jobId: "job-1" },

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -14,6 +14,7 @@ import {
 } from "./types";
 import { reportExchangeBilling } from "../../lib/exchange";
 import { getACUCTeam } from "../../controllers/auth";
+import { orgIdFromAcuc } from "../../lib/team-org";
 
 // Upper bound on concurrent Exchange confirmation requests across the
 // whole worker, so slow or retrying deliveries from overlapping batch
@@ -224,7 +225,7 @@ export async function processBillingBatch() {
         try {
           legacyOrgIds.set(teamId, {
             resolved: true,
-            orgId: (await getACUCTeam(teamId))?.org_id ?? null,
+            orgId: orgIdFromAcuc(await getACUCTeam(teamId)),
           });
         } catch (error) {
           logger.warn("Failed to resolve the org for a legacy billing op", {

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -13,6 +13,7 @@ import {
   type BillingMetadata,
 } from "./types";
 import { reportExchangeBilling } from "../../lib/exchange";
+import { getACUCTeam } from "../../controllers/auth";
 
 // Upper bound on concurrent Exchange confirmation requests across the
 // whole worker, so slow or retrying deliveries from overlapping batch
@@ -85,6 +86,12 @@ const LOCK_TIMEOUT = 30000; // 30 seconds lock timeout
 // Define interfaces for billing operations
 interface BillingOperation {
   team_id: string;
+  /**
+   * The team's org — the Autumn customer a refund would go back to. Absent
+   * (not null) on operations enqueued before this field existed; `null` is a
+   * team that genuinely has no org. See the transitional lookup below.
+   */
+  org_id?: string | null;
   credits: number;
   billing?: BillingMetadata;
   endpoint?: BillingEndpoint;
@@ -102,6 +109,7 @@ interface BillingOperation {
 // Grouped billing operations for batch processing
 interface GroupedBillingOperation {
   team_id: string;
+  org_id: string | null;
   total_credits: number;
   billing: BillingMetadata;
   is_extract: boolean;
@@ -135,9 +143,20 @@ async function refundRequestTrackedCredits(group: GroupedBillingOperation) {
 
   if (requestTrackedCredits <= 0) return;
 
+  if (group.org_id === null) {
+    // No org, no Autumn customer to refund against — the same nothing the
+    // refund did when it could not name one.
+    logger.warn("Skipping Autumn refund: no org for the team", {
+      team_id: group.team_id,
+      credits: requestTrackedCredits,
+    });
+    return;
+  }
+
   try {
     await autumnService.refundCredits({
       teamId: group.team_id,
+      orgId: group.org_id,
       value: requestTrackedCredits,
       properties: {
         source: "processBillingBatch",
@@ -190,7 +209,27 @@ export async function processBillingBatch() {
       `📦 Processing batch of ${operations.length} billing operations`,
     );
 
-    // Group operations by team_id, endpoint, is_extract, and api_key_id
+    // transitional: operations enqueued before org_id was carried; remove
+    // after one deploy. Memoized per team, and never fatal — a batch already
+    // popped off Redis must not be lost to a lookup failure.
+    const legacyOrgIds = new Map<string, string | null>();
+    const resolveLegacyOrgId = async (teamId: string) => {
+      if (!legacyOrgIds.has(teamId)) {
+        let orgId: string | null = null;
+        try {
+          orgId = (await getACUCTeam(teamId))?.org_id ?? null;
+        } catch (error) {
+          logger.warn("Failed to resolve the org for a legacy billing op", {
+            team_id: teamId,
+            error,
+          });
+        }
+        legacyOrgIds.set(teamId, orgId);
+      }
+      return legacyOrgIds.get(teamId)!;
+    };
+
+    // Group operations by team_id, org_id, endpoint, is_extract, and api_key_id
     const groupedOperations = new Map<string, GroupedBillingOperation>();
 
     for (const op of operations) {
@@ -199,11 +238,16 @@ export async function processBillingBatch() {
           op.billing ?? (op.endpoint ? { endpoint: op.endpoint } : undefined),
         isExtract: op.is_extract,
       });
-      const key = `${op.team_id}:${billing.endpoint}:${op.is_extract}:${op.api_key_id}`;
+      const orgId =
+        op.org_id === undefined
+          ? await resolveLegacyOrgId(op.team_id)
+          : op.org_id;
+      const key = `${op.team_id}:${orgId}:${billing.endpoint}:${op.is_extract}:${op.api_key_id}`;
 
       if (!groupedOperations.has(key)) {
         groupedOperations.set(key, {
           team_id: op.team_id,
+          org_id: orgId,
           total_credits: 0,
           billing,
           is_extract: op.is_extract,
@@ -325,6 +369,11 @@ export function startBillingBatchProcessing() {
  */
 export async function queueBillingOperation(
   team_id: string,
+  /**
+   * The team's org. `undefined` only while draining `bill_team` jobs enqueued
+   * before the field existed; those resolve it in the batch instead.
+   */
+  org_id: string | null | undefined,
   credits: number,
   api_key_id: number | null,
   billing: BillingMetadata,
@@ -348,6 +397,7 @@ export async function queueBillingOperation(
   try {
     const operation: BillingOperation = {
       team_id,
+      ...(org_id === undefined ? {} : { org_id }),
       credits,
       billing,
       is_extract,

--- a/apps/api/src/services/billing/batch_billing.ts
+++ b/apps/api/src/services/billing/batch_billing.ts
@@ -210,27 +210,36 @@ export async function processBillingBatch() {
     );
 
     // transitional: operations enqueued before org_id was carried; remove
-    // after one deploy. Memoized per team, and never fatal — a batch already
-    // popped off Redis must not be lost to a lookup failure.
-    const legacyOrgIds = new Map<string, string | null>();
+    // after one deploy. An answer of null is a team that genuinely has no org
+    // and is memoized as such; a lookup that throws leaves the org unknown, and
+    // billing those as org-less would silently skip their refund — so they are
+    // requeued untouched instead. The failure is memoized too, so a failing
+    // lookup costs one call per team per batch rather than one per operation.
+    const legacyOrgIds = new Map<
+      string,
+      { resolved: true; orgId: string | null } | { resolved: false }
+    >();
     const resolveLegacyOrgId = async (teamId: string) => {
       if (!legacyOrgIds.has(teamId)) {
-        let orgId: string | null = null;
         try {
-          orgId = (await getACUCTeam(teamId))?.org_id ?? null;
+          legacyOrgIds.set(teamId, {
+            resolved: true,
+            orgId: (await getACUCTeam(teamId))?.org_id ?? null,
+          });
         } catch (error) {
           logger.warn("Failed to resolve the org for a legacy billing op", {
             team_id: teamId,
             error,
           });
+          legacyOrgIds.set(teamId, { resolved: false });
         }
-        legacyOrgIds.set(teamId, orgId);
       }
       return legacyOrgIds.get(teamId)!;
     };
 
     // Group operations by team_id, org_id, endpoint, is_extract, and api_key_id
     const groupedOperations = new Map<string, GroupedBillingOperation>();
+    const unresolvedOperations: BillingOperation[] = [];
 
     for (const op of operations) {
       const billing = resolveBillingMetadata({
@@ -238,10 +247,17 @@ export async function processBillingBatch() {
           op.billing ?? (op.endpoint ? { endpoint: op.endpoint } : undefined),
         isExtract: op.is_extract,
       });
-      const orgId =
-        op.org_id === undefined
-          ? await resolveLegacyOrgId(op.team_id)
-          : op.org_id;
+      let orgId: string | null;
+      if (op.org_id === undefined) {
+        const lookup = await resolveLegacyOrgId(op.team_id);
+        if (!lookup.resolved) {
+          unresolvedOperations.push(op);
+          continue;
+        }
+        orgId = lookup.orgId;
+      } else {
+        orgId = op.org_id;
+      }
       const key = `${op.team_id}:${orgId}:${billing.endpoint}:${op.is_extract}:${op.api_key_id}`;
 
       if (!groupedOperations.has(key)) {
@@ -259,6 +275,20 @@ export async function processBillingBatch() {
       const group = groupedOperations.get(key)!;
       group.total_credits += op.credits;
       group.operations.push(op);
+    }
+
+    if (unresolvedOperations.length > 0) {
+      // Back onto the same list in the same shape — still without org_id — so
+      // the next batch retries the lookup. Nothing is billed or refunded for
+      // them here.
+      logger.warn(
+        "Requeueing legacy billing operations whose org could not be resolved",
+        { count: unresolvedOperations.length },
+      );
+      await redis.rpush(
+        BATCH_KEY,
+        ...unresolvedOperations.map(op => JSON.stringify(op)),
+      );
     }
 
     // Process each group of operations

--- a/apps/api/src/services/billing/credit_billing.ts
+++ b/apps/api/src/services/billing/credit_billing.ts
@@ -7,8 +7,17 @@ import {
 import { toAutumnBillingProperties, type BillingMetadata } from "./types";
 import type { Logger } from "winston";
 
+/**
+ * `org_id` is the team's Autumn customer. It is nullable here and nowhere
+ * below: this is the facade every controller and worker bills through, and
+ * preview/keyless teams legitimately have no org. Without one there is no
+ * customer to charge, so the Autumn track is skipped — the same `false` it
+ * already answers for those teams — while the ledger enqueue, which needs no
+ * org, still runs.
+ */
 export async function billTeam(
   team_id: string,
+  org_id: string | null,
   credits: number,
   api_key_id: number | null,
   billing: BillingMetadata,
@@ -17,6 +26,7 @@ export async function billTeam(
   return withAuth(
     async (
       team_id: string,
+      org_id: string | null,
       credits: number,
       api_key_id: number | null,
       billing: BillingMetadata,
@@ -28,20 +38,33 @@ export async function billTeam(
         apiKeyId: api_key_id,
       };
       const featureId = featureIdForBillingEndpoint(billing.endpoint);
-      // Stable per-charge key (firebill route only): a caller retry or re-run
-      // job with the same chargeId dedupes instead of double-billing.
-      const trackedInRequest = await autumnService.trackCredits({
-        teamId: team_id,
-        value: credits,
-        properties: autumnProperties,
-        featureId,
-        idempotencyKey: billing.chargeId
-          ? `fc:track:${billing.endpoint}:${billing.chargeId}`
-          : undefined,
-      });
+
+      let trackedInRequest = false;
+      if (org_id !== null) {
+        // Stable per-charge key (firebill route only): a caller retry or re-run
+        // job with the same chargeId dedupes instead of double-billing.
+        trackedInRequest = await autumnService.trackCredits({
+          teamId: team_id,
+          orgId: org_id,
+          value: credits,
+          properties: autumnProperties,
+          featureId,
+          idempotencyKey: billing.chargeId
+            ? `fc:track:${billing.endpoint}:${billing.chargeId}`
+            : undefined,
+        });
+      } else if (team_id !== "preview" && !team_id.startsWith("preview_")) {
+        // Preview teams are never tracked anyway; a real team arriving without
+        // an org is not expected, and its usage is about to go unmetered.
+        logger?.error(
+          "No org for the team; billing the ledger but not Autumn",
+          { team_id, credits, billing },
+        );
+      }
 
       const result = await queueBillingOperation(
         team_id,
+        org_id,
         credits,
         api_key_id,
         billing,
@@ -49,8 +72,9 @@ export async function billTeam(
         trackedInRequest,
       );
 
-      if (!result.success && trackedInRequest) {
-        if (await autumnService.isRoutedThroughFirebill(team_id)) {
+      // A track only happens with an org in hand; named again so the type says so.
+      if (!result.success && trackedInRequest && org_id !== null) {
+        if (await autumnService.isRoutedThroughFirebill(team_id, org_id)) {
           // No compensating refund on the firebill route: the tracked charge
           // is durable and correct, and a refund here poisons a retried
           // request — its track would be deduped by Autumn against the same
@@ -63,6 +87,7 @@ export async function billTeam(
         } else {
           await autumnService.refundCredits({
             teamId: team_id,
+            orgId: org_id,
             value: credits,
             properties: autumnProperties,
             featureId,
@@ -77,5 +102,5 @@ export async function billTeam(
       return result;
     },
     { success: true, message: "No DB, bypassed." },
-  )(team_id, credits, api_key_id, billing, logger);
+  )(team_id, org_id, credits, api_key_id, billing, logger);
 }

--- a/apps/api/src/services/indexing/index-worker.ts
+++ b/apps/api/src/services/indexing/index-worker.ts
@@ -82,6 +82,9 @@ const processBillingJobInternal = async (token: string, job: Job) => {
       // This is an individual billing operation that should be queued for batch processing
       const {
         team_id,
+        // Undefined on a job enqueued before the producer carried the org;
+        // passed through as such so the batch resolves it once instead.
+        org_id,
         credits,
         billing,
         endpoint,
@@ -100,6 +103,7 @@ const processBillingJobInternal = async (token: string, job: Job) => {
       // Add to the REDIS batch queue
       await queueBillingOperation(
         team_id,
+        org_id,
         credits,
         api_key_id ?? null,
         resolveBillingMetadata({

--- a/apps/api/src/services/integrations/slack/commands.ts
+++ b/apps/api/src/services/integrations/slack/commands.ts
@@ -19,6 +19,7 @@ import {
 } from "../../monitoring/types";
 import { getTeamBalance } from "../../autumn/usage";
 import { autumnService } from "../../autumn/autumn.service";
+import { getACUCTeam } from "../../../controllers/auth";
 import { getCombinedTeamActiveCount } from "../../worker/nuq-router";
 import type { SlackInstallationRow } from "./types";
 import { escapeSlackText, slackLink } from "./messages";
@@ -477,7 +478,12 @@ async function accountResponse(
   const teamId = installation.team_id;
   const [balance, concurrencyLimit, activeJobs] = await Promise.all([
     getTeamBalance(teamId).catch(() => null),
-    autumnService.getConcurrencyLimit(teamId).catch(() => null),
+    getACUCTeam(teamId)
+      .catch(() => null)
+      .then(acuc =>
+        autumnService.getConcurrencyLimit(teamId, acuc?.org_id ?? null),
+      )
+      .catch(() => null),
     getCombinedTeamActiveCount(teamId).catch(() => null),
   ]);
 

--- a/apps/api/src/services/integrations/slack/commands.ts
+++ b/apps/api/src/services/integrations/slack/commands.ts
@@ -19,7 +19,7 @@ import {
 } from "../../monitoring/types";
 import { getTeamBalance } from "../../autumn/usage";
 import { autumnService } from "../../autumn/autumn.service";
-import { getACUCTeam } from "../../../controllers/auth";
+import { orgIdForTeam } from "../../../lib/team-org";
 import { getCombinedTeamActiveCount } from "../../worker/nuq-router";
 import type { SlackInstallationRow } from "./types";
 import { escapeSlackText, slackLink } from "./messages";
@@ -478,11 +478,8 @@ async function accountResponse(
   const teamId = installation.team_id;
   const [balance, concurrencyLimit, activeJobs] = await Promise.all([
     getTeamBalance(teamId).catch(() => null),
-    getACUCTeam(teamId)
-      .catch(() => null)
-      .then(acuc =>
-        autumnService.getConcurrencyLimit(teamId, acuc?.org_id ?? null),
-      )
+    orgIdForTeam(teamId)
+      .then(orgId => autumnService.getConcurrencyLimit(teamId, orgId))
       .catch(() => null),
     getCombinedTeamActiveCount(teamId).catch(() => null),
   ]);

--- a/apps/api/src/services/monitoring/runner.finalization.test.ts
+++ b/apps/api/src/services/monitoring/runner.finalization.test.ts
@@ -319,6 +319,42 @@ describe("monitor check finalization ownership", () => {
   );
 
   it.each([
+    {
+      name: "answers no org",
+      acuc: async () => ({ org_id: null }) as any,
+    },
+    {
+      name: "cannot be read",
+      acuc: async () => {
+        throw new Error("ACUC unavailable");
+      },
+    },
+  ])(
+    "releases a stale hold with no team when the ACUC $name",
+    async ({ acuc }) => {
+      vi.mocked(getACUCTeam).mockImplementation(acuc);
+      current.started_at = new Date(
+        Date.now() - 2 * 60 * 60 * 1000,
+      ).toISOString();
+
+      await reconcileRunningMonitorChecks();
+
+      expect(current).toMatchObject({
+        status: "failed",
+        billing_status: "released",
+      });
+      // Fail open: the release still happens, just without a team to name.
+      const calls = vi.mocked(autumnService.finalizeCreditsLock).mock.calls;
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toMatchObject({
+        action: "release",
+        lockId: "monitor_check-1",
+      });
+      expect(calls[0][0].team).toBeUndefined();
+    },
+  );
+
+  it.each([
     { kind: "stale", throws: false },
     { kind: "stale", throws: true },
     { kind: "orphan", throws: false },

--- a/apps/api/src/services/monitoring/runner.finalization.test.ts
+++ b/apps/api/src/services/monitoring/runner.finalization.test.ts
@@ -32,7 +32,7 @@ vi.mock("./search/judge", () => ({}));
 vi.mock("./search/dedupe", () => ({}));
 vi.mock("./search/persist", () => ({}));
 vi.mock("../../scraper/WebScraper/utils/blocklist", () => ({}));
-vi.mock("../../controllers/auth", () => ({}));
+vi.mock("../../controllers/auth", () => ({ getACUCTeam: vi.fn() }));
 vi.mock("./store", () => ({
   getMonitorCheckForUpdate: vi.fn(),
   getMonitorForUpdate: vi.fn(),
@@ -58,6 +58,7 @@ import {
   reconcileRunningMonitorChecks,
 } from "./runner";
 import * as store from "./store";
+import { getACUCTeam } from "../../controllers/auth";
 import { autumnService } from "../autumn/autumn.service";
 import { getBillingQueue } from "../queue-service";
 import { redisEvictConnection } from "../redis";
@@ -136,6 +137,7 @@ describe("monitor check finalization ownership", () => {
       async ({ status }) => (!status || status === "same" ? 1 : 0),
     );
     vi.mocked(store.calculateMonitorCheckActualCredits).mockResolvedValue(1);
+    vi.mocked(getACUCTeam).mockResolvedValue({ org_id: "org-1" } as any);
     vi.mocked(autumnService.finalizeCreditsLock).mockResolvedValue(true);
     vi.mocked(getBillingQueue).mockReturnValue({
       add: bill,
@@ -543,7 +545,7 @@ describe("monitor check finalization ownership", () => {
             endpoint: "monitor",
             jobId: current.id,
           },
-          teamId: monitor.team_id,
+          team: { teamId: monitor.team_id, orgId: "org-1" },
         });
       } else {
         expect(autumnService.finalizeCreditsLock).not.toHaveBeenCalled();

--- a/apps/api/src/services/monitoring/runner.finalization.test.ts
+++ b/apps/api/src/services/monitoring/runner.finalization.test.ts
@@ -58,6 +58,7 @@ import {
   reconcileRunningMonitorChecks,
 } from "./runner";
 import * as store from "./store";
+import { config } from "../../config";
 import { getACUCTeam } from "../../controllers/auth";
 import { autumnService } from "../autumn/autumn.service";
 import { getBillingQueue } from "../queue-service";
@@ -137,6 +138,8 @@ describe("monitor check finalization ownership", () => {
       async ({ status }) => (!status || status === "same" ? 1 : 0),
     );
     vi.mocked(store.calculateMonitorCheckActualCredits).mockResolvedValue(1);
+    (config as { USE_DB_AUTHENTICATION?: boolean }).USE_DB_AUTHENTICATION =
+      true;
     vi.mocked(getACUCTeam).mockResolvedValue({ org_id: "org-1" } as any);
     vi.mocked(autumnService.finalizeCreditsLock).mockResolvedValue(true);
     vi.mocked(getBillingQueue).mockReturnValue({
@@ -353,6 +356,27 @@ describe("monitor check finalization ownership", () => {
       expect(calls[0][0].team).toBeUndefined();
     },
   );
+
+  it("names no team when DB authentication is off", async () => {
+    // The mock ACUC's org is the sentinel "bypass", so the ACUC is not even
+    // read: releasing against "bypass" would name a customer that isn't one.
+    (config as { USE_DB_AUTHENTICATION?: boolean }).USE_DB_AUTHENTICATION =
+      false;
+    vi.mocked(getACUCTeam).mockResolvedValue({
+      team_id: "bypass",
+      org_id: "bypass",
+    } as any);
+    current.started_at = new Date(
+      Date.now() - 2 * 60 * 60 * 1000,
+    ).toISOString();
+
+    await reconcileRunningMonitorChecks();
+
+    const calls = vi.mocked(autumnService.finalizeCreditsLock).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].team).toBeUndefined();
+    expect(getACUCTeam).not.toHaveBeenCalled();
+  });
 
   it.each([
     { kind: "stale", throws: false },

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -356,6 +356,9 @@ async function billMonitorCheck(params: {
   check: MonitorCheckRow;
   actualCredits: number;
   lockId: string | null;
+  /** The team's org. Null means none could be named, which is how the settle
+   * already behaved then: straight to Autumn, and unreportable to a partner. */
+  orgId: string | null;
 }): Promise<boolean> {
   let settled = true;
   if (params.lockId) {
@@ -368,7 +371,9 @@ async function billMonitorCheck(params: {
         endpoint: "monitor",
         jobId: params.check.id,
       },
-      teamId: params.monitor.team_id,
+      team: params.orgId
+        ? { teamId: params.monitor.team_id, orgId: params.orgId }
+        : undefined,
       // Confirm only: a release bills nothing, so there is nothing to report.
       externalRequestId: params.check.partner_run_token,
       // What the lock reserved. firebill adds it back to the ghost's reported
@@ -934,6 +939,7 @@ async function releaseUnpersistedMonitorHold(
   monitor: MonitorRow,
   checkId: string,
   lockId: string | null,
+  orgId: string | null,
 ): Promise<void> {
   if (!lockId) return;
   const latest = await getMonitorCheckForUpdate(
@@ -957,7 +963,7 @@ async function releaseUnpersistedMonitorHold(
         endpoint: "monitor",
         jobId: checkId,
       },
-      teamId: monitor.team_id,
+      team: orgId ? { teamId: monitor.team_id, orgId } : undefined,
     });
   }
 }
@@ -1007,25 +1013,40 @@ export async function processMonitorCheckJob(
     }),
   );
 
+  // One org lookup for the whole check job — the billing service no longer
+  // makes it, so every hold, settle and release below shares this one. A
+  // failure answers null, which is what the lookup inside the biller did.
+  const orgId =
+    (await getACUCTeam(monitor.team_id).catch(() => null))?.org_id ?? null;
+  const partnerJobToken = check.partner_run_token
+    ? null
+    : monitor.partner_job_token;
+
   let lockId: string | null = null;
   try {
-    const lock = await autumnService.lockCredits({
-      teamId: monitor.team_id,
-      value: check.estimated_credits ?? 1,
-      lockId: `monitor_${check.id}`,
-      expiresAt: Date.now() + 60 * 60 * 1000,
-      properties: {
-        source: "monitorCheck",
-        endpoint: "monitor",
-        jobId: check.id,
-      },
-      // Arms firebill's partner gate; NULL is today's lock. Withheld once this
-      // check holds a run token: a redelivery is the same occurrence, and
-      // asking twice would orphan the first token.
-      partnerJobToken: check.partner_run_token
-        ? null
-        : monitor.partner_job_token,
-    });
+    const lock = orgId
+      ? await autumnService.lockCredits({
+          teamId: monitor.team_id,
+          orgId,
+          value: check.estimated_credits ?? 1,
+          lockId: `monitor_${check.id}`,
+          expiresAt: Date.now() + 60 * 60 * 1000,
+          properties: {
+            source: "monitorCheck",
+            endpoint: "monitor",
+            jobId: check.id,
+          },
+          // Arms firebill's partner gate; NULL is today's lock. Withheld once this
+          // check holds a run token: a redelivery is the same occurrence, and
+          // asking twice would orphan the first token.
+          partnerJobToken,
+        })
+      : // No org, no customer to hold against — the same answers the hold gave
+        // when it could not name one: proceed unlocked, except for a gated run,
+        // which is unauthorized until a partner says otherwise.
+        partnerJobToken
+        ? ({ status: "denied", reason: "gate_unavailable" } as const)
+        : ({ status: "skipped" } as const);
 
     if (lock.status === "denied") {
       const revoked = lock.reason === "job_revoked";
@@ -1092,7 +1113,7 @@ export async function processMonitorCheckJob(
     });
 
     if (!reserved) {
-      await releaseUnpersistedMonitorHold(monitor, check.id, lockId);
+      await releaseUnpersistedMonitorHold(monitor, check.id, lockId, orgId);
       return;
     }
     check = reserved;
@@ -1170,7 +1191,7 @@ export async function processMonitorCheckJob(
     });
 
     if (!failed) {
-      await releaseUnpersistedMonitorHold(monitor, check.id, lockId);
+      await releaseUnpersistedMonitorHold(monitor, check.id, lockId, orgId);
       throw error;
     }
     check = failed;
@@ -1189,7 +1210,7 @@ export async function processMonitorCheckJob(
             endpoint: "monitor",
             jobId: check.id,
           },
-          teamId: monitor.team_id,
+          team: orgId ? { teamId: monitor.team_id, orgId } : undefined,
         })
         .catch(releaseError => {
           logger.warn("Failed to release monitor check credit lock", {
@@ -1364,6 +1385,8 @@ async function isMonitorCheckComplete(
 async function failStaleMonitorCheck(params: {
   monitor: MonitorRow;
   check: MonitorCheckRow;
+  /** See billMonitorCheck's orgId. */
+  orgId: string | null;
 }): Promise<boolean> {
   if (!isMonitorCheckStale(params.check, new Date(), params.monitor.targets))
     return false;
@@ -1388,7 +1411,9 @@ async function failStaleMonitorCheck(params: {
           endpoint: "monitor",
           jobId: params.check.id,
         },
-        teamId: params.monitor.team_id,
+        team: params.orgId
+          ? { teamId: params.monitor.team_id, orgId: params.orgId }
+          : undefined,
       })
       .catch(releaseError => {
         logger.warn("Failed to release stale monitor check credit lock", {
@@ -1496,6 +1521,11 @@ export async function reconcileRunningMonitorChecks(
       );
       if (!check || check.status !== "running") continue;
 
+      // One org lookup per check — the billing service no longer makes it, so
+      // the release, the stale-fail and the settle below all share this one.
+      const orgId =
+        (await getACUCTeam(check.team_id).catch(() => null))?.org_id ?? null;
+
       const monitor = await getMonitorForUpdate(
         check.team_id,
         check.monitor_id,
@@ -1520,7 +1550,7 @@ export async function reconcileRunningMonitorChecks(
                 endpoint: "monitor",
                 jobId: check.id,
               },
-              teamId: check.team_id,
+              team: orgId ? { teamId: check.team_id, orgId } : undefined,
             })
             .catch(error => {
               logger.warn(
@@ -1550,7 +1580,7 @@ export async function reconcileRunningMonitorChecks(
         continue;
       }
 
-      if (await failStaleMonitorCheck({ monitor, check })) continue;
+      if (await failStaleMonitorCheck({ monitor, check, orgId })) continue;
 
       // The inline handler may still write target results after our primary read.
       let targetResults = Array.isArray(check.target_results)
@@ -1636,6 +1666,7 @@ export async function reconcileRunningMonitorChecks(
           check: finalized,
           actualCredits,
           lockId: claimed.autumn_lock_id,
+          orgId,
         });
       } catch (error) {
         logger.warn("Failed to bill monitor check during reconciliation", {

--- a/apps/api/src/services/monitoring/runner.ts
+++ b/apps/api/src/services/monitoring/runner.ts
@@ -74,6 +74,7 @@ import { verdictJsonSchema } from "./search/judge";
 import { computeGoalVersion } from "./search/dedupe";
 import { isUrlBlocked } from "../../scraper/WebScraper/utils/blocklist";
 import { getACUCTeam } from "../../controllers/auth";
+import { orgIdForTeam } from "../../lib/team-org";
 import {
   reconstructKnownState,
   searchStatusToPageStatus,
@@ -1016,8 +1017,7 @@ export async function processMonitorCheckJob(
   // One org lookup for the whole check job — the billing service no longer
   // makes it, so every hold, settle and release below shares this one. A
   // failure answers null, which is what the lookup inside the biller did.
-  const orgId =
-    (await getACUCTeam(monitor.team_id).catch(() => null))?.org_id ?? null;
+  const orgId = await orgIdForTeam(monitor.team_id);
   const partnerJobToken = check.partner_run_token
     ? null
     : monitor.partner_job_token;
@@ -1523,8 +1523,7 @@ export async function reconcileRunningMonitorChecks(
 
       // One org lookup per check — the billing service no longer makes it, so
       // the release, the stale-fail and the settle below all share this one.
-      const orgId =
-        (await getACUCTeam(check.team_id).catch(() => null))?.org_id ?? null;
+      const orgId = await orgIdForTeam(check.team_id);
 
       const monitor = await getMonitorForUpdate(
         check.team_id,

--- a/apps/api/src/services/monitoring/scheduler.ts
+++ b/apps/api/src/services/monitoring/scheduler.ts
@@ -13,6 +13,7 @@ import {
   updateMonitorScheduleAfterRun,
 } from "./store";
 import { autumnService } from "../autumn/autumn.service";
+import { getACUCTeam } from "../../controllers/auth";
 import { isMonitorCheckStale, MONITOR_CHECK_STALE_ERROR } from "./stale";
 import { validateMonitorCron } from "./cron";
 import { monitorJitterOffsetMs } from "./jitter";
@@ -210,6 +211,10 @@ async function clearFinishedOrStaleCurrentCheck(
 
     let released = true;
     if (failed.autumn_lock_id) {
+      // The billing service no longer finds the org for itself; without one
+      // the release goes straight to Autumn, as it already did then.
+      const orgId =
+        (await getACUCTeam(monitor.team_id).catch(() => null))?.org_id ?? null;
       released = await autumnService
         .finalizeCreditsLock({
           lockId: failed.autumn_lock_id,
@@ -219,7 +224,7 @@ async function clearFinishedOrStaleCurrentCheck(
             endpoint: "monitor",
             jobId: failed.id,
           },
-          teamId: monitor.team_id,
+          team: orgId ? { teamId: monitor.team_id, orgId } : undefined,
         })
         .catch(error => {
           logger.warn("Failed to release stale monitor check credit lock", {

--- a/apps/api/src/services/monitoring/scheduler.ts
+++ b/apps/api/src/services/monitoring/scheduler.ts
@@ -13,7 +13,7 @@ import {
   updateMonitorScheduleAfterRun,
 } from "./store";
 import { autumnService } from "../autumn/autumn.service";
-import { getACUCTeam } from "../../controllers/auth";
+import { orgIdForTeam } from "../../lib/team-org";
 import { isMonitorCheckStale, MONITOR_CHECK_STALE_ERROR } from "./stale";
 import { validateMonitorCron } from "./cron";
 import { monitorJitterOffsetMs } from "./jitter";
@@ -213,8 +213,7 @@ async function clearFinishedOrStaleCurrentCheck(
     if (failed.autumn_lock_id) {
       // The billing service no longer finds the org for itself; without one
       // the release goes straight to Autumn, as it already did then.
-      const orgId =
-        (await getACUCTeam(monitor.team_id).catch(() => null))?.org_id ?? null;
+      const orgId = await orgIdForTeam(monitor.team_id);
       released = await autumnService
         .finalizeCreditsLock({
           lockId: failed.autumn_lock_id,

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -38,6 +38,7 @@ import {
 import { serializeTraceContext } from "../lib/otel-tracer";
 import { isSelfHosted } from "../lib/deployment";
 import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
+import { getACUCTeam } from "../controllers/auth";
 
 // Queue-wait deadline for a backlogged job (how long its owner still cares about the result)
 function backlogTimeoutMs(data: ScrapeJobData): number {
@@ -345,6 +346,27 @@ async function maybeSendConcurrencyNotificationFdb(
   }
 }
 
+// The org for a team's concurrency lookup. It rides the job payload,
+// snapshotted from the request ACUC at acceptance; every job here is one
+// team's, so any of them answers. The ACUC is the fallback for a job enqueued
+// without one (monitor jobs null the field deliberately — it also gates
+// blocklist enforcement), so a monitor team is still gated on its real limit
+// rather than falling open. One resolution per enqueue, never per job.
+async function orgIdForEnqueue(
+  jobs: ScrapeJobData[],
+  teamId: string,
+): Promise<string | null> {
+  return (
+    jobs
+      .map(d =>
+        "internalOptions" in d ? (d.internalOptions?.orgId ?? null) : null,
+      )
+      .find(o => o !== null) ??
+    (await getACUCTeam(teamId).catch(() => null))?.org_id ??
+    null
+  );
+}
+
 async function addScrapeJobRaw(
   webScraperOptions: ScrapeJobData,
   jobId: string,
@@ -400,6 +422,7 @@ async function addScrapeJobRaw(
 
     maxConcurrency = await getEffectiveConcurrencyLimit(
       webScraperOptions.team_id,
+      await orgIdForEnqueue([webScraperOptions], webScraperOptions.team_id),
     );
 
     if (concurrencyLimited === null) {
@@ -693,7 +716,13 @@ export async function addScrapeJobs(
       addToCQ = jobsForcedToCQ;
     } else {
       const now = Date.now();
-      maxConcurrency = await getEffectiveConcurrencyLimit(teamId);
+      maxConcurrency = await getEffectiveConcurrencyLimit(
+        teamId,
+        await orgIdForEnqueue(
+          allTeamJobs.map(j => j.data),
+          teamId,
+        ),
+      );
       await cleanOldConcurrencyLimitEntries(teamId, now);
 
       currentActiveConcurrency = (

--- a/apps/api/src/services/queue-jobs.ts
+++ b/apps/api/src/services/queue-jobs.ts
@@ -38,7 +38,7 @@ import {
 import { serializeTraceContext } from "../lib/otel-tracer";
 import { isSelfHosted } from "../lib/deployment";
 import { MONITOR_CHECK_STALE_TIMEOUT_MS } from "./monitoring/stale";
-import { getACUCTeam } from "../controllers/auth";
+import { orgIdForTeam } from "../lib/team-org";
 
 // Queue-wait deadline for a backlogged job (how long its owner still cares about the result)
 function backlogTimeoutMs(data: ScrapeJobData): number {
@@ -361,9 +361,7 @@ async function orgIdForEnqueue(
       .map(d =>
         "internalOptions" in d ? (d.internalOptions?.orgId ?? null) : null,
       )
-      .find(o => o !== null) ??
-    (await getACUCTeam(teamId).catch(() => null))?.org_id ??
-    null
+      .find(o => o !== null) ?? (await orgIdForTeam(teamId))
   );
 }
 

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -3,6 +3,7 @@ import { logger as _logger } from "../../lib/logger";
 import { config } from "../../config";
 import { RateLimiterMode, ScrapeJobData } from "../../types";
 import { getACUCTeam } from "../../controllers/auth";
+import { orgIdForTeam } from "../../lib/team-org";
 import { autumnService } from "../autumn/autumn.service";
 import { redisEvictConnection } from "../../services/redis";
 import { isSelfHosted } from "../../lib/deployment";
@@ -263,9 +264,7 @@ export async function fdbEnqueueScrapeJobs(
             ? (j.data.internalOptions?.orgId ?? null)
             : null,
         )
-        .find(o => o !== null) ??
-      (await getACUCTeam(teamId).catch(() => null))?.org_id ??
-      null;
+        .find(o => o !== null) ?? (await orgIdForTeam(teamId));
     const autumnLimit = await autumnService.getConcurrencyLimit(teamId, orgId);
     // fdbForced: leave unlimited (null) when Autumn has no concurrency value.
     teamLimit = fdbForced() ? autumnLimit : (autumnLimit ?? 2);

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -249,10 +249,23 @@ export async function fdbEnqueueScrapeJobs(
 }> {
   let teamLimit: number | null = null;
   if (!isSelfHosted()) {
-    // The org comes from the team's ACUC — the same lookup the concurrency
-    // limit used to make for itself, now that the billing service resolves
-    // nothing. One per enqueue batch, not per job.
-    const orgId = (await getACUCTeam(teamId).catch(() => null))?.org_id ?? null;
+    // The org rides the job payload, snapshotted from the request ACUC at
+    // acceptance; every job in a batch is one team's, so any of them answers.
+    // The ACUC lookup is the fallback for a job enqueued without one (monitor
+    // jobs null the field deliberately — it also gates blocklist enforcement),
+    // so a monitor team is still gated on its real limit rather than falling
+    // open. Batches are enqueued per discovered link, so the payload org keeps
+    // the common path free of a lookup.
+    const orgId =
+      jobs
+        .map(j =>
+          "internalOptions" in j.data
+            ? (j.data.internalOptions?.orgId ?? null)
+            : null,
+        )
+        .find(o => o !== null) ??
+      (await getACUCTeam(teamId).catch(() => null))?.org_id ??
+      null;
     const autumnLimit = await autumnService.getConcurrencyLimit(teamId, orgId);
     // fdbForced: leave unlimited (null) when Autumn has no concurrency value.
     teamLimit = fdbForced() ? autumnLimit : (autumnLimit ?? 2);

--- a/apps/api/src/services/worker/nuq-router.ts
+++ b/apps/api/src/services/worker/nuq-router.ts
@@ -248,11 +248,14 @@ export async function fdbEnqueueScrapeJobs(
   teamLimit: number | null;
 }> {
   let teamLimit: number | null = null;
-  if (!isSelfHosted() && !fdbForced()) {
-    teamLimit = (await autumnService.getConcurrencyLimit(teamId)) ?? 2;
-  } else if (!isSelfHosted()) {
+  if (!isSelfHosted()) {
+    // The org comes from the team's ACUC — the same lookup the concurrency
+    // limit used to make for itself, now that the billing service resolves
+    // nothing. One per enqueue batch, not per job.
+    const orgId = (await getACUCTeam(teamId).catch(() => null))?.org_id ?? null;
+    const autumnLimit = await autumnService.getConcurrencyLimit(teamId, orgId);
     // fdbForced: leave unlimited (null) when Autumn has no concurrency value.
-    teamLimit = await autumnService.getConcurrencyLimit(teamId);
+    teamLimit = fdbForced() ? autumnLimit : (autumnLimit ?? 2);
   }
 
   const queueCap =

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -121,6 +121,22 @@ if (require.main === module) {
   warmExchangeCatalog();
 }
 
+// The org for a job's Autumn lookups. It rides the job payload, snapshotted
+// from the request ACUC at acceptance; the ACUC answers only for a job
+// enqueued without one (monitor jobs null it deliberately, since the field
+// also gates blocklist enforcement) — the same lookup getJobPriority used to
+// make for itself, now hoisted to once per job instead of once per link.
+async function orgIdForJob(
+  orgIdFromJob: string | null | undefined,
+  teamId: string,
+): Promise<string | null> {
+  return (
+    orgIdFromJob ??
+    (await getACUCTeam(teamId).catch(() => null))?.org_id ??
+    null
+  );
+}
+
 async function billScrapeJob(
   job: NuQJob<any>,
   document: Document | null,
@@ -692,11 +708,18 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
               }
             }
 
+            // Hoisted: one org resolution per job, not one per discovered link.
+            const crawlOrgId =
+              discoveredLinks.length > 0
+                ? await orgIdForJob(sc.internalOptions?.orgId, sc.team_id)
+                : null;
+
             for (const link of discoveredLinks) {
               if (await lockURL(job.data.crawl_id, sc, link)) {
                 // This seems to work really welel
                 const jobPriority = await getJobPriority({
                   team_id: sc.team_id,
+                  org_id: crawlOrgId,
                   basePriority: job.data.crawl_id ? 20 : 10,
                 });
                 const jobId = uuidv7();
@@ -1321,7 +1344,11 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
           : undefined,
       },
       jobId,
-      await getJobPriority({ team_id: job.data.team_id, basePriority: 15 }),
+      await getJobPriority({
+        team_id: job.data.team_id,
+        org_id: await orgIdForJob(sc.internalOptions?.orgId, job.data.team_id),
+        basePriority: 15,
+      }),
     );
     logger.debug("Adding scrape job to BullMQ...", { jobId });
     await addCrawlJob(job.data.crawl_id, jobId, logger);
@@ -1432,6 +1459,10 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
 
       let jobPriority = await getJobPriority({
         team_id: job.data.team_id,
+        org_id: await orgIdForJob(
+          job.data.internalOptions?.orgId,
+          job.data.team_id,
+        ),
         basePriority: 21,
       });
       logger.debug("Using job priority " + jobPriority, { jobPriority });
@@ -1600,6 +1631,7 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
 
       const jobPriority = await getJobPriority({
         team_id: job.data.team_id,
+        org_id: await orgIdForJob(sc.internalOptions?.orgId, job.data.team_id),
         basePriority: 21,
       });
 

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -684,7 +684,13 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
                 billThreatBlockedDiscoveries(
                   {
                     teamId: job.data.team_id,
-                    orgId: job.data.internalOptions?.orgId ?? null,
+                    // A null org here would drop a real charge, so this falls
+                    // through the payload, the stored crawl, then the ACUC.
+                    orgId: await orgIdForJob(
+                      job.data.internalOptions?.orgId ??
+                        sc.internalOptions?.orgId,
+                      job.data.team_id,
+                    ),
                     apiKeyId: job.data.apiKeyId ?? null,
                     billing: resolveBillingMetadata({
                       billing: job.data.billing,
@@ -1437,7 +1443,12 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
         billThreatBlockedDiscoveries(
           {
             teamId: job.data.team_id,
-            orgId: job.data.internalOptions?.orgId ?? null,
+            // Kickoff jobs may carry no internalOptions; the stored crawl and
+            // then the ACUC answer, since a null org would drop a real charge.
+            orgId: await orgIdForJob(
+              job.data.internalOptions?.orgId ?? sc.internalOptions?.orgId,
+              job.data.team_id,
+            ),
             apiKeyId: job.data.apiKeyId ?? null,
             billing: resolveBillingMetadata({
               billing: job.data.billing,
@@ -1609,7 +1620,12 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
         billThreatBlockedDiscoveries(
           {
             teamId: job.data.team_id,
-            orgId: sc.internalOptions?.orgId ?? null,
+            // Same as the other kickoff path: the ACUC answers when the crawl
+            // names no org, so a real charge is not dropped.
+            orgId: await orgIdForJob(
+              sc.internalOptions?.orgId,
+              job.data.team_id,
+            ),
             apiKeyId: job.data.apiKeyId ?? null,
             billing: resolveBillingMetadata({
               billing: job.data.billing,

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -51,6 +51,7 @@ import { getJobPriority } from "../../lib/job-priority";
 import { Document, scrapeOptions, TeamFlags } from "../../controllers/v2/types";
 import { hasFormatOfType } from "../../lib/format-utils";
 import { getACUCTeam } from "../../controllers/auth";
+import { orgIdForTeam } from "../../lib/team-org";
 import { createWebhookSender, WebhookEvent } from "../webhook/index";
 import { CustomError } from "../../lib/custom-error";
 import { startWebScraperPipeline } from "../../main/runWebScraper";
@@ -130,11 +131,7 @@ async function orgIdForJob(
   orgIdFromJob: string | null | undefined,
   teamId: string,
 ): Promise<string | null> {
-  return (
-    orgIdFromJob ??
-    (await getACUCTeam(teamId).catch(() => null))?.org_id ??
-    null
-  );
+  return orgIdFromJob ?? (await orgIdForTeam(teamId));
 }
 
 async function billScrapeJob(
@@ -191,10 +188,10 @@ async function billScrapeJob(
       // The org rides the job payload, snapshotted from the request ACUC at
       // acceptance. The ACUC answers only for a job enqueued without one —
       // the same lookup the billing service used to make on every charge.
-      const orgId =
-        job.data.internalOptions?.orgId ??
-        (await getACUCTeam(job.data.team_id).catch(() => null))?.org_id ??
-        null;
+      const orgId = await orgIdForJob(
+        job.data.internalOptions?.orgId,
+        job.data.team_id,
+      );
 
       // Resolved outside the try so the catch's refund decision can see it.
       let routedToFirebill = false;

--- a/apps/api/src/services/worker/scrape-worker.ts
+++ b/apps/api/src/services/worker/scrape-worker.ts
@@ -172,24 +172,35 @@ async function billScrapeJob(
       job.data.team_id !== config.BACKGROUND_INDEX_TEAM_ID! &&
       config.USE_DB_AUTHENTICATION
     ) {
+      // The org rides the job payload, snapshotted from the request ACUC at
+      // acceptance. The ACUC answers only for a job enqueued without one —
+      // the same lookup the billing service used to make on every charge.
+      const orgId =
+        job.data.internalOptions?.orgId ??
+        (await getACUCTeam(job.data.team_id).catch(() => null))?.org_id ??
+        null;
+
       // Resolved outside the try so the catch's refund decision can see it.
       let routedToFirebill = false;
       try {
-        routedToFirebill = await autumnService.isRoutedThroughFirebill(
-          job.data.team_id,
-        );
-        trackedInRequest = await autumnService.trackCredits({
-          teamId: job.data.team_id,
-          value: creditsToBeBilled,
-          properties: autumnProperties,
-          featureId,
-          // The worker job id is the one identity that is unique per charge
-          // (a crawl id is shared by every page — keying on it would collapse
-          // a crawl's pages into one billed event) AND survives a stall
-          // requeue, which re-runs the job under the same id: with this key,
-          // the re-run dedupes instead of double-billing (firebill route).
-          idempotencyKey: `fc:track:${billing.endpoint}:${job.id}`,
-        });
+        routedToFirebill = orgId
+          ? await autumnService.isRoutedThroughFirebill(job.data.team_id, orgId)
+          : false;
+        trackedInRequest = orgId
+          ? await autumnService.trackCredits({
+              teamId: job.data.team_id,
+              orgId,
+              value: creditsToBeBilled,
+              properties: autumnProperties,
+              featureId,
+              // The worker job id is the one identity that is unique per charge
+              // (a crawl id is shared by every page — keying on it would collapse
+              // a crawl's pages into one billed event) AND survives a stall
+              // requeue, which re-runs the job under the same id: with this key,
+              // the re-run dedupes instead of double-billing (firebill route).
+              idempotencyKey: `fc:track:${billing.endpoint}:${job.id}`,
+            })
+          : false;
         // On the firebill route the ledger enqueue must be idempotent by the
         // originating job: a stalled job reruns under the same job.id, the
         // track dedupes in firebill, and a fresh random billing job id would
@@ -226,6 +237,7 @@ async function billScrapeJob(
               "bill_team",
               {
                 team_id: job.data.team_id,
+                org_id: orgId,
                 credits: creditsToBeBilled,
                 billing,
                 is_extract: false,
@@ -280,9 +292,10 @@ async function billScrapeJob(
                 billing,
               },
             );
-          } else {
+          } else if (orgId) {
             await autumnService.refundCredits({
               teamId: job.data.team_id,
+              orgId,
               value: creditsToBeBilled,
               properties: autumnProperties,
               featureId,
@@ -325,6 +338,8 @@ async function billScrapeJob(
 function billThreatBlockedDiscoveries(
   args: {
     teamId: string;
+    /** Snapshotted onto the job at acceptance; see InternalOptions.orgId. */
+    orgId: string | null;
     apiKeyId: number | null;
     billing: BillingMetadata;
     bypassBilling: boolean;
@@ -341,14 +356,18 @@ function billThreatBlockedDiscoveries(
   // billing metadata (each page job that discovers new blocked URLs bills its
   // own batch under the same crawl id) — a shared key would collapse them
   // into one charge, i.e. underbill. Keyless until per-batch identity exists.
-  billTeam(args.teamId, threatScanCredits, args.apiKeyId, args.billing).catch(
-    error => {
-      logger.error(
-        `Failed to bill team ${args.teamId} for ${threatScanCredits} threat scan credit(s)`,
-        { error },
-      );
-    },
-  );
+  billTeam(
+    args.teamId,
+    args.orgId,
+    threatScanCredits,
+    args.apiKeyId,
+    args.billing,
+  ).catch(error => {
+    logger.error(
+      `Failed to bill team ${args.teamId} for ${threatScanCredits} threat scan credit(s)`,
+      { error },
+    );
+  });
 }
 
 async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
@@ -649,6 +668,7 @@ async function processJob(job: NuQJob<ScrapeJobSingleUrls>) {
                 billThreatBlockedDiscoveries(
                   {
                     teamId: job.data.team_id,
+                    orgId: job.data.internalOptions?.orgId ?? null,
                     apiKeyId: job.data.apiKeyId ?? null,
                     billing: resolveBillingMetadata({
                       billing: job.data.billing,
@@ -1390,6 +1410,7 @@ async function processKickoffJob(job: NuQJob<ScrapeJobKickoff>) {
         billThreatBlockedDiscoveries(
           {
             teamId: job.data.team_id,
+            orgId: job.data.internalOptions?.orgId ?? null,
             apiKeyId: job.data.apiKeyId ?? null,
             billing: resolveBillingMetadata({
               billing: job.data.billing,
@@ -1557,6 +1578,7 @@ async function processKickoffSitemapJob(job: NuQJob<ScrapeJobKickoffSitemap>) {
         billThreatBlockedDiscoveries(
           {
             teamId: job.data.team_id,
+            orgId: sc.internalOptions?.orgId ?? null,
             apiKeyId: job.data.apiKeyId ?? null,
             billing: resolveBillingMetadata({
               billing: job.data.billing,


### PR DESCRIPTION
## What

PR 1 of the middleware credit-check cleanup agreed with @mogery (Asana "Middleware Tech Debt"). Spec: firecrawl/firebill#35 `docs/spec-middleware-credit-check.md`.

The billing service used to resolve a team's org for itself (a `teams.org_id` read plus a per-pod cache) before every billing call. Per review, it now resolves nothing:

- **`AutumnService` takes `orgId: string`** on `checkCredits`, `trackCredits`, `refundCredits`, `lockCredits`, `isRoutedThroughFirebill`, `ensureTeamProvisioned`; `finalizeCreditsLock` takes `team?: { teamId, orgId }`. `resolveOrgId`, `lookupOrgIdForTeam`, `customerOrgCache`, `pendingOrgLookups` and `AUTUMN_ORG_CACHE_TTL_SECONDS` are deleted. A test seam fails the suite if the service ever imports `controllers/auth` or `lib/team-org`.
- **Request path:** `checkCreditsMiddleware` passes `req.auth.org_id`; a null org (keyless, preview, bypass) takes the fail-open branch directly, which is what `checkCredits` returned for those identities before. Controllers pass `req.acuc.org_id` to `billTeam`, `getJobPriority` and `getEffectiveConcurrencyLimit`.
- **`billTeam(team_id, org_id, …)`** is the one null-tolerant boundary: preview teams legitimately have no org and are skipped exactly as `trackCredits` skipped them.
- **Team-id-only workers** get the org from one standalone helper, `lib/team-org.ts` `orgIdForTeam(teamId)`: null when DB auth is off or the team is a preview team, otherwise the team ACUC (`getACUCTeam`, Redis then DB), null on failure. Used by the scrape worker (payload org first), nuq-router and queue-jobs (batch payload first), the concurrency cleanup and reconciler, the monitor runner and scheduler, the browser webhook teardown and the Slack command. Payload-first matters because monitors null `internalOptions.orgId` deliberately for blocklist reasons.
- **Alexandria** (added to main after this branch's base; merged in): `retrieveProviders` takes `orgId` from `req.acuc.org_id`, threads it into `isRoutedThroughFirebill`, `lockCredits`, both `finalizeCreditsLock` calls and the queued `bill_team` job; a null org yields a skipped hold, as the service produced for an unresolvable org.
- **Every `bill_team` producer carries `org_id`** (scrape worker, monitor runner, Alexandria), and the queue is typed `Queue<BillTeamJobData>` with `org_id: string | null` required, so a new producer cannot omit it. Only operations enqueued by pre-deploy code reach the transitional lookup.
- **Batch billing** carries `org_id` on queued operations. Operations already in Redis at deploy (no `org_id` field) resolve once via the team ACUC; a thrown lookup requeues them for the next batch instead of billing them as org-less. Marked transitional, remove after one deploy.
- **`getACUCTeam`** treats a malformed cached JSON as a miss and falls through to the DB.
- Two counters: `firecrawl_autumn_entity_created_inline_total{path}` and `firecrawl_autumn_customer_get_or_create_total`, so we can see how often the request path still provisions inline.

## Behaviour change

None in any reachable configuration: same org billed, same fail-open answers, same limits. Notes:

- Workers now read the team ACUC (Redis GET) where a warm per-pod cache used to answer. `getJobPriority` is called per discovered link, so the org is threaded from the job, not fetched.
- Residual, unreachable: with `USE_DB_AUTHENTICATION` off **and** an Autumn key set, controllers' `req.acuc.org_id` is the mock `"bypass"`, which main already sent to Autumn from the rate limiter. Self-hosted deployments have no Autumn key. Left as on main.
- **Before merging:** confirm in Supabase that `auth_chunk_1_from_team` returns a row for every team that can carry billable usage (teams with no API key, if any). If not, the worker fallback is a `teams.org_id` read on that miss only.

## Tests

tsc, prettier, knip clean. `vitest run src/services/autumn src/__tests__ src/services/billing src/services/monitoring src/controllers src/lib src/services/worker`: 1654 passed (main merged in at cc06662bd); the 10 failures are pre-existing on main (browser-billing ×2, research-timeouts ×3, ranker ×2, crawl-redis, html-to-markdown, monitoring/search/run) and unrelated. New: org threaded through every caller; null org at the middleware fails open without a service call; `orgIdForTeam` null when DB auth is off / preview / lookup fails; legacy batch op requeued on a thrown lookup; monitor release with no org names no team; fireclaw fixture bills with a real org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
