### PR TITLE
fix(api): exempt text/plain responses from minimum body length check

### DIFF
--- a/apps/api/src/scraper/scrapeURL/index.ts
+++ b/apps/api/src/scraper/scrapeURL/index.ts
@@ -744,9 +744,17 @@ async function scrapeURLLoopIter(
     // engine in its waterfall, surface as an all-engines failure.
     const isParsedImage =
       engine === "image" && isGoodStatusCode && hasNoPageError;
+    // A text/plain response (e.g. llms.txt) is a complete result even when
+    // the body is empty: the server deliberately served an empty plain-text
+    // document, so the minimum-length check must not reject it and trigger
+    // pointless engine fallbacks. Media types are case-insensitive per RFC,
+    // so normalize before matching.
+    const isPlainText =
+      hasNoPageError &&
+      engineResult.contentType?.toLowerCase().includes("text/plain") === true;
     const hasRequiredOutput = hasRawBase64
       ? engineResult.rawBase64 !== undefined
-      : isParsedImage || isLongEnough || !isGoodStatusCode;
+      : isParsedImage || isPlainText || isLongEnough || !isGoodStatusCode;
     const isLikelyProxyError = [401, 403, 429].includes(
       engineResult.statusCode,
     );
@@ -779,6 +787,7 @@ async function scrapeURLLoopIter(
           isGoodStatusCode,
           hasNoPageError,
           isParsedImage,
+          isPlainText,
         },
       });
       return engineResult;


### PR DESCRIPTION
## Problem

`scrapeURLLoopIter` deems a scrape unsuccessful unless the extracted content has at least 1 character (`isLongEnough = checkMarkdown.trim().length > 0` feeding into `hasRequiredOutput`). For `text/plain` responses that's wrong: an empty plain-text document (e.g. an empty `llms.txt`) is a deliberate, complete response. Instead of succeeding, it got thrown through every fallback engine in the waterfall and then failed the scrape entirely.

## Fix

Add an `isPlainText` factor alongside the existing `isParsedImage` exemption: when the engine result's content type includes `text/plain` (normalized to lowercase, since media types are case-insensitive per RFC), the response counts as having required output regardless of body length. The new factor is included in the "deemed successful" log line for observability.

Bad status codes were already exempt from the length check via `!isGoodStatusCode`, so this only changes behavior for good-status empty `text/plain` responses — the masking risk is negligible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats empty `text/plain` responses (e.g. an empty `llms.txt`) as successful scrapes instead of routing them through every fallback engine and failing the scrape.

- Adds an `isPlainText` check alongside the existing image exemption, matching content type case-insensitively.
- Includes the new factor in the success-decision log line for observability.
- Only affects good-status empty plain-text responses; bad status codes were already exempt.

<sup>Written for commit 48d04e77bb7273f19f63f45166e73de80f46d84b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl/pull/4624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

