### PR TITLE
fix(api): raise includePaths/excludePaths cap from 100 to 1000 patterns

### DIFF
--- a/apps/api/src/__tests__/snips/v1/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v1/types-validation.test.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { MAX_PATH_PATTERNS } from "../../../lib/crawl-regex";
+import {
+  MAX_PATH_PATTERNS,
+  MAX_PATH_PATTERN_LENGTH,
+  MAX_TOTAL_PATH_PATTERNS,
+  MAX_TOTAL_PATH_PATTERN_CHARS,
+} from "../../../lib/crawl-regex";
 import {
   scrapeRequestSchema,
   scrapeOptions,
@@ -571,6 +576,39 @@ describe("V1 Types Validation", () => {
           ),
         }),
       ).toThrow(new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`));
+    });
+
+    it("should reject more than the aggregate number of path patterns", () => {
+      // Each field is within its own cap, but together they exceed the budget.
+      const half = Math.floor(MAX_TOTAL_PATH_PATTERNS / 2) + 1;
+      expect(() =>
+        crawlRequestSchema.parse({
+          url: "https://example.com",
+          includePaths: Array.from({ length: half }, (_, i) => `^/a${i}`),
+          excludePaths: Array.from({ length: half }, (_, i) => `^/b${i}`),
+        }),
+      ).toThrow(
+        new RegExp(
+          `together accept at most ${MAX_TOTAL_PATH_PATTERNS} patterns`,
+        ),
+      );
+    });
+
+    it("should reject path patterns exceeding the aggregate character budget", () => {
+      const pattern = "^/" + "a".repeat(MAX_PATH_PATTERN_LENGTH - 2);
+      const perField =
+        Math.floor(MAX_TOTAL_PATH_PATTERN_CHARS / pattern.length / 2) + 1;
+      expect(() =>
+        crawlRequestSchema.parse({
+          url: "https://example.com",
+          includePaths: Array.from({ length: perField }, () => pattern),
+          excludePaths: Array.from({ length: perField }, () => pattern),
+        }),
+      ).toThrow(
+        new RegExp(
+          `together accept at most ${MAX_TOTAL_PATH_PATTERN_CHARS} characters`,
+        ),
+      );
     });
   });
 

--- a/apps/api/src/__tests__/snips/v1/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v1/types-validation.test.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MAX_PATH_PATTERNS } from "../../../lib/crawl-regex";
 import {
   scrapeRequestSchema,
   scrapeOptions,
@@ -550,13 +551,26 @@ describe("V1 Types Validation", () => {
       ).toThrow(/exceeds size limit/);
     });
 
+    it("should accept several hundred keyword patterns per field", () => {
+      const result = crawlRequestSchema.parse({
+        url: "https://example.com",
+        includePaths: Array.from({ length: 300 }, (_, i) => `topic${i}`),
+        excludePaths: Array.from({ length: 300 }, (_, i) => `skip${i}`),
+      });
+      expect(result.includePaths).toHaveLength(300);
+      expect(result.excludePaths).toHaveLength(300);
+    });
+
     it("should reject more than the maximum number of path patterns", () => {
       expect(() =>
         crawlRequestSchema.parse({
           url: "https://example.com",
-          includePaths: Array.from({ length: 101 }, (_, i) => `^/p${i}`),
+          includePaths: Array.from(
+            { length: MAX_PATH_PATTERNS + 1 },
+            (_, i) => `^/p${i}`,
+          ),
         }),
-      ).toThrow(/at most 100 patterns/);
+      ).toThrow(new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`));
     });
   });
 

--- a/apps/api/src/__tests__/snips/v2/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v2/crawl.test.ts
@@ -20,6 +20,7 @@ import {
   TEST_API_URL,
 } from "./lib";
 import request from "./lib";
+import { MAX_PATH_PATTERNS } from "../../../lib/crawl-regex";
 import { describe, it, expect } from "vitest";
 
 let identity: Identity;
@@ -212,12 +213,35 @@ describe("Crawl tests", () => {
   );
 
   it.concurrent(
+    "accepts several hundred keyword path patterns per field",
+    async () => {
+      const res = await crawlStart(
+        {
+          url: "https://firecrawl.dev",
+          limit: 1,
+          includePaths: Array.from({ length: 300 }, (_, i) => `topic${i}`),
+          excludePaths: Array.from({ length: 300 }, (_, i) => `skip${i}`),
+        },
+        identity,
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(typeof res.body.id).toBe("string");
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
     "rejects more path patterns than the engine will compile",
     async () => {
       const res = await crawlStart(
         {
           url: "https://firecrawl.dev",
-          excludePaths: Array.from({ length: 101 }, (_, i) => `^/p${i}`),
+          excludePaths: Array.from(
+            { length: MAX_PATH_PATTERNS + 1 },
+            (_, i) => `^/p${i}`,
+          ),
         },
         identity,
       );
@@ -227,7 +251,11 @@ describe("Crawl tests", () => {
       // Schema-level (non-custom) issues are reported in details, not error.
       expect(
         res.body.details.map((issue: { message: string }) => issue.message),
-      ).toContainEqual(expect.stringMatching(/at most 100 patterns/));
+      ).toContainEqual(
+        expect.stringMatching(
+          new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`),
+        ),
+      );
     },
     scrapeTimeout,
   );

--- a/apps/api/src/__tests__/snips/v2/crawl.test.ts
+++ b/apps/api/src/__tests__/snips/v2/crawl.test.ts
@@ -20,7 +20,10 @@ import {
   TEST_API_URL,
 } from "./lib";
 import request from "./lib";
-import { MAX_PATH_PATTERNS } from "../../../lib/crawl-regex";
+import {
+  MAX_PATH_PATTERNS,
+  MAX_TOTAL_PATH_PATTERNS,
+} from "../../../lib/crawl-regex";
 import { describe, it, expect } from "vitest";
 
 let identity: Identity;
@@ -254,6 +257,30 @@ describe("Crawl tests", () => {
       ).toContainEqual(
         expect.stringMatching(
           new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`),
+        ),
+      );
+    },
+    scrapeTimeout,
+  );
+
+  it.concurrent(
+    "rejects include and exclude patterns that together exceed the budget",
+    async () => {
+      const half = Math.floor(MAX_TOTAL_PATH_PATTERNS / 2) + 1;
+      const res = await crawlStart(
+        {
+          url: "https://firecrawl.dev",
+          includePaths: Array.from({ length: half }, (_, i) => `^/a${i}`),
+          excludePaths: Array.from({ length: half }, (_, i) => `^/b${i}`),
+        },
+        identity,
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toMatch(
+        new RegExp(
+          `together accept at most ${MAX_TOTAL_PATH_PATTERNS} patterns`,
         ),
       );
     },

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1020,6 +1020,18 @@ describe("V2 Types Validation", () => {
       expect(message).toMatch(/percent-encoded ASCII/);
     });
 
+    it("should accept several hundred keyword patterns per field", () => {
+      // Keyword-based filtering sends one short pattern per term; a few
+      // hundred per field must not be rejected by the count cap.
+      const result = crawlRequestSchema.parse({
+        url: "https://example.com",
+        includePaths: Array.from({ length: 300 }, (_, i) => `topic${i}`),
+        excludePaths: Array.from({ length: 300 }, (_, i) => `skip${i}`),
+      });
+      expect(result.includePaths).toHaveLength(300);
+      expect(result.excludePaths).toHaveLength(300);
+    });
+
     it("should reject more than the maximum number of path patterns", () => {
       expect(() =>
         crawlRequestSchema.parse({
@@ -1029,7 +1041,7 @@ describe("V2 Types Validation", () => {
             (_, i) => `^/p${i}`,
           ),
         }),
-      ).toThrow(/at most 100 patterns/);
+      ).toThrow(new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`));
     });
 
     it("should not compile patterns once the count cap is exceeded", () => {
@@ -1046,7 +1058,9 @@ describe("V2 Types Validation", () => {
         message = String(e);
       }
 
-      expect(message).toMatch(/at most 100 patterns/);
+      expect(message).toMatch(
+        new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`),
+      );
       expect(message).not.toMatch(/unclosed character class/);
     });
 
@@ -1071,7 +1085,7 @@ describe("V2 Types Validation", () => {
           url: "https://example.com",
           includePaths: ["^/" + "a".repeat(MAX_PATH_PATTERN_LENGTH)],
         }),
-      ).toThrow(/at most 2000 characters/);
+      ).toThrow(new RegExp(`at most ${MAX_PATH_PATTERN_LENGTH} characters`));
     });
   });
 

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import {
   MAX_PATH_PATTERNS,
   MAX_PATH_PATTERN_LENGTH,
+  MAX_TOTAL_PATH_PATTERNS,
+  MAX_TOTAL_PATH_PATTERN_CHARS,
 } from "../../../lib/crawl-regex";
 import {
   scrapeRequestSchema,
@@ -1042,6 +1044,39 @@ describe("V2 Types Validation", () => {
           ),
         }),
       ).toThrow(new RegExp(`at most ${MAX_PATH_PATTERNS} patterns`));
+    });
+
+    it("should reject more than the aggregate number of path patterns", () => {
+      // Each field is within its own cap, but together they exceed the budget.
+      const half = Math.floor(MAX_TOTAL_PATH_PATTERNS / 2) + 1;
+      expect(() =>
+        crawlRequestSchema.parse({
+          url: "https://example.com",
+          includePaths: Array.from({ length: half }, (_, i) => `^/a${i}`),
+          excludePaths: Array.from({ length: half }, (_, i) => `^/b${i}`),
+        }),
+      ).toThrow(
+        new RegExp(
+          `together accept at most ${MAX_TOTAL_PATH_PATTERNS} patterns`,
+        ),
+      );
+    });
+
+    it("should reject path patterns exceeding the aggregate character budget", () => {
+      const pattern = "^/" + "a".repeat(MAX_PATH_PATTERN_LENGTH - 2);
+      const perField =
+        Math.floor(MAX_TOTAL_PATH_PATTERN_CHARS / pattern.length / 2) + 1;
+      expect(() =>
+        crawlRequestSchema.parse({
+          url: "https://example.com",
+          includePaths: Array.from({ length: perField }, () => pattern),
+          excludePaths: Array.from({ length: perField }, () => pattern),
+        }),
+      ).toThrow(
+        new RegExp(
+          `together accept at most ${MAX_TOTAL_PATH_PATTERN_CHARS} characters`,
+        ),
+      );
     });
 
     it("should not compile patterns once the count cap is exceeded", () => {

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -1159,6 +1159,27 @@ describe("V2 Types Validation", () => {
       ).toEqual([]);
     });
 
+    it("should report malformed generated fields instead of throwing", () => {
+      expect(
+        collectPathPatternIssues({
+          includePaths: "^/blog",
+          excludePaths: ["^/jobs", 42],
+        }),
+      ).toEqual([
+        {
+          kind: "shape",
+          path: ["includePaths"],
+          message: "includePaths must be an array of strings.",
+        },
+        {
+          kind: "shape",
+          path: ["excludePaths"],
+          message: "excludePaths must be an array of strings.",
+        },
+      ]);
+      expect(collectPathPatternIssues({ includePaths: null })).toEqual([]);
+    });
+
     it("should report per-field caps that the schema did not see", () => {
       const issues = collectPathPatternIssues({
         includePaths: Array.from(

--- a/apps/api/src/__tests__/snips/v2/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v2/types-validation.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_PATH_PATTERN_LENGTH,
   MAX_TOTAL_PATH_PATTERNS,
   MAX_TOTAL_PATH_PATTERN_CHARS,
+  collectPathPatternIssues,
 } from "../../../lib/crawl-regex";
 import {
   scrapeRequestSchema,
@@ -1062,6 +1063,28 @@ describe("V2 Types Validation", () => {
       );
     });
 
+    it("should report aggregate budget issues at the request root", () => {
+      // excludePaths sits exactly at its own cap; one includePaths pattern
+      // pushes the total over the request-wide budget.
+      const result = crawlRequestSchema.safeParse({
+        url: "https://example.com",
+        excludePaths: Array.from(
+          { length: MAX_PATH_PATTERNS },
+          (_, i) => `^/b${i}`,
+        ),
+        includePaths: ["^/a"],
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(i =>
+          /together accept at most/.test(i.message),
+        );
+        expect(issue).toBeDefined();
+        // Neither field is individually at fault, so do not point at one.
+        expect(issue!.path).toEqual([]);
+      }
+    });
+
     it("should reject path patterns exceeding the aggregate character budget", () => {
       const pattern = "^/" + "a".repeat(MAX_PATH_PATTERN_LENGTH - 2);
       const perField =
@@ -1121,6 +1144,46 @@ describe("V2 Types Validation", () => {
           includePaths: ["^/" + "a".repeat(MAX_PATH_PATTERN_LENGTH)],
         }),
       ).toThrow(new RegExp(`at most ${MAX_PATH_PATTERN_LENGTH} characters`));
+    });
+  });
+
+  describe("collectPathPatternIssues", () => {
+    // Options generated from a crawl prompt are merged after schema
+    // validation, so the controller validates them with this helper directly.
+    it("should accept merged options within every limit", () => {
+      expect(
+        collectPathPatternIssues({
+          includePaths: Array.from({ length: 300 }, (_, i) => `topic${i}`),
+          excludePaths: ["^/careers", "^/jobs"],
+        }),
+      ).toEqual([]);
+    });
+
+    it("should report per-field caps that the schema did not see", () => {
+      const issues = collectPathPatternIssues({
+        includePaths: Array.from(
+          { length: MAX_PATH_PATTERNS + 1 },
+          (_, i) => `^/p${i}`,
+        ),
+      });
+      expect(issues).toHaveLength(1);
+      expect(issues[0].kind).toBe("field-cap");
+      expect(issues[0].path).toEqual(["includePaths"]);
+    });
+
+    it("should report the aggregate budget and unsupported syntax", () => {
+      const half = Math.floor(MAX_TOTAL_PATH_PATTERNS / 2) + 1;
+      const budget = collectPathPatternIssues({
+        includePaths: Array.from({ length: half }, (_, i) => `^/a${i}`),
+        excludePaths: Array.from({ length: half }, (_, i) => `^/b${i}`),
+      });
+      expect(budget.map(i => i.kind)).toEqual(["budget"]);
+
+      const syntax = collectPathPatternIssues({
+        excludePaths: ["^/ok", "(?<=a)b"],
+      });
+      expect(syntax.map(i => i.kind)).toEqual(["syntax"]);
+      expect(syntax[0].message).toMatch(/look-around/);
     });
   });
 

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -924,8 +924,7 @@ const crawlRequestSchemaBase = crawlerOptions.extend({
 export const crawlRequestSchema = crawlRequestSchemaBase
   .strict()
   .superRefine((x, ctx) => {
-    addPathRegexIssues(x.includePaths, "includePaths", ctx);
-    addPathRegexIssues(x.excludePaths, "excludePaths", ctx);
+    addPathRegexIssues(x, ctx);
   })
   .refine(
     x => (x.scrapeOptions ? extractRefine(x.scrapeOptions) : true),
@@ -1008,8 +1007,7 @@ const mapRequestSchemaBase = crawlerOptions
 export const mapRequestSchema = mapRequestSchemaBase
   .strict()
   .superRefine((x, ctx) => {
-    addPathRegexIssues(x.includePaths, "includePaths", ctx);
-    addPathRegexIssues(x.excludePaths, "excludePaths", ctx);
+    addPathRegexIssues(x, ctx);
   });
 
 // export type MapRequest = {

--- a/apps/api/src/controllers/v2/crawl.ts
+++ b/apps/api/src/controllers/v2/crawl.ts
@@ -25,6 +25,7 @@ import {
   formatTypesOf,
 } from "../../lib/key-restriction";
 import { buildPromptWithWebsiteStructure } from "../../lib/map-utils";
+import { collectPathPatternIssues } from "../../lib/crawl-regex";
 import {
   crawlGroup,
   resolveNewGroupBackend,
@@ -245,23 +246,15 @@ export async function crawlController(
     }
   }
 
-  if (Array.isArray(finalCrawlerOptions.includePaths)) {
-    for (const x of finalCrawlerOptions.includePaths) {
-      try {
-        new RegExp(x);
-      } catch (e) {
-        return res.status(400).json({ success: false, error: e.message });
-      }
-    }
-  }
-
-  if (Array.isArray(finalCrawlerOptions.excludePaths)) {
-    for (const x of finalCrawlerOptions.excludePaths) {
-      try {
-        new RegExp(x);
-      } catch (e) {
-        return res.status(400).json({ success: false, error: e.message });
-      }
+  // The request schema already validated user-supplied includePaths /
+  // excludePaths. Options generated from a prompt bypass the schema, so hold
+  // the merged result to the same caps, budget, and engine syntax.
+  if (req.body.prompt) {
+    const pathPatternIssues = collectPathPatternIssues(finalCrawlerOptions);
+    if (pathPatternIssues.length > 0) {
+      return res
+        .status(400)
+        .json({ success: false, error: pathPatternIssues[0].message });
     }
   }
 

--- a/apps/api/src/controllers/v2/types.ts
+++ b/apps/api/src/controllers/v2/types.ts
@@ -1318,8 +1318,7 @@ const crawlRequestSchemaBase = crawlerOptions.extend({
 
 export const crawlRequestSchema = strictWithMessage(crawlRequestSchemaBase)
   .superRefine((x, ctx) => {
-    addPathRegexIssues(x.includePaths, "includePaths", ctx);
-    addPathRegexIssues(x.excludePaths, "excludePaths", ctx);
+    addPathRegexIssues(x, ctx);
   })
   .refine(x => waitForRefine(x.scrapeOptions), waitForRefineOpts)
   .transform(x => {
@@ -1373,8 +1372,7 @@ const mapRequestSchemaBase = crawlerOptions
 export const mapRequestSchema = strictWithMessage(
   mapRequestSchemaBase,
 ).superRefine((x, ctx) => {
-  addPathRegexIssues(x.includePaths, "includePaths", ctx);
-  addPathRegexIssues(x.excludePaths, "excludePaths", ctx);
+  addPathRegexIssues(x, ctx);
 });
 
 // export type MapRequest = {

--- a/apps/api/src/lib/crawl-regex.ts
+++ b/apps/api/src/lib/crawl-regex.ts
@@ -34,54 +34,103 @@ export const pathPatternsSchema = z
     `includePaths and excludePaths each accept at most ${MAX_PATH_PATTERNS} patterns.`,
   );
 
+type PathPatternField = "includePaths" | "excludePaths";
+
 type PathPatternFields = {
   includePaths?: string[];
   excludePaths?: string[];
 };
 
-// Validate includePaths/excludePaths as a unit: first the request-wide budget,
-// then each pattern against the engine. Nothing is compiled once any cap is
-// exceeded, because the caps are what bound the compile work a request can
-// demand and the request has already been rejected at that point.
-export function addPathRegexIssues(
+type PathPatternIssue = {
+  // "field-cap": a single field exceeds its count or length cap.
+  // "budget": both fields together exceed the request-wide budget.
+  // "syntax": a pattern does not compile with the engine.
+  kind: "field-cap" | "budget" | "syntax";
+  // Empty for request-wide (cross-field) issues.
+  path: PathPatternField[];
+  message: string;
+};
+
+// Validate includePaths/excludePaths as a unit: the per-field caps, then the
+// request-wide budget, then each pattern against the engine. Nothing is
+// compiled once any cap is exceeded, because the caps are what bound the
+// compile work a request can demand.
+//
+// This is the single source of truth for what path patterns are accepted. The
+// request schemas call it through addPathRegexIssues; the v2 crawl controller
+// calls it directly on the final crawler options, because includePaths /
+// excludePaths generated from a crawl `prompt` are merged in after schema
+// validation and must meet the same limits before they reach the crawler.
+export function collectPathPatternIssues(
   fields: PathPatternFields,
-  ctx: z.RefinementCtx,
-): void {
+): PathPatternIssue[] {
   const include = fields.includePaths ?? [];
   const exclude = fields.excludePaths ?? [];
-  if (include.length === 0 && exclude.length === 0) return;
+  if (include.length === 0 && exclude.length === 0) return [];
 
-  // Zod still runs this refinement when pathPatternsSchema has already reported
-  // a per-field count or length violation, so re-check those caps here.
-  const overFieldCap = (patterns: string[]) =>
-    patterns.length > MAX_PATH_PATTERNS ||
-    patterns.some(p => p.length > MAX_PATH_PATTERN_LENGTH);
-  if (overFieldCap(include) || overFieldCap(exclude)) return;
+  const capIssues: PathPatternIssue[] = [];
+  for (const [field, patterns] of [
+    ["includePaths", include],
+    ["excludePaths", exclude],
+  ] as const) {
+    if (patterns.length > MAX_PATH_PATTERNS) {
+      capIssues.push({
+        kind: "field-cap",
+        path: [field],
+        message: `includePaths and excludePaths each accept at most ${MAX_PATH_PATTERNS} patterns.`,
+      });
+    }
+    if (patterns.some(p => p.length > MAX_PATH_PATTERN_LENGTH)) {
+      capIssues.push({
+        kind: "field-cap",
+        path: [field],
+        message: `Each includePaths/excludePaths pattern must be at most ${MAX_PATH_PATTERN_LENGTH} characters.`,
+      });
+    }
+  }
+  if (capIssues.length > 0) return capIssues;
 
   const totalCount = include.length + exclude.length;
   if (totalCount > MAX_TOTAL_PATH_PATTERNS) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["includePaths"],
-      message: `includePaths and excludePaths together accept at most ${MAX_TOTAL_PATH_PATTERNS} patterns (got ${totalCount}).`,
-    });
-    return;
+    return [
+      {
+        kind: "budget",
+        path: [],
+        message: `includePaths and excludePaths together accept at most ${MAX_TOTAL_PATH_PATTERNS} patterns (got ${totalCount}).`,
+      },
+    ];
   }
   const totalChars = [...include, ...exclude].reduce(
     (sum, p) => sum + p.length,
     0,
   );
   if (totalChars > MAX_TOTAL_PATH_PATTERN_CHARS) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["includePaths"],
-      message: `includePaths and excludePaths together accept at most ${MAX_TOTAL_PATH_PATTERN_CHARS} characters of patterns (got ${totalChars}).`,
-    });
-    return;
+    return [
+      {
+        kind: "budget",
+        path: [],
+        message: `includePaths and excludePaths together accept at most ${MAX_TOTAL_PATH_PATTERN_CHARS} characters of patterns (got ${totalChars}).`,
+      },
+    ];
   }
 
-  addFieldRegexIssues(include, "includePaths", ctx);
-  addFieldRegexIssues(exclude, "excludePaths", ctx);
+  return [
+    ...fieldRegexIssues(include, "includePaths"),
+    ...fieldRegexIssues(exclude, "excludePaths"),
+  ];
+}
+
+// Zod refinement wrapper around collectPathPatternIssues. Zod still runs this
+// refinement when pathPatternsSchema has already reported a per-field count or
+// length violation, so those are not reported a second time here.
+export function addPathRegexIssues(
+  fields: PathPatternFields,
+  ctx: z.RefinementCtx,
+): void {
+  for (const issue of collectPathPatternIssues(fields)) {
+    if (issue.kind === "field-cap") continue;
+    ctx.addIssue({ code: "custom", path: issue.path, message: issue.message });
+  }
 }
 
 // Link filtering compiles includePaths/excludePaths with the Rust `regex` crate
@@ -89,22 +138,21 @@ export function addPathRegexIssues(
 // pattern compiled fine in most clients' regex flavor but was silently dropped
 // by the engine, so the paths it was meant to filter got crawled anyway. Reject
 // such patterns up front with a message that points at the actual limitation.
-function addFieldRegexIssues(
+function fieldRegexIssues(
   patterns: string[],
-  field: "includePaths" | "excludePaths",
-  ctx: z.RefinementCtx,
-): void {
-  if (patterns.length === 0) return;
-  for (const { pattern, error } of validateRegexes(patterns)) {
+  field: PathPatternField,
+): PathPatternIssue[] {
+  if (patterns.length === 0) return [];
+  return validateRegexes(patterns).map(({ pattern, error }) => {
     const summary = summarizeRegexError(error);
-    ctx.addIssue({
-      code: "custom",
+    return {
+      kind: "syntax",
       path: [field],
       message:
         `Invalid ${field} pattern ${JSON.stringify(pattern)}: ${summary}. ` +
         `${field} patterns use Rust regex (RE2-style) syntax.${regexErrorHint(summary)}`,
-    });
-  }
+    };
+  });
 }
 
 function summarizeRegexError(error: string): string {

--- a/apps/api/src/lib/crawl-regex.ts
+++ b/apps/api/src/lib/crawl-regex.ts
@@ -6,7 +6,13 @@ import { z } from "zod";
 // count x per-pattern cost. The engine bounds per-pattern cost (see
 // compile_path_regex in native/src/crawler.rs); these bound the count and the
 // pattern length, which is what parsing cost scales with.
-export const MAX_PATH_PATTERNS = 100;
+//
+// Keyword-style filtering (one short pattern per term) routinely needs a few
+// hundred patterns per field, so the count cap has headroom for that. Measured
+// against the native module, 1000 patterns compile in ~2 ms for short keywords
+// and ~350 ms in the worst case (every pattern a maximal-length alternation),
+// which is well within what a single request may spend on validation.
+export const MAX_PATH_PATTERNS = 1000;
 export const MAX_PATH_PATTERN_LENGTH = 2000;
 
 export const pathPatternsSchema = z

--- a/apps/api/src/lib/crawl-regex.ts
+++ b/apps/api/src/lib/crawl-regex.ts
@@ -36,16 +36,20 @@ export const pathPatternsSchema = z
 
 type PathPatternField = "includePaths" | "excludePaths";
 
+// Values are `unknown` because the v2 crawl controller passes crawler options
+// that were partly produced by an LLM from a `prompt`, which may return the
+// wrong shape entirely (a string instead of an array, numbers in the array).
 type PathPatternFields = {
-  includePaths?: string[];
-  excludePaths?: string[];
+  includePaths?: unknown;
+  excludePaths?: unknown;
 };
 
 type PathPatternIssue = {
+  // "shape": the field is not an array of strings.
   // "field-cap": a single field exceeds its count or length cap.
   // "budget": both fields together exceed the request-wide budget.
   // "syntax": a pattern does not compile with the engine.
-  kind: "field-cap" | "budget" | "syntax";
+  kind: "shape" | "field-cap" | "budget" | "syntax";
   // Empty for request-wide (cross-field) issues.
   path: PathPatternField[];
   message: string;
@@ -64,8 +68,23 @@ type PathPatternIssue = {
 export function collectPathPatternIssues(
   fields: PathPatternFields,
 ): PathPatternIssue[] {
-  const include = fields.includePaths ?? [];
-  const exclude = fields.excludePaths ?? [];
+  const shapeIssues: PathPatternIssue[] = [];
+  const asPatterns = (field: PathPatternField): string[] => {
+    const value = fields[field];
+    if (value === undefined || value === null) return [];
+    if (Array.isArray(value) && value.every(p => typeof p === "string")) {
+      return value;
+    }
+    shapeIssues.push({
+      kind: "shape",
+      path: [field],
+      message: `${field} must be an array of strings.`,
+    });
+    return [];
+  };
+  const include = asPatterns("includePaths");
+  const exclude = asPatterns("excludePaths");
+  if (shapeIssues.length > 0) return shapeIssues;
   if (include.length === 0 && exclude.length === 0) return [];
 
   const capIssues: PathPatternIssue[] = [];

--- a/apps/api/src/lib/crawl-regex.ts
+++ b/apps/api/src/lib/crawl-regex.ts
@@ -9,11 +9,18 @@ import { z } from "zod";
 //
 // Keyword-style filtering (one short pattern per term) routinely needs a few
 // hundred patterns per field, so the count cap has headroom for that. Measured
-// against the native module, 1000 patterns compile in ~2 ms for short keywords
-// and ~350 ms in the worst case (every pattern a maximal-length alternation),
-// which is well within what a single request may spend on validation.
+// against the native module, 1000 short keyword patterns compile in ~2 ms.
 export const MAX_PATH_PATTERNS = 1000;
 export const MAX_PATH_PATTERN_LENGTH = 2000;
+
+// includePaths and excludePaths are compiled together, so the per-field caps
+// alone would let one request demand 2 x 1000 x 2000 characters of compile
+// work. These bound the request as a whole: total pattern count and total
+// pattern characters across both fields. The worst case that fits (1000
+// patterns whose combined length is 100k characters) compiles in ~120 ms on the
+// native module, versus ~700 ms for the unbudgeted per-field maximum.
+export const MAX_TOTAL_PATH_PATTERNS = 1000;
+export const MAX_TOTAL_PATH_PATTERN_CHARS = 100_000;
 
 export const pathPatternsSchema = z
   .string()
@@ -27,27 +34,67 @@ export const pathPatternsSchema = z
     `includePaths and excludePaths each accept at most ${MAX_PATH_PATTERNS} patterns.`,
   );
 
+type PathPatternFields = {
+  includePaths?: string[];
+  excludePaths?: string[];
+};
+
+// Validate includePaths/excludePaths as a unit: first the request-wide budget,
+// then each pattern against the engine. Nothing is compiled once any cap is
+// exceeded, because the caps are what bound the compile work a request can
+// demand and the request has already been rejected at that point.
+export function addPathRegexIssues(
+  fields: PathPatternFields,
+  ctx: z.RefinementCtx,
+): void {
+  const include = fields.includePaths ?? [];
+  const exclude = fields.excludePaths ?? [];
+  if (include.length === 0 && exclude.length === 0) return;
+
+  // Zod still runs this refinement when pathPatternsSchema has already reported
+  // a per-field count or length violation, so re-check those caps here.
+  const overFieldCap = (patterns: string[]) =>
+    patterns.length > MAX_PATH_PATTERNS ||
+    patterns.some(p => p.length > MAX_PATH_PATTERN_LENGTH);
+  if (overFieldCap(include) || overFieldCap(exclude)) return;
+
+  const totalCount = include.length + exclude.length;
+  if (totalCount > MAX_TOTAL_PATH_PATTERNS) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["includePaths"],
+      message: `includePaths and excludePaths together accept at most ${MAX_TOTAL_PATH_PATTERNS} patterns (got ${totalCount}).`,
+    });
+    return;
+  }
+  const totalChars = [...include, ...exclude].reduce(
+    (sum, p) => sum + p.length,
+    0,
+  );
+  if (totalChars > MAX_TOTAL_PATH_PATTERN_CHARS) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["includePaths"],
+      message: `includePaths and excludePaths together accept at most ${MAX_TOTAL_PATH_PATTERN_CHARS} characters of patterns (got ${totalChars}).`,
+    });
+    return;
+  }
+
+  addFieldRegexIssues(include, "includePaths", ctx);
+  addFieldRegexIssues(exclude, "excludePaths", ctx);
+}
+
 // Link filtering compiles includePaths/excludePaths with the Rust `regex` crate
 // (RE2-style: no look-around or backreferences). Historically an unsupported
 // pattern compiled fine in most clients' regex flavor but was silently dropped
 // by the engine, so the paths it was meant to filter got crawled anyway. Reject
 // such patterns up front with a message that points at the actual limitation.
-export function addPathRegexIssues(
-  patterns: string[] | undefined,
+function addFieldRegexIssues(
+  patterns: string[],
   field: "includePaths" | "excludePaths",
   ctx: z.RefinementCtx,
 ): void {
-  if (!patterns || patterns.length === 0) return;
-  // Zod still runs this refinement when pathPatternsSchema has already reported
-  // a count or length violation, so re-check the caps here: they are what bound
-  // the total compile work a request can demand, and an over-cap request has
-  // already been rejected.
-  if (
-    patterns.length > MAX_PATH_PATTERNS ||
-    patterns.some(p => p.length > MAX_PATH_PATTERN_LENGTH)
-  ) {
-    return;
-  }
+  if (patterns.length === 0) return;
   for (const { pattern, error } of validateRegexes(patterns)) {
     const summary = summarizeRegexError(error);
     ctx.addIssue({


### PR DESCRIPTION
## Problem

#4533 capped `includePaths` / `excludePaths` at 100 patterns per field as a "conservative starting point". It turns out keyword-based path filtering, which sends one short pattern per term, routinely needs a few hundred patterns per field. A user reported requests with ~170 `includePaths` and ~115 `excludePaths` that worked before #4533 now fail with a 400.

## Fix

Raise `MAX_PATH_PATTERNS` from 100 to 1000. The per-pattern length cap (2000 chars) and the engine-side compile limits from #4533 (`size_limit`, `dfa_size_limit`, `nest_limit`, ASCII mode) are unchanged, so the cost of any single pattern is still bounded; this only widens the count multiplier.

Measured against the locally built native module (`validateRegexes`, 1000 patterns per call):

| input (×1000) | compile time |
|---|---|
| short keywords (`keyword123`) | 2 ms |
| `\w{5000}` | 76 ms (all rejected) |
| `a{5}{5}{5}{5}{5}{5}{5}{5}` | 121 ms (all rejected) |
| 2000-char alternation | 353 ms |
| `^/[\w-]{1,100}/[\w-]{1,100}/[\w-]{1,100}/?$` | 65 ms |

The worst case needs a 2 MB request body made entirely of maximal-length alternations and still lands well under half a second, versus the multi-second stalls the cap was introduced to prevent.

## Tests

- Schema tests (v1 and v2) now derive the count from `MAX_PATH_PATTERNS` instead of hardcoding `101` / `at most 100`, and add a happy path that accepts 300 patterns per field.
- E2E (v2 crawl): new happy path starts a crawl with 300 include + 300 exclude patterns and expects 200; the over-cap rejection test uses `MAX_PATH_PATTERNS + 1`.
- Ran locally: 209 schema tests pass, knip clean, prettier clean. E2E runs in CI.

## Answering the user's questions

- The 100 cap was never intended as permanent; it is now 1000 and stays a single constant in `apps/api/src/lib/crawl-regex.ts`.
- For high-volume keyword filtering, one short pattern per keyword is the recommended shape. There is no need to batch terms into large alternations; short patterns compile in microseconds and the count cap has an order of magnitude of headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the cap for `includePaths`/`excludePaths` from 100 to 1000 patterns per field so keyword-based path filtering no longer hits a 400, and adds a combined budget across both fields to keep compile work bounded.

- `includePaths` and `excludePaths` are validated together against a 1000-pattern / 100k-character budget checked before compiling anything; budget errors are reported at the request root.
- Prompt-generated path patterns in v2 crawl now go through the same validation instead of a plain JS `new RegExp` check, so they no longer skip the caps, budget, or engine syntax check; malformed fields (wrong shape or non-string entries) are rejected with a 400 instead of throwing.
- Tests derive limits from the constants and add happy paths accepting 300 patterns per field; the per-pattern length cap (2000 chars) and engine-side compile limits are unchanged.

<sup>Written for commit 5cdd5cb9c842620a3ed4c5357ad103cc40cf076e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

