### PR TITLE
fix(python-sdk): drop shadowed duplicate V1ExtractParams / V1SearchResponse in v1 client

### DIFF
--- a/apps/python-sdk/firecrawl/v1/client.py
+++ b/apps/python-sdk/firecrawl/v1/client.py
@@ -318,18 +318,6 @@ class V1MapResponse(pydantic.BaseModel):
     links: Optional[List[str]] = None
     error: Optional[str] = None
 
-class V1ExtractParams(pydantic.BaseModel):
-    """Parameters for extracting information from URLs."""
-    prompt: Optional[str] = None
-    schema_field: Optional[Any] = pydantic.Field(None, alias='schema')
-    systemPrompt: Optional[str] = None
-    allowExternalLinks: Optional[bool] = None
-    enableWebSearch: Optional[bool] = None
-    includeSubdomains: Optional[bool] = None
-    origin: Optional[str] = None
-    showSources: Optional[bool] = None
-    scrapeOptions: Optional[V1ScrapeOptions] = None
-
 class V1ExtractResponse(pydantic.BaseModel, Generic[T]):
     """Response from extract operations."""
     id: Optional[str] = None
@@ -355,13 +343,6 @@ class V1SearchParams(pydantic.BaseModel):
     origin: Optional[str] = "api"
     timeout: Optional[int] = 60000
     scrapeOptions: Optional[V1ScrapeOptions] = None
-
-class V1SearchResponse(pydantic.BaseModel):
-    """Response from search operations."""
-    success: bool = True
-    data: List[V1FirecrawlDocument]
-    warning: Optional[str] = None
-    error: Optional[str] = None
 
 class V1CreditUsageData(pydantic.BaseModel):
     remaining_credits: int


### PR DESCRIPTION
### What

In `apps/python-sdk/firecrawl/v1/client.py`, two model classes are each declared **twice** at module level:

| class | dead (shadowed) | live (winning) |
|---|---|---|
| `V1ExtractParams` | L321 | L484 |
| `V1SearchResponse` | L359 | L475 |

Python binds a module-level name to its **last** definition, so the first copy of each class never takes effect — it is dead code.

The two copies are **not** identical, which is why this went unnoticed:
- the live `V1ExtractParams` uses snake_case fields (`system_prompt`, `allow_external_links`, `enable_web_search`), a backwards-compat `enableWebSearch`, and an `agent` field;
- the live `V1SearchResponse` uses `data: List[Dict[str, Any]]` (the dead one used `List[V1FirecrawlDocument]`).

So the earlier definitions are stale leftovers that the interpreter already discards.

### Why it's safe

This is a pure no-op. I verified with an AST diff that the class object bound to each name **after the full module loads is byte-identical before and after** this change — only the unreachable earlier definitions are removed (+0/−19). All in-file usages (`V1SearchResponse(**response_json)`, the return annotations) already resolve to the surviving definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate `V1ExtractParams` and `V1SearchResponse` definitions in the v1 client so only the live versions remain. The earlier copies were always shadowed by the later ones, so module behavior is unchanged.

<sup>Written for commit b8f75b5a5ba05f53f4709731e3e787dd947be6c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

