### PR TITLE
fix(python-sdk): drop non-existent `CrawlJobData` from `firecrawl.types.__all__`

### DIFF
--- a/apps/python-sdk/firecrawl/types.py
+++ b/apps/python-sdk/firecrawl/types.py
@@ -126,7 +126,6 @@ __all__ = [
     # Crawl types
     'CrawlRequest',
     'CrawlJob',
-    'CrawlJobData',
     'CrawlResponse',
     'CrawlParamsRequest',
     'CrawlParamsData',


### PR DESCRIPTION
## Problem

`apps/python-sdk/firecrawl/types.py` is the SDK's "unified access to Firecrawl
types" module: it re-exports names from `.v2.types` and declares `__all__`.

The re-export block imports **68** names. `__all__` lists **69** — the extra one
is `'CrawlJobData'`, which is not imported here and does not exist anywhere in
the repository (`grep -rn CrawlJobData apps/` matches only this line):

```python
    # Crawl types
    'CrawlRequest',
    'CrawlJob',
    'CrawlJobData',      # <- not imported, not defined anywhere
    'CrawlResponse',
    'CrawlParamsRequest',
```

CPython resolves `__all__` entries by attribute lookup, so any star-import of the
module fails:

```
>>> from firecrawl.types import *
AttributeError: module 'firecrawl.types' has no attribute 'CrawlJobData'
```

`pyflakes` reports it as `undefined name 'CrawlJobData' in __all__`.

Everything else lines up exactly — the imported set and `__all__` are otherwise a
perfect 1:1 match, which makes this a single leftover entry rather than a missing
import (there is no `CrawlJobData` in `v2/types.py` to import).

## Fix

Drop the stale entry. After the change:

```
imported: 68   __all__: 68
in __all__ but not imported: []
imported but not in __all__: []
```

One line removed, no other change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale `CrawlJobData` entry from `firecrawl.types.__all__` so `from firecrawl.types import *` no longer raises `AttributeError`.

<sup>Written for commit cc199babc03b1e2fd1ea641ec0a9214d3d4d5de8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

