### PR TITLE
fix(self-host): wait for NuQ PostgreSQL readiness

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,6 +111,8 @@ services:
         condition: service_started
       rabbitmq:
         condition: service_healthy
+      nuq-postgres:
+        condition: service_healthy
     ports:
       - "${PORT:-3002}:${INTERNAL_PORT:-3002}"
     volumes:
@@ -166,6 +168,16 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     networks:
       - backend
     logging:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,8 +111,11 @@ services:
         condition: service_started
       rabbitmq:
         condition: service_healthy
+      # Only the pg backend uses nuq-postgres, so an unhealthy Postgres must not
+      # block startup when NUQ_BACKEND=fdb.
       nuq-postgres:
         condition: service_healthy
+        required: false
     ports:
       - "${PORT:-3002}:${INTERNAL_PORT:-3002}"
     volumes:


### PR DESCRIPTION
## Problem

Self-hosted Compose can start the API harness before NuQ PostgreSQL is ready, so initial worker queries fail and scrape jobs are left unprocessed.

## Changes

- Add a `pg_isready` healthcheck to `nuq-postgres`.
- Gate the API service start on `nuq-postgres` reporting healthy, alongside the existing `rabbitmq` dependency.

Fixes #4595
