### PR TITLE
fix(api): handle extendLock rejections in lock-extension intervals

### DIFF
--- a/apps/api/src/services/queue-worker.ts
+++ b/apps/api/src/services/queue-worker.ts
@@ -61,7 +61,9 @@ const processDeepResearchJobInternal = async (
 
   const extendLockInterval = setInterval(async () => {
     logger.info(`🔄 Worker extending lock on job ${job.id}`);
-    await job.extendLock(token, jobLockExtensionTime);
+    job.extendLock(token, jobLockExtensionTime).catch((err) => {
+      logger.error(`Failed to extend lock on job ${job.id}: ${err}`);
+    });
   }, jobLockExtendInterval);
 
   try {
@@ -130,7 +132,9 @@ const processGenerateLlmsTxtJobInternal = async (
 
   const extendLockInterval = setInterval(async () => {
     logger.info(`🔄 Worker extending lock on job ${job.id}`);
-    await job.extendLock(token, jobLockExtensionTime);
+    job.extendLock(token, jobLockExtensionTime).catch((err) => {
+      logger.error(`Failed to extend lock on job ${job.id}: ${err}`);
+    });
   }, jobLockExtendInterval);
 
   try {


### PR DESCRIPTION
## The bug

The `setInterval` callbacks in `queue-worker.ts` (deep-research and llms.txt workers) awaited `job.extendLock(token, ...)` without a `.catch`. When the Redis lock was gone (job stalled after a network blip, pod freeze, or failover), the unhandled promise rejection terminated the worker process by default on Node 22 — killing the mid-job and restarting from scratch. There was no `process.on('unhandledRejection')` handler in this entrypoint.

## Fix

Replace `await` with `.catch()` so the rejection is caught and logged instead of crashing the process. The nuq path already checked `renewLock`'s return value; this brings the BullMQ path to parity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `extendLock` failures in the lock-extension intervals from crashing the worker process. Previously, an unhandled promise rejection (triggered when the Redis lock was gone) terminated the process on Node 22; now the rejection is caught and logged, so the worker keeps running and the in-flight job isn't restarted from scratch.

<sup>Written for commit 2f9f6135a994897bbb018adc1dcb6222596a6a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

