### PR TITLE
feat(api): add provider terms to the Exchange preview proxy

### DIFF
--- a/apps/api/src/lib/exchange-provider-access.test.ts
+++ b/apps/api/src/lib/exchange-provider-access.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, expect, it, vi } from "vitest";
+const mocks = vi.hoisted(() => ({ forward: vi.fn(), execute: vi.fn() }));
+
+vi.mock("../db/connection", () => ({ db: { execute: mocks.execute } }));
+import { authorizeExchangeProviders } from "./exchange-provider-access";
+const terms = { key: "particle", version: "v1", digest: "a".repeat(64) };
+const input = {
+  teamId: "team-a",
+  body: { provider: "particle" },
+  requirements: mocks.forward,
+};
+const accepted = {
+  org_id: "org-a",
+  data_source_id: "particle",
+  status: "enabled",
+  terms_key: "particle",
+  terms_version: "v1",
+  terms_accepted_at: "2026-09-10",
+  settings: { terms_digest: terms.digest },
+};
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.forward.mockResolvedValue({
+    status: 200,
+    body: { providers: [{ provider: "particle", required: true, terms }] },
+  });
+  mocks.execute.mockResolvedValue({ rows: [accepted] });
+});
+it("allows a current enabled acceptance and requests authoritative requirements", async () => {
+  expect(await authorizeExchangeProviders(input)).toBeUndefined();
+  expect(mocks.forward).toHaveBeenCalledWith(["particle"]);
+  expect(mocks.execute).toHaveBeenCalledOnce();
+});
+it.each([
+  {
+    ...accepted,
+    data_source_id: null,
+    terms_version: null,
+    terms_accepted_at: null,
+  },
+  { ...accepted, status: "disabled" },
+  { ...accepted, status: "suspended" },
+  { ...accepted, terms_version: "old" },
+  { ...accepted, settings: { terms_digest: "b".repeat(64) } },
+  { ...accepted, terms_accepted_at: null },
+])(
+  "refuses missing, disabled, suspended or outdated acceptance %#",
+  async row => {
+    mocks.execute.mockResolvedValue({ rows: [row] });
+    expect((await authorizeExchangeProviders(input))?.status).toBe(403);
+  },
+);
+it("refuses the whole batch when any provider lacks acceptance", async () => {
+  mocks.forward.mockResolvedValue({
+    status: 200,
+    body: {
+      providers: [
+        { provider: "particle", required: true, terms },
+        {
+          provider: "second",
+          required: true,
+          terms: { ...terms, key: "second" },
+        },
+      ],
+    },
+  });
+  expect(
+    (
+      await authorizeExchangeProviders({
+        ...input,
+        body: { requests: [{ provider: "particle" }, { provider: "second" }] },
+      })
+    )?.status,
+  ).toBe(403);
+});
+it.each([
+  { providers: [] },
+  { providers: [{ provider: "different", required: false, terms: null }] },
+  { providers: [{ provider: "particle", required: true, terms: null }] },
+  {
+    providers: [
+      {
+        provider: "particle",
+        required: true,
+        terms: { key: "particle", version: "v1" },
+      },
+    ],
+  },
+])(
+  "fails closed for incomplete or mismatched requirement metadata %#",
+  async body => {
+    mocks.forward.mockResolvedValue({ status: 200, body });
+    expect((await authorizeExchangeProviders(input))?.status).toBe(503);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  },
+);
+it("fails closed on database errors", async () => {
+  mocks.execute.mockRejectedValue(new Error("database unavailable"));
+  expect((await authorizeExchangeProviders(input))?.status).toBe(503);
+});
+it("allows an enabled provider with no agreement", async () => {
+  mocks.forward.mockResolvedValue({
+    status: 200,
+    body: {
+      providers: [{ provider: "particle", required: false, terms: null }],
+    },
+  });
+  expect(await authorizeExchangeProviders(input)).toBeUndefined();
+  expect(mocks.execute).toHaveBeenCalledOnce();
+});
+it("still honors disabled access when agreement acceptance is optional", async () => {
+  mocks.forward.mockResolvedValue({
+    status: 200,
+    body: { providers: [{ provider: "particle", required: false, terms }] },
+  });
+  mocks.execute.mockResolvedValue({
+    rows: [{ ...accepted, status: "disabled" }],
+  });
+  expect((await authorizeExchangeProviders(input))?.status).toBe(403);
+});
+it("honors disablement even after a provider document is removed", async () => {
+  mocks.forward.mockResolvedValue({
+    status: 200,
+    body: {
+      providers: [{ provider: "particle", required: false, terms: null }],
+    },
+  });
+  mocks.execute.mockResolvedValue({
+    rows: [{ ...accepted, status: "disabled" }],
+  });
+  expect((await authorizeExchangeProviders(input))?.status).toBe(403);
+});
+it.each([
+  null,
+  {},
+  { provider: "" },
+  { requests: [] },
+  { requests: "invalid" },
+  { requests: Array.from({ length: 11 }, () => ({ provider: "particle" })) },
+])("refuses malformed requests before lookup %#", async body => {
+  expect((await authorizeExchangeProviders({ ...input, body }))?.status).toBe(
+    400,
+  );
+  expect(mocks.forward).not.toHaveBeenCalled();
+});
+it("deduplicates provider lookup for a valid batch", async () => {
+  await authorizeExchangeProviders({
+    ...input,
+    body: { requests: [{ provider: "particle" }, { provider: "particle" }] },
+  });
+  expect(mocks.forward).toHaveBeenCalledWith(["particle"]);
+});

--- a/apps/api/src/lib/exchange-provider-access.ts
+++ b/apps/api/src/lib/exchange-provider-access.ts
@@ -1,0 +1,132 @@
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/connection";
+function refusal(status: number, error: string) {
+  return { status, body: { success: false, error } };
+}
+const callSchema = z.object({ provider: z.string().min(1) }).passthrough();
+const batchSchema = z
+  .object({ requests: z.array(callSchema).min(1).max(10) })
+  .passthrough();
+
+const requirementsSchema = z.object({
+  providers: z.array(
+    z
+      .object({
+        provider: z.string().min(1),
+        required: z.boolean(),
+        terms: z
+          .object({
+            key: z.string().min(1),
+            version: z.string().min(1),
+            digest: z.string().regex(/^[a-f0-9]{64}$/),
+          })
+          .nullable(),
+      })
+      .refine(item => !item.required || item.terms !== null),
+  ),
+});
+const accessRows = z.array(
+  z.object({
+    org_id: z.string().nullable(),
+    data_source_id: z.string().nullable(),
+    status: z.string().nullable(),
+    terms_key: z.string().nullable(),
+    terms_version: z.string().nullable(),
+    terms_accepted_at: z.unknown(),
+    settings: z.record(z.string(), z.unknown()).nullable(),
+  }),
+);
+
+export async function authorizeExchangeProviders(input: {
+  teamId: string;
+  body: unknown;
+  requirements: (
+    providers: string[],
+  ) => Promise<{ status: number; body: unknown }>;
+}) {
+  const batch =
+    typeof input.body === "object" &&
+    input.body !== null &&
+    "requests" in input.body;
+  const parsedBody = (batch ? batchSchema : callSchema).safeParse(input.body);
+  if (!parsedBody.success)
+    return refusal(
+      400,
+      "Provide a provider or a batch of 1–10 provider requests.",
+    );
+  const calls = batch
+    ? (parsedBody.data as z.infer<typeof batchSchema>).requests
+    : [parsedBody.data as z.infer<typeof callSchema>];
+  const providers = [...new Set(calls.map(call => call.provider))];
+  const upstream = await input.requirements(providers);
+  if (upstream.status < 200 || upstream.status >= 300)
+    return refusal(
+      upstream.status === 404 ? 404 : 503,
+      upstream.status === 404
+        ? "Provider not found or agreement service unavailable."
+        : "Unable to verify provider agreements. No provider was executed.",
+    );
+  const parsed = requirementsSchema.safeParse(upstream.body);
+  if (
+    !parsed.success ||
+    parsed.data.providers.length !== providers.length ||
+    new Set(parsed.data.providers.map(item => item.provider)).size !==
+      providers.length ||
+    parsed.data.providers.some(item => !providers.includes(item.provider))
+  )
+    return refusal(
+      503,
+      "Unable to verify provider agreements. No provider was executed.",
+    );
+  try {
+    // Read the primary database so disabling access does not wait for an auth-cache refresh.
+    const result = await db.execute(sql`
+      SELECT t.org_id, a.data_source_id, a.status, a.terms_key, a.terms_version,
+             a.terms_accepted_at, a.settings
+      FROM teams t
+      LEFT JOIN organization_data_source_access a ON a.org_id = t.org_id
+        AND a.data_source_id IN (${sql.join(
+          providers.map(provider => sql`${provider}`),
+          sql`, `,
+        )})
+      WHERE t.id = ${input.teamId}
+    `);
+    const parsedRows = accessRows.safeParse(result.rows);
+    if (
+      !parsedRows.success ||
+      !parsedRows.data.length ||
+      !parsedRows.data[0]?.org_id
+    )
+      return refusal(
+        503,
+        "Organization provider access is unavailable. No provider was executed.",
+      );
+    const rows = new Map(parsedRows.data.map(row => [row.data_source_id, row]));
+    for (const provider of parsed.data.providers) {
+      const row = rows.get(provider.provider);
+      if (row && row.status !== "enabled")
+        return refusal(
+          403,
+          `Access to ${provider.provider} is disabled for this organization.`,
+        );
+      if (
+        provider.required &&
+        (!row ||
+          !row.terms_accepted_at ||
+          row.terms_key !== provider.terms?.key ||
+          row.terms_version !== provider.terms?.version ||
+          row.settings?.terms_digest !== provider.terms?.digest)
+      )
+        return refusal(
+          403,
+          `An organization admin must accept the current ${provider.provider} agreement in provider settings before this tool can run.`,
+        );
+    }
+  } catch {
+    return refusal(
+      503,
+      "Organization provider access is unavailable. No provider was executed.",
+    );
+  }
+}

--- a/apps/api/src/routes/exchange-provider-terms.test.ts
+++ b/apps/api/src/routes/exchange-provider-terms.test.ts
@@ -1,0 +1,184 @@
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from "express";
+import request from "supertest";
+import { beforeEach, expect, it, vi } from "vitest";
+const state = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  execute: vi.fn(),
+  enabled: true,
+}));
+vi.mock("undici", async importOriginal => ({
+  ...(await importOriginal<typeof import("undici")>()),
+  fetch: state.fetch,
+}));
+vi.mock("../config", () => ({
+  config: { FIRE_EXCHANGE_URL: "http://exchange.internal" },
+}));
+vi.mock("../db/connection", () => ({ db: { execute: state.execute } }));
+vi.mock("../lib/logger", () => ({
+  logger: { child: () => ({ error: vi.fn() }) },
+}));
+vi.mock("./exchange-blocklist", () => ({
+  bountyBlocklistMiddleware: (
+    _req: Request,
+    _res: Response,
+    next: NextFunction,
+  ) => next(),
+}));
+vi.mock("./shared", () => ({
+  wrap: (handler: unknown) => handler,
+  authMiddleware: () => (req: Request, res: Response, next: NextFunction) => {
+    if (req.headers.authorization !== "Bearer test-key")
+      return res.sendStatus(401);
+    Object.assign(req, {
+      auth: { team_id: "trusted-team" },
+      acuc: { flags: { exchangeRetrieve: state.enabled } },
+    });
+    next();
+  },
+}));
+import { exchangeRouter } from "./exchange";
+const app = express().use(express.json()).use("/exchange", exchangeRouter);
+const terms = { key: "particle", version: "v1", digest: "a".repeat(64) };
+const call = {
+  provider: "particle",
+  capability: "podcasts/search",
+  options: {},
+};
+function answer(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.enabled = true;
+  state.execute.mockResolvedValue({
+    rows: [
+      {
+        org_id: "org",
+        data_source_id: "particle",
+        status: "enabled",
+        terms_key: "particle",
+        terms_version: "v1",
+        terms_accepted_at: "2026-09-10",
+        settings: { terms_digest: terms.digest },
+      },
+    ],
+  });
+  state.fetch.mockImplementation(async (url: string) =>
+    url.endsWith("/requirements")
+      ? answer({ providers: [{ provider: "particle", required: true, terms }] })
+      : answer({ success: true }),
+  );
+});
+it("exposes the terms catalogue without the retrieval flag, using trusted identity", async () => {
+  state.enabled = false;
+  const res = await request(app)
+    .get("/exchange/provider-terms?surface=web")
+    .set("authorization", "Bearer test-key")
+    .set("x-exchange-team-id", "spoof")
+    .set("x-exchange-extended-catalog-access", "true");
+  expect(res.status).toBe(200);
+  expect(res.headers["cache-control"]).toBe("no-store");
+  expect(state.fetch).toHaveBeenCalledWith(
+    "http://exchange.internal/v1/provider-terms?surface=web",
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        "x-exchange-team-id": "trusted-team",
+        "x-exchange-extended-catalog-access": "false",
+      }),
+    }),
+  );
+  expect(state.execute).not.toHaveBeenCalled();
+});
+it("requires authentication for terms", async () => {
+  expect((await request(app).get("/exchange/provider-terms")).status).toBe(401);
+  expect(state.fetch).not.toHaveBeenCalled();
+});
+it("forwards an accepted request only after checking requirements and the database", async () => {
+  const res = await request(app)
+    .post("/exchange/retrieve")
+    .set("authorization", "Bearer test-key")
+    .send(call);
+  expect(res.status).toBe(200);
+  expect(state.fetch.mock.calls.map(([url]) => url)).toEqual([
+    "http://exchange.internal/v1/provider-terms/requirements",
+    "http://exchange.internal/v1/retrieve",
+  ]);
+  expect(JSON.parse(state.fetch.mock.calls[1][1].body)).toEqual(call);
+  expect(state.execute.mock.invocationCallOrder[0]).toBeLessThan(
+    state.fetch.mock.invocationCallOrder[1],
+  );
+});
+it("blocks an unaccepted batch before forwarding any execution", async () => {
+  state.execute.mockResolvedValue({
+    rows: [
+      {
+        org_id: "org",
+        data_source_id: null,
+        status: null,
+        terms_key: null,
+        terms_version: null,
+        terms_accepted_at: null,
+        settings: null,
+      },
+    ],
+  });
+  const res = await request(app)
+    .post("/exchange/retrieve")
+    .set("authorization", "Bearer test-key")
+    .send({ requests: [call, call] });
+  expect(res.status).toBe(403);
+  expect(state.fetch).toHaveBeenCalledTimes(1);
+});
+it("does not check or execute when the preview flag is absent", async () => {
+  state.enabled = false;
+  expect(
+    (
+      await request(app)
+        .post("/exchange/retrieve")
+        .set("authorization", "Bearer test-key")
+        .send(call)
+    ).status,
+  ).toBe(403);
+  expect(state.fetch).not.toHaveBeenCalled();
+});
+it.each(["unavailable", "malformed", "timeout", "database"])(
+  "fails closed on %s",
+  async failure => {
+    if (failure === "unavailable")
+      state.fetch.mockResolvedValue(answer({ error: "not deployed" }, 503));
+    if (failure === "malformed")
+      state.fetch.mockResolvedValue(answer({ providers: [] }));
+    if (failure === "timeout")
+      state.fetch.mockRejectedValue(
+        new DOMException("timeout", "TimeoutError"),
+      );
+    if (failure === "database")
+      state.execute.mockRejectedValue(new Error("unavailable"));
+    const res = await request(app)
+      .post("/exchange/retrieve")
+      .set("authorization", "Bearer test-key")
+      .send(call);
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(state.fetch).toHaveBeenCalledTimes(1);
+  },
+);
+it("keeps discovery independent of acceptance", async () => {
+  expect(
+    (
+      await request(app)
+        .get("/exchange/discover")
+        .set("authorization", "Bearer test-key")
+    ).status,
+  ).toBe(200);
+  expect(state.execute).not.toHaveBeenCalled();
+  expect(state.fetch.mock.calls[0][0]).toBe(
+    "http://exchange.internal/v1/discover",
+  );
+});

--- a/apps/api/src/routes/exchange.ts
+++ b/apps/api/src/routes/exchange.ts
@@ -1,3 +1,4 @@
+import { authorizeExchangeProviders } from "../lib/exchange-provider-access";
 import { bountyBlocklistMiddleware } from "./exchange-blocklist";
 import express, { Request, Response } from "express";
 import { Agent, fetch } from "undici";
@@ -37,12 +38,16 @@ function upstreamBase(): string | null {
 
 function exchangeProxy(
   timeout: number,
-  options: { requiresRetrieveFlag?: boolean } = {},
+  options: {
+    requiresRetrieveFlag?: boolean;
+    checkProviderAccess?: boolean;
+  } = {},
 ) {
   const requiresRetrieveFlag = options.requiresRetrieveFlag !== false;
   const dispatcher = dispatcherFor(timeout);
 
   return async function controller(req: Request, res: Response) {
+    res.setHeader("cache-control", "no-store");
     const authedReq = req as RequestWithAuth<any, any, any>;
     const logger = rootLogger.child({
       module: "api/exchange",
@@ -64,10 +69,41 @@ function exchangeProxy(
       );
     }
 
+    const signal = AbortSignal.timeout(timeout);
     const hasBody = req.method !== "GET";
     const path = req.originalUrl.replace(/^\/exchange/, "/v1");
 
     try {
+      if (options.checkProviderAccess) {
+        const denied = await authorizeExchangeProviders({
+          teamId: authedReq.auth.team_id,
+          body: req.body,
+          requirements: async providers => {
+            const response = await fetch(
+              `${base}/v1/provider-terms/requirements`,
+              {
+                method: "POST",
+                headers: {
+                  "content-type": "application/json",
+                  "x-exchange-team-id": authedReq.auth.team_id,
+                  "x-exchange-extended-catalog-access": String(
+                    authedReq.acuc?.flags?.exchangeRetrieve === true,
+                  ),
+                },
+                body: JSON.stringify({ providers }),
+                signal: AbortSignal.any([
+                  signal,
+                  AbortSignal.timeout(DISCOVER_TIMEOUT_MS),
+                ]),
+                dispatcher,
+              },
+            );
+            return { status: response.status, body: await response.json() };
+          },
+        });
+        if (denied) return res.status(denied.status).json(denied.body);
+      }
+      signal.throwIfAborted();
       const upstream = await fetch(base + path, {
         method: req.method,
         headers: {
@@ -79,9 +115,12 @@ function exchangeProxy(
           ),
           ...(hasBody ? { "content-type": "application/json" } : {}),
           "x-exchange-team-id": authedReq.auth.team_id,
+          "x-exchange-extended-catalog-access": String(
+            authedReq.acuc?.flags?.exchangeRetrieve === true,
+          ),
         },
         body: hasBody ? JSON.stringify(req.body ?? {}) : undefined,
-        signal: AbortSignal.timeout(timeout),
+        signal,
         dispatcher,
       });
 
@@ -116,6 +155,12 @@ function exchangeProxy(
 export const exchangeRouter = express.Router();
 
 exchangeRouter.get(
+  "/provider-terms",
+  authMiddleware(RateLimiterMode.Labs),
+  wrap(exchangeProxy(DISCOVER_TIMEOUT_MS, { requiresRetrieveFlag: false })),
+);
+
+exchangeRouter.get(
   "/discover{/*path}",
   authMiddleware(RateLimiterMode.Labs),
   wrap(exchangeProxy(DISCOVER_TIMEOUT_MS)),
@@ -137,7 +182,7 @@ exchangeRouter.get(
 exchangeRouter.post(
   "/retrieve",
   authMiddleware(RateLimiterMode.Labs),
-  wrap(exchangeProxy(RETRIEVE_TIMEOUT_MS)),
+  wrap(exchangeProxy(RETRIEVE_TIMEOUT_MS, { checkProviderAccess: true })),
 );
 
 exchangeRouter.get(


### PR DESCRIPTION
The existing Exchange retrieval proxy forwards requests without checking whether the caller's organization accepted the provider's agreement. This adds an interim consent gate that can ship independently of #4582.

- Expose authenticated, non-billable `GET /exchange/provider-terms` for the dashboard, without requiring the retrieval preview flag.
- Before forwarding `/exchange/retrieve`, validate the single request or batch, load authoritative provider requirements from Exchange, and check the authenticated team's organization against the primary `organization_data_source_access` table. Missing/stale required acceptance and disabled/suspended access reject the entire batch before execution. Discovery remains independent of consent.
- Derive upstream identity/catalog-access headers from authentication, mark proxy responses non-cacheable, and keep the requirement lookup and execution within the existing request deadline.

Billing behavior is unchanged. This PR adds no v1/v2 scrape, crawl, batch-scrape, SDK, or database-schema changes. Acceptance writes remain in the signed-in dashboard; no API-key acceptance endpoint is introduced.

### Preview rollout dependencies

Keep this draft until the companion Exchange endpoints (`GET /v1/provider-terms` and `POST /v1/provider-terms/requirements`) and dashboard acceptance flow are available. Those changes are currently local and not included in this PR. Deploy Exchange first: if the requirements endpoint is absent or unavailable, retrieval fails closed, including for providers without agreements. The dashboard must be available before enabling required agreements.

Provider agreements must contain approved real documents; local preview fixtures are not production agreements. PlanetScale agreement persistence is not part of this PR. This only enforces the existing `/exchange/retrieve` proxy; the billing PR must carry the same check into its shared execution path before adding other execution routes.

### Validation

- 33 focused tests pass: request/batch validation, exact version/digest acceptance, disablement/suspension, missing or malformed requirements, database failures, authenticated route behavior, identity spoofing, and discovery independence.
- TypeScript `tsc --noEmit`, Prettier, Knip, and lint-staged pass.
- Route tests exercise Express with mocked authentication, Exchange transport, and database. Live cross-service/real-database validation remains pending the companion deployments.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates Exchange retrieval on the caller's organization having accepted the provider's agreement, and exposes a non-billable provider-terms endpoint for the dashboard. Previously, `/exchange/retrieve` forwarded requests without checking consent; now a missing or stale acceptance, or disabled/suspended access, rejects the entire request or batch before execution.

- New authenticated `GET /exchange/provider-terms` works without the retrieval preview flag.
- Before forwarding `/exchange/retrieve`, loads authoritative requirement metadata from Exchange and checks the authenticated team's organization in `organization_data_source_access`; discovery remains independent of consent.
- Proxy responses are now non-cacheable, and upstream identity/catalog-access headers come from authentication.
- Billing behavior is unchanged; this PR adds no v1/v2 scrape, crawl, batch-scrape, SDK, or database-schema changes.

**Rollout dependencies**
- Keep this draft until the companion Exchange endpoints (`GET /v1/provider-terms` and `POST /v1/provider-terms/requirements`) and dashboard acceptance flow are available; those changes are currently local and not included here.
- Deploy Exchange first — if the requirements endpoint is absent or unavailable, retrieval fails closed, including for providers without agreements.
- The dashboard must be available before enabling required agreements.
- Provider agreements must contain approved real documents; local preview fixtures are not production agreements.
- This only enforces the existing `/exchange/retrieve` proxy; the billing PR must carry the same check into its shared execution path before adding other execution routes.

**Validation**
- 33 focused tests pass: request/batch validation, exact version/digest acceptance, disablement/suspension, missing or malformed requirements, database failures, authenticated route behavior, identity spoofing, and discovery independence.
- TypeScript `tsc --noEmit`, Prettier, Knip, and lint-staged pass.
- Live cross-service/real-database validation remains pending the companion deployments.

<sup>Written for commit e6709977981fdced3a549e638276b32f6d0435f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

