### PR TITLE
feat(api): default v1 proxy to auto when no country is specified

### DIFF
--- a/apps/api/src/__tests__/snips/v1/types-validation.test.ts
+++ b/apps/api/src/__tests__/snips/v1/types-validation.test.ts
@@ -34,7 +34,7 @@ describe("V1 Types Validation", () => {
       const result = scrapeRequestSchema.parse(input);
       expect(result.url).toBe("https://example.com");
       expect(result.origin).toBe("api");
-      expect(result.timeout).toBe(30000);
+      expect(result.timeout).toBe(120000); // bumped because default proxy is "auto"
       expect(result.formats).toEqual(["markdown"]);
     });
 
@@ -286,7 +286,7 @@ describe("V1 Types Validation", () => {
 
       const result = scrapeRequestSchema.parse(input);
       expect(result.origin).toBe("api");
-      expect(result.timeout).toBe(30000);
+      expect(result.timeout).toBe(120000); // bumped because default proxy is "auto"
       expect(result.formats).toEqual(["markdown"]);
       expect(result.onlyMainContent).toBe(true);
       expect(result.onlyCleanContent).toBe(false);
@@ -296,7 +296,7 @@ describe("V1 Types Validation", () => {
       expect(result.removeBase64Images).toBe(true);
       expect(result.fastMode).toBe(false);
       expect(result.blockAds).toBe(true);
-      expect(result.proxy).toBe("basic");
+      expect(result.proxy).toBe("auto");
       expect(result.storeInCache).toBe(true);
     });
 

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -542,7 +542,10 @@ const baseScrapeOptions = z.strictObject({
   fastMode: z.boolean().prefault(false),
   useMock: z.string().optional(),
   blockAds: z.boolean().prefault(true),
-  proxy: z.enum(["basic", "stealth", "enhanced", "auto"]).prefault("basic"),
+  // No prefault here: the default is conditional on location (see extractTransform).
+  // Requests without a non-default country default to "auto"; requests with one
+  // default to "basic".
+  proxy: z.enum(["basic", "stealth", "enhanced", "auto"]).optional(),
   maxAge: z
     .int()
     .gte(0)
@@ -580,6 +583,20 @@ const extractTransformRequired = <T extends ScrapeOptions>(obj: T): T => {
 };
 
 const extractTransform = (obj: ScrapeOptions) => {
+  // Proxy default: "auto" when no non-default country is specified, so
+  // requests can upgrade to stealth on proxy failures. When a country is
+  // specified, keep the historical "basic" default.
+  if (obj.proxy === undefined) {
+    const country = obj.location?.country ?? obj.geolocation?.country;
+    obj = {
+      ...obj,
+      proxy:
+        country === undefined || country.toLowerCase() === "us-generic"
+          ? "auto"
+          : "basic",
+    };
+  }
+
   // Handle timeout
   if (
     (includesFormat(obj.formats, "extract") ||

--- a/apps/api/src/controllers/v1/types.ts
+++ b/apps/api/src/controllers/v1/types.ts
@@ -587,14 +587,17 @@ const extractTransform = (obj: ScrapeOptions) => {
   // requests can upgrade to stealth on proxy failures. When a country is
   // specified, keep the historical "basic" default.
   if (obj.proxy === undefined) {
-    const country = obj.location?.country ?? obj.geolocation?.country;
-    obj = {
-      ...obj,
-      proxy:
-        country === undefined || country.toLowerCase() === "us-generic"
-          ? "auto"
-          : "basic",
-    };
+    // Check both location fields: a non-default country in either one counts
+    // as specified, even if the other omitted its country (its schema fills
+    // in the "us-generic" default, which must not shadow the other field).
+    const hasNonDefaultCountry = [
+      obj.location?.country,
+      obj.geolocation?.country,
+    ].some(
+      country =>
+        country !== undefined && country.toLowerCase() !== "us-generic",
+    );
+    obj = { ...obj, proxy: hasNonDefaultCountry ? "basic" : "auto" };
   }
 
   // Handle timeout


### PR DESCRIPTION
## Summary

Changes the v1 API's default proxy from `basic` to `auto` for requests that do not specify a non-default country.

- The `proxy` field's `.prefault("basic")` is removed so explicit values (including explicit `basic`) can be distinguished from an unset field. The default is now applied conditionally in `extractTransform`, which every v1 request schema (scrape, batch scrape, crawl, extract, search) funnels through.
- No country specified (or the default `us-generic`, via `location` or the deprecated `geolocation`) → default `auto`, letting scrapes upgrade to stealth on proxy failures. This matches v2, which already defaults to `auto` unconditionally.
- A non-default country specified → historical `basic` default is kept. `us-whitelist` counts as an explicitly specified country and also keeps `basic`.

## Behavior changes to be aware of

- The existing timeout rule (proxy `stealth`/`enhanced`/`auto` + default 30s timeout → bump to 120s) now applies to default v1 requests, so plain v1 scrapes get a 120s timeout ceiling instead of 30s. Same as v2 today.
- v0 search rides along (it parses through the v1 schema), which makes it consistent with v0 scrape/crawl, where the v2 schema's `auto` prefault already applied.
- The v1 search endpoint's top-level `country` param only feeds the search engine, not `scrapeOptions`, so geo-targeted searches without `scrapeOptions.location` now scrape with `auto`.

## Test plan

- `npx tsc --noEmit` in `apps/api` passes.
- Updated expectations in `src/__tests__/snips/v1/types-validation.test.ts` (`proxy: "auto"` and the bumped 120s timeout on bare requests); the file's 80 cases pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the v1 API default proxy to `auto` when no non-default country is specified, matching v2 behavior and allowing scrapes to upgrade to stealth on proxy failures. A non-default country in either `location` or the deprecated `geolocation` keeps the historical `basic` default, and explicit proxy values are always respected.

**Behavior changes**
- Default v1 requests now get a 120s timeout ceiling instead of 30s, because the existing timeout rule applies to `auto` proxy.
- v0 search requests now follow the same default as v0 scrape/crawl.
- Removing the `prefault` lets explicit `basic` be distinguished from an unset field, but no migration is required.

<sup>Written for commit 6146436c537b112f0422c590dda54e5ac917bb59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

