### PR TITLE
feat(exchange): pass provider access context

### DIFF
--- a/apps/api/src/__tests__/routes/exchange-access.routes.test.ts
+++ b/apps/api/src/__tests__/routes/exchange-access.routes.test.ts
@@ -48,11 +48,11 @@ beforeEach(() => {
     } as unknown as Awaited<ReturnType<typeof fetch>>);
 });
 
-it("derives special access from authentication and preserves private cache policy", async () => {
+it("derives extended catalogue access from authentication and preserves private cache policy", async () => {
   const response = await request(app())
     .get("/exchange/discover")
     .set("x-exchange-team-id", "spoofed-team")
-    .set("x-exchange-special-access", "false");
+    .set("x-exchange-extended-catalog-access", "false");
   expect(response.status).toBe(200);
   expect(response.headers["cache-control"]).toBe("no-store");
   expect(fetch).toHaveBeenCalledWith(
@@ -60,40 +60,40 @@ it("derives special access from authentication and preserves private cache polic
     expect.objectContaining({
       headers: expect.objectContaining({
         "x-exchange-team-id": "authenticated-team",
-        "x-exchange-special-access": "true",
+        "x-exchange-extended-catalog-access": "true",
       }),
     }),
   );
 });
 
 it.each([false, undefined, "true"])(
-  "does not grant special access from client headers when the flag is %s",
+  "does not grant extended catalogue access from client headers when the flag is %s",
   async access => {
     state.access = access;
     const response = await request(app())
-      .get("/exchange/platform/catalogue?specialAccess=true")
-      .set("x-exchange-special-access", "true");
+      .get("/exchange/platform/catalogue?hasExtendedCatalogAccess=true")
+      .set("x-exchange-extended-catalog-access", "true");
     expect(response.status).toBe(200);
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
         headers: expect.objectContaining({
-          "x-exchange-special-access": "false",
+          "x-exchange-extended-catalog-access": "false",
         }),
       }),
     );
   },
 );
 
-it("keeps the existing retrieval gate even when the caller spoofs special access", async () => {
+it("keeps the existing retrieval gate even when the caller spoofs extended catalogue access", async () => {
   state.access = false;
   const response = await request(app())
     .post("/exchange/retrieve")
-    .set("x-exchange-special-access", "true")
+    .set("x-exchange-extended-catalog-access", "true")
     .send({
       provider: "preview-catalog",
       capability: "items/search",
-      specialAccess: true,
+      hasExtendedCatalogAccess: true,
     });
   expect(response.status).toBe(403);
   expect(fetch).not.toHaveBeenCalled();

--- a/apps/api/src/__tests__/routes/exchange-access.routes.test.ts
+++ b/apps/api/src/__tests__/routes/exchange-access.routes.test.ts
@@ -1,0 +1,100 @@
+import express from "express";
+import request from "supertest";
+import { fetch } from "undici";
+
+const state = vi.hoisted(() => ({ access: true as unknown }));
+
+vi.mock("../../config", () => ({
+  config: { FIRE_EXCHANGE_URL: "https://exchange.internal" },
+}));
+vi.mock("../../lib/logger", () => {
+  const logger = { child: () => logger, error: vi.fn() };
+  return { logger };
+});
+vi.mock("undici", () => ({ Agent: class {}, fetch: vi.fn() }));
+vi.mock("../../routes/exchange-blocklist", () => ({
+  bountyBlocklistMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+}));
+vi.mock("../../routes/shared", () => ({
+  authMiddleware: () => (req: any, _res: unknown, next: () => void) => {
+    req.auth = { team_id: "authenticated-team" };
+    req.acuc = { flags: { exchangeRetrieve: state.access } };
+    next();
+  },
+  wrap: (fn: unknown) => fn,
+}));
+
+import { exchangeRouter } from "../../routes/exchange";
+
+function app() {
+  const app = express();
+  app.use(express.json());
+  app.use("/exchange", exchangeRouter);
+  return app;
+}
+
+beforeEach(() => {
+  state.access = true;
+  vi.mocked(fetch)
+    .mockReset()
+    .mockResolvedValue({
+      status: 200,
+      headers: new Headers({
+        "cache-control": "no-store",
+        "content-type": "application/json",
+      }),
+      text: async () => '{"cohorts":[]}',
+    } as unknown as Awaited<ReturnType<typeof fetch>>);
+});
+
+it("derives special access from authentication and preserves private cache policy", async () => {
+  const response = await request(app())
+    .get("/exchange/discover")
+    .set("x-exchange-team-id", "spoofed-team")
+    .set("x-exchange-special-access", "false");
+  expect(response.status).toBe(200);
+  expect(response.headers["cache-control"]).toBe("no-store");
+  expect(fetch).toHaveBeenCalledWith(
+    "https://exchange.internal/v1/discover",
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        "x-exchange-team-id": "authenticated-team",
+        "x-exchange-special-access": "true",
+      }),
+    }),
+  );
+});
+
+it.each([false, undefined, "true"])(
+  "does not grant special access from client headers when the flag is %s",
+  async access => {
+    state.access = access;
+    const response = await request(app())
+      .get("/exchange/platform/catalogue?specialAccess=true")
+      .set("x-exchange-special-access", "true");
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-exchange-special-access": "false",
+        }),
+      }),
+    );
+  },
+);
+
+it("keeps the existing retrieval gate even when the caller spoofs special access", async () => {
+  state.access = false;
+  const response = await request(app())
+    .post("/exchange/retrieve")
+    .set("x-exchange-special-access", "true")
+    .send({
+      provider: "preview-catalog",
+      capability: "items/search",
+      specialAccess: true,
+    });
+  expect(response.status).toBe(403);
+  expect(fetch).not.toHaveBeenCalled();
+});

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1913,6 +1913,7 @@ export type TeamFlags = {
   menuBeta?: boolean;
   enrichBeta?: boolean;
   professionalProfileCompanyDataBeta?: boolean;
+  exchangeRetrieve?: boolean;
   organizationDataSourceAccess?: Record<
     string,
     {

--- a/apps/api/src/lib/exchange-request.ts
+++ b/apps/api/src/lib/exchange-request.ts
@@ -16,6 +16,7 @@ type ExchangeFlags = Parameters<
 export function getExchangeAccessForRequestBody(input: {
   body: Record<string, any>;
   flags: ExchangeFlags;
+  teamId?: string;
   url: string;
   zeroDataRetention: boolean;
 }): Promise<ExchangeAccess> {
@@ -27,6 +28,7 @@ export function getExchangeAccessForRequestBody(input: {
 
   return getExchangeAccessForRequest({
     url: input.url,
+    teamId: input.teamId,
     formats: scrapeOptions.formats,
     actions: scrapeOptions.actions,
     headers: scrapeOptions.headers,

--- a/apps/api/src/lib/exchange.test.ts
+++ b/apps/api/src/lib/exchange.test.ts
@@ -101,6 +101,70 @@ describe("Exchange routing", () => {
     ).resolves.not.toBeNull();
   });
 
+  it.each([false, true])(
+    "isolates routing catalogues when approved access is requested first: %s",
+    async approvedFirst => {
+      clearExchangeProvidersForTest();
+      vi.mocked(fetch).mockImplementation(async (_url, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        const approved = headers?.["x-exchange-special-access"] === "true";
+        if (approved)
+          expect(headers?.["x-exchange-team-id"]).toBe("approved-team");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: approved
+              ? [
+                  {
+                    id: "preview-catalog",
+                    creditsCost: 0,
+                    capabilities: {
+                      scrape: {
+                        urlRoutes: [
+                          { domains: ["preview.example"], pathPrefixes: [] },
+                        ],
+                      },
+                    },
+                  },
+                ]
+              : [],
+          }),
+        } as unknown as Awaited<ReturnType<typeof fetch>>;
+      });
+      const input = {
+        url: "https://preview.example/item",
+        formats: [{ type: "markdown" }],
+        teamId: "approved-team",
+        flags: {
+          professionalProfileCompanyDataBeta: true,
+          exchangeRetrieve: true,
+        },
+      };
+      for (const approved of [approvedFirst, !approvedFirst]) {
+        expect(
+          await canUseExchangeForRequest({
+            ...input,
+            flags: { ...input.flags, exchangeRetrieve: approved },
+          }),
+        ).toBe(approved);
+      }
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(
+        await canUseExchangeForRequest({ ...input, teamId: undefined }),
+      ).toBe(false);
+      expect(
+        await canUseExchangeForRequest({
+          ...input,
+          flags: { ...input.flags, exchangeRetrieve: false },
+        }),
+      ).toBe(false);
+      expect(await canUseExchangeForRequest(input)).toBe(true);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("respects path segment boundaries for prefixes without trailing slashes", async () => {
     setExchangeProvidersForTest([
       {

--- a/apps/api/src/lib/exchange.test.ts
+++ b/apps/api/src/lib/exchange.test.ts
@@ -107,7 +107,8 @@ describe("Exchange routing", () => {
       clearExchangeProvidersForTest();
       vi.mocked(fetch).mockImplementation(async (_url, init) => {
         const headers = init?.headers as Record<string, string> | undefined;
-        const approved = headers?.["x-exchange-special-access"] === "true";
+        const approved =
+          headers?.["x-exchange-extended-catalog-access"] === "true";
         if (approved)
           expect(headers?.["x-exchange-team-id"]).toBe("approved-team");
         return {
@@ -356,9 +357,7 @@ describe("Exchange routing", () => {
 
   it("accepts only formats the Exchange can return directly", () => {
     expect(isSupportedExchangeFormatRequest(undefined)).toBe(true);
-    expect(isSupportedExchangeFormatRequest([{ type: "markdown" }])).toBe(
-      true,
-    );
+    expect(isSupportedExchangeFormatRequest([{ type: "markdown" }])).toBe(true);
     expect(isSupportedExchangeFormatRequest(["json"])).toBe(true);
     expect(
       isSupportedExchangeFormatRequest([
@@ -369,9 +368,9 @@ describe("Exchange routing", () => {
     expect(isSupportedExchangeFormatRequest([{ type: "html" }])).toBe(false);
     // deterministicJson extractors run against page HTML, which Exchange
     // responses do not carry.
-    expect(isSupportedExchangeFormatRequest([{ type: "deterministicJson" }])).toBe(
-      false,
-    );
+    expect(
+      isSupportedExchangeFormatRequest([{ type: "deterministicJson" }]),
+    ).toBe(false);
     expect(isSupportedExchangeFormatRequest([])).toBe(false);
   });
 
@@ -626,7 +625,10 @@ describe("Exchange routing", () => {
       "https://exchange.example/v1/access-events/6f1f5aab-3f78-4d0a-8a3d-2b1d3c4e5f60/billing",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ status: "confirmed", billingReference: "bill-1" }),
+        body: JSON.stringify({
+          status: "confirmed",
+          billingReference: "bill-1",
+        }),
       }),
     );
 

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -22,6 +22,7 @@ type OrganizationDataSourceAccess = Record<
 
 type RouteInput = {
   url: string;
+  teamId?: string;
   formats?: FormatObject[] | unknown[];
   actions?: unknown[];
   headers?: Record<string, unknown>;
@@ -38,6 +39,7 @@ type RouteInput = {
   zeroDataRetention?: boolean;
   lockdown?: boolean;
   flags?: {
+    exchangeRetrieve?: boolean;
     professionalProfileCompanyDataBeta?: boolean;
     organizationDataSourceAccess?: OrganizationDataSourceAccess | null;
   } | null;
@@ -117,13 +119,15 @@ const exchangeProvidersSchema = z.object({
   ),
 });
 
-let cachedProviders:
-  | {
-      expiresAt: number;
-      value: ExchangeProvider[] | null;
-    }
-  | undefined;
-let providersRequest: Promise<ExchangeProvider[] | null> | undefined;
+type ProviderCatalog = {
+  cached?: {
+    expiresAt: number;
+    value: ExchangeProvider[] | null;
+  };
+  request?: Promise<ExchangeProvider[] | null>;
+};
+type CatalogAccess = { teamId: string; specialAccess: boolean };
+const providerCatalogs = new Map<boolean, ProviderCatalog>();
 
 function normalizeHost(host: string): string {
   return host.trim().toLowerCase().replace(/\.$/, "");
@@ -162,7 +166,9 @@ function normalizeProviders(
     .filter(provider => provider.routes.length > 0);
 }
 
-async function fetchExchangeProviders(): Promise<ExchangeProvider[] | null> {
+async function fetchExchangeProviders(
+  access?: CatalogAccess,
+): Promise<ExchangeProvider[] | null> {
   const baseUrl = getExchangeBaseUrl();
   if (!baseUrl) {
     return null;
@@ -171,6 +177,16 @@ async function fetchExchangeProviders(): Promise<ExchangeProvider[] | null> {
   try {
     const response = await fetch(`${baseUrl}${EXCHANGE_PROVIDERS_PATH}`, {
       method: "GET",
+      ...(access
+        ? {
+            headers: {
+              "x-exchange-team-id": access.teamId,
+              "x-exchange-special-access": String(
+                access.specialAccess === true,
+              ),
+            },
+          }
+        : {}),
       signal: AbortSignal.timeout(EXCHANGE_PROVIDERS_TIMEOUT_MS),
     });
 
@@ -189,42 +205,49 @@ async function fetchExchangeProviders(): Promise<ExchangeProvider[] | null> {
   }
 }
 
-async function getExchangeProviders(): Promise<ExchangeProvider[] | null> {
-  if (cachedProviders && cachedProviders.expiresAt > Date.now()) {
-    return cachedProviders.value;
+async function getExchangeProviders(
+  access?: CatalogAccess,
+): Promise<ExchangeProvider[] | null> {
+  const specialAccess =
+    access?.specialAccess === true && access.teamId.trim() !== "";
+  // This endpoint's catalogue varies by access tier, never by the requesting team.
+  const catalog = providerCatalogs.get(specialAccess) ?? {};
+  providerCatalogs.set(specialAccess, catalog);
+  if (catalog.cached && catalog.cached.expiresAt > Date.now()) {
+    return catalog.cached.value;
   }
 
-  if (!providersRequest) {
-    providersRequest = fetchExchangeProviders()
+  if (!catalog.request) {
+    catalog.request = fetchExchangeProviders(specialAccess ? access : undefined)
       .then(providers => {
         if (providers === null) {
           // Keep serving the last good catalog through transient outages;
           // the failure TTL only delays the next refresh attempt.
-          cachedProviders = {
-            value: cachedProviders?.value ?? null,
+          catalog.cached = {
+            value: catalog.cached?.value ?? null,
             expiresAt: Date.now() + EXCHANGE_PROVIDERS_FAILURE_TTL_MS,
           };
         } else {
-          cachedProviders = {
+          catalog.cached = {
             value: providers,
             expiresAt: Date.now() + EXCHANGE_PROVIDERS_TTL_MS,
           };
         }
-        return cachedProviders.value;
+        return catalog.cached.value;
       })
       .finally(() => {
-        providersRequest = undefined;
+        catalog.request = undefined;
       });
   }
 
   // Serve the stale catalog while the refresh runs in the background so
   // request latency never depends on the catalog endpoint; only the very
   // first lookup after boot has nothing to serve and waits.
-  if (cachedProviders) {
-    return cachedProviders.value;
+  if (catalog.cached) {
+    return catalog.cached.value;
   }
 
-  return providersRequest;
+  return catalog.request;
 }
 
 function providerMatchesUrl(
@@ -262,8 +285,9 @@ function providerMatchesUrl(
 
 export async function resolveExchangeProvider(
   inputUrl: string,
+  access?: CatalogAccess,
 ): Promise<ExchangeProvider | null> {
-  const providers = await getExchangeProviders();
+  const providers = await getExchangeProviders(access);
   if (providers === null) {
     return null;
   }
@@ -487,7 +511,15 @@ export async function getExchangeAccessForRequest(
       return { allowed: false, termsRequired: false };
     }
 
-    const provider = await resolveExchangeProvider(input.url);
+    const provider = await resolveExchangeProvider(
+      input.url,
+      input.teamId
+        ? {
+            teamId: input.teamId,
+            specialAccess: input.flags?.exchangeRetrieve === true,
+          }
+        : undefined,
+    );
     if (provider === null) {
       return { allowed: false, termsRequired: false };
     }
@@ -692,21 +724,22 @@ export function setExchangeProvidersForTest(
   }[],
   ttlMs = 300_000,
 ) {
-  cachedProviders = {
-    value: providers.map(provider => ({
-      id: provider.id,
-      creditsCost: provider.creditsCost ?? 0,
-      ...(provider.terms === undefined ? {} : { terms: provider.terms }),
-      routes: provider.routes.map(route => ({
-        domains: new Set(route.domains.map(normalizeHost)),
-        pathPrefixes: (route.pathPrefixes ?? []).map(normalizePathPrefix),
+  providerCatalogs.set(false, {
+    cached: {
+      value: providers.map(provider => ({
+        id: provider.id,
+        creditsCost: provider.creditsCost ?? 0,
+        ...(provider.terms === undefined ? {} : { terms: provider.terms }),
+        routes: provider.routes.map(route => ({
+          domains: new Set(route.domains.map(normalizeHost)),
+          pathPrefixes: (route.pathPrefixes ?? []).map(normalizePathPrefix),
+        })),
       })),
-    })),
-    expiresAt: Date.now() + ttlMs,
-  };
+      expiresAt: Date.now() + ttlMs,
+    },
+  });
 }
 
 export function clearExchangeProvidersForTest() {
-  cachedProviders = undefined;
-  providersRequest = undefined;
+  providerCatalogs.clear();
 }

--- a/apps/api/src/lib/exchange.ts
+++ b/apps/api/src/lib/exchange.ts
@@ -126,7 +126,7 @@ type ProviderCatalog = {
   };
   request?: Promise<ExchangeProvider[] | null>;
 };
-type CatalogAccess = { teamId: string; specialAccess: boolean };
+type CatalogAccess = { teamId: string; hasExtendedCatalogAccess: boolean };
 const providerCatalogs = new Map<boolean, ProviderCatalog>();
 
 function normalizeHost(host: string): string {
@@ -181,8 +181,8 @@ async function fetchExchangeProviders(
         ? {
             headers: {
               "x-exchange-team-id": access.teamId,
-              "x-exchange-special-access": String(
-                access.specialAccess === true,
+              "x-exchange-extended-catalog-access": String(
+                access.hasExtendedCatalogAccess === true,
               ),
             },
           }
@@ -208,17 +208,19 @@ async function fetchExchangeProviders(
 async function getExchangeProviders(
   access?: CatalogAccess,
 ): Promise<ExchangeProvider[] | null> {
-  const specialAccess =
-    access?.specialAccess === true && access.teamId.trim() !== "";
+  const hasExtendedCatalogAccess =
+    access?.hasExtendedCatalogAccess === true && access.teamId.trim() !== "";
   // This endpoint's catalogue varies by access tier, never by the requesting team.
-  const catalog = providerCatalogs.get(specialAccess) ?? {};
-  providerCatalogs.set(specialAccess, catalog);
+  const catalog = providerCatalogs.get(hasExtendedCatalogAccess) ?? {};
+  providerCatalogs.set(hasExtendedCatalogAccess, catalog);
   if (catalog.cached && catalog.cached.expiresAt > Date.now()) {
     return catalog.cached.value;
   }
 
   if (!catalog.request) {
-    catalog.request = fetchExchangeProviders(specialAccess ? access : undefined)
+    catalog.request = fetchExchangeProviders(
+      hasExtendedCatalogAccess ? access : undefined,
+    )
       .then(providers => {
         if (providers === null) {
           // Keep serving the last good catalog through transient outages;
@@ -516,7 +518,7 @@ export async function getExchangeAccessForRequest(
       input.teamId
         ? {
             teamId: input.teamId,
-            specialAccess: input.flags?.exchangeRetrieve === true,
+            hasExtendedCatalogAccess: input.flags?.exchangeRetrieve === true,
           }
         : undefined,
     );

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -83,7 +83,7 @@ function exchangeProxy(
           ),
           ...(hasBody ? { "content-type": "application/json" } : {}),
           "x-exchange-team-id": authedReq.auth.team_id,
-          "x-exchange-special-access": String(
+          "x-exchange-extended-catalog-access": String(
             authedReq.acuc?.flags?.exchangeRetrieve === true,
           ),
         },

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -16,7 +16,11 @@ const SUPPLY_TIMEOUT_MS = 30_000;
 const INGEST_TIMEOUT_MS = 50_000;
 
 const FORWARDED_REQUEST_HEADERS = ["accept", "x-request-id"];
-const FORWARDED_RESPONSE_HEADERS = ["content-type", "x-request-id"];
+const FORWARDED_RESPONSE_HEADERS = [
+  "content-type",
+  "x-request-id",
+  "cache-control",
+];
 
 function dispatcherFor(timeout: number) {
   return new Agent({
@@ -79,6 +83,9 @@ function exchangeProxy(
           ),
           ...(hasBody ? { "content-type": "application/json" } : {}),
           "x-exchange-team-id": authedReq.auth.team_id,
+          "x-exchange-special-access": String(
+            authedReq.acuc?.flags?.exchangeRetrieve === true,
+          ),
         },
         body: hasBody ? JSON.stringify(req.body ?? {}) : undefined,
         signal: AbortSignal.timeout(timeout),

--- a/apps/api/src/routes/shared.ts
+++ b/apps/api/src/routes/shared.ts
@@ -355,6 +355,7 @@ function blocklistGate(
       (await getExchangeAccessForRequestBody({
         body: req.body,
         flags: req.acuc?.flags ?? null,
+        teamId: req.acuc?.team_id,
         url: req.body.url,
         zeroDataRetention,
       }));

--- a/apps/api/src/scraper/scrapeURL/engines/exchange.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/exchange.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../../lib/otel-tracer", () => ({
 afterEach(() => vi.clearAllMocks());
 
 it.each([true, false, undefined])(
-  "carries only authenticated special access %s into legacy record retrieval",
+  "carries only authenticated extended catalogue access %s into legacy record retrieval",
   async access => {
     const logger = { child: () => logger, info: vi.fn(), warn: vi.fn() };
     vi.mocked(robustFetch).mockResolvedValue({
@@ -32,7 +32,7 @@ it.each([true, false, undefined])(
       options: {
         headers: {
           "x-exchange-team-id": "spoofed",
-          "x-exchange-special-access": "true",
+          "x-exchange-extended-catalog-access": "true",
         },
       },
       internalOptions: {
@@ -48,7 +48,7 @@ it.each([true, false, undefined])(
         url: "https://exchange.internal/v1/scrape",
         headers: {
           "x-exchange-team-id": "real-team",
-          "x-exchange-special-access": String(access === true),
+          "x-exchange-extended-catalog-access": String(access === true),
         },
       }),
     );

--- a/apps/api/src/scraper/scrapeURL/engines/exchange.test.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/exchange.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { robustFetch } from "../lib/fetch";
+import { scrapeURLWithExchange } from "./exchange";
+
+vi.mock("../../../config", () => ({
+  config: { FIRE_EXCHANGE_URL: "https://exchange.internal" },
+}));
+vi.mock("../lib/fetch", () => ({ robustFetch: vi.fn() }));
+vi.mock("../../../lib/exchange", () => ({
+  getExchangeRequestLogContext: () => ({}),
+  getExchangeResponseLogContext: () => ({}),
+}));
+vi.mock("../../../lib/otel-tracer", () => ({
+  withSpan: (_name: string, run: () => unknown) => run(),
+  setSpanAttributes: vi.fn(),
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+it.each([true, false, undefined])(
+  "carries only authenticated special access %s into legacy record retrieval",
+  async access => {
+    const logger = { child: () => logger, info: vi.fn(), warn: vi.fn() };
+    vi.mocked(robustFetch).mockResolvedValue({
+      success: true,
+      creditsCost: 0,
+      data: { markdown: "Record", metadata: {}, source: { provider: "test" } },
+    });
+    await scrapeURLWithExchange({
+      id: "job-1",
+      url: "https://records.example/item",
+      options: {
+        headers: {
+          "x-exchange-team-id": "spoofed",
+          "x-exchange-special-access": "true",
+        },
+      },
+      internalOptions: {
+        teamId: "real-team",
+        teamFlags: { exchangeRetrieve: access },
+      },
+      logger,
+      mock: null,
+      abort: { asSignal: () => new AbortController().signal },
+    } as unknown as Parameters<typeof scrapeURLWithExchange>[0]);
+    expect(robustFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://exchange.internal/v1/scrape",
+        headers: {
+          "x-exchange-team-id": "real-team",
+          "x-exchange-special-access": String(access === true),
+        },
+      }),
+    );
+  },
+);

--- a/apps/api/src/scraper/scrapeURL/engines/exchange.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/exchange.ts
@@ -101,6 +101,12 @@ export async function scrapeURLWithExchange(
       const response = await robustFetch({
         url: `${config.FIRE_EXCHANGE_URL!.replace(/\/+$/, "")}/v1/scrape`,
         method: "POST",
+        headers: {
+          "x-exchange-team-id": meta.internalOptions.teamId,
+          "x-exchange-special-access": String(
+            meta.internalOptions.teamFlags?.exchangeRetrieve === true,
+          ),
+        },
         body: {
           requestId: meta.id,
           teamId: meta.internalOptions.teamId,

--- a/apps/api/src/scraper/scrapeURL/engines/exchange.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/exchange.ts
@@ -66,7 +66,8 @@ function escapeHtml(value: string): string {
 // Exchange responses carry no page HTML; synthesize a minimal head so the
 // metadata transformer can populate the document's title and description.
 function buildMetadataHtml(title?: string, description?: string): string {
-  const titleTag = title === undefined ? "" : `<title>${escapeHtml(title)}</title>`;
+  const titleTag =
+    title === undefined ? "" : `<title>${escapeHtml(title)}</title>`;
   const descriptionTag =
     description === undefined
       ? ""
@@ -103,7 +104,7 @@ export async function scrapeURLWithExchange(
         method: "POST",
         headers: {
           "x-exchange-team-id": meta.internalOptions.teamId,
-          "x-exchange-special-access": String(
+          "x-exchange-extended-catalog-access": String(
             meta.internalOptions.teamFlags?.exchangeRetrieve === true,
           ),
         },

--- a/apps/api/src/scraper/scrapeURL/engines/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/index.ts
@@ -670,6 +670,7 @@ export async function buildFallbackList(meta: Meta): Promise<
     if (
       await canUseExchangeForRequest({
         url: meta.rewrittenUrl ?? meta.url,
+        teamId: meta.internalOptions.teamId,
         formats: meta.options.formats,
         actions: meta.options.actions,
         headers: meta.options.headers,


### PR DESCRIPTION
Forward the authenticated team's `exchangeRetrieve` flag as Exchange's internal extended catalogue assertion. Keep the existing endpoint gates, strip caller-supplied assertions and separate the ordinary and approved URL-routing catalogues so cached metadata cannot cross access tiers.

Companion Exchange policy: https://github.com/firecrawl/exchange/pull/195. Equivalent propagation is included in https://github.com/firecrawl/firecrawl/pull/4582 for its refactored forwarding paths.

Validation: API typecheck and 30 proxy, routing, cache-isolation and scrape-engine tests passed. No team gains access or provider becomes restricted by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards the authenticated team's `exchangeRetrieve` flag to Exchange as its extended-catalog-access assertion, and separates the routing catalogues by access tier so cached metadata cannot leak across tiers.

**Changes**
- The proxy and scrape engine set `x-exchange-extended-catalog-access` from the team's flag, ignoring any client-supplied value.
- Provider catalogues are cached separately for approved and ordinary access; approved lookups require an authenticated team ID.
- The proxy now forwards Exchange's `cache-control` header so private catalog responses keep their cache policy.
- The existing retrieve gate still returns 403 when the flag is false, and no team gains access or provider becomes restricted by default.

<sup>Written for commit c19fcef71fd442bc07ec92fbab4ad90b301fe61f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

