### PR TITLE
fix(search): forward domain filters to fire engine

### DIFF
--- a/apps/api/src/search/execute.ts
+++ b/apps/api/src/search/execute.ts
@@ -140,6 +140,8 @@ export async function executeSearch(
         safe: options.safe,
         type: searchTypes,
         enterprise: options.enterprise,
+        includeDomains: options.includeDomains,
+        excludeDomains: options.excludeDomains,
       })) as SearchV2Response);
   let developerResults = developerResultsPromise
     ? await developerResultsPromise

--- a/apps/api/src/search/v2/fireEngine-v2.ts
+++ b/apps/api/src/search/v2/fireEngine-v2.ts
@@ -47,6 +47,8 @@ export async function fire_engine_search_v2(
     page?: number;
     type?: SearchResultType | SearchResultType[];
     enterprise?: ("default" | "anon" | "zdr")[];
+    includeDomains?: string[];
+    excludeDomains?: string[];
   },
   abort?: AbortSignal,
 ): Promise<SearchV2Response> {
@@ -68,6 +70,8 @@ export async function fire_engine_search_v2(
     type: options.type || "web",
     enterprise: options.enterprise,
     safe: options.safe ? ("active" as const) : undefined,
+    includeDomains: options.includeDomains,
+    excludeDomains: options.excludeDomains,
   };
 
   const requestedTypes = normalizeSearchTypes(options.type);

--- a/apps/api/src/search/v2/index.ts
+++ b/apps/api/src/search/v2/index.ts
@@ -22,6 +22,8 @@ export async function search({
   timeout = 5000,
   type = undefined,
   enterprise = undefined,
+  includeDomains = undefined,
+  excludeDomains = undefined,
 }: {
   query: string;
   logger: Logger;
@@ -39,6 +41,8 @@ export async function search({
   timeout?: number;
   type?: SearchResultType | SearchResultType[];
   enterprise?: ("default" | "anon" | "zdr")[];
+  includeDomains?: string[];
+  excludeDomains?: string[];
 }): Promise<SearchV2Response> {
   try {
     if (config.FIRE_ENGINE_BETA_URL) {
@@ -54,11 +58,16 @@ export async function search({
         safe,
         type,
         enterprise,
+        includeDomains,
+        excludeDomains,
       });
 
       return results;
     }
 
+    // includeDomains/excludeDomains are enforced on returned URLs only on
+    // the fire engine path above; the fallback providers below receive them
+    // solely as the site: chain baked into the query.
     if (config.SEARXNG_ENDPOINT) {
       logger.info("Using searxng search");
       const results = await searxng_search(query, {


### PR DESCRIPTION
## Problem

`includeDomains`/`excludeDomains` on `/v2/search` were only expressed as a `site:` chain baked into the query sent upstream. The search backend can loosen or drop that chain — especially on multi-domain lists — so off-domain results leaked through to customers, and with scrape formats set, every leaked page billed scrape credits too.

## Fix

Enforcement now lives in fire engine, which filters returned URLs against the lists and paginates to backfill whatever it discards (https://github.com/firecrawl/fire-engine/pull/651). This PR forwards the two lists through the v2 search stack (`executeSearch` → `search()` → `fire_engine_search_v2`) into the engine payload.

The query keeps its baked `site:` chain as an upstream bias — the more the backend honors it, the less the engine has to discard and backfill. The searxng/DuckDuckGo fallback paths (self-hosted) keep the previous hint-only behavior, now noted in a comment.

Deploy order is safe either way: the engine ignores unknown body fields until its PR lands, and this change is inert until then.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards `includeDomains`/`excludeDomains` from `/v2/search` into the fire engine payload so the engine enforces them on returned URLs and paginates to backfill discarded results. Previously the filters were only a `site:` chain baked into the query, which the backend could drop, leaking off-domain results.

**Rollout**
- Safe either way: the engine ignores unknown body fields until its PR lands.
- The searxng/DuckDuckGo fallback paths keep the old hint-only behavior.

<sup>Written for commit ab530cb7284440a667634140864722c53676562a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

