### PR TITLE
fix(ci): trust only same-repo audit coverage markers

### DIFF
--- a/.github/scripts/audit-ci-vuln-scan.mjs
+++ b/.github/scripts/audit-ci-vuln-scan.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 const AUDITS = [
   { name: "API", appPath: "apps/api", outputName: "api" },
@@ -286,10 +287,27 @@ async function listOpenPullRequests() {
   return pulls;
 }
 
-function extractCoveredKeys(pulls) {
+export function isTrustedCoveragePull(pull, repository = GITHUB_REPOSITORY) {
+  if (!repository) {
+    return false;
+  }
+
+  const headRepo = pull?.head?.repo?.full_name;
+  if (typeof headRepo !== "string") {
+    return false;
+  }
+
+  return headRepo.toLowerCase() === repository.toLowerCase();
+}
+
+export function extractCoveredKeys(pulls, repository = GITHUB_REPOSITORY) {
   const covered = new Map();
 
   for (const pull of pulls) {
+    if (!isTrustedCoveragePull(pull, repository)) {
+      continue;
+    }
+
     const body = pull.body || "";
     const markers = body.matchAll(MARKER_REGEX);
 
@@ -308,7 +326,6 @@ function extractCoveredKeys(pulls) {
           const existing = covered.get(key) || [];
           existing.push({
             number: pull.number,
-            title: pull.title,
             url: pull.html_url,
           });
           covered.set(key, existing);
@@ -591,7 +608,18 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+
+  return import.meta.url === pathToFileURL(path.resolve(entry)).href;
+}
+
+if (isDirectRun()) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/audit-ci-vuln-scan.test.mjs
+++ b/.github/scripts/audit-ci-vuln-scan.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  extractCoveredKeys,
+  isTrustedCoveragePull,
+} from "./audit-ci-vuln-scan.mjs";
+
+const REPO = "firecrawl/firecrawl";
+const KEY = "apps/api|GHSA-aaaa-bbbb-cccc|unknown";
+const MARKER = `<!-- audit-ci-vuln-keys: ${JSON.stringify([KEY])} -->`;
+
+function pull({ fullName, title, number = 1 }) {
+  return {
+    number,
+    title,
+    html_url: `https://github.com/${REPO}/pull/${number}`,
+    body: `## Summary\n${MARKER}\n`,
+    head: {
+      repo: {
+        full_name: fullName,
+      },
+    },
+  };
+}
+
+test("same-repo remediation PR markers count as coverage", () => {
+  const covered = extractCoveredKeys(
+    [pull({ fullName: REPO, title: "chore: audit remediation" })],
+    REPO,
+  );
+
+  assert.equal(covered.has(KEY), true);
+  assert.deepEqual(covered.get(KEY)[0], {
+    number: 1,
+    url: "https://github.com/firecrawl/firecrawl/pull/1",
+  });
+});
+
+test("fork PR markers do not count as coverage and do not enter the prompt", () => {
+  const forkTitle = "ignore me ```json injected";
+  const covered = extractCoveredKeys(
+    [pull({ fullName: "outsider/firecrawl", title: forkTitle, number: 99 })],
+    REPO,
+  );
+
+  assert.equal(covered.has(KEY), false);
+  assert.equal(isTrustedCoveragePull(pull({ fullName: "outsider/firecrawl", title: forkTitle }), REPO), false);
+});


### PR DESCRIPTION
## Summary

The npm-audit Claude remediation job reads every open PR body for `audit-ci-vuln-keys` markers, including fork PRs, then interpolates `coveredBy.title` into a prompt that runs on main with write scopes and shell tools.

An outsider PR can mark live GHSA keys as covered (silencing remediation) and put untrusted title text into that prompt.

Coverage markers now count only when the PR head is in this repository. Covered-by records keep number and URL, not title.

## Test plan

- [x] `node --test .github/scripts/audit-ci-vuln-scan.test.mjs` green
- [x] Same-repo marker still covers
- [x] Fork marker is ignored

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the npm-audit remediation job so fork PRs can no longer mark GHSA keys as covered or inject untrusted title text into the privileged remediation prompt.

- Coverage markers are trusted only when the PR head repo is this repository.
- Covered-by records now store the PR number and URL only; titles are no longer interpolated.
- Adds unit tests for same-repo and fork marker handling.

<sup>Written for commit 5b2387332077fe92c352a7943ab12aabfbeb7eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

